### PR TITLE
private/model/api: Add generated setters for API parameters

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -39,6 +39,9 @@ type API struct {
 	// Set to true to not generate validation shapes
 	NoValidataShapeMethods bool
 
+	// Set to true to not generate struct field accessors
+	NoGenStructFieldAccessors bool
+
 	SvcClientImportPath string
 
 	initialized bool

--- a/private/protocol/ec2query/build_test.go
+++ b/private/protocol/ec2query/build_test.go
@@ -163,6 +163,18 @@ type InputService1TestShapeInputService1TestCaseOperation1Input struct {
 	Foo *string `type:"string"`
 }
 
+// SetBar sets the Bar field's value.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Input) SetBar(v string) *InputService1TestShapeInputService1TestCaseOperation1Input {
+	s.Bar = &v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Input) SetFoo(v string) *InputService1TestShapeInputService1TestCaseOperation1Input {
+	s.Foo = &v
+	return s
+}
+
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -289,6 +301,24 @@ type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	Yuck *string `locationName:"yuckLocationName" queryName:"yuckQueryName" type:"string"`
 }
 
+// SetBar sets the Bar field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetBar(v string) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.Bar = &v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetFoo(v string) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.Foo = &v
+	return s
+}
+
+// SetYuck sets the Yuck field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetYuck(v string) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.Yuck = &v
+	return s
+}
+
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -411,6 +441,12 @@ type InputService3TestShapeInputService3TestCaseOperation1Input struct {
 	StructArg *InputService3TestShapeStructType `locationName:"Struct" type:"structure"`
 }
 
+// SetStructArg sets the StructArg field's value.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Input) SetStructArg(v *InputService3TestShapeStructType) *InputService3TestShapeInputService3TestCaseOperation1Input {
+	s.StructArg = v
+	return s
+}
+
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -419,6 +455,12 @@ type InputService3TestShapeStructType struct {
 	_ struct{} `type:"structure"`
 
 	ScalarArg *string `locationName:"Scalar" type:"string"`
+}
+
+// SetScalarArg sets the ScalarArg field's value.
+func (s *InputService3TestShapeStructType) SetScalarArg(v string) *InputService3TestShapeStructType {
+	s.ScalarArg = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -537,6 +579,12 @@ type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	ListArg []*string `type:"list"`
+}
+
+// SetListArg sets the ListArg field's value.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetListArg(v []*string) *InputService4TestShapeInputService4TestCaseOperation1Input {
+	s.ListArg = v
+	return s
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -661,6 +709,12 @@ type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 	ListArg []*string `locationName:"ListMemberName" locationNameList:"item" type:"list"`
 }
 
+// SetListArg sets the ListArg field's value.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetListArg(v []*string) *InputService5TestShapeInputService5TestCaseOperation1Input {
+	s.ListArg = v
+	return s
+}
+
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -781,6 +835,12 @@ type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	ListArg []*string `locationName:"ListMemberName" queryName:"ListQueryName" locationNameList:"item" type:"list"`
+}
+
+// SetListArg sets the ListArg field's value.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetListArg(v []*string) *InputService6TestShapeInputService6TestCaseOperation1Input {
+	s.ListArg = v
+	return s
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -906,6 +966,12 @@ type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 	BlobArg []byte `type:"blob"`
 }
 
+// SetBlobArg sets the BlobArg field's value.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetBlobArg(v []byte) *InputService7TestShapeInputService7TestCaseOperation1Input {
+	s.BlobArg = v
+	return s
+}
+
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1026,6 +1092,12 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
+}
+
+// SetTimeArg sets the TimeArg field's value.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetTimeArg(v time.Time) *InputService8TestShapeInputService8TestCaseOperation1Input {
+	s.TimeArg = &v
+	return s
 }
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
@@ -1216,6 +1288,12 @@ type InputService9TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
+}
+
+// SetToken sets the Token field's value.
+func (s *InputService9TestShapeInputShape) SetToken(v string) *InputService9TestShapeInputShape {
+	s.Token = &v
+	return s
 }
 
 //

--- a/private/protocol/ec2query/unmarshal_test.go
+++ b/private/protocol/ec2query/unmarshal_test.go
@@ -177,6 +177,54 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	TrueBool *bool `type:"boolean"`
 }
 
+// SetChar sets the Char field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetChar(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Char = &v
+	return s
+}
+
+// SetDouble sets the Double field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetDouble(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Double = &v
+	return s
+}
+
+// SetFalseBool sets the FalseBool field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFalseBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.FalseBool = &v
+	return s
+}
+
+// SetFloat sets the Float field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFloat(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Float = &v
+	return s
+}
+
+// SetLong sets the Long field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetLong(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Long = &v
+	return s
+}
+
+// SetNum sets the Num field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetNum(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Num = &v
+	return s
+}
+
+// SetStr sets the Str field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetStr(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Str = &v
+	return s
+}
+
+// SetTrueBool sets the TrueBool field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.TrueBool = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService2ProtocolTest struct {
@@ -296,6 +344,12 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 
 	// Blob is automatically base64 encoded/decoded by the SDK.
 	Blob []byte `type:"blob"`
+}
+
+// SetBlob sets the Blob field's value.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetBlob(v []byte) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
+	s.Blob = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -418,6 +472,12 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	ListMember []*string `type:"list"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetListMember(v []*string) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
+	s.ListMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService4ProtocolTest struct {
@@ -536,6 +596,12 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	ListMember []*string `locationNameList:"item" type:"list"`
+}
+
+// SetListMember sets the ListMember field's value.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
+	s.ListMember = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -658,6 +724,12 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	ListMember []*string `type:"list" flattened:"true"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetListMember(v []*string) *OutputService5TestShapeOutputService5TestCaseOperation1Output {
+	s.ListMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService6ProtocolTest struct {
@@ -778,10 +850,22 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	Map map[string]*OutputService6TestShapeStructureType `type:"map"`
 }
 
+// SetMap sets the Map field's value.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetMap(v map[string]*OutputService6TestShapeStructureType) *OutputService6TestShapeOutputService6TestCaseOperation1Output {
+	s.Map = v
+	return s
+}
+
 type OutputService6TestShapeStructureType struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `locationName:"foo" type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService6TestShapeStructureType) SetFoo(v string) *OutputService6TestShapeStructureType {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -904,6 +988,12 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	Map map[string]*string `type:"map" flattened:"true"`
 }
 
+// SetMap sets the Map field's value.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService7TestShapeOutputService7TestCaseOperation1Output {
+	s.Map = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService8ProtocolTest struct {
@@ -1024,6 +1114,12 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
 }
 
+// SetMap sets the Map field's value.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService8TestShapeOutputService8TestCaseOperation1Output {
+	s.Map = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService9ProtocolTest struct {
@@ -1142,6 +1238,12 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetFoo(v string) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
+	s.Foo = &v
+	return s
 }
 
 //

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -164,6 +164,12 @@ type InputService1TestShapeInputService1TestCaseOperation1Input struct {
 	Name *string `type:"string"`
 }
 
+// SetName sets the Name field's value.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Input) SetName(v string) *InputService1TestShapeInputService1TestCaseOperation1Input {
+	s.Name = &v
+	return s
+}
+
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -286,6 +292,12 @@ type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"unix"`
+}
+
+// SetTimeArg sets the TimeArg field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetTimeArg(v time.Time) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.TimeArg = &v
+	return s
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -481,6 +493,18 @@ type InputService3TestShapeInputShape struct {
 	BlobMap map[string][]byte `type:"map"`
 }
 
+// SetBlobArg sets the BlobArg field's value.
+func (s *InputService3TestShapeInputShape) SetBlobArg(v []byte) *InputService3TestShapeInputShape {
+	s.BlobArg = v
+	return s
+}
+
+// SetBlobMap sets the BlobMap field's value.
+func (s *InputService3TestShapeInputShape) SetBlobMap(v map[string][]byte) *InputService3TestShapeInputShape {
+	s.BlobMap = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type InputService4ProtocolTest struct {
@@ -600,6 +624,12 @@ type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	ListParam [][]byte `type:"list"`
+}
+
+// SetListParam sets the ListParam field's value.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetListParam(v [][]byte) *InputService4TestShapeInputService4TestCaseOperation1Input {
+	s.ListParam = v
+	return s
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -1040,6 +1070,12 @@ type InputService5TestShapeInputShape struct {
 	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
 }
 
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService5TestShapeInputShape) SetRecursiveStruct(v *InputService5TestShapeRecursiveStructType) *InputService5TestShapeInputShape {
+	s.RecursiveStruct = v
+	return s
+}
+
 type InputService5TestShapeRecursiveStructType struct {
 	_ struct{} `type:"structure"`
 
@@ -1050,6 +1086,30 @@ type InputService5TestShapeRecursiveStructType struct {
 	RecursiveMap map[string]*InputService5TestShapeRecursiveStructType `type:"map"`
 
 	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetNoRecurse sets the NoRecurse field's value.
+func (s *InputService5TestShapeRecursiveStructType) SetNoRecurse(v string) *InputService5TestShapeRecursiveStructType {
+	s.NoRecurse = &v
+	return s
+}
+
+// SetRecursiveList sets the RecursiveList field's value.
+func (s *InputService5TestShapeRecursiveStructType) SetRecursiveList(v []*InputService5TestShapeRecursiveStructType) *InputService5TestShapeRecursiveStructType {
+	s.RecursiveList = v
+	return s
+}
+
+// SetRecursiveMap sets the RecursiveMap field's value.
+func (s *InputService5TestShapeRecursiveStructType) SetRecursiveMap(v map[string]*InputService5TestShapeRecursiveStructType) *InputService5TestShapeRecursiveStructType {
+	s.RecursiveMap = v
+	return s
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService5TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService5TestShapeRecursiveStructType) *InputService5TestShapeRecursiveStructType {
+	s.RecursiveStruct = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1171,6 +1231,12 @@ type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	Map map[string]*string `type:"map"`
+}
+
+// SetMap sets the Map field's value.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetMap(v map[string]*string) *InputService6TestShapeInputService6TestCaseOperation1Input {
+	s.Map = v
+	return s
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -1363,6 +1429,12 @@ type InputService7TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
+}
+
+// SetToken sets the Token field's value.
+func (s *InputService7TestShapeInputShape) SetToken(v string) *InputService7TestShapeInputShape {
+	s.Token = &v
+	return s
 }
 
 //

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -179,6 +179,54 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	TrueBool *bool `type:"boolean"`
 }
 
+// SetChar sets the Char field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetChar(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Char = &v
+	return s
+}
+
+// SetDouble sets the Double field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetDouble(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Double = &v
+	return s
+}
+
+// SetFalseBool sets the FalseBool field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFalseBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.FalseBool = &v
+	return s
+}
+
+// SetFloat sets the Float field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFloat(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Float = &v
+	return s
+}
+
+// SetLong sets the Long field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetLong(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Long = &v
+	return s
+}
+
+// SetNum sets the Num field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetNum(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Num = &v
+	return s
+}
+
+// SetStr sets the Str field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetStr(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Str = &v
+	return s
+}
+
+// SetTrueBool sets the TrueBool field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.TrueBool = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService2ProtocolTest struct {
@@ -298,6 +346,12 @@ type OutputService2TestShapeBlobContainer struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 }
 
+// SetFoo sets the Foo field's value.
+func (s *OutputService2TestShapeBlobContainer) SetFoo(v []byte) *OutputService2TestShapeBlobContainer {
+	s.Foo = v
+	return s
+}
+
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
@@ -309,6 +363,18 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	BlobMember []byte `type:"blob"`
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`
+}
+
+// SetBlobMember sets the BlobMember field's value.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetBlobMember(v []byte) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
+	s.BlobMember = v
+	return s
+}
+
+// SetStructMember sets the StructMember field's value.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetStructMember(v *OutputService2TestShapeBlobContainer) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
+	s.StructMember = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -435,10 +501,28 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	TimeMember *time.Time `type:"timestamp" timestampFormat:"unix"`
 }
 
+// SetStructMember sets the StructMember field's value.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetStructMember(v *OutputService3TestShapeTimeContainer) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
+	s.StructMember = v
+	return s
+}
+
+// SetTimeMember sets the TimeMember field's value.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetTimeMember(v time.Time) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
+	s.TimeMember = &v
+	return s
+}
+
 type OutputService3TestShapeTimeContainer struct {
 	_ struct{} `type:"structure"`
 
 	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService3TestShapeTimeContainer) SetFoo(v time.Time) *OutputService3TestShapeTimeContainer {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -627,6 +711,24 @@ type OutputService4TestShapeOutputShape struct {
 	ListMemberStruct []*OutputService4TestShapeStructType `type:"list"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService4TestShapeOutputShape) SetListMember(v []*string) *OutputService4TestShapeOutputShape {
+	s.ListMember = v
+	return s
+}
+
+// SetListMemberMap sets the ListMemberMap field's value.
+func (s *OutputService4TestShapeOutputShape) SetListMemberMap(v []map[string]*string) *OutputService4TestShapeOutputShape {
+	s.ListMemberMap = v
+	return s
+}
+
+// SetListMemberStruct sets the ListMemberStruct field's value.
+func (s *OutputService4TestShapeOutputShape) SetListMemberStruct(v []*OutputService4TestShapeStructType) *OutputService4TestShapeOutputShape {
+	s.ListMemberStruct = v
+	return s
+}
+
 type OutputService4TestShapeStructType struct {
 	_ struct{} `type:"structure"`
 }
@@ -753,6 +855,12 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	MapMember map[string][]*int64 `type:"map"`
 }
 
+// SetMapMember sets the MapMember field's value.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetMapMember(v map[string][]*int64) *OutputService5TestShapeOutputService5TestCaseOperation1Output {
+	s.MapMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService6ProtocolTest struct {
@@ -873,6 +981,12 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	StrType *string `type:"string"`
+}
+
+// SetStrType sets the StrType field's value.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetStrType(v string) *OutputService6TestShapeOutputService6TestCaseOperation1Output {
+	s.StrType = &v
+	return s
 }
 
 //

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -293,6 +293,24 @@ type InputService1TestShapeInputShape struct {
 	Foo *string `type:"string"`
 }
 
+// SetBar sets the Bar field's value.
+func (s *InputService1TestShapeInputShape) SetBar(v string) *InputService1TestShapeInputShape {
+	s.Bar = &v
+	return s
+}
+
+// SetBaz sets the Baz field's value.
+func (s *InputService1TestShapeInputShape) SetBaz(v bool) *InputService1TestShapeInputShape {
+	s.Baz = &v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService1TestShapeInputShape) SetFoo(v string) *InputService1TestShapeInputShape {
+	s.Foo = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type InputService2ProtocolTest struct {
@@ -411,6 +429,12 @@ type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	StructArg *InputService2TestShapeStructType `type:"structure"`
 }
 
+// SetStructArg sets the StructArg field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetStructArg(v *InputService2TestShapeStructType) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.StructArg = v
+	return s
+}
+
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -419,6 +443,12 @@ type InputService2TestShapeStructType struct {
 	_ struct{} `type:"structure"`
 
 	ScalarArg *string `type:"string"`
+}
+
+// SetScalarArg sets the ScalarArg field's value.
+func (s *InputService2TestShapeStructType) SetScalarArg(v string) *InputService2TestShapeStructType {
+	s.ScalarArg = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -603,6 +633,12 @@ type InputService3TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	ListArg []*string `type:"list"`
+}
+
+// SetListArg sets the ListArg field's value.
+func (s *InputService3TestShapeInputShape) SetListArg(v []*string) *InputService3TestShapeInputShape {
+	s.ListArg = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -793,6 +829,24 @@ type InputService4TestShapeInputShape struct {
 	ScalarArg *string `type:"string"`
 }
 
+// SetListArg sets the ListArg field's value.
+func (s *InputService4TestShapeInputShape) SetListArg(v []*string) *InputService4TestShapeInputShape {
+	s.ListArg = v
+	return s
+}
+
+// SetNamedListArg sets the NamedListArg field's value.
+func (s *InputService4TestShapeInputShape) SetNamedListArg(v []*string) *InputService4TestShapeInputShape {
+	s.NamedListArg = v
+	return s
+}
+
+// SetScalarArg sets the ScalarArg field's value.
+func (s *InputService4TestShapeInputShape) SetScalarArg(v string) *InputService4TestShapeInputShape {
+	s.ScalarArg = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type InputService5ProtocolTest struct {
@@ -909,6 +963,12 @@ type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	MapArg map[string]*string `type:"map" flattened:"true"`
+}
+
+// SetMapArg sets the MapArg field's value.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetMapArg(v map[string]*string) *InputService5TestShapeInputService5TestCaseOperation1Input {
+	s.MapArg = v
+	return s
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -1031,6 +1091,12 @@ type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	ListArg []*string `locationNameList:"item" type:"list"`
+}
+
+// SetListArg sets the ListArg field's value.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetListArg(v []*string) *InputService6TestShapeInputService6TestCaseOperation1Input {
+	s.ListArg = v
+	return s
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -1157,6 +1223,18 @@ type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 	ScalarArg *string `type:"string"`
 }
 
+// SetListArg sets the ListArg field's value.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetListArg(v []*string) *InputService7TestShapeInputService7TestCaseOperation1Input {
+	s.ListArg = v
+	return s
+}
+
+// SetScalarArg sets the ScalarArg field's value.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetScalarArg(v string) *InputService7TestShapeInputService7TestCaseOperation1Input {
+	s.ScalarArg = &v
+	return s
+}
+
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1279,6 +1357,12 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 	MapArg map[string]*string `type:"map"`
 }
 
+// SetMapArg sets the MapArg field's value.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetMapArg(v map[string]*string) *InputService8TestShapeInputService8TestCaseOperation1Input {
+	s.MapArg = v
+	return s
+}
+
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1399,6 +1483,12 @@ type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	MapArg map[string]*string `locationNameKey:"TheKey" locationNameValue:"TheValue" type:"map"`
+}
+
+// SetMapArg sets the MapArg field's value.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetMapArg(v map[string]*string) *InputService9TestShapeInputService9TestCaseOperation1Input {
+	s.MapArg = v
+	return s
 }
 
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
@@ -1524,6 +1614,12 @@ type InputService10TestShapeInputService10TestCaseOperation1Input struct {
 	BlobArg []byte `type:"blob"`
 }
 
+// SetBlobArg sets the BlobArg field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetBlobArg(v []byte) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.BlobArg = v
+	return s
+}
+
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1644,6 +1740,12 @@ type InputService11TestShapeInputService11TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	TimeArg *time.Time `type:"timestamp" timestampFormat:"iso8601"`
+}
+
+// SetTimeArg sets the TimeArg field's value.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetTimeArg(v time.Time) *InputService11TestShapeInputService11TestCaseOperation1Input {
+	s.TimeArg = &v
+	return s
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
@@ -2082,6 +2184,12 @@ type InputService12TestShapeInputShape struct {
 	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
 }
 
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService12TestShapeInputShape) SetRecursiveStruct(v *InputService12TestShapeRecursiveStructType) *InputService12TestShapeInputShape {
+	s.RecursiveStruct = v
+	return s
+}
+
 type InputService12TestShapeRecursiveStructType struct {
 	_ struct{} `type:"structure"`
 
@@ -2092,6 +2200,30 @@ type InputService12TestShapeRecursiveStructType struct {
 	RecursiveMap map[string]*InputService12TestShapeRecursiveStructType `type:"map"`
 
 	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetNoRecurse sets the NoRecurse field's value.
+func (s *InputService12TestShapeRecursiveStructType) SetNoRecurse(v string) *InputService12TestShapeRecursiveStructType {
+	s.NoRecurse = &v
+	return s
+}
+
+// SetRecursiveList sets the RecursiveList field's value.
+func (s *InputService12TestShapeRecursiveStructType) SetRecursiveList(v []*InputService12TestShapeRecursiveStructType) *InputService12TestShapeRecursiveStructType {
+	s.RecursiveList = v
+	return s
+}
+
+// SetRecursiveMap sets the RecursiveMap field's value.
+func (s *InputService12TestShapeRecursiveStructType) SetRecursiveMap(v map[string]*InputService12TestShapeRecursiveStructType) *InputService12TestShapeRecursiveStructType {
+	s.RecursiveMap = v
+	return s
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService12TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService12TestShapeRecursiveStructType) *InputService12TestShapeRecursiveStructType {
+	s.RecursiveStruct = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2278,6 +2410,12 @@ type InputService13TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
+}
+
+// SetToken sets the Token field's value.
+func (s *InputService13TestShapeInputShape) SetToken(v string) *InputService13TestShapeInputShape {
+	s.Token = &v
+	return s
 }
 
 //

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -179,6 +179,60 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	TrueBool *bool `type:"boolean"`
 }
 
+// SetChar sets the Char field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetChar(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Char = &v
+	return s
+}
+
+// SetDouble sets the Double field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetDouble(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Double = &v
+	return s
+}
+
+// SetFalseBool sets the FalseBool field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFalseBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.FalseBool = &v
+	return s
+}
+
+// SetFloat sets the Float field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFloat(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Float = &v
+	return s
+}
+
+// SetLong sets the Long field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetLong(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Long = &v
+	return s
+}
+
+// SetNum sets the Num field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetNum(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Num = &v
+	return s
+}
+
+// SetStr sets the Str field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetStr(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Str = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTimestamp(v time.Time) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Timestamp = &v
+	return s
+}
+
+// SetTrueBool sets the TrueBool field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.TrueBool = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService2ProtocolTest struct {
@@ -299,6 +353,18 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	Num *int64 `type:"integer"`
 
 	Str *string `type:"string"`
+}
+
+// SetNum sets the Num field's value.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetNum(v int64) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
+	s.Num = &v
+	return s
+}
+
+// SetStr sets the Str field's value.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetStr(v string) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
+	s.Str = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -422,6 +488,12 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	Blob []byte `type:"blob"`
 }
 
+// SetBlob sets the Blob field's value.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetBlob(v []byte) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
+	s.Blob = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService4ProtocolTest struct {
@@ -540,6 +612,12 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	ListMember []*string `type:"list"`
+}
+
+// SetListMember sets the ListMember field's value.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
+	s.ListMember = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -662,6 +740,12 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	ListMember []*string `locationNameList:"item" type:"list"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetListMember(v []*string) *OutputService5TestShapeOutputService5TestCaseOperation1Output {
+	s.ListMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService6ProtocolTest struct {
@@ -780,6 +864,12 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	ListMember []*string `type:"list" flattened:"true"`
+}
+
+// SetListMember sets the ListMember field's value.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetListMember(v []*string) *OutputService6TestShapeOutputService6TestCaseOperation1Output {
+	s.ListMember = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -902,6 +992,12 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	ListMember []*string `type:"list" flattened:"true"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) SetListMember(v []*string) *OutputService7TestShapeOutputService7TestCaseOperation1Output {
+	s.ListMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService8ProtocolTest struct {
@@ -1022,6 +1118,12 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	List []*OutputService8TestShapeStructureShape `type:"list"`
 }
 
+// SetList sets the List field's value.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) SetList(v []*OutputService8TestShapeStructureShape) *OutputService8TestShapeOutputService8TestCaseOperation1Output {
+	s.List = v
+	return s
+}
+
 type OutputService8TestShapeStructureShape struct {
 	_ struct{} `type:"structure"`
 
@@ -1030,6 +1132,24 @@ type OutputService8TestShapeStructureShape struct {
 	Baz *string `type:"string"`
 
 	Foo *string `type:"string"`
+}
+
+// SetBar sets the Bar field's value.
+func (s *OutputService8TestShapeStructureShape) SetBar(v string) *OutputService8TestShapeStructureShape {
+	s.Bar = &v
+	return s
+}
+
+// SetBaz sets the Baz field's value.
+func (s *OutputService8TestShapeStructureShape) SetBaz(v string) *OutputService8TestShapeStructureShape {
+	s.Baz = &v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService8TestShapeStructureShape) SetFoo(v string) *OutputService8TestShapeStructureShape {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1152,6 +1272,12 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	List []*OutputService9TestShapeStructureShape `type:"list" flattened:"true"`
 }
 
+// SetList sets the List field's value.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetList(v []*OutputService9TestShapeStructureShape) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
+	s.List = v
+	return s
+}
+
 type OutputService9TestShapeStructureShape struct {
 	_ struct{} `type:"structure"`
 
@@ -1160,6 +1286,24 @@ type OutputService9TestShapeStructureShape struct {
 	Baz *string `type:"string"`
 
 	Foo *string `type:"string"`
+}
+
+// SetBar sets the Bar field's value.
+func (s *OutputService9TestShapeStructureShape) SetBar(v string) *OutputService9TestShapeStructureShape {
+	s.Bar = &v
+	return s
+}
+
+// SetBaz sets the Baz field's value.
+func (s *OutputService9TestShapeStructureShape) SetBaz(v string) *OutputService9TestShapeStructureShape {
+	s.Baz = &v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService9TestShapeStructureShape) SetFoo(v string) *OutputService9TestShapeStructureShape {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1282,6 +1426,12 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 	List []*string `locationNameList:"NamedList" type:"list" flattened:"true"`
 }
 
+// SetList sets the List field's value.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetList(v []*string) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
+	s.List = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService11ProtocolTest struct {
@@ -1402,10 +1552,22 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	Map map[string]*OutputService11TestShapeStructType `type:"map"`
 }
 
+// SetMap sets the Map field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetMap(v map[string]*OutputService11TestShapeStructType) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Map = v
+	return s
+}
+
 type OutputService11TestShapeStructType struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `locationName:"foo" type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService11TestShapeStructType) SetFoo(v string) *OutputService11TestShapeStructType {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1528,6 +1690,12 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 	Map map[string]*string `type:"map" flattened:"true"`
 }
 
+// SetMap sets the Map field's value.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
+	s.Map = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService13ProtocolTest struct {
@@ -1646,6 +1814,12 @@ type OutputService13TestShapeOutputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	Map map[string]*string `locationName:"Attribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
+}
+
+// SetMap sets the Map field's value.
+func (s *OutputService13TestShapeOutputService13TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService13TestShapeOutputService13TestCaseOperation1Output {
+	s.Map = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1768,6 +1942,12 @@ type OutputService14TestShapeOutputService14TestCaseOperation1Output struct {
 	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map" flattened:"true"`
 }
 
+// SetMap sets the Map field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService14TestShapeOutputService14TestCaseOperation1Output {
+	s.Map = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService15ProtocolTest struct {
@@ -1886,6 +2066,12 @@ type OutputService15TestShapeOutputService15TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService15TestShapeOutputService15TestCaseOperation1Output) SetFoo(v string) *OutputService15TestShapeOutputService15TestCaseOperation1Output {
+	s.Foo = &v
+	return s
 }
 
 //

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -283,6 +283,12 @@ type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	PipelineId *string `location:"uri" type:"string"`
 }
 
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetPipelineId(v string) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.PipelineId = &v
+	return s
+}
+
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -406,6 +412,12 @@ type InputService3TestShapeInputService3TestCaseOperation1Input struct {
 	Foo *string `location:"uri" locationName:"PipelineId" type:"string"`
 }
 
+// SetFoo sets the Foo field's value.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Input) SetFoo(v string) *InputService3TestShapeInputService3TestCaseOperation1Input {
+	s.Foo = &v
+	return s
+}
+
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -527,6 +539,12 @@ type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	Items []*string `location:"querystring" locationName:"item" type:"list"`
+}
+
+// SetItems sets the Items field's value.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetItems(v []*string) *InputService4TestShapeInputService4TestCaseOperation1Input {
+	s.Items = v
+	return s
 }
 
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
@@ -654,6 +672,18 @@ type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 	QueryDoc map[string]*string `location:"querystring" type:"map"`
 }
 
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetPipelineId(v string) *InputService5TestShapeInputService5TestCaseOperation1Input {
+	s.PipelineId = &v
+	return s
+}
+
+// SetQueryDoc sets the QueryDoc field's value.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetQueryDoc(v map[string]*string) *InputService5TestShapeInputService5TestCaseOperation1Input {
+	s.QueryDoc = v
+	return s
+}
+
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -777,6 +807,18 @@ type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	PipelineId *string `location:"uri" type:"string"`
 
 	QueryDoc map[string][]*string `location:"querystring" type:"map"`
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetPipelineId(v string) *InputService6TestShapeInputService6TestCaseOperation1Input {
+	s.PipelineId = &v
+	return s
+}
+
+// SetQueryDoc sets the QueryDoc field's value.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetQueryDoc(v map[string][]*string) *InputService6TestShapeInputService6TestCaseOperation1Input {
+	s.QueryDoc = v
+	return s
 }
 
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
@@ -904,6 +946,24 @@ type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
+}
+
+// SetAscending sets the Ascending field's value.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetAscending(v string) *InputService7TestShapeInputService7TestCaseOperation1Input {
+	s.Ascending = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetPageToken(v string) *InputService7TestShapeInputService7TestCaseOperation1Input {
+	s.PageToken = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetPipelineId(v string) *InputService7TestShapeInputService7TestCaseOperation1Input {
+	s.PipelineId = &v
+	return s
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -1035,6 +1095,30 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 }
 
+// SetAscending sets the Ascending field's value.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetAscending(v string) *InputService8TestShapeInputService8TestCaseOperation1Input {
+	s.Ascending = &v
+	return s
+}
+
+// SetConfig sets the Config field's value.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetConfig(v *InputService8TestShapeStructType) *InputService8TestShapeInputService8TestCaseOperation1Input {
+	s.Config = v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetPageToken(v string) *InputService8TestShapeInputService8TestCaseOperation1Input {
+	s.PageToken = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetPipelineId(v string) *InputService8TestShapeInputService8TestCaseOperation1Input {
+	s.PipelineId = &v
+	return s
+}
+
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1045,6 +1129,18 @@ type InputService8TestShapeStructType struct {
 	A *string `type:"string"`
 
 	B *string `type:"string"`
+}
+
+// SetA sets the A field's value.
+func (s *InputService8TestShapeStructType) SetA(v string) *InputService8TestShapeStructType {
+	s.A = &v
+	return s
+}
+
+// SetB sets the B field's value.
+func (s *InputService8TestShapeStructType) SetB(v string) *InputService8TestShapeStructType {
+	s.B = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1174,6 +1270,36 @@ type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 }
 
+// SetAscending sets the Ascending field's value.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetAscending(v string) *InputService9TestShapeInputService9TestCaseOperation1Input {
+	s.Ascending = &v
+	return s
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetChecksum(v string) *InputService9TestShapeInputService9TestCaseOperation1Input {
+	s.Checksum = &v
+	return s
+}
+
+// SetConfig sets the Config field's value.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetConfig(v *InputService9TestShapeStructType) *InputService9TestShapeInputService9TestCaseOperation1Input {
+	s.Config = v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetPageToken(v string) *InputService9TestShapeInputService9TestCaseOperation1Input {
+	s.PageToken = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetPipelineId(v string) *InputService9TestShapeInputService9TestCaseOperation1Input {
+	s.PipelineId = &v
+	return s
+}
+
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1184,6 +1310,18 @@ type InputService9TestShapeStructType struct {
 	A *string `type:"string"`
 
 	B *string `type:"string"`
+}
+
+// SetA sets the A field's value.
+func (s *InputService9TestShapeStructType) SetA(v string) *InputService9TestShapeStructType {
+	s.A = &v
+	return s
+}
+
+// SetB sets the B field's value.
+func (s *InputService9TestShapeStructType) SetB(v string) *InputService9TestShapeStructType {
+	s.B = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1321,6 +1459,24 @@ func (s *InputService10TestShapeInputService10TestCaseOperation1Input) Validate(
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBody sets the Body field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetBody(v io.ReadSeeker) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.Body = v
+	return s
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetChecksum(v string) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.Checksum = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetVaultName(v string) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.VaultName = &v
+	return s
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
@@ -1461,6 +1617,18 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) Validate(
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBar sets the Bar field's value.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetBar(v []byte) *InputService11TestShapeInputService11TestCaseOperation1Input {
+	s.Bar = v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetFoo(v string) *InputService11TestShapeInputService11TestCaseOperation1Input {
+	s.Foo = &v
+	return s
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
@@ -1653,6 +1821,12 @@ type InputService12TestShapeInputShape struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 }
 
+// SetFoo sets the Foo field's value.
+func (s *InputService12TestShapeInputShape) SetFoo(v []byte) *InputService12TestShapeInputShape {
+	s.Foo = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type InputService13ProtocolTest struct {
@@ -1831,6 +2005,12 @@ type InputService13TestShapeFooShape struct {
 	Baz *string `locationName:"baz" type:"string"`
 }
 
+// SetBaz sets the Baz field's value.
+func (s *InputService13TestShapeFooShape) SetBaz(v string) *InputService13TestShapeFooShape {
+	s.Baz = &v
+	return s
+}
+
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1843,6 +2023,12 @@ type InputService13TestShapeInputShape struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
 	Foo *InputService13TestShapeFooShape `locationName:"foo" type:"structure"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService13TestShapeInputShape) SetFoo(v *InputService13TestShapeFooShape) *InputService13TestShapeInputShape {
+	s.Foo = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2029,6 +2215,12 @@ type InputService14TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService14TestShapeInputShape) SetFoo(v string) *InputService14TestShapeInputShape {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2469,6 +2661,12 @@ type InputService15TestShapeInputShape struct {
 	RecursiveStruct *InputService15TestShapeRecursiveStructType `type:"structure"`
 }
 
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService15TestShapeInputShape) SetRecursiveStruct(v *InputService15TestShapeRecursiveStructType) *InputService15TestShapeInputShape {
+	s.RecursiveStruct = v
+	return s
+}
+
 type InputService15TestShapeRecursiveStructType struct {
 	_ struct{} `type:"structure"`
 
@@ -2479,6 +2677,30 @@ type InputService15TestShapeRecursiveStructType struct {
 	RecursiveMap map[string]*InputService15TestShapeRecursiveStructType `type:"map"`
 
 	RecursiveStruct *InputService15TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetNoRecurse sets the NoRecurse field's value.
+func (s *InputService15TestShapeRecursiveStructType) SetNoRecurse(v string) *InputService15TestShapeRecursiveStructType {
+	s.NoRecurse = &v
+	return s
+}
+
+// SetRecursiveList sets the RecursiveList field's value.
+func (s *InputService15TestShapeRecursiveStructType) SetRecursiveList(v []*InputService15TestShapeRecursiveStructType) *InputService15TestShapeRecursiveStructType {
+	s.RecursiveList = v
+	return s
+}
+
+// SetRecursiveMap sets the RecursiveMap field's value.
+func (s *InputService15TestShapeRecursiveStructType) SetRecursiveMap(v map[string]*InputService15TestShapeRecursiveStructType) *InputService15TestShapeRecursiveStructType {
+	s.RecursiveMap = v
+	return s
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService15TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService15TestShapeRecursiveStructType) *InputService15TestShapeRecursiveStructType {
+	s.RecursiveStruct = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2669,6 +2891,18 @@ type InputService16TestShapeInputShape struct {
 	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
 }
 
+// SetTimeArg sets the TimeArg field's value.
+func (s *InputService16TestShapeInputShape) SetTimeArg(v time.Time) *InputService16TestShapeInputShape {
+	s.TimeArg = &v
+	return s
+}
+
+// SetTimeArgInHeader sets the TimeArgInHeader field's value.
+func (s *InputService16TestShapeInputShape) SetTimeArgInHeader(v time.Time) *InputService16TestShapeInputShape {
+	s.TimeArgInHeader = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type InputService17ProtocolTest struct {
@@ -2786,6 +3020,12 @@ type InputService17TestShapeInputService17TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	TimeArg *time.Time `locationName:"timestamp_location" type:"timestamp" timestampFormat:"unix"`
+}
+
+// SetTimeArg sets the TimeArg field's value.
+func (s *InputService17TestShapeInputService17TestCaseOperation1Input) SetTimeArg(v time.Time) *InputService17TestShapeInputService17TestCaseOperation1Input {
+	s.TimeArg = &v
+	return s
 }
 
 type InputService17TestShapeInputService17TestCaseOperation1Output struct {
@@ -2909,6 +3149,12 @@ type InputService18TestShapeInputService18TestCaseOperation1Input struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
 	Foo *string `locationName:"foo" type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Input) SetFoo(v string) *InputService18TestShapeInputService18TestCaseOperation1Input {
+	s.Foo = &v
+	return s
 }
 
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
@@ -3099,6 +3345,12 @@ type InputService19TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
+}
+
+// SetToken sets the Token field's value.
+func (s *InputService19TestShapeInputShape) SetToken(v string) *InputService19TestShapeInputShape {
+	s.Token = &v
+	return s
 }
 
 //

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -183,6 +183,72 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	TrueBool *bool `type:"boolean"`
 }
 
+// SetChar sets the Char field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetChar(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Char = &v
+	return s
+}
+
+// SetDouble sets the Double field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetDouble(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Double = &v
+	return s
+}
+
+// SetFalseBool sets the FalseBool field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFalseBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.FalseBool = &v
+	return s
+}
+
+// SetFloat sets the Float field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFloat(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Float = &v
+	return s
+}
+
+// SetImaHeader sets the ImaHeader field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetImaHeader(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.ImaHeader = &v
+	return s
+}
+
+// SetImaHeaderLocation sets the ImaHeaderLocation field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetImaHeaderLocation(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.ImaHeaderLocation = &v
+	return s
+}
+
+// SetLong sets the Long field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetLong(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Long = &v
+	return s
+}
+
+// SetNum sets the Num field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetNum(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Num = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetStatus(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Status = &v
+	return s
+}
+
+// SetStr sets the Str field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetStr(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.Str = &v
+	return s
+}
+
+// SetTrueBool sets the TrueBool field's value.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+	s.TrueBool = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService2ProtocolTest struct {
@@ -300,6 +366,12 @@ type OutputService2TestShapeBlobContainer struct {
 	Foo []byte `locationName:"foo" type:"blob"`
 }
 
+// SetFoo sets the Foo field's value.
+func (s *OutputService2TestShapeBlobContainer) SetFoo(v []byte) *OutputService2TestShapeBlobContainer {
+	s.Foo = v
+	return s
+}
+
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
@@ -311,6 +383,18 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	BlobMember []byte `type:"blob"`
 
 	StructMember *OutputService2TestShapeBlobContainer `type:"structure"`
+}
+
+// SetBlobMember sets the BlobMember field's value.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetBlobMember(v []byte) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
+	s.BlobMember = v
+	return s
+}
+
+// SetStructMember sets the StructMember field's value.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetStructMember(v *OutputService2TestShapeBlobContainer) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
+	s.StructMember = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -435,10 +519,28 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	TimeMember *time.Time `type:"timestamp" timestampFormat:"unix"`
 }
 
+// SetStructMember sets the StructMember field's value.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetStructMember(v *OutputService3TestShapeTimeContainer) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
+	s.StructMember = v
+	return s
+}
+
+// SetTimeMember sets the TimeMember field's value.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetTimeMember(v time.Time) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
+	s.TimeMember = &v
+	return s
+}
+
 type OutputService3TestShapeTimeContainer struct {
 	_ struct{} `type:"structure"`
 
 	Foo *time.Time `locationName:"foo" type:"timestamp" timestampFormat:"unix"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService3TestShapeTimeContainer) SetFoo(v time.Time) *OutputService3TestShapeTimeContainer {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -561,6 +663,12 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	ListMember []*string `type:"list"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
+	s.ListMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService5ProtocolTest struct {
@@ -681,10 +789,22 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	ListMember []*OutputService5TestShapeSingleStruct `type:"list"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetListMember(v []*OutputService5TestShapeSingleStruct) *OutputService5TestShapeOutputService5TestCaseOperation1Output {
+	s.ListMember = v
+	return s
+}
+
 type OutputService5TestShapeSingleStruct struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService5TestShapeSingleStruct) SetFoo(v string) *OutputService5TestShapeSingleStruct {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -807,6 +927,12 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	MapMember map[string][]*int64 `type:"map"`
 }
 
+// SetMapMember sets the MapMember field's value.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetMapMember(v map[string][]*int64) *OutputService6TestShapeOutputService6TestCaseOperation1Output {
+	s.MapMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService7ProtocolTest struct {
@@ -927,6 +1053,12 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	MapMember map[string]*time.Time `type:"map"`
 }
 
+// SetMapMember sets the MapMember field's value.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) SetMapMember(v map[string]*time.Time) *OutputService7TestShapeOutputService7TestCaseOperation1Output {
+	s.MapMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService8ProtocolTest struct {
@@ -1045,6 +1177,12 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	StrType *string `type:"string"`
+}
+
+// SetStrType sets the StrType field's value.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) SetStrType(v string) *OutputService8TestShapeOutputService8TestCaseOperation1Output {
+	s.StrType = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1169,6 +1307,18 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	PrefixedHeaders map[string]*string `location:"headers" locationName:"X-" type:"map"`
 }
 
+// SetAllHeaders sets the AllHeaders field's value.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetAllHeaders(v map[string]*string) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
+	s.AllHeaders = v
+	return s
+}
+
+// SetPrefixedHeaders sets the PrefixedHeaders field's value.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetPrefixedHeaders(v map[string]*string) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
+	s.PrefixedHeaders = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService10ProtocolTest struct {
@@ -1285,6 +1435,12 @@ type OutputService10TestShapeBodyStructure struct {
 	Foo *string `type:"string"`
 }
 
+// SetFoo sets the Foo field's value.
+func (s *OutputService10TestShapeBodyStructure) SetFoo(v string) *OutputService10TestShapeBodyStructure {
+	s.Foo = &v
+	return s
+}
+
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
@@ -1295,6 +1451,18 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 	Data *OutputService10TestShapeBodyStructure `type:"structure"`
 
 	Header *string `location:"header" locationName:"X-Foo" type:"string"`
+}
+
+// SetData sets the Data field's value.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetData(v *OutputService10TestShapeBodyStructure) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
+	s.Data = v
+	return s
+}
+
+// SetHeader sets the Header field's value.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetHeader(v string) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
+	s.Header = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1415,6 +1583,12 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure" payload:"Stream"`
 
 	Stream []byte `type:"blob"`
+}
+
+// SetStream sets the Stream field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetStream(v []byte) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Stream = v
+	return s
 }
 
 //

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -298,6 +298,18 @@ type InputService1TestShapeInputShape struct {
 	Name *string `type:"string"`
 }
 
+// SetDescription sets the Description field's value.
+func (s *InputService1TestShapeInputShape) SetDescription(v string) *InputService1TestShapeInputShape {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InputService1TestShapeInputShape) SetName(v string) *InputService1TestShapeInputShape {
+	s.Name = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type InputService2ProtocolTest struct {
@@ -421,6 +433,30 @@ type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	Second *bool `type:"boolean"`
 
 	Third *float64 `type:"float"`
+}
+
+// SetFirst sets the First field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetFirst(v bool) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.First = &v
+	return s
+}
+
+// SetFourth sets the Fourth field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetFourth(v int64) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.Fourth = &v
+	return s
+}
+
+// SetSecond sets the Second field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetSecond(v bool) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.Second = &v
+	return s
+}
+
+// SetThird sets the Third field's value.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetThird(v float64) *InputService2TestShapeInputService2TestCaseOperation1Input {
+	s.Third = &v
+	return s
 }
 
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
@@ -615,12 +651,36 @@ type InputService3TestShapeInputShape struct {
 	SubStructure *InputService3TestShapeSubStructure `type:"structure"`
 }
 
+// SetDescription sets the Description field's value.
+func (s *InputService3TestShapeInputShape) SetDescription(v string) *InputService3TestShapeInputShape {
+	s.Description = &v
+	return s
+}
+
+// SetSubStructure sets the SubStructure field's value.
+func (s *InputService3TestShapeInputShape) SetSubStructure(v *InputService3TestShapeSubStructure) *InputService3TestShapeInputShape {
+	s.SubStructure = v
+	return s
+}
+
 type InputService3TestShapeSubStructure struct {
 	_ struct{} `type:"structure"`
 
 	Bar *string `type:"string"`
 
 	Foo *string `type:"string"`
+}
+
+// SetBar sets the Bar field's value.
+func (s *InputService3TestShapeSubStructure) SetBar(v string) *InputService3TestShapeSubStructure {
+	s.Bar = &v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService3TestShapeSubStructure) SetFoo(v string) *InputService3TestShapeSubStructure {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -744,6 +804,18 @@ type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 	SubStructure *InputService4TestShapeSubStructure `type:"structure"`
 }
 
+// SetDescription sets the Description field's value.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetDescription(v string) *InputService4TestShapeInputService4TestCaseOperation1Input {
+	s.Description = &v
+	return s
+}
+
+// SetSubStructure sets the SubStructure field's value.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetSubStructure(v *InputService4TestShapeSubStructure) *InputService4TestShapeInputService4TestCaseOperation1Input {
+	s.SubStructure = v
+	return s
+}
+
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -754,6 +826,18 @@ type InputService4TestShapeSubStructure struct {
 	Bar *string `type:"string"`
 
 	Foo *string `type:"string"`
+}
+
+// SetBar sets the Bar field's value.
+func (s *InputService4TestShapeSubStructure) SetBar(v string) *InputService4TestShapeSubStructure {
+	s.Bar = &v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService4TestShapeSubStructure) SetFoo(v string) *InputService4TestShapeSubStructure {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -873,6 +957,12 @@ type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 
 	ListParam []*string `type:"list"`
+}
+
+// SetListParam sets the ListParam field's value.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetListParam(v []*string) *InputService5TestShapeInputService5TestCaseOperation1Input {
+	s.ListParam = v
+	return s
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -998,6 +1088,12 @@ type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	ListParam []*string `locationName:"AlternateName" locationNameList:"NotMember" type:"list"`
 }
 
+// SetListParam sets the ListParam field's value.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetListParam(v []*string) *InputService6TestShapeInputService6TestCaseOperation1Input {
+	s.ListParam = v
+	return s
+}
+
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1119,6 +1215,12 @@ type InputService7TestShapeInputService7TestCaseOperation1Input struct {
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 
 	ListParam []*string `type:"list" flattened:"true"`
+}
+
+// SetListParam sets the ListParam field's value.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetListParam(v []*string) *InputService7TestShapeInputService7TestCaseOperation1Input {
+	s.ListParam = v
+	return s
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
@@ -1244,6 +1346,12 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 	ListParam []*string `locationName:"item" type:"list" flattened:"true"`
 }
 
+// SetListParam sets the ListParam field's value.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetListParam(v []*string) *InputService8TestShapeInputService8TestCaseOperation1Input {
+	s.ListParam = v
+	return s
+}
+
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1367,6 +1475,12 @@ type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 	ListParam []*InputService9TestShapeSingleFieldStruct `locationName:"item" type:"list" flattened:"true"`
 }
 
+// SetListParam sets the ListParam field's value.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetListParam(v []*InputService9TestShapeSingleFieldStruct) *InputService9TestShapeInputService9TestCaseOperation1Input {
+	s.ListParam = v
+	return s
+}
+
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1375,6 +1489,12 @@ type InputService9TestShapeSingleFieldStruct struct {
 	_ struct{} `type:"structure"`
 
 	Element *string `locationName:"value" type:"string"`
+}
+
+// SetElement sets the Element field's value.
+func (s *InputService9TestShapeSingleFieldStruct) SetElement(v string) *InputService9TestShapeSingleFieldStruct {
+	s.Element = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1496,6 +1616,12 @@ type InputService10TestShapeInputService10TestCaseOperation1Input struct {
 	StructureParam *InputService10TestShapeStructureShape `type:"structure"`
 }
 
+// SetStructureParam sets the StructureParam field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetStructureParam(v *InputService10TestShapeStructureShape) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.StructureParam = v
+	return s
+}
+
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -1507,6 +1633,18 @@ type InputService10TestShapeStructureShape struct {
 	B []byte `locationName:"b" type:"blob"`
 
 	T *time.Time `locationName:"t" type:"timestamp" timestampFormat:"iso8601"`
+}
+
+// SetB sets the B field's value.
+func (s *InputService10TestShapeStructureShape) SetB(v []byte) *InputService10TestShapeStructureShape {
+	s.B = v
+	return s
+}
+
+// SetT sets the T field's value.
+func (s *InputService10TestShapeStructureShape) SetT(v time.Time) *InputService10TestShapeStructureShape {
+	s.T = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1626,6 +1764,12 @@ type InputService11TestShapeInputService11TestCaseOperation1Input struct {
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 
 	Foo map[string]*string `location:"headers" locationName:"x-foo-" type:"map"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetFoo(v map[string]*string) *InputService11TestShapeInputService11TestCaseOperation1Input {
+	s.Foo = v
+	return s
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
@@ -1749,6 +1893,12 @@ type InputService12TestShapeInputService12TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	Items []*string `location:"querystring" locationName:"item" type:"list"`
+}
+
+// SetItems sets the Items field's value.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) SetItems(v []*string) *InputService12TestShapeInputService12TestCaseOperation1Input {
+	s.Items = v
+	return s
 }
 
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
@@ -1876,6 +2026,18 @@ type InputService13TestShapeInputService13TestCaseOperation1Input struct {
 	QueryDoc map[string]*string `location:"querystring" type:"map"`
 }
 
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService13TestShapeInputService13TestCaseOperation1Input) SetPipelineId(v string) *InputService13TestShapeInputService13TestCaseOperation1Input {
+	s.PipelineId = &v
+	return s
+}
+
+// SetQueryDoc sets the QueryDoc field's value.
+func (s *InputService13TestShapeInputService13TestCaseOperation1Input) SetQueryDoc(v map[string]*string) *InputService13TestShapeInputService13TestCaseOperation1Input {
+	s.QueryDoc = v
+	return s
+}
+
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -2001,6 +2163,18 @@ type InputService14TestShapeInputService14TestCaseOperation1Input struct {
 	QueryDoc map[string][]*string `location:"querystring" type:"map"`
 }
 
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Input) SetPipelineId(v string) *InputService14TestShapeInputService14TestCaseOperation1Input {
+	s.PipelineId = &v
+	return s
+}
+
+// SetQueryDoc sets the QueryDoc field's value.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Input) SetQueryDoc(v map[string][]*string) *InputService14TestShapeInputService14TestCaseOperation1Input {
+	s.QueryDoc = v
+	return s
+}
+
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -2122,6 +2296,12 @@ type InputService15TestShapeInputService15TestCaseOperation1Input struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
 	Foo *string `locationName:"foo" type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService15TestShapeInputService15TestCaseOperation1Input) SetFoo(v string) *InputService15TestShapeInputService15TestCaseOperation1Input {
+	s.Foo = &v
+	return s
 }
 
 type InputService15TestShapeInputService15TestCaseOperation1Output struct {
@@ -2312,6 +2492,12 @@ type InputService16TestShapeInputShape struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
 	Foo []byte `locationName:"foo" type:"blob"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService16TestShapeInputShape) SetFoo(v []byte) *InputService16TestShapeInputShape {
+	s.Foo = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2610,6 +2796,12 @@ type InputService17TestShapeFooShape struct {
 	Baz *string `locationName:"baz" type:"string"`
 }
 
+// SetBaz sets the Baz field's value.
+func (s *InputService17TestShapeFooShape) SetBaz(v string) *InputService17TestShapeFooShape {
+	s.Baz = &v
+	return s
+}
+
 type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -2630,6 +2822,12 @@ type InputService17TestShapeInputShape struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
 	Foo *InputService17TestShapeFooShape `locationName:"foo" type:"structure"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService17TestShapeInputShape) SetFoo(v *InputService17TestShapeFooShape) *InputService17TestShapeInputShape {
+	s.Foo = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -2751,6 +2949,12 @@ type InputService18TestShapeGrant struct {
 	Grantee *InputService18TestShapeGrantee `type:"structure"`
 }
 
+// SetGrantee sets the Grantee field's value.
+func (s *InputService18TestShapeGrant) SetGrantee(v *InputService18TestShapeGrantee) *InputService18TestShapeGrant {
+	s.Grantee = v
+	return s
+}
+
 type InputService18TestShapeGrantee struct {
 	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 
@@ -2759,10 +2963,28 @@ type InputService18TestShapeGrantee struct {
 	Type *string `locationName:"xsi:type" type:"string" xmlAttribute:"true"`
 }
 
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *InputService18TestShapeGrantee) SetEmailAddress(v string) *InputService18TestShapeGrantee {
+	s.EmailAddress = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *InputService18TestShapeGrantee) SetType(v string) *InputService18TestShapeGrantee {
+	s.Type = &v
+	return s
+}
+
 type InputService18TestShapeInputService18TestCaseOperation1Input struct {
 	_ struct{} `type:"structure" payload:"Grant"`
 
 	Grant *InputService18TestShapeGrant `locationName:"Grant" type:"structure"`
+}
+
+// SetGrant sets the Grant field's value.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Input) SetGrant(v *InputService18TestShapeGrant) *InputService18TestShapeInputService18TestCaseOperation1Input {
+	s.Grant = v
+	return s
 }
 
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
@@ -2888,6 +3110,18 @@ type InputService19TestShapeInputService19TestCaseOperation1Input struct {
 	Bucket *string `location:"uri" type:"string"`
 
 	Key *string `location:"uri" type:"string"`
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetBucket(v string) *InputService19TestShapeInputService19TestCaseOperation1Input {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetKey(v string) *InputService19TestShapeInputService19TestCaseOperation1Input {
+	s.Key = &v
+	return s
 }
 
 type InputService19TestShapeInputService19TestCaseOperation1Output struct {
@@ -3078,6 +3312,12 @@ type InputService20TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService20TestShapeInputShape) SetFoo(v string) *InputService20TestShapeInputShape {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -3518,6 +3758,12 @@ type InputService21TestShapeInputShape struct {
 	RecursiveStruct *InputService21TestShapeRecursiveStructType `type:"structure"`
 }
 
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService21TestShapeInputShape) SetRecursiveStruct(v *InputService21TestShapeRecursiveStructType) *InputService21TestShapeInputShape {
+	s.RecursiveStruct = v
+	return s
+}
+
 type InputService21TestShapeRecursiveStructType struct {
 	_ struct{} `type:"structure"`
 
@@ -3528,6 +3774,30 @@ type InputService21TestShapeRecursiveStructType struct {
 	RecursiveMap map[string]*InputService21TestShapeRecursiveStructType `type:"map"`
 
 	RecursiveStruct *InputService21TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetNoRecurse sets the NoRecurse field's value.
+func (s *InputService21TestShapeRecursiveStructType) SetNoRecurse(v string) *InputService21TestShapeRecursiveStructType {
+	s.NoRecurse = &v
+	return s
+}
+
+// SetRecursiveList sets the RecursiveList field's value.
+func (s *InputService21TestShapeRecursiveStructType) SetRecursiveList(v []*InputService21TestShapeRecursiveStructType) *InputService21TestShapeRecursiveStructType {
+	s.RecursiveList = v
+	return s
+}
+
+// SetRecursiveMap sets the RecursiveMap field's value.
+func (s *InputService21TestShapeRecursiveStructType) SetRecursiveMap(v map[string]*InputService21TestShapeRecursiveStructType) *InputService21TestShapeRecursiveStructType {
+	s.RecursiveMap = v
+	return s
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService21TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService21TestShapeRecursiveStructType) *InputService21TestShapeRecursiveStructType {
+	s.RecursiveStruct = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -3647,6 +3917,12 @@ type InputService22TestShapeInputService22TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
+}
+
+// SetTimeArgInHeader sets the TimeArgInHeader field's value.
+func (s *InputService22TestShapeInputService22TestCaseOperation1Input) SetTimeArgInHeader(v time.Time) *InputService22TestShapeInputService22TestCaseOperation1Input {
+	s.TimeArgInHeader = &v
+	return s
 }
 
 type InputService22TestShapeInputService22TestCaseOperation1Output struct {
@@ -3837,6 +4113,12 @@ type InputService23TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
+}
+
+// SetToken sets the Token field's value.
+func (s *InputService23TestShapeInputShape) SetToken(v string) *InputService23TestShapeInputShape {
+	s.Token = &v
+	return s
 }
 
 //

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -243,6 +243,72 @@ type OutputService1TestShapeOutputShape struct {
 	TrueBool *bool `type:"boolean"`
 }
 
+// SetChar sets the Char field's value.
+func (s *OutputService1TestShapeOutputShape) SetChar(v string) *OutputService1TestShapeOutputShape {
+	s.Char = &v
+	return s
+}
+
+// SetDouble sets the Double field's value.
+func (s *OutputService1TestShapeOutputShape) SetDouble(v float64) *OutputService1TestShapeOutputShape {
+	s.Double = &v
+	return s
+}
+
+// SetFalseBool sets the FalseBool field's value.
+func (s *OutputService1TestShapeOutputShape) SetFalseBool(v bool) *OutputService1TestShapeOutputShape {
+	s.FalseBool = &v
+	return s
+}
+
+// SetFloat sets the Float field's value.
+func (s *OutputService1TestShapeOutputShape) SetFloat(v float64) *OutputService1TestShapeOutputShape {
+	s.Float = &v
+	return s
+}
+
+// SetImaHeader sets the ImaHeader field's value.
+func (s *OutputService1TestShapeOutputShape) SetImaHeader(v string) *OutputService1TestShapeOutputShape {
+	s.ImaHeader = &v
+	return s
+}
+
+// SetImaHeaderLocation sets the ImaHeaderLocation field's value.
+func (s *OutputService1TestShapeOutputShape) SetImaHeaderLocation(v string) *OutputService1TestShapeOutputShape {
+	s.ImaHeaderLocation = &v
+	return s
+}
+
+// SetLong sets the Long field's value.
+func (s *OutputService1TestShapeOutputShape) SetLong(v int64) *OutputService1TestShapeOutputShape {
+	s.Long = &v
+	return s
+}
+
+// SetNum sets the Num field's value.
+func (s *OutputService1TestShapeOutputShape) SetNum(v int64) *OutputService1TestShapeOutputShape {
+	s.Num = &v
+	return s
+}
+
+// SetStr sets the Str field's value.
+func (s *OutputService1TestShapeOutputShape) SetStr(v string) *OutputService1TestShapeOutputShape {
+	s.Str = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *OutputService1TestShapeOutputShape) SetTimestamp(v time.Time) *OutputService1TestShapeOutputShape {
+	s.Timestamp = &v
+	return s
+}
+
+// SetTrueBool sets the TrueBool field's value.
+func (s *OutputService1TestShapeOutputShape) SetTrueBool(v bool) *OutputService1TestShapeOutputShape {
+	s.TrueBool = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService2ProtocolTest struct {
@@ -362,6 +428,12 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 
 	// Blob is automatically base64 encoded/decoded by the SDK.
 	Blob []byte `type:"blob"`
+}
+
+// SetBlob sets the Blob field's value.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetBlob(v []byte) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
+	s.Blob = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -484,6 +556,12 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	ListMember []*string `type:"list"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetListMember(v []*string) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
+	s.ListMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService4ProtocolTest struct {
@@ -602,6 +680,12 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	ListMember []*string `locationNameList:"item" type:"list"`
+}
+
+// SetListMember sets the ListMember field's value.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
+	s.ListMember = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -724,6 +808,12 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	ListMember []*string `type:"list" flattened:"true"`
 }
 
+// SetListMember sets the ListMember field's value.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetListMember(v []*string) *OutputService5TestShapeOutputService5TestCaseOperation1Output {
+	s.ListMember = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService6ProtocolTest struct {
@@ -844,10 +934,22 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	Map map[string]*OutputService6TestShapeSingleStructure `type:"map"`
 }
 
+// SetMap sets the Map field's value.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetMap(v map[string]*OutputService6TestShapeSingleStructure) *OutputService6TestShapeOutputService6TestCaseOperation1Output {
+	s.Map = v
+	return s
+}
+
 type OutputService6TestShapeSingleStructure struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `locationName:"foo" type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService6TestShapeSingleStructure) SetFoo(v string) *OutputService6TestShapeSingleStructure {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -970,6 +1072,12 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	Map map[string]*string `type:"map" flattened:"true"`
 }
 
+// SetMap sets the Map field's value.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService7TestShapeOutputService7TestCaseOperation1Output {
+	s.Map = v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService8ProtocolTest struct {
@@ -1088,6 +1196,12 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	Map map[string]*string `locationNameKey:"foo" locationNameValue:"bar" type:"map"`
+}
+
+// SetMap sets the Map field's value.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService8TestShapeOutputService8TestCaseOperation1Output {
+	s.Map = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1212,10 +1326,28 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	Header *string `location:"header" locationName:"X-Foo" type:"string"`
 }
 
+// SetData sets the Data field's value.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetData(v *OutputService9TestShapeSingleStructure) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
+	s.Data = v
+	return s
+}
+
+// SetHeader sets the Header field's value.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetHeader(v string) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
+	s.Header = &v
+	return s
+}
+
 type OutputService9TestShapeSingleStructure struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService9TestShapeSingleStructure) SetFoo(v string) *OutputService9TestShapeSingleStructure {
+	s.Foo = &v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1336,6 +1468,12 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure" payload:"Stream"`
 
 	Stream []byte `type:"blob"`
+}
+
+// SetStream sets the Stream field's value.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetStream(v []byte) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
+	s.Stream = v
+	return s
 }
 
 //The service client's operations are safe to be used concurrently.
@@ -1474,6 +1612,60 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	TrueBool *bool `location:"header" locationName:"x-true-bool" type:"boolean"`
 }
 
+// SetChar sets the Char field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetChar(v string) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Char = &v
+	return s
+}
+
+// SetDouble sets the Double field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetDouble(v float64) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Double = &v
+	return s
+}
+
+// SetFalseBool sets the FalseBool field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetFalseBool(v bool) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.FalseBool = &v
+	return s
+}
+
+// SetFloat sets the Float field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetFloat(v float64) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Float = &v
+	return s
+}
+
+// SetInteger sets the Integer field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetInteger(v int64) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Integer = &v
+	return s
+}
+
+// SetLong sets the Long field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetLong(v int64) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Long = &v
+	return s
+}
+
+// SetStr sets the Str field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetStr(v string) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Str = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetTimestamp(v time.Time) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Timestamp = &v
+	return s
+}
+
+// SetTrueBool sets the TrueBool field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetTrueBool(v bool) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.TrueBool = &v
+	return s
+}
+
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type OutputService12ProtocolTest struct {
@@ -1592,6 +1784,12 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetFoo(v string) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
+	s.Foo = &v
+	return s
 }
 
 //

--- a/service/acm/api.go
+++ b/service/acm/api.go
@@ -907,6 +907,18 @@ func (s *AddTagsToCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *AddTagsToCertificateInput) SetCertificateArn(v string) *AddTagsToCertificateInput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToCertificateInput) SetTags(v []*Tag) *AddTagsToCertificateInput {
+	s.Tags = v
+	return s
+}
+
 type AddTagsToCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1022,6 +1034,126 @@ func (s CertificateDetail) GoString() string {
 	return s.String()
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *CertificateDetail) SetCertificateArn(v string) *CertificateDetail {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *CertificateDetail) SetCreatedAt(v time.Time) *CertificateDetail {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *CertificateDetail) SetDomainName(v string) *CertificateDetail {
+	s.DomainName = &v
+	return s
+}
+
+// SetDomainValidationOptions sets the DomainValidationOptions field's value.
+func (s *CertificateDetail) SetDomainValidationOptions(v []*DomainValidation) *CertificateDetail {
+	s.DomainValidationOptions = v
+	return s
+}
+
+// SetFailureReason sets the FailureReason field's value.
+func (s *CertificateDetail) SetFailureReason(v string) *CertificateDetail {
+	s.FailureReason = &v
+	return s
+}
+
+// SetImportedAt sets the ImportedAt field's value.
+func (s *CertificateDetail) SetImportedAt(v time.Time) *CertificateDetail {
+	s.ImportedAt = &v
+	return s
+}
+
+// SetInUseBy sets the InUseBy field's value.
+func (s *CertificateDetail) SetInUseBy(v []*string) *CertificateDetail {
+	s.InUseBy = v
+	return s
+}
+
+// SetIssuedAt sets the IssuedAt field's value.
+func (s *CertificateDetail) SetIssuedAt(v time.Time) *CertificateDetail {
+	s.IssuedAt = &v
+	return s
+}
+
+// SetIssuer sets the Issuer field's value.
+func (s *CertificateDetail) SetIssuer(v string) *CertificateDetail {
+	s.Issuer = &v
+	return s
+}
+
+// SetKeyAlgorithm sets the KeyAlgorithm field's value.
+func (s *CertificateDetail) SetKeyAlgorithm(v string) *CertificateDetail {
+	s.KeyAlgorithm = &v
+	return s
+}
+
+// SetNotAfter sets the NotAfter field's value.
+func (s *CertificateDetail) SetNotAfter(v time.Time) *CertificateDetail {
+	s.NotAfter = &v
+	return s
+}
+
+// SetNotBefore sets the NotBefore field's value.
+func (s *CertificateDetail) SetNotBefore(v time.Time) *CertificateDetail {
+	s.NotBefore = &v
+	return s
+}
+
+// SetRevocationReason sets the RevocationReason field's value.
+func (s *CertificateDetail) SetRevocationReason(v string) *CertificateDetail {
+	s.RevocationReason = &v
+	return s
+}
+
+// SetRevokedAt sets the RevokedAt field's value.
+func (s *CertificateDetail) SetRevokedAt(v time.Time) *CertificateDetail {
+	s.RevokedAt = &v
+	return s
+}
+
+// SetSerial sets the Serial field's value.
+func (s *CertificateDetail) SetSerial(v string) *CertificateDetail {
+	s.Serial = &v
+	return s
+}
+
+// SetSignatureAlgorithm sets the SignatureAlgorithm field's value.
+func (s *CertificateDetail) SetSignatureAlgorithm(v string) *CertificateDetail {
+	s.SignatureAlgorithm = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CertificateDetail) SetStatus(v string) *CertificateDetail {
+	s.Status = &v
+	return s
+}
+
+// SetSubject sets the Subject field's value.
+func (s *CertificateDetail) SetSubject(v string) *CertificateDetail {
+	s.Subject = &v
+	return s
+}
+
+// SetSubjectAlternativeNames sets the SubjectAlternativeNames field's value.
+func (s *CertificateDetail) SetSubjectAlternativeNames(v []*string) *CertificateDetail {
+	s.SubjectAlternativeNames = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CertificateDetail) SetType(v string) *CertificateDetail {
+	s.Type = &v
+	return s
+}
+
 // This structure is returned in the response object of ListCertificates action.
 type CertificateSummary struct {
 	_ struct{} `type:"structure"`
@@ -1047,6 +1179,18 @@ func (s CertificateSummary) String() string {
 // GoString returns the string representation
 func (s CertificateSummary) GoString() string {
 	return s.String()
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *CertificateSummary) SetCertificateArn(v string) *CertificateSummary {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *CertificateSummary) SetDomainName(v string) *CertificateSummary {
+	s.DomainName = &v
+	return s
 }
 
 type DeleteCertificateInput struct {
@@ -1088,6 +1232,12 @@ func (s *DeleteCertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *DeleteCertificateInput) SetCertificateArn(v string) *DeleteCertificateInput {
+	s.CertificateArn = &v
+	return s
 }
 
 type DeleteCertificateOutput struct {
@@ -1144,6 +1294,12 @@ func (s *DescribeCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *DescribeCertificateInput) SetCertificateArn(v string) *DescribeCertificateInput {
+	s.CertificateArn = &v
+	return s
+}
+
 type DescribeCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1159,6 +1315,12 @@ func (s DescribeCertificateOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificate sets the Certificate field's value.
+func (s *DescribeCertificateOutput) SetCertificate(v *CertificateDetail) *DescribeCertificateOutput {
+	s.Certificate = v
+	return s
 }
 
 // Structure that contains the domain name, the base validation domain to which
@@ -1188,6 +1350,24 @@ func (s DomainValidation) String() string {
 // GoString returns the string representation
 func (s DomainValidation) GoString() string {
 	return s.String()
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DomainValidation) SetDomainName(v string) *DomainValidation {
+	s.DomainName = &v
+	return s
+}
+
+// SetValidationDomain sets the ValidationDomain field's value.
+func (s *DomainValidation) SetValidationDomain(v string) *DomainValidation {
+	s.ValidationDomain = &v
+	return s
+}
+
+// SetValidationEmails sets the ValidationEmails field's value.
+func (s *DomainValidation) SetValidationEmails(v []*string) *DomainValidation {
+	s.ValidationEmails = v
+	return s
 }
 
 // This structure is used in the request object of the RequestCertificate action.
@@ -1253,6 +1433,18 @@ func (s *DomainValidationOption) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DomainValidationOption) SetDomainName(v string) *DomainValidationOption {
+	s.DomainName = &v
+	return s
+}
+
+// SetValidationDomain sets the ValidationDomain field's value.
+func (s *DomainValidationOption) SetValidationDomain(v string) *DomainValidationOption {
+	s.ValidationDomain = &v
+	return s
+}
+
 type GetCertificateInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1293,6 +1485,12 @@ func (s *GetCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *GetCertificateInput) SetCertificateArn(v string) *GetCertificateInput {
+	s.CertificateArn = &v
+	return s
+}
+
 type GetCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1313,6 +1511,18 @@ func (s GetCertificateOutput) String() string {
 // GoString returns the string representation
 func (s GetCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificate sets the Certificate field's value.
+func (s *GetCertificateOutput) SetCertificate(v string) *GetCertificateOutput {
+	s.Certificate = &v
+	return s
+}
+
+// SetCertificateChain sets the CertificateChain field's value.
+func (s *GetCertificateOutput) SetCertificateChain(v string) *GetCertificateOutput {
+	s.CertificateChain = &v
+	return s
 }
 
 type ImportCertificateInput struct {
@@ -1395,6 +1605,30 @@ func (s *ImportCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificate sets the Certificate field's value.
+func (s *ImportCertificateInput) SetCertificate(v []byte) *ImportCertificateInput {
+	s.Certificate = v
+	return s
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *ImportCertificateInput) SetCertificateArn(v string) *ImportCertificateInput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateChain sets the CertificateChain field's value.
+func (s *ImportCertificateInput) SetCertificateChain(v []byte) *ImportCertificateInput {
+	s.CertificateChain = v
+	return s
+}
+
+// SetPrivateKey sets the PrivateKey field's value.
+func (s *ImportCertificateInput) SetPrivateKey(v []byte) *ImportCertificateInput {
+	s.PrivateKey = v
+	return s
+}
+
 type ImportCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1411,6 +1645,12 @@ func (s ImportCertificateOutput) String() string {
 // GoString returns the string representation
 func (s ImportCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *ImportCertificateOutput) SetCertificateArn(v string) *ImportCertificateOutput {
+	s.CertificateArn = &v
+	return s
 }
 
 type ListCertificatesInput struct {
@@ -1457,6 +1697,24 @@ func (s *ListCertificatesInput) Validate() error {
 	return nil
 }
 
+// SetCertificateStatuses sets the CertificateStatuses field's value.
+func (s *ListCertificatesInput) SetCertificateStatuses(v []*string) *ListCertificatesInput {
+	s.CertificateStatuses = v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListCertificatesInput) SetMaxItems(v int64) *ListCertificatesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListCertificatesInput) SetNextToken(v string) *ListCertificatesInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListCertificatesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1476,6 +1734,18 @@ func (s ListCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s ListCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateSummaryList sets the CertificateSummaryList field's value.
+func (s *ListCertificatesOutput) SetCertificateSummaryList(v []*CertificateSummary) *ListCertificatesOutput {
+	s.CertificateSummaryList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListCertificatesOutput) SetNextToken(v string) *ListCertificatesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListTagsForCertificateInput struct {
@@ -1519,6 +1789,12 @@ func (s *ListTagsForCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *ListTagsForCertificateInput) SetCertificateArn(v string) *ListTagsForCertificateInput {
+	s.CertificateArn = &v
+	return s
+}
+
 type ListTagsForCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1534,6 +1810,12 @@ func (s ListTagsForCertificateOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForCertificateOutput) SetTags(v []*Tag) *ListTagsForCertificateOutput {
+	s.Tags = v
+	return s
 }
 
 type RemoveTagsFromCertificateInput struct {
@@ -1596,6 +1878,18 @@ func (s *RemoveTagsFromCertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *RemoveTagsFromCertificateInput) SetCertificateArn(v string) *RemoveTagsFromCertificateInput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RemoveTagsFromCertificateInput) SetTags(v []*Tag) *RemoveTagsFromCertificateInput {
+	s.Tags = v
+	return s
 }
 
 type RemoveTagsFromCertificateOutput struct {
@@ -1701,6 +1995,30 @@ func (s *RequestCertificateInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *RequestCertificateInput) SetDomainName(v string) *RequestCertificateInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetDomainValidationOptions sets the DomainValidationOptions field's value.
+func (s *RequestCertificateInput) SetDomainValidationOptions(v []*DomainValidationOption) *RequestCertificateInput {
+	s.DomainValidationOptions = v
+	return s
+}
+
+// SetIdempotencyToken sets the IdempotencyToken field's value.
+func (s *RequestCertificateInput) SetIdempotencyToken(v string) *RequestCertificateInput {
+	s.IdempotencyToken = &v
+	return s
+}
+
+// SetSubjectAlternativeNames sets the SubjectAlternativeNames field's value.
+func (s *RequestCertificateInput) SetSubjectAlternativeNames(v []*string) *RequestCertificateInput {
+	s.SubjectAlternativeNames = v
+	return s
+}
+
 type RequestCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1719,6 +2037,12 @@ func (s RequestCertificateOutput) String() string {
 // GoString returns the string representation
 func (s RequestCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *RequestCertificateOutput) SetCertificateArn(v string) *RequestCertificateOutput {
+	s.CertificateArn = &v
+	return s
 }
 
 type ResendValidationEmailInput struct {
@@ -1801,6 +2125,24 @@ func (s *ResendValidationEmailInput) Validate() error {
 	return nil
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *ResendValidationEmailInput) SetCertificateArn(v string) *ResendValidationEmailInput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *ResendValidationEmailInput) SetDomain(v string) *ResendValidationEmailInput {
+	s.Domain = &v
+	return s
+}
+
+// SetValidationDomain sets the ValidationDomain field's value.
+func (s *ResendValidationEmailInput) SetValidationDomain(v string) *ResendValidationEmailInput {
+	s.ValidationDomain = &v
+	return s
+}
+
 type ResendValidationEmailOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1852,6 +2194,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 const (

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -7050,6 +7050,30 @@ func (s Account) GoString() string {
 	return s.String()
 }
 
+// SetApiKeyVersion sets the ApiKeyVersion field's value.
+func (s *Account) SetApiKeyVersion(v string) *Account {
+	s.ApiKeyVersion = &v
+	return s
+}
+
+// SetCloudwatchRoleArn sets the CloudwatchRoleArn field's value.
+func (s *Account) SetCloudwatchRoleArn(v string) *Account {
+	s.CloudwatchRoleArn = &v
+	return s
+}
+
+// SetFeatures sets the Features field's value.
+func (s *Account) SetFeatures(v []*string) *Account {
+	s.Features = v
+	return s
+}
+
+// SetThrottleSettings sets the ThrottleSettings field's value.
+func (s *Account) SetThrottleSettings(v *ThrottleSettings) *Account {
+	s.ThrottleSettings = v
+	return s
+}
+
 // A resource that can be distributed to callers for executing Method resources
 // that require an API key. API keys can be mapped to any Stage on any RestApi,
 // which indicates that the callers with the API key can make requests to that
@@ -7094,6 +7118,54 @@ func (s ApiKey) GoString() string {
 	return s.String()
 }
 
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *ApiKey) SetCreatedDate(v time.Time) *ApiKey {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ApiKey) SetDescription(v string) *ApiKey {
+	s.Description = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *ApiKey) SetEnabled(v bool) *ApiKey {
+	s.Enabled = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ApiKey) SetId(v string) *ApiKey {
+	s.Id = &v
+	return s
+}
+
+// SetLastUpdatedDate sets the LastUpdatedDate field's value.
+func (s *ApiKey) SetLastUpdatedDate(v time.Time) *ApiKey {
+	s.LastUpdatedDate = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ApiKey) SetName(v string) *ApiKey {
+	s.Name = &v
+	return s
+}
+
+// SetStageKeys sets the StageKeys field's value.
+func (s *ApiKey) SetStageKeys(v []*string) *ApiKey {
+	s.StageKeys = v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ApiKey) SetValue(v string) *ApiKey {
+	s.Value = &v
+	return s
+}
+
 // API stage name of the associated API stage in a usage plan.
 type ApiStage struct {
 	_ struct{} `type:"structure"`
@@ -7113,6 +7185,18 @@ func (s ApiStage) String() string {
 // GoString returns the string representation
 func (s ApiStage) GoString() string {
 	return s.String()
+}
+
+// SetApiId sets the ApiId field's value.
+func (s *ApiStage) SetApiId(v string) *ApiStage {
+	s.ApiId = &v
+	return s
+}
+
+// SetStage sets the Stage field's value.
+func (s *ApiStage) SetStage(v string) *ApiStage {
+	s.Stage = &v
+	return s
 }
 
 // Represents an authorization layer for methods. If enabled on a method, API
@@ -7183,6 +7267,66 @@ func (s Authorizer) GoString() string {
 	return s.String()
 }
 
+// SetAuthType sets the AuthType field's value.
+func (s *Authorizer) SetAuthType(v string) *Authorizer {
+	s.AuthType = &v
+	return s
+}
+
+// SetAuthorizerCredentials sets the AuthorizerCredentials field's value.
+func (s *Authorizer) SetAuthorizerCredentials(v string) *Authorizer {
+	s.AuthorizerCredentials = &v
+	return s
+}
+
+// SetAuthorizerResultTtlInSeconds sets the AuthorizerResultTtlInSeconds field's value.
+func (s *Authorizer) SetAuthorizerResultTtlInSeconds(v int64) *Authorizer {
+	s.AuthorizerResultTtlInSeconds = &v
+	return s
+}
+
+// SetAuthorizerUri sets the AuthorizerUri field's value.
+func (s *Authorizer) SetAuthorizerUri(v string) *Authorizer {
+	s.AuthorizerUri = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Authorizer) SetId(v string) *Authorizer {
+	s.Id = &v
+	return s
+}
+
+// SetIdentitySource sets the IdentitySource field's value.
+func (s *Authorizer) SetIdentitySource(v string) *Authorizer {
+	s.IdentitySource = &v
+	return s
+}
+
+// SetIdentityValidationExpression sets the IdentityValidationExpression field's value.
+func (s *Authorizer) SetIdentityValidationExpression(v string) *Authorizer {
+	s.IdentityValidationExpression = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Authorizer) SetName(v string) *Authorizer {
+	s.Name = &v
+	return s
+}
+
+// SetProviderARNs sets the ProviderARNs field's value.
+func (s *Authorizer) SetProviderARNs(v []*string) *Authorizer {
+	s.ProviderARNs = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Authorizer) SetType(v string) *Authorizer {
+	s.Type = &v
+	return s
+}
+
 // Represents the base path that callers of the API must provide as part of
 // the URL after the domain name.
 //
@@ -7211,6 +7355,24 @@ func (s BasePathMapping) String() string {
 // GoString returns the string representation
 func (s BasePathMapping) GoString() string {
 	return s.String()
+}
+
+// SetBasePath sets the BasePath field's value.
+func (s *BasePathMapping) SetBasePath(v string) *BasePathMapping {
+	s.BasePath = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *BasePathMapping) SetRestApiId(v string) *BasePathMapping {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStage sets the Stage field's value.
+func (s *BasePathMapping) SetStage(v string) *BasePathMapping {
+	s.Stage = &v
+	return s
 }
 
 // Represents a client certificate used to configure client-side SSL authentication
@@ -7249,6 +7411,36 @@ func (s ClientCertificate) GoString() string {
 	return s.String()
 }
 
+// SetClientCertificateId sets the ClientCertificateId field's value.
+func (s *ClientCertificate) SetClientCertificateId(v string) *ClientCertificate {
+	s.ClientCertificateId = &v
+	return s
+}
+
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *ClientCertificate) SetCreatedDate(v time.Time) *ClientCertificate {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ClientCertificate) SetDescription(v string) *ClientCertificate {
+	s.Description = &v
+	return s
+}
+
+// SetExpirationDate sets the ExpirationDate field's value.
+func (s *ClientCertificate) SetExpirationDate(v time.Time) *ClientCertificate {
+	s.ExpirationDate = &v
+	return s
+}
+
+// SetPemEncodedCertificate sets the PemEncodedCertificate field's value.
+func (s *ClientCertificate) SetPemEncodedCertificate(v string) *ClientCertificate {
+	s.PemEncodedCertificate = &v
+	return s
+}
+
 // Request to create an ApiKey resource.
 type CreateApiKeyInput struct {
 	_ struct{} `type:"structure"`
@@ -7281,6 +7473,42 @@ func (s CreateApiKeyInput) String() string {
 // GoString returns the string representation
 func (s CreateApiKeyInput) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateApiKeyInput) SetDescription(v string) *CreateApiKeyInput {
+	s.Description = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *CreateApiKeyInput) SetEnabled(v bool) *CreateApiKeyInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetGenerateDistinctId sets the GenerateDistinctId field's value.
+func (s *CreateApiKeyInput) SetGenerateDistinctId(v bool) *CreateApiKeyInput {
+	s.GenerateDistinctId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateApiKeyInput) SetName(v string) *CreateApiKeyInput {
+	s.Name = &v
+	return s
+}
+
+// SetStageKeys sets the StageKeys field's value.
+func (s *CreateApiKeyInput) SetStageKeys(v []*StageKey) *CreateApiKeyInput {
+	s.StageKeys = v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *CreateApiKeyInput) SetValue(v string) *CreateApiKeyInput {
+	s.Value = &v
+	return s
 }
 
 // Request to add a new Authorizer to an existing RestApi resource.
@@ -7359,6 +7587,66 @@ func (s *CreateAuthorizerInput) Validate() error {
 	return nil
 }
 
+// SetAuthType sets the AuthType field's value.
+func (s *CreateAuthorizerInput) SetAuthType(v string) *CreateAuthorizerInput {
+	s.AuthType = &v
+	return s
+}
+
+// SetAuthorizerCredentials sets the AuthorizerCredentials field's value.
+func (s *CreateAuthorizerInput) SetAuthorizerCredentials(v string) *CreateAuthorizerInput {
+	s.AuthorizerCredentials = &v
+	return s
+}
+
+// SetAuthorizerResultTtlInSeconds sets the AuthorizerResultTtlInSeconds field's value.
+func (s *CreateAuthorizerInput) SetAuthorizerResultTtlInSeconds(v int64) *CreateAuthorizerInput {
+	s.AuthorizerResultTtlInSeconds = &v
+	return s
+}
+
+// SetAuthorizerUri sets the AuthorizerUri field's value.
+func (s *CreateAuthorizerInput) SetAuthorizerUri(v string) *CreateAuthorizerInput {
+	s.AuthorizerUri = &v
+	return s
+}
+
+// SetIdentitySource sets the IdentitySource field's value.
+func (s *CreateAuthorizerInput) SetIdentitySource(v string) *CreateAuthorizerInput {
+	s.IdentitySource = &v
+	return s
+}
+
+// SetIdentityValidationExpression sets the IdentityValidationExpression field's value.
+func (s *CreateAuthorizerInput) SetIdentityValidationExpression(v string) *CreateAuthorizerInput {
+	s.IdentityValidationExpression = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateAuthorizerInput) SetName(v string) *CreateAuthorizerInput {
+	s.Name = &v
+	return s
+}
+
+// SetProviderARNs sets the ProviderARNs field's value.
+func (s *CreateAuthorizerInput) SetProviderARNs(v []*string) *CreateAuthorizerInput {
+	s.ProviderARNs = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *CreateAuthorizerInput) SetRestApiId(v string) *CreateAuthorizerInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CreateAuthorizerInput) SetType(v string) *CreateAuthorizerInput {
+	s.Type = &v
+	return s
+}
+
 // Requests Amazon API Gateway to create a new BasePathMapping resource.
 type CreateBasePathMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -7409,6 +7697,30 @@ func (s *CreateBasePathMappingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBasePath sets the BasePath field's value.
+func (s *CreateBasePathMappingInput) SetBasePath(v string) *CreateBasePathMappingInput {
+	s.BasePath = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *CreateBasePathMappingInput) SetDomainName(v string) *CreateBasePathMappingInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *CreateBasePathMappingInput) SetRestApiId(v string) *CreateBasePathMappingInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStage sets the Stage field's value.
+func (s *CreateBasePathMappingInput) SetStage(v string) *CreateBasePathMappingInput {
+	s.Stage = &v
+	return s
 }
 
 // Requests Amazon API Gateway to create a Deployment resource.
@@ -7468,6 +7780,48 @@ func (s *CreateDeploymentInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCacheClusterEnabled sets the CacheClusterEnabled field's value.
+func (s *CreateDeploymentInput) SetCacheClusterEnabled(v bool) *CreateDeploymentInput {
+	s.CacheClusterEnabled = &v
+	return s
+}
+
+// SetCacheClusterSize sets the CacheClusterSize field's value.
+func (s *CreateDeploymentInput) SetCacheClusterSize(v string) *CreateDeploymentInput {
+	s.CacheClusterSize = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateDeploymentInput) SetDescription(v string) *CreateDeploymentInput {
+	s.Description = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *CreateDeploymentInput) SetRestApiId(v string) *CreateDeploymentInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageDescription sets the StageDescription field's value.
+func (s *CreateDeploymentInput) SetStageDescription(v string) *CreateDeploymentInput {
+	s.StageDescription = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *CreateDeploymentInput) SetStageName(v string) *CreateDeploymentInput {
+	s.StageName = &v
+	return s
+}
+
+// SetVariables sets the Variables field's value.
+func (s *CreateDeploymentInput) SetVariables(v map[string]*string) *CreateDeploymentInput {
+	s.Variables = v
+	return s
 }
 
 // A request to create a new domain name.
@@ -7540,6 +7894,36 @@ func (s *CreateDomainNameInput) Validate() error {
 	return nil
 }
 
+// SetCertificateBody sets the CertificateBody field's value.
+func (s *CreateDomainNameInput) SetCertificateBody(v string) *CreateDomainNameInput {
+	s.CertificateBody = &v
+	return s
+}
+
+// SetCertificateChain sets the CertificateChain field's value.
+func (s *CreateDomainNameInput) SetCertificateChain(v string) *CreateDomainNameInput {
+	s.CertificateChain = &v
+	return s
+}
+
+// SetCertificateName sets the CertificateName field's value.
+func (s *CreateDomainNameInput) SetCertificateName(v string) *CreateDomainNameInput {
+	s.CertificateName = &v
+	return s
+}
+
+// SetCertificatePrivateKey sets the CertificatePrivateKey field's value.
+func (s *CreateDomainNameInput) SetCertificatePrivateKey(v string) *CreateDomainNameInput {
+	s.CertificatePrivateKey = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *CreateDomainNameInput) SetDomainName(v string) *CreateDomainNameInput {
+	s.DomainName = &v
+	return s
+}
+
 // Request to add a new Model to an existing RestApi resource.
 type CreateModelInput struct {
 	_ struct{} `type:"structure"`
@@ -7596,6 +7980,36 @@ func (s *CreateModelInput) Validate() error {
 	return nil
 }
 
+// SetContentType sets the ContentType field's value.
+func (s *CreateModelInput) SetContentType(v string) *CreateModelInput {
+	s.ContentType = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateModelInput) SetDescription(v string) *CreateModelInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateModelInput) SetName(v string) *CreateModelInput {
+	s.Name = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *CreateModelInput) SetRestApiId(v string) *CreateModelInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetSchema sets the Schema field's value.
+func (s *CreateModelInput) SetSchema(v string) *CreateModelInput {
+	s.Schema = &v
+	return s
+}
+
 // Requests Amazon API Gateway to create a Resource resource.
 type CreateResourceInput struct {
 	_ struct{} `type:"structure"`
@@ -7645,6 +8059,24 @@ func (s *CreateResourceInput) Validate() error {
 	return nil
 }
 
+// SetParentId sets the ParentId field's value.
+func (s *CreateResourceInput) SetParentId(v string) *CreateResourceInput {
+	s.ParentId = &v
+	return s
+}
+
+// SetPathPart sets the PathPart field's value.
+func (s *CreateResourceInput) SetPathPart(v string) *CreateResourceInput {
+	s.PathPart = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *CreateResourceInput) SetRestApiId(v string) *CreateResourceInput {
+	s.RestApiId = &v
+	return s
+}
+
 // The POST Request to add a new RestApi resource to your collection.
 type CreateRestApiInput struct {
 	_ struct{} `type:"structure"`
@@ -7682,6 +8114,24 @@ func (s *CreateRestApiInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCloneFrom sets the CloneFrom field's value.
+func (s *CreateRestApiInput) SetCloneFrom(v string) *CreateRestApiInput {
+	s.CloneFrom = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateRestApiInput) SetDescription(v string) *CreateRestApiInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateRestApiInput) SetName(v string) *CreateRestApiInput {
+	s.Name = &v
+	return s
 }
 
 // Requests Amazon API Gateway to create a Stage resource.
@@ -7747,6 +8197,48 @@ func (s *CreateStageInput) Validate() error {
 	return nil
 }
 
+// SetCacheClusterEnabled sets the CacheClusterEnabled field's value.
+func (s *CreateStageInput) SetCacheClusterEnabled(v bool) *CreateStageInput {
+	s.CacheClusterEnabled = &v
+	return s
+}
+
+// SetCacheClusterSize sets the CacheClusterSize field's value.
+func (s *CreateStageInput) SetCacheClusterSize(v string) *CreateStageInput {
+	s.CacheClusterSize = &v
+	return s
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *CreateStageInput) SetDeploymentId(v string) *CreateStageInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateStageInput) SetDescription(v string) *CreateStageInput {
+	s.Description = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *CreateStageInput) SetRestApiId(v string) *CreateStageInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *CreateStageInput) SetStageName(v string) *CreateStageInput {
+	s.StageName = &v
+	return s
+}
+
+// SetVariables sets the Variables field's value.
+func (s *CreateStageInput) SetVariables(v map[string]*string) *CreateStageInput {
+	s.Variables = v
+	return s
+}
+
 // The POST request to create a usage plan with the name, description, throttle
 // limits and quota limits, as well as the associated API stages, specified
 // in the payload.
@@ -7792,6 +8284,36 @@ func (s *CreateUsagePlanInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApiStages sets the ApiStages field's value.
+func (s *CreateUsagePlanInput) SetApiStages(v []*ApiStage) *CreateUsagePlanInput {
+	s.ApiStages = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateUsagePlanInput) SetDescription(v string) *CreateUsagePlanInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateUsagePlanInput) SetName(v string) *CreateUsagePlanInput {
+	s.Name = &v
+	return s
+}
+
+// SetQuota sets the Quota field's value.
+func (s *CreateUsagePlanInput) SetQuota(v *QuotaSettings) *CreateUsagePlanInput {
+	s.Quota = v
+	return s
+}
+
+// SetThrottle sets the Throttle field's value.
+func (s *CreateUsagePlanInput) SetThrottle(v *ThrottleSettings) *CreateUsagePlanInput {
+	s.Throttle = v
+	return s
 }
 
 // The POST request to create a usage plan key for adding an existing API key
@@ -7845,6 +8367,24 @@ func (s *CreateUsagePlanKeyInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *CreateUsagePlanKeyInput) SetKeyId(v string) *CreateUsagePlanKeyInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeyType sets the KeyType field's value.
+func (s *CreateUsagePlanKeyInput) SetKeyType(v string) *CreateUsagePlanKeyInput {
+	s.KeyType = &v
+	return s
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *CreateUsagePlanKeyInput) SetUsagePlanId(v string) *CreateUsagePlanKeyInput {
+	s.UsagePlanId = &v
+	return s
+}
+
 // A request to delete the ApiKey resource.
 type DeleteApiKeyInput struct {
 	_ struct{} `type:"structure"`
@@ -7876,6 +8416,12 @@ func (s *DeleteApiKeyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApiKey sets the ApiKey field's value.
+func (s *DeleteApiKeyInput) SetApiKey(v string) *DeleteApiKeyInput {
+	s.ApiKey = &v
+	return s
 }
 
 type DeleteApiKeyOutput struct {
@@ -7933,6 +8479,18 @@ func (s *DeleteAuthorizerInput) Validate() error {
 	return nil
 }
 
+// SetAuthorizerId sets the AuthorizerId field's value.
+func (s *DeleteAuthorizerInput) SetAuthorizerId(v string) *DeleteAuthorizerInput {
+	s.AuthorizerId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteAuthorizerInput) SetRestApiId(v string) *DeleteAuthorizerInput {
+	s.RestApiId = &v
+	return s
+}
+
 type DeleteAuthorizerOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7988,6 +8546,18 @@ func (s *DeleteBasePathMappingInput) Validate() error {
 	return nil
 }
 
+// SetBasePath sets the BasePath field's value.
+func (s *DeleteBasePathMappingInput) SetBasePath(v string) *DeleteBasePathMappingInput {
+	s.BasePath = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteBasePathMappingInput) SetDomainName(v string) *DeleteBasePathMappingInput {
+	s.DomainName = &v
+	return s
+}
+
 type DeleteBasePathMappingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8033,6 +8603,12 @@ func (s *DeleteClientCertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClientCertificateId sets the ClientCertificateId field's value.
+func (s *DeleteClientCertificateInput) SetClientCertificateId(v string) *DeleteClientCertificateInput {
+	s.ClientCertificateId = &v
+	return s
 }
 
 type DeleteClientCertificateOutput struct {
@@ -8090,6 +8666,18 @@ func (s *DeleteDeploymentInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *DeleteDeploymentInput) SetDeploymentId(v string) *DeleteDeploymentInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteDeploymentInput) SetRestApiId(v string) *DeleteDeploymentInput {
+	s.RestApiId = &v
+	return s
+}
+
 type DeleteDeploymentOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8135,6 +8723,12 @@ func (s *DeleteDomainNameInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteDomainNameInput) SetDomainName(v string) *DeleteDomainNameInput {
+	s.DomainName = &v
+	return s
 }
 
 type DeleteDomainNameOutput struct {
@@ -8198,6 +8792,24 @@ func (s *DeleteIntegrationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *DeleteIntegrationInput) SetHttpMethod(v string) *DeleteIntegrationInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteIntegrationInput) SetResourceId(v string) *DeleteIntegrationInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteIntegrationInput) SetRestApiId(v string) *DeleteIntegrationInput {
+	s.RestApiId = &v
+	return s
 }
 
 type DeleteIntegrationOutput struct {
@@ -8271,6 +8883,30 @@ func (s *DeleteIntegrationResponseInput) Validate() error {
 	return nil
 }
 
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *DeleteIntegrationResponseInput) SetHttpMethod(v string) *DeleteIntegrationResponseInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteIntegrationResponseInput) SetResourceId(v string) *DeleteIntegrationResponseInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteIntegrationResponseInput) SetRestApiId(v string) *DeleteIntegrationResponseInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *DeleteIntegrationResponseInput) SetStatusCode(v string) *DeleteIntegrationResponseInput {
+	s.StatusCode = &v
+	return s
+}
+
 type DeleteIntegrationResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8332,6 +8968,24 @@ func (s *DeleteMethodInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *DeleteMethodInput) SetHttpMethod(v string) *DeleteMethodInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteMethodInput) SetResourceId(v string) *DeleteMethodInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteMethodInput) SetRestApiId(v string) *DeleteMethodInput {
+	s.RestApiId = &v
+	return s
 }
 
 type DeleteMethodOutput struct {
@@ -8405,6 +9059,30 @@ func (s *DeleteMethodResponseInput) Validate() error {
 	return nil
 }
 
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *DeleteMethodResponseInput) SetHttpMethod(v string) *DeleteMethodResponseInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteMethodResponseInput) SetResourceId(v string) *DeleteMethodResponseInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteMethodResponseInput) SetRestApiId(v string) *DeleteMethodResponseInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *DeleteMethodResponseInput) SetStatusCode(v string) *DeleteMethodResponseInput {
+	s.StatusCode = &v
+	return s
+}
+
 type DeleteMethodResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8458,6 +9136,18 @@ func (s *DeleteModelInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetModelName sets the ModelName field's value.
+func (s *DeleteModelInput) SetModelName(v string) *DeleteModelInput {
+	s.ModelName = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteModelInput) SetRestApiId(v string) *DeleteModelInput {
+	s.RestApiId = &v
+	return s
 }
 
 type DeleteModelOutput struct {
@@ -8515,6 +9205,18 @@ func (s *DeleteResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteResourceInput) SetResourceId(v string) *DeleteResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteResourceInput) SetRestApiId(v string) *DeleteResourceInput {
+	s.RestApiId = &v
+	return s
+}
+
 type DeleteResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8560,6 +9262,12 @@ func (s *DeleteRestApiInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteRestApiInput) SetRestApiId(v string) *DeleteRestApiInput {
+	s.RestApiId = &v
+	return s
 }
 
 type DeleteRestApiOutput struct {
@@ -8617,6 +9325,18 @@ func (s *DeleteStageInput) Validate() error {
 	return nil
 }
 
+// SetRestApiId sets the RestApiId field's value.
+func (s *DeleteStageInput) SetRestApiId(v string) *DeleteStageInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *DeleteStageInput) SetStageName(v string) *DeleteStageInput {
+	s.StageName = &v
+	return s
+}
+
 type DeleteStageOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8664,6 +9384,12 @@ func (s *DeleteUsagePlanInput) Validate() error {
 	return nil
 }
 
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *DeleteUsagePlanInput) SetUsagePlanId(v string) *DeleteUsagePlanInput {
+	s.UsagePlanId = &v
+	return s
+}
+
 // The DELETE request to delete a usage plan key and remove the underlying API
 // key from the associated usage plan.
 type DeleteUsagePlanKeyInput struct {
@@ -8705,6 +9431,18 @@ func (s *DeleteUsagePlanKeyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *DeleteUsagePlanKeyInput) SetKeyId(v string) *DeleteUsagePlanKeyInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *DeleteUsagePlanKeyInput) SetUsagePlanId(v string) *DeleteUsagePlanKeyInput {
+	s.UsagePlanId = &v
+	return s
 }
 
 type DeleteUsagePlanKeyOutput struct {
@@ -8772,6 +9510,30 @@ func (s Deployment) GoString() string {
 	return s.String()
 }
 
+// SetApiSummary sets the ApiSummary field's value.
+func (s *Deployment) SetApiSummary(v map[string]map[string]*MethodSnapshot) *Deployment {
+	s.ApiSummary = v
+	return s
+}
+
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *Deployment) SetCreatedDate(v time.Time) *Deployment {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Deployment) SetDescription(v string) *Deployment {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Deployment) SetId(v string) *Deployment {
+	s.Id = &v
+	return s
+}
+
 // Represents a domain name that is contained in a simpler, more intuitive URL
 // that can be called.
 //
@@ -8801,6 +9563,30 @@ func (s DomainName) String() string {
 // GoString returns the string representation
 func (s DomainName) GoString() string {
 	return s.String()
+}
+
+// SetCertificateName sets the CertificateName field's value.
+func (s *DomainName) SetCertificateName(v string) *DomainName {
+	s.CertificateName = &v
+	return s
+}
+
+// SetCertificateUploadDate sets the CertificateUploadDate field's value.
+func (s *DomainName) SetCertificateUploadDate(v time.Time) *DomainName {
+	s.CertificateUploadDate = &v
+	return s
+}
+
+// SetDistributionDomainName sets the DistributionDomainName field's value.
+func (s *DomainName) SetDistributionDomainName(v string) *DomainName {
+	s.DistributionDomainName = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DomainName) SetDomainName(v string) *DomainName {
+	s.DomainName = &v
+	return s
 }
 
 // Request to flush authorizer cache entries on a specified stage.
@@ -8842,6 +9628,18 @@ func (s *FlushStageAuthorizersCacheInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *FlushStageAuthorizersCacheInput) SetRestApiId(v string) *FlushStageAuthorizersCacheInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *FlushStageAuthorizersCacheInput) SetStageName(v string) *FlushStageAuthorizersCacheInput {
+	s.StageName = &v
+	return s
 }
 
 type FlushStageAuthorizersCacheOutput struct {
@@ -8899,6 +9697,18 @@ func (s *FlushStageCacheInput) Validate() error {
 	return nil
 }
 
+// SetRestApiId sets the RestApiId field's value.
+func (s *FlushStageCacheInput) SetRestApiId(v string) *FlushStageCacheInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *FlushStageCacheInput) SetStageName(v string) *FlushStageCacheInput {
+	s.StageName = &v
+	return s
+}
+
 type FlushStageCacheOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8929,6 +9739,12 @@ func (s GenerateClientCertificateInput) String() string {
 // GoString returns the string representation
 func (s GenerateClientCertificateInput) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *GenerateClientCertificateInput) SetDescription(v string) *GenerateClientCertificateInput {
+	s.Description = &v
+	return s
 }
 
 // Requests Amazon API Gateway to get information about the current Account
@@ -8984,6 +9800,18 @@ func (s *GetApiKeyInput) Validate() error {
 	return nil
 }
 
+// SetApiKey sets the ApiKey field's value.
+func (s *GetApiKeyInput) SetApiKey(v string) *GetApiKeyInput {
+	s.ApiKey = &v
+	return s
+}
+
+// SetIncludeValue sets the IncludeValue field's value.
+func (s *GetApiKeyInput) SetIncludeValue(v bool) *GetApiKeyInput {
+	s.IncludeValue = &v
+	return s
+}
+
 // A request to get information about the current ApiKeys resource.
 type GetApiKeysInput struct {
 	_ struct{} `type:"structure"`
@@ -9012,6 +9840,30 @@ func (s GetApiKeysInput) GoString() string {
 	return s.String()
 }
 
+// SetIncludeValues sets the IncludeValues field's value.
+func (s *GetApiKeysInput) SetIncludeValues(v bool) *GetApiKeysInput {
+	s.IncludeValues = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *GetApiKeysInput) SetLimit(v int64) *GetApiKeysInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNameQuery sets the NameQuery field's value.
+func (s *GetApiKeysInput) SetNameQuery(v string) *GetApiKeysInput {
+	s.NameQuery = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetApiKeysInput) SetPosition(v string) *GetApiKeysInput {
+	s.Position = &v
+	return s
+}
+
 // Represents a collection of API keys as represented by an ApiKeys resource.
 //
 // Use API Keys (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html)
@@ -9036,6 +9888,24 @@ func (s GetApiKeysOutput) String() string {
 // GoString returns the string representation
 func (s GetApiKeysOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetApiKeysOutput) SetItems(v []*ApiKey) *GetApiKeysOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetApiKeysOutput) SetPosition(v string) *GetApiKeysOutput {
+	s.Position = &v
+	return s
+}
+
+// SetWarnings sets the Warnings field's value.
+func (s *GetApiKeysOutput) SetWarnings(v []*string) *GetApiKeysOutput {
+	s.Warnings = v
+	return s
 }
 
 // Request to describe an existing Authorizer resource.
@@ -9079,6 +9949,18 @@ func (s *GetAuthorizerInput) Validate() error {
 	return nil
 }
 
+// SetAuthorizerId sets the AuthorizerId field's value.
+func (s *GetAuthorizerInput) SetAuthorizerId(v string) *GetAuthorizerInput {
+	s.AuthorizerId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetAuthorizerInput) SetRestApiId(v string) *GetAuthorizerInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Request to describe an existing Authorizers resource.
 type GetAuthorizersInput struct {
 	_ struct{} `type:"structure"`
@@ -9119,6 +10001,24 @@ func (s *GetAuthorizersInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetAuthorizersInput) SetLimit(v int64) *GetAuthorizersInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetAuthorizersInput) SetPosition(v string) *GetAuthorizersInput {
+	s.Position = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetAuthorizersInput) SetRestApiId(v string) *GetAuthorizersInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Represents a collection of Authorizer resources.
 //
 // Enable custom authorization (http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html)
@@ -9139,6 +10039,18 @@ func (s GetAuthorizersOutput) String() string {
 // GoString returns the string representation
 func (s GetAuthorizersOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetAuthorizersOutput) SetItems(v []*Authorizer) *GetAuthorizersOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetAuthorizersOutput) SetPosition(v string) *GetAuthorizersOutput {
+	s.Position = &v
+	return s
 }
 
 // Request to describe a BasePathMapping resource.
@@ -9185,6 +10097,18 @@ func (s *GetBasePathMappingInput) Validate() error {
 	return nil
 }
 
+// SetBasePath sets the BasePath field's value.
+func (s *GetBasePathMappingInput) SetBasePath(v string) *GetBasePathMappingInput {
+	s.BasePath = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetBasePathMappingInput) SetDomainName(v string) *GetBasePathMappingInput {
+	s.DomainName = &v
+	return s
+}
+
 // A request to get information about a collection of BasePathMapping resources.
 type GetBasePathMappingsInput struct {
 	_ struct{} `type:"structure"`
@@ -9227,6 +10151,24 @@ func (s *GetBasePathMappingsInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *GetBasePathMappingsInput) SetDomainName(v string) *GetBasePathMappingsInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *GetBasePathMappingsInput) SetLimit(v int64) *GetBasePathMappingsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetBasePathMappingsInput) SetPosition(v string) *GetBasePathMappingsInput {
+	s.Position = &v
+	return s
+}
+
 // Represents a collection of BasePathMapping resources.
 //
 // Use Custom Domain Names (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html)
@@ -9248,6 +10190,18 @@ func (s GetBasePathMappingsOutput) String() string {
 // GoString returns the string representation
 func (s GetBasePathMappingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetBasePathMappingsOutput) SetItems(v []*BasePathMapping) *GetBasePathMappingsOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetBasePathMappingsOutput) SetPosition(v string) *GetBasePathMappingsOutput {
+	s.Position = &v
+	return s
 }
 
 // A request to get information about the current ClientCertificate resource.
@@ -9283,6 +10237,12 @@ func (s *GetClientCertificateInput) Validate() error {
 	return nil
 }
 
+// SetClientCertificateId sets the ClientCertificateId field's value.
+func (s *GetClientCertificateInput) SetClientCertificateId(v string) *GetClientCertificateInput {
+	s.ClientCertificateId = &v
+	return s
+}
+
 // A request to get information about a collection of ClientCertificate resources.
 type GetClientCertificatesInput struct {
 	_ struct{} `type:"structure"`
@@ -9307,6 +10267,18 @@ func (s GetClientCertificatesInput) GoString() string {
 	return s.String()
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetClientCertificatesInput) SetLimit(v int64) *GetClientCertificatesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetClientCertificatesInput) SetPosition(v string) *GetClientCertificatesInput {
+	s.Position = &v
+	return s
+}
+
 // Represents a collection of ClientCertificate resources.
 //
 // Use Client-Side Certificate (http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html)
@@ -9328,6 +10300,18 @@ func (s GetClientCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s GetClientCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetClientCertificatesOutput) SetItems(v []*ClientCertificate) *GetClientCertificatesOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetClientCertificatesOutput) SetPosition(v string) *GetClientCertificatesOutput {
+	s.Position = &v
+	return s
 }
 
 // Requests Amazon API Gateway to get information about a Deployment resource.
@@ -9372,6 +10356,18 @@ func (s *GetDeploymentInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *GetDeploymentInput) SetDeploymentId(v string) *GetDeploymentInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetDeploymentInput) SetRestApiId(v string) *GetDeploymentInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Requests Amazon API Gateway to get information about a Deployments collection.
 type GetDeploymentsInput struct {
 	_ struct{} `type:"structure"`
@@ -9414,6 +10410,24 @@ func (s *GetDeploymentsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetDeploymentsInput) SetLimit(v int64) *GetDeploymentsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetDeploymentsInput) SetPosition(v string) *GetDeploymentsInput {
+	s.Position = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetDeploymentsInput) SetRestApiId(v string) *GetDeploymentsInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Represents a collection resource that contains zero or more references to
 // your existing deployments, and links that guide you on how to interact with
 // your collection. The collection offers a paginated view of the contained
@@ -9444,6 +10458,18 @@ func (s GetDeploymentsOutput) String() string {
 // GoString returns the string representation
 func (s GetDeploymentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetDeploymentsOutput) SetItems(v []*Deployment) *GetDeploymentsOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetDeploymentsOutput) SetPosition(v string) *GetDeploymentsOutput {
+	s.Position = &v
+	return s
 }
 
 // Request to get the name of a DomainName resource.
@@ -9479,6 +10505,12 @@ func (s *GetDomainNameInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *GetDomainNameInput) SetDomainName(v string) *GetDomainNameInput {
+	s.DomainName = &v
+	return s
+}
+
 // Request to describe a collection of DomainName resources.
 type GetDomainNamesInput struct {
 	_ struct{} `type:"structure"`
@@ -9499,6 +10531,18 @@ func (s GetDomainNamesInput) String() string {
 // GoString returns the string representation
 func (s GetDomainNamesInput) GoString() string {
 	return s.String()
+}
+
+// SetLimit sets the Limit field's value.
+func (s *GetDomainNamesInput) SetLimit(v int64) *GetDomainNamesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetDomainNamesInput) SetPosition(v string) *GetDomainNamesInput {
+	s.Position = &v
+	return s
 }
 
 // Represents a collection of DomainName resources.
@@ -9522,6 +10566,18 @@ func (s GetDomainNamesOutput) String() string {
 // GoString returns the string representation
 func (s GetDomainNamesOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetDomainNamesOutput) SetItems(v []*DomainName) *GetDomainNamesOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetDomainNamesOutput) SetPosition(v string) *GetDomainNamesOutput {
+	s.Position = &v
+	return s
 }
 
 // Request a new export of a RestApi for a particular Stage.
@@ -9587,6 +10643,36 @@ func (s *GetExportInput) Validate() error {
 	return nil
 }
 
+// SetAccepts sets the Accepts field's value.
+func (s *GetExportInput) SetAccepts(v string) *GetExportInput {
+	s.Accepts = &v
+	return s
+}
+
+// SetExportType sets the ExportType field's value.
+func (s *GetExportInput) SetExportType(v string) *GetExportInput {
+	s.ExportType = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *GetExportInput) SetParameters(v map[string]*string) *GetExportInput {
+	s.Parameters = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetExportInput) SetRestApiId(v string) *GetExportInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *GetExportInput) SetStageName(v string) *GetExportInput {
+	s.StageName = &v
+	return s
+}
+
 // The binary blob response to GetExport, which contains the generated SDK.
 type GetExportOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -9610,6 +10696,24 @@ func (s GetExportOutput) String() string {
 // GoString returns the string representation
 func (s GetExportOutput) GoString() string {
 	return s.String()
+}
+
+// SetBody sets the Body field's value.
+func (s *GetExportOutput) SetBody(v []byte) *GetExportOutput {
+	s.Body = v
+	return s
+}
+
+// SetContentDisposition sets the ContentDisposition field's value.
+func (s *GetExportOutput) SetContentDisposition(v string) *GetExportOutput {
+	s.ContentDisposition = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *GetExportOutput) SetContentType(v string) *GetExportOutput {
+	s.ContentType = &v
+	return s
 }
 
 // Represents a get integration request.
@@ -9659,6 +10763,24 @@ func (s *GetIntegrationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *GetIntegrationInput) SetHttpMethod(v string) *GetIntegrationInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *GetIntegrationInput) SetResourceId(v string) *GetIntegrationInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetIntegrationInput) SetRestApiId(v string) *GetIntegrationInput {
+	s.RestApiId = &v
+	return s
 }
 
 // Represents a get integration response request.
@@ -9718,6 +10840,30 @@ func (s *GetIntegrationResponseInput) Validate() error {
 	return nil
 }
 
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *GetIntegrationResponseInput) SetHttpMethod(v string) *GetIntegrationResponseInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *GetIntegrationResponseInput) SetResourceId(v string) *GetIntegrationResponseInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetIntegrationResponseInput) SetRestApiId(v string) *GetIntegrationResponseInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *GetIntegrationResponseInput) SetStatusCode(v string) *GetIntegrationResponseInput {
+	s.StatusCode = &v
+	return s
+}
+
 // Request to describe an existing Method resource.
 type GetMethodInput struct {
 	_ struct{} `type:"structure"`
@@ -9765,6 +10911,24 @@ func (s *GetMethodInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *GetMethodInput) SetHttpMethod(v string) *GetMethodInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *GetMethodInput) SetResourceId(v string) *GetMethodInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetMethodInput) SetRestApiId(v string) *GetMethodInput {
+	s.RestApiId = &v
+	return s
 }
 
 // Request to describe a MethodResponse resource.
@@ -9824,6 +10988,30 @@ func (s *GetMethodResponseInput) Validate() error {
 	return nil
 }
 
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *GetMethodResponseInput) SetHttpMethod(v string) *GetMethodResponseInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *GetMethodResponseInput) SetResourceId(v string) *GetMethodResponseInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetMethodResponseInput) SetRestApiId(v string) *GetMethodResponseInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *GetMethodResponseInput) SetStatusCode(v string) *GetMethodResponseInput {
+	s.StatusCode = &v
+	return s
+}
+
 // Request to list information about a model in an existing RestApi resource.
 type GetModelInput struct {
 	_ struct{} `type:"structure"`
@@ -9870,6 +11058,24 @@ func (s *GetModelInput) Validate() error {
 	return nil
 }
 
+// SetFlatten sets the Flatten field's value.
+func (s *GetModelInput) SetFlatten(v bool) *GetModelInput {
+	s.Flatten = &v
+	return s
+}
+
+// SetModelName sets the ModelName field's value.
+func (s *GetModelInput) SetModelName(v string) *GetModelInput {
+	s.ModelName = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetModelInput) SetRestApiId(v string) *GetModelInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Request to generate a sample mapping template used to transform the payload.
 type GetModelTemplateInput struct {
 	_ struct{} `type:"structure"`
@@ -9911,6 +11117,18 @@ func (s *GetModelTemplateInput) Validate() error {
 	return nil
 }
 
+// SetModelName sets the ModelName field's value.
+func (s *GetModelTemplateInput) SetModelName(v string) *GetModelTemplateInput {
+	s.ModelName = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetModelTemplateInput) SetRestApiId(v string) *GetModelTemplateInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Represents a mapping template used to transform a payload.
 //
 // Mapping Templates (http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings)
@@ -9930,6 +11148,12 @@ func (s GetModelTemplateOutput) String() string {
 // GoString returns the string representation
 func (s GetModelTemplateOutput) GoString() string {
 	return s.String()
+}
+
+// SetValue sets the Value field's value.
+func (s *GetModelTemplateOutput) SetValue(v string) *GetModelTemplateOutput {
+	s.Value = &v
+	return s
 }
 
 // Request to list existing Models defined for a RestApi resource.
@@ -9973,6 +11197,24 @@ func (s *GetModelsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetModelsInput) SetLimit(v int64) *GetModelsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetModelsInput) SetPosition(v string) *GetModelsInput {
+	s.Position = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetModelsInput) SetRestApiId(v string) *GetModelsInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Represents a collection of Model resources.
 //
 // Method, MethodResponse, Models and Mappings (http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html)
@@ -9993,6 +11235,18 @@ func (s GetModelsOutput) String() string {
 // GoString returns the string representation
 func (s GetModelsOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetModelsOutput) SetItems(v []*Model) *GetModelsOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetModelsOutput) SetPosition(v string) *GetModelsOutput {
+	s.Position = &v
+	return s
 }
 
 // Request to list information about a resource.
@@ -10036,6 +11290,18 @@ func (s *GetResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *GetResourceInput) SetResourceId(v string) *GetResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetResourceInput) SetRestApiId(v string) *GetResourceInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Request to list information about a collection of resources.
 type GetResourcesInput struct {
 	_ struct{} `type:"structure"`
@@ -10077,6 +11343,24 @@ func (s *GetResourcesInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetResourcesInput) SetLimit(v int64) *GetResourcesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetResourcesInput) SetPosition(v string) *GetResourcesInput {
+	s.Position = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetResourcesInput) SetRestApiId(v string) *GetResourcesInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Represents a collection of Resource resources.
 //
 // Create an API (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html)
@@ -10097,6 +11381,18 @@ func (s GetResourcesOutput) String() string {
 // GoString returns the string representation
 func (s GetResourcesOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetResourcesOutput) SetItems(v []*Resource) *GetResourcesOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetResourcesOutput) SetPosition(v string) *GetResourcesOutput {
+	s.Position = &v
+	return s
 }
 
 // The GET request to list an existing RestApi defined for your collection.
@@ -10132,6 +11428,12 @@ func (s *GetRestApiInput) Validate() error {
 	return nil
 }
 
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetRestApiInput) SetRestApiId(v string) *GetRestApiInput {
+	s.RestApiId = &v
+	return s
+}
+
 // The GET request to list existing RestApis defined for your collection.
 type GetRestApisInput struct {
 	_ struct{} `type:"structure"`
@@ -10155,6 +11457,18 @@ func (s GetRestApisInput) GoString() string {
 	return s.String()
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetRestApisInput) SetLimit(v int64) *GetRestApisInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetRestApisInput) SetPosition(v string) *GetRestApisInput {
+	s.Position = &v
+	return s
+}
+
 // Contains references to your APIs and links that guide you in how to interact
 // with your collection. A collection offers a paginated view of your APIs.
 //
@@ -10176,6 +11490,18 @@ func (s GetRestApisOutput) String() string {
 // GoString returns the string representation
 func (s GetRestApisOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetRestApisOutput) SetItems(v []*RestApi) *GetRestApisOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetRestApisOutput) SetPosition(v string) *GetRestApisOutput {
+	s.Position = &v
+	return s
 }
 
 // Request a new generated client SDK for a RestApi and Stage.
@@ -10234,6 +11560,30 @@ func (s *GetSdkInput) Validate() error {
 	return nil
 }
 
+// SetParameters sets the Parameters field's value.
+func (s *GetSdkInput) SetParameters(v map[string]*string) *GetSdkInput {
+	s.Parameters = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetSdkInput) SetRestApiId(v string) *GetSdkInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetSdkType sets the SdkType field's value.
+func (s *GetSdkInput) SetSdkType(v string) *GetSdkInput {
+	s.SdkType = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *GetSdkInput) SetStageName(v string) *GetSdkInput {
+	s.StageName = &v
+	return s
+}
+
 // The binary blob response to GetSdk, which contains the generated SDK.
 type GetSdkOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -10256,6 +11606,24 @@ func (s GetSdkOutput) String() string {
 // GoString returns the string representation
 func (s GetSdkOutput) GoString() string {
 	return s.String()
+}
+
+// SetBody sets the Body field's value.
+func (s *GetSdkOutput) SetBody(v []byte) *GetSdkOutput {
+	s.Body = v
+	return s
+}
+
+// SetContentDisposition sets the ContentDisposition field's value.
+func (s *GetSdkOutput) SetContentDisposition(v string) *GetSdkOutput {
+	s.ContentDisposition = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *GetSdkOutput) SetContentType(v string) *GetSdkOutput {
+	s.ContentType = &v
+	return s
 }
 
 // Requests Amazon API Gateway to get information about a Stage resource.
@@ -10300,6 +11668,18 @@ func (s *GetStageInput) Validate() error {
 	return nil
 }
 
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetStageInput) SetRestApiId(v string) *GetStageInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *GetStageInput) SetStageName(v string) *GetStageInput {
+	s.StageName = &v
+	return s
+}
+
 // Requests Amazon API Gateway to get information about one or more Stage resources.
 type GetStagesInput struct {
 	_ struct{} `type:"structure"`
@@ -10336,6 +11716,18 @@ func (s *GetStagesInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *GetStagesInput) SetDeploymentId(v string) *GetStagesInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *GetStagesInput) SetRestApiId(v string) *GetStagesInput {
+	s.RestApiId = &v
+	return s
+}
+
 // A list of Stage resources that are associated with the ApiKey resource.
 //
 // Deploying API in Stages (http://docs.aws.amazon.com/apigateway/latest/developerguide/stages.html)
@@ -10354,6 +11746,12 @@ func (s GetStagesOutput) String() string {
 // GoString returns the string representation
 func (s GetStagesOutput) GoString() string {
 	return s.String()
+}
+
+// SetItem sets the Item field's value.
+func (s *GetStagesOutput) SetItem(v []*Stage) *GetStagesOutput {
+	s.Item = v
+	return s
 }
 
 // The GET request to get the usage data of a usage plan in a specified time
@@ -10415,6 +11813,42 @@ func (s *GetUsageInput) Validate() error {
 	return nil
 }
 
+// SetEndDate sets the EndDate field's value.
+func (s *GetUsageInput) SetEndDate(v string) *GetUsageInput {
+	s.EndDate = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GetUsageInput) SetKeyId(v string) *GetUsageInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *GetUsageInput) SetLimit(v int64) *GetUsageInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetUsageInput) SetPosition(v string) *GetUsageInput {
+	s.Position = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *GetUsageInput) SetStartDate(v string) *GetUsageInput {
+	s.StartDate = &v
+	return s
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *GetUsageInput) SetUsagePlanId(v string) *GetUsageInput {
+	s.UsagePlanId = &v
+	return s
+}
+
 // The GET request to get a usage plan of a given plan identifier.
 type GetUsagePlanInput struct {
 	_ struct{} `type:"structure"`
@@ -10446,6 +11880,12 @@ func (s *GetUsagePlanInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *GetUsagePlanInput) SetUsagePlanId(v string) *GetUsagePlanInput {
+	s.UsagePlanId = &v
+	return s
 }
 
 // The GET request to get a usage plan key of a given key identifier.
@@ -10489,6 +11929,18 @@ func (s *GetUsagePlanKeyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GetUsagePlanKeyInput) SetKeyId(v string) *GetUsagePlanKeyInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *GetUsagePlanKeyInput) SetUsagePlanId(v string) *GetUsagePlanKeyInput {
+	s.UsagePlanId = &v
+	return s
 }
 
 // The GET request to get all the usage plan keys representing the API keys
@@ -10537,6 +11989,30 @@ func (s *GetUsagePlanKeysInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetUsagePlanKeysInput) SetLimit(v int64) *GetUsagePlanKeysInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNameQuery sets the NameQuery field's value.
+func (s *GetUsagePlanKeysInput) SetNameQuery(v string) *GetUsagePlanKeysInput {
+	s.NameQuery = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetUsagePlanKeysInput) SetPosition(v string) *GetUsagePlanKeysInput {
+	s.Position = &v
+	return s
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *GetUsagePlanKeysInput) SetUsagePlanId(v string) *GetUsagePlanKeysInput {
+	s.UsagePlanId = &v
+	return s
+}
+
 // Represents the collection of usage plan keys added to usage plans for the
 // associated API keys and, possibly, other types of keys.
 //
@@ -10558,6 +12034,18 @@ func (s GetUsagePlanKeysOutput) String() string {
 // GoString returns the string representation
 func (s GetUsagePlanKeysOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetUsagePlanKeysOutput) SetItems(v []*UsagePlanKey) *GetUsagePlanKeysOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetUsagePlanKeysOutput) SetPosition(v string) *GetUsagePlanKeysOutput {
+	s.Position = &v
+	return s
 }
 
 // The GET request to get all the usage plans of the caller's account.
@@ -10585,6 +12073,24 @@ func (s GetUsagePlansInput) GoString() string {
 	return s.String()
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *GetUsagePlansInput) SetKeyId(v string) *GetUsagePlansInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *GetUsagePlansInput) SetLimit(v int64) *GetUsagePlansInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetUsagePlansInput) SetPosition(v string) *GetUsagePlansInput {
+	s.Position = &v
+	return s
+}
+
 // Represents a collection of usage plans for an AWS account.
 //
 // Create and Use Usage Plans (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html)
@@ -10605,6 +12111,18 @@ func (s GetUsagePlansOutput) String() string {
 // GoString returns the string representation
 func (s GetUsagePlansOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *GetUsagePlansOutput) SetItems(v []*UsagePlan) *GetUsagePlansOutput {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *GetUsagePlansOutput) SetPosition(v string) *GetUsagePlansOutput {
+	s.Position = &v
+	return s
 }
 
 // The POST request to import API keys from an external source, such as a CSV-formatted
@@ -10655,6 +12173,24 @@ func (s *ImportApiKeysInput) Validate() error {
 	return nil
 }
 
+// SetBody sets the Body field's value.
+func (s *ImportApiKeysInput) SetBody(v []byte) *ImportApiKeysInput {
+	s.Body = v
+	return s
+}
+
+// SetFailOnWarnings sets the FailOnWarnings field's value.
+func (s *ImportApiKeysInput) SetFailOnWarnings(v bool) *ImportApiKeysInput {
+	s.FailOnWarnings = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *ImportApiKeysInput) SetFormat(v string) *ImportApiKeysInput {
+	s.Format = &v
+	return s
+}
+
 // The identifier of an API key used to reference an API key in a usage plan.
 type ImportApiKeysOutput struct {
 	_ struct{} `type:"structure"`
@@ -10674,6 +12210,18 @@ func (s ImportApiKeysOutput) String() string {
 // GoString returns the string representation
 func (s ImportApiKeysOutput) GoString() string {
 	return s.String()
+}
+
+// SetIds sets the Ids field's value.
+func (s *ImportApiKeysOutput) SetIds(v []*string) *ImportApiKeysOutput {
+	s.Ids = v
+	return s
+}
+
+// SetWarnings sets the Warnings field's value.
+func (s *ImportApiKeysOutput) SetWarnings(v []*string) *ImportApiKeysOutput {
+	s.Warnings = v
+	return s
 }
 
 // A POST request to import an API to Amazon API Gateway using an input of an
@@ -10716,6 +12264,24 @@ func (s *ImportRestApiInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBody sets the Body field's value.
+func (s *ImportRestApiInput) SetBody(v []byte) *ImportRestApiInput {
+	s.Body = v
+	return s
+}
+
+// SetFailOnWarnings sets the FailOnWarnings field's value.
+func (s *ImportRestApiInput) SetFailOnWarnings(v bool) *ImportRestApiInput {
+	s.FailOnWarnings = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ImportRestApiInput) SetParameters(v map[string]*string) *ImportRestApiInput {
+	s.Parameters = v
+	return s
 }
 
 // Represents an HTTP, AWS, or Mock integration.
@@ -10833,6 +12399,66 @@ func (s Integration) GoString() string {
 	return s.String()
 }
 
+// SetCacheKeyParameters sets the CacheKeyParameters field's value.
+func (s *Integration) SetCacheKeyParameters(v []*string) *Integration {
+	s.CacheKeyParameters = v
+	return s
+}
+
+// SetCacheNamespace sets the CacheNamespace field's value.
+func (s *Integration) SetCacheNamespace(v string) *Integration {
+	s.CacheNamespace = &v
+	return s
+}
+
+// SetCredentials sets the Credentials field's value.
+func (s *Integration) SetCredentials(v string) *Integration {
+	s.Credentials = &v
+	return s
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *Integration) SetHttpMethod(v string) *Integration {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetIntegrationResponses sets the IntegrationResponses field's value.
+func (s *Integration) SetIntegrationResponses(v map[string]*IntegrationResponse) *Integration {
+	s.IntegrationResponses = v
+	return s
+}
+
+// SetPassthroughBehavior sets the PassthroughBehavior field's value.
+func (s *Integration) SetPassthroughBehavior(v string) *Integration {
+	s.PassthroughBehavior = &v
+	return s
+}
+
+// SetRequestParameters sets the RequestParameters field's value.
+func (s *Integration) SetRequestParameters(v map[string]*string) *Integration {
+	s.RequestParameters = v
+	return s
+}
+
+// SetRequestTemplates sets the RequestTemplates field's value.
+func (s *Integration) SetRequestTemplates(v map[string]*string) *Integration {
+	s.RequestTemplates = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Integration) SetType(v string) *Integration {
+	s.Type = &v
+	return s
+}
+
+// SetUri sets the Uri field's value.
+func (s *Integration) SetUri(v string) *Integration {
+	s.Uri = &v
+	return s
+}
+
 // Represents an integration response. The status code must map to an existing
 // MethodResponse, and parameters and templates can be used to transform the
 // back-end response.
@@ -10881,6 +12507,30 @@ func (s IntegrationResponse) String() string {
 // GoString returns the string representation
 func (s IntegrationResponse) GoString() string {
 	return s.String()
+}
+
+// SetResponseParameters sets the ResponseParameters field's value.
+func (s *IntegrationResponse) SetResponseParameters(v map[string]*string) *IntegrationResponse {
+	s.ResponseParameters = v
+	return s
+}
+
+// SetResponseTemplates sets the ResponseTemplates field's value.
+func (s *IntegrationResponse) SetResponseTemplates(v map[string]*string) *IntegrationResponse {
+	s.ResponseTemplates = v
+	return s
+}
+
+// SetSelectionPattern sets the SelectionPattern field's value.
+func (s *IntegrationResponse) SetSelectionPattern(v string) *IntegrationResponse {
+	s.SelectionPattern = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *IntegrationResponse) SetStatusCode(v string) *IntegrationResponse {
+	s.StatusCode = &v
+	return s
 }
 
 // Represents a client-facing interface by which the client calls the API to
@@ -11069,6 +12719,54 @@ func (s Method) GoString() string {
 	return s.String()
 }
 
+// SetApiKeyRequired sets the ApiKeyRequired field's value.
+func (s *Method) SetApiKeyRequired(v bool) *Method {
+	s.ApiKeyRequired = &v
+	return s
+}
+
+// SetAuthorizationType sets the AuthorizationType field's value.
+func (s *Method) SetAuthorizationType(v string) *Method {
+	s.AuthorizationType = &v
+	return s
+}
+
+// SetAuthorizerId sets the AuthorizerId field's value.
+func (s *Method) SetAuthorizerId(v string) *Method {
+	s.AuthorizerId = &v
+	return s
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *Method) SetHttpMethod(v string) *Method {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetMethodIntegration sets the MethodIntegration field's value.
+func (s *Method) SetMethodIntegration(v *Integration) *Method {
+	s.MethodIntegration = v
+	return s
+}
+
+// SetMethodResponses sets the MethodResponses field's value.
+func (s *Method) SetMethodResponses(v map[string]*MethodResponse) *Method {
+	s.MethodResponses = v
+	return s
+}
+
+// SetRequestModels sets the RequestModels field's value.
+func (s *Method) SetRequestModels(v map[string]*string) *Method {
+	s.RequestModels = v
+	return s
+}
+
+// SetRequestParameters sets the RequestParameters field's value.
+func (s *Method) SetRequestParameters(v map[string]*bool) *Method {
+	s.RequestParameters = v
+	return s
+}
+
 // Represents a method response of a given HTTP status code returned to the
 // client. The method response is passed from the back end through the associated
 // integration response that can be transformed using a mapping template.
@@ -11128,6 +12826,24 @@ func (s MethodResponse) String() string {
 // GoString returns the string representation
 func (s MethodResponse) GoString() string {
 	return s.String()
+}
+
+// SetResponseModels sets the ResponseModels field's value.
+func (s *MethodResponse) SetResponseModels(v map[string]*string) *MethodResponse {
+	s.ResponseModels = v
+	return s
+}
+
+// SetResponseParameters sets the ResponseParameters field's value.
+func (s *MethodResponse) SetResponseParameters(v map[string]*bool) *MethodResponse {
+	s.ResponseParameters = v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *MethodResponse) SetStatusCode(v string) *MethodResponse {
+	s.StatusCode = &v
+	return s
 }
 
 // Specifies the method setting properties.
@@ -11196,6 +12912,66 @@ func (s MethodSetting) GoString() string {
 	return s.String()
 }
 
+// SetCacheDataEncrypted sets the CacheDataEncrypted field's value.
+func (s *MethodSetting) SetCacheDataEncrypted(v bool) *MethodSetting {
+	s.CacheDataEncrypted = &v
+	return s
+}
+
+// SetCacheTtlInSeconds sets the CacheTtlInSeconds field's value.
+func (s *MethodSetting) SetCacheTtlInSeconds(v int64) *MethodSetting {
+	s.CacheTtlInSeconds = &v
+	return s
+}
+
+// SetCachingEnabled sets the CachingEnabled field's value.
+func (s *MethodSetting) SetCachingEnabled(v bool) *MethodSetting {
+	s.CachingEnabled = &v
+	return s
+}
+
+// SetDataTraceEnabled sets the DataTraceEnabled field's value.
+func (s *MethodSetting) SetDataTraceEnabled(v bool) *MethodSetting {
+	s.DataTraceEnabled = &v
+	return s
+}
+
+// SetLoggingLevel sets the LoggingLevel field's value.
+func (s *MethodSetting) SetLoggingLevel(v string) *MethodSetting {
+	s.LoggingLevel = &v
+	return s
+}
+
+// SetMetricsEnabled sets the MetricsEnabled field's value.
+func (s *MethodSetting) SetMetricsEnabled(v bool) *MethodSetting {
+	s.MetricsEnabled = &v
+	return s
+}
+
+// SetRequireAuthorizationForCacheControl sets the RequireAuthorizationForCacheControl field's value.
+func (s *MethodSetting) SetRequireAuthorizationForCacheControl(v bool) *MethodSetting {
+	s.RequireAuthorizationForCacheControl = &v
+	return s
+}
+
+// SetThrottlingBurstLimit sets the ThrottlingBurstLimit field's value.
+func (s *MethodSetting) SetThrottlingBurstLimit(v int64) *MethodSetting {
+	s.ThrottlingBurstLimit = &v
+	return s
+}
+
+// SetThrottlingRateLimit sets the ThrottlingRateLimit field's value.
+func (s *MethodSetting) SetThrottlingRateLimit(v float64) *MethodSetting {
+	s.ThrottlingRateLimit = &v
+	return s
+}
+
+// SetUnauthorizedCacheControlHeaderStrategy sets the UnauthorizedCacheControlHeaderStrategy field's value.
+func (s *MethodSetting) SetUnauthorizedCacheControlHeaderStrategy(v string) *MethodSetting {
+	s.UnauthorizedCacheControlHeaderStrategy = &v
+	return s
+}
+
 // Represents a summary of a Method resource, given a particular date and time.
 type MethodSnapshot struct {
 	_ struct{} `type:"structure"`
@@ -11215,6 +12991,18 @@ func (s MethodSnapshot) String() string {
 // GoString returns the string representation
 func (s MethodSnapshot) GoString() string {
 	return s.String()
+}
+
+// SetApiKeyRequired sets the ApiKeyRequired field's value.
+func (s *MethodSnapshot) SetApiKeyRequired(v bool) *MethodSnapshot {
+	s.ApiKeyRequired = &v
+	return s
+}
+
+// SetAuthorizationType sets the AuthorizationType field's value.
+func (s *MethodSnapshot) SetAuthorizationType(v string) *MethodSnapshot {
+	s.AuthorizationType = &v
+	return s
 }
 
 // Represents the data structure of a method's request or response payload.
@@ -11262,6 +13050,36 @@ func (s Model) GoString() string {
 	return s.String()
 }
 
+// SetContentType sets the ContentType field's value.
+func (s *Model) SetContentType(v string) *Model {
+	s.ContentType = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Model) SetDescription(v string) *Model {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Model) SetId(v string) *Model {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Model) SetName(v string) *Model {
+	s.Name = &v
+	return s
+}
+
+// SetSchema sets the Schema field's value.
+func (s *Model) SetSchema(v string) *Model {
+	s.Schema = &v
+	return s
+}
+
 // A single patch operation to apply to the specified resource. Please refer
 // to http://tools.ietf.org/html/rfc6902#section-4 for an explanation of how
 // each operation is used.
@@ -11300,6 +13118,30 @@ func (s PatchOperation) String() string {
 // GoString returns the string representation
 func (s PatchOperation) GoString() string {
 	return s.String()
+}
+
+// SetFrom sets the From field's value.
+func (s *PatchOperation) SetFrom(v string) *PatchOperation {
+	s.From = &v
+	return s
+}
+
+// SetOp sets the Op field's value.
+func (s *PatchOperation) SetOp(v string) *PatchOperation {
+	s.Op = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *PatchOperation) SetPath(v string) *PatchOperation {
+	s.Path = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *PatchOperation) SetValue(v string) *PatchOperation {
+	s.Value = &v
+	return s
 }
 
 // Represents a put integration request.
@@ -11409,6 +13251,78 @@ func (s *PutIntegrationInput) Validate() error {
 	return nil
 }
 
+// SetCacheKeyParameters sets the CacheKeyParameters field's value.
+func (s *PutIntegrationInput) SetCacheKeyParameters(v []*string) *PutIntegrationInput {
+	s.CacheKeyParameters = v
+	return s
+}
+
+// SetCacheNamespace sets the CacheNamespace field's value.
+func (s *PutIntegrationInput) SetCacheNamespace(v string) *PutIntegrationInput {
+	s.CacheNamespace = &v
+	return s
+}
+
+// SetCredentials sets the Credentials field's value.
+func (s *PutIntegrationInput) SetCredentials(v string) *PutIntegrationInput {
+	s.Credentials = &v
+	return s
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *PutIntegrationInput) SetHttpMethod(v string) *PutIntegrationInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetIntegrationHttpMethod sets the IntegrationHttpMethod field's value.
+func (s *PutIntegrationInput) SetIntegrationHttpMethod(v string) *PutIntegrationInput {
+	s.IntegrationHttpMethod = &v
+	return s
+}
+
+// SetPassthroughBehavior sets the PassthroughBehavior field's value.
+func (s *PutIntegrationInput) SetPassthroughBehavior(v string) *PutIntegrationInput {
+	s.PassthroughBehavior = &v
+	return s
+}
+
+// SetRequestParameters sets the RequestParameters field's value.
+func (s *PutIntegrationInput) SetRequestParameters(v map[string]*string) *PutIntegrationInput {
+	s.RequestParameters = v
+	return s
+}
+
+// SetRequestTemplates sets the RequestTemplates field's value.
+func (s *PutIntegrationInput) SetRequestTemplates(v map[string]*string) *PutIntegrationInput {
+	s.RequestTemplates = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *PutIntegrationInput) SetResourceId(v string) *PutIntegrationInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *PutIntegrationInput) SetRestApiId(v string) *PutIntegrationInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *PutIntegrationInput) SetType(v string) *PutIntegrationInput {
+	s.Type = &v
+	return s
+}
+
+// SetUri sets the Uri field's value.
+func (s *PutIntegrationInput) SetUri(v string) *PutIntegrationInput {
+	s.Uri = &v
+	return s
+}
+
 // Represents a put integration response request.
 type PutIntegrationResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -11483,6 +13397,48 @@ func (s *PutIntegrationResponseInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *PutIntegrationResponseInput) SetHttpMethod(v string) *PutIntegrationResponseInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *PutIntegrationResponseInput) SetResourceId(v string) *PutIntegrationResponseInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResponseParameters sets the ResponseParameters field's value.
+func (s *PutIntegrationResponseInput) SetResponseParameters(v map[string]*string) *PutIntegrationResponseInput {
+	s.ResponseParameters = v
+	return s
+}
+
+// SetResponseTemplates sets the ResponseTemplates field's value.
+func (s *PutIntegrationResponseInput) SetResponseTemplates(v map[string]*string) *PutIntegrationResponseInput {
+	s.ResponseTemplates = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *PutIntegrationResponseInput) SetRestApiId(v string) *PutIntegrationResponseInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetSelectionPattern sets the SelectionPattern field's value.
+func (s *PutIntegrationResponseInput) SetSelectionPattern(v string) *PutIntegrationResponseInput {
+	s.SelectionPattern = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *PutIntegrationResponseInput) SetStatusCode(v string) *PutIntegrationResponseInput {
+	s.StatusCode = &v
+	return s
 }
 
 // Request to add a method to an existing Resource resource.
@@ -11564,6 +13520,54 @@ func (s *PutMethodInput) Validate() error {
 	return nil
 }
 
+// SetApiKeyRequired sets the ApiKeyRequired field's value.
+func (s *PutMethodInput) SetApiKeyRequired(v bool) *PutMethodInput {
+	s.ApiKeyRequired = &v
+	return s
+}
+
+// SetAuthorizationType sets the AuthorizationType field's value.
+func (s *PutMethodInput) SetAuthorizationType(v string) *PutMethodInput {
+	s.AuthorizationType = &v
+	return s
+}
+
+// SetAuthorizerId sets the AuthorizerId field's value.
+func (s *PutMethodInput) SetAuthorizerId(v string) *PutMethodInput {
+	s.AuthorizerId = &v
+	return s
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *PutMethodInput) SetHttpMethod(v string) *PutMethodInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetRequestModels sets the RequestModels field's value.
+func (s *PutMethodInput) SetRequestModels(v map[string]*string) *PutMethodInput {
+	s.RequestModels = v
+	return s
+}
+
+// SetRequestParameters sets the RequestParameters field's value.
+func (s *PutMethodInput) SetRequestParameters(v map[string]*bool) *PutMethodInput {
+	s.RequestParameters = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *PutMethodInput) SetResourceId(v string) *PutMethodInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *PutMethodInput) SetRestApiId(v string) *PutMethodInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Request to add a MethodResponse to an existing Method resource.
 type PutMethodResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -11639,6 +13643,42 @@ func (s *PutMethodResponseInput) Validate() error {
 	return nil
 }
 
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *PutMethodResponseInput) SetHttpMethod(v string) *PutMethodResponseInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *PutMethodResponseInput) SetResourceId(v string) *PutMethodResponseInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResponseModels sets the ResponseModels field's value.
+func (s *PutMethodResponseInput) SetResponseModels(v map[string]*string) *PutMethodResponseInput {
+	s.ResponseModels = v
+	return s
+}
+
+// SetResponseParameters sets the ResponseParameters field's value.
+func (s *PutMethodResponseInput) SetResponseParameters(v map[string]*bool) *PutMethodResponseInput {
+	s.ResponseParameters = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *PutMethodResponseInput) SetRestApiId(v string) *PutMethodResponseInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *PutMethodResponseInput) SetStatusCode(v string) *PutMethodResponseInput {
+	s.StatusCode = &v
+	return s
+}
+
 // A PUT request to update an existing API, with external API definitions specified
 // as the request body.
 type PutRestApiInput struct {
@@ -11693,6 +13733,36 @@ func (s *PutRestApiInput) Validate() error {
 	return nil
 }
 
+// SetBody sets the Body field's value.
+func (s *PutRestApiInput) SetBody(v []byte) *PutRestApiInput {
+	s.Body = v
+	return s
+}
+
+// SetFailOnWarnings sets the FailOnWarnings field's value.
+func (s *PutRestApiInput) SetFailOnWarnings(v bool) *PutRestApiInput {
+	s.FailOnWarnings = &v
+	return s
+}
+
+// SetMode sets the Mode field's value.
+func (s *PutRestApiInput) SetMode(v string) *PutRestApiInput {
+	s.Mode = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *PutRestApiInput) SetParameters(v map[string]*string) *PutRestApiInput {
+	s.Parameters = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *PutRestApiInput) SetRestApiId(v string) *PutRestApiInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Quotas configured for a usage plan.
 type QuotaSettings struct {
 	_ struct{} `type:"structure"`
@@ -11717,6 +13787,24 @@ func (s QuotaSettings) String() string {
 // GoString returns the string representation
 func (s QuotaSettings) GoString() string {
 	return s.String()
+}
+
+// SetLimit sets the Limit field's value.
+func (s *QuotaSettings) SetLimit(v int64) *QuotaSettings {
+	s.Limit = &v
+	return s
+}
+
+// SetOffset sets the Offset field's value.
+func (s *QuotaSettings) SetOffset(v int64) *QuotaSettings {
+	s.Offset = &v
+	return s
+}
+
+// SetPeriod sets the Period field's value.
+func (s *QuotaSettings) SetPeriod(v string) *QuotaSettings {
+	s.Period = &v
+	return s
 }
 
 // Represents an API resource.
@@ -11807,6 +13895,36 @@ func (s Resource) GoString() string {
 	return s.String()
 }
 
+// SetId sets the Id field's value.
+func (s *Resource) SetId(v string) *Resource {
+	s.Id = &v
+	return s
+}
+
+// SetParentId sets the ParentId field's value.
+func (s *Resource) SetParentId(v string) *Resource {
+	s.ParentId = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *Resource) SetPath(v string) *Resource {
+	s.Path = &v
+	return s
+}
+
+// SetPathPart sets the PathPart field's value.
+func (s *Resource) SetPathPart(v string) *Resource {
+	s.PathPart = &v
+	return s
+}
+
+// SetResourceMethods sets the ResourceMethods field's value.
+func (s *Resource) SetResourceMethods(v map[string]*Method) *Resource {
+	s.ResourceMethods = v
+	return s
+}
+
 // Represents a REST API.
 //
 // Create an API (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html)
@@ -11839,6 +13957,36 @@ func (s RestApi) String() string {
 // GoString returns the string representation
 func (s RestApi) GoString() string {
 	return s.String()
+}
+
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *RestApi) SetCreatedDate(v time.Time) *RestApi {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *RestApi) SetDescription(v string) *RestApi {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *RestApi) SetId(v string) *RestApi {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RestApi) SetName(v string) *RestApi {
+	s.Name = &v
+	return s
+}
+
+// SetWarnings sets the Warnings field's value.
+func (s *RestApi) SetWarnings(v []*string) *RestApi {
+	s.Warnings = v
+	return s
 }
 
 // Represents a unique identifier for a version of a deployed RestApi that is
@@ -11899,6 +14047,72 @@ func (s Stage) GoString() string {
 	return s.String()
 }
 
+// SetCacheClusterEnabled sets the CacheClusterEnabled field's value.
+func (s *Stage) SetCacheClusterEnabled(v bool) *Stage {
+	s.CacheClusterEnabled = &v
+	return s
+}
+
+// SetCacheClusterSize sets the CacheClusterSize field's value.
+func (s *Stage) SetCacheClusterSize(v string) *Stage {
+	s.CacheClusterSize = &v
+	return s
+}
+
+// SetCacheClusterStatus sets the CacheClusterStatus field's value.
+func (s *Stage) SetCacheClusterStatus(v string) *Stage {
+	s.CacheClusterStatus = &v
+	return s
+}
+
+// SetClientCertificateId sets the ClientCertificateId field's value.
+func (s *Stage) SetClientCertificateId(v string) *Stage {
+	s.ClientCertificateId = &v
+	return s
+}
+
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *Stage) SetCreatedDate(v time.Time) *Stage {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *Stage) SetDeploymentId(v string) *Stage {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Stage) SetDescription(v string) *Stage {
+	s.Description = &v
+	return s
+}
+
+// SetLastUpdatedDate sets the LastUpdatedDate field's value.
+func (s *Stage) SetLastUpdatedDate(v time.Time) *Stage {
+	s.LastUpdatedDate = &v
+	return s
+}
+
+// SetMethodSettings sets the MethodSettings field's value.
+func (s *Stage) SetMethodSettings(v map[string]*MethodSetting) *Stage {
+	s.MethodSettings = v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *Stage) SetStageName(v string) *Stage {
+	s.StageName = &v
+	return s
+}
+
+// SetVariables sets the Variables field's value.
+func (s *Stage) SetVariables(v map[string]*string) *Stage {
+	s.Variables = v
+	return s
+}
+
 // A reference to a unique stage identified in the format {restApiId}/{stage}.
 type StageKey struct {
 	_ struct{} `type:"structure"`
@@ -11918,6 +14132,18 @@ func (s StageKey) String() string {
 // GoString returns the string representation
 func (s StageKey) GoString() string {
 	return s.String()
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *StageKey) SetRestApiId(v string) *StageKey {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *StageKey) SetStageName(v string) *StageKey {
+	s.StageName = &v
+	return s
 }
 
 // Make a request to simulate the execution of an Authorizer.
@@ -11980,6 +14206,48 @@ func (s *TestInvokeAuthorizerInput) Validate() error {
 	return nil
 }
 
+// SetAdditionalContext sets the AdditionalContext field's value.
+func (s *TestInvokeAuthorizerInput) SetAdditionalContext(v map[string]*string) *TestInvokeAuthorizerInput {
+	s.AdditionalContext = v
+	return s
+}
+
+// SetAuthorizerId sets the AuthorizerId field's value.
+func (s *TestInvokeAuthorizerInput) SetAuthorizerId(v string) *TestInvokeAuthorizerInput {
+	s.AuthorizerId = &v
+	return s
+}
+
+// SetBody sets the Body field's value.
+func (s *TestInvokeAuthorizerInput) SetBody(v string) *TestInvokeAuthorizerInput {
+	s.Body = &v
+	return s
+}
+
+// SetHeaders sets the Headers field's value.
+func (s *TestInvokeAuthorizerInput) SetHeaders(v map[string]*string) *TestInvokeAuthorizerInput {
+	s.Headers = v
+	return s
+}
+
+// SetPathWithQueryString sets the PathWithQueryString field's value.
+func (s *TestInvokeAuthorizerInput) SetPathWithQueryString(v string) *TestInvokeAuthorizerInput {
+	s.PathWithQueryString = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *TestInvokeAuthorizerInput) SetRestApiId(v string) *TestInvokeAuthorizerInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageVariables sets the StageVariables field's value.
+func (s *TestInvokeAuthorizerInput) SetStageVariables(v map[string]*string) *TestInvokeAuthorizerInput {
+	s.StageVariables = v
+	return s
+}
+
 // Represents the response of the test invoke request for a custom Authorizer
 type TestInvokeAuthorizerOutput struct {
 	_ struct{} `type:"structure"`
@@ -12016,6 +14284,48 @@ func (s TestInvokeAuthorizerOutput) String() string {
 // GoString returns the string representation
 func (s TestInvokeAuthorizerOutput) GoString() string {
 	return s.String()
+}
+
+// SetAuthorization sets the Authorization field's value.
+func (s *TestInvokeAuthorizerOutput) SetAuthorization(v map[string][]*string) *TestInvokeAuthorizerOutput {
+	s.Authorization = v
+	return s
+}
+
+// SetClaims sets the Claims field's value.
+func (s *TestInvokeAuthorizerOutput) SetClaims(v map[string]*string) *TestInvokeAuthorizerOutput {
+	s.Claims = v
+	return s
+}
+
+// SetClientStatus sets the ClientStatus field's value.
+func (s *TestInvokeAuthorizerOutput) SetClientStatus(v int64) *TestInvokeAuthorizerOutput {
+	s.ClientStatus = &v
+	return s
+}
+
+// SetLatency sets the Latency field's value.
+func (s *TestInvokeAuthorizerOutput) SetLatency(v int64) *TestInvokeAuthorizerOutput {
+	s.Latency = &v
+	return s
+}
+
+// SetLog sets the Log field's value.
+func (s *TestInvokeAuthorizerOutput) SetLog(v string) *TestInvokeAuthorizerOutput {
+	s.Log = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *TestInvokeAuthorizerOutput) SetPolicy(v string) *TestInvokeAuthorizerOutput {
+	s.Policy = &v
+	return s
+}
+
+// SetPrincipalId sets the PrincipalId field's value.
+func (s *TestInvokeAuthorizerOutput) SetPrincipalId(v string) *TestInvokeAuthorizerOutput {
+	s.PrincipalId = &v
+	return s
 }
 
 // Make a request to simulate the execution of a Method.
@@ -12086,6 +14396,54 @@ func (s *TestInvokeMethodInput) Validate() error {
 	return nil
 }
 
+// SetBody sets the Body field's value.
+func (s *TestInvokeMethodInput) SetBody(v string) *TestInvokeMethodInput {
+	s.Body = &v
+	return s
+}
+
+// SetClientCertificateId sets the ClientCertificateId field's value.
+func (s *TestInvokeMethodInput) SetClientCertificateId(v string) *TestInvokeMethodInput {
+	s.ClientCertificateId = &v
+	return s
+}
+
+// SetHeaders sets the Headers field's value.
+func (s *TestInvokeMethodInput) SetHeaders(v map[string]*string) *TestInvokeMethodInput {
+	s.Headers = v
+	return s
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *TestInvokeMethodInput) SetHttpMethod(v string) *TestInvokeMethodInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetPathWithQueryString sets the PathWithQueryString field's value.
+func (s *TestInvokeMethodInput) SetPathWithQueryString(v string) *TestInvokeMethodInput {
+	s.PathWithQueryString = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *TestInvokeMethodInput) SetResourceId(v string) *TestInvokeMethodInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *TestInvokeMethodInput) SetRestApiId(v string) *TestInvokeMethodInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageVariables sets the StageVariables field's value.
+func (s *TestInvokeMethodInput) SetStageVariables(v map[string]*string) *TestInvokeMethodInput {
+	s.StageVariables = v
+	return s
+}
+
 // Represents the response of the test invoke request in the HTTP method.
 //
 // Test API using the API Gateway console (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-test-method.html#how-to-test-method-console)
@@ -12118,6 +14476,36 @@ func (s TestInvokeMethodOutput) GoString() string {
 	return s.String()
 }
 
+// SetBody sets the Body field's value.
+func (s *TestInvokeMethodOutput) SetBody(v string) *TestInvokeMethodOutput {
+	s.Body = &v
+	return s
+}
+
+// SetHeaders sets the Headers field's value.
+func (s *TestInvokeMethodOutput) SetHeaders(v map[string]*string) *TestInvokeMethodOutput {
+	s.Headers = v
+	return s
+}
+
+// SetLatency sets the Latency field's value.
+func (s *TestInvokeMethodOutput) SetLatency(v int64) *TestInvokeMethodOutput {
+	s.Latency = &v
+	return s
+}
+
+// SetLog sets the Log field's value.
+func (s *TestInvokeMethodOutput) SetLog(v string) *TestInvokeMethodOutput {
+	s.Log = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *TestInvokeMethodOutput) SetStatus(v int64) *TestInvokeMethodOutput {
+	s.Status = &v
+	return s
+}
+
 // The API request rate limits.
 type ThrottleSettings struct {
 	_ struct{} `type:"structure"`
@@ -12141,6 +14529,18 @@ func (s ThrottleSettings) GoString() string {
 	return s.String()
 }
 
+// SetBurstLimit sets the BurstLimit field's value.
+func (s *ThrottleSettings) SetBurstLimit(v int64) *ThrottleSettings {
+	s.BurstLimit = &v
+	return s
+}
+
+// SetRateLimit sets the RateLimit field's value.
+func (s *ThrottleSettings) SetRateLimit(v float64) *ThrottleSettings {
+	s.RateLimit = &v
+	return s
+}
+
 // Requests Amazon API Gateway to change information about the current Account
 // resource.
 type UpdateAccountInput struct {
@@ -12159,6 +14559,12 @@ func (s UpdateAccountInput) String() string {
 // GoString returns the string representation
 func (s UpdateAccountInput) GoString() string {
 	return s.String()
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateAccountInput) SetPatchOperations(v []*PatchOperation) *UpdateAccountInput {
+	s.PatchOperations = v
+	return s
 }
 
 // A request to change information about an ApiKey resource.
@@ -12196,6 +14602,18 @@ func (s *UpdateApiKeyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApiKey sets the ApiKey field's value.
+func (s *UpdateApiKeyInput) SetApiKey(v string) *UpdateApiKeyInput {
+	s.ApiKey = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateApiKeyInput) SetPatchOperations(v []*PatchOperation) *UpdateApiKeyInput {
+	s.PatchOperations = v
+	return s
 }
 
 // Request to update an existing Authorizer resource.
@@ -12243,6 +14661,24 @@ func (s *UpdateAuthorizerInput) Validate() error {
 	return nil
 }
 
+// SetAuthorizerId sets the AuthorizerId field's value.
+func (s *UpdateAuthorizerInput) SetAuthorizerId(v string) *UpdateAuthorizerInput {
+	s.AuthorizerId = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateAuthorizerInput) SetPatchOperations(v []*PatchOperation) *UpdateAuthorizerInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateAuthorizerInput) SetRestApiId(v string) *UpdateAuthorizerInput {
+	s.RestApiId = &v
+	return s
+}
+
 // A request to change information about the BasePathMapping resource.
 type UpdateBasePathMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -12288,6 +14724,24 @@ func (s *UpdateBasePathMappingInput) Validate() error {
 	return nil
 }
 
+// SetBasePath sets the BasePath field's value.
+func (s *UpdateBasePathMappingInput) SetBasePath(v string) *UpdateBasePathMappingInput {
+	s.BasePath = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateBasePathMappingInput) SetDomainName(v string) *UpdateBasePathMappingInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateBasePathMappingInput) SetPatchOperations(v []*PatchOperation) *UpdateBasePathMappingInput {
+	s.PatchOperations = v
+	return s
+}
+
 // A request to change information about an ClientCertificate resource.
 type UpdateClientCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -12323,6 +14777,18 @@ func (s *UpdateClientCertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClientCertificateId sets the ClientCertificateId field's value.
+func (s *UpdateClientCertificateInput) SetClientCertificateId(v string) *UpdateClientCertificateInput {
+	s.ClientCertificateId = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateClientCertificateInput) SetPatchOperations(v []*PatchOperation) *UpdateClientCertificateInput {
+	s.PatchOperations = v
+	return s
 }
 
 // Requests Amazon API Gateway to change information about a Deployment resource.
@@ -12372,6 +14838,24 @@ func (s *UpdateDeploymentInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *UpdateDeploymentInput) SetDeploymentId(v string) *UpdateDeploymentInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateDeploymentInput) SetPatchOperations(v []*PatchOperation) *UpdateDeploymentInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateDeploymentInput) SetRestApiId(v string) *UpdateDeploymentInput {
+	s.RestApiId = &v
+	return s
+}
+
 // A request to change information about the DomainName resource.
 type UpdateDomainNameInput struct {
 	_ struct{} `type:"structure"`
@@ -12407,6 +14891,18 @@ func (s *UpdateDomainNameInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateDomainNameInput) SetDomainName(v string) *UpdateDomainNameInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateDomainNameInput) SetPatchOperations(v []*PatchOperation) *UpdateDomainNameInput {
+	s.PatchOperations = v
+	return s
 }
 
 // Represents an update integration request.
@@ -12460,6 +14956,30 @@ func (s *UpdateIntegrationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *UpdateIntegrationInput) SetHttpMethod(v string) *UpdateIntegrationInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateIntegrationInput) SetPatchOperations(v []*PatchOperation) *UpdateIntegrationInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *UpdateIntegrationInput) SetResourceId(v string) *UpdateIntegrationInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateIntegrationInput) SetRestApiId(v string) *UpdateIntegrationInput {
+	s.RestApiId = &v
+	return s
 }
 
 // Represents an update integration response request.
@@ -12523,6 +15043,36 @@ func (s *UpdateIntegrationResponseInput) Validate() error {
 	return nil
 }
 
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *UpdateIntegrationResponseInput) SetHttpMethod(v string) *UpdateIntegrationResponseInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateIntegrationResponseInput) SetPatchOperations(v []*PatchOperation) *UpdateIntegrationResponseInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *UpdateIntegrationResponseInput) SetResourceId(v string) *UpdateIntegrationResponseInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateIntegrationResponseInput) SetRestApiId(v string) *UpdateIntegrationResponseInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *UpdateIntegrationResponseInput) SetStatusCode(v string) *UpdateIntegrationResponseInput {
+	s.StatusCode = &v
+	return s
+}
+
 // Request to update an existing Method resource.
 type UpdateMethodInput struct {
 	_ struct{} `type:"structure"`
@@ -12574,6 +15124,30 @@ func (s *UpdateMethodInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *UpdateMethodInput) SetHttpMethod(v string) *UpdateMethodInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateMethodInput) SetPatchOperations(v []*PatchOperation) *UpdateMethodInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *UpdateMethodInput) SetResourceId(v string) *UpdateMethodInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateMethodInput) SetRestApiId(v string) *UpdateMethodInput {
+	s.RestApiId = &v
+	return s
 }
 
 // A request to update an existing MethodResponse resource.
@@ -12637,6 +15211,36 @@ func (s *UpdateMethodResponseInput) Validate() error {
 	return nil
 }
 
+// SetHttpMethod sets the HttpMethod field's value.
+func (s *UpdateMethodResponseInput) SetHttpMethod(v string) *UpdateMethodResponseInput {
+	s.HttpMethod = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateMethodResponseInput) SetPatchOperations(v []*PatchOperation) *UpdateMethodResponseInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *UpdateMethodResponseInput) SetResourceId(v string) *UpdateMethodResponseInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateMethodResponseInput) SetRestApiId(v string) *UpdateMethodResponseInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *UpdateMethodResponseInput) SetStatusCode(v string) *UpdateMethodResponseInput {
+	s.StatusCode = &v
+	return s
+}
+
 // Request to update an existing model in an existing RestApi resource.
 type UpdateModelInput struct {
 	_ struct{} `type:"structure"`
@@ -12680,6 +15284,24 @@ func (s *UpdateModelInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetModelName sets the ModelName field's value.
+func (s *UpdateModelInput) SetModelName(v string) *UpdateModelInput {
+	s.ModelName = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateModelInput) SetPatchOperations(v []*PatchOperation) *UpdateModelInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateModelInput) SetRestApiId(v string) *UpdateModelInput {
+	s.RestApiId = &v
+	return s
 }
 
 // Request to change information about a Resource resource.
@@ -12727,6 +15349,24 @@ func (s *UpdateResourceInput) Validate() error {
 	return nil
 }
 
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateResourceInput) SetPatchOperations(v []*PatchOperation) *UpdateResourceInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *UpdateResourceInput) SetResourceId(v string) *UpdateResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateResourceInput) SetRestApiId(v string) *UpdateResourceInput {
+	s.RestApiId = &v
+	return s
+}
+
 // Request to update an existing RestApi resource in your collection.
 type UpdateRestApiInput struct {
 	_ struct{} `type:"structure"`
@@ -12762,6 +15402,18 @@ func (s *UpdateRestApiInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateRestApiInput) SetPatchOperations(v []*PatchOperation) *UpdateRestApiInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateRestApiInput) SetRestApiId(v string) *UpdateRestApiInput {
+	s.RestApiId = &v
+	return s
 }
 
 // Requests Amazon API Gateway to change information about a Stage resource.
@@ -12808,6 +15460,24 @@ func (s *UpdateStageInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateStageInput) SetPatchOperations(v []*PatchOperation) *UpdateStageInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetRestApiId sets the RestApiId field's value.
+func (s *UpdateStageInput) SetRestApiId(v string) *UpdateStageInput {
+	s.RestApiId = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *UpdateStageInput) SetStageName(v string) *UpdateStageInput {
+	s.StageName = &v
+	return s
 }
 
 // The PATCH request to grant a temporary extension to the reamining quota of
@@ -12857,6 +15527,24 @@ func (s *UpdateUsageInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *UpdateUsageInput) SetKeyId(v string) *UpdateUsageInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateUsageInput) SetPatchOperations(v []*PatchOperation) *UpdateUsageInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *UpdateUsageInput) SetUsagePlanId(v string) *UpdateUsageInput {
+	s.UsagePlanId = &v
+	return s
+}
+
 // The PATCH request to update a usage plan of a given plan Id.
 type UpdateUsagePlanInput struct {
 	_ struct{} `type:"structure"`
@@ -12894,6 +15582,18 @@ func (s *UpdateUsagePlanInput) Validate() error {
 	return nil
 }
 
+// SetPatchOperations sets the PatchOperations field's value.
+func (s *UpdateUsagePlanInput) SetPatchOperations(v []*PatchOperation) *UpdateUsagePlanInput {
+	s.PatchOperations = v
+	return s
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *UpdateUsagePlanInput) SetUsagePlanId(v string) *UpdateUsagePlanInput {
+	s.UsagePlanId = &v
+	return s
+}
+
 // Represents the usage data of a usage plan.
 //
 // Create and Use Usage Plans (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html), Manage Usage in a Usage Plan (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-usage-plans-with-console.html#api-gateway-usage-plan-manage-usage)
@@ -12927,6 +15627,36 @@ func (s Usage) String() string {
 // GoString returns the string representation
 func (s Usage) GoString() string {
 	return s.String()
+}
+
+// SetEndDate sets the EndDate field's value.
+func (s *Usage) SetEndDate(v string) *Usage {
+	s.EndDate = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *Usage) SetItems(v map[string][][]*int64) *Usage {
+	s.Items = v
+	return s
+}
+
+// SetPosition sets the Position field's value.
+func (s *Usage) SetPosition(v string) *Usage {
+	s.Position = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *Usage) SetStartDate(v string) *Usage {
+	s.StartDate = &v
+	return s
+}
+
+// SetUsagePlanId sets the UsagePlanId field's value.
+func (s *Usage) SetUsagePlanId(v string) *Usage {
+	s.UsagePlanId = &v
+	return s
 }
 
 // Represents a usage plan than can specify who can assess associated API stages
@@ -12969,6 +15699,42 @@ func (s UsagePlan) GoString() string {
 	return s.String()
 }
 
+// SetApiStages sets the ApiStages field's value.
+func (s *UsagePlan) SetApiStages(v []*ApiStage) *UsagePlan {
+	s.ApiStages = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UsagePlan) SetDescription(v string) *UsagePlan {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UsagePlan) SetId(v string) *UsagePlan {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UsagePlan) SetName(v string) *UsagePlan {
+	s.Name = &v
+	return s
+}
+
+// SetQuota sets the Quota field's value.
+func (s *UsagePlan) SetQuota(v *QuotaSettings) *UsagePlan {
+	s.Quota = v
+	return s
+}
+
+// SetThrottle sets the Throttle field's value.
+func (s *UsagePlan) SetThrottle(v *ThrottleSettings) *UsagePlan {
+	s.Throttle = v
+	return s
+}
+
 // Represents a usage plan key to identify a plan customer.
 //
 // To associate an API stage with a selected API key in a usage plan, you must
@@ -12999,6 +15765,30 @@ func (s UsagePlanKey) String() string {
 // GoString returns the string representation
 func (s UsagePlanKey) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *UsagePlanKey) SetId(v string) *UsagePlanKey {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UsagePlanKey) SetName(v string) *UsagePlanKey {
+	s.Name = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *UsagePlanKey) SetType(v string) *UsagePlanKey {
+	s.Type = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *UsagePlanKey) SetValue(v string) *UsagePlanKey {
+	s.Value = &v
+	return s
 }
 
 const (

--- a/service/applicationautoscaling/api.go
+++ b/service/applicationautoscaling/api.go
@@ -742,6 +742,18 @@ func (s Alarm) GoString() string {
 	return s.String()
 }
 
+// SetAlarmARN sets the AlarmARN field's value.
+func (s *Alarm) SetAlarmARN(v string) *Alarm {
+	s.AlarmARN = &v
+	return s
+}
+
+// SetAlarmName sets the AlarmName field's value.
+func (s *Alarm) SetAlarmName(v string) *Alarm {
+	s.AlarmName = &v
+	return s
+}
+
 type DeleteScalingPolicyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -812,6 +824,30 @@ func (s *DeleteScalingPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeleteScalingPolicyInput) SetPolicyName(v string) *DeleteScalingPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteScalingPolicyInput) SetResourceId(v string) *DeleteScalingPolicyInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *DeleteScalingPolicyInput) SetScalableDimension(v string) *DeleteScalingPolicyInput {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *DeleteScalingPolicyInput) SetServiceNamespace(v string) *DeleteScalingPolicyInput {
+	s.ServiceNamespace = &v
+	return s
 }
 
 type DeleteScalingPolicyOutput struct {
@@ -887,6 +923,24 @@ func (s *DeregisterScalableTargetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DeregisterScalableTargetInput) SetResourceId(v string) *DeregisterScalableTargetInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *DeregisterScalableTargetInput) SetScalableDimension(v string) *DeregisterScalableTargetInput {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *DeregisterScalableTargetInput) SetServiceNamespace(v string) *DeregisterScalableTargetInput {
+	s.ServiceNamespace = &v
+	return s
 }
 
 type DeregisterScalableTargetOutput struct {
@@ -969,6 +1023,36 @@ func (s *DescribeScalableTargetsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeScalableTargetsInput) SetMaxResults(v int64) *DescribeScalableTargetsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalableTargetsInput) SetNextToken(v string) *DescribeScalableTargetsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceIds sets the ResourceIds field's value.
+func (s *DescribeScalableTargetsInput) SetResourceIds(v []*string) *DescribeScalableTargetsInput {
+	s.ResourceIds = v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *DescribeScalableTargetsInput) SetScalableDimension(v string) *DescribeScalableTargetsInput {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *DescribeScalableTargetsInput) SetServiceNamespace(v string) *DescribeScalableTargetsInput {
+	s.ServiceNamespace = &v
+	return s
+}
+
 type DescribeScalableTargetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -990,6 +1074,18 @@ func (s DescribeScalableTargetsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScalableTargetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalableTargetsOutput) SetNextToken(v string) *DescribeScalableTargetsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScalableTargets sets the ScalableTargets field's value.
+func (s *DescribeScalableTargetsOutput) SetScalableTargets(v []*ScalableTarget) *DescribeScalableTargetsOutput {
+	s.ScalableTargets = v
+	return s
 }
 
 type DescribeScalingActivitiesInput struct {
@@ -1062,6 +1158,36 @@ func (s *DescribeScalingActivitiesInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeScalingActivitiesInput) SetMaxResults(v int64) *DescribeScalingActivitiesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalingActivitiesInput) SetNextToken(v string) *DescribeScalingActivitiesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DescribeScalingActivitiesInput) SetResourceId(v string) *DescribeScalingActivitiesInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *DescribeScalingActivitiesInput) SetScalableDimension(v string) *DescribeScalingActivitiesInput {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *DescribeScalingActivitiesInput) SetServiceNamespace(v string) *DescribeScalingActivitiesInput {
+	s.ServiceNamespace = &v
+	return s
+}
+
 type DescribeScalingActivitiesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1083,6 +1209,18 @@ func (s DescribeScalingActivitiesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingActivitiesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalingActivitiesOutput) SetNextToken(v string) *DescribeScalingActivitiesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScalingActivities sets the ScalingActivities field's value.
+func (s *DescribeScalingActivitiesOutput) SetScalingActivities(v []*ScalingActivity) *DescribeScalingActivitiesOutput {
+	s.ScalingActivities = v
+	return s
 }
 
 type DescribeScalingPoliciesInput struct {
@@ -1158,6 +1296,42 @@ func (s *DescribeScalingPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeScalingPoliciesInput) SetMaxResults(v int64) *DescribeScalingPoliciesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalingPoliciesInput) SetNextToken(v string) *DescribeScalingPoliciesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *DescribeScalingPoliciesInput) SetPolicyNames(v []*string) *DescribeScalingPoliciesInput {
+	s.PolicyNames = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DescribeScalingPoliciesInput) SetResourceId(v string) *DescribeScalingPoliciesInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *DescribeScalingPoliciesInput) SetScalableDimension(v string) *DescribeScalingPoliciesInput {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *DescribeScalingPoliciesInput) SetServiceNamespace(v string) *DescribeScalingPoliciesInput {
+	s.ServiceNamespace = &v
+	return s
+}
+
 type DescribeScalingPoliciesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1179,6 +1353,18 @@ func (s DescribeScalingPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalingPoliciesOutput) SetNextToken(v string) *DescribeScalingPoliciesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScalingPolicies sets the ScalingPolicies field's value.
+func (s *DescribeScalingPoliciesOutput) SetScalingPolicies(v []*ScalingPolicy) *DescribeScalingPoliciesOutput {
+	s.ScalingPolicies = v
+	return s
 }
 
 type PutScalingPolicyInput struct {
@@ -1268,6 +1454,42 @@ func (s *PutScalingPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyName sets the PolicyName field's value.
+func (s *PutScalingPolicyInput) SetPolicyName(v string) *PutScalingPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyType sets the PolicyType field's value.
+func (s *PutScalingPolicyInput) SetPolicyType(v string) *PutScalingPolicyInput {
+	s.PolicyType = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *PutScalingPolicyInput) SetResourceId(v string) *PutScalingPolicyInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *PutScalingPolicyInput) SetScalableDimension(v string) *PutScalingPolicyInput {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *PutScalingPolicyInput) SetServiceNamespace(v string) *PutScalingPolicyInput {
+	s.ServiceNamespace = &v
+	return s
+}
+
+// SetStepScalingPolicyConfiguration sets the StepScalingPolicyConfiguration field's value.
+func (s *PutScalingPolicyInput) SetStepScalingPolicyConfiguration(v *StepScalingPolicyConfiguration) *PutScalingPolicyInput {
+	s.StepScalingPolicyConfiguration = v
+	return s
+}
+
 type PutScalingPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1285,6 +1507,12 @@ func (s PutScalingPolicyOutput) String() string {
 // GoString returns the string representation
 func (s PutScalingPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyARN sets the PolicyARN field's value.
+func (s *PutScalingPolicyOutput) SetPolicyARN(v string) *PutScalingPolicyOutput {
+	s.PolicyARN = &v
+	return s
 }
 
 type RegisterScalableTargetInput struct {
@@ -1368,6 +1596,42 @@ func (s *RegisterScalableTargetInput) Validate() error {
 	return nil
 }
 
+// SetMaxCapacity sets the MaxCapacity field's value.
+func (s *RegisterScalableTargetInput) SetMaxCapacity(v int64) *RegisterScalableTargetInput {
+	s.MaxCapacity = &v
+	return s
+}
+
+// SetMinCapacity sets the MinCapacity field's value.
+func (s *RegisterScalableTargetInput) SetMinCapacity(v int64) *RegisterScalableTargetInput {
+	s.MinCapacity = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *RegisterScalableTargetInput) SetResourceId(v string) *RegisterScalableTargetInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *RegisterScalableTargetInput) SetRoleARN(v string) *RegisterScalableTargetInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *RegisterScalableTargetInput) SetScalableDimension(v string) *RegisterScalableTargetInput {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *RegisterScalableTargetInput) SetServiceNamespace(v string) *RegisterScalableTargetInput {
+	s.ServiceNamespace = &v
+	return s
+}
+
 type RegisterScalableTargetOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1445,6 +1709,48 @@ func (s ScalableTarget) GoString() string {
 	return s.String()
 }
 
+// SetCreationTime sets the CreationTime field's value.
+func (s *ScalableTarget) SetCreationTime(v time.Time) *ScalableTarget {
+	s.CreationTime = &v
+	return s
+}
+
+// SetMaxCapacity sets the MaxCapacity field's value.
+func (s *ScalableTarget) SetMaxCapacity(v int64) *ScalableTarget {
+	s.MaxCapacity = &v
+	return s
+}
+
+// SetMinCapacity sets the MinCapacity field's value.
+func (s *ScalableTarget) SetMinCapacity(v int64) *ScalableTarget {
+	s.MinCapacity = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ScalableTarget) SetResourceId(v string) *ScalableTarget {
+	s.ResourceId = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *ScalableTarget) SetRoleARN(v string) *ScalableTarget {
+	s.RoleARN = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *ScalableTarget) SetScalableDimension(v string) *ScalableTarget {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *ScalableTarget) SetServiceNamespace(v string) *ScalableTarget {
+	s.ServiceNamespace = &v
+	return s
+}
+
 // An object representing a scaling activity.
 type ScalingActivity struct {
 	_ struct{} `type:"structure"`
@@ -1520,6 +1826,72 @@ func (s ScalingActivity) GoString() string {
 	return s.String()
 }
 
+// SetActivityId sets the ActivityId field's value.
+func (s *ScalingActivity) SetActivityId(v string) *ScalingActivity {
+	s.ActivityId = &v
+	return s
+}
+
+// SetCause sets the Cause field's value.
+func (s *ScalingActivity) SetCause(v string) *ScalingActivity {
+	s.Cause = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ScalingActivity) SetDescription(v string) *ScalingActivity {
+	s.Description = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *ScalingActivity) SetDetails(v string) *ScalingActivity {
+	s.Details = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *ScalingActivity) SetEndTime(v time.Time) *ScalingActivity {
+	s.EndTime = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ScalingActivity) SetResourceId(v string) *ScalingActivity {
+	s.ResourceId = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *ScalingActivity) SetScalableDimension(v string) *ScalingActivity {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *ScalingActivity) SetServiceNamespace(v string) *ScalingActivity {
+	s.ServiceNamespace = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ScalingActivity) SetStartTime(v time.Time) *ScalingActivity {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *ScalingActivity) SetStatusCode(v string) *ScalingActivity {
+	s.StatusCode = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ScalingActivity) SetStatusMessage(v string) *ScalingActivity {
+	s.StatusMessage = &v
+	return s
+}
+
 // An object representing a scaling policy.
 type ScalingPolicy struct {
 	_ struct{} `type:"structure"`
@@ -1584,6 +1956,60 @@ func (s ScalingPolicy) String() string {
 // GoString returns the string representation
 func (s ScalingPolicy) GoString() string {
 	return s.String()
+}
+
+// SetAlarms sets the Alarms field's value.
+func (s *ScalingPolicy) SetAlarms(v []*Alarm) *ScalingPolicy {
+	s.Alarms = v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *ScalingPolicy) SetCreationTime(v time.Time) *ScalingPolicy {
+	s.CreationTime = &v
+	return s
+}
+
+// SetPolicyARN sets the PolicyARN field's value.
+func (s *ScalingPolicy) SetPolicyARN(v string) *ScalingPolicy {
+	s.PolicyARN = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *ScalingPolicy) SetPolicyName(v string) *ScalingPolicy {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyType sets the PolicyType field's value.
+func (s *ScalingPolicy) SetPolicyType(v string) *ScalingPolicy {
+	s.PolicyType = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ScalingPolicy) SetResourceId(v string) *ScalingPolicy {
+	s.ResourceId = &v
+	return s
+}
+
+// SetScalableDimension sets the ScalableDimension field's value.
+func (s *ScalingPolicy) SetScalableDimension(v string) *ScalingPolicy {
+	s.ScalableDimension = &v
+	return s
+}
+
+// SetServiceNamespace sets the ServiceNamespace field's value.
+func (s *ScalingPolicy) SetServiceNamespace(v string) *ScalingPolicy {
+	s.ServiceNamespace = &v
+	return s
+}
+
+// SetStepScalingPolicyConfiguration sets the StepScalingPolicyConfiguration field's value.
+func (s *ScalingPolicy) SetStepScalingPolicyConfiguration(v *StepScalingPolicyConfiguration) *ScalingPolicy {
+	s.StepScalingPolicyConfiguration = v
+	return s
 }
 
 // An object representing a step adjustment for a StepScalingPolicyConfiguration.
@@ -1666,6 +2092,24 @@ func (s *StepAdjustment) Validate() error {
 	return nil
 }
 
+// SetMetricIntervalLowerBound sets the MetricIntervalLowerBound field's value.
+func (s *StepAdjustment) SetMetricIntervalLowerBound(v float64) *StepAdjustment {
+	s.MetricIntervalLowerBound = &v
+	return s
+}
+
+// SetMetricIntervalUpperBound sets the MetricIntervalUpperBound field's value.
+func (s *StepAdjustment) SetMetricIntervalUpperBound(v float64) *StepAdjustment {
+	s.MetricIntervalUpperBound = &v
+	return s
+}
+
+// SetScalingAdjustment sets the ScalingAdjustment field's value.
+func (s *StepAdjustment) SetScalingAdjustment(v int64) *StepAdjustment {
+	s.ScalingAdjustment = &v
+	return s
+}
+
 // An object representing a step scaling policy configuration.
 type StepScalingPolicyConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -1739,6 +2183,36 @@ func (s *StepScalingPolicyConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAdjustmentType sets the AdjustmentType field's value.
+func (s *StepScalingPolicyConfiguration) SetAdjustmentType(v string) *StepScalingPolicyConfiguration {
+	s.AdjustmentType = &v
+	return s
+}
+
+// SetCooldown sets the Cooldown field's value.
+func (s *StepScalingPolicyConfiguration) SetCooldown(v int64) *StepScalingPolicyConfiguration {
+	s.Cooldown = &v
+	return s
+}
+
+// SetMetricAggregationType sets the MetricAggregationType field's value.
+func (s *StepScalingPolicyConfiguration) SetMetricAggregationType(v string) *StepScalingPolicyConfiguration {
+	s.MetricAggregationType = &v
+	return s
+}
+
+// SetMinAdjustmentMagnitude sets the MinAdjustmentMagnitude field's value.
+func (s *StepScalingPolicyConfiguration) SetMinAdjustmentMagnitude(v int64) *StepScalingPolicyConfiguration {
+	s.MinAdjustmentMagnitude = &v
+	return s
+}
+
+// SetStepAdjustments sets the StepAdjustments field's value.
+func (s *StepScalingPolicyConfiguration) SetStepAdjustments(v []*StepAdjustment) *StepScalingPolicyConfiguration {
+	s.StepAdjustments = v
+	return s
 }
 
 const (

--- a/service/applicationdiscoveryservice/api.go
+++ b/service/applicationdiscoveryservice/api.go
@@ -827,6 +827,24 @@ func (s AgentConfigurationStatus) GoString() string {
 	return s.String()
 }
 
+// SetAgentId sets the AgentId field's value.
+func (s *AgentConfigurationStatus) SetAgentId(v string) *AgentConfigurationStatus {
+	s.AgentId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *AgentConfigurationStatus) SetDescription(v string) *AgentConfigurationStatus {
+	s.Description = &v
+	return s
+}
+
+// SetOperationSucceeded sets the OperationSucceeded field's value.
+func (s *AgentConfigurationStatus) SetOperationSucceeded(v bool) *AgentConfigurationStatus {
+	s.OperationSucceeded = &v
+	return s
+}
+
 // Information about agents associated with the user’s AWS account. Information
 // includes agent IDs, IP addresses, media access control (MAC) addresses, agent
 // health, hostname where the agent resides, and agent version for each agent.
@@ -863,6 +881,42 @@ func (s AgentInfo) GoString() string {
 	return s.String()
 }
 
+// SetAgentId sets the AgentId field's value.
+func (s *AgentInfo) SetAgentId(v string) *AgentInfo {
+	s.AgentId = &v
+	return s
+}
+
+// SetAgentNetworkInfoList sets the AgentNetworkInfoList field's value.
+func (s *AgentInfo) SetAgentNetworkInfoList(v []*AgentNetworkInfo) *AgentInfo {
+	s.AgentNetworkInfoList = v
+	return s
+}
+
+// SetConnectorId sets the ConnectorId field's value.
+func (s *AgentInfo) SetConnectorId(v string) *AgentInfo {
+	s.ConnectorId = &v
+	return s
+}
+
+// SetHealth sets the Health field's value.
+func (s *AgentInfo) SetHealth(v string) *AgentInfo {
+	s.Health = &v
+	return s
+}
+
+// SetHostName sets the HostName field's value.
+func (s *AgentInfo) SetHostName(v string) *AgentInfo {
+	s.HostName = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *AgentInfo) SetVersion(v string) *AgentInfo {
+	s.Version = &v
+	return s
+}
+
 // Network details about the host where the agent resides.
 type AgentNetworkInfo struct {
 	_ struct{} `type:"structure"`
@@ -882,6 +936,18 @@ func (s AgentNetworkInfo) String() string {
 // GoString returns the string representation
 func (s AgentNetworkInfo) GoString() string {
 	return s.String()
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *AgentNetworkInfo) SetIpAddress(v string) *AgentNetworkInfo {
+	s.IpAddress = &v
+	return s
+}
+
+// SetMacAddress sets the MacAddress field's value.
+func (s *AgentNetworkInfo) SetMacAddress(v string) *AgentNetworkInfo {
+	s.MacAddress = &v
+	return s
 }
 
 // Tags for a configuration item. Tags are metadata that help you categorize
@@ -915,6 +981,36 @@ func (s ConfigurationTag) String() string {
 // GoString returns the string representation
 func (s ConfigurationTag) GoString() string {
 	return s.String()
+}
+
+// SetConfigurationId sets the ConfigurationId field's value.
+func (s *ConfigurationTag) SetConfigurationId(v string) *ConfigurationTag {
+	s.ConfigurationId = &v
+	return s
+}
+
+// SetConfigurationType sets the ConfigurationType field's value.
+func (s *ConfigurationTag) SetConfigurationType(v string) *ConfigurationTag {
+	s.ConfigurationType = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *ConfigurationTag) SetKey(v string) *ConfigurationTag {
+	s.Key = &v
+	return s
+}
+
+// SetTimeOfCreation sets the TimeOfCreation field's value.
+func (s *ConfigurationTag) SetTimeOfCreation(v time.Time) *ConfigurationTag {
+	s.TimeOfCreation = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ConfigurationTag) SetValue(v string) *ConfigurationTag {
+	s.Value = &v
+	return s
 }
 
 type CreateTagsInput struct {
@@ -968,6 +1064,18 @@ func (s *CreateTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConfigurationIds sets the ConfigurationIds field's value.
+func (s *CreateTagsInput) SetConfigurationIds(v []*string) *CreateTagsInput {
+	s.ConfigurationIds = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateTagsInput) SetTags(v []*Tag) *CreateTagsInput {
+	s.Tags = v
+	return s
 }
 
 type CreateTagsOutput struct {
@@ -1032,6 +1140,18 @@ func (s *DeleteTagsInput) Validate() error {
 	return nil
 }
 
+// SetConfigurationIds sets the ConfigurationIds field's value.
+func (s *DeleteTagsInput) SetConfigurationIds(v []*string) *DeleteTagsInput {
+	s.ConfigurationIds = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DeleteTagsInput) SetTags(v []*Tag) *DeleteTagsInput {
+	s.Tags = v
+	return s
+}
+
 type DeleteTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1071,6 +1191,24 @@ func (s DescribeAgentsInput) GoString() string {
 	return s.String()
 }
 
+// SetAgentIds sets the AgentIds field's value.
+func (s *DescribeAgentsInput) SetAgentIds(v []*string) *DescribeAgentsInput {
+	s.AgentIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeAgentsInput) SetMaxResults(v int64) *DescribeAgentsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAgentsInput) SetNextToken(v string) *DescribeAgentsInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeAgentsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1092,6 +1230,18 @@ func (s DescribeAgentsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAgentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAgentsInfo sets the AgentsInfo field's value.
+func (s *DescribeAgentsOutput) SetAgentsInfo(v []*AgentInfo) *DescribeAgentsOutput {
+	s.AgentsInfo = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAgentsOutput) SetNextToken(v string) *DescribeAgentsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeConfigurationsInput struct {
@@ -1126,6 +1276,12 @@ func (s *DescribeConfigurationsInput) Validate() error {
 	return nil
 }
 
+// SetConfigurationIds sets the ConfigurationIds field's value.
+func (s *DescribeConfigurationsInput) SetConfigurationIds(v []*string) *DescribeConfigurationsInput {
+	s.ConfigurationIds = v
+	return s
+}
+
 type DescribeConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1141,6 +1297,12 @@ func (s DescribeConfigurationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConfigurationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigurations sets the Configurations field's value.
+func (s *DescribeConfigurationsOutput) SetConfigurations(v []map[string]*string) *DescribeConfigurationsOutput {
+	s.Configurations = v
+	return s
 }
 
 type DescribeExportConfigurationsInput struct {
@@ -1169,6 +1331,24 @@ func (s DescribeExportConfigurationsInput) GoString() string {
 	return s.String()
 }
 
+// SetExportIds sets the ExportIds field's value.
+func (s *DescribeExportConfigurationsInput) SetExportIds(v []*string) *DescribeExportConfigurationsInput {
+	s.ExportIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeExportConfigurationsInput) SetMaxResults(v int64) *DescribeExportConfigurationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeExportConfigurationsInput) SetNextToken(v string) *DescribeExportConfigurationsInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeExportConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1191,6 +1371,18 @@ func (s DescribeExportConfigurationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeExportConfigurationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetExportsInfo sets the ExportsInfo field's value.
+func (s *DescribeExportConfigurationsOutput) SetExportsInfo(v []*ExportInfo) *DescribeExportConfigurationsOutput {
+	s.ExportsInfo = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeExportConfigurationsOutput) SetNextToken(v string) *DescribeExportConfigurationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeTagsInput struct {
@@ -1238,6 +1430,24 @@ func (s *DescribeTagsInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeTagsInput) SetFilters(v []*TagFilter) *DescribeTagsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeTagsInput) SetMaxResults(v int64) *DescribeTagsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTagsInput) SetNextToken(v string) *DescribeTagsInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1257,6 +1467,18 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTagsOutput) SetNextToken(v string) *DescribeTagsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DescribeTagsOutput) SetTags(v []*ConfigurationTag) *DescribeTagsOutput {
+	s.Tags = v
+	return s
 }
 
 type ExportConfigurationsInput struct {
@@ -1288,6 +1510,12 @@ func (s ExportConfigurationsOutput) String() string {
 // GoString returns the string representation
 func (s ExportConfigurationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetExportId sets the ExportId field's value.
+func (s *ExportConfigurationsOutput) SetExportId(v string) *ExportConfigurationsOutput {
+	s.ExportId = &v
+	return s
 }
 
 // Information regarding the export status of the discovered data. The value
@@ -1330,6 +1558,36 @@ func (s ExportInfo) String() string {
 // GoString returns the string representation
 func (s ExportInfo) GoString() string {
 	return s.String()
+}
+
+// SetConfigurationsDownloadUrl sets the ConfigurationsDownloadUrl field's value.
+func (s *ExportInfo) SetConfigurationsDownloadUrl(v string) *ExportInfo {
+	s.ConfigurationsDownloadUrl = &v
+	return s
+}
+
+// SetExportId sets the ExportId field's value.
+func (s *ExportInfo) SetExportId(v string) *ExportInfo {
+	s.ExportId = &v
+	return s
+}
+
+// SetExportRequestTime sets the ExportRequestTime field's value.
+func (s *ExportInfo) SetExportRequestTime(v time.Time) *ExportInfo {
+	s.ExportRequestTime = &v
+	return s
+}
+
+// SetExportStatus sets the ExportStatus field's value.
+func (s *ExportInfo) SetExportStatus(v string) *ExportInfo {
+	s.ExportStatus = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ExportInfo) SetStatusMessage(v string) *ExportInfo {
+	s.StatusMessage = &v
+	return s
 }
 
 // A filter that can use conditional operators.
@@ -1465,6 +1723,24 @@ func (s *Filter) Validate() error {
 	return nil
 }
 
+// SetCondition sets the Condition field's value.
+func (s *Filter) SetCondition(v string) *Filter {
+	s.Condition = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Filter) SetName(v string) *Filter {
+	s.Name = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *Filter) SetValues(v []*string) *Filter {
+	s.Values = v
+	return s
+}
+
 type ListConfigurationsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1520,6 +1796,30 @@ func (s *ListConfigurationsInput) Validate() error {
 	return nil
 }
 
+// SetConfigurationType sets the ConfigurationType field's value.
+func (s *ListConfigurationsInput) SetConfigurationType(v string) *ListConfigurationsInput {
+	s.ConfigurationType = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *ListConfigurationsInput) SetFilters(v []*Filter) *ListConfigurationsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListConfigurationsInput) SetMaxResults(v int64) *ListConfigurationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListConfigurationsInput) SetNextToken(v string) *ListConfigurationsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1539,6 +1839,18 @@ func (s ListConfigurationsOutput) String() string {
 // GoString returns the string representation
 func (s ListConfigurationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigurations sets the Configurations field's value.
+func (s *ListConfigurationsOutput) SetConfigurations(v []map[string]*string) *ListConfigurationsOutput {
+	s.Configurations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListConfigurationsOutput) SetNextToken(v string) *ListConfigurationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type StartDataCollectionByAgentIdsInput struct {
@@ -1579,6 +1891,12 @@ func (s *StartDataCollectionByAgentIdsInput) Validate() error {
 	return nil
 }
 
+// SetAgentIds sets the AgentIds field's value.
+func (s *StartDataCollectionByAgentIdsInput) SetAgentIds(v []*string) *StartDataCollectionByAgentIdsInput {
+	s.AgentIds = v
+	return s
+}
+
 type StartDataCollectionByAgentIdsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1596,6 +1914,12 @@ func (s StartDataCollectionByAgentIdsOutput) String() string {
 // GoString returns the string representation
 func (s StartDataCollectionByAgentIdsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAgentsConfigurationStatus sets the AgentsConfigurationStatus field's value.
+func (s *StartDataCollectionByAgentIdsOutput) SetAgentsConfigurationStatus(v []*AgentConfigurationStatus) *StartDataCollectionByAgentIdsOutput {
+	s.AgentsConfigurationStatus = v
+	return s
 }
 
 type StopDataCollectionByAgentIdsInput struct {
@@ -1630,6 +1954,12 @@ func (s *StopDataCollectionByAgentIdsInput) Validate() error {
 	return nil
 }
 
+// SetAgentIds sets the AgentIds field's value.
+func (s *StopDataCollectionByAgentIdsInput) SetAgentIds(v []*string) *StopDataCollectionByAgentIdsInput {
+	s.AgentIds = v
+	return s
+}
+
 type StopDataCollectionByAgentIdsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1647,6 +1977,12 @@ func (s StopDataCollectionByAgentIdsOutput) String() string {
 // GoString returns the string representation
 func (s StopDataCollectionByAgentIdsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAgentsConfigurationStatus sets the AgentsConfigurationStatus field's value.
+func (s *StopDataCollectionByAgentIdsOutput) SetAgentsConfigurationStatus(v []*AgentConfigurationStatus) *StopDataCollectionByAgentIdsOutput {
+	s.AgentsConfigurationStatus = v
+	return s
 }
 
 // Metadata that help you categorize IT assets.
@@ -1690,6 +2026,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // The name of a tag filter. Valid names are: tagKey, tagValue, configurationId.
 type TagFilter struct {
 	_ struct{} `type:"structure"`
@@ -1729,6 +2077,18 @@ func (s *TagFilter) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *TagFilter) SetName(v string) *TagFilter {
+	s.Name = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *TagFilter) SetValues(v []*string) *TagFilter {
+	s.Values = v
+	return s
 }
 
 const (

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -4125,6 +4125,66 @@ func (s Activity) GoString() string {
 	return s.String()
 }
 
+// SetActivityId sets the ActivityId field's value.
+func (s *Activity) SetActivityId(v string) *Activity {
+	s.ActivityId = &v
+	return s
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *Activity) SetAutoScalingGroupName(v string) *Activity {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetCause sets the Cause field's value.
+func (s *Activity) SetCause(v string) *Activity {
+	s.Cause = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Activity) SetDescription(v string) *Activity {
+	s.Description = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *Activity) SetDetails(v string) *Activity {
+	s.Details = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *Activity) SetEndTime(v time.Time) *Activity {
+	s.EndTime = &v
+	return s
+}
+
+// SetProgress sets the Progress field's value.
+func (s *Activity) SetProgress(v int64) *Activity {
+	s.Progress = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *Activity) SetStartTime(v time.Time) *Activity {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *Activity) SetStatusCode(v string) *Activity {
+	s.StatusCode = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *Activity) SetStatusMessage(v string) *Activity {
+	s.StatusMessage = &v
+	return s
+}
+
 // Describes a policy adjustment type.
 //
 // For more information, see Dynamic Scaling (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html)
@@ -4147,6 +4207,12 @@ func (s AdjustmentType) GoString() string {
 	return s.String()
 }
 
+// SetAdjustmentType sets the AdjustmentType field's value.
+func (s *AdjustmentType) SetAdjustmentType(v string) *AdjustmentType {
+	s.AdjustmentType = &v
+	return s
+}
+
 // Describes an alarm.
 type Alarm struct {
 	_ struct{} `type:"structure"`
@@ -4166,6 +4232,18 @@ func (s Alarm) String() string {
 // GoString returns the string representation
 func (s Alarm) GoString() string {
 	return s.String()
+}
+
+// SetAlarmARN sets the AlarmARN field's value.
+func (s *Alarm) SetAlarmARN(v string) *Alarm {
+	s.AlarmARN = &v
+	return s
+}
+
+// SetAlarmName sets the AlarmName field's value.
+func (s *Alarm) SetAlarmName(v string) *Alarm {
+	s.AlarmName = &v
+	return s
 }
 
 // Contains the parameters for AttachInstances.
@@ -4205,6 +4283,18 @@ func (s *AttachInstancesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *AttachInstancesInput) SetAutoScalingGroupName(v string) *AttachInstancesInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *AttachInstancesInput) SetInstanceIds(v []*string) *AttachInstancesInput {
+	s.InstanceIds = v
+	return s
 }
 
 type AttachInstancesOutput struct {
@@ -4265,6 +4355,18 @@ func (s *AttachLoadBalancerTargetGroupsInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *AttachLoadBalancerTargetGroupsInput) SetAutoScalingGroupName(v string) *AttachLoadBalancerTargetGroupsInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetTargetGroupARNs sets the TargetGroupARNs field's value.
+func (s *AttachLoadBalancerTargetGroupsInput) SetTargetGroupARNs(v []*string) *AttachLoadBalancerTargetGroupsInput {
+	s.TargetGroupARNs = v
+	return s
+}
+
 type AttachLoadBalancerTargetGroupsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4321,6 +4423,18 @@ func (s *AttachLoadBalancersInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *AttachLoadBalancersInput) SetAutoScalingGroupName(v string) *AttachLoadBalancersInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetLoadBalancerNames sets the LoadBalancerNames field's value.
+func (s *AttachLoadBalancersInput) SetLoadBalancerNames(v []*string) *AttachLoadBalancersInput {
+	s.LoadBalancerNames = v
+	return s
 }
 
 // Contains the output of AttachLoadBalancers.
@@ -4395,6 +4509,30 @@ func (s *BlockDeviceMapping) Validate() error {
 	return nil
 }
 
+// SetDeviceName sets the DeviceName field's value.
+func (s *BlockDeviceMapping) SetDeviceName(v string) *BlockDeviceMapping {
+	s.DeviceName = &v
+	return s
+}
+
+// SetEbs sets the Ebs field's value.
+func (s *BlockDeviceMapping) SetEbs(v *Ebs) *BlockDeviceMapping {
+	s.Ebs = v
+	return s
+}
+
+// SetNoDevice sets the NoDevice field's value.
+func (s *BlockDeviceMapping) SetNoDevice(v bool) *BlockDeviceMapping {
+	s.NoDevice = &v
+	return s
+}
+
+// SetVirtualName sets the VirtualName field's value.
+func (s *BlockDeviceMapping) SetVirtualName(v string) *BlockDeviceMapping {
+	s.VirtualName = &v
+	return s
+}
+
 // Contains the parameters for CompleteLifecycleAction.
 type CompleteLifecycleActionInput struct {
 	_ struct{} `type:"structure"`
@@ -4463,6 +4601,36 @@ func (s *CompleteLifecycleActionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *CompleteLifecycleActionInput) SetAutoScalingGroupName(v string) *CompleteLifecycleActionInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CompleteLifecycleActionInput) SetInstanceId(v string) *CompleteLifecycleActionInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLifecycleActionResult sets the LifecycleActionResult field's value.
+func (s *CompleteLifecycleActionInput) SetLifecycleActionResult(v string) *CompleteLifecycleActionInput {
+	s.LifecycleActionResult = &v
+	return s
+}
+
+// SetLifecycleActionToken sets the LifecycleActionToken field's value.
+func (s *CompleteLifecycleActionInput) SetLifecycleActionToken(v string) *CompleteLifecycleActionInput {
+	s.LifecycleActionToken = &v
+	return s
+}
+
+// SetLifecycleHookName sets the LifecycleHookName field's value.
+func (s *CompleteLifecycleActionInput) SetLifecycleHookName(v string) *CompleteLifecycleActionInput {
+	s.LifecycleHookName = &v
+	return s
 }
 
 // Contains the output of CompleteLifecycleAction.
@@ -4654,6 +4822,108 @@ func (s *CreateAutoScalingGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *CreateAutoScalingGroupInput) SetAutoScalingGroupName(v string) *CreateAutoScalingGroupInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *CreateAutoScalingGroupInput) SetAvailabilityZones(v []*string) *CreateAutoScalingGroupInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetDefaultCooldown sets the DefaultCooldown field's value.
+func (s *CreateAutoScalingGroupInput) SetDefaultCooldown(v int64) *CreateAutoScalingGroupInput {
+	s.DefaultCooldown = &v
+	return s
+}
+
+// SetDesiredCapacity sets the DesiredCapacity field's value.
+func (s *CreateAutoScalingGroupInput) SetDesiredCapacity(v int64) *CreateAutoScalingGroupInput {
+	s.DesiredCapacity = &v
+	return s
+}
+
+// SetHealthCheckGracePeriod sets the HealthCheckGracePeriod field's value.
+func (s *CreateAutoScalingGroupInput) SetHealthCheckGracePeriod(v int64) *CreateAutoScalingGroupInput {
+	s.HealthCheckGracePeriod = &v
+	return s
+}
+
+// SetHealthCheckType sets the HealthCheckType field's value.
+func (s *CreateAutoScalingGroupInput) SetHealthCheckType(v string) *CreateAutoScalingGroupInput {
+	s.HealthCheckType = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CreateAutoScalingGroupInput) SetInstanceId(v string) *CreateAutoScalingGroupInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
+func (s *CreateAutoScalingGroupInput) SetLaunchConfigurationName(v string) *CreateAutoScalingGroupInput {
+	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetLoadBalancerNames sets the LoadBalancerNames field's value.
+func (s *CreateAutoScalingGroupInput) SetLoadBalancerNames(v []*string) *CreateAutoScalingGroupInput {
+	s.LoadBalancerNames = v
+	return s
+}
+
+// SetMaxSize sets the MaxSize field's value.
+func (s *CreateAutoScalingGroupInput) SetMaxSize(v int64) *CreateAutoScalingGroupInput {
+	s.MaxSize = &v
+	return s
+}
+
+// SetMinSize sets the MinSize field's value.
+func (s *CreateAutoScalingGroupInput) SetMinSize(v int64) *CreateAutoScalingGroupInput {
+	s.MinSize = &v
+	return s
+}
+
+// SetNewInstancesProtectedFromScaleIn sets the NewInstancesProtectedFromScaleIn field's value.
+func (s *CreateAutoScalingGroupInput) SetNewInstancesProtectedFromScaleIn(v bool) *CreateAutoScalingGroupInput {
+	s.NewInstancesProtectedFromScaleIn = &v
+	return s
+}
+
+// SetPlacementGroup sets the PlacementGroup field's value.
+func (s *CreateAutoScalingGroupInput) SetPlacementGroup(v string) *CreateAutoScalingGroupInput {
+	s.PlacementGroup = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateAutoScalingGroupInput) SetTags(v []*Tag) *CreateAutoScalingGroupInput {
+	s.Tags = v
+	return s
+}
+
+// SetTargetGroupARNs sets the TargetGroupARNs field's value.
+func (s *CreateAutoScalingGroupInput) SetTargetGroupARNs(v []*string) *CreateAutoScalingGroupInput {
+	s.TargetGroupARNs = v
+	return s
+}
+
+// SetTerminationPolicies sets the TerminationPolicies field's value.
+func (s *CreateAutoScalingGroupInput) SetTerminationPolicies(v []*string) *CreateAutoScalingGroupInput {
+	s.TerminationPolicies = v
+	return s
+}
+
+// SetVPCZoneIdentifier sets the VPCZoneIdentifier field's value.
+func (s *CreateAutoScalingGroupInput) SetVPCZoneIdentifier(v string) *CreateAutoScalingGroupInput {
+	s.VPCZoneIdentifier = &v
+	return s
 }
 
 type CreateAutoScalingGroupOutput struct {
@@ -4876,6 +5146,114 @@ func (s *CreateLaunchConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetAssociatePublicIpAddress sets the AssociatePublicIpAddress field's value.
+func (s *CreateLaunchConfigurationInput) SetAssociatePublicIpAddress(v bool) *CreateLaunchConfigurationInput {
+	s.AssociatePublicIpAddress = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *CreateLaunchConfigurationInput) SetBlockDeviceMappings(v []*BlockDeviceMapping) *CreateLaunchConfigurationInput {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetClassicLinkVPCId sets the ClassicLinkVPCId field's value.
+func (s *CreateLaunchConfigurationInput) SetClassicLinkVPCId(v string) *CreateLaunchConfigurationInput {
+	s.ClassicLinkVPCId = &v
+	return s
+}
+
+// SetClassicLinkVPCSecurityGroups sets the ClassicLinkVPCSecurityGroups field's value.
+func (s *CreateLaunchConfigurationInput) SetClassicLinkVPCSecurityGroups(v []*string) *CreateLaunchConfigurationInput {
+	s.ClassicLinkVPCSecurityGroups = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *CreateLaunchConfigurationInput) SetEbsOptimized(v bool) *CreateLaunchConfigurationInput {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *CreateLaunchConfigurationInput) SetIamInstanceProfile(v string) *CreateLaunchConfigurationInput {
+	s.IamInstanceProfile = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *CreateLaunchConfigurationInput) SetImageId(v string) *CreateLaunchConfigurationInput {
+	s.ImageId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CreateLaunchConfigurationInput) SetInstanceId(v string) *CreateLaunchConfigurationInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceMonitoring sets the InstanceMonitoring field's value.
+func (s *CreateLaunchConfigurationInput) SetInstanceMonitoring(v *InstanceMonitoring) *CreateLaunchConfigurationInput {
+	s.InstanceMonitoring = v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *CreateLaunchConfigurationInput) SetInstanceType(v string) *CreateLaunchConfigurationInput {
+	s.InstanceType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *CreateLaunchConfigurationInput) SetKernelId(v string) *CreateLaunchConfigurationInput {
+	s.KernelId = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *CreateLaunchConfigurationInput) SetKeyName(v string) *CreateLaunchConfigurationInput {
+	s.KeyName = &v
+	return s
+}
+
+// SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
+func (s *CreateLaunchConfigurationInput) SetLaunchConfigurationName(v string) *CreateLaunchConfigurationInput {
+	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetPlacementTenancy sets the PlacementTenancy field's value.
+func (s *CreateLaunchConfigurationInput) SetPlacementTenancy(v string) *CreateLaunchConfigurationInput {
+	s.PlacementTenancy = &v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *CreateLaunchConfigurationInput) SetRamdiskId(v string) *CreateLaunchConfigurationInput {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *CreateLaunchConfigurationInput) SetSecurityGroups(v []*string) *CreateLaunchConfigurationInput {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSpotPrice sets the SpotPrice field's value.
+func (s *CreateLaunchConfigurationInput) SetSpotPrice(v string) *CreateLaunchConfigurationInput {
+	s.SpotPrice = &v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *CreateLaunchConfigurationInput) SetUserData(v string) *CreateLaunchConfigurationInput {
+	s.UserData = &v
+	return s
+}
+
 type CreateLaunchConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4933,6 +5311,12 @@ func (s *CreateOrUpdateTagsInput) Validate() error {
 	return nil
 }
 
+// SetTags sets the Tags field's value.
+func (s *CreateOrUpdateTagsInput) SetTags(v []*Tag) *CreateOrUpdateTagsInput {
+	s.Tags = v
+	return s
+}
+
 type CreateOrUpdateTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4988,6 +5372,18 @@ func (s *DeleteAutoScalingGroupInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DeleteAutoScalingGroupInput) SetAutoScalingGroupName(v string) *DeleteAutoScalingGroupInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetForceDelete sets the ForceDelete field's value.
+func (s *DeleteAutoScalingGroupInput) SetForceDelete(v bool) *DeleteAutoScalingGroupInput {
+	s.ForceDelete = &v
+	return s
+}
+
 type DeleteAutoScalingGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5036,6 +5432,12 @@ func (s *DeleteLaunchConfigurationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
+func (s *DeleteLaunchConfigurationInput) SetLaunchConfigurationName(v string) *DeleteLaunchConfigurationInput {
+	s.LaunchConfigurationName = &v
+	return s
 }
 
 type DeleteLaunchConfigurationOutput struct {
@@ -5097,6 +5499,18 @@ func (s *DeleteLifecycleHookInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DeleteLifecycleHookInput) SetAutoScalingGroupName(v string) *DeleteLifecycleHookInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetLifecycleHookName sets the LifecycleHookName field's value.
+func (s *DeleteLifecycleHookInput) SetLifecycleHookName(v string) *DeleteLifecycleHookInput {
+	s.LifecycleHookName = &v
+	return s
 }
 
 // Contains the output of DeleteLifecycleHook.
@@ -5162,6 +5576,18 @@ func (s *DeleteNotificationConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DeleteNotificationConfigurationInput) SetAutoScalingGroupName(v string) *DeleteNotificationConfigurationInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetTopicARN sets the TopicARN field's value.
+func (s *DeleteNotificationConfigurationInput) SetTopicARN(v string) *DeleteNotificationConfigurationInput {
+	s.TopicARN = &v
+	return s
+}
+
 type DeleteNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5216,6 +5642,18 @@ func (s *DeletePolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DeletePolicyInput) SetAutoScalingGroupName(v string) *DeletePolicyInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeletePolicyInput) SetPolicyName(v string) *DeletePolicyInput {
+	s.PolicyName = &v
+	return s
 }
 
 type DeletePolicyOutput struct {
@@ -5279,6 +5717,18 @@ func (s *DeleteScheduledActionInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DeleteScheduledActionInput) SetAutoScalingGroupName(v string) *DeleteScheduledActionInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetScheduledActionName sets the ScheduledActionName field's value.
+func (s *DeleteScheduledActionInput) SetScheduledActionName(v string) *DeleteScheduledActionInput {
+	s.ScheduledActionName = &v
+	return s
+}
+
 type DeleteScheduledActionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5334,6 +5784,12 @@ func (s *DeleteTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetTags sets the Tags field's value.
+func (s *DeleteTagsInput) SetTags(v []*Tag) *DeleteTagsInput {
+	s.Tags = v
+	return s
 }
 
 type DeleteTagsOutput struct {
@@ -5393,6 +5849,30 @@ func (s DescribeAccountLimitsOutput) GoString() string {
 	return s.String()
 }
 
+// SetMaxNumberOfAutoScalingGroups sets the MaxNumberOfAutoScalingGroups field's value.
+func (s *DescribeAccountLimitsOutput) SetMaxNumberOfAutoScalingGroups(v int64) *DescribeAccountLimitsOutput {
+	s.MaxNumberOfAutoScalingGroups = &v
+	return s
+}
+
+// SetMaxNumberOfLaunchConfigurations sets the MaxNumberOfLaunchConfigurations field's value.
+func (s *DescribeAccountLimitsOutput) SetMaxNumberOfLaunchConfigurations(v int64) *DescribeAccountLimitsOutput {
+	s.MaxNumberOfLaunchConfigurations = &v
+	return s
+}
+
+// SetNumberOfAutoScalingGroups sets the NumberOfAutoScalingGroups field's value.
+func (s *DescribeAccountLimitsOutput) SetNumberOfAutoScalingGroups(v int64) *DescribeAccountLimitsOutput {
+	s.NumberOfAutoScalingGroups = &v
+	return s
+}
+
+// SetNumberOfLaunchConfigurations sets the NumberOfLaunchConfigurations field's value.
+func (s *DescribeAccountLimitsOutput) SetNumberOfLaunchConfigurations(v int64) *DescribeAccountLimitsOutput {
+	s.NumberOfLaunchConfigurations = &v
+	return s
+}
+
 type DescribeAdjustmentTypesInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5425,6 +5905,12 @@ func (s DescribeAdjustmentTypesOutput) GoString() string {
 	return s.String()
 }
 
+// SetAdjustmentTypes sets the AdjustmentTypes field's value.
+func (s *DescribeAdjustmentTypesOutput) SetAdjustmentTypes(v []*AdjustmentType) *DescribeAdjustmentTypesOutput {
+	s.AdjustmentTypes = v
+	return s
+}
+
 // Contains the parameters for DescribeAutoScalingGroups.
 type DescribeAutoScalingGroupsInput struct {
 	_ struct{} `type:"structure"`
@@ -5451,6 +5937,24 @@ func (s DescribeAutoScalingGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetAutoScalingGroupNames sets the AutoScalingGroupNames field's value.
+func (s *DescribeAutoScalingGroupsInput) SetAutoScalingGroupNames(v []*string) *DescribeAutoScalingGroupsInput {
+	s.AutoScalingGroupNames = v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeAutoScalingGroupsInput) SetMaxRecords(v int64) *DescribeAutoScalingGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAutoScalingGroupsInput) SetNextToken(v string) *DescribeAutoScalingGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output for DescribeAutoScalingGroups.
 type DescribeAutoScalingGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5473,6 +5977,18 @@ func (s DescribeAutoScalingGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAutoScalingGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAutoScalingGroups sets the AutoScalingGroups field's value.
+func (s *DescribeAutoScalingGroupsOutput) SetAutoScalingGroups(v []*Group) *DescribeAutoScalingGroupsOutput {
+	s.AutoScalingGroups = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAutoScalingGroupsOutput) SetNextToken(v string) *DescribeAutoScalingGroupsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeAutoScalingInstances.
@@ -5502,6 +6018,24 @@ func (s DescribeAutoScalingInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *DescribeAutoScalingInstancesInput) SetInstanceIds(v []*string) *DescribeAutoScalingInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeAutoScalingInstancesInput) SetMaxRecords(v int64) *DescribeAutoScalingInstancesInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAutoScalingInstancesInput) SetNextToken(v string) *DescribeAutoScalingInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeAutoScalingInstances.
 type DescribeAutoScalingInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5522,6 +6056,18 @@ func (s DescribeAutoScalingInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAutoScalingInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAutoScalingInstances sets the AutoScalingInstances field's value.
+func (s *DescribeAutoScalingInstancesOutput) SetAutoScalingInstances(v []*InstanceDetails) *DescribeAutoScalingInstancesOutput {
+	s.AutoScalingInstances = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAutoScalingInstancesOutput) SetNextToken(v string) *DescribeAutoScalingInstancesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeAutoScalingNotificationTypesInput struct {
@@ -5556,6 +6102,12 @@ func (s DescribeAutoScalingNotificationTypesOutput) GoString() string {
 	return s.String()
 }
 
+// SetAutoScalingNotificationTypes sets the AutoScalingNotificationTypes field's value.
+func (s *DescribeAutoScalingNotificationTypesOutput) SetAutoScalingNotificationTypes(v []*string) *DescribeAutoScalingNotificationTypesOutput {
+	s.AutoScalingNotificationTypes = v
+	return s
+}
+
 // Contains the parameters for DescribeLaunchConfigurations.
 type DescribeLaunchConfigurationsInput struct {
 	_ struct{} `type:"structure"`
@@ -5582,6 +6134,24 @@ func (s DescribeLaunchConfigurationsInput) GoString() string {
 	return s.String()
 }
 
+// SetLaunchConfigurationNames sets the LaunchConfigurationNames field's value.
+func (s *DescribeLaunchConfigurationsInput) SetLaunchConfigurationNames(v []*string) *DescribeLaunchConfigurationsInput {
+	s.LaunchConfigurationNames = v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeLaunchConfigurationsInput) SetMaxRecords(v int64) *DescribeLaunchConfigurationsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLaunchConfigurationsInput) SetNextToken(v string) *DescribeLaunchConfigurationsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeLaunchConfigurations.
 type DescribeLaunchConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5604,6 +6174,18 @@ func (s DescribeLaunchConfigurationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLaunchConfigurationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetLaunchConfigurations sets the LaunchConfigurations field's value.
+func (s *DescribeLaunchConfigurationsOutput) SetLaunchConfigurations(v []*LaunchConfiguration) *DescribeLaunchConfigurationsOutput {
+	s.LaunchConfigurations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLaunchConfigurationsOutput) SetNextToken(v string) *DescribeLaunchConfigurationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeLifecycleHookTypesInput struct {
@@ -5636,6 +6218,12 @@ func (s DescribeLifecycleHookTypesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLifecycleHookTypesOutput) GoString() string {
 	return s.String()
+}
+
+// SetLifecycleHookTypes sets the LifecycleHookTypes field's value.
+func (s *DescribeLifecycleHookTypesOutput) SetLifecycleHookTypes(v []*string) *DescribeLifecycleHookTypesOutput {
+	s.LifecycleHookTypes = v
+	return s
 }
 
 // Contains the parameters for DescribeLifecycleHooks.
@@ -5678,6 +6266,18 @@ func (s *DescribeLifecycleHooksInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DescribeLifecycleHooksInput) SetAutoScalingGroupName(v string) *DescribeLifecycleHooksInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetLifecycleHookNames sets the LifecycleHookNames field's value.
+func (s *DescribeLifecycleHooksInput) SetLifecycleHookNames(v []*string) *DescribeLifecycleHooksInput {
+	s.LifecycleHookNames = v
+	return s
+}
+
 // Contains the output of DescribeLifecycleHooks.
 type DescribeLifecycleHooksOutput struct {
 	_ struct{} `type:"structure"`
@@ -5694,6 +6294,12 @@ func (s DescribeLifecycleHooksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLifecycleHooksOutput) GoString() string {
 	return s.String()
+}
+
+// SetLifecycleHooks sets the LifecycleHooks field's value.
+func (s *DescribeLifecycleHooksOutput) SetLifecycleHooks(v []*LifecycleHook) *DescribeLifecycleHooksOutput {
+	s.LifecycleHooks = v
+	return s
 }
 
 // Contains the parameters for DescribeLoadBalancerTargetGroups.
@@ -5739,6 +6345,24 @@ func (s *DescribeLoadBalancerTargetGroupsInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DescribeLoadBalancerTargetGroupsInput) SetAutoScalingGroupName(v string) *DescribeLoadBalancerTargetGroupsInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeLoadBalancerTargetGroupsInput) SetMaxRecords(v int64) *DescribeLoadBalancerTargetGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLoadBalancerTargetGroupsInput) SetNextToken(v string) *DescribeLoadBalancerTargetGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeLoadBalancerTargetGroups.
 type DescribeLoadBalancerTargetGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5759,6 +6383,18 @@ func (s DescribeLoadBalancerTargetGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancerTargetGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancerTargetGroups sets the LoadBalancerTargetGroups field's value.
+func (s *DescribeLoadBalancerTargetGroupsOutput) SetLoadBalancerTargetGroups(v []*LoadBalancerTargetGroupState) *DescribeLoadBalancerTargetGroupsOutput {
+	s.LoadBalancerTargetGroups = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLoadBalancerTargetGroupsOutput) SetNextToken(v string) *DescribeLoadBalancerTargetGroupsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeLoadBalancers.
@@ -5804,6 +6440,24 @@ func (s *DescribeLoadBalancersInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DescribeLoadBalancersInput) SetAutoScalingGroupName(v string) *DescribeLoadBalancersInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeLoadBalancersInput) SetMaxRecords(v int64) *DescribeLoadBalancersInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLoadBalancersInput) SetNextToken(v string) *DescribeLoadBalancersInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeLoadBalancers.
 type DescribeLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
@@ -5824,6 +6478,18 @@ func (s DescribeLoadBalancersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancersOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancers sets the LoadBalancers field's value.
+func (s *DescribeLoadBalancersOutput) SetLoadBalancers(v []*LoadBalancerState) *DescribeLoadBalancersOutput {
+	s.LoadBalancers = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLoadBalancersOutput) SetNextToken(v string) *DescribeLoadBalancersOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeMetricCollectionTypesInput struct {
@@ -5861,6 +6527,18 @@ func (s DescribeMetricCollectionTypesOutput) GoString() string {
 	return s.String()
 }
 
+// SetGranularities sets the Granularities field's value.
+func (s *DescribeMetricCollectionTypesOutput) SetGranularities(v []*MetricGranularityType) *DescribeMetricCollectionTypesOutput {
+	s.Granularities = v
+	return s
+}
+
+// SetMetrics sets the Metrics field's value.
+func (s *DescribeMetricCollectionTypesOutput) SetMetrics(v []*MetricCollectionType) *DescribeMetricCollectionTypesOutput {
+	s.Metrics = v
+	return s
+}
+
 // Contains the parameters for DescribeNotificationConfigurations.
 type DescribeNotificationConfigurationsInput struct {
 	_ struct{} `type:"structure"`
@@ -5886,6 +6564,24 @@ func (s DescribeNotificationConfigurationsInput) GoString() string {
 	return s.String()
 }
 
+// SetAutoScalingGroupNames sets the AutoScalingGroupNames field's value.
+func (s *DescribeNotificationConfigurationsInput) SetAutoScalingGroupNames(v []*string) *DescribeNotificationConfigurationsInput {
+	s.AutoScalingGroupNames = v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeNotificationConfigurationsInput) SetMaxRecords(v int64) *DescribeNotificationConfigurationsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeNotificationConfigurationsInput) SetNextToken(v string) *DescribeNotificationConfigurationsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output from DescribeNotificationConfigurations.
 type DescribeNotificationConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5908,6 +6604,18 @@ func (s DescribeNotificationConfigurationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeNotificationConfigurationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeNotificationConfigurationsOutput) SetNextToken(v string) *DescribeNotificationConfigurationsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetNotificationConfigurations sets the NotificationConfigurations field's value.
+func (s *DescribeNotificationConfigurationsOutput) SetNotificationConfigurations(v []*NotificationConfiguration) *DescribeNotificationConfigurationsOutput {
+	s.NotificationConfigurations = v
+	return s
 }
 
 // Contains the parameters for DescribePolicies.
@@ -5957,6 +6665,36 @@ func (s *DescribePoliciesInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DescribePoliciesInput) SetAutoScalingGroupName(v string) *DescribePoliciesInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribePoliciesInput) SetMaxRecords(v int64) *DescribePoliciesInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribePoliciesInput) SetNextToken(v string) *DescribePoliciesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *DescribePoliciesInput) SetPolicyNames(v []*string) *DescribePoliciesInput {
+	s.PolicyNames = v
+	return s
+}
+
+// SetPolicyTypes sets the PolicyTypes field's value.
+func (s *DescribePoliciesInput) SetPolicyTypes(v []*string) *DescribePoliciesInput {
+	s.PolicyTypes = v
+	return s
+}
+
 // Contains the output of DescribePolicies.
 type DescribePoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5977,6 +6715,18 @@ func (s DescribePoliciesOutput) String() string {
 // GoString returns the string representation
 func (s DescribePoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribePoliciesOutput) SetNextToken(v string) *DescribePoliciesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScalingPolicies sets the ScalingPolicies field's value.
+func (s *DescribePoliciesOutput) SetScalingPolicies(v []*ScalingPolicy) *DescribePoliciesOutput {
+	s.ScalingPolicies = v
+	return s
 }
 
 // Contains the parameters for DescribeScalingActivities.
@@ -6024,6 +6774,30 @@ func (s *DescribeScalingActivitiesInput) Validate() error {
 	return nil
 }
 
+// SetActivityIds sets the ActivityIds field's value.
+func (s *DescribeScalingActivitiesInput) SetActivityIds(v []*string) *DescribeScalingActivitiesInput {
+	s.ActivityIds = v
+	return s
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DescribeScalingActivitiesInput) SetAutoScalingGroupName(v string) *DescribeScalingActivitiesInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeScalingActivitiesInput) SetMaxRecords(v int64) *DescribeScalingActivitiesInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalingActivitiesInput) SetNextToken(v string) *DescribeScalingActivitiesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeScalingActivities.
 type DescribeScalingActivitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6047,6 +6821,18 @@ func (s DescribeScalingActivitiesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingActivitiesOutput) GoString() string {
 	return s.String()
+}
+
+// SetActivities sets the Activities field's value.
+func (s *DescribeScalingActivitiesOutput) SetActivities(v []*Activity) *DescribeScalingActivitiesOutput {
+	s.Activities = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalingActivitiesOutput) SetNextToken(v string) *DescribeScalingActivitiesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeScalingProcessTypesInput struct {
@@ -6079,6 +6865,12 @@ func (s DescribeScalingProcessTypesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingProcessTypesOutput) GoString() string {
 	return s.String()
+}
+
+// SetProcesses sets the Processes field's value.
+func (s *DescribeScalingProcessTypesOutput) SetProcesses(v []*ProcessType) *DescribeScalingProcessTypesOutput {
+	s.Processes = v
+	return s
 }
 
 // Contains the parameters for DescribeScheduledActions.
@@ -6136,6 +6928,42 @@ func (s *DescribeScheduledActionsInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DescribeScheduledActionsInput) SetAutoScalingGroupName(v string) *DescribeScheduledActionsInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeScheduledActionsInput) SetEndTime(v time.Time) *DescribeScheduledActionsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeScheduledActionsInput) SetMaxRecords(v int64) *DescribeScheduledActionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScheduledActionsInput) SetNextToken(v string) *DescribeScheduledActionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScheduledActionNames sets the ScheduledActionNames field's value.
+func (s *DescribeScheduledActionsInput) SetScheduledActionNames(v []*string) *DescribeScheduledActionsInput {
+	s.ScheduledActionNames = v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeScheduledActionsInput) SetStartTime(v time.Time) *DescribeScheduledActionsInput {
+	s.StartTime = &v
+	return s
+}
+
 // Contains the output of DescribeScheduledActions.
 type DescribeScheduledActionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6156,6 +6984,18 @@ func (s DescribeScheduledActionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScheduledActionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScheduledActionsOutput) SetNextToken(v string) *DescribeScheduledActionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScheduledUpdateGroupActions sets the ScheduledUpdateGroupActions field's value.
+func (s *DescribeScheduledActionsOutput) SetScheduledUpdateGroupActions(v []*ScheduledUpdateGroupAction) *DescribeScheduledActionsOutput {
+	s.ScheduledUpdateGroupActions = v
+	return s
 }
 
 // Contains the parameters for DescribeTags.
@@ -6183,6 +7023,24 @@ func (s DescribeTagsInput) GoString() string {
 	return s.String()
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeTagsInput) SetFilters(v []*Filter) *DescribeTagsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeTagsInput) SetMaxRecords(v int64) *DescribeTagsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTagsInput) SetNextToken(v string) *DescribeTagsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeTags.
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6203,6 +7061,18 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTagsOutput) SetNextToken(v string) *DescribeTagsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DescribeTagsOutput) SetTags(v []*TagDescription) *DescribeTagsOutput {
+	s.Tags = v
+	return s
 }
 
 type DescribeTerminationPolicyTypesInput struct {
@@ -6236,6 +7106,12 @@ func (s DescribeTerminationPolicyTypesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTerminationPolicyTypesOutput) GoString() string {
 	return s.String()
+}
+
+// SetTerminationPolicyTypes sets the TerminationPolicyTypes field's value.
+func (s *DescribeTerminationPolicyTypesOutput) SetTerminationPolicyTypes(v []*string) *DescribeTerminationPolicyTypesOutput {
+	s.TerminationPolicyTypes = v
+	return s
 }
 
 // Contains the parameters for DetachInstances.
@@ -6286,6 +7162,24 @@ func (s *DetachInstancesInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DetachInstancesInput) SetAutoScalingGroupName(v string) *DetachInstancesInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *DetachInstancesInput) SetInstanceIds(v []*string) *DetachInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetShouldDecrementDesiredCapacity sets the ShouldDecrementDesiredCapacity field's value.
+func (s *DetachInstancesInput) SetShouldDecrementDesiredCapacity(v bool) *DetachInstancesInput {
+	s.ShouldDecrementDesiredCapacity = &v
+	return s
+}
+
 // Contains the output of DetachInstances.
 type DetachInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6302,6 +7196,12 @@ func (s DetachInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DetachInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetActivities sets the Activities field's value.
+func (s *DetachInstancesOutput) SetActivities(v []*Activity) *DetachInstancesOutput {
+	s.Activities = v
+	return s
 }
 
 type DetachLoadBalancerTargetGroupsInput struct {
@@ -6345,6 +7245,18 @@ func (s *DetachLoadBalancerTargetGroupsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DetachLoadBalancerTargetGroupsInput) SetAutoScalingGroupName(v string) *DetachLoadBalancerTargetGroupsInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetTargetGroupARNs sets the TargetGroupARNs field's value.
+func (s *DetachLoadBalancerTargetGroupsInput) SetTargetGroupARNs(v []*string) *DetachLoadBalancerTargetGroupsInput {
+	s.TargetGroupARNs = v
+	return s
 }
 
 type DetachLoadBalancerTargetGroupsOutput struct {
@@ -6403,6 +7315,18 @@ func (s *DetachLoadBalancersInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DetachLoadBalancersInput) SetAutoScalingGroupName(v string) *DetachLoadBalancersInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetLoadBalancerNames sets the LoadBalancerNames field's value.
+func (s *DetachLoadBalancersInput) SetLoadBalancerNames(v []*string) *DetachLoadBalancersInput {
+	s.LoadBalancerNames = v
+	return s
 }
 
 // Contains the output for DetachLoadBalancers.
@@ -6474,6 +7398,18 @@ func (s *DisableMetricsCollectionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *DisableMetricsCollectionInput) SetAutoScalingGroupName(v string) *DisableMetricsCollectionInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetMetrics sets the Metrics field's value.
+func (s *DisableMetricsCollectionInput) SetMetrics(v []*string) *DisableMetricsCollectionInput {
+	s.Metrics = v
+	return s
 }
 
 type DisableMetricsCollectionOutput struct {
@@ -6566,6 +7502,42 @@ func (s *Ebs) Validate() error {
 	return nil
 }
 
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *Ebs) SetDeleteOnTermination(v bool) *Ebs {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *Ebs) SetEncrypted(v bool) *Ebs {
+	s.Encrypted = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *Ebs) SetIops(v int64) *Ebs {
+	s.Iops = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *Ebs) SetSnapshotId(v string) *Ebs {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetVolumeSize sets the VolumeSize field's value.
+func (s *Ebs) SetVolumeSize(v int64) *Ebs {
+	s.VolumeSize = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *Ebs) SetVolumeType(v string) *Ebs {
+	s.VolumeType = &v
+	return s
+}
+
 // Contains the parameters for EnableMetricsCollection.
 type EnableMetricsCollectionInput struct {
 	_ struct{} `type:"structure"`
@@ -6634,6 +7606,24 @@ func (s *EnableMetricsCollectionInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *EnableMetricsCollectionInput) SetAutoScalingGroupName(v string) *EnableMetricsCollectionInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetGranularity sets the Granularity field's value.
+func (s *EnableMetricsCollectionInput) SetGranularity(v string) *EnableMetricsCollectionInput {
+	s.Granularity = &v
+	return s
+}
+
+// SetMetrics sets the Metrics field's value.
+func (s *EnableMetricsCollectionInput) SetMetrics(v []*string) *EnableMetricsCollectionInput {
+	s.Metrics = v
+	return s
+}
+
 type EnableMetricsCollectionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6683,6 +7673,18 @@ func (s EnabledMetric) String() string {
 // GoString returns the string representation
 func (s EnabledMetric) GoString() string {
 	return s.String()
+}
+
+// SetGranularity sets the Granularity field's value.
+func (s *EnabledMetric) SetGranularity(v string) *EnabledMetric {
+	s.Granularity = &v
+	return s
+}
+
+// SetMetric sets the Metric field's value.
+func (s *EnabledMetric) SetMetric(v string) *EnabledMetric {
+	s.Metric = &v
+	return s
 }
 
 // Contains the parameters for EnteStandby.
@@ -6736,6 +7738,24 @@ func (s *EnterStandbyInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *EnterStandbyInput) SetAutoScalingGroupName(v string) *EnterStandbyInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *EnterStandbyInput) SetInstanceIds(v []*string) *EnterStandbyInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetShouldDecrementDesiredCapacity sets the ShouldDecrementDesiredCapacity field's value.
+func (s *EnterStandbyInput) SetShouldDecrementDesiredCapacity(v bool) *EnterStandbyInput {
+	s.ShouldDecrementDesiredCapacity = &v
+	return s
+}
+
 // Contains the output of EnterStandby.
 type EnterStandbyOutput struct {
 	_ struct{} `type:"structure"`
@@ -6752,6 +7772,12 @@ func (s EnterStandbyOutput) String() string {
 // GoString returns the string representation
 func (s EnterStandbyOutput) GoString() string {
 	return s.String()
+}
+
+// SetActivities sets the Activities field's value.
+func (s *EnterStandbyOutput) SetActivities(v []*Activity) *EnterStandbyOutput {
+	s.Activities = v
+	return s
 }
 
 // Contains the parameters for ExecutePolicy.
@@ -6825,6 +7851,36 @@ func (s *ExecutePolicyInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *ExecutePolicyInput) SetAutoScalingGroupName(v string) *ExecutePolicyInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetBreachThreshold sets the BreachThreshold field's value.
+func (s *ExecutePolicyInput) SetBreachThreshold(v float64) *ExecutePolicyInput {
+	s.BreachThreshold = &v
+	return s
+}
+
+// SetHonorCooldown sets the HonorCooldown field's value.
+func (s *ExecutePolicyInput) SetHonorCooldown(v bool) *ExecutePolicyInput {
+	s.HonorCooldown = &v
+	return s
+}
+
+// SetMetricValue sets the MetricValue field's value.
+func (s *ExecutePolicyInput) SetMetricValue(v float64) *ExecutePolicyInput {
+	s.MetricValue = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *ExecutePolicyInput) SetPolicyName(v string) *ExecutePolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 type ExecutePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6878,6 +7934,18 @@ func (s *ExitStandbyInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *ExitStandbyInput) SetAutoScalingGroupName(v string) *ExitStandbyInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *ExitStandbyInput) SetInstanceIds(v []*string) *ExitStandbyInput {
+	s.InstanceIds = v
+	return s
+}
+
 // Contains the parameters for ExitStandby.
 type ExitStandbyOutput struct {
 	_ struct{} `type:"structure"`
@@ -6894,6 +7962,12 @@ func (s ExitStandbyOutput) String() string {
 // GoString returns the string representation
 func (s ExitStandbyOutput) GoString() string {
 	return s.String()
+}
+
+// SetActivities sets the Activities field's value.
+func (s *ExitStandbyOutput) SetActivities(v []*Activity) *ExitStandbyOutput {
+	s.Activities = v
+	return s
 }
 
 // Describes a filter.
@@ -6916,6 +7990,18 @@ func (s Filter) String() string {
 // GoString returns the string representation
 func (s Filter) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *Filter) SetName(v string) *Filter {
+	s.Name = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *Filter) SetValues(v []*string) *Filter {
+	s.Values = v
+	return s
 }
 
 // Describes an Auto Scaling group.
@@ -7023,6 +8109,138 @@ func (s Group) GoString() string {
 	return s.String()
 }
 
+// SetAutoScalingGroupARN sets the AutoScalingGroupARN field's value.
+func (s *Group) SetAutoScalingGroupARN(v string) *Group {
+	s.AutoScalingGroupARN = &v
+	return s
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *Group) SetAutoScalingGroupName(v string) *Group {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *Group) SetAvailabilityZones(v []*string) *Group {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *Group) SetCreatedTime(v time.Time) *Group {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetDefaultCooldown sets the DefaultCooldown field's value.
+func (s *Group) SetDefaultCooldown(v int64) *Group {
+	s.DefaultCooldown = &v
+	return s
+}
+
+// SetDesiredCapacity sets the DesiredCapacity field's value.
+func (s *Group) SetDesiredCapacity(v int64) *Group {
+	s.DesiredCapacity = &v
+	return s
+}
+
+// SetEnabledMetrics sets the EnabledMetrics field's value.
+func (s *Group) SetEnabledMetrics(v []*EnabledMetric) *Group {
+	s.EnabledMetrics = v
+	return s
+}
+
+// SetHealthCheckGracePeriod sets the HealthCheckGracePeriod field's value.
+func (s *Group) SetHealthCheckGracePeriod(v int64) *Group {
+	s.HealthCheckGracePeriod = &v
+	return s
+}
+
+// SetHealthCheckType sets the HealthCheckType field's value.
+func (s *Group) SetHealthCheckType(v string) *Group {
+	s.HealthCheckType = &v
+	return s
+}
+
+// SetInstances sets the Instances field's value.
+func (s *Group) SetInstances(v []*Instance) *Group {
+	s.Instances = v
+	return s
+}
+
+// SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
+func (s *Group) SetLaunchConfigurationName(v string) *Group {
+	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetLoadBalancerNames sets the LoadBalancerNames field's value.
+func (s *Group) SetLoadBalancerNames(v []*string) *Group {
+	s.LoadBalancerNames = v
+	return s
+}
+
+// SetMaxSize sets the MaxSize field's value.
+func (s *Group) SetMaxSize(v int64) *Group {
+	s.MaxSize = &v
+	return s
+}
+
+// SetMinSize sets the MinSize field's value.
+func (s *Group) SetMinSize(v int64) *Group {
+	s.MinSize = &v
+	return s
+}
+
+// SetNewInstancesProtectedFromScaleIn sets the NewInstancesProtectedFromScaleIn field's value.
+func (s *Group) SetNewInstancesProtectedFromScaleIn(v bool) *Group {
+	s.NewInstancesProtectedFromScaleIn = &v
+	return s
+}
+
+// SetPlacementGroup sets the PlacementGroup field's value.
+func (s *Group) SetPlacementGroup(v string) *Group {
+	s.PlacementGroup = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Group) SetStatus(v string) *Group {
+	s.Status = &v
+	return s
+}
+
+// SetSuspendedProcesses sets the SuspendedProcesses field's value.
+func (s *Group) SetSuspendedProcesses(v []*SuspendedProcess) *Group {
+	s.SuspendedProcesses = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Group) SetTags(v []*TagDescription) *Group {
+	s.Tags = v
+	return s
+}
+
+// SetTargetGroupARNs sets the TargetGroupARNs field's value.
+func (s *Group) SetTargetGroupARNs(v []*string) *Group {
+	s.TargetGroupARNs = v
+	return s
+}
+
+// SetTerminationPolicies sets the TerminationPolicies field's value.
+func (s *Group) SetTerminationPolicies(v []*string) *Group {
+	s.TerminationPolicies = v
+	return s
+}
+
+// SetVPCZoneIdentifier sets the VPCZoneIdentifier field's value.
+func (s *Group) SetVPCZoneIdentifier(v string) *Group {
+	s.VPCZoneIdentifier = &v
+	return s
+}
+
 // Describes an EC2 instance.
 type Instance struct {
 	_ struct{} `type:"structure"`
@@ -7070,6 +8288,42 @@ func (s Instance) String() string {
 // GoString returns the string representation
 func (s Instance) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Instance) SetAvailabilityZone(v string) *Instance {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetHealthStatus sets the HealthStatus field's value.
+func (s *Instance) SetHealthStatus(v string) *Instance {
+	s.HealthStatus = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Instance) SetInstanceId(v string) *Instance {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
+func (s *Instance) SetLaunchConfigurationName(v string) *Instance {
+	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetLifecycleState sets the LifecycleState field's value.
+func (s *Instance) SetLifecycleState(v string) *Instance {
+	s.LifecycleState = &v
+	return s
+}
+
+// SetProtectedFromScaleIn sets the ProtectedFromScaleIn field's value.
+func (s *Instance) SetProtectedFromScaleIn(v bool) *Instance {
+	s.ProtectedFromScaleIn = &v
+	return s
 }
 
 // Describes an EC2 instance associated with an Auto Scaling group.
@@ -7127,6 +8381,48 @@ func (s InstanceDetails) GoString() string {
 	return s.String()
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *InstanceDetails) SetAutoScalingGroupName(v string) *InstanceDetails {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *InstanceDetails) SetAvailabilityZone(v string) *InstanceDetails {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetHealthStatus sets the HealthStatus field's value.
+func (s *InstanceDetails) SetHealthStatus(v string) *InstanceDetails {
+	s.HealthStatus = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceDetails) SetInstanceId(v string) *InstanceDetails {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
+func (s *InstanceDetails) SetLaunchConfigurationName(v string) *InstanceDetails {
+	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetLifecycleState sets the LifecycleState field's value.
+func (s *InstanceDetails) SetLifecycleState(v string) *InstanceDetails {
+	s.LifecycleState = &v
+	return s
+}
+
+// SetProtectedFromScaleIn sets the ProtectedFromScaleIn field's value.
+func (s *InstanceDetails) SetProtectedFromScaleIn(v bool) *InstanceDetails {
+	s.ProtectedFromScaleIn = &v
+	return s
+}
+
 // Describes whether instance monitoring is enabled.
 type InstanceMonitoring struct {
 	_ struct{} `type:"structure"`
@@ -7143,6 +8439,12 @@ func (s InstanceMonitoring) String() string {
 // GoString returns the string representation
 func (s InstanceMonitoring) GoString() string {
 	return s.String()
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *InstanceMonitoring) SetEnabled(v bool) *InstanceMonitoring {
+	s.Enabled = &v
+	return s
 }
 
 // Describes a launch configuration.
@@ -7235,6 +8537,120 @@ func (s LaunchConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetAssociatePublicIpAddress sets the AssociatePublicIpAddress field's value.
+func (s *LaunchConfiguration) SetAssociatePublicIpAddress(v bool) *LaunchConfiguration {
+	s.AssociatePublicIpAddress = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *LaunchConfiguration) SetBlockDeviceMappings(v []*BlockDeviceMapping) *LaunchConfiguration {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetClassicLinkVPCId sets the ClassicLinkVPCId field's value.
+func (s *LaunchConfiguration) SetClassicLinkVPCId(v string) *LaunchConfiguration {
+	s.ClassicLinkVPCId = &v
+	return s
+}
+
+// SetClassicLinkVPCSecurityGroups sets the ClassicLinkVPCSecurityGroups field's value.
+func (s *LaunchConfiguration) SetClassicLinkVPCSecurityGroups(v []*string) *LaunchConfiguration {
+	s.ClassicLinkVPCSecurityGroups = v
+	return s
+}
+
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *LaunchConfiguration) SetCreatedTime(v time.Time) *LaunchConfiguration {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *LaunchConfiguration) SetEbsOptimized(v bool) *LaunchConfiguration {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *LaunchConfiguration) SetIamInstanceProfile(v string) *LaunchConfiguration {
+	s.IamInstanceProfile = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *LaunchConfiguration) SetImageId(v string) *LaunchConfiguration {
+	s.ImageId = &v
+	return s
+}
+
+// SetInstanceMonitoring sets the InstanceMonitoring field's value.
+func (s *LaunchConfiguration) SetInstanceMonitoring(v *InstanceMonitoring) *LaunchConfiguration {
+	s.InstanceMonitoring = v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *LaunchConfiguration) SetInstanceType(v string) *LaunchConfiguration {
+	s.InstanceType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *LaunchConfiguration) SetKernelId(v string) *LaunchConfiguration {
+	s.KernelId = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *LaunchConfiguration) SetKeyName(v string) *LaunchConfiguration {
+	s.KeyName = &v
+	return s
+}
+
+// SetLaunchConfigurationARN sets the LaunchConfigurationARN field's value.
+func (s *LaunchConfiguration) SetLaunchConfigurationARN(v string) *LaunchConfiguration {
+	s.LaunchConfigurationARN = &v
+	return s
+}
+
+// SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
+func (s *LaunchConfiguration) SetLaunchConfigurationName(v string) *LaunchConfiguration {
+	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetPlacementTenancy sets the PlacementTenancy field's value.
+func (s *LaunchConfiguration) SetPlacementTenancy(v string) *LaunchConfiguration {
+	s.PlacementTenancy = &v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *LaunchConfiguration) SetRamdiskId(v string) *LaunchConfiguration {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *LaunchConfiguration) SetSecurityGroups(v []*string) *LaunchConfiguration {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSpotPrice sets the SpotPrice field's value.
+func (s *LaunchConfiguration) SetSpotPrice(v string) *LaunchConfiguration {
+	s.SpotPrice = &v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *LaunchConfiguration) SetUserData(v string) *LaunchConfiguration {
+	s.UserData = &v
+	return s
+}
+
 // Describes a lifecycle hook, which tells Auto Scaling that you want to perform
 // an action when an instance launches or terminates. When you have a lifecycle
 // hook in place, the Auto Scaling group will either:
@@ -7313,6 +8729,60 @@ func (s LifecycleHook) GoString() string {
 	return s.String()
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *LifecycleHook) SetAutoScalingGroupName(v string) *LifecycleHook {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetDefaultResult sets the DefaultResult field's value.
+func (s *LifecycleHook) SetDefaultResult(v string) *LifecycleHook {
+	s.DefaultResult = &v
+	return s
+}
+
+// SetGlobalTimeout sets the GlobalTimeout field's value.
+func (s *LifecycleHook) SetGlobalTimeout(v int64) *LifecycleHook {
+	s.GlobalTimeout = &v
+	return s
+}
+
+// SetHeartbeatTimeout sets the HeartbeatTimeout field's value.
+func (s *LifecycleHook) SetHeartbeatTimeout(v int64) *LifecycleHook {
+	s.HeartbeatTimeout = &v
+	return s
+}
+
+// SetLifecycleHookName sets the LifecycleHookName field's value.
+func (s *LifecycleHook) SetLifecycleHookName(v string) *LifecycleHook {
+	s.LifecycleHookName = &v
+	return s
+}
+
+// SetLifecycleTransition sets the LifecycleTransition field's value.
+func (s *LifecycleHook) SetLifecycleTransition(v string) *LifecycleHook {
+	s.LifecycleTransition = &v
+	return s
+}
+
+// SetNotificationMetadata sets the NotificationMetadata field's value.
+func (s *LifecycleHook) SetNotificationMetadata(v string) *LifecycleHook {
+	s.NotificationMetadata = &v
+	return s
+}
+
+// SetNotificationTargetARN sets the NotificationTargetARN field's value.
+func (s *LifecycleHook) SetNotificationTargetARN(v string) *LifecycleHook {
+	s.NotificationTargetARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *LifecycleHook) SetRoleARN(v string) *LifecycleHook {
+	s.RoleARN = &v
+	return s
+}
+
 // Describes the state of a Classic load balancer.
 //
 // If you specify a load balancer when creating the Auto Scaling group, the
@@ -7359,6 +8829,18 @@ func (s LoadBalancerState) GoString() string {
 	return s.String()
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *LoadBalancerState) SetLoadBalancerName(v string) *LoadBalancerState {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LoadBalancerState) SetState(v string) *LoadBalancerState {
+	s.State = &v
+	return s
+}
+
 // Describes the state of a target group.
 //
 // If you attach a target group to an existing Auto Scaling group, the initial
@@ -7402,6 +8884,18 @@ func (s LoadBalancerTargetGroupState) GoString() string {
 	return s.String()
 }
 
+// SetLoadBalancerTargetGroupARN sets the LoadBalancerTargetGroupARN field's value.
+func (s *LoadBalancerTargetGroupState) SetLoadBalancerTargetGroupARN(v string) *LoadBalancerTargetGroupState {
+	s.LoadBalancerTargetGroupARN = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LoadBalancerTargetGroupState) SetState(v string) *LoadBalancerTargetGroupState {
+	s.State = &v
+	return s
+}
+
 // Describes a metric.
 type MetricCollectionType struct {
 	_ struct{} `type:"structure"`
@@ -7436,6 +8930,12 @@ func (s MetricCollectionType) GoString() string {
 	return s.String()
 }
 
+// SetMetric sets the Metric field's value.
+func (s *MetricCollectionType) SetMetric(v string) *MetricCollectionType {
+	s.Metric = &v
+	return s
+}
+
 // Describes a granularity of a metric.
 type MetricGranularityType struct {
 	_ struct{} `type:"structure"`
@@ -7452,6 +8952,12 @@ func (s MetricGranularityType) String() string {
 // GoString returns the string representation
 func (s MetricGranularityType) GoString() string {
 	return s.String()
+}
+
+// SetGranularity sets the Granularity field's value.
+func (s *MetricGranularityType) SetGranularity(v string) *MetricGranularityType {
+	s.Granularity = &v
+	return s
 }
 
 // Describes a notification.
@@ -7487,6 +8993,24 @@ func (s NotificationConfiguration) String() string {
 // GoString returns the string representation
 func (s NotificationConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *NotificationConfiguration) SetAutoScalingGroupName(v string) *NotificationConfiguration {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetNotificationType sets the NotificationType field's value.
+func (s *NotificationConfiguration) SetNotificationType(v string) *NotificationConfiguration {
+	s.NotificationType = &v
+	return s
+}
+
+// SetTopicARN sets the TopicARN field's value.
+func (s *NotificationConfiguration) SetTopicARN(v string) *NotificationConfiguration {
+	s.TopicARN = &v
+	return s
 }
 
 // Describes a process type.
@@ -7526,6 +9050,12 @@ func (s ProcessType) String() string {
 // GoString returns the string representation
 func (s ProcessType) GoString() string {
 	return s.String()
+}
+
+// SetProcessName sets the ProcessName field's value.
+func (s *ProcessType) SetProcessName(v string) *ProcessType {
+	s.ProcessName = &v
+	return s
 }
 
 // Contains the parameters for PutLifecycleHook.
@@ -7625,6 +9155,54 @@ func (s *PutLifecycleHookInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *PutLifecycleHookInput) SetAutoScalingGroupName(v string) *PutLifecycleHookInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetDefaultResult sets the DefaultResult field's value.
+func (s *PutLifecycleHookInput) SetDefaultResult(v string) *PutLifecycleHookInput {
+	s.DefaultResult = &v
+	return s
+}
+
+// SetHeartbeatTimeout sets the HeartbeatTimeout field's value.
+func (s *PutLifecycleHookInput) SetHeartbeatTimeout(v int64) *PutLifecycleHookInput {
+	s.HeartbeatTimeout = &v
+	return s
+}
+
+// SetLifecycleHookName sets the LifecycleHookName field's value.
+func (s *PutLifecycleHookInput) SetLifecycleHookName(v string) *PutLifecycleHookInput {
+	s.LifecycleHookName = &v
+	return s
+}
+
+// SetLifecycleTransition sets the LifecycleTransition field's value.
+func (s *PutLifecycleHookInput) SetLifecycleTransition(v string) *PutLifecycleHookInput {
+	s.LifecycleTransition = &v
+	return s
+}
+
+// SetNotificationMetadata sets the NotificationMetadata field's value.
+func (s *PutLifecycleHookInput) SetNotificationMetadata(v string) *PutLifecycleHookInput {
+	s.NotificationMetadata = &v
+	return s
+}
+
+// SetNotificationTargetARN sets the NotificationTargetARN field's value.
+func (s *PutLifecycleHookInput) SetNotificationTargetARN(v string) *PutLifecycleHookInput {
+	s.NotificationTargetARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *PutLifecycleHookInput) SetRoleARN(v string) *PutLifecycleHookInput {
+	s.RoleARN = &v
+	return s
+}
+
 // Contains the output of PutLifecycleHook.
 type PutLifecycleHookOutput struct {
 	_ struct{} `type:"structure"`
@@ -7695,6 +9273,24 @@ func (s *PutNotificationConfigurationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *PutNotificationConfigurationInput) SetAutoScalingGroupName(v string) *PutNotificationConfigurationInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetNotificationTypes sets the NotificationTypes field's value.
+func (s *PutNotificationConfigurationInput) SetNotificationTypes(v []*string) *PutNotificationConfigurationInput {
+	s.NotificationTypes = v
+	return s
+}
+
+// SetTopicARN sets the TopicARN field's value.
+func (s *PutNotificationConfigurationInput) SetTopicARN(v string) *PutNotificationConfigurationInput {
+	s.TopicARN = &v
+	return s
 }
 
 type PutNotificationConfigurationOutput struct {
@@ -7841,6 +9437,72 @@ func (s *PutScalingPolicyInput) Validate() error {
 	return nil
 }
 
+// SetAdjustmentType sets the AdjustmentType field's value.
+func (s *PutScalingPolicyInput) SetAdjustmentType(v string) *PutScalingPolicyInput {
+	s.AdjustmentType = &v
+	return s
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *PutScalingPolicyInput) SetAutoScalingGroupName(v string) *PutScalingPolicyInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetCooldown sets the Cooldown field's value.
+func (s *PutScalingPolicyInput) SetCooldown(v int64) *PutScalingPolicyInput {
+	s.Cooldown = &v
+	return s
+}
+
+// SetEstimatedInstanceWarmup sets the EstimatedInstanceWarmup field's value.
+func (s *PutScalingPolicyInput) SetEstimatedInstanceWarmup(v int64) *PutScalingPolicyInput {
+	s.EstimatedInstanceWarmup = &v
+	return s
+}
+
+// SetMetricAggregationType sets the MetricAggregationType field's value.
+func (s *PutScalingPolicyInput) SetMetricAggregationType(v string) *PutScalingPolicyInput {
+	s.MetricAggregationType = &v
+	return s
+}
+
+// SetMinAdjustmentMagnitude sets the MinAdjustmentMagnitude field's value.
+func (s *PutScalingPolicyInput) SetMinAdjustmentMagnitude(v int64) *PutScalingPolicyInput {
+	s.MinAdjustmentMagnitude = &v
+	return s
+}
+
+// SetMinAdjustmentStep sets the MinAdjustmentStep field's value.
+func (s *PutScalingPolicyInput) SetMinAdjustmentStep(v int64) *PutScalingPolicyInput {
+	s.MinAdjustmentStep = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *PutScalingPolicyInput) SetPolicyName(v string) *PutScalingPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyType sets the PolicyType field's value.
+func (s *PutScalingPolicyInput) SetPolicyType(v string) *PutScalingPolicyInput {
+	s.PolicyType = &v
+	return s
+}
+
+// SetScalingAdjustment sets the ScalingAdjustment field's value.
+func (s *PutScalingPolicyInput) SetScalingAdjustment(v int64) *PutScalingPolicyInput {
+	s.ScalingAdjustment = &v
+	return s
+}
+
+// SetStepAdjustments sets the StepAdjustments field's value.
+func (s *PutScalingPolicyInput) SetStepAdjustments(v []*StepAdjustment) *PutScalingPolicyInput {
+	s.StepAdjustments = v
+	return s
+}
+
 // Contains the output of PutScalingPolicy.
 type PutScalingPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -7857,6 +9519,12 @@ func (s PutScalingPolicyOutput) String() string {
 // GoString returns the string representation
 func (s PutScalingPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyARN sets the PolicyARN field's value.
+func (s *PutScalingPolicyOutput) SetPolicyARN(v string) *PutScalingPolicyOutput {
+	s.PolicyARN = &v
+	return s
 }
 
 // Contains the parameters for PutScheduledUpdateGroupAction.
@@ -7939,6 +9607,60 @@ func (s *PutScheduledUpdateGroupActionInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetAutoScalingGroupName(v string) *PutScheduledUpdateGroupActionInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetDesiredCapacity sets the DesiredCapacity field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetDesiredCapacity(v int64) *PutScheduledUpdateGroupActionInput {
+	s.DesiredCapacity = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetEndTime(v time.Time) *PutScheduledUpdateGroupActionInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetMaxSize sets the MaxSize field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetMaxSize(v int64) *PutScheduledUpdateGroupActionInput {
+	s.MaxSize = &v
+	return s
+}
+
+// SetMinSize sets the MinSize field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetMinSize(v int64) *PutScheduledUpdateGroupActionInput {
+	s.MinSize = &v
+	return s
+}
+
+// SetRecurrence sets the Recurrence field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetRecurrence(v string) *PutScheduledUpdateGroupActionInput {
+	s.Recurrence = &v
+	return s
+}
+
+// SetScheduledActionName sets the ScheduledActionName field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetScheduledActionName(v string) *PutScheduledUpdateGroupActionInput {
+	s.ScheduledActionName = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetStartTime(v time.Time) *PutScheduledUpdateGroupActionInput {
+	s.StartTime = &v
+	return s
+}
+
+// SetTime sets the Time field's value.
+func (s *PutScheduledUpdateGroupActionInput) SetTime(v time.Time) *PutScheduledUpdateGroupActionInput {
+	s.Time = &v
+	return s
+}
+
 type PutScheduledUpdateGroupActionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8012,6 +9734,30 @@ func (s *RecordLifecycleActionHeartbeatInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *RecordLifecycleActionHeartbeatInput) SetAutoScalingGroupName(v string) *RecordLifecycleActionHeartbeatInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *RecordLifecycleActionHeartbeatInput) SetInstanceId(v string) *RecordLifecycleActionHeartbeatInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLifecycleActionToken sets the LifecycleActionToken field's value.
+func (s *RecordLifecycleActionHeartbeatInput) SetLifecycleActionToken(v string) *RecordLifecycleActionHeartbeatInput {
+	s.LifecycleActionToken = &v
+	return s
+}
+
+// SetLifecycleHookName sets the LifecycleHookName field's value.
+func (s *RecordLifecycleActionHeartbeatInput) SetLifecycleHookName(v string) *RecordLifecycleActionHeartbeatInput {
+	s.LifecycleHookName = &v
+	return s
 }
 
 // Contains the output of RecordLifecycleActionHeartBeat.
@@ -8107,6 +9853,84 @@ func (s ScalingPolicy) GoString() string {
 	return s.String()
 }
 
+// SetAdjustmentType sets the AdjustmentType field's value.
+func (s *ScalingPolicy) SetAdjustmentType(v string) *ScalingPolicy {
+	s.AdjustmentType = &v
+	return s
+}
+
+// SetAlarms sets the Alarms field's value.
+func (s *ScalingPolicy) SetAlarms(v []*Alarm) *ScalingPolicy {
+	s.Alarms = v
+	return s
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *ScalingPolicy) SetAutoScalingGroupName(v string) *ScalingPolicy {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetCooldown sets the Cooldown field's value.
+func (s *ScalingPolicy) SetCooldown(v int64) *ScalingPolicy {
+	s.Cooldown = &v
+	return s
+}
+
+// SetEstimatedInstanceWarmup sets the EstimatedInstanceWarmup field's value.
+func (s *ScalingPolicy) SetEstimatedInstanceWarmup(v int64) *ScalingPolicy {
+	s.EstimatedInstanceWarmup = &v
+	return s
+}
+
+// SetMetricAggregationType sets the MetricAggregationType field's value.
+func (s *ScalingPolicy) SetMetricAggregationType(v string) *ScalingPolicy {
+	s.MetricAggregationType = &v
+	return s
+}
+
+// SetMinAdjustmentMagnitude sets the MinAdjustmentMagnitude field's value.
+func (s *ScalingPolicy) SetMinAdjustmentMagnitude(v int64) *ScalingPolicy {
+	s.MinAdjustmentMagnitude = &v
+	return s
+}
+
+// SetMinAdjustmentStep sets the MinAdjustmentStep field's value.
+func (s *ScalingPolicy) SetMinAdjustmentStep(v int64) *ScalingPolicy {
+	s.MinAdjustmentStep = &v
+	return s
+}
+
+// SetPolicyARN sets the PolicyARN field's value.
+func (s *ScalingPolicy) SetPolicyARN(v string) *ScalingPolicy {
+	s.PolicyARN = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *ScalingPolicy) SetPolicyName(v string) *ScalingPolicy {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyType sets the PolicyType field's value.
+func (s *ScalingPolicy) SetPolicyType(v string) *ScalingPolicy {
+	s.PolicyType = &v
+	return s
+}
+
+// SetScalingAdjustment sets the ScalingAdjustment field's value.
+func (s *ScalingPolicy) SetScalingAdjustment(v int64) *ScalingPolicy {
+	s.ScalingAdjustment = &v
+	return s
+}
+
+// SetStepAdjustments sets the StepAdjustments field's value.
+func (s *ScalingPolicy) SetStepAdjustments(v []*StepAdjustment) *ScalingPolicy {
+	s.StepAdjustments = v
+	return s
+}
+
 // Contains the parameters for SuspendProcesses and ResumeProcesses.
 type ScalingProcessQuery struct {
 	_ struct{} `type:"structure"`
@@ -8163,6 +9987,18 @@ func (s *ScalingProcessQuery) Validate() error {
 	return nil
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *ScalingProcessQuery) SetAutoScalingGroupName(v string) *ScalingProcessQuery {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetScalingProcesses sets the ScalingProcesses field's value.
+func (s *ScalingProcessQuery) SetScalingProcesses(v []*string) *ScalingProcessQuery {
+	s.ScalingProcesses = v
+	return s
+}
+
 // Describes a scheduled update to an Auto Scaling group.
 type ScheduledUpdateGroupAction struct {
 	_ struct{} `type:"structure"`
@@ -8213,6 +10049,66 @@ func (s ScheduledUpdateGroupAction) GoString() string {
 	return s.String()
 }
 
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *ScheduledUpdateGroupAction) SetAutoScalingGroupName(v string) *ScheduledUpdateGroupAction {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetDesiredCapacity sets the DesiredCapacity field's value.
+func (s *ScheduledUpdateGroupAction) SetDesiredCapacity(v int64) *ScheduledUpdateGroupAction {
+	s.DesiredCapacity = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *ScheduledUpdateGroupAction) SetEndTime(v time.Time) *ScheduledUpdateGroupAction {
+	s.EndTime = &v
+	return s
+}
+
+// SetMaxSize sets the MaxSize field's value.
+func (s *ScheduledUpdateGroupAction) SetMaxSize(v int64) *ScheduledUpdateGroupAction {
+	s.MaxSize = &v
+	return s
+}
+
+// SetMinSize sets the MinSize field's value.
+func (s *ScheduledUpdateGroupAction) SetMinSize(v int64) *ScheduledUpdateGroupAction {
+	s.MinSize = &v
+	return s
+}
+
+// SetRecurrence sets the Recurrence field's value.
+func (s *ScheduledUpdateGroupAction) SetRecurrence(v string) *ScheduledUpdateGroupAction {
+	s.Recurrence = &v
+	return s
+}
+
+// SetScheduledActionARN sets the ScheduledActionARN field's value.
+func (s *ScheduledUpdateGroupAction) SetScheduledActionARN(v string) *ScheduledUpdateGroupAction {
+	s.ScheduledActionARN = &v
+	return s
+}
+
+// SetScheduledActionName sets the ScheduledActionName field's value.
+func (s *ScheduledUpdateGroupAction) SetScheduledActionName(v string) *ScheduledUpdateGroupAction {
+	s.ScheduledActionName = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ScheduledUpdateGroupAction) SetStartTime(v time.Time) *ScheduledUpdateGroupAction {
+	s.StartTime = &v
+	return s
+}
+
+// SetTime sets the Time field's value.
+func (s *ScheduledUpdateGroupAction) SetTime(v time.Time) *ScheduledUpdateGroupAction {
+	s.Time = &v
+	return s
+}
+
 // Contains the parameters for SetDesiredCapacity.
 type SetDesiredCapacityInput struct {
 	_ struct{} `type:"structure"`
@@ -8261,6 +10157,24 @@ func (s *SetDesiredCapacityInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *SetDesiredCapacityInput) SetAutoScalingGroupName(v string) *SetDesiredCapacityInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetDesiredCapacity sets the DesiredCapacity field's value.
+func (s *SetDesiredCapacityInput) SetDesiredCapacity(v int64) *SetDesiredCapacityInput {
+	s.DesiredCapacity = &v
+	return s
+}
+
+// SetHonorCooldown sets the HonorCooldown field's value.
+func (s *SetDesiredCapacityInput) SetHonorCooldown(v bool) *SetDesiredCapacityInput {
+	s.HonorCooldown = &v
+	return s
 }
 
 type SetDesiredCapacityOutput struct {
@@ -8335,6 +10249,24 @@ func (s *SetInstanceHealthInput) Validate() error {
 	return nil
 }
 
+// SetHealthStatus sets the HealthStatus field's value.
+func (s *SetInstanceHealthInput) SetHealthStatus(v string) *SetInstanceHealthInput {
+	s.HealthStatus = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *SetInstanceHealthInput) SetInstanceId(v string) *SetInstanceHealthInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetShouldRespectGracePeriod sets the ShouldRespectGracePeriod field's value.
+func (s *SetInstanceHealthInput) SetShouldRespectGracePeriod(v bool) *SetInstanceHealthInput {
+	s.ShouldRespectGracePeriod = &v
+	return s
+}
+
 type SetInstanceHealthOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8400,6 +10332,24 @@ func (s *SetInstanceProtectionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *SetInstanceProtectionInput) SetAutoScalingGroupName(v string) *SetInstanceProtectionInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *SetInstanceProtectionInput) SetInstanceIds(v []*string) *SetInstanceProtectionInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetProtectedFromScaleIn sets the ProtectedFromScaleIn field's value.
+func (s *SetInstanceProtectionInput) SetProtectedFromScaleIn(v bool) *SetInstanceProtectionInput {
+	s.ProtectedFromScaleIn = &v
+	return s
 }
 
 // Contains the output of SetInstanceProtection.
@@ -8496,6 +10446,24 @@ func (s *StepAdjustment) Validate() error {
 	return nil
 }
 
+// SetMetricIntervalLowerBound sets the MetricIntervalLowerBound field's value.
+func (s *StepAdjustment) SetMetricIntervalLowerBound(v float64) *StepAdjustment {
+	s.MetricIntervalLowerBound = &v
+	return s
+}
+
+// SetMetricIntervalUpperBound sets the MetricIntervalUpperBound field's value.
+func (s *StepAdjustment) SetMetricIntervalUpperBound(v float64) *StepAdjustment {
+	s.MetricIntervalUpperBound = &v
+	return s
+}
+
+// SetScalingAdjustment sets the ScalingAdjustment field's value.
+func (s *StepAdjustment) SetScalingAdjustment(v int64) *StepAdjustment {
+	s.ScalingAdjustment = &v
+	return s
+}
+
 type SuspendProcessesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8530,6 +10498,18 @@ func (s SuspendedProcess) String() string {
 // GoString returns the string representation
 func (s SuspendedProcess) GoString() string {
 	return s.String()
+}
+
+// SetProcessName sets the ProcessName field's value.
+func (s *SuspendedProcess) SetProcessName(v string) *SuspendedProcess {
+	s.ProcessName = &v
+	return s
+}
+
+// SetSuspensionReason sets the SuspensionReason field's value.
+func (s *SuspendedProcess) SetSuspensionReason(v string) *SuspendedProcess {
+	s.SuspensionReason = &v
+	return s
 }
 
 // Describes a tag for an Auto Scaling group.
@@ -8581,6 +10561,36 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetPropagateAtLaunch sets the PropagateAtLaunch field's value.
+func (s *Tag) SetPropagateAtLaunch(v bool) *Tag {
+	s.PropagateAtLaunch = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *Tag) SetResourceId(v string) *Tag {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *Tag) SetResourceType(v string) *Tag {
+	s.ResourceType = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // Describes a tag for an Auto Scaling group.
 type TagDescription struct {
 	_ struct{} `type:"structure"`
@@ -8610,6 +10620,36 @@ func (s TagDescription) String() string {
 // GoString returns the string representation
 func (s TagDescription) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *TagDescription) SetKey(v string) *TagDescription {
+	s.Key = &v
+	return s
+}
+
+// SetPropagateAtLaunch sets the PropagateAtLaunch field's value.
+func (s *TagDescription) SetPropagateAtLaunch(v bool) *TagDescription {
+	s.PropagateAtLaunch = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *TagDescription) SetResourceId(v string) *TagDescription {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *TagDescription) SetResourceType(v string) *TagDescription {
+	s.ResourceType = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *TagDescription) SetValue(v string) *TagDescription {
+	s.Value = &v
+	return s
 }
 
 // Contains the parameters for TerminateInstanceInAutoScalingGroup.
@@ -8657,6 +10697,18 @@ func (s *TerminateInstanceInAutoScalingGroupInput) Validate() error {
 	return nil
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *TerminateInstanceInAutoScalingGroupInput) SetInstanceId(v string) *TerminateInstanceInAutoScalingGroupInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetShouldDecrementDesiredCapacity sets the ShouldDecrementDesiredCapacity field's value.
+func (s *TerminateInstanceInAutoScalingGroupInput) SetShouldDecrementDesiredCapacity(v bool) *TerminateInstanceInAutoScalingGroupInput {
+	s.ShouldDecrementDesiredCapacity = &v
+	return s
+}
+
 // Contains the output of TerminateInstancesInAutoScalingGroup.
 type TerminateInstanceInAutoScalingGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -8673,6 +10725,12 @@ func (s TerminateInstanceInAutoScalingGroupOutput) String() string {
 // GoString returns the string representation
 func (s TerminateInstanceInAutoScalingGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetActivity sets the Activity field's value.
+func (s *TerminateInstanceInAutoScalingGroupOutput) SetActivity(v *Activity) *TerminateInstanceInAutoScalingGroupOutput {
+	s.Activity = v
+	return s
 }
 
 // Contains the parameters for UpdateAutoScalingGroup.
@@ -8787,6 +10845,84 @@ func (s *UpdateAutoScalingGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *UpdateAutoScalingGroupInput) SetAutoScalingGroupName(v string) *UpdateAutoScalingGroupInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *UpdateAutoScalingGroupInput) SetAvailabilityZones(v []*string) *UpdateAutoScalingGroupInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetDefaultCooldown sets the DefaultCooldown field's value.
+func (s *UpdateAutoScalingGroupInput) SetDefaultCooldown(v int64) *UpdateAutoScalingGroupInput {
+	s.DefaultCooldown = &v
+	return s
+}
+
+// SetDesiredCapacity sets the DesiredCapacity field's value.
+func (s *UpdateAutoScalingGroupInput) SetDesiredCapacity(v int64) *UpdateAutoScalingGroupInput {
+	s.DesiredCapacity = &v
+	return s
+}
+
+// SetHealthCheckGracePeriod sets the HealthCheckGracePeriod field's value.
+func (s *UpdateAutoScalingGroupInput) SetHealthCheckGracePeriod(v int64) *UpdateAutoScalingGroupInput {
+	s.HealthCheckGracePeriod = &v
+	return s
+}
+
+// SetHealthCheckType sets the HealthCheckType field's value.
+func (s *UpdateAutoScalingGroupInput) SetHealthCheckType(v string) *UpdateAutoScalingGroupInput {
+	s.HealthCheckType = &v
+	return s
+}
+
+// SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
+func (s *UpdateAutoScalingGroupInput) SetLaunchConfigurationName(v string) *UpdateAutoScalingGroupInput {
+	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetMaxSize sets the MaxSize field's value.
+func (s *UpdateAutoScalingGroupInput) SetMaxSize(v int64) *UpdateAutoScalingGroupInput {
+	s.MaxSize = &v
+	return s
+}
+
+// SetMinSize sets the MinSize field's value.
+func (s *UpdateAutoScalingGroupInput) SetMinSize(v int64) *UpdateAutoScalingGroupInput {
+	s.MinSize = &v
+	return s
+}
+
+// SetNewInstancesProtectedFromScaleIn sets the NewInstancesProtectedFromScaleIn field's value.
+func (s *UpdateAutoScalingGroupInput) SetNewInstancesProtectedFromScaleIn(v bool) *UpdateAutoScalingGroupInput {
+	s.NewInstancesProtectedFromScaleIn = &v
+	return s
+}
+
+// SetPlacementGroup sets the PlacementGroup field's value.
+func (s *UpdateAutoScalingGroupInput) SetPlacementGroup(v string) *UpdateAutoScalingGroupInput {
+	s.PlacementGroup = &v
+	return s
+}
+
+// SetTerminationPolicies sets the TerminationPolicies field's value.
+func (s *UpdateAutoScalingGroupInput) SetTerminationPolicies(v []*string) *UpdateAutoScalingGroupInput {
+	s.TerminationPolicies = v
+	return s
+}
+
+// SetVPCZoneIdentifier sets the VPCZoneIdentifier field's value.
+func (s *UpdateAutoScalingGroupInput) SetVPCZoneIdentifier(v string) *UpdateAutoScalingGroupInput {
+	s.VPCZoneIdentifier = &v
+	return s
 }
 
 type UpdateAutoScalingGroupOutput struct {

--- a/service/budgets/api.go
+++ b/service/budgets/api.go
@@ -1084,6 +1084,54 @@ func (s *Budget) Validate() error {
 	return nil
 }
 
+// SetBudgetLimit sets the BudgetLimit field's value.
+func (s *Budget) SetBudgetLimit(v *Spend) *Budget {
+	s.BudgetLimit = v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *Budget) SetBudgetName(v string) *Budget {
+	s.BudgetName = &v
+	return s
+}
+
+// SetBudgetType sets the BudgetType field's value.
+func (s *Budget) SetBudgetType(v string) *Budget {
+	s.BudgetType = &v
+	return s
+}
+
+// SetCalculatedSpend sets the CalculatedSpend field's value.
+func (s *Budget) SetCalculatedSpend(v *CalculatedSpend) *Budget {
+	s.CalculatedSpend = v
+	return s
+}
+
+// SetCostFilters sets the CostFilters field's value.
+func (s *Budget) SetCostFilters(v map[string][]*string) *Budget {
+	s.CostFilters = v
+	return s
+}
+
+// SetCostTypes sets the CostTypes field's value.
+func (s *Budget) SetCostTypes(v *CostTypes) *Budget {
+	s.CostTypes = v
+	return s
+}
+
+// SetTimePeriod sets the TimePeriod field's value.
+func (s *Budget) SetTimePeriod(v *TimePeriod) *Budget {
+	s.TimePeriod = v
+	return s
+}
+
+// SetTimeUnit sets the TimeUnit field's value.
+func (s *Budget) SetTimeUnit(v string) *Budget {
+	s.TimeUnit = &v
+	return s
+}
+
 // A structure holds the actual and forecasted spend for a budget.
 type CalculatedSpend struct {
 	_ struct{} `type:"structure"`
@@ -1130,6 +1178,18 @@ func (s *CalculatedSpend) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetActualSpend sets the ActualSpend field's value.
+func (s *CalculatedSpend) SetActualSpend(v *Spend) *CalculatedSpend {
+	s.ActualSpend = v
+	return s
+}
+
+// SetForecastedSpend sets the ForecastedSpend field's value.
+func (s *CalculatedSpend) SetForecastedSpend(v *Spend) *CalculatedSpend {
+	s.ForecastedSpend = v
+	return s
 }
 
 // This includes the options for getting the cost of a budget.
@@ -1179,6 +1239,24 @@ func (s *CostTypes) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIncludeSubscription sets the IncludeSubscription field's value.
+func (s *CostTypes) SetIncludeSubscription(v bool) *CostTypes {
+	s.IncludeSubscription = &v
+	return s
+}
+
+// SetIncludeTax sets the IncludeTax field's value.
+func (s *CostTypes) SetIncludeTax(v bool) *CostTypes {
+	s.IncludeTax = &v
+	return s
+}
+
+// SetUseBlended sets the UseBlended field's value.
+func (s *CostTypes) SetUseBlended(v bool) *CostTypes {
+	s.UseBlended = &v
+	return s
 }
 
 // Request of CreateBudget
@@ -1241,6 +1319,24 @@ func (s *CreateBudgetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *CreateBudgetInput) SetAccountId(v string) *CreateBudgetInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudget sets the Budget field's value.
+func (s *CreateBudgetInput) SetBudget(v *Budget) *CreateBudgetInput {
+	s.Budget = v
+	return s
+}
+
+// SetNotificationsWithSubscribers sets the NotificationsWithSubscribers field's value.
+func (s *CreateBudgetInput) SetNotificationsWithSubscribers(v []*NotificationWithSubscribers) *CreateBudgetInput {
+	s.NotificationsWithSubscribers = v
+	return s
 }
 
 // Response of CreateBudget
@@ -1337,6 +1433,30 @@ func (s *CreateNotificationInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *CreateNotificationInput) SetAccountId(v string) *CreateNotificationInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *CreateNotificationInput) SetBudgetName(v string) *CreateNotificationInput {
+	s.BudgetName = &v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *CreateNotificationInput) SetNotification(v *Notification) *CreateNotificationInput {
+	s.Notification = v
+	return s
+}
+
+// SetSubscribers sets the Subscribers field's value.
+func (s *CreateNotificationInput) SetSubscribers(v []*Subscriber) *CreateNotificationInput {
+	s.Subscribers = v
+	return s
+}
+
 // Response of CreateNotification
 type CreateNotificationOutput struct {
 	_ struct{} `type:"structure"`
@@ -1424,6 +1544,30 @@ func (s *CreateSubscriberInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *CreateSubscriberInput) SetAccountId(v string) *CreateSubscriberInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *CreateSubscriberInput) SetBudgetName(v string) *CreateSubscriberInput {
+	s.BudgetName = &v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *CreateSubscriberInput) SetNotification(v *Notification) *CreateSubscriberInput {
+	s.Notification = v
+	return s
+}
+
+// SetSubscriber sets the Subscriber field's value.
+func (s *CreateSubscriberInput) SetSubscriber(v *Subscriber) *CreateSubscriberInput {
+	s.Subscriber = v
+	return s
+}
+
 // Response of CreateSubscriber
 type CreateSubscriberOutput struct {
 	_ struct{} `type:"structure"`
@@ -1481,6 +1625,18 @@ func (s *DeleteBudgetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteBudgetInput) SetAccountId(v string) *DeleteBudgetInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *DeleteBudgetInput) SetBudgetName(v string) *DeleteBudgetInput {
+	s.BudgetName = &v
+	return s
 }
 
 // Response of DeleteBudget
@@ -1554,6 +1710,24 @@ func (s *DeleteNotificationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteNotificationInput) SetAccountId(v string) *DeleteNotificationInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *DeleteNotificationInput) SetBudgetName(v string) *DeleteNotificationInput {
+	s.BudgetName = &v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *DeleteNotificationInput) SetNotification(v *Notification) *DeleteNotificationInput {
+	s.Notification = v
+	return s
 }
 
 // Response of DeleteNotification
@@ -1643,6 +1817,30 @@ func (s *DeleteSubscriberInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteSubscriberInput) SetAccountId(v string) *DeleteSubscriberInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *DeleteSubscriberInput) SetBudgetName(v string) *DeleteSubscriberInput {
+	s.BudgetName = &v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *DeleteSubscriberInput) SetNotification(v *Notification) *DeleteSubscriberInput {
+	s.Notification = v
+	return s
+}
+
+// SetSubscriber sets the Subscriber field's value.
+func (s *DeleteSubscriberInput) SetSubscriber(v *Subscriber) *DeleteSubscriberInput {
+	s.Subscriber = v
+	return s
+}
+
 // Response of DeleteSubscriber
 type DeleteSubscriberOutput struct {
 	_ struct{} `type:"structure"`
@@ -1702,6 +1900,18 @@ func (s *DescribeBudgetInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DescribeBudgetInput) SetAccountId(v string) *DescribeBudgetInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *DescribeBudgetInput) SetBudgetName(v string) *DescribeBudgetInput {
+	s.BudgetName = &v
+	return s
+}
+
 // Response of DescribeBudget
 type DescribeBudgetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1718,6 +1928,12 @@ func (s DescribeBudgetOutput) String() string {
 // GoString returns the string representation
 func (s DescribeBudgetOutput) GoString() string {
 	return s.String()
+}
+
+// SetBudget sets the Budget field's value.
+func (s *DescribeBudgetOutput) SetBudget(v *Budget) *DescribeBudgetOutput {
+	s.Budget = v
+	return s
 }
 
 // Request of DescribeBudgets
@@ -1766,6 +1982,24 @@ func (s *DescribeBudgetsInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DescribeBudgetsInput) SetAccountId(v string) *DescribeBudgetsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeBudgetsInput) SetMaxResults(v int64) *DescribeBudgetsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeBudgetsInput) SetNextToken(v string) *DescribeBudgetsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Response of DescribeBudgets
 type DescribeBudgetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1785,6 +2019,18 @@ func (s DescribeBudgetsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeBudgetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetBudgets sets the Budgets field's value.
+func (s *DescribeBudgetsOutput) SetBudgets(v []*Budget) *DescribeBudgetsOutput {
+	s.Budgets = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeBudgetsOutput) SetNextToken(v string) *DescribeBudgetsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Request of DescribeNotificationsForBudget
@@ -1841,6 +2087,30 @@ func (s *DescribeNotificationsForBudgetInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DescribeNotificationsForBudgetInput) SetAccountId(v string) *DescribeNotificationsForBudgetInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *DescribeNotificationsForBudgetInput) SetBudgetName(v string) *DescribeNotificationsForBudgetInput {
+	s.BudgetName = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeNotificationsForBudgetInput) SetMaxResults(v int64) *DescribeNotificationsForBudgetInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeNotificationsForBudgetInput) SetNextToken(v string) *DescribeNotificationsForBudgetInput {
+	s.NextToken = &v
+	return s
+}
+
 // Response of GetNotificationsForBudget
 type DescribeNotificationsForBudgetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1860,6 +2130,18 @@ func (s DescribeNotificationsForBudgetOutput) String() string {
 // GoString returns the string representation
 func (s DescribeNotificationsForBudgetOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeNotificationsForBudgetOutput) SetNextToken(v string) *DescribeNotificationsForBudgetOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetNotifications sets the Notifications field's value.
+func (s *DescribeNotificationsForBudgetOutput) SetNotifications(v []*Notification) *DescribeNotificationsForBudgetOutput {
+	s.Notifications = v
+	return s
 }
 
 // Request of DescribeSubscribersForNotification
@@ -1930,6 +2212,36 @@ func (s *DescribeSubscribersForNotificationInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DescribeSubscribersForNotificationInput) SetAccountId(v string) *DescribeSubscribersForNotificationInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *DescribeSubscribersForNotificationInput) SetBudgetName(v string) *DescribeSubscribersForNotificationInput {
+	s.BudgetName = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeSubscribersForNotificationInput) SetMaxResults(v int64) *DescribeSubscribersForNotificationInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSubscribersForNotificationInput) SetNextToken(v string) *DescribeSubscribersForNotificationInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *DescribeSubscribersForNotificationInput) SetNotification(v *Notification) *DescribeSubscribersForNotificationInput {
+	s.Notification = v
+	return s
+}
+
 // Response of DescribeSubscribersForNotification
 type DescribeSubscribersForNotificationOutput struct {
 	_ struct{} `type:"structure"`
@@ -1949,6 +2261,18 @@ func (s DescribeSubscribersForNotificationOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSubscribersForNotificationOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSubscribersForNotificationOutput) SetNextToken(v string) *DescribeSubscribersForNotificationOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSubscribers sets the Subscribers field's value.
+func (s *DescribeSubscribersForNotificationOutput) SetSubscribers(v []*Subscriber) *DescribeSubscribersForNotificationOutput {
+	s.Subscribers = v
+	return s
 }
 
 // Notification model. Each budget may contain multiple notifications with different
@@ -2004,6 +2328,24 @@ func (s *Notification) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *Notification) SetComparisonOperator(v string) *Notification {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetNotificationType sets the NotificationType field's value.
+func (s *Notification) SetNotificationType(v string) *Notification {
+	s.NotificationType = &v
+	return s
+}
+
+// SetThreshold sets the Threshold field's value.
+func (s *Notification) SetThreshold(v float64) *Notification {
+	s.Threshold = &v
+	return s
 }
 
 // A structure to relate notification and a list of subscribers who belong to
@@ -2067,6 +2409,18 @@ func (s *NotificationWithSubscribers) Validate() error {
 	return nil
 }
 
+// SetNotification sets the Notification field's value.
+func (s *NotificationWithSubscribers) SetNotification(v *Notification) *NotificationWithSubscribers {
+	s.Notification = v
+	return s
+}
+
+// SetSubscribers sets the Subscribers field's value.
+func (s *NotificationWithSubscribers) SetSubscribers(v []*Subscriber) *NotificationWithSubscribers {
+	s.Subscribers = v
+	return s
+}
+
 // A structure represent either a cost spend or usage spend. Contains an amount
 // and a unit.
 type Spend struct {
@@ -2107,6 +2461,18 @@ func (s *Spend) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAmount sets the Amount field's value.
+func (s *Spend) SetAmount(v string) *Spend {
+	s.Amount = &v
+	return s
+}
+
+// SetUnit sets the Unit field's value.
+func (s *Spend) SetUnit(v string) *Spend {
+	s.Unit = &v
+	return s
 }
 
 // Subscriber model. Each notification may contain multiple subscribers with
@@ -2151,6 +2517,18 @@ func (s *Subscriber) Validate() error {
 	return nil
 }
 
+// SetAddress sets the Address field's value.
+func (s *Subscriber) SetAddress(v string) *Subscriber {
+	s.Address = &v
+	return s
+}
+
+// SetSubscriptionType sets the SubscriptionType field's value.
+func (s *Subscriber) SetSubscriptionType(v string) *Subscriber {
+	s.SubscriptionType = &v
+	return s
+}
+
 // A time period indicated the start date and end date of a budget.
 type TimePeriod struct {
 	_ struct{} `type:"structure"`
@@ -2190,6 +2568,18 @@ func (s *TimePeriod) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEnd sets the End field's value.
+func (s *TimePeriod) SetEnd(v time.Time) *TimePeriod {
+	s.End = &v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *TimePeriod) SetStart(v time.Time) *TimePeriod {
+	s.Start = &v
+	return s
 }
 
 // Request of UpdateBudget
@@ -2239,6 +2629,18 @@ func (s *UpdateBudgetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *UpdateBudgetInput) SetAccountId(v string) *UpdateBudgetInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetNewBudget sets the NewBudget field's value.
+func (s *UpdateBudgetInput) SetNewBudget(v *Budget) *UpdateBudgetInput {
+	s.NewBudget = v
+	return s
 }
 
 // Response of UpdateBudget
@@ -2326,6 +2728,30 @@ func (s *UpdateNotificationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *UpdateNotificationInput) SetAccountId(v string) *UpdateNotificationInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *UpdateNotificationInput) SetBudgetName(v string) *UpdateNotificationInput {
+	s.BudgetName = &v
+	return s
+}
+
+// SetNewNotification sets the NewNotification field's value.
+func (s *UpdateNotificationInput) SetNewNotification(v *Notification) *UpdateNotificationInput {
+	s.NewNotification = v
+	return s
+}
+
+// SetOldNotification sets the OldNotification field's value.
+func (s *UpdateNotificationInput) SetOldNotification(v *Notification) *UpdateNotificationInput {
+	s.OldNotification = v
+	return s
 }
 
 // Response of UpdateNotification
@@ -2427,6 +2853,36 @@ func (s *UpdateSubscriberInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *UpdateSubscriberInput) SetAccountId(v string) *UpdateSubscriberInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBudgetName sets the BudgetName field's value.
+func (s *UpdateSubscriberInput) SetBudgetName(v string) *UpdateSubscriberInput {
+	s.BudgetName = &v
+	return s
+}
+
+// SetNewSubscriber sets the NewSubscriber field's value.
+func (s *UpdateSubscriberInput) SetNewSubscriber(v *Subscriber) *UpdateSubscriberInput {
+	s.NewSubscriber = v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *UpdateSubscriberInput) SetNotification(v *Notification) *UpdateSubscriberInput {
+	s.Notification = v
+	return s
+}
+
+// SetOldSubscriber sets the OldSubscriber field's value.
+func (s *UpdateSubscriberInput) SetOldSubscriber(v *Subscriber) *UpdateSubscriberInput {
+	s.OldSubscriber = v
+	return s
 }
 
 // Response of UpdateSubscriber

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -1757,6 +1757,18 @@ func (s AccountLimit) GoString() string {
 	return s.String()
 }
 
+// SetName sets the Name field's value.
+func (s *AccountLimit) SetName(v string) *AccountLimit {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *AccountLimit) SetValue(v int64) *AccountLimit {
+	s.Value = &v
+	return s
+}
+
 // The input for the CancelUpdateStack action.
 type CancelUpdateStackInput struct {
 	_ struct{} `type:"structure"`
@@ -1788,6 +1800,12 @@ func (s *CancelUpdateStackInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetStackName sets the StackName field's value.
+func (s *CancelUpdateStackInput) SetStackName(v string) *CancelUpdateStackInput {
+	s.StackName = &v
+	return s
 }
 
 type CancelUpdateStackOutput struct {
@@ -1826,6 +1844,18 @@ func (s Change) String() string {
 // GoString returns the string representation
 func (s Change) GoString() string {
 	return s.String()
+}
+
+// SetResourceChange sets the ResourceChange field's value.
+func (s *Change) SetResourceChange(v *ResourceChange) *Change {
+	s.ResourceChange = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Change) SetType(v string) *Change {
+	s.Type = &v
+	return s
 }
 
 // The ChangeSetSummary structure describes a change set, its status, and the
@@ -1875,6 +1905,60 @@ func (s ChangeSetSummary) String() string {
 // GoString returns the string representation
 func (s ChangeSetSummary) GoString() string {
 	return s.String()
+}
+
+// SetChangeSetId sets the ChangeSetId field's value.
+func (s *ChangeSetSummary) SetChangeSetId(v string) *ChangeSetSummary {
+	s.ChangeSetId = &v
+	return s
+}
+
+// SetChangeSetName sets the ChangeSetName field's value.
+func (s *ChangeSetSummary) SetChangeSetName(v string) *ChangeSetSummary {
+	s.ChangeSetName = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *ChangeSetSummary) SetCreationTime(v time.Time) *ChangeSetSummary {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ChangeSetSummary) SetDescription(v string) *ChangeSetSummary {
+	s.Description = &v
+	return s
+}
+
+// SetExecutionStatus sets the ExecutionStatus field's value.
+func (s *ChangeSetSummary) SetExecutionStatus(v string) *ChangeSetSummary {
+	s.ExecutionStatus = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *ChangeSetSummary) SetStackId(v string) *ChangeSetSummary {
+	s.StackId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *ChangeSetSummary) SetStackName(v string) *ChangeSetSummary {
+	s.StackName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ChangeSetSummary) SetStatus(v string) *ChangeSetSummary {
+	s.Status = &v
+	return s
+}
+
+// SetStatusReason sets the StatusReason field's value.
+func (s *ChangeSetSummary) SetStatusReason(v string) *ChangeSetSummary {
+	s.StatusReason = &v
+	return s
 }
 
 // The input for the ContinueUpdateRollback action.
@@ -1928,6 +2012,18 @@ func (s *ContinueUpdateRollbackInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *ContinueUpdateRollbackInput) SetRoleARN(v string) *ContinueUpdateRollbackInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *ContinueUpdateRollbackInput) SetStackName(v string) *ContinueUpdateRollbackInput {
+	s.StackName = &v
+	return s
 }
 
 // The output for a ContinueUpdateRollback action.
@@ -2110,6 +2206,84 @@ func (s *CreateChangeSetInput) Validate() error {
 	return nil
 }
 
+// SetCapabilities sets the Capabilities field's value.
+func (s *CreateChangeSetInput) SetCapabilities(v []*string) *CreateChangeSetInput {
+	s.Capabilities = v
+	return s
+}
+
+// SetChangeSetName sets the ChangeSetName field's value.
+func (s *CreateChangeSetInput) SetChangeSetName(v string) *CreateChangeSetInput {
+	s.ChangeSetName = &v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateChangeSetInput) SetClientToken(v string) *CreateChangeSetInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateChangeSetInput) SetDescription(v string) *CreateChangeSetInput {
+	s.Description = &v
+	return s
+}
+
+// SetNotificationARNs sets the NotificationARNs field's value.
+func (s *CreateChangeSetInput) SetNotificationARNs(v []*string) *CreateChangeSetInput {
+	s.NotificationARNs = v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *CreateChangeSetInput) SetParameters(v []*Parameter) *CreateChangeSetInput {
+	s.Parameters = v
+	return s
+}
+
+// SetResourceTypes sets the ResourceTypes field's value.
+func (s *CreateChangeSetInput) SetResourceTypes(v []*string) *CreateChangeSetInput {
+	s.ResourceTypes = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *CreateChangeSetInput) SetRoleARN(v string) *CreateChangeSetInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *CreateChangeSetInput) SetStackName(v string) *CreateChangeSetInput {
+	s.StackName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateChangeSetInput) SetTags(v []*Tag) *CreateChangeSetInput {
+	s.Tags = v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *CreateChangeSetInput) SetTemplateBody(v string) *CreateChangeSetInput {
+	s.TemplateBody = &v
+	return s
+}
+
+// SetTemplateURL sets the TemplateURL field's value.
+func (s *CreateChangeSetInput) SetTemplateURL(v string) *CreateChangeSetInput {
+	s.TemplateURL = &v
+	return s
+}
+
+// SetUsePreviousTemplate sets the UsePreviousTemplate field's value.
+func (s *CreateChangeSetInput) SetUsePreviousTemplate(v bool) *CreateChangeSetInput {
+	s.UsePreviousTemplate = &v
+	return s
+}
+
 // The output for the CreateChangeSet action.
 type CreateChangeSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -2126,6 +2300,12 @@ func (s CreateChangeSetOutput) String() string {
 // GoString returns the string representation
 func (s CreateChangeSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *CreateChangeSetOutput) SetId(v string) *CreateChangeSetOutput {
+	s.Id = &v
+	return s
 }
 
 // The input for CreateStack action.
@@ -2302,6 +2482,90 @@ func (s *CreateStackInput) Validate() error {
 	return nil
 }
 
+// SetCapabilities sets the Capabilities field's value.
+func (s *CreateStackInput) SetCapabilities(v []*string) *CreateStackInput {
+	s.Capabilities = v
+	return s
+}
+
+// SetDisableRollback sets the DisableRollback field's value.
+func (s *CreateStackInput) SetDisableRollback(v bool) *CreateStackInput {
+	s.DisableRollback = &v
+	return s
+}
+
+// SetNotificationARNs sets the NotificationARNs field's value.
+func (s *CreateStackInput) SetNotificationARNs(v []*string) *CreateStackInput {
+	s.NotificationARNs = v
+	return s
+}
+
+// SetOnFailure sets the OnFailure field's value.
+func (s *CreateStackInput) SetOnFailure(v string) *CreateStackInput {
+	s.OnFailure = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *CreateStackInput) SetParameters(v []*Parameter) *CreateStackInput {
+	s.Parameters = v
+	return s
+}
+
+// SetResourceTypes sets the ResourceTypes field's value.
+func (s *CreateStackInput) SetResourceTypes(v []*string) *CreateStackInput {
+	s.ResourceTypes = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *CreateStackInput) SetRoleARN(v string) *CreateStackInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *CreateStackInput) SetStackName(v string) *CreateStackInput {
+	s.StackName = &v
+	return s
+}
+
+// SetStackPolicyBody sets the StackPolicyBody field's value.
+func (s *CreateStackInput) SetStackPolicyBody(v string) *CreateStackInput {
+	s.StackPolicyBody = &v
+	return s
+}
+
+// SetStackPolicyURL sets the StackPolicyURL field's value.
+func (s *CreateStackInput) SetStackPolicyURL(v string) *CreateStackInput {
+	s.StackPolicyURL = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateStackInput) SetTags(v []*Tag) *CreateStackInput {
+	s.Tags = v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *CreateStackInput) SetTemplateBody(v string) *CreateStackInput {
+	s.TemplateBody = &v
+	return s
+}
+
+// SetTemplateURL sets the TemplateURL field's value.
+func (s *CreateStackInput) SetTemplateURL(v string) *CreateStackInput {
+	s.TemplateURL = &v
+	return s
+}
+
+// SetTimeoutInMinutes sets the TimeoutInMinutes field's value.
+func (s *CreateStackInput) SetTimeoutInMinutes(v int64) *CreateStackInput {
+	s.TimeoutInMinutes = &v
+	return s
+}
+
 // The output for a CreateStack action.
 type CreateStackOutput struct {
 	_ struct{} `type:"structure"`
@@ -2318,6 +2582,12 @@ func (s CreateStackOutput) String() string {
 // GoString returns the string representation
 func (s CreateStackOutput) GoString() string {
 	return s.String()
+}
+
+// SetStackId sets the StackId field's value.
+func (s *CreateStackOutput) SetStackId(v string) *CreateStackOutput {
+	s.StackId = &v
+	return s
 }
 
 // The input for the DeleteChangeSet action.
@@ -2362,6 +2632,18 @@ func (s *DeleteChangeSetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetChangeSetName sets the ChangeSetName field's value.
+func (s *DeleteChangeSetInput) SetChangeSetName(v string) *DeleteChangeSetInput {
+	s.ChangeSetName = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *DeleteChangeSetInput) SetStackName(v string) *DeleteChangeSetInput {
+	s.StackName = &v
+	return s
 }
 
 // The output for the DeleteChangeSet action.
@@ -2432,6 +2714,24 @@ func (s *DeleteStackInput) Validate() error {
 	return nil
 }
 
+// SetRetainResources sets the RetainResources field's value.
+func (s *DeleteStackInput) SetRetainResources(v []*string) *DeleteStackInput {
+	s.RetainResources = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *DeleteStackInput) SetRoleARN(v string) *DeleteStackInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *DeleteStackInput) SetStackName(v string) *DeleteStackInput {
+	s.StackName = &v
+	return s
+}
+
 type DeleteStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2477,6 +2777,12 @@ func (s *DescribeAccountLimitsInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAccountLimitsInput) SetNextToken(v string) *DescribeAccountLimitsInput {
+	s.NextToken = &v
+	return s
+}
+
 // The output for the DescribeAccountLimits action.
 type DescribeAccountLimitsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2498,6 +2804,18 @@ func (s DescribeAccountLimitsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAccountLimitsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccountLimits sets the AccountLimits field's value.
+func (s *DescribeAccountLimitsOutput) SetAccountLimits(v []*AccountLimit) *DescribeAccountLimitsOutput {
+	s.AccountLimits = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAccountLimitsOutput) SetNextToken(v string) *DescribeAccountLimitsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // The input for the DescribeChangeSet action.
@@ -2549,6 +2867,24 @@ func (s *DescribeChangeSetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetChangeSetName sets the ChangeSetName field's value.
+func (s *DescribeChangeSetInput) SetChangeSetName(v string) *DescribeChangeSetInput {
+	s.ChangeSetName = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeChangeSetInput) SetNextToken(v string) *DescribeChangeSetInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *DescribeChangeSetInput) SetStackName(v string) *DescribeChangeSetInput {
+	s.StackName = &v
+	return s
 }
 
 // The output for the DescribeChangeSet action.
@@ -2625,6 +2961,96 @@ func (s DescribeChangeSetOutput) GoString() string {
 	return s.String()
 }
 
+// SetCapabilities sets the Capabilities field's value.
+func (s *DescribeChangeSetOutput) SetCapabilities(v []*string) *DescribeChangeSetOutput {
+	s.Capabilities = v
+	return s
+}
+
+// SetChangeSetId sets the ChangeSetId field's value.
+func (s *DescribeChangeSetOutput) SetChangeSetId(v string) *DescribeChangeSetOutput {
+	s.ChangeSetId = &v
+	return s
+}
+
+// SetChangeSetName sets the ChangeSetName field's value.
+func (s *DescribeChangeSetOutput) SetChangeSetName(v string) *DescribeChangeSetOutput {
+	s.ChangeSetName = &v
+	return s
+}
+
+// SetChanges sets the Changes field's value.
+func (s *DescribeChangeSetOutput) SetChanges(v []*Change) *DescribeChangeSetOutput {
+	s.Changes = v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *DescribeChangeSetOutput) SetCreationTime(v time.Time) *DescribeChangeSetOutput {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DescribeChangeSetOutput) SetDescription(v string) *DescribeChangeSetOutput {
+	s.Description = &v
+	return s
+}
+
+// SetExecutionStatus sets the ExecutionStatus field's value.
+func (s *DescribeChangeSetOutput) SetExecutionStatus(v string) *DescribeChangeSetOutput {
+	s.ExecutionStatus = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeChangeSetOutput) SetNextToken(v string) *DescribeChangeSetOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetNotificationARNs sets the NotificationARNs field's value.
+func (s *DescribeChangeSetOutput) SetNotificationARNs(v []*string) *DescribeChangeSetOutput {
+	s.NotificationARNs = v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *DescribeChangeSetOutput) SetParameters(v []*Parameter) *DescribeChangeSetOutput {
+	s.Parameters = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeChangeSetOutput) SetStackId(v string) *DescribeChangeSetOutput {
+	s.StackId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *DescribeChangeSetOutput) SetStackName(v string) *DescribeChangeSetOutput {
+	s.StackName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DescribeChangeSetOutput) SetStatus(v string) *DescribeChangeSetOutput {
+	s.Status = &v
+	return s
+}
+
+// SetStatusReason sets the StatusReason field's value.
+func (s *DescribeChangeSetOutput) SetStatusReason(v string) *DescribeChangeSetOutput {
+	s.StatusReason = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DescribeChangeSetOutput) SetTags(v []*Tag) *DescribeChangeSetOutput {
+	s.Tags = v
+	return s
+}
+
 // The input for DescribeStackEvents action.
 type DescribeStackEventsInput struct {
 	_ struct{} `type:"structure"`
@@ -2667,6 +3093,18 @@ func (s *DescribeStackEventsInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeStackEventsInput) SetNextToken(v string) *DescribeStackEventsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *DescribeStackEventsInput) SetStackName(v string) *DescribeStackEventsInput {
+	s.StackName = &v
+	return s
+}
+
 // The output for a DescribeStackEvents action.
 type DescribeStackEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2687,6 +3125,18 @@ func (s DescribeStackEventsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStackEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeStackEventsOutput) SetNextToken(v string) *DescribeStackEventsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackEvents sets the StackEvents field's value.
+func (s *DescribeStackEventsOutput) SetStackEvents(v []*StackEvent) *DescribeStackEventsOutput {
+	s.StackEvents = v
+	return s
 }
 
 // The input for DescribeStackResource action.
@@ -2740,6 +3190,18 @@ func (s *DescribeStackResourceInput) Validate() error {
 	return nil
 }
 
+// SetLogicalResourceId sets the LogicalResourceId field's value.
+func (s *DescribeStackResourceInput) SetLogicalResourceId(v string) *DescribeStackResourceInput {
+	s.LogicalResourceId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *DescribeStackResourceInput) SetStackName(v string) *DescribeStackResourceInput {
+	s.StackName = &v
+	return s
+}
+
 // The output for a DescribeStackResource action.
 type DescribeStackResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -2757,6 +3219,12 @@ func (s DescribeStackResourceOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStackResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetStackResourceDetail sets the StackResourceDetail field's value.
+func (s *DescribeStackResourceOutput) SetStackResourceDetail(v *StackResourceDetail) *DescribeStackResourceOutput {
+	s.StackResourceDetail = v
+	return s
 }
 
 // The input for DescribeStackResources action.
@@ -2807,6 +3275,24 @@ func (s DescribeStackResourcesInput) GoString() string {
 	return s.String()
 }
 
+// SetLogicalResourceId sets the LogicalResourceId field's value.
+func (s *DescribeStackResourcesInput) SetLogicalResourceId(v string) *DescribeStackResourcesInput {
+	s.LogicalResourceId = &v
+	return s
+}
+
+// SetPhysicalResourceId sets the PhysicalResourceId field's value.
+func (s *DescribeStackResourcesInput) SetPhysicalResourceId(v string) *DescribeStackResourcesInput {
+	s.PhysicalResourceId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *DescribeStackResourcesInput) SetStackName(v string) *DescribeStackResourcesInput {
+	s.StackName = &v
+	return s
+}
+
 // The output for a DescribeStackResources action.
 type DescribeStackResourcesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2823,6 +3309,12 @@ func (s DescribeStackResourcesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStackResourcesOutput) GoString() string {
 	return s.String()
+}
+
+// SetStackResources sets the StackResources field's value.
+func (s *DescribeStackResourcesOutput) SetStackResources(v []*StackResource) *DescribeStackResourcesOutput {
+	s.StackResources = v
+	return s
 }
 
 // The input for DescribeStacks action.
@@ -2867,6 +3359,18 @@ func (s *DescribeStacksInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeStacksInput) SetNextToken(v string) *DescribeStacksInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *DescribeStacksInput) SetStackName(v string) *DescribeStacksInput {
+	s.StackName = &v
+	return s
+}
+
 // The output for a DescribeStacks action.
 type DescribeStacksOutput struct {
 	_ struct{} `type:"structure"`
@@ -2887,6 +3391,18 @@ func (s DescribeStacksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStacksOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeStacksOutput) SetNextToken(v string) *DescribeStacksOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStacks sets the Stacks field's value.
+func (s *DescribeStacksOutput) SetStacks(v []*Stack) *DescribeStacksOutput {
+	s.Stacks = v
+	return s
 }
 
 // The input for an EstimateTemplateCost action.
@@ -2941,6 +3457,24 @@ func (s *EstimateTemplateCostInput) Validate() error {
 	return nil
 }
 
+// SetParameters sets the Parameters field's value.
+func (s *EstimateTemplateCostInput) SetParameters(v []*Parameter) *EstimateTemplateCostInput {
+	s.Parameters = v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *EstimateTemplateCostInput) SetTemplateBody(v string) *EstimateTemplateCostInput {
+	s.TemplateBody = &v
+	return s
+}
+
+// SetTemplateURL sets the TemplateURL field's value.
+func (s *EstimateTemplateCostInput) SetTemplateURL(v string) *EstimateTemplateCostInput {
+	s.TemplateURL = &v
+	return s
+}
+
 // The output for a EstimateTemplateCost action.
 type EstimateTemplateCostOutput struct {
 	_ struct{} `type:"structure"`
@@ -2958,6 +3492,12 @@ func (s EstimateTemplateCostOutput) String() string {
 // GoString returns the string representation
 func (s EstimateTemplateCostOutput) GoString() string {
 	return s.String()
+}
+
+// SetUrl sets the Url field's value.
+func (s *EstimateTemplateCostOutput) SetUrl(v string) *EstimateTemplateCostOutput {
+	s.Url = &v
+	return s
 }
 
 // The input for the ExecuteChangeSet action.
@@ -3002,6 +3542,18 @@ func (s *ExecuteChangeSetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetChangeSetName sets the ChangeSetName field's value.
+func (s *ExecuteChangeSetInput) SetChangeSetName(v string) *ExecuteChangeSetInput {
+	s.ChangeSetName = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *ExecuteChangeSetInput) SetStackName(v string) *ExecuteChangeSetInput {
+	s.StackName = &v
+	return s
 }
 
 // The output for the ExecuteChangeSet action.
@@ -3053,6 +3605,12 @@ func (s *GetStackPolicyInput) Validate() error {
 	return nil
 }
 
+// SetStackName sets the StackName field's value.
+func (s *GetStackPolicyInput) SetStackName(v string) *GetStackPolicyInput {
+	s.StackName = &v
+	return s
+}
+
 // The output for the GetStackPolicy action.
 type GetStackPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -3071,6 +3629,12 @@ func (s GetStackPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetStackPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetStackPolicyBody sets the StackPolicyBody field's value.
+func (s *GetStackPolicyOutput) SetStackPolicyBody(v string) *GetStackPolicyOutput {
+	s.StackPolicyBody = &v
+	return s
 }
 
 // The input for a GetTemplate action.
@@ -3114,6 +3678,12 @@ func (s *GetTemplateInput) Validate() error {
 	return nil
 }
 
+// SetStackName sets the StackName field's value.
+func (s *GetTemplateInput) SetStackName(v string) *GetTemplateInput {
+	s.StackName = &v
+	return s
+}
+
 // The output for GetTemplate action.
 type GetTemplateOutput struct {
 	_ struct{} `type:"structure"`
@@ -3135,6 +3705,12 @@ func (s GetTemplateOutput) String() string {
 // GoString returns the string representation
 func (s GetTemplateOutput) GoString() string {
 	return s.String()
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *GetTemplateOutput) SetTemplateBody(v string) *GetTemplateOutput {
+	s.TemplateBody = &v
+	return s
 }
 
 // The input for the GetTemplateSummary action.
@@ -3198,6 +3774,24 @@ func (s *GetTemplateSummaryInput) Validate() error {
 	return nil
 }
 
+// SetStackName sets the StackName field's value.
+func (s *GetTemplateSummaryInput) SetStackName(v string) *GetTemplateSummaryInput {
+	s.StackName = &v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *GetTemplateSummaryInput) SetTemplateBody(v string) *GetTemplateSummaryInput {
+	s.TemplateBody = &v
+	return s
+}
+
+// SetTemplateURL sets the TemplateURL field's value.
+func (s *GetTemplateSummaryInput) SetTemplateURL(v string) *GetTemplateSummaryInput {
+	s.TemplateURL = &v
+	return s
+}
+
 // The output for the GetTemplateSummary action.
 type GetTemplateSummaryOutput struct {
 	_ struct{} `type:"structure"`
@@ -3245,6 +3839,48 @@ func (s GetTemplateSummaryOutput) GoString() string {
 	return s.String()
 }
 
+// SetCapabilities sets the Capabilities field's value.
+func (s *GetTemplateSummaryOutput) SetCapabilities(v []*string) *GetTemplateSummaryOutput {
+	s.Capabilities = v
+	return s
+}
+
+// SetCapabilitiesReason sets the CapabilitiesReason field's value.
+func (s *GetTemplateSummaryOutput) SetCapabilitiesReason(v string) *GetTemplateSummaryOutput {
+	s.CapabilitiesReason = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *GetTemplateSummaryOutput) SetDescription(v string) *GetTemplateSummaryOutput {
+	s.Description = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *GetTemplateSummaryOutput) SetMetadata(v string) *GetTemplateSummaryOutput {
+	s.Metadata = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *GetTemplateSummaryOutput) SetParameters(v []*ParameterDeclaration) *GetTemplateSummaryOutput {
+	s.Parameters = v
+	return s
+}
+
+// SetResourceTypes sets the ResourceTypes field's value.
+func (s *GetTemplateSummaryOutput) SetResourceTypes(v []*string) *GetTemplateSummaryOutput {
+	s.ResourceTypes = v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *GetTemplateSummaryOutput) SetVersion(v string) *GetTemplateSummaryOutput {
+	s.Version = &v
+	return s
+}
+
 // The input for the ListChangeSets action.
 type ListChangeSetsInput struct {
 	_ struct{} `type:"structure"`
@@ -3289,6 +3925,18 @@ func (s *ListChangeSetsInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListChangeSetsInput) SetNextToken(v string) *ListChangeSetsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *ListChangeSetsInput) SetStackName(v string) *ListChangeSetsInput {
+	s.StackName = &v
+	return s
+}
+
 // The output for the ListChangeSets action.
 type ListChangeSetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3310,6 +3958,18 @@ func (s ListChangeSetsOutput) String() string {
 // GoString returns the string representation
 func (s ListChangeSetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListChangeSetsOutput) SetNextToken(v string) *ListChangeSetsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSummaries sets the Summaries field's value.
+func (s *ListChangeSetsOutput) SetSummaries(v []*ChangeSetSummary) *ListChangeSetsOutput {
+	s.Summaries = v
+	return s
 }
 
 // The input for the ListStackResource action.
@@ -3360,6 +4020,18 @@ func (s *ListStackResourcesInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListStackResourcesInput) SetNextToken(v string) *ListStackResourcesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *ListStackResourcesInput) SetStackName(v string) *ListStackResourcesInput {
+	s.StackName = &v
+	return s
+}
+
 // The output for a ListStackResources action.
 type ListStackResourcesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3380,6 +4052,18 @@ func (s ListStackResourcesOutput) String() string {
 // GoString returns the string representation
 func (s ListStackResourcesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListStackResourcesOutput) SetNextToken(v string) *ListStackResourcesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackResourceSummaries sets the StackResourceSummaries field's value.
+func (s *ListStackResourcesOutput) SetStackResourceSummaries(v []*StackResourceSummary) *ListStackResourcesOutput {
+	s.StackResourceSummaries = v
+	return s
 }
 
 // The input for ListStacks action.
@@ -3418,6 +4102,18 @@ func (s *ListStacksInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListStacksInput) SetNextToken(v string) *ListStacksInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackStatusFilter sets the StackStatusFilter field's value.
+func (s *ListStacksInput) SetStackStatusFilter(v []*string) *ListStacksInput {
+	s.StackStatusFilter = v
+	return s
+}
+
 // The output for ListStacks action.
 type ListStacksOutput struct {
 	_ struct{} `type:"structure"`
@@ -3439,6 +4135,18 @@ func (s ListStacksOutput) String() string {
 // GoString returns the string representation
 func (s ListStacksOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListStacksOutput) SetNextToken(v string) *ListStacksOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackSummaries sets the StackSummaries field's value.
+func (s *ListStacksOutput) SetStackSummaries(v []*StackSummary) *ListStacksOutput {
+	s.StackSummaries = v
+	return s
 }
 
 // The Output data type.
@@ -3463,6 +4171,24 @@ func (s Output) String() string {
 // GoString returns the string representation
 func (s Output) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *Output) SetDescription(v string) *Output {
+	s.Description = &v
+	return s
+}
+
+// SetOutputKey sets the OutputKey field's value.
+func (s *Output) SetOutputKey(v string) *Output {
+	s.OutputKey = &v
+	return s
+}
+
+// SetOutputValue sets the OutputValue field's value.
+func (s *Output) SetOutputValue(v string) *Output {
+	s.OutputValue = &v
+	return s
 }
 
 // The Parameter data type.
@@ -3493,6 +4219,24 @@ func (s Parameter) GoString() string {
 	return s.String()
 }
 
+// SetParameterKey sets the ParameterKey field's value.
+func (s *Parameter) SetParameterKey(v string) *Parameter {
+	s.ParameterKey = &v
+	return s
+}
+
+// SetParameterValue sets the ParameterValue field's value.
+func (s *Parameter) SetParameterValue(v string) *Parameter {
+	s.ParameterValue = &v
+	return s
+}
+
+// SetUsePreviousValue sets the UsePreviousValue field's value.
+func (s *Parameter) SetUsePreviousValue(v bool) *Parameter {
+	s.UsePreviousValue = &v
+	return s
+}
+
 // A set of criteria that AWS CloudFormation uses to validate parameter values.
 // Although other constraints might be defined in the stack template, AWS CloudFormation
 // returns only the AllowedValues property.
@@ -3511,6 +4255,12 @@ func (s ParameterConstraints) String() string {
 // GoString returns the string representation
 func (s ParameterConstraints) GoString() string {
 	return s.String()
+}
+
+// SetAllowedValues sets the AllowedValues field's value.
+func (s *ParameterConstraints) SetAllowedValues(v []*string) *ParameterConstraints {
+	s.AllowedValues = v
+	return s
 }
 
 // The ParameterDeclaration data type.
@@ -3545,6 +4295,42 @@ func (s ParameterDeclaration) String() string {
 // GoString returns the string representation
 func (s ParameterDeclaration) GoString() string {
 	return s.String()
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *ParameterDeclaration) SetDefaultValue(v string) *ParameterDeclaration {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ParameterDeclaration) SetDescription(v string) *ParameterDeclaration {
+	s.Description = &v
+	return s
+}
+
+// SetNoEcho sets the NoEcho field's value.
+func (s *ParameterDeclaration) SetNoEcho(v bool) *ParameterDeclaration {
+	s.NoEcho = &v
+	return s
+}
+
+// SetParameterConstraints sets the ParameterConstraints field's value.
+func (s *ParameterDeclaration) SetParameterConstraints(v *ParameterConstraints) *ParameterDeclaration {
+	s.ParameterConstraints = v
+	return s
+}
+
+// SetParameterKey sets the ParameterKey field's value.
+func (s *ParameterDeclaration) SetParameterKey(v string) *ParameterDeclaration {
+	s.ParameterKey = &v
+	return s
+}
+
+// SetParameterType sets the ParameterType field's value.
+func (s *ParameterDeclaration) SetParameterType(v string) *ParameterDeclaration {
+	s.ParameterType = &v
+	return s
 }
 
 // The ResourceChange structure describes the resource and the action that AWS
@@ -3597,6 +4383,48 @@ func (s ResourceChange) String() string {
 // GoString returns the string representation
 func (s ResourceChange) GoString() string {
 	return s.String()
+}
+
+// SetAction sets the Action field's value.
+func (s *ResourceChange) SetAction(v string) *ResourceChange {
+	s.Action = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *ResourceChange) SetDetails(v []*ResourceChangeDetail) *ResourceChange {
+	s.Details = v
+	return s
+}
+
+// SetLogicalResourceId sets the LogicalResourceId field's value.
+func (s *ResourceChange) SetLogicalResourceId(v string) *ResourceChange {
+	s.LogicalResourceId = &v
+	return s
+}
+
+// SetPhysicalResourceId sets the PhysicalResourceId field's value.
+func (s *ResourceChange) SetPhysicalResourceId(v string) *ResourceChange {
+	s.PhysicalResourceId = &v
+	return s
+}
+
+// SetReplacement sets the Replacement field's value.
+func (s *ResourceChange) SetReplacement(v string) *ResourceChange {
+	s.Replacement = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ResourceChange) SetResourceType(v string) *ResourceChange {
+	s.ResourceType = &v
+	return s
+}
+
+// SetScope sets the Scope field's value.
+func (s *ResourceChange) SetScope(v []*string) *ResourceChange {
+	s.Scope = v
+	return s
 }
 
 // For a resource with Modify as the action, the ResourceChange structure describes
@@ -3668,6 +4496,30 @@ func (s ResourceChangeDetail) GoString() string {
 	return s.String()
 }
 
+// SetCausingEntity sets the CausingEntity field's value.
+func (s *ResourceChangeDetail) SetCausingEntity(v string) *ResourceChangeDetail {
+	s.CausingEntity = &v
+	return s
+}
+
+// SetChangeSource sets the ChangeSource field's value.
+func (s *ResourceChangeDetail) SetChangeSource(v string) *ResourceChangeDetail {
+	s.ChangeSource = &v
+	return s
+}
+
+// SetEvaluation sets the Evaluation field's value.
+func (s *ResourceChangeDetail) SetEvaluation(v string) *ResourceChangeDetail {
+	s.Evaluation = &v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *ResourceChangeDetail) SetTarget(v *ResourceTargetDefinition) *ResourceChangeDetail {
+	s.Target = v
+	return s
+}
+
 // The field that AWS CloudFormation will change, such as the name of a resource's
 // property, and whether the resource will be recreated.
 type ResourceTargetDefinition struct {
@@ -3697,6 +4549,24 @@ func (s ResourceTargetDefinition) String() string {
 // GoString returns the string representation
 func (s ResourceTargetDefinition) GoString() string {
 	return s.String()
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *ResourceTargetDefinition) SetAttribute(v string) *ResourceTargetDefinition {
+	s.Attribute = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ResourceTargetDefinition) SetName(v string) *ResourceTargetDefinition {
+	s.Name = &v
+	return s
+}
+
+// SetRequiresRecreation sets the RequiresRecreation field's value.
+func (s *ResourceTargetDefinition) SetRequiresRecreation(v string) *ResourceTargetDefinition {
+	s.RequiresRecreation = &v
+	return s
 }
 
 // The input for the SetStackPolicy action.
@@ -3748,6 +4618,24 @@ func (s *SetStackPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetStackName sets the StackName field's value.
+func (s *SetStackPolicyInput) SetStackName(v string) *SetStackPolicyInput {
+	s.StackName = &v
+	return s
+}
+
+// SetStackPolicyBody sets the StackPolicyBody field's value.
+func (s *SetStackPolicyInput) SetStackPolicyBody(v string) *SetStackPolicyInput {
+	s.StackPolicyBody = &v
+	return s
+}
+
+// SetStackPolicyURL sets the StackPolicyURL field's value.
+func (s *SetStackPolicyInput) SetStackPolicyURL(v string) *SetStackPolicyInput {
+	s.StackPolicyURL = &v
+	return s
 }
 
 type SetStackPolicyOutput struct {
@@ -3831,6 +4719,30 @@ func (s *SignalResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLogicalResourceId sets the LogicalResourceId field's value.
+func (s *SignalResourceInput) SetLogicalResourceId(v string) *SignalResourceInput {
+	s.LogicalResourceId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *SignalResourceInput) SetStackName(v string) *SignalResourceInput {
+	s.StackName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SignalResourceInput) SetStatus(v string) *SignalResourceInput {
+	s.Status = &v
+	return s
+}
+
+// SetUniqueId sets the UniqueId field's value.
+func (s *SignalResourceInput) SetUniqueId(v string) *SignalResourceInput {
+	s.UniqueId = &v
+	return s
 }
 
 type SignalResourceOutput struct {
@@ -3920,6 +4832,96 @@ func (s Stack) GoString() string {
 	return s.String()
 }
 
+// SetCapabilities sets the Capabilities field's value.
+func (s *Stack) SetCapabilities(v []*string) *Stack {
+	s.Capabilities = v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *Stack) SetCreationTime(v time.Time) *Stack {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Stack) SetDescription(v string) *Stack {
+	s.Description = &v
+	return s
+}
+
+// SetDisableRollback sets the DisableRollback field's value.
+func (s *Stack) SetDisableRollback(v bool) *Stack {
+	s.DisableRollback = &v
+	return s
+}
+
+// SetLastUpdatedTime sets the LastUpdatedTime field's value.
+func (s *Stack) SetLastUpdatedTime(v time.Time) *Stack {
+	s.LastUpdatedTime = &v
+	return s
+}
+
+// SetNotificationARNs sets the NotificationARNs field's value.
+func (s *Stack) SetNotificationARNs(v []*string) *Stack {
+	s.NotificationARNs = v
+	return s
+}
+
+// SetOutputs sets the Outputs field's value.
+func (s *Stack) SetOutputs(v []*Output) *Stack {
+	s.Outputs = v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *Stack) SetParameters(v []*Parameter) *Stack {
+	s.Parameters = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *Stack) SetRoleARN(v string) *Stack {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *Stack) SetStackId(v string) *Stack {
+	s.StackId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *Stack) SetStackName(v string) *Stack {
+	s.StackName = &v
+	return s
+}
+
+// SetStackStatus sets the StackStatus field's value.
+func (s *Stack) SetStackStatus(v string) *Stack {
+	s.StackStatus = &v
+	return s
+}
+
+// SetStackStatusReason sets the StackStatusReason field's value.
+func (s *Stack) SetStackStatusReason(v string) *Stack {
+	s.StackStatusReason = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Stack) SetTags(v []*Tag) *Stack {
+	s.Tags = v
+	return s
+}
+
+// SetTimeoutInMinutes sets the TimeoutInMinutes field's value.
+func (s *Stack) SetTimeoutInMinutes(v int64) *Stack {
+	s.TimeoutInMinutes = &v
+	return s
+}
+
 // The StackEvent data type.
 type StackEvent struct {
 	_ struct{} `type:"structure"`
@@ -3976,6 +4978,66 @@ func (s StackEvent) GoString() string {
 	return s.String()
 }
 
+// SetEventId sets the EventId field's value.
+func (s *StackEvent) SetEventId(v string) *StackEvent {
+	s.EventId = &v
+	return s
+}
+
+// SetLogicalResourceId sets the LogicalResourceId field's value.
+func (s *StackEvent) SetLogicalResourceId(v string) *StackEvent {
+	s.LogicalResourceId = &v
+	return s
+}
+
+// SetPhysicalResourceId sets the PhysicalResourceId field's value.
+func (s *StackEvent) SetPhysicalResourceId(v string) *StackEvent {
+	s.PhysicalResourceId = &v
+	return s
+}
+
+// SetResourceProperties sets the ResourceProperties field's value.
+func (s *StackEvent) SetResourceProperties(v string) *StackEvent {
+	s.ResourceProperties = &v
+	return s
+}
+
+// SetResourceStatus sets the ResourceStatus field's value.
+func (s *StackEvent) SetResourceStatus(v string) *StackEvent {
+	s.ResourceStatus = &v
+	return s
+}
+
+// SetResourceStatusReason sets the ResourceStatusReason field's value.
+func (s *StackEvent) SetResourceStatusReason(v string) *StackEvent {
+	s.ResourceStatusReason = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *StackEvent) SetResourceType(v string) *StackEvent {
+	s.ResourceType = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *StackEvent) SetStackId(v string) *StackEvent {
+	s.StackId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *StackEvent) SetStackName(v string) *StackEvent {
+	s.StackName = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *StackEvent) SetTimestamp(v time.Time) *StackEvent {
+	s.Timestamp = &v
+	return s
+}
+
 // The StackResource data type.
 type StackResource struct {
 	_ struct{} `type:"structure"`
@@ -4027,6 +5089,60 @@ func (s StackResource) String() string {
 // GoString returns the string representation
 func (s StackResource) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *StackResource) SetDescription(v string) *StackResource {
+	s.Description = &v
+	return s
+}
+
+// SetLogicalResourceId sets the LogicalResourceId field's value.
+func (s *StackResource) SetLogicalResourceId(v string) *StackResource {
+	s.LogicalResourceId = &v
+	return s
+}
+
+// SetPhysicalResourceId sets the PhysicalResourceId field's value.
+func (s *StackResource) SetPhysicalResourceId(v string) *StackResource {
+	s.PhysicalResourceId = &v
+	return s
+}
+
+// SetResourceStatus sets the ResourceStatus field's value.
+func (s *StackResource) SetResourceStatus(v string) *StackResource {
+	s.ResourceStatus = &v
+	return s
+}
+
+// SetResourceStatusReason sets the ResourceStatusReason field's value.
+func (s *StackResource) SetResourceStatusReason(v string) *StackResource {
+	s.ResourceStatusReason = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *StackResource) SetResourceType(v string) *StackResource {
+	s.ResourceType = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *StackResource) SetStackId(v string) *StackResource {
+	s.StackId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *StackResource) SetStackName(v string) *StackResource {
+	s.StackName = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *StackResource) SetTimestamp(v time.Time) *StackResource {
+	s.Timestamp = &v
+	return s
 }
 
 // Contains detailed information about the specified stack resource.
@@ -4087,6 +5203,66 @@ func (s StackResourceDetail) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *StackResourceDetail) SetDescription(v string) *StackResourceDetail {
+	s.Description = &v
+	return s
+}
+
+// SetLastUpdatedTimestamp sets the LastUpdatedTimestamp field's value.
+func (s *StackResourceDetail) SetLastUpdatedTimestamp(v time.Time) *StackResourceDetail {
+	s.LastUpdatedTimestamp = &v
+	return s
+}
+
+// SetLogicalResourceId sets the LogicalResourceId field's value.
+func (s *StackResourceDetail) SetLogicalResourceId(v string) *StackResourceDetail {
+	s.LogicalResourceId = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *StackResourceDetail) SetMetadata(v string) *StackResourceDetail {
+	s.Metadata = &v
+	return s
+}
+
+// SetPhysicalResourceId sets the PhysicalResourceId field's value.
+func (s *StackResourceDetail) SetPhysicalResourceId(v string) *StackResourceDetail {
+	s.PhysicalResourceId = &v
+	return s
+}
+
+// SetResourceStatus sets the ResourceStatus field's value.
+func (s *StackResourceDetail) SetResourceStatus(v string) *StackResourceDetail {
+	s.ResourceStatus = &v
+	return s
+}
+
+// SetResourceStatusReason sets the ResourceStatusReason field's value.
+func (s *StackResourceDetail) SetResourceStatusReason(v string) *StackResourceDetail {
+	s.ResourceStatusReason = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *StackResourceDetail) SetResourceType(v string) *StackResourceDetail {
+	s.ResourceType = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *StackResourceDetail) SetStackId(v string) *StackResourceDetail {
+	s.StackId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *StackResourceDetail) SetStackName(v string) *StackResourceDetail {
+	s.StackName = &v
+	return s
+}
+
 // Contains high-level information about the specified stack resource.
 type StackResourceSummary struct {
 	_ struct{} `type:"structure"`
@@ -4129,6 +5305,42 @@ func (s StackResourceSummary) String() string {
 // GoString returns the string representation
 func (s StackResourceSummary) GoString() string {
 	return s.String()
+}
+
+// SetLastUpdatedTimestamp sets the LastUpdatedTimestamp field's value.
+func (s *StackResourceSummary) SetLastUpdatedTimestamp(v time.Time) *StackResourceSummary {
+	s.LastUpdatedTimestamp = &v
+	return s
+}
+
+// SetLogicalResourceId sets the LogicalResourceId field's value.
+func (s *StackResourceSummary) SetLogicalResourceId(v string) *StackResourceSummary {
+	s.LogicalResourceId = &v
+	return s
+}
+
+// SetPhysicalResourceId sets the PhysicalResourceId field's value.
+func (s *StackResourceSummary) SetPhysicalResourceId(v string) *StackResourceSummary {
+	s.PhysicalResourceId = &v
+	return s
+}
+
+// SetResourceStatus sets the ResourceStatus field's value.
+func (s *StackResourceSummary) SetResourceStatus(v string) *StackResourceSummary {
+	s.ResourceStatus = &v
+	return s
+}
+
+// SetResourceStatusReason sets the ResourceStatusReason field's value.
+func (s *StackResourceSummary) SetResourceStatusReason(v string) *StackResourceSummary {
+	s.ResourceStatusReason = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *StackResourceSummary) SetResourceType(v string) *StackResourceSummary {
+	s.ResourceType = &v
+	return s
 }
 
 // The StackSummary Data Type
@@ -4177,6 +5389,54 @@ func (s StackSummary) GoString() string {
 	return s.String()
 }
 
+// SetCreationTime sets the CreationTime field's value.
+func (s *StackSummary) SetCreationTime(v time.Time) *StackSummary {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDeletionTime sets the DeletionTime field's value.
+func (s *StackSummary) SetDeletionTime(v time.Time) *StackSummary {
+	s.DeletionTime = &v
+	return s
+}
+
+// SetLastUpdatedTime sets the LastUpdatedTime field's value.
+func (s *StackSummary) SetLastUpdatedTime(v time.Time) *StackSummary {
+	s.LastUpdatedTime = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *StackSummary) SetStackId(v string) *StackSummary {
+	s.StackId = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *StackSummary) SetStackName(v string) *StackSummary {
+	s.StackName = &v
+	return s
+}
+
+// SetStackStatus sets the StackStatus field's value.
+func (s *StackSummary) SetStackStatus(v string) *StackSummary {
+	s.StackStatus = &v
+	return s
+}
+
+// SetStackStatusReason sets the StackStatusReason field's value.
+func (s *StackSummary) SetStackStatusReason(v string) *StackSummary {
+	s.StackStatusReason = &v
+	return s
+}
+
+// SetTemplateDescription sets the TemplateDescription field's value.
+func (s *StackSummary) SetTemplateDescription(v string) *StackSummary {
+	s.TemplateDescription = &v
+	return s
+}
+
 // The Tag type enables you to specify a key-value pair that can be used to
 // store information about an AWS CloudFormation stack.
 type Tag struct {
@@ -4200,6 +5460,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // The TemplateParameter data type.
@@ -4228,6 +5500,30 @@ func (s TemplateParameter) String() string {
 // GoString returns the string representation
 func (s TemplateParameter) GoString() string {
 	return s.String()
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *TemplateParameter) SetDefaultValue(v string) *TemplateParameter {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *TemplateParameter) SetDescription(v string) *TemplateParameter {
+	s.Description = &v
+	return s
+}
+
+// SetNoEcho sets the NoEcho field's value.
+func (s *TemplateParameter) SetNoEcho(v bool) *TemplateParameter {
+	s.NoEcho = &v
+	return s
+}
+
+// SetParameterKey sets the ParameterKey field's value.
+func (s *TemplateParameter) SetParameterKey(v string) *TemplateParameter {
+	s.ParameterKey = &v
+	return s
 }
 
 // The input for an UpdateStack action.
@@ -4412,6 +5708,90 @@ func (s *UpdateStackInput) Validate() error {
 	return nil
 }
 
+// SetCapabilities sets the Capabilities field's value.
+func (s *UpdateStackInput) SetCapabilities(v []*string) *UpdateStackInput {
+	s.Capabilities = v
+	return s
+}
+
+// SetNotificationARNs sets the NotificationARNs field's value.
+func (s *UpdateStackInput) SetNotificationARNs(v []*string) *UpdateStackInput {
+	s.NotificationARNs = v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *UpdateStackInput) SetParameters(v []*Parameter) *UpdateStackInput {
+	s.Parameters = v
+	return s
+}
+
+// SetResourceTypes sets the ResourceTypes field's value.
+func (s *UpdateStackInput) SetResourceTypes(v []*string) *UpdateStackInput {
+	s.ResourceTypes = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *UpdateStackInput) SetRoleARN(v string) *UpdateStackInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *UpdateStackInput) SetStackName(v string) *UpdateStackInput {
+	s.StackName = &v
+	return s
+}
+
+// SetStackPolicyBody sets the StackPolicyBody field's value.
+func (s *UpdateStackInput) SetStackPolicyBody(v string) *UpdateStackInput {
+	s.StackPolicyBody = &v
+	return s
+}
+
+// SetStackPolicyDuringUpdateBody sets the StackPolicyDuringUpdateBody field's value.
+func (s *UpdateStackInput) SetStackPolicyDuringUpdateBody(v string) *UpdateStackInput {
+	s.StackPolicyDuringUpdateBody = &v
+	return s
+}
+
+// SetStackPolicyDuringUpdateURL sets the StackPolicyDuringUpdateURL field's value.
+func (s *UpdateStackInput) SetStackPolicyDuringUpdateURL(v string) *UpdateStackInput {
+	s.StackPolicyDuringUpdateURL = &v
+	return s
+}
+
+// SetStackPolicyURL sets the StackPolicyURL field's value.
+func (s *UpdateStackInput) SetStackPolicyURL(v string) *UpdateStackInput {
+	s.StackPolicyURL = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *UpdateStackInput) SetTags(v []*Tag) *UpdateStackInput {
+	s.Tags = v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *UpdateStackInput) SetTemplateBody(v string) *UpdateStackInput {
+	s.TemplateBody = &v
+	return s
+}
+
+// SetTemplateURL sets the TemplateURL field's value.
+func (s *UpdateStackInput) SetTemplateURL(v string) *UpdateStackInput {
+	s.TemplateURL = &v
+	return s
+}
+
+// SetUsePreviousTemplate sets the UsePreviousTemplate field's value.
+func (s *UpdateStackInput) SetUsePreviousTemplate(v bool) *UpdateStackInput {
+	s.UsePreviousTemplate = &v
+	return s
+}
+
 // The output for an UpdateStack action.
 type UpdateStackOutput struct {
 	_ struct{} `type:"structure"`
@@ -4428,6 +5808,12 @@ func (s UpdateStackOutput) String() string {
 // GoString returns the string representation
 func (s UpdateStackOutput) GoString() string {
 	return s.String()
+}
+
+// SetStackId sets the StackId field's value.
+func (s *UpdateStackOutput) SetStackId(v string) *UpdateStackOutput {
+	s.StackId = &v
+	return s
 }
 
 // The input for ValidateTemplate action.
@@ -4479,6 +5865,18 @@ func (s *ValidateTemplateInput) Validate() error {
 	return nil
 }
 
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *ValidateTemplateInput) SetTemplateBody(v string) *ValidateTemplateInput {
+	s.TemplateBody = &v
+	return s
+}
+
+// SetTemplateURL sets the TemplateURL field's value.
+func (s *ValidateTemplateInput) SetTemplateURL(v string) *ValidateTemplateInput {
+	s.TemplateURL = &v
+	return s
+}
+
 // The output for ValidateTemplate action.
 type ValidateTemplateOutput struct {
 	_ struct{} `type:"structure"`
@@ -4512,6 +5910,30 @@ func (s ValidateTemplateOutput) String() string {
 // GoString returns the string representation
 func (s ValidateTemplateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCapabilities sets the Capabilities field's value.
+func (s *ValidateTemplateOutput) SetCapabilities(v []*string) *ValidateTemplateOutput {
+	s.Capabilities = v
+	return s
+}
+
+// SetCapabilitiesReason sets the CapabilitiesReason field's value.
+func (s *ValidateTemplateOutput) SetCapabilitiesReason(v string) *ValidateTemplateOutput {
+	s.CapabilitiesReason = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ValidateTemplateOutput) SetDescription(v string) *ValidateTemplateOutput {
+	s.Description = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ValidateTemplateOutput) SetParameters(v []*TemplateParameter) *ValidateTemplateOutput {
+	s.Parameters = v
+	return s
 }
 
 const (

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -2607,6 +2607,24 @@ func (s ActiveTrustedSigners) GoString() string {
 	return s.String()
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *ActiveTrustedSigners) SetEnabled(v bool) *ActiveTrustedSigners {
+	s.Enabled = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *ActiveTrustedSigners) SetItems(v []*Signer) *ActiveTrustedSigners {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *ActiveTrustedSigners) SetQuantity(v int64) *ActiveTrustedSigners {
+	s.Quantity = &v
+	return s
+}
+
 // A complex type that contains information about CNAMEs (alternate domain names),
 // if any, for this distribution.
 type Aliases struct {
@@ -2644,6 +2662,18 @@ func (s *Aliases) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetItems sets the Items field's value.
+func (s *Aliases) SetItems(v []*string) *Aliases {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *Aliases) SetQuantity(v int64) *Aliases {
+	s.Quantity = &v
+	return s
 }
 
 // A complex type that controls which HTTP methods CloudFront processes and
@@ -2719,6 +2749,24 @@ func (s *AllowedMethods) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCachedMethods sets the CachedMethods field's value.
+func (s *AllowedMethods) SetCachedMethods(v *CachedMethods) *AllowedMethods {
+	s.CachedMethods = v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *AllowedMethods) SetItems(v []*string) *AllowedMethods {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *AllowedMethods) SetQuantity(v int64) *AllowedMethods {
+	s.Quantity = &v
+	return s
 }
 
 // A complex type that describes how CloudFront processes requests.
@@ -2946,6 +2994,72 @@ func (s *CacheBehavior) Validate() error {
 	return nil
 }
 
+// SetAllowedMethods sets the AllowedMethods field's value.
+func (s *CacheBehavior) SetAllowedMethods(v *AllowedMethods) *CacheBehavior {
+	s.AllowedMethods = v
+	return s
+}
+
+// SetCompress sets the Compress field's value.
+func (s *CacheBehavior) SetCompress(v bool) *CacheBehavior {
+	s.Compress = &v
+	return s
+}
+
+// SetDefaultTTL sets the DefaultTTL field's value.
+func (s *CacheBehavior) SetDefaultTTL(v int64) *CacheBehavior {
+	s.DefaultTTL = &v
+	return s
+}
+
+// SetForwardedValues sets the ForwardedValues field's value.
+func (s *CacheBehavior) SetForwardedValues(v *ForwardedValues) *CacheBehavior {
+	s.ForwardedValues = v
+	return s
+}
+
+// SetMaxTTL sets the MaxTTL field's value.
+func (s *CacheBehavior) SetMaxTTL(v int64) *CacheBehavior {
+	s.MaxTTL = &v
+	return s
+}
+
+// SetMinTTL sets the MinTTL field's value.
+func (s *CacheBehavior) SetMinTTL(v int64) *CacheBehavior {
+	s.MinTTL = &v
+	return s
+}
+
+// SetPathPattern sets the PathPattern field's value.
+func (s *CacheBehavior) SetPathPattern(v string) *CacheBehavior {
+	s.PathPattern = &v
+	return s
+}
+
+// SetSmoothStreaming sets the SmoothStreaming field's value.
+func (s *CacheBehavior) SetSmoothStreaming(v bool) *CacheBehavior {
+	s.SmoothStreaming = &v
+	return s
+}
+
+// SetTargetOriginId sets the TargetOriginId field's value.
+func (s *CacheBehavior) SetTargetOriginId(v string) *CacheBehavior {
+	s.TargetOriginId = &v
+	return s
+}
+
+// SetTrustedSigners sets the TrustedSigners field's value.
+func (s *CacheBehavior) SetTrustedSigners(v *TrustedSigners) *CacheBehavior {
+	s.TrustedSigners = v
+	return s
+}
+
+// SetViewerProtocolPolicy sets the ViewerProtocolPolicy field's value.
+func (s *CacheBehavior) SetViewerProtocolPolicy(v string) *CacheBehavior {
+	s.ViewerProtocolPolicy = &v
+	return s
+}
+
 // A complex type that contains zero or more CacheBehavior elements.
 type CacheBehaviors struct {
 	_ struct{} `type:"structure"`
@@ -2991,6 +3105,18 @@ func (s *CacheBehaviors) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetItems sets the Items field's value.
+func (s *CacheBehaviors) SetItems(v []*CacheBehavior) *CacheBehaviors {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *CacheBehaviors) SetQuantity(v int64) *CacheBehaviors {
+	s.Quantity = &v
+	return s
 }
 
 // A complex type that controls whether CloudFront caches the response to requests
@@ -3046,6 +3172,18 @@ func (s *CachedMethods) Validate() error {
 	return nil
 }
 
+// SetItems sets the Items field's value.
+func (s *CachedMethods) SetItems(v []*string) *CachedMethods {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *CachedMethods) SetQuantity(v int64) *CachedMethods {
+	s.Quantity = &v
+	return s
+}
+
 // A complex type that specifies whether you want CloudFront to forward cookies
 // to the origin and, if so, which ones. For more information about forwarding
 // cookies to the origin, see How CloudFront Forwards, Caches, and Logs Cookies
@@ -3086,6 +3224,18 @@ func (s *CookieNames) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetItems sets the Items field's value.
+func (s *CookieNames) SetItems(v []*string) *CookieNames {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *CookieNames) SetQuantity(v int64) *CookieNames {
+	s.Quantity = &v
+	return s
 }
 
 // A complex type that specifies whether you want CloudFront to forward cookies
@@ -3150,6 +3300,18 @@ func (s *CookiePreference) Validate() error {
 	return nil
 }
 
+// SetForward sets the Forward field's value.
+func (s *CookiePreference) SetForward(v string) *CookiePreference {
+	s.Forward = &v
+	return s
+}
+
+// SetWhitelistedNames sets the WhitelistedNames field's value.
+func (s *CookiePreference) SetWhitelistedNames(v *CookieNames) *CookiePreference {
+	s.WhitelistedNames = v
+	return s
+}
+
 // The request to create a new origin access identity.
 type CreateCloudFrontOriginAccessIdentityInput struct {
 	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
@@ -3188,6 +3350,12 @@ func (s *CreateCloudFrontOriginAccessIdentityInput) Validate() error {
 	return nil
 }
 
+// SetCloudFrontOriginAccessIdentityConfig sets the CloudFrontOriginAccessIdentityConfig field's value.
+func (s *CreateCloudFrontOriginAccessIdentityInput) SetCloudFrontOriginAccessIdentityConfig(v *OriginAccessIdentityConfig) *CreateCloudFrontOriginAccessIdentityInput {
+	s.CloudFrontOriginAccessIdentityConfig = v
+	return s
+}
+
 // The returned result of the corresponding request.
 type CreateCloudFrontOriginAccessIdentityOutput struct {
 	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
@@ -3211,6 +3379,24 @@ func (s CreateCloudFrontOriginAccessIdentityOutput) String() string {
 // GoString returns the string representation
 func (s CreateCloudFrontOriginAccessIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// SetCloudFrontOriginAccessIdentity sets the CloudFrontOriginAccessIdentity field's value.
+func (s *CreateCloudFrontOriginAccessIdentityOutput) SetCloudFrontOriginAccessIdentity(v *OriginAccessIdentity) *CreateCloudFrontOriginAccessIdentityOutput {
+	s.CloudFrontOriginAccessIdentity = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *CreateCloudFrontOriginAccessIdentityOutput) SetETag(v string) *CreateCloudFrontOriginAccessIdentityOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateCloudFrontOriginAccessIdentityOutput) SetLocation(v string) *CreateCloudFrontOriginAccessIdentityOutput {
+	s.Location = &v
+	return s
 }
 
 // The request to create a new distribution.
@@ -3251,6 +3437,12 @@ func (s *CreateDistributionInput) Validate() error {
 	return nil
 }
 
+// SetDistributionConfig sets the DistributionConfig field's value.
+func (s *CreateDistributionInput) SetDistributionConfig(v *DistributionConfig) *CreateDistributionInput {
+	s.DistributionConfig = v
+	return s
+}
+
 // The returned result of the corresponding request.
 type CreateDistributionOutput struct {
 	_ struct{} `type:"structure" payload:"Distribution"`
@@ -3274,6 +3466,24 @@ func (s CreateDistributionOutput) String() string {
 // GoString returns the string representation
 func (s CreateDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// SetDistribution sets the Distribution field's value.
+func (s *CreateDistributionOutput) SetDistribution(v *Distribution) *CreateDistributionOutput {
+	s.Distribution = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *CreateDistributionOutput) SetETag(v string) *CreateDistributionOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateDistributionOutput) SetLocation(v string) *CreateDistributionOutput {
+	s.Location = &v
+	return s
 }
 
 // The request to create a new distribution with tags.
@@ -3314,6 +3524,12 @@ func (s *CreateDistributionWithTagsInput) Validate() error {
 	return nil
 }
 
+// SetDistributionConfigWithTags sets the DistributionConfigWithTags field's value.
+func (s *CreateDistributionWithTagsInput) SetDistributionConfigWithTags(v *DistributionConfigWithTags) *CreateDistributionWithTagsInput {
+	s.DistributionConfigWithTags = v
+	return s
+}
+
 // The returned result of the corresponding request.
 type CreateDistributionWithTagsOutput struct {
 	_ struct{} `type:"structure" payload:"Distribution"`
@@ -3337,6 +3553,24 @@ func (s CreateDistributionWithTagsOutput) String() string {
 // GoString returns the string representation
 func (s CreateDistributionWithTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDistribution sets the Distribution field's value.
+func (s *CreateDistributionWithTagsOutput) SetDistribution(v *Distribution) *CreateDistributionWithTagsOutput {
+	s.Distribution = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *CreateDistributionWithTagsOutput) SetETag(v string) *CreateDistributionWithTagsOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateDistributionWithTagsOutput) SetLocation(v string) *CreateDistributionWithTagsOutput {
+	s.Location = &v
+	return s
 }
 
 // The request to create an invalidation.
@@ -3385,6 +3619,18 @@ func (s *CreateInvalidationInput) Validate() error {
 	return nil
 }
 
+// SetDistributionId sets the DistributionId field's value.
+func (s *CreateInvalidationInput) SetDistributionId(v string) *CreateInvalidationInput {
+	s.DistributionId = &v
+	return s
+}
+
+// SetInvalidationBatch sets the InvalidationBatch field's value.
+func (s *CreateInvalidationInput) SetInvalidationBatch(v *InvalidationBatch) *CreateInvalidationInput {
+	s.InvalidationBatch = v
+	return s
+}
+
 // The returned result of the corresponding request.
 type CreateInvalidationOutput struct {
 	_ struct{} `type:"structure" payload:"Invalidation"`
@@ -3405,6 +3651,18 @@ func (s CreateInvalidationOutput) String() string {
 // GoString returns the string representation
 func (s CreateInvalidationOutput) GoString() string {
 	return s.String()
+}
+
+// SetInvalidation sets the Invalidation field's value.
+func (s *CreateInvalidationOutput) SetInvalidation(v *Invalidation) *CreateInvalidationOutput {
+	s.Invalidation = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateInvalidationOutput) SetLocation(v string) *CreateInvalidationOutput {
+	s.Location = &v
+	return s
 }
 
 // The request to create a new streaming distribution.
@@ -3445,6 +3703,12 @@ func (s *CreateStreamingDistributionInput) Validate() error {
 	return nil
 }
 
+// SetStreamingDistributionConfig sets the StreamingDistributionConfig field's value.
+func (s *CreateStreamingDistributionInput) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *CreateStreamingDistributionInput {
+	s.StreamingDistributionConfig = v
+	return s
+}
+
 // The returned result of the corresponding request.
 type CreateStreamingDistributionOutput struct {
 	_ struct{} `type:"structure" payload:"StreamingDistribution"`
@@ -3468,6 +3732,24 @@ func (s CreateStreamingDistributionOutput) String() string {
 // GoString returns the string representation
 func (s CreateStreamingDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *CreateStreamingDistributionOutput) SetETag(v string) *CreateStreamingDistributionOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateStreamingDistributionOutput) SetLocation(v string) *CreateStreamingDistributionOutput {
+	s.Location = &v
+	return s
+}
+
+// SetStreamingDistribution sets the StreamingDistribution field's value.
+func (s *CreateStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *CreateStreamingDistributionOutput {
+	s.StreamingDistribution = v
+	return s
 }
 
 // The request to create a new streaming distribution with tags.
@@ -3508,6 +3790,12 @@ func (s *CreateStreamingDistributionWithTagsInput) Validate() error {
 	return nil
 }
 
+// SetStreamingDistributionConfigWithTags sets the StreamingDistributionConfigWithTags field's value.
+func (s *CreateStreamingDistributionWithTagsInput) SetStreamingDistributionConfigWithTags(v *StreamingDistributionConfigWithTags) *CreateStreamingDistributionWithTagsInput {
+	s.StreamingDistributionConfigWithTags = v
+	return s
+}
+
 // The returned result of the corresponding request.
 type CreateStreamingDistributionWithTagsOutput struct {
 	_ struct{} `type:"structure" payload:"StreamingDistribution"`
@@ -3530,6 +3818,24 @@ func (s CreateStreamingDistributionWithTagsOutput) String() string {
 // GoString returns the string representation
 func (s CreateStreamingDistributionWithTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *CreateStreamingDistributionWithTagsOutput) SetETag(v string) *CreateStreamingDistributionWithTagsOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateStreamingDistributionWithTagsOutput) SetLocation(v string) *CreateStreamingDistributionWithTagsOutput {
+	s.Location = &v
+	return s
+}
+
+// SetStreamingDistribution sets the StreamingDistribution field's value.
+func (s *CreateStreamingDistributionWithTagsOutput) SetStreamingDistribution(v *StreamingDistribution) *CreateStreamingDistributionWithTagsOutput {
+	s.StreamingDistribution = v
+	return s
 }
 
 // A complex type that controls:
@@ -3636,6 +3942,30 @@ func (s *CustomErrorResponse) Validate() error {
 	return nil
 }
 
+// SetErrorCachingMinTTL sets the ErrorCachingMinTTL field's value.
+func (s *CustomErrorResponse) SetErrorCachingMinTTL(v int64) *CustomErrorResponse {
+	s.ErrorCachingMinTTL = &v
+	return s
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *CustomErrorResponse) SetErrorCode(v int64) *CustomErrorResponse {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetResponseCode sets the ResponseCode field's value.
+func (s *CustomErrorResponse) SetResponseCode(v string) *CustomErrorResponse {
+	s.ResponseCode = &v
+	return s
+}
+
+// SetResponsePagePath sets the ResponsePagePath field's value.
+func (s *CustomErrorResponse) SetResponsePagePath(v string) *CustomErrorResponse {
+	s.ResponsePagePath = &v
+	return s
+}
+
 // A complex type that controls:
 //
 //    * Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range
@@ -3694,6 +4024,18 @@ func (s *CustomErrorResponses) Validate() error {
 	return nil
 }
 
+// SetItems sets the Items field's value.
+func (s *CustomErrorResponses) SetItems(v []*CustomErrorResponse) *CustomErrorResponses {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *CustomErrorResponses) SetQuantity(v int64) *CustomErrorResponses {
+	s.Quantity = &v
+	return s
+}
+
 // A complex type that contains the list of Custom Headers for each origin.
 type CustomHeaders struct {
 	_ struct{} `type:"structure"`
@@ -3740,6 +4082,18 @@ func (s *CustomHeaders) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetItems sets the Items field's value.
+func (s *CustomHeaders) SetItems(v []*OriginCustomHeader) *CustomHeaders {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *CustomHeaders) SetQuantity(v int64) *CustomHeaders {
+	s.Quantity = &v
+	return s
 }
 
 // A customer origin.
@@ -3798,6 +4152,30 @@ func (s *CustomOriginConfig) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHTTPPort sets the HTTPPort field's value.
+func (s *CustomOriginConfig) SetHTTPPort(v int64) *CustomOriginConfig {
+	s.HTTPPort = &v
+	return s
+}
+
+// SetHTTPSPort sets the HTTPSPort field's value.
+func (s *CustomOriginConfig) SetHTTPSPort(v int64) *CustomOriginConfig {
+	s.HTTPSPort = &v
+	return s
+}
+
+// SetOriginProtocolPolicy sets the OriginProtocolPolicy field's value.
+func (s *CustomOriginConfig) SetOriginProtocolPolicy(v string) *CustomOriginConfig {
+	s.OriginProtocolPolicy = &v
+	return s
+}
+
+// SetOriginSslProtocols sets the OriginSslProtocols field's value.
+func (s *CustomOriginConfig) SetOriginSslProtocols(v *OriginSslProtocols) *CustomOriginConfig {
+	s.OriginSslProtocols = v
+	return s
 }
 
 // A complex type that describes the default cache behavior if you do not specify
@@ -3972,6 +4350,66 @@ func (s *DefaultCacheBehavior) Validate() error {
 	return nil
 }
 
+// SetAllowedMethods sets the AllowedMethods field's value.
+func (s *DefaultCacheBehavior) SetAllowedMethods(v *AllowedMethods) *DefaultCacheBehavior {
+	s.AllowedMethods = v
+	return s
+}
+
+// SetCompress sets the Compress field's value.
+func (s *DefaultCacheBehavior) SetCompress(v bool) *DefaultCacheBehavior {
+	s.Compress = &v
+	return s
+}
+
+// SetDefaultTTL sets the DefaultTTL field's value.
+func (s *DefaultCacheBehavior) SetDefaultTTL(v int64) *DefaultCacheBehavior {
+	s.DefaultTTL = &v
+	return s
+}
+
+// SetForwardedValues sets the ForwardedValues field's value.
+func (s *DefaultCacheBehavior) SetForwardedValues(v *ForwardedValues) *DefaultCacheBehavior {
+	s.ForwardedValues = v
+	return s
+}
+
+// SetMaxTTL sets the MaxTTL field's value.
+func (s *DefaultCacheBehavior) SetMaxTTL(v int64) *DefaultCacheBehavior {
+	s.MaxTTL = &v
+	return s
+}
+
+// SetMinTTL sets the MinTTL field's value.
+func (s *DefaultCacheBehavior) SetMinTTL(v int64) *DefaultCacheBehavior {
+	s.MinTTL = &v
+	return s
+}
+
+// SetSmoothStreaming sets the SmoothStreaming field's value.
+func (s *DefaultCacheBehavior) SetSmoothStreaming(v bool) *DefaultCacheBehavior {
+	s.SmoothStreaming = &v
+	return s
+}
+
+// SetTargetOriginId sets the TargetOriginId field's value.
+func (s *DefaultCacheBehavior) SetTargetOriginId(v string) *DefaultCacheBehavior {
+	s.TargetOriginId = &v
+	return s
+}
+
+// SetTrustedSigners sets the TrustedSigners field's value.
+func (s *DefaultCacheBehavior) SetTrustedSigners(v *TrustedSigners) *DefaultCacheBehavior {
+	s.TrustedSigners = v
+	return s
+}
+
+// SetViewerProtocolPolicy sets the ViewerProtocolPolicy field's value.
+func (s *DefaultCacheBehavior) SetViewerProtocolPolicy(v string) *DefaultCacheBehavior {
+	s.ViewerProtocolPolicy = &v
+	return s
+}
+
 // Deletes a origin access identity.
 type DeleteCloudFrontOriginAccessIdentityInput struct {
 	_ struct{} `type:"structure"`
@@ -4007,6 +4445,18 @@ func (s *DeleteCloudFrontOriginAccessIdentityInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *DeleteCloudFrontOriginAccessIdentityInput) SetId(v string) *DeleteCloudFrontOriginAccessIdentityInput {
+	s.Id = &v
+	return s
+}
+
+// SetIfMatch sets the IfMatch field's value.
+func (s *DeleteCloudFrontOriginAccessIdentityInput) SetIfMatch(v string) *DeleteCloudFrontOriginAccessIdentityInput {
+	s.IfMatch = &v
+	return s
 }
 
 type DeleteCloudFrontOriginAccessIdentityOutput struct {
@@ -4094,6 +4544,18 @@ func (s *DeleteDistributionInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *DeleteDistributionInput) SetId(v string) *DeleteDistributionInput {
+	s.Id = &v
+	return s
+}
+
+// SetIfMatch sets the IfMatch field's value.
+func (s *DeleteDistributionInput) SetIfMatch(v string) *DeleteDistributionInput {
+	s.IfMatch = &v
+	return s
+}
+
 type DeleteDistributionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4143,6 +4605,18 @@ func (s *DeleteStreamingDistributionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *DeleteStreamingDistributionInput) SetId(v string) *DeleteStreamingDistributionInput {
+	s.Id = &v
+	return s
+}
+
+// SetIfMatch sets the IfMatch field's value.
+func (s *DeleteStreamingDistributionInput) SetIfMatch(v string) *DeleteStreamingDistributionInput {
+	s.IfMatch = &v
+	return s
 }
 
 type DeleteStreamingDistributionOutput struct {
@@ -4223,6 +4697,54 @@ func (s Distribution) String() string {
 // GoString returns the string representation
 func (s Distribution) GoString() string {
 	return s.String()
+}
+
+// SetARN sets the ARN field's value.
+func (s *Distribution) SetARN(v string) *Distribution {
+	s.ARN = &v
+	return s
+}
+
+// SetActiveTrustedSigners sets the ActiveTrustedSigners field's value.
+func (s *Distribution) SetActiveTrustedSigners(v *ActiveTrustedSigners) *Distribution {
+	s.ActiveTrustedSigners = v
+	return s
+}
+
+// SetDistributionConfig sets the DistributionConfig field's value.
+func (s *Distribution) SetDistributionConfig(v *DistributionConfig) *Distribution {
+	s.DistributionConfig = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *Distribution) SetDomainName(v string) *Distribution {
+	s.DomainName = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Distribution) SetId(v string) *Distribution {
+	s.Id = &v
+	return s
+}
+
+// SetInProgressInvalidationBatches sets the InProgressInvalidationBatches field's value.
+func (s *Distribution) SetInProgressInvalidationBatches(v int64) *Distribution {
+	s.InProgressInvalidationBatches = &v
+	return s
+}
+
+// SetLastModifiedTime sets the LastModifiedTime field's value.
+func (s *Distribution) SetLastModifiedTime(v time.Time) *Distribution {
+	s.LastModifiedTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Distribution) SetStatus(v string) *Distribution {
+	s.Status = &v
+	return s
 }
 
 // A distribution configuration.
@@ -4500,6 +5022,102 @@ func (s *DistributionConfig) Validate() error {
 	return nil
 }
 
+// SetAliases sets the Aliases field's value.
+func (s *DistributionConfig) SetAliases(v *Aliases) *DistributionConfig {
+	s.Aliases = v
+	return s
+}
+
+// SetCacheBehaviors sets the CacheBehaviors field's value.
+func (s *DistributionConfig) SetCacheBehaviors(v *CacheBehaviors) *DistributionConfig {
+	s.CacheBehaviors = v
+	return s
+}
+
+// SetCallerReference sets the CallerReference field's value.
+func (s *DistributionConfig) SetCallerReference(v string) *DistributionConfig {
+	s.CallerReference = &v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *DistributionConfig) SetComment(v string) *DistributionConfig {
+	s.Comment = &v
+	return s
+}
+
+// SetCustomErrorResponses sets the CustomErrorResponses field's value.
+func (s *DistributionConfig) SetCustomErrorResponses(v *CustomErrorResponses) *DistributionConfig {
+	s.CustomErrorResponses = v
+	return s
+}
+
+// SetDefaultCacheBehavior sets the DefaultCacheBehavior field's value.
+func (s *DistributionConfig) SetDefaultCacheBehavior(v *DefaultCacheBehavior) *DistributionConfig {
+	s.DefaultCacheBehavior = v
+	return s
+}
+
+// SetDefaultRootObject sets the DefaultRootObject field's value.
+func (s *DistributionConfig) SetDefaultRootObject(v string) *DistributionConfig {
+	s.DefaultRootObject = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *DistributionConfig) SetEnabled(v bool) *DistributionConfig {
+	s.Enabled = &v
+	return s
+}
+
+// SetHttpVersion sets the HttpVersion field's value.
+func (s *DistributionConfig) SetHttpVersion(v string) *DistributionConfig {
+	s.HttpVersion = &v
+	return s
+}
+
+// SetIsIPV6Enabled sets the IsIPV6Enabled field's value.
+func (s *DistributionConfig) SetIsIPV6Enabled(v bool) *DistributionConfig {
+	s.IsIPV6Enabled = &v
+	return s
+}
+
+// SetLogging sets the Logging field's value.
+func (s *DistributionConfig) SetLogging(v *LoggingConfig) *DistributionConfig {
+	s.Logging = v
+	return s
+}
+
+// SetOrigins sets the Origins field's value.
+func (s *DistributionConfig) SetOrigins(v *Origins) *DistributionConfig {
+	s.Origins = v
+	return s
+}
+
+// SetPriceClass sets the PriceClass field's value.
+func (s *DistributionConfig) SetPriceClass(v string) *DistributionConfig {
+	s.PriceClass = &v
+	return s
+}
+
+// SetRestrictions sets the Restrictions field's value.
+func (s *DistributionConfig) SetRestrictions(v *Restrictions) *DistributionConfig {
+	s.Restrictions = v
+	return s
+}
+
+// SetViewerCertificate sets the ViewerCertificate field's value.
+func (s *DistributionConfig) SetViewerCertificate(v *ViewerCertificate) *DistributionConfig {
+	s.ViewerCertificate = v
+	return s
+}
+
+// SetWebACLId sets the WebACLId field's value.
+func (s *DistributionConfig) SetWebACLId(v string) *DistributionConfig {
+	s.WebACLId = &v
+	return s
+}
+
 // A distribution Configuration and a list of tags to be associated with the
 // distribution.
 type DistributionConfigWithTags struct {
@@ -4552,6 +5170,18 @@ func (s *DistributionConfigWithTags) Validate() error {
 	return nil
 }
 
+// SetDistributionConfig sets the DistributionConfig field's value.
+func (s *DistributionConfigWithTags) SetDistributionConfig(v *DistributionConfig) *DistributionConfigWithTags {
+	s.DistributionConfig = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DistributionConfigWithTags) SetTags(v *Tags) *DistributionConfigWithTags {
+	s.Tags = v
+	return s
+}
+
 // A distribution list.
 type DistributionList struct {
 	_ struct{} `type:"structure"`
@@ -4597,6 +5227,42 @@ func (s DistributionList) String() string {
 // GoString returns the string representation
 func (s DistributionList) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *DistributionList) SetIsTruncated(v bool) *DistributionList {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *DistributionList) SetItems(v []*DistributionSummary) *DistributionList {
+	s.Items = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DistributionList) SetMarker(v string) *DistributionList {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *DistributionList) SetMaxItems(v int64) *DistributionList {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DistributionList) SetNextMarker(v string) *DistributionList {
+	s.NextMarker = &v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *DistributionList) SetQuantity(v int64) *DistributionList {
+	s.Quantity = &v
+	return s
 }
 
 // A summary of the information about a CloudFront distribution.
@@ -4724,6 +5390,114 @@ func (s DistributionSummary) GoString() string {
 	return s.String()
 }
 
+// SetARN sets the ARN field's value.
+func (s *DistributionSummary) SetARN(v string) *DistributionSummary {
+	s.ARN = &v
+	return s
+}
+
+// SetAliases sets the Aliases field's value.
+func (s *DistributionSummary) SetAliases(v *Aliases) *DistributionSummary {
+	s.Aliases = v
+	return s
+}
+
+// SetCacheBehaviors sets the CacheBehaviors field's value.
+func (s *DistributionSummary) SetCacheBehaviors(v *CacheBehaviors) *DistributionSummary {
+	s.CacheBehaviors = v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *DistributionSummary) SetComment(v string) *DistributionSummary {
+	s.Comment = &v
+	return s
+}
+
+// SetCustomErrorResponses sets the CustomErrorResponses field's value.
+func (s *DistributionSummary) SetCustomErrorResponses(v *CustomErrorResponses) *DistributionSummary {
+	s.CustomErrorResponses = v
+	return s
+}
+
+// SetDefaultCacheBehavior sets the DefaultCacheBehavior field's value.
+func (s *DistributionSummary) SetDefaultCacheBehavior(v *DefaultCacheBehavior) *DistributionSummary {
+	s.DefaultCacheBehavior = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DistributionSummary) SetDomainName(v string) *DistributionSummary {
+	s.DomainName = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *DistributionSummary) SetEnabled(v bool) *DistributionSummary {
+	s.Enabled = &v
+	return s
+}
+
+// SetHttpVersion sets the HttpVersion field's value.
+func (s *DistributionSummary) SetHttpVersion(v string) *DistributionSummary {
+	s.HttpVersion = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *DistributionSummary) SetId(v string) *DistributionSummary {
+	s.Id = &v
+	return s
+}
+
+// SetIsIPV6Enabled sets the IsIPV6Enabled field's value.
+func (s *DistributionSummary) SetIsIPV6Enabled(v bool) *DistributionSummary {
+	s.IsIPV6Enabled = &v
+	return s
+}
+
+// SetLastModifiedTime sets the LastModifiedTime field's value.
+func (s *DistributionSummary) SetLastModifiedTime(v time.Time) *DistributionSummary {
+	s.LastModifiedTime = &v
+	return s
+}
+
+// SetOrigins sets the Origins field's value.
+func (s *DistributionSummary) SetOrigins(v *Origins) *DistributionSummary {
+	s.Origins = v
+	return s
+}
+
+// SetPriceClass sets the PriceClass field's value.
+func (s *DistributionSummary) SetPriceClass(v string) *DistributionSummary {
+	s.PriceClass = &v
+	return s
+}
+
+// SetRestrictions sets the Restrictions field's value.
+func (s *DistributionSummary) SetRestrictions(v *Restrictions) *DistributionSummary {
+	s.Restrictions = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DistributionSummary) SetStatus(v string) *DistributionSummary {
+	s.Status = &v
+	return s
+}
+
+// SetViewerCertificate sets the ViewerCertificate field's value.
+func (s *DistributionSummary) SetViewerCertificate(v *ViewerCertificate) *DistributionSummary {
+	s.ViewerCertificate = v
+	return s
+}
+
+// SetWebACLId sets the WebACLId field's value.
+func (s *DistributionSummary) SetWebACLId(v string) *DistributionSummary {
+	s.WebACLId = &v
+	return s
+}
+
 // A complex type that specifies how CloudFront handles query strings and cookies.
 type ForwardedValues struct {
 	_ struct{} `type:"structure"`
@@ -4814,6 +5588,30 @@ func (s *ForwardedValues) Validate() error {
 	return nil
 }
 
+// SetCookies sets the Cookies field's value.
+func (s *ForwardedValues) SetCookies(v *CookiePreference) *ForwardedValues {
+	s.Cookies = v
+	return s
+}
+
+// SetHeaders sets the Headers field's value.
+func (s *ForwardedValues) SetHeaders(v *Headers) *ForwardedValues {
+	s.Headers = v
+	return s
+}
+
+// SetQueryString sets the QueryString field's value.
+func (s *ForwardedValues) SetQueryString(v bool) *ForwardedValues {
+	s.QueryString = &v
+	return s
+}
+
+// SetQueryStringCacheKeys sets the QueryStringCacheKeys field's value.
+func (s *ForwardedValues) SetQueryStringCacheKeys(v *QueryStringCacheKeys) *ForwardedValues {
+	s.QueryStringCacheKeys = v
+	return s
+}
+
 // A complex type that controls the countries in which your content is distributed.
 // CloudFront determines the location of your users using MaxMind GeoIP databases.
 type GeoRestriction struct {
@@ -4883,6 +5681,24 @@ func (s *GeoRestriction) Validate() error {
 	return nil
 }
 
+// SetItems sets the Items field's value.
+func (s *GeoRestriction) SetItems(v []*string) *GeoRestriction {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *GeoRestriction) SetQuantity(v int64) *GeoRestriction {
+	s.Quantity = &v
+	return s
+}
+
+// SetRestrictionType sets the RestrictionType field's value.
+func (s *GeoRestriction) SetRestrictionType(v string) *GeoRestriction {
+	s.RestrictionType = &v
+	return s
+}
+
 // The origin access identity's configuration information. For more information,
 // see CloudFrontOriginAccessIdentityConfigComplexType.
 type GetCloudFrontOriginAccessIdentityConfigInput struct {
@@ -4917,6 +5733,12 @@ func (s *GetCloudFrontOriginAccessIdentityConfigInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetCloudFrontOriginAccessIdentityConfigInput) SetId(v string) *GetCloudFrontOriginAccessIdentityConfigInput {
+	s.Id = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type GetCloudFrontOriginAccessIdentityConfigOutput struct {
 	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
@@ -4936,6 +5758,18 @@ func (s GetCloudFrontOriginAccessIdentityConfigOutput) String() string {
 // GoString returns the string representation
 func (s GetCloudFrontOriginAccessIdentityConfigOutput) GoString() string {
 	return s.String()
+}
+
+// SetCloudFrontOriginAccessIdentityConfig sets the CloudFrontOriginAccessIdentityConfig field's value.
+func (s *GetCloudFrontOriginAccessIdentityConfigOutput) SetCloudFrontOriginAccessIdentityConfig(v *OriginAccessIdentityConfig) *GetCloudFrontOriginAccessIdentityConfigOutput {
+	s.CloudFrontOriginAccessIdentityConfig = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *GetCloudFrontOriginAccessIdentityConfigOutput) SetETag(v string) *GetCloudFrontOriginAccessIdentityConfigOutput {
+	s.ETag = &v
+	return s
 }
 
 // The request to get an origin access identity's information.
@@ -4971,6 +5805,12 @@ func (s *GetCloudFrontOriginAccessIdentityInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetCloudFrontOriginAccessIdentityInput) SetId(v string) *GetCloudFrontOriginAccessIdentityInput {
+	s.Id = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type GetCloudFrontOriginAccessIdentityOutput struct {
 	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
@@ -4991,6 +5831,18 @@ func (s GetCloudFrontOriginAccessIdentityOutput) String() string {
 // GoString returns the string representation
 func (s GetCloudFrontOriginAccessIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// SetCloudFrontOriginAccessIdentity sets the CloudFrontOriginAccessIdentity field's value.
+func (s *GetCloudFrontOriginAccessIdentityOutput) SetCloudFrontOriginAccessIdentity(v *OriginAccessIdentity) *GetCloudFrontOriginAccessIdentityOutput {
+	s.CloudFrontOriginAccessIdentity = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *GetCloudFrontOriginAccessIdentityOutput) SetETag(v string) *GetCloudFrontOriginAccessIdentityOutput {
+	s.ETag = &v
+	return s
 }
 
 // The request to get a distribution configuration.
@@ -5026,6 +5878,12 @@ func (s *GetDistributionConfigInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetDistributionConfigInput) SetId(v string) *GetDistributionConfigInput {
+	s.Id = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type GetDistributionConfigOutput struct {
 	_ struct{} `type:"structure" payload:"DistributionConfig"`
@@ -5045,6 +5903,18 @@ func (s GetDistributionConfigOutput) String() string {
 // GoString returns the string representation
 func (s GetDistributionConfigOutput) GoString() string {
 	return s.String()
+}
+
+// SetDistributionConfig sets the DistributionConfig field's value.
+func (s *GetDistributionConfigOutput) SetDistributionConfig(v *DistributionConfig) *GetDistributionConfigOutput {
+	s.DistributionConfig = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *GetDistributionConfigOutput) SetETag(v string) *GetDistributionConfigOutput {
+	s.ETag = &v
+	return s
 }
 
 // The request to get a distribution's information.
@@ -5080,6 +5950,12 @@ func (s *GetDistributionInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetDistributionInput) SetId(v string) *GetDistributionInput {
+	s.Id = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type GetDistributionOutput struct {
 	_ struct{} `type:"structure" payload:"Distribution"`
@@ -5099,6 +5975,18 @@ func (s GetDistributionOutput) String() string {
 // GoString returns the string representation
 func (s GetDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// SetDistribution sets the Distribution field's value.
+func (s *GetDistributionOutput) SetDistribution(v *Distribution) *GetDistributionOutput {
+	s.Distribution = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *GetDistributionOutput) SetETag(v string) *GetDistributionOutput {
+	s.ETag = &v
+	return s
 }
 
 // The request to get an invalidation's information.
@@ -5142,6 +6030,18 @@ func (s *GetInvalidationInput) Validate() error {
 	return nil
 }
 
+// SetDistributionId sets the DistributionId field's value.
+func (s *GetInvalidationInput) SetDistributionId(v string) *GetInvalidationInput {
+	s.DistributionId = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *GetInvalidationInput) SetId(v string) *GetInvalidationInput {
+	s.Id = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type GetInvalidationOutput struct {
 	_ struct{} `type:"structure" payload:"Invalidation"`
@@ -5159,6 +6059,12 @@ func (s GetInvalidationOutput) String() string {
 // GoString returns the string representation
 func (s GetInvalidationOutput) GoString() string {
 	return s.String()
+}
+
+// SetInvalidation sets the Invalidation field's value.
+func (s *GetInvalidationOutput) SetInvalidation(v *Invalidation) *GetInvalidationOutput {
+	s.Invalidation = v
+	return s
 }
 
 // To request to get a streaming distribution configuration.
@@ -5194,6 +6100,12 @@ func (s *GetStreamingDistributionConfigInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetStreamingDistributionConfigInput) SetId(v string) *GetStreamingDistributionConfigInput {
+	s.Id = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type GetStreamingDistributionConfigOutput struct {
 	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
@@ -5213,6 +6125,18 @@ func (s GetStreamingDistributionConfigOutput) String() string {
 // GoString returns the string representation
 func (s GetStreamingDistributionConfigOutput) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *GetStreamingDistributionConfigOutput) SetETag(v string) *GetStreamingDistributionConfigOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetStreamingDistributionConfig sets the StreamingDistributionConfig field's value.
+func (s *GetStreamingDistributionConfigOutput) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *GetStreamingDistributionConfigOutput {
+	s.StreamingDistributionConfig = v
+	return s
 }
 
 // The request to get a streaming distribution's information.
@@ -5248,6 +6172,12 @@ func (s *GetStreamingDistributionInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetStreamingDistributionInput) SetId(v string) *GetStreamingDistributionInput {
+	s.Id = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type GetStreamingDistributionOutput struct {
 	_ struct{} `type:"structure" payload:"StreamingDistribution"`
@@ -5268,6 +6198,18 @@ func (s GetStreamingDistributionOutput) String() string {
 // GoString returns the string representation
 func (s GetStreamingDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *GetStreamingDistributionOutput) SetETag(v string) *GetStreamingDistributionOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetStreamingDistribution sets the StreamingDistribution field's value.
+func (s *GetStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *GetStreamingDistributionOutput {
+	s.StreamingDistribution = v
+	return s
 }
 
 // A complex type that specifies the headers that you want CloudFront to forward
@@ -5339,6 +6281,18 @@ func (s *Headers) Validate() error {
 	return nil
 }
 
+// SetItems sets the Items field's value.
+func (s *Headers) SetItems(v []*string) *Headers {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *Headers) SetQuantity(v int64) *Headers {
+	s.Quantity = &v
+	return s
+}
+
 // An invalidation.
 type Invalidation struct {
 	_ struct{} `type:"structure"`
@@ -5373,6 +6327,30 @@ func (s Invalidation) String() string {
 // GoString returns the string representation
 func (s Invalidation) GoString() string {
 	return s.String()
+}
+
+// SetCreateTime sets the CreateTime field's value.
+func (s *Invalidation) SetCreateTime(v time.Time) *Invalidation {
+	s.CreateTime = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Invalidation) SetId(v string) *Invalidation {
+	s.Id = &v
+	return s
+}
+
+// SetInvalidationBatch sets the InvalidationBatch field's value.
+func (s *Invalidation) SetInvalidationBatch(v *InvalidationBatch) *Invalidation {
+	s.InvalidationBatch = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Invalidation) SetStatus(v string) *Invalidation {
+	s.Status = &v
+	return s
 }
 
 // An invalidation batch.
@@ -5438,6 +6416,18 @@ func (s *InvalidationBatch) Validate() error {
 	return nil
 }
 
+// SetCallerReference sets the CallerReference field's value.
+func (s *InvalidationBatch) SetCallerReference(v string) *InvalidationBatch {
+	s.CallerReference = &v
+	return s
+}
+
+// SetPaths sets the Paths field's value.
+func (s *InvalidationBatch) SetPaths(v *Paths) *InvalidationBatch {
+	s.Paths = v
+	return s
+}
+
 // The InvalidationList complex type describes the list of invalidation objects.
 // For more information about invalidation, see Invalidating Objects (Web Distributions
 // Only) (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html)
@@ -5488,6 +6478,42 @@ func (s InvalidationList) GoString() string {
 	return s.String()
 }
 
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *InvalidationList) SetIsTruncated(v bool) *InvalidationList {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *InvalidationList) SetItems(v []*InvalidationSummary) *InvalidationList {
+	s.Items = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *InvalidationList) SetMarker(v string) *InvalidationList {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *InvalidationList) SetMaxItems(v int64) *InvalidationList {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *InvalidationList) SetNextMarker(v string) *InvalidationList {
+	s.NextMarker = &v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *InvalidationList) SetQuantity(v int64) *InvalidationList {
+	s.Quantity = &v
+	return s
+}
+
 // A summary of an invalidation request.
 type InvalidationSummary struct {
 	_ struct{} `type:"structure"`
@@ -5514,6 +6540,24 @@ func (s InvalidationSummary) String() string {
 // GoString returns the string representation
 func (s InvalidationSummary) GoString() string {
 	return s.String()
+}
+
+// SetCreateTime sets the CreateTime field's value.
+func (s *InvalidationSummary) SetCreateTime(v time.Time) *InvalidationSummary {
+	s.CreateTime = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *InvalidationSummary) SetId(v string) *InvalidationSummary {
+	s.Id = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *InvalidationSummary) SetStatus(v string) *InvalidationSummary {
+	s.Status = &v
+	return s
 }
 
 // A complex type that lists the active CloudFront key pairs, if any, that are
@@ -5547,6 +6591,18 @@ func (s KeyPairIds) GoString() string {
 	return s.String()
 }
 
+// SetItems sets the Items field's value.
+func (s *KeyPairIds) SetItems(v []*string) *KeyPairIds {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *KeyPairIds) SetQuantity(v int64) *KeyPairIds {
+	s.Quantity = &v
+	return s
+}
+
 // The request to list origin access identities.
 type ListCloudFrontOriginAccessIdentitiesInput struct {
 	_ struct{} `type:"structure"`
@@ -5572,6 +6628,18 @@ func (s ListCloudFrontOriginAccessIdentitiesInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListCloudFrontOriginAccessIdentitiesInput) SetMarker(v string) *ListCloudFrontOriginAccessIdentitiesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListCloudFrontOriginAccessIdentitiesInput) SetMaxItems(v int64) *ListCloudFrontOriginAccessIdentitiesInput {
+	s.MaxItems = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type ListCloudFrontOriginAccessIdentitiesOutput struct {
 	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityList"`
@@ -5588,6 +6656,12 @@ func (s ListCloudFrontOriginAccessIdentitiesOutput) String() string {
 // GoString returns the string representation
 func (s ListCloudFrontOriginAccessIdentitiesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCloudFrontOriginAccessIdentityList sets the CloudFrontOriginAccessIdentityList field's value.
+func (s *ListCloudFrontOriginAccessIdentitiesOutput) SetCloudFrontOriginAccessIdentityList(v *OriginAccessIdentityList) *ListCloudFrontOriginAccessIdentitiesOutput {
+	s.CloudFrontOriginAccessIdentityList = v
+	return s
 }
 
 // The request to list distributions that are associated with a specified AWS
@@ -5637,6 +6711,24 @@ func (s *ListDistributionsByWebACLIdInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListDistributionsByWebACLIdInput) SetMarker(v string) *ListDistributionsByWebACLIdInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListDistributionsByWebACLIdInput) SetMaxItems(v int64) *ListDistributionsByWebACLIdInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetWebACLId sets the WebACLId field's value.
+func (s *ListDistributionsByWebACLIdInput) SetWebACLId(v string) *ListDistributionsByWebACLIdInput {
+	s.WebACLId = &v
+	return s
+}
+
 // The response to a request to list the distributions that are associated with
 // a specified AWS WAF web ACL.
 type ListDistributionsByWebACLIdOutput struct {
@@ -5654,6 +6746,12 @@ func (s ListDistributionsByWebACLIdOutput) String() string {
 // GoString returns the string representation
 func (s ListDistributionsByWebACLIdOutput) GoString() string {
 	return s.String()
+}
+
+// SetDistributionList sets the DistributionList field's value.
+func (s *ListDistributionsByWebACLIdOutput) SetDistributionList(v *DistributionList) *ListDistributionsByWebACLIdOutput {
+	s.DistributionList = v
+	return s
 }
 
 // The request to list your distributions.
@@ -5681,6 +6779,18 @@ func (s ListDistributionsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListDistributionsInput) SetMarker(v string) *ListDistributionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListDistributionsInput) SetMaxItems(v int64) *ListDistributionsInput {
+	s.MaxItems = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type ListDistributionsOutput struct {
 	_ struct{} `type:"structure" payload:"DistributionList"`
@@ -5697,6 +6807,12 @@ func (s ListDistributionsOutput) String() string {
 // GoString returns the string representation
 func (s ListDistributionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDistributionList sets the DistributionList field's value.
+func (s *ListDistributionsOutput) SetDistributionList(v *DistributionList) *ListDistributionsOutput {
+	s.DistributionList = v
+	return s
 }
 
 // The request to list invalidations.
@@ -5745,6 +6861,24 @@ func (s *ListInvalidationsInput) Validate() error {
 	return nil
 }
 
+// SetDistributionId sets the DistributionId field's value.
+func (s *ListInvalidationsInput) SetDistributionId(v string) *ListInvalidationsInput {
+	s.DistributionId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListInvalidationsInput) SetMarker(v string) *ListInvalidationsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListInvalidationsInput) SetMaxItems(v int64) *ListInvalidationsInput {
+	s.MaxItems = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type ListInvalidationsOutput struct {
 	_ struct{} `type:"structure" payload:"InvalidationList"`
@@ -5761,6 +6895,12 @@ func (s ListInvalidationsOutput) String() string {
 // GoString returns the string representation
 func (s ListInvalidationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetInvalidationList sets the InvalidationList field's value.
+func (s *ListInvalidationsOutput) SetInvalidationList(v *InvalidationList) *ListInvalidationsOutput {
+	s.InvalidationList = v
+	return s
 }
 
 // The request to list your streaming distributions.
@@ -5784,6 +6924,18 @@ func (s ListStreamingDistributionsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListStreamingDistributionsInput) SetMarker(v string) *ListStreamingDistributionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListStreamingDistributionsInput) SetMaxItems(v int64) *ListStreamingDistributionsInput {
+	s.MaxItems = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type ListStreamingDistributionsOutput struct {
 	_ struct{} `type:"structure" payload:"StreamingDistributionList"`
@@ -5800,6 +6952,12 @@ func (s ListStreamingDistributionsOutput) String() string {
 // GoString returns the string representation
 func (s ListStreamingDistributionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetStreamingDistributionList sets the StreamingDistributionList field's value.
+func (s *ListStreamingDistributionsOutput) SetStreamingDistributionList(v *StreamingDistributionList) *ListStreamingDistributionsOutput {
+	s.StreamingDistributionList = v
+	return s
 }
 
 // The request to list tags for a CloudFront resource.
@@ -5835,6 +6993,12 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetResource sets the Resource field's value.
+func (s *ListTagsForResourceInput) SetResource(v string) *ListTagsForResourceInput {
+	s.Resource = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure" payload:"Tags"`
@@ -5853,6 +7017,12 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForResourceOutput) SetTags(v *Tags) *ListTagsForResourceOutput {
+	s.Tags = v
+	return s
 }
 
 // A complex type that controls whether access logs are written for the distribution.
@@ -5923,6 +7093,30 @@ func (s *LoggingConfig) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *LoggingConfig) SetBucket(v string) *LoggingConfig {
+	s.Bucket = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *LoggingConfig) SetEnabled(v bool) *LoggingConfig {
+	s.Enabled = &v
+	return s
+}
+
+// SetIncludeCookies sets the IncludeCookies field's value.
+func (s *LoggingConfig) SetIncludeCookies(v bool) *LoggingConfig {
+	s.IncludeCookies = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *LoggingConfig) SetPrefix(v string) *LoggingConfig {
+	s.Prefix = &v
+	return s
 }
 
 // A complex type that describes the Amazon S3 bucket or the HTTP server (for
@@ -6052,6 +7246,42 @@ func (s *Origin) Validate() error {
 	return nil
 }
 
+// SetCustomHeaders sets the CustomHeaders field's value.
+func (s *Origin) SetCustomHeaders(v *CustomHeaders) *Origin {
+	s.CustomHeaders = v
+	return s
+}
+
+// SetCustomOriginConfig sets the CustomOriginConfig field's value.
+func (s *Origin) SetCustomOriginConfig(v *CustomOriginConfig) *Origin {
+	s.CustomOriginConfig = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *Origin) SetDomainName(v string) *Origin {
+	s.DomainName = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Origin) SetId(v string) *Origin {
+	s.Id = &v
+	return s
+}
+
+// SetOriginPath sets the OriginPath field's value.
+func (s *Origin) SetOriginPath(v string) *Origin {
+	s.OriginPath = &v
+	return s
+}
+
+// SetS3OriginConfig sets the S3OriginConfig field's value.
+func (s *Origin) SetS3OriginConfig(v *S3OriginConfig) *Origin {
+	s.S3OriginConfig = v
+	return s
+}
+
 // CloudFront origin access identity.
 type OriginAccessIdentity struct {
 	_ struct{} `type:"structure"`
@@ -6080,6 +7310,24 @@ func (s OriginAccessIdentity) String() string {
 // GoString returns the string representation
 func (s OriginAccessIdentity) GoString() string {
 	return s.String()
+}
+
+// SetCloudFrontOriginAccessIdentityConfig sets the CloudFrontOriginAccessIdentityConfig field's value.
+func (s *OriginAccessIdentity) SetCloudFrontOriginAccessIdentityConfig(v *OriginAccessIdentityConfig) *OriginAccessIdentity {
+	s.CloudFrontOriginAccessIdentityConfig = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *OriginAccessIdentity) SetId(v string) *OriginAccessIdentity {
+	s.Id = &v
+	return s
+}
+
+// SetS3CanonicalUserId sets the S3CanonicalUserId field's value.
+func (s *OriginAccessIdentity) SetS3CanonicalUserId(v string) *OriginAccessIdentity {
+	s.S3CanonicalUserId = &v
+	return s
 }
 
 // Origin access identity configuration. Send a GET request to the /CloudFront
@@ -6135,6 +7383,18 @@ func (s *OriginAccessIdentityConfig) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCallerReference sets the CallerReference field's value.
+func (s *OriginAccessIdentityConfig) SetCallerReference(v string) *OriginAccessIdentityConfig {
+	s.CallerReference = &v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *OriginAccessIdentityConfig) SetComment(v string) *OriginAccessIdentityConfig {
+	s.Comment = &v
+	return s
 }
 
 // Lists the origin access identities for CloudFront.Send a GET request to the
@@ -6194,6 +7454,42 @@ func (s OriginAccessIdentityList) GoString() string {
 	return s.String()
 }
 
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *OriginAccessIdentityList) SetIsTruncated(v bool) *OriginAccessIdentityList {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *OriginAccessIdentityList) SetItems(v []*OriginAccessIdentitySummary) *OriginAccessIdentityList {
+	s.Items = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *OriginAccessIdentityList) SetMarker(v string) *OriginAccessIdentityList {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *OriginAccessIdentityList) SetMaxItems(v int64) *OriginAccessIdentityList {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *OriginAccessIdentityList) SetNextMarker(v string) *OriginAccessIdentityList {
+	s.NextMarker = &v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *OriginAccessIdentityList) SetQuantity(v int64) *OriginAccessIdentityList {
+	s.Quantity = &v
+	return s
+}
+
 // Summary of the information about a CloudFront origin access identity.
 type OriginAccessIdentitySummary struct {
 	_ struct{} `type:"structure"`
@@ -6225,6 +7521,24 @@ func (s OriginAccessIdentitySummary) String() string {
 // GoString returns the string representation
 func (s OriginAccessIdentitySummary) GoString() string {
 	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *OriginAccessIdentitySummary) SetComment(v string) *OriginAccessIdentitySummary {
+	s.Comment = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *OriginAccessIdentitySummary) SetId(v string) *OriginAccessIdentitySummary {
+	s.Id = &v
+	return s
+}
+
+// SetS3CanonicalUserId sets the S3CanonicalUserId field's value.
+func (s *OriginAccessIdentitySummary) SetS3CanonicalUserId(v string) *OriginAccessIdentitySummary {
+	s.S3CanonicalUserId = &v
+	return s
 }
 
 // A complex type that contains HeaderName and HeaderValue elements, if any,
@@ -6272,6 +7586,18 @@ func (s *OriginCustomHeader) Validate() error {
 	return nil
 }
 
+// SetHeaderName sets the HeaderName field's value.
+func (s *OriginCustomHeader) SetHeaderName(v string) *OriginCustomHeader {
+	s.HeaderName = &v
+	return s
+}
+
+// SetHeaderValue sets the HeaderValue field's value.
+func (s *OriginCustomHeader) SetHeaderValue(v string) *OriginCustomHeader {
+	s.HeaderValue = &v
+	return s
+}
+
 // A complex type that contains information about the SSL/TLS protocols that
 // CloudFront can use when establishing an HTTPS connection with your origin.
 type OriginSslProtocols struct {
@@ -6313,6 +7639,18 @@ func (s *OriginSslProtocols) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetItems sets the Items field's value.
+func (s *OriginSslProtocols) SetItems(v []*string) *OriginSslProtocols {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *OriginSslProtocols) SetQuantity(v int64) *OriginSslProtocols {
+	s.Quantity = &v
+	return s
 }
 
 // A complex type that contains information about origins for this distribution.
@@ -6364,6 +7702,18 @@ func (s *Origins) Validate() error {
 	return nil
 }
 
+// SetItems sets the Items field's value.
+func (s *Origins) SetItems(v []*Origin) *Origins {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *Origins) SetQuantity(v int64) *Origins {
+	s.Quantity = &v
+	return s
+}
+
 // A complex type that contains information about the objects that you want
 // to invalidate. For more information, see Specifying the Objects to Invalidate
 // (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects)
@@ -6403,6 +7753,18 @@ func (s *Paths) Validate() error {
 	return nil
 }
 
+// SetItems sets the Items field's value.
+func (s *Paths) SetItems(v []*string) *Paths {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *Paths) SetQuantity(v int64) *Paths {
+	s.Quantity = &v
+	return s
+}
+
 type QueryStringCacheKeys struct {
 	_ struct{} `type:"structure"`
 
@@ -6438,6 +7800,18 @@ func (s *QueryStringCacheKeys) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetItems sets the Items field's value.
+func (s *QueryStringCacheKeys) SetItems(v []*string) *QueryStringCacheKeys {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *QueryStringCacheKeys) SetQuantity(v int64) *QueryStringCacheKeys {
+	s.Quantity = &v
+	return s
 }
 
 // A complex type that identifies ways in which you want to restrict distribution
@@ -6478,6 +7852,12 @@ func (s *Restrictions) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGeoRestriction sets the GeoRestriction field's value.
+func (s *Restrictions) SetGeoRestriction(v *GeoRestriction) *Restrictions {
+	s.GeoRestriction = v
+	return s
 }
 
 // A complex type that contains information about the Amazon S3 bucket from
@@ -6538,6 +7918,18 @@ func (s *S3Origin) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *S3Origin) SetDomainName(v string) *S3Origin {
+	s.DomainName = &v
+	return s
+}
+
+// SetOriginAccessIdentity sets the OriginAccessIdentity field's value.
+func (s *S3Origin) SetOriginAccessIdentity(v string) *S3Origin {
+	s.OriginAccessIdentity = &v
+	return s
+}
+
 // A complex type that contains information about the Amazon S3 origin. If the
 // origin is a custom origin, use the CustomOriginConfig element instead.
 type S3OriginConfig struct {
@@ -6594,6 +7986,12 @@ func (s *S3OriginConfig) Validate() error {
 	return nil
 }
 
+// SetOriginAccessIdentity sets the OriginAccessIdentity field's value.
+func (s *S3OriginConfig) SetOriginAccessIdentity(v string) *S3OriginConfig {
+	s.OriginAccessIdentity = &v
+	return s
+}
+
 // A complex type that lists the AWS accounts that were included in the TrustedSigners
 // complex type, as well as their active CloudFront key pair IDs, if any.
 type Signer struct {
@@ -6620,6 +8018,18 @@ func (s Signer) String() string {
 // GoString returns the string representation
 func (s Signer) GoString() string {
 	return s.String()
+}
+
+// SetAwsAccountNumber sets the AwsAccountNumber field's value.
+func (s *Signer) SetAwsAccountNumber(v string) *Signer {
+	s.AwsAccountNumber = &v
+	return s
+}
+
+// SetKeyPairIds sets the KeyPairIds field's value.
+func (s *Signer) SetKeyPairIds(v *KeyPairIds) *Signer {
+	s.KeyPairIds = v
+	return s
 }
 
 // A streaming distribution.
@@ -6679,6 +8089,48 @@ func (s StreamingDistribution) String() string {
 // GoString returns the string representation
 func (s StreamingDistribution) GoString() string {
 	return s.String()
+}
+
+// SetARN sets the ARN field's value.
+func (s *StreamingDistribution) SetARN(v string) *StreamingDistribution {
+	s.ARN = &v
+	return s
+}
+
+// SetActiveTrustedSigners sets the ActiveTrustedSigners field's value.
+func (s *StreamingDistribution) SetActiveTrustedSigners(v *ActiveTrustedSigners) *StreamingDistribution {
+	s.ActiveTrustedSigners = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *StreamingDistribution) SetDomainName(v string) *StreamingDistribution {
+	s.DomainName = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *StreamingDistribution) SetId(v string) *StreamingDistribution {
+	s.Id = &v
+	return s
+}
+
+// SetLastModifiedTime sets the LastModifiedTime field's value.
+func (s *StreamingDistribution) SetLastModifiedTime(v time.Time) *StreamingDistribution {
+	s.LastModifiedTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *StreamingDistribution) SetStatus(v string) *StreamingDistribution {
+	s.Status = &v
+	return s
+}
+
+// SetStreamingDistributionConfig sets the StreamingDistributionConfig field's value.
+func (s *StreamingDistribution) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *StreamingDistribution {
+	s.StreamingDistributionConfig = v
+	return s
 }
 
 // The RTMP distribution's configuration information.
@@ -6794,6 +8246,54 @@ func (s *StreamingDistributionConfig) Validate() error {
 	return nil
 }
 
+// SetAliases sets the Aliases field's value.
+func (s *StreamingDistributionConfig) SetAliases(v *Aliases) *StreamingDistributionConfig {
+	s.Aliases = v
+	return s
+}
+
+// SetCallerReference sets the CallerReference field's value.
+func (s *StreamingDistributionConfig) SetCallerReference(v string) *StreamingDistributionConfig {
+	s.CallerReference = &v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *StreamingDistributionConfig) SetComment(v string) *StreamingDistributionConfig {
+	s.Comment = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *StreamingDistributionConfig) SetEnabled(v bool) *StreamingDistributionConfig {
+	s.Enabled = &v
+	return s
+}
+
+// SetLogging sets the Logging field's value.
+func (s *StreamingDistributionConfig) SetLogging(v *StreamingLoggingConfig) *StreamingDistributionConfig {
+	s.Logging = v
+	return s
+}
+
+// SetPriceClass sets the PriceClass field's value.
+func (s *StreamingDistributionConfig) SetPriceClass(v string) *StreamingDistributionConfig {
+	s.PriceClass = &v
+	return s
+}
+
+// SetS3Origin sets the S3Origin field's value.
+func (s *StreamingDistributionConfig) SetS3Origin(v *S3Origin) *StreamingDistributionConfig {
+	s.S3Origin = v
+	return s
+}
+
+// SetTrustedSigners sets the TrustedSigners field's value.
+func (s *StreamingDistributionConfig) SetTrustedSigners(v *TrustedSigners) *StreamingDistributionConfig {
+	s.TrustedSigners = v
+	return s
+}
+
 // A streaming distribution Configuration and a list of tags to be associated
 // with the streaming distribution.
 type StreamingDistributionConfigWithTags struct {
@@ -6846,6 +8346,18 @@ func (s *StreamingDistributionConfigWithTags) Validate() error {
 	return nil
 }
 
+// SetStreamingDistributionConfig sets the StreamingDistributionConfig field's value.
+func (s *StreamingDistributionConfigWithTags) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *StreamingDistributionConfigWithTags {
+	s.StreamingDistributionConfig = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *StreamingDistributionConfigWithTags) SetTags(v *Tags) *StreamingDistributionConfigWithTags {
+	s.Tags = v
+	return s
+}
+
 // A streaming distribution list.
 type StreamingDistributionList struct {
 	_ struct{} `type:"structure"`
@@ -6892,6 +8404,42 @@ func (s StreamingDistributionList) String() string {
 // GoString returns the string representation
 func (s StreamingDistributionList) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *StreamingDistributionList) SetIsTruncated(v bool) *StreamingDistributionList {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *StreamingDistributionList) SetItems(v []*StreamingDistributionSummary) *StreamingDistributionList {
+	s.Items = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *StreamingDistributionList) SetMarker(v string) *StreamingDistributionList {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *StreamingDistributionList) SetMaxItems(v int64) *StreamingDistributionList {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *StreamingDistributionList) SetNextMarker(v string) *StreamingDistributionList {
+	s.NextMarker = &v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *StreamingDistributionList) SetQuantity(v int64) *StreamingDistributionList {
+	s.Quantity = &v
+	return s
 }
 
 // A summary of the information for an Amazon CloudFront streaming distribution.
@@ -6977,6 +8525,72 @@ func (s StreamingDistributionSummary) GoString() string {
 	return s.String()
 }
 
+// SetARN sets the ARN field's value.
+func (s *StreamingDistributionSummary) SetARN(v string) *StreamingDistributionSummary {
+	s.ARN = &v
+	return s
+}
+
+// SetAliases sets the Aliases field's value.
+func (s *StreamingDistributionSummary) SetAliases(v *Aliases) *StreamingDistributionSummary {
+	s.Aliases = v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *StreamingDistributionSummary) SetComment(v string) *StreamingDistributionSummary {
+	s.Comment = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *StreamingDistributionSummary) SetDomainName(v string) *StreamingDistributionSummary {
+	s.DomainName = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *StreamingDistributionSummary) SetEnabled(v bool) *StreamingDistributionSummary {
+	s.Enabled = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *StreamingDistributionSummary) SetId(v string) *StreamingDistributionSummary {
+	s.Id = &v
+	return s
+}
+
+// SetLastModifiedTime sets the LastModifiedTime field's value.
+func (s *StreamingDistributionSummary) SetLastModifiedTime(v time.Time) *StreamingDistributionSummary {
+	s.LastModifiedTime = &v
+	return s
+}
+
+// SetPriceClass sets the PriceClass field's value.
+func (s *StreamingDistributionSummary) SetPriceClass(v string) *StreamingDistributionSummary {
+	s.PriceClass = &v
+	return s
+}
+
+// SetS3Origin sets the S3Origin field's value.
+func (s *StreamingDistributionSummary) SetS3Origin(v *S3Origin) *StreamingDistributionSummary {
+	s.S3Origin = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *StreamingDistributionSummary) SetStatus(v string) *StreamingDistributionSummary {
+	s.Status = &v
+	return s
+}
+
+// SetTrustedSigners sets the TrustedSigners field's value.
+func (s *StreamingDistributionSummary) SetTrustedSigners(v *TrustedSigners) *StreamingDistributionSummary {
+	s.TrustedSigners = v
+	return s
+}
+
 // A complex type that controls whether access logs are written for this streaming
 // distribution.
 type StreamingLoggingConfig struct {
@@ -7035,6 +8649,24 @@ func (s *StreamingLoggingConfig) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *StreamingLoggingConfig) SetBucket(v string) *StreamingLoggingConfig {
+	s.Bucket = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *StreamingLoggingConfig) SetEnabled(v bool) *StreamingLoggingConfig {
+	s.Enabled = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *StreamingLoggingConfig) SetPrefix(v string) *StreamingLoggingConfig {
+	s.Prefix = &v
+	return s
+}
+
 // A complex type that contains Tag key and Tag value.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -7080,6 +8712,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // A complex type that contains zero or more Tag elements.
 type TagKeys struct {
 	_ struct{} `type:"structure"`
@@ -7096,6 +8740,12 @@ func (s TagKeys) String() string {
 // GoString returns the string representation
 func (s TagKeys) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *TagKeys) SetItems(v []*string) *TagKeys {
+	s.Items = v
+	return s
 }
 
 // The request to add tags to a CloudFront resource.
@@ -7142,6 +8792,18 @@ func (s *TagResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResource sets the Resource field's value.
+func (s *TagResourceInput) SetResource(v string) *TagResourceInput {
+	s.Resource = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagResourceInput) SetTags(v *Tags) *TagResourceInput {
+	s.Tags = v
+	return s
 }
 
 type TagResourceOutput struct {
@@ -7194,6 +8856,12 @@ func (s *Tags) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetItems sets the Items field's value.
+func (s *Tags) SetItems(v []*Tag) *Tags {
+	s.Items = v
+	return s
 }
 
 // A complex type that specifies the AWS accounts, if any, that you want to
@@ -7259,6 +8927,24 @@ func (s *TrustedSigners) Validate() error {
 	return nil
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *TrustedSigners) SetEnabled(v bool) *TrustedSigners {
+	s.Enabled = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *TrustedSigners) SetItems(v []*string) *TrustedSigners {
+	s.Items = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *TrustedSigners) SetQuantity(v int64) *TrustedSigners {
+	s.Quantity = &v
+	return s
+}
+
 // The request to remove tags from a CloudFront resource.
 type UntagResourceInput struct {
 	_ struct{} `type:"structure" payload:"TagKeys"`
@@ -7298,6 +8984,18 @@ func (s *UntagResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResource sets the Resource field's value.
+func (s *UntagResourceInput) SetResource(v string) *UntagResourceInput {
+	s.Resource = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *UntagResourceInput) SetTagKeys(v *TagKeys) *UntagResourceInput {
+	s.TagKeys = v
+	return s
 }
 
 type UntagResourceOutput struct {
@@ -7364,6 +9062,24 @@ func (s *UpdateCloudFrontOriginAccessIdentityInput) Validate() error {
 	return nil
 }
 
+// SetCloudFrontOriginAccessIdentityConfig sets the CloudFrontOriginAccessIdentityConfig field's value.
+func (s *UpdateCloudFrontOriginAccessIdentityInput) SetCloudFrontOriginAccessIdentityConfig(v *OriginAccessIdentityConfig) *UpdateCloudFrontOriginAccessIdentityInput {
+	s.CloudFrontOriginAccessIdentityConfig = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UpdateCloudFrontOriginAccessIdentityInput) SetId(v string) *UpdateCloudFrontOriginAccessIdentityInput {
+	s.Id = &v
+	return s
+}
+
+// SetIfMatch sets the IfMatch field's value.
+func (s *UpdateCloudFrontOriginAccessIdentityInput) SetIfMatch(v string) *UpdateCloudFrontOriginAccessIdentityInput {
+	s.IfMatch = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type UpdateCloudFrontOriginAccessIdentityOutput struct {
 	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
@@ -7383,6 +9099,18 @@ func (s UpdateCloudFrontOriginAccessIdentityOutput) String() string {
 // GoString returns the string representation
 func (s UpdateCloudFrontOriginAccessIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// SetCloudFrontOriginAccessIdentity sets the CloudFrontOriginAccessIdentity field's value.
+func (s *UpdateCloudFrontOriginAccessIdentityOutput) SetCloudFrontOriginAccessIdentity(v *OriginAccessIdentity) *UpdateCloudFrontOriginAccessIdentityOutput {
+	s.CloudFrontOriginAccessIdentity = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *UpdateCloudFrontOriginAccessIdentityOutput) SetETag(v string) *UpdateCloudFrontOriginAccessIdentityOutput {
+	s.ETag = &v
+	return s
 }
 
 // The request to update a distribution.
@@ -7435,6 +9163,24 @@ func (s *UpdateDistributionInput) Validate() error {
 	return nil
 }
 
+// SetDistributionConfig sets the DistributionConfig field's value.
+func (s *UpdateDistributionInput) SetDistributionConfig(v *DistributionConfig) *UpdateDistributionInput {
+	s.DistributionConfig = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UpdateDistributionInput) SetId(v string) *UpdateDistributionInput {
+	s.Id = &v
+	return s
+}
+
+// SetIfMatch sets the IfMatch field's value.
+func (s *UpdateDistributionInput) SetIfMatch(v string) *UpdateDistributionInput {
+	s.IfMatch = &v
+	return s
+}
+
 // The returned result of the corresponding request.
 type UpdateDistributionOutput struct {
 	_ struct{} `type:"structure" payload:"Distribution"`
@@ -7454,6 +9200,18 @@ func (s UpdateDistributionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// SetDistribution sets the Distribution field's value.
+func (s *UpdateDistributionOutput) SetDistribution(v *Distribution) *UpdateDistributionOutput {
+	s.Distribution = v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *UpdateDistributionOutput) SetETag(v string) *UpdateDistributionOutput {
+	s.ETag = &v
+	return s
 }
 
 // The request to update a streaming distribution.
@@ -7506,6 +9264,24 @@ func (s *UpdateStreamingDistributionInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *UpdateStreamingDistributionInput) SetId(v string) *UpdateStreamingDistributionInput {
+	s.Id = &v
+	return s
+}
+
+// SetIfMatch sets the IfMatch field's value.
+func (s *UpdateStreamingDistributionInput) SetIfMatch(v string) *UpdateStreamingDistributionInput {
+	s.IfMatch = &v
+	return s
+}
+
+// SetStreamingDistributionConfig sets the StreamingDistributionConfig field's value.
+func (s *UpdateStreamingDistributionInput) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *UpdateStreamingDistributionInput {
+	s.StreamingDistributionConfig = v
+	return s
+}
+
 // The returned result of the corresponding request.
 type UpdateStreamingDistributionOutput struct {
 	_ struct{} `type:"structure" payload:"StreamingDistribution"`
@@ -7525,6 +9301,18 @@ func (s UpdateStreamingDistributionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateStreamingDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *UpdateStreamingDistributionOutput) SetETag(v string) *UpdateStreamingDistributionOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetStreamingDistribution sets the StreamingDistribution field's value.
+func (s *UpdateStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *UpdateStreamingDistributionOutput {
+	s.StreamingDistribution = v
+	return s
 }
 
 // A complex type that specifies the following:
@@ -7701,6 +9489,48 @@ func (s ViewerCertificate) String() string {
 // GoString returns the string representation
 func (s ViewerCertificate) GoString() string {
 	return s.String()
+}
+
+// SetACMCertificateArn sets the ACMCertificateArn field's value.
+func (s *ViewerCertificate) SetACMCertificateArn(v string) *ViewerCertificate {
+	s.ACMCertificateArn = &v
+	return s
+}
+
+// SetCertificate sets the Certificate field's value.
+func (s *ViewerCertificate) SetCertificate(v string) *ViewerCertificate {
+	s.Certificate = &v
+	return s
+}
+
+// SetCertificateSource sets the CertificateSource field's value.
+func (s *ViewerCertificate) SetCertificateSource(v string) *ViewerCertificate {
+	s.CertificateSource = &v
+	return s
+}
+
+// SetCloudFrontDefaultCertificate sets the CloudFrontDefaultCertificate field's value.
+func (s *ViewerCertificate) SetCloudFrontDefaultCertificate(v bool) *ViewerCertificate {
+	s.CloudFrontDefaultCertificate = &v
+	return s
+}
+
+// SetIAMCertificateId sets the IAMCertificateId field's value.
+func (s *ViewerCertificate) SetIAMCertificateId(v string) *ViewerCertificate {
+	s.IAMCertificateId = &v
+	return s
+}
+
+// SetMinimumProtocolVersion sets the MinimumProtocolVersion field's value.
+func (s *ViewerCertificate) SetMinimumProtocolVersion(v string) *ViewerCertificate {
+	s.MinimumProtocolVersion = &v
+	return s
+}
+
+// SetSSLSupportMethod sets the SSLSupportMethod field's value.
+func (s *ViewerCertificate) SetSSLSupportMethod(v string) *ViewerCertificate {
+	s.SSLSupportMethod = &v
+	return s
 }
 
 const (

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -1498,6 +1498,18 @@ func (s *AddTagsToResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceArn sets the ResourceArn field's value.
+func (s *AddTagsToResourceInput) SetResourceArn(v string) *AddTagsToResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *AddTagsToResourceInput) SetTagList(v []*Tag) *AddTagsToResourceInput {
+	s.TagList = v
+	return s
+}
+
 type AddTagsToResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1515,6 +1527,12 @@ func (s AddTagsToResourceOutput) String() string {
 // GoString returns the string representation
 func (s AddTagsToResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *AddTagsToResourceOutput) SetStatus(v string) *AddTagsToResourceOutput {
+	s.Status = &v
+	return s
 }
 
 // Contains the inputs for the CreateHapgRequest action.
@@ -1550,6 +1568,12 @@ func (s *CreateHapgInput) Validate() error {
 	return nil
 }
 
+// SetLabel sets the Label field's value.
+func (s *CreateHapgInput) SetLabel(v string) *CreateHapgInput {
+	s.Label = &v
+	return s
+}
+
 // Contains the output of the CreateHAPartitionGroup action.
 type CreateHapgOutput struct {
 	_ struct{} `type:"structure"`
@@ -1566,6 +1590,12 @@ func (s CreateHapgOutput) String() string {
 // GoString returns the string representation
 func (s CreateHapgOutput) GoString() string {
 	return s.String()
+}
+
+// SetHapgArn sets the HapgArn field's value.
+func (s *CreateHapgOutput) SetHapgArn(v string) *CreateHapgOutput {
+	s.HapgArn = &v
+	return s
 }
 
 // Contains the inputs for the CreateHsm operation.
@@ -1646,6 +1676,54 @@ func (s *CreateHsmInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateHsmInput) SetClientToken(v string) *CreateHsmInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetEniIp sets the EniIp field's value.
+func (s *CreateHsmInput) SetEniIp(v string) *CreateHsmInput {
+	s.EniIp = &v
+	return s
+}
+
+// SetExternalId sets the ExternalId field's value.
+func (s *CreateHsmInput) SetExternalId(v string) *CreateHsmInput {
+	s.ExternalId = &v
+	return s
+}
+
+// SetIamRoleArn sets the IamRoleArn field's value.
+func (s *CreateHsmInput) SetIamRoleArn(v string) *CreateHsmInput {
+	s.IamRoleArn = &v
+	return s
+}
+
+// SetSshKey sets the SshKey field's value.
+func (s *CreateHsmInput) SetSshKey(v string) *CreateHsmInput {
+	s.SshKey = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *CreateHsmInput) SetSubnetId(v string) *CreateHsmInput {
+	s.SubnetId = &v
+	return s
+}
+
+// SetSubscriptionType sets the SubscriptionType field's value.
+func (s *CreateHsmInput) SetSubscriptionType(v string) *CreateHsmInput {
+	s.SubscriptionType = &v
+	return s
+}
+
+// SetSyslogIp sets the SyslogIp field's value.
+func (s *CreateHsmInput) SetSyslogIp(v string) *CreateHsmInput {
+	s.SyslogIp = &v
+	return s
+}
+
 // Contains the output of the CreateHsm operation.
 type CreateHsmOutput struct {
 	_ struct{} `type:"structure"`
@@ -1662,6 +1740,12 @@ func (s CreateHsmOutput) String() string {
 // GoString returns the string representation
 func (s CreateHsmOutput) GoString() string {
 	return s.String()
+}
+
+// SetHsmArn sets the HsmArn field's value.
+func (s *CreateHsmOutput) SetHsmArn(v string) *CreateHsmOutput {
+	s.HsmArn = &v
+	return s
 }
 
 // Contains the inputs for the CreateLunaClient action.
@@ -1704,6 +1788,18 @@ func (s *CreateLunaClientInput) Validate() error {
 	return nil
 }
 
+// SetCertificate sets the Certificate field's value.
+func (s *CreateLunaClientInput) SetCertificate(v string) *CreateLunaClientInput {
+	s.Certificate = &v
+	return s
+}
+
+// SetLabel sets the Label field's value.
+func (s *CreateLunaClientInput) SetLabel(v string) *CreateLunaClientInput {
+	s.Label = &v
+	return s
+}
+
 // Contains the output of the CreateLunaClient action.
 type CreateLunaClientOutput struct {
 	_ struct{} `type:"structure"`
@@ -1720,6 +1816,12 @@ func (s CreateLunaClientOutput) String() string {
 // GoString returns the string representation
 func (s CreateLunaClientOutput) GoString() string {
 	return s.String()
+}
+
+// SetClientArn sets the ClientArn field's value.
+func (s *CreateLunaClientOutput) SetClientArn(v string) *CreateLunaClientOutput {
+	s.ClientArn = &v
+	return s
 }
 
 // Contains the inputs for the DeleteHapg action.
@@ -1755,6 +1857,12 @@ func (s *DeleteHapgInput) Validate() error {
 	return nil
 }
 
+// SetHapgArn sets the HapgArn field's value.
+func (s *DeleteHapgInput) SetHapgArn(v string) *DeleteHapgInput {
+	s.HapgArn = &v
+	return s
+}
+
 // Contains the output of the DeleteHapg action.
 type DeleteHapgOutput struct {
 	_ struct{} `type:"structure"`
@@ -1773,6 +1881,12 @@ func (s DeleteHapgOutput) String() string {
 // GoString returns the string representation
 func (s DeleteHapgOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *DeleteHapgOutput) SetStatus(v string) *DeleteHapgOutput {
+	s.Status = &v
+	return s
 }
 
 // Contains the inputs for the DeleteHsm operation.
@@ -1808,6 +1922,12 @@ func (s *DeleteHsmInput) Validate() error {
 	return nil
 }
 
+// SetHsmArn sets the HsmArn field's value.
+func (s *DeleteHsmInput) SetHsmArn(v string) *DeleteHsmInput {
+	s.HsmArn = &v
+	return s
+}
+
 // Contains the output of the DeleteHsm operation.
 type DeleteHsmOutput struct {
 	_ struct{} `type:"structure"`
@@ -1826,6 +1946,12 @@ func (s DeleteHsmOutput) String() string {
 // GoString returns the string representation
 func (s DeleteHsmOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *DeleteHsmOutput) SetStatus(v string) *DeleteHsmOutput {
+	s.Status = &v
+	return s
 }
 
 type DeleteLunaClientInput struct {
@@ -1860,6 +1986,12 @@ func (s *DeleteLunaClientInput) Validate() error {
 	return nil
 }
 
+// SetClientArn sets the ClientArn field's value.
+func (s *DeleteLunaClientInput) SetClientArn(v string) *DeleteLunaClientInput {
+	s.ClientArn = &v
+	return s
+}
+
 type DeleteLunaClientOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1877,6 +2009,12 @@ func (s DeleteLunaClientOutput) String() string {
 // GoString returns the string representation
 func (s DeleteLunaClientOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *DeleteLunaClientOutput) SetStatus(v string) *DeleteLunaClientOutput {
+	s.Status = &v
+	return s
 }
 
 // Contains the inputs for the DescribeHapg action.
@@ -1910,6 +2048,12 @@ func (s *DescribeHapgInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHapgArn sets the HapgArn field's value.
+func (s *DescribeHapgInput) SetHapgArn(v string) *DescribeHapgInput {
+	s.HapgArn = &v
+	return s
 }
 
 // Contains the output of the DescribeHapg action.
@@ -1955,6 +2099,60 @@ func (s DescribeHapgOutput) GoString() string {
 	return s.String()
 }
 
+// SetHapgArn sets the HapgArn field's value.
+func (s *DescribeHapgOutput) SetHapgArn(v string) *DescribeHapgOutput {
+	s.HapgArn = &v
+	return s
+}
+
+// SetHapgSerial sets the HapgSerial field's value.
+func (s *DescribeHapgOutput) SetHapgSerial(v string) *DescribeHapgOutput {
+	s.HapgSerial = &v
+	return s
+}
+
+// SetHsmsLastActionFailed sets the HsmsLastActionFailed field's value.
+func (s *DescribeHapgOutput) SetHsmsLastActionFailed(v []*string) *DescribeHapgOutput {
+	s.HsmsLastActionFailed = v
+	return s
+}
+
+// SetHsmsPendingDeletion sets the HsmsPendingDeletion field's value.
+func (s *DescribeHapgOutput) SetHsmsPendingDeletion(v []*string) *DescribeHapgOutput {
+	s.HsmsPendingDeletion = v
+	return s
+}
+
+// SetHsmsPendingRegistration sets the HsmsPendingRegistration field's value.
+func (s *DescribeHapgOutput) SetHsmsPendingRegistration(v []*string) *DescribeHapgOutput {
+	s.HsmsPendingRegistration = v
+	return s
+}
+
+// SetLabel sets the Label field's value.
+func (s *DescribeHapgOutput) SetLabel(v string) *DescribeHapgOutput {
+	s.Label = &v
+	return s
+}
+
+// SetLastModifiedTimestamp sets the LastModifiedTimestamp field's value.
+func (s *DescribeHapgOutput) SetLastModifiedTimestamp(v string) *DescribeHapgOutput {
+	s.LastModifiedTimestamp = &v
+	return s
+}
+
+// SetPartitionSerialList sets the PartitionSerialList field's value.
+func (s *DescribeHapgOutput) SetPartitionSerialList(v []*string) *DescribeHapgOutput {
+	s.PartitionSerialList = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *DescribeHapgOutput) SetState(v string) *DescribeHapgOutput {
+	s.State = &v
+	return s
+}
+
 // Contains the inputs for the DescribeHsm operation.
 type DescribeHsmInput struct {
 	_ struct{} `type:"structure"`
@@ -1976,6 +2174,18 @@ func (s DescribeHsmInput) String() string {
 // GoString returns the string representation
 func (s DescribeHsmInput) GoString() string {
 	return s.String()
+}
+
+// SetHsmArn sets the HsmArn field's value.
+func (s *DescribeHsmInput) SetHsmArn(v string) *DescribeHsmInput {
+	s.HsmArn = &v
+	return s
+}
+
+// SetHsmSerialNumber sets the HsmSerialNumber field's value.
+func (s *DescribeHsmInput) SetHsmSerialNumber(v string) *DescribeHsmInput {
+	s.HsmSerialNumber = &v
+	return s
 }
 
 // Contains the output of the DescribeHsm operation.
@@ -2059,6 +2269,132 @@ func (s DescribeHsmOutput) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *DescribeHsmOutput) SetAvailabilityZone(v string) *DescribeHsmOutput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetEniId sets the EniId field's value.
+func (s *DescribeHsmOutput) SetEniId(v string) *DescribeHsmOutput {
+	s.EniId = &v
+	return s
+}
+
+// SetEniIp sets the EniIp field's value.
+func (s *DescribeHsmOutput) SetEniIp(v string) *DescribeHsmOutput {
+	s.EniIp = &v
+	return s
+}
+
+// SetHsmArn sets the HsmArn field's value.
+func (s *DescribeHsmOutput) SetHsmArn(v string) *DescribeHsmOutput {
+	s.HsmArn = &v
+	return s
+}
+
+// SetHsmType sets the HsmType field's value.
+func (s *DescribeHsmOutput) SetHsmType(v string) *DescribeHsmOutput {
+	s.HsmType = &v
+	return s
+}
+
+// SetIamRoleArn sets the IamRoleArn field's value.
+func (s *DescribeHsmOutput) SetIamRoleArn(v string) *DescribeHsmOutput {
+	s.IamRoleArn = &v
+	return s
+}
+
+// SetPartitions sets the Partitions field's value.
+func (s *DescribeHsmOutput) SetPartitions(v []*string) *DescribeHsmOutput {
+	s.Partitions = v
+	return s
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *DescribeHsmOutput) SetSerialNumber(v string) *DescribeHsmOutput {
+	s.SerialNumber = &v
+	return s
+}
+
+// SetServerCertLastUpdated sets the ServerCertLastUpdated field's value.
+func (s *DescribeHsmOutput) SetServerCertLastUpdated(v string) *DescribeHsmOutput {
+	s.ServerCertLastUpdated = &v
+	return s
+}
+
+// SetServerCertUri sets the ServerCertUri field's value.
+func (s *DescribeHsmOutput) SetServerCertUri(v string) *DescribeHsmOutput {
+	s.ServerCertUri = &v
+	return s
+}
+
+// SetSoftwareVersion sets the SoftwareVersion field's value.
+func (s *DescribeHsmOutput) SetSoftwareVersion(v string) *DescribeHsmOutput {
+	s.SoftwareVersion = &v
+	return s
+}
+
+// SetSshKeyLastUpdated sets the SshKeyLastUpdated field's value.
+func (s *DescribeHsmOutput) SetSshKeyLastUpdated(v string) *DescribeHsmOutput {
+	s.SshKeyLastUpdated = &v
+	return s
+}
+
+// SetSshPublicKey sets the SshPublicKey field's value.
+func (s *DescribeHsmOutput) SetSshPublicKey(v string) *DescribeHsmOutput {
+	s.SshPublicKey = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DescribeHsmOutput) SetStatus(v string) *DescribeHsmOutput {
+	s.Status = &v
+	return s
+}
+
+// SetStatusDetails sets the StatusDetails field's value.
+func (s *DescribeHsmOutput) SetStatusDetails(v string) *DescribeHsmOutput {
+	s.StatusDetails = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *DescribeHsmOutput) SetSubnetId(v string) *DescribeHsmOutput {
+	s.SubnetId = &v
+	return s
+}
+
+// SetSubscriptionEndDate sets the SubscriptionEndDate field's value.
+func (s *DescribeHsmOutput) SetSubscriptionEndDate(v string) *DescribeHsmOutput {
+	s.SubscriptionEndDate = &v
+	return s
+}
+
+// SetSubscriptionStartDate sets the SubscriptionStartDate field's value.
+func (s *DescribeHsmOutput) SetSubscriptionStartDate(v string) *DescribeHsmOutput {
+	s.SubscriptionStartDate = &v
+	return s
+}
+
+// SetSubscriptionType sets the SubscriptionType field's value.
+func (s *DescribeHsmOutput) SetSubscriptionType(v string) *DescribeHsmOutput {
+	s.SubscriptionType = &v
+	return s
+}
+
+// SetVendorName sets the VendorName field's value.
+func (s *DescribeHsmOutput) SetVendorName(v string) *DescribeHsmOutput {
+	s.VendorName = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DescribeHsmOutput) SetVpcId(v string) *DescribeHsmOutput {
+	s.VpcId = &v
+	return s
+}
+
 type DescribeLunaClientInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2077,6 +2413,18 @@ func (s DescribeLunaClientInput) String() string {
 // GoString returns the string representation
 func (s DescribeLunaClientInput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateFingerprint sets the CertificateFingerprint field's value.
+func (s *DescribeLunaClientInput) SetCertificateFingerprint(v string) *DescribeLunaClientInput {
+	s.CertificateFingerprint = &v
+	return s
+}
+
+// SetClientArn sets the ClientArn field's value.
+func (s *DescribeLunaClientInput) SetClientArn(v string) *DescribeLunaClientInput {
+	s.ClientArn = &v
+	return s
 }
 
 type DescribeLunaClientOutput struct {
@@ -2106,6 +2454,36 @@ func (s DescribeLunaClientOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLunaClientOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificate sets the Certificate field's value.
+func (s *DescribeLunaClientOutput) SetCertificate(v string) *DescribeLunaClientOutput {
+	s.Certificate = &v
+	return s
+}
+
+// SetCertificateFingerprint sets the CertificateFingerprint field's value.
+func (s *DescribeLunaClientOutput) SetCertificateFingerprint(v string) *DescribeLunaClientOutput {
+	s.CertificateFingerprint = &v
+	return s
+}
+
+// SetClientArn sets the ClientArn field's value.
+func (s *DescribeLunaClientOutput) SetClientArn(v string) *DescribeLunaClientOutput {
+	s.ClientArn = &v
+	return s
+}
+
+// SetLabel sets the Label field's value.
+func (s *DescribeLunaClientOutput) SetLabel(v string) *DescribeLunaClientOutput {
+	s.Label = &v
+	return s
+}
+
+// SetLastModifiedTimestamp sets the LastModifiedTimestamp field's value.
+func (s *DescribeLunaClientOutput) SetLastModifiedTimestamp(v string) *DescribeLunaClientOutput {
+	s.LastModifiedTimestamp = &v
+	return s
 }
 
 type GetConfigInput struct {
@@ -2157,6 +2535,24 @@ func (s *GetConfigInput) Validate() error {
 	return nil
 }
 
+// SetClientArn sets the ClientArn field's value.
+func (s *GetConfigInput) SetClientArn(v string) *GetConfigInput {
+	s.ClientArn = &v
+	return s
+}
+
+// SetClientVersion sets the ClientVersion field's value.
+func (s *GetConfigInput) SetClientVersion(v string) *GetConfigInput {
+	s.ClientVersion = &v
+	return s
+}
+
+// SetHapgList sets the HapgList field's value.
+func (s *GetConfigInput) SetHapgList(v []*string) *GetConfigInput {
+	s.HapgList = v
+	return s
+}
+
 type GetConfigOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2178,6 +2574,24 @@ func (s GetConfigOutput) String() string {
 // GoString returns the string representation
 func (s GetConfigOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigCred sets the ConfigCred field's value.
+func (s *GetConfigOutput) SetConfigCred(v string) *GetConfigOutput {
+	s.ConfigCred = &v
+	return s
+}
+
+// SetConfigFile sets the ConfigFile field's value.
+func (s *GetConfigOutput) SetConfigFile(v string) *GetConfigOutput {
+	s.ConfigFile = &v
+	return s
+}
+
+// SetConfigType sets the ConfigType field's value.
+func (s *GetConfigOutput) SetConfigType(v string) *GetConfigOutput {
+	s.ConfigType = &v
+	return s
 }
 
 // Contains the inputs for the ListAvailableZones action.
@@ -2212,6 +2626,12 @@ func (s ListAvailableZonesOutput) GoString() string {
 	return s.String()
 }
 
+// SetAZList sets the AZList field's value.
+func (s *ListAvailableZonesOutput) SetAZList(v []*string) *ListAvailableZonesOutput {
+	s.AZList = v
+	return s
+}
+
 type ListHapgsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2228,6 +2648,12 @@ func (s ListHapgsInput) String() string {
 // GoString returns the string representation
 func (s ListHapgsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListHapgsInput) SetNextToken(v string) *ListHapgsInput {
+	s.NextToken = &v
+	return s
 }
 
 type ListHapgsOutput struct {
@@ -2253,6 +2679,18 @@ func (s ListHapgsOutput) GoString() string {
 	return s.String()
 }
 
+// SetHapgList sets the HapgList field's value.
+func (s *ListHapgsOutput) SetHapgList(v []*string) *ListHapgsOutput {
+	s.HapgList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListHapgsOutput) SetNextToken(v string) *ListHapgsOutput {
+	s.NextToken = &v
+	return s
+}
+
 type ListHsmsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2269,6 +2707,12 @@ func (s ListHsmsInput) String() string {
 // GoString returns the string representation
 func (s ListHsmsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListHsmsInput) SetNextToken(v string) *ListHsmsInput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the output of the ListHsms operation.
@@ -2293,6 +2737,18 @@ func (s ListHsmsOutput) GoString() string {
 	return s.String()
 }
 
+// SetHsmList sets the HsmList field's value.
+func (s *ListHsmsOutput) SetHsmList(v []*string) *ListHsmsOutput {
+	s.HsmList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListHsmsOutput) SetNextToken(v string) *ListHsmsOutput {
+	s.NextToken = &v
+	return s
+}
+
 type ListLunaClientsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2309,6 +2765,12 @@ func (s ListLunaClientsInput) String() string {
 // GoString returns the string representation
 func (s ListLunaClientsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListLunaClientsInput) SetNextToken(v string) *ListLunaClientsInput {
+	s.NextToken = &v
+	return s
 }
 
 type ListLunaClientsOutput struct {
@@ -2332,6 +2794,18 @@ func (s ListLunaClientsOutput) String() string {
 // GoString returns the string representation
 func (s ListLunaClientsOutput) GoString() string {
 	return s.String()
+}
+
+// SetClientList sets the ClientList field's value.
+func (s *ListLunaClientsOutput) SetClientList(v []*string) *ListLunaClientsOutput {
+	s.ClientList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListLunaClientsOutput) SetNextToken(v string) *ListLunaClientsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListTagsForResourceInput struct {
@@ -2366,6 +2840,12 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceArn sets the ResourceArn field's value.
+func (s *ListTagsForResourceInput) SetResourceArn(v string) *ListTagsForResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2383,6 +2863,12 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagList sets the TagList field's value.
+func (s *ListTagsForResourceOutput) SetTagList(v []*Tag) *ListTagsForResourceOutput {
+	s.TagList = v
+	return s
 }
 
 type ModifyHapgInput struct {
@@ -2424,6 +2910,24 @@ func (s *ModifyHapgInput) Validate() error {
 	return nil
 }
 
+// SetHapgArn sets the HapgArn field's value.
+func (s *ModifyHapgInput) SetHapgArn(v string) *ModifyHapgInput {
+	s.HapgArn = &v
+	return s
+}
+
+// SetLabel sets the Label field's value.
+func (s *ModifyHapgInput) SetLabel(v string) *ModifyHapgInput {
+	s.Label = &v
+	return s
+}
+
+// SetPartitionSerialList sets the PartitionSerialList field's value.
+func (s *ModifyHapgInput) SetPartitionSerialList(v []*string) *ModifyHapgInput {
+	s.PartitionSerialList = v
+	return s
+}
+
 type ModifyHapgOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2439,6 +2943,12 @@ func (s ModifyHapgOutput) String() string {
 // GoString returns the string representation
 func (s ModifyHapgOutput) GoString() string {
 	return s.String()
+}
+
+// SetHapgArn sets the HapgArn field's value.
+func (s *ModifyHapgOutput) SetHapgArn(v string) *ModifyHapgOutput {
+	s.HapgArn = &v
+	return s
 }
 
 // Contains the inputs for the ModifyHsm operation.
@@ -2495,6 +3005,42 @@ func (s *ModifyHsmInput) Validate() error {
 	return nil
 }
 
+// SetEniIp sets the EniIp field's value.
+func (s *ModifyHsmInput) SetEniIp(v string) *ModifyHsmInput {
+	s.EniIp = &v
+	return s
+}
+
+// SetExternalId sets the ExternalId field's value.
+func (s *ModifyHsmInput) SetExternalId(v string) *ModifyHsmInput {
+	s.ExternalId = &v
+	return s
+}
+
+// SetHsmArn sets the HsmArn field's value.
+func (s *ModifyHsmInput) SetHsmArn(v string) *ModifyHsmInput {
+	s.HsmArn = &v
+	return s
+}
+
+// SetIamRoleArn sets the IamRoleArn field's value.
+func (s *ModifyHsmInput) SetIamRoleArn(v string) *ModifyHsmInput {
+	s.IamRoleArn = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *ModifyHsmInput) SetSubnetId(v string) *ModifyHsmInput {
+	s.SubnetId = &v
+	return s
+}
+
+// SetSyslogIp sets the SyslogIp field's value.
+func (s *ModifyHsmInput) SetSyslogIp(v string) *ModifyHsmInput {
+	s.SyslogIp = &v
+	return s
+}
+
 // Contains the output of the ModifyHsm operation.
 type ModifyHsmOutput struct {
 	_ struct{} `type:"structure"`
@@ -2511,6 +3057,12 @@ func (s ModifyHsmOutput) String() string {
 // GoString returns the string representation
 func (s ModifyHsmOutput) GoString() string {
 	return s.String()
+}
+
+// SetHsmArn sets the HsmArn field's value.
+func (s *ModifyHsmOutput) SetHsmArn(v string) *ModifyHsmOutput {
+	s.HsmArn = &v
+	return s
 }
 
 type ModifyLunaClientInput struct {
@@ -2556,6 +3108,18 @@ func (s *ModifyLunaClientInput) Validate() error {
 	return nil
 }
 
+// SetCertificate sets the Certificate field's value.
+func (s *ModifyLunaClientInput) SetCertificate(v string) *ModifyLunaClientInput {
+	s.Certificate = &v
+	return s
+}
+
+// SetClientArn sets the ClientArn field's value.
+func (s *ModifyLunaClientInput) SetClientArn(v string) *ModifyLunaClientInput {
+	s.ClientArn = &v
+	return s
+}
+
 type ModifyLunaClientOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2571,6 +3135,12 @@ func (s ModifyLunaClientOutput) String() string {
 // GoString returns the string representation
 func (s ModifyLunaClientOutput) GoString() string {
 	return s.String()
+}
+
+// SetClientArn sets the ClientArn field's value.
+func (s *ModifyLunaClientOutput) SetClientArn(v string) *ModifyLunaClientOutput {
+	s.ClientArn = &v
+	return s
 }
 
 type RemoveTagsFromResourceInput struct {
@@ -2616,6 +3186,18 @@ func (s *RemoveTagsFromResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceArn sets the ResourceArn field's value.
+func (s *RemoveTagsFromResourceInput) SetResourceArn(v string) *RemoveTagsFromResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTagKeyList sets the TagKeyList field's value.
+func (s *RemoveTagsFromResourceInput) SetTagKeyList(v []*string) *RemoveTagsFromResourceInput {
+	s.TagKeyList = v
+	return s
+}
+
 type RemoveTagsFromResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2633,6 +3215,12 @@ func (s RemoveTagsFromResourceOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *RemoveTagsFromResourceOutput) SetStatus(v string) *RemoveTagsFromResourceOutput {
+	s.Status = &v
+	return s
 }
 
 // A key-value pair that identifies or specifies metadata about an AWS CloudHSM
@@ -2678,6 +3266,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 const (

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -1904,6 +1904,18 @@ func (s AccessPoliciesStatus) GoString() string {
 	return s.String()
 }
 
+// SetOptions sets the Options field's value.
+func (s *AccessPoliciesStatus) SetOptions(v string) *AccessPoliciesStatus {
+	s.Options = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AccessPoliciesStatus) SetStatus(v *OptionStatus) *AccessPoliciesStatus {
+	s.Status = v
+	return s
+}
+
 // Synonyms, stopwords, and stemming options for an analysis scheme. Includes
 // tokenization dictionary for Japanese.
 type AnalysisOptions struct {
@@ -1954,6 +1966,36 @@ func (s AnalysisOptions) String() string {
 // GoString returns the string representation
 func (s AnalysisOptions) GoString() string {
 	return s.String()
+}
+
+// SetAlgorithmicStemming sets the AlgorithmicStemming field's value.
+func (s *AnalysisOptions) SetAlgorithmicStemming(v string) *AnalysisOptions {
+	s.AlgorithmicStemming = &v
+	return s
+}
+
+// SetJapaneseTokenizationDictionary sets the JapaneseTokenizationDictionary field's value.
+func (s *AnalysisOptions) SetJapaneseTokenizationDictionary(v string) *AnalysisOptions {
+	s.JapaneseTokenizationDictionary = &v
+	return s
+}
+
+// SetStemmingDictionary sets the StemmingDictionary field's value.
+func (s *AnalysisOptions) SetStemmingDictionary(v string) *AnalysisOptions {
+	s.StemmingDictionary = &v
+	return s
+}
+
+// SetStopwords sets the Stopwords field's value.
+func (s *AnalysisOptions) SetStopwords(v string) *AnalysisOptions {
+	s.Stopwords = &v
+	return s
+}
+
+// SetSynonyms sets the Synonyms field's value.
+func (s *AnalysisOptions) SetSynonyms(v string) *AnalysisOptions {
+	s.Synonyms = &v
+	return s
 }
 
 // Configuration information for an analysis scheme. Each analysis scheme has
@@ -2009,6 +2051,24 @@ func (s *AnalysisScheme) Validate() error {
 	return nil
 }
 
+// SetAnalysisOptions sets the AnalysisOptions field's value.
+func (s *AnalysisScheme) SetAnalysisOptions(v *AnalysisOptions) *AnalysisScheme {
+	s.AnalysisOptions = v
+	return s
+}
+
+// SetAnalysisSchemeLanguage sets the AnalysisSchemeLanguage field's value.
+func (s *AnalysisScheme) SetAnalysisSchemeLanguage(v string) *AnalysisScheme {
+	s.AnalysisSchemeLanguage = &v
+	return s
+}
+
+// SetAnalysisSchemeName sets the AnalysisSchemeName field's value.
+func (s *AnalysisScheme) SetAnalysisSchemeName(v string) *AnalysisScheme {
+	s.AnalysisSchemeName = &v
+	return s
+}
+
 // The status and configuration of an AnalysisScheme.
 type AnalysisSchemeStatus struct {
 	_ struct{} `type:"structure"`
@@ -2037,6 +2097,18 @@ func (s AnalysisSchemeStatus) GoString() string {
 	return s.String()
 }
 
+// SetOptions sets the Options field's value.
+func (s *AnalysisSchemeStatus) SetOptions(v *AnalysisScheme) *AnalysisSchemeStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AnalysisSchemeStatus) SetStatus(v *OptionStatus) *AnalysisSchemeStatus {
+	s.Status = v
+	return s
+}
+
 // The status and configuration of the domain's availability options.
 type AvailabilityOptionsStatus struct {
 	_ struct{} `type:"structure"`
@@ -2060,6 +2132,18 @@ func (s AvailabilityOptionsStatus) String() string {
 // GoString returns the string representation
 func (s AvailabilityOptionsStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *AvailabilityOptionsStatus) SetOptions(v bool) *AvailabilityOptionsStatus {
+	s.Options = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AvailabilityOptionsStatus) SetStatus(v *OptionStatus) *AvailabilityOptionsStatus {
+	s.Status = v
+	return s
 }
 
 // Container for the parameters to the BuildSuggester operation. Specifies the
@@ -2102,6 +2186,12 @@ func (s *BuildSuggestersInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *BuildSuggestersInput) SetDomainName(v string) *BuildSuggestersInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a BuildSuggester request. Contains a list of the fields used
 // for suggestions.
 type BuildSuggestersOutput struct {
@@ -2119,6 +2209,12 @@ func (s BuildSuggestersOutput) String() string {
 // GoString returns the string representation
 func (s BuildSuggestersOutput) GoString() string {
 	return s.String()
+}
+
+// SetFieldNames sets the FieldNames field's value.
+func (s *BuildSuggestersOutput) SetFieldNames(v []*string) *BuildSuggestersOutput {
+	s.FieldNames = v
+	return s
 }
 
 // Container for the parameters to the CreateDomain operation. Specifies a name
@@ -2160,6 +2256,12 @@ func (s *CreateDomainInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *CreateDomainInput) SetDomainName(v string) *CreateDomainInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a CreateDomainRequest. Contains the status of a newly created
 // domain.
 type CreateDomainOutput struct {
@@ -2177,6 +2279,12 @@ func (s CreateDomainOutput) String() string {
 // GoString returns the string representation
 func (s CreateDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainStatus sets the DomainStatus field's value.
+func (s *CreateDomainOutput) SetDomainStatus(v *DomainStatus) *CreateDomainOutput {
+	s.DomainStatus = v
+	return s
 }
 
 // Options for a field that contains an array of dates. Present if IndexFieldType
@@ -2208,6 +2316,36 @@ func (s DateArrayOptions) String() string {
 // GoString returns the string representation
 func (s DateArrayOptions) GoString() string {
 	return s.String()
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *DateArrayOptions) SetDefaultValue(v string) *DateArrayOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *DateArrayOptions) SetFacetEnabled(v bool) *DateArrayOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *DateArrayOptions) SetReturnEnabled(v bool) *DateArrayOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *DateArrayOptions) SetSearchEnabled(v bool) *DateArrayOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSourceFields sets the SourceFields field's value.
+func (s *DateArrayOptions) SetSourceFields(v string) *DateArrayOptions {
+	s.SourceFields = &v
+	return s
 }
 
 // Options for a date field. Dates and times are specified in UTC (Coordinated
@@ -2272,6 +2410,42 @@ func (s *DateOptions) Validate() error {
 	return nil
 }
 
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *DateOptions) SetDefaultValue(v string) *DateOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *DateOptions) SetFacetEnabled(v bool) *DateOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *DateOptions) SetReturnEnabled(v bool) *DateOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *DateOptions) SetSearchEnabled(v bool) *DateOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSortEnabled sets the SortEnabled field's value.
+func (s *DateOptions) SetSortEnabled(v bool) *DateOptions {
+	s.SortEnabled = &v
+	return s
+}
+
+// SetSourceField sets the SourceField field's value.
+func (s *DateOptions) SetSourceField(v string) *DateOptions {
+	s.SourceField = &v
+	return s
+}
+
 // Container for the parameters to the DefineAnalysisScheme operation. Specifies
 // the name of the domain you want to update and the analysis scheme configuration.
 type DefineAnalysisSchemeInput struct {
@@ -2328,6 +2502,18 @@ func (s *DefineAnalysisSchemeInput) Validate() error {
 	return nil
 }
 
+// SetAnalysisScheme sets the AnalysisScheme field's value.
+func (s *DefineAnalysisSchemeInput) SetAnalysisScheme(v *AnalysisScheme) *DefineAnalysisSchemeInput {
+	s.AnalysisScheme = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DefineAnalysisSchemeInput) SetDomainName(v string) *DefineAnalysisSchemeInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DefineAnalysisScheme request. Contains the status of the
 // newly-configured analysis scheme.
 type DefineAnalysisSchemeOutput struct {
@@ -2347,6 +2533,12 @@ func (s DefineAnalysisSchemeOutput) String() string {
 // GoString returns the string representation
 func (s DefineAnalysisSchemeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAnalysisScheme sets the AnalysisScheme field's value.
+func (s *DefineAnalysisSchemeOutput) SetAnalysisScheme(v *AnalysisSchemeStatus) *DefineAnalysisSchemeOutput {
+	s.AnalysisScheme = v
+	return s
 }
 
 // Container for the parameters to the DefineExpression operation. Specifies
@@ -2405,6 +2597,18 @@ func (s *DefineExpressionInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DefineExpressionInput) SetDomainName(v string) *DefineExpressionInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetExpression sets the Expression field's value.
+func (s *DefineExpressionInput) SetExpression(v *Expression) *DefineExpressionInput {
+	s.Expression = v
+	return s
+}
+
 // The result of a DefineExpression request. Contains the status of the newly-configured
 // expression.
 type DefineExpressionOutput struct {
@@ -2424,6 +2628,12 @@ func (s DefineExpressionOutput) String() string {
 // GoString returns the string representation
 func (s DefineExpressionOutput) GoString() string {
 	return s.String()
+}
+
+// SetExpression sets the Expression field's value.
+func (s *DefineExpressionOutput) SetExpression(v *ExpressionStatus) *DefineExpressionOutput {
+	s.Expression = v
+	return s
 }
 
 // Container for the parameters to the DefineIndexField operation. Specifies
@@ -2479,6 +2689,18 @@ func (s *DefineIndexFieldInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DefineIndexFieldInput) SetDomainName(v string) *DefineIndexFieldInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetIndexField sets the IndexField field's value.
+func (s *DefineIndexFieldInput) SetIndexField(v *IndexField) *DefineIndexFieldInput {
+	s.IndexField = v
+	return s
+}
+
 // The result of a DefineIndexField request. Contains the status of the newly-configured
 // index field.
 type DefineIndexFieldOutput struct {
@@ -2498,6 +2720,12 @@ func (s DefineIndexFieldOutput) String() string {
 // GoString returns the string representation
 func (s DefineIndexFieldOutput) GoString() string {
 	return s.String()
+}
+
+// SetIndexField sets the IndexField field's value.
+func (s *DefineIndexFieldOutput) SetIndexField(v *IndexFieldStatus) *DefineIndexFieldOutput {
+	s.IndexField = v
+	return s
 }
 
 // Container for the parameters to the DefineSuggester operation. Specifies
@@ -2555,6 +2783,18 @@ func (s *DefineSuggesterInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DefineSuggesterInput) SetDomainName(v string) *DefineSuggesterInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetSuggester sets the Suggester field's value.
+func (s *DefineSuggesterInput) SetSuggester(v *Suggester) *DefineSuggesterInput {
+	s.Suggester = v
+	return s
+}
+
 // The result of a DefineSuggester request. Contains the status of the newly-configured
 // suggester.
 type DefineSuggesterOutput struct {
@@ -2574,6 +2814,12 @@ func (s DefineSuggesterOutput) String() string {
 // GoString returns the string representation
 func (s DefineSuggesterOutput) GoString() string {
 	return s.String()
+}
+
+// SetSuggester sets the Suggester field's value.
+func (s *DefineSuggesterOutput) SetSuggester(v *SuggesterStatus) *DefineSuggesterOutput {
+	s.Suggester = v
+	return s
 }
 
 // Container for the parameters to the DeleteAnalysisScheme operation. Specifies
@@ -2628,6 +2874,18 @@ func (s *DeleteAnalysisSchemeInput) Validate() error {
 	return nil
 }
 
+// SetAnalysisSchemeName sets the AnalysisSchemeName field's value.
+func (s *DeleteAnalysisSchemeInput) SetAnalysisSchemeName(v string) *DeleteAnalysisSchemeInput {
+	s.AnalysisSchemeName = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteAnalysisSchemeInput) SetDomainName(v string) *DeleteAnalysisSchemeInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DeleteAnalysisScheme request. Contains the status of the
 // deleted analysis scheme.
 type DeleteAnalysisSchemeOutput struct {
@@ -2647,6 +2905,12 @@ func (s DeleteAnalysisSchemeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteAnalysisSchemeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAnalysisScheme sets the AnalysisScheme field's value.
+func (s *DeleteAnalysisSchemeOutput) SetAnalysisScheme(v *AnalysisSchemeStatus) *DeleteAnalysisSchemeOutput {
+	s.AnalysisScheme = v
+	return s
 }
 
 // Container for the parameters to the DeleteDomain operation. Specifies the
@@ -2686,6 +2950,12 @@ func (s *DeleteDomainInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteDomainInput) SetDomainName(v string) *DeleteDomainInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DeleteDomain request. Contains the status of a newly deleted
 // domain, or no status if the domain has already been completely deleted.
 type DeleteDomainOutput struct {
@@ -2703,6 +2973,12 @@ func (s DeleteDomainOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainStatus sets the DomainStatus field's value.
+func (s *DeleteDomainOutput) SetDomainStatus(v *DomainStatus) *DeleteDomainOutput {
+	s.DomainStatus = v
+	return s
 }
 
 // Container for the parameters to the DeleteExpression operation. Specifies
@@ -2757,6 +3033,18 @@ func (s *DeleteExpressionInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteExpressionInput) SetDomainName(v string) *DeleteExpressionInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetExpressionName sets the ExpressionName field's value.
+func (s *DeleteExpressionInput) SetExpressionName(v string) *DeleteExpressionInput {
+	s.ExpressionName = &v
+	return s
+}
+
 // The result of a DeleteExpression request. Specifies the expression being
 // deleted.
 type DeleteExpressionOutput struct {
@@ -2776,6 +3064,12 @@ func (s DeleteExpressionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteExpressionOutput) GoString() string {
 	return s.String()
+}
+
+// SetExpression sets the Expression field's value.
+func (s *DeleteExpressionOutput) SetExpression(v *ExpressionStatus) *DeleteExpressionOutput {
+	s.Expression = v
+	return s
 }
 
 // Container for the parameters to the DeleteIndexField operation. Specifies
@@ -2831,6 +3125,18 @@ func (s *DeleteIndexFieldInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteIndexFieldInput) SetDomainName(v string) *DeleteIndexFieldInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetIndexFieldName sets the IndexFieldName field's value.
+func (s *DeleteIndexFieldInput) SetIndexFieldName(v string) *DeleteIndexFieldInput {
+	s.IndexFieldName = &v
+	return s
+}
+
 // The result of a DeleteIndexField request.
 type DeleteIndexFieldOutput struct {
 	_ struct{} `type:"structure"`
@@ -2849,6 +3155,12 @@ func (s DeleteIndexFieldOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIndexFieldOutput) GoString() string {
 	return s.String()
+}
+
+// SetIndexField sets the IndexField field's value.
+func (s *DeleteIndexFieldOutput) SetIndexField(v *IndexFieldStatus) *DeleteIndexFieldOutput {
+	s.IndexField = v
+	return s
 }
 
 // Container for the parameters to the DeleteSuggester operation. Specifies
@@ -2903,6 +3215,18 @@ func (s *DeleteSuggesterInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteSuggesterInput) SetDomainName(v string) *DeleteSuggesterInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetSuggesterName sets the SuggesterName field's value.
+func (s *DeleteSuggesterInput) SetSuggesterName(v string) *DeleteSuggesterInput {
+	s.SuggesterName = &v
+	return s
+}
+
 // The result of a DeleteSuggester request. Contains the status of the deleted
 // suggester.
 type DeleteSuggesterOutput struct {
@@ -2922,6 +3246,12 @@ func (s DeleteSuggesterOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSuggesterOutput) GoString() string {
 	return s.String()
+}
+
+// SetSuggester sets the Suggester field's value.
+func (s *DeleteSuggesterOutput) SetSuggester(v *SuggesterStatus) *DeleteSuggesterOutput {
+	s.Suggester = v
+	return s
 }
 
 // Container for the parameters to the DescribeAnalysisSchemes operation. Specifies
@@ -2971,6 +3301,24 @@ func (s *DescribeAnalysisSchemesInput) Validate() error {
 	return nil
 }
 
+// SetAnalysisSchemeNames sets the AnalysisSchemeNames field's value.
+func (s *DescribeAnalysisSchemesInput) SetAnalysisSchemeNames(v []*string) *DescribeAnalysisSchemesInput {
+	s.AnalysisSchemeNames = v
+	return s
+}
+
+// SetDeployed sets the Deployed field's value.
+func (s *DescribeAnalysisSchemesInput) SetDeployed(v bool) *DescribeAnalysisSchemesInput {
+	s.Deployed = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeAnalysisSchemesInput) SetDomainName(v string) *DescribeAnalysisSchemesInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DescribeAnalysisSchemes request. Contains the analysis schemes
 // configured for the domain specified in the request.
 type DescribeAnalysisSchemesOutput struct {
@@ -2990,6 +3338,12 @@ func (s DescribeAnalysisSchemesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAnalysisSchemesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAnalysisSchemes sets the AnalysisSchemes field's value.
+func (s *DescribeAnalysisSchemesOutput) SetAnalysisSchemes(v []*AnalysisSchemeStatus) *DescribeAnalysisSchemesOutput {
+	s.AnalysisSchemes = v
+	return s
 }
 
 // Container for the parameters to the DescribeAvailabilityOptions operation.
@@ -3035,6 +3389,18 @@ func (s *DescribeAvailabilityOptionsInput) Validate() error {
 	return nil
 }
 
+// SetDeployed sets the Deployed field's value.
+func (s *DescribeAvailabilityOptionsInput) SetDeployed(v bool) *DescribeAvailabilityOptionsInput {
+	s.Deployed = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeAvailabilityOptionsInput) SetDomainName(v string) *DescribeAvailabilityOptionsInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DescribeAvailabilityOptions request. Indicates whether or
 // not the Multi-AZ option is enabled for the domain specified in the request.
 type DescribeAvailabilityOptionsOutput struct {
@@ -3053,6 +3419,12 @@ func (s DescribeAvailabilityOptionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAvailabilityOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityOptions sets the AvailabilityOptions field's value.
+func (s *DescribeAvailabilityOptionsOutput) SetAvailabilityOptions(v *AvailabilityOptionsStatus) *DescribeAvailabilityOptionsOutput {
+	s.AvailabilityOptions = v
+	return s
 }
 
 // Container for the parameters to the DescribeDomains operation. By default
@@ -3075,6 +3447,12 @@ func (s DescribeDomainsInput) GoString() string {
 	return s.String()
 }
 
+// SetDomainNames sets the DomainNames field's value.
+func (s *DescribeDomainsInput) SetDomainNames(v []*string) *DescribeDomainsInput {
+	s.DomainNames = v
+	return s
+}
+
 // The result of a DescribeDomains request. Contains the status of the domains
 // specified in the request or all domains owned by the account.
 type DescribeDomainsOutput struct {
@@ -3094,6 +3472,12 @@ func (s DescribeDomainsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDomainsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainStatusList sets the DomainStatusList field's value.
+func (s *DescribeDomainsOutput) SetDomainStatusList(v []*DomainStatus) *DescribeDomainsOutput {
+	s.DomainStatusList = v
+	return s
 }
 
 // Container for the parameters to the DescribeDomains operation. Specifies
@@ -3144,6 +3528,24 @@ func (s *DescribeExpressionsInput) Validate() error {
 	return nil
 }
 
+// SetDeployed sets the Deployed field's value.
+func (s *DescribeExpressionsInput) SetDeployed(v bool) *DescribeExpressionsInput {
+	s.Deployed = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeExpressionsInput) SetDomainName(v string) *DescribeExpressionsInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetExpressionNames sets the ExpressionNames field's value.
+func (s *DescribeExpressionsInput) SetExpressionNames(v []*string) *DescribeExpressionsInput {
+	s.ExpressionNames = v
+	return s
+}
+
 // The result of a DescribeExpressions request. Contains the expressions configured
 // for the domain specified in the request.
 type DescribeExpressionsOutput struct {
@@ -3163,6 +3565,12 @@ func (s DescribeExpressionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeExpressionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetExpressions sets the Expressions field's value.
+func (s *DescribeExpressionsOutput) SetExpressions(v []*ExpressionStatus) *DescribeExpressionsOutput {
+	s.Expressions = v
+	return s
 }
 
 // Container for the parameters to the DescribeIndexFields operation. Specifies
@@ -3213,6 +3621,24 @@ func (s *DescribeIndexFieldsInput) Validate() error {
 	return nil
 }
 
+// SetDeployed sets the Deployed field's value.
+func (s *DescribeIndexFieldsInput) SetDeployed(v bool) *DescribeIndexFieldsInput {
+	s.Deployed = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeIndexFieldsInput) SetDomainName(v string) *DescribeIndexFieldsInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetFieldNames sets the FieldNames field's value.
+func (s *DescribeIndexFieldsInput) SetFieldNames(v []*string) *DescribeIndexFieldsInput {
+	s.FieldNames = v
+	return s
+}
+
 // The result of a DescribeIndexFields request. Contains the index fields configured
 // for the domain specified in the request.
 type DescribeIndexFieldsOutput struct {
@@ -3232,6 +3658,12 @@ func (s DescribeIndexFieldsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeIndexFieldsOutput) GoString() string {
 	return s.String()
+}
+
+// SetIndexFields sets the IndexFields field's value.
+func (s *DescribeIndexFieldsOutput) SetIndexFields(v []*IndexFieldStatus) *DescribeIndexFieldsOutput {
+	s.IndexFields = v
+	return s
 }
 
 // Container for the parameters to the DescribeScalingParameters operation.
@@ -3274,6 +3706,12 @@ func (s *DescribeScalingParametersInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeScalingParametersInput) SetDomainName(v string) *DescribeScalingParametersInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DescribeScalingParameters request. Contains the scaling parameters
 // configured for the domain specified in the request.
 type DescribeScalingParametersOutput struct {
@@ -3293,6 +3731,12 @@ func (s DescribeScalingParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetScalingParameters sets the ScalingParameters field's value.
+func (s *DescribeScalingParametersOutput) SetScalingParameters(v *ScalingParametersStatus) *DescribeScalingParametersOutput {
+	s.ScalingParameters = v
+	return s
 }
 
 // Container for the parameters to the DescribeServiceAccessPolicies operation.
@@ -3338,6 +3782,18 @@ func (s *DescribeServiceAccessPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetDeployed sets the Deployed field's value.
+func (s *DescribeServiceAccessPoliciesInput) SetDeployed(v bool) *DescribeServiceAccessPoliciesInput {
+	s.Deployed = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeServiceAccessPoliciesInput) SetDomainName(v string) *DescribeServiceAccessPoliciesInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DescribeServiceAccessPolicies request.
 type DescribeServiceAccessPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3356,6 +3812,12 @@ func (s DescribeServiceAccessPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeServiceAccessPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccessPolicies sets the AccessPolicies field's value.
+func (s *DescribeServiceAccessPoliciesOutput) SetAccessPolicies(v *AccessPoliciesStatus) *DescribeServiceAccessPoliciesOutput {
+	s.AccessPolicies = v
+	return s
 }
 
 // Container for the parameters to the DescribeSuggester operation. Specifies
@@ -3405,6 +3867,24 @@ func (s *DescribeSuggestersInput) Validate() error {
 	return nil
 }
 
+// SetDeployed sets the Deployed field's value.
+func (s *DescribeSuggestersInput) SetDeployed(v bool) *DescribeSuggestersInput {
+	s.Deployed = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeSuggestersInput) SetDomainName(v string) *DescribeSuggestersInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetSuggesterNames sets the SuggesterNames field's value.
+func (s *DescribeSuggestersInput) SetSuggesterNames(v []*string) *DescribeSuggestersInput {
+	s.SuggesterNames = v
+	return s
+}
+
 // The result of a DescribeSuggesters request.
 type DescribeSuggestersOutput struct {
 	_ struct{} `type:"structure"`
@@ -3423,6 +3903,12 @@ func (s DescribeSuggestersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSuggestersOutput) GoString() string {
 	return s.String()
+}
+
+// SetSuggesters sets the Suggesters field's value.
+func (s *DescribeSuggestersOutput) SetSuggesters(v []*SuggesterStatus) *DescribeSuggestersOutput {
+	s.Suggesters = v
+	return s
 }
 
 // Options for a search suggester.
@@ -3475,6 +3961,24 @@ func (s *DocumentSuggesterOptions) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFuzzyMatching sets the FuzzyMatching field's value.
+func (s *DocumentSuggesterOptions) SetFuzzyMatching(v string) *DocumentSuggesterOptions {
+	s.FuzzyMatching = &v
+	return s
+}
+
+// SetSortExpression sets the SortExpression field's value.
+func (s *DocumentSuggesterOptions) SetSortExpression(v string) *DocumentSuggesterOptions {
+	s.SortExpression = &v
+	return s
+}
+
+// SetSourceField sets the SourceField field's value.
+func (s *DocumentSuggesterOptions) SetSourceField(v string) *DocumentSuggesterOptions {
+	s.SourceField = &v
+	return s
 }
 
 // The current status of the search domain.
@@ -3548,6 +4052,84 @@ func (s DomainStatus) GoString() string {
 	return s.String()
 }
 
+// SetARN sets the ARN field's value.
+func (s *DomainStatus) SetARN(v string) *DomainStatus {
+	s.ARN = &v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *DomainStatus) SetCreated(v bool) *DomainStatus {
+	s.Created = &v
+	return s
+}
+
+// SetDeleted sets the Deleted field's value.
+func (s *DomainStatus) SetDeleted(v bool) *DomainStatus {
+	s.Deleted = &v
+	return s
+}
+
+// SetDocService sets the DocService field's value.
+func (s *DomainStatus) SetDocService(v *ServiceEndpoint) *DomainStatus {
+	s.DocService = v
+	return s
+}
+
+// SetDomainId sets the DomainId field's value.
+func (s *DomainStatus) SetDomainId(v string) *DomainStatus {
+	s.DomainId = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DomainStatus) SetDomainName(v string) *DomainStatus {
+	s.DomainName = &v
+	return s
+}
+
+// SetLimits sets the Limits field's value.
+func (s *DomainStatus) SetLimits(v *Limits) *DomainStatus {
+	s.Limits = v
+	return s
+}
+
+// SetProcessing sets the Processing field's value.
+func (s *DomainStatus) SetProcessing(v bool) *DomainStatus {
+	s.Processing = &v
+	return s
+}
+
+// SetRequiresIndexDocuments sets the RequiresIndexDocuments field's value.
+func (s *DomainStatus) SetRequiresIndexDocuments(v bool) *DomainStatus {
+	s.RequiresIndexDocuments = &v
+	return s
+}
+
+// SetSearchInstanceCount sets the SearchInstanceCount field's value.
+func (s *DomainStatus) SetSearchInstanceCount(v int64) *DomainStatus {
+	s.SearchInstanceCount = &v
+	return s
+}
+
+// SetSearchInstanceType sets the SearchInstanceType field's value.
+func (s *DomainStatus) SetSearchInstanceType(v string) *DomainStatus {
+	s.SearchInstanceType = &v
+	return s
+}
+
+// SetSearchPartitionCount sets the SearchPartitionCount field's value.
+func (s *DomainStatus) SetSearchPartitionCount(v int64) *DomainStatus {
+	s.SearchPartitionCount = &v
+	return s
+}
+
+// SetSearchService sets the SearchService field's value.
+func (s *DomainStatus) SetSearchService(v *ServiceEndpoint) *DomainStatus {
+	s.SearchService = v
+	return s
+}
+
 // Options for a field that contains an array of double-precision 64-bit floating
 // point values. Present if IndexFieldType specifies the field is of type double-array.
 // All options are enabled by default.
@@ -3578,6 +4160,36 @@ func (s DoubleArrayOptions) String() string {
 // GoString returns the string representation
 func (s DoubleArrayOptions) GoString() string {
 	return s.String()
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *DoubleArrayOptions) SetDefaultValue(v float64) *DoubleArrayOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *DoubleArrayOptions) SetFacetEnabled(v bool) *DoubleArrayOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *DoubleArrayOptions) SetReturnEnabled(v bool) *DoubleArrayOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *DoubleArrayOptions) SetSearchEnabled(v bool) *DoubleArrayOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSourceFields sets the SourceFields field's value.
+func (s *DoubleArrayOptions) SetSourceFields(v string) *DoubleArrayOptions {
+	s.SourceFields = &v
+	return s
 }
 
 // Options for a double-precision 64-bit floating point field. Present if IndexFieldType
@@ -3627,6 +4239,42 @@ func (s *DoubleOptions) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *DoubleOptions) SetDefaultValue(v float64) *DoubleOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *DoubleOptions) SetFacetEnabled(v bool) *DoubleOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *DoubleOptions) SetReturnEnabled(v bool) *DoubleOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *DoubleOptions) SetSearchEnabled(v bool) *DoubleOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSortEnabled sets the SortEnabled field's value.
+func (s *DoubleOptions) SetSortEnabled(v bool) *DoubleOptions {
+	s.SortEnabled = &v
+	return s
+}
+
+// SetSourceField sets the SourceField field's value.
+func (s *DoubleOptions) SetSourceField(v string) *DoubleOptions {
+	s.SourceField = &v
+	return s
 }
 
 // A named expression that can be evaluated at search time. Can be used to sort
@@ -3682,6 +4330,18 @@ func (s *Expression) Validate() error {
 	return nil
 }
 
+// SetExpressionName sets the ExpressionName field's value.
+func (s *Expression) SetExpressionName(v string) *Expression {
+	s.ExpressionName = &v
+	return s
+}
+
+// SetExpressionValue sets the ExpressionValue field's value.
+func (s *Expression) SetExpressionValue(v string) *Expression {
+	s.ExpressionValue = &v
+	return s
+}
+
 // The value of an Expression and its current status.
 type ExpressionStatus struct {
 	_ struct{} `type:"structure"`
@@ -3705,6 +4365,18 @@ func (s ExpressionStatus) String() string {
 // GoString returns the string representation
 func (s ExpressionStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *ExpressionStatus) SetOptions(v *Expression) *ExpressionStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ExpressionStatus) SetStatus(v *OptionStatus) *ExpressionStatus {
+	s.Status = v
+	return s
 }
 
 // Container for the parameters to the IndexDocuments operation. Specifies the
@@ -3747,6 +4419,12 @@ func (s *IndexDocumentsInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *IndexDocumentsInput) SetDomainName(v string) *IndexDocumentsInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of an IndexDocuments request. Contains the status of the indexing
 // operation, including the fields being indexed.
 type IndexDocumentsOutput struct {
@@ -3764,6 +4442,12 @@ func (s IndexDocumentsOutput) String() string {
 // GoString returns the string representation
 func (s IndexDocumentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFieldNames sets the FieldNames field's value.
+func (s *IndexDocumentsOutput) SetFieldNames(v []*string) *IndexDocumentsOutput {
+	s.FieldNames = v
+	return s
 }
 
 // Configuration information for a field in the index, including its name, type,
@@ -3909,6 +4593,84 @@ func (s *IndexField) Validate() error {
 	return nil
 }
 
+// SetDateArrayOptions sets the DateArrayOptions field's value.
+func (s *IndexField) SetDateArrayOptions(v *DateArrayOptions) *IndexField {
+	s.DateArrayOptions = v
+	return s
+}
+
+// SetDateOptions sets the DateOptions field's value.
+func (s *IndexField) SetDateOptions(v *DateOptions) *IndexField {
+	s.DateOptions = v
+	return s
+}
+
+// SetDoubleArrayOptions sets the DoubleArrayOptions field's value.
+func (s *IndexField) SetDoubleArrayOptions(v *DoubleArrayOptions) *IndexField {
+	s.DoubleArrayOptions = v
+	return s
+}
+
+// SetDoubleOptions sets the DoubleOptions field's value.
+func (s *IndexField) SetDoubleOptions(v *DoubleOptions) *IndexField {
+	s.DoubleOptions = v
+	return s
+}
+
+// SetIndexFieldName sets the IndexFieldName field's value.
+func (s *IndexField) SetIndexFieldName(v string) *IndexField {
+	s.IndexFieldName = &v
+	return s
+}
+
+// SetIndexFieldType sets the IndexFieldType field's value.
+func (s *IndexField) SetIndexFieldType(v string) *IndexField {
+	s.IndexFieldType = &v
+	return s
+}
+
+// SetIntArrayOptions sets the IntArrayOptions field's value.
+func (s *IndexField) SetIntArrayOptions(v *IntArrayOptions) *IndexField {
+	s.IntArrayOptions = v
+	return s
+}
+
+// SetIntOptions sets the IntOptions field's value.
+func (s *IndexField) SetIntOptions(v *IntOptions) *IndexField {
+	s.IntOptions = v
+	return s
+}
+
+// SetLatLonOptions sets the LatLonOptions field's value.
+func (s *IndexField) SetLatLonOptions(v *LatLonOptions) *IndexField {
+	s.LatLonOptions = v
+	return s
+}
+
+// SetLiteralArrayOptions sets the LiteralArrayOptions field's value.
+func (s *IndexField) SetLiteralArrayOptions(v *LiteralArrayOptions) *IndexField {
+	s.LiteralArrayOptions = v
+	return s
+}
+
+// SetLiteralOptions sets the LiteralOptions field's value.
+func (s *IndexField) SetLiteralOptions(v *LiteralOptions) *IndexField {
+	s.LiteralOptions = v
+	return s
+}
+
+// SetTextArrayOptions sets the TextArrayOptions field's value.
+func (s *IndexField) SetTextArrayOptions(v *TextArrayOptions) *IndexField {
+	s.TextArrayOptions = v
+	return s
+}
+
+// SetTextOptions sets the TextOptions field's value.
+func (s *IndexField) SetTextOptions(v *TextOptions) *IndexField {
+	s.TextOptions = v
+	return s
+}
+
 // The value of an IndexField and its current status.
 type IndexFieldStatus struct {
 	_ struct{} `type:"structure"`
@@ -3933,6 +4695,18 @@ func (s IndexFieldStatus) String() string {
 // GoString returns the string representation
 func (s IndexFieldStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *IndexFieldStatus) SetOptions(v *IndexField) *IndexFieldStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *IndexFieldStatus) SetStatus(v *OptionStatus) *IndexFieldStatus {
+	s.Status = v
+	return s
 }
 
 // Options for a field that contains an array of 64-bit signed integers. Present
@@ -3965,6 +4739,36 @@ func (s IntArrayOptions) String() string {
 // GoString returns the string representation
 func (s IntArrayOptions) GoString() string {
 	return s.String()
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *IntArrayOptions) SetDefaultValue(v int64) *IntArrayOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *IntArrayOptions) SetFacetEnabled(v bool) *IntArrayOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *IntArrayOptions) SetReturnEnabled(v bool) *IntArrayOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *IntArrayOptions) SetSearchEnabled(v bool) *IntArrayOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSourceFields sets the SourceFields field's value.
+func (s *IntArrayOptions) SetSourceFields(v string) *IntArrayOptions {
+	s.SourceFields = &v
+	return s
 }
 
 // Options for a 64-bit signed integer field. Present if IndexFieldType specifies
@@ -4014,6 +4818,42 @@ func (s *IntOptions) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *IntOptions) SetDefaultValue(v int64) *IntOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *IntOptions) SetFacetEnabled(v bool) *IntOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *IntOptions) SetReturnEnabled(v bool) *IntOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *IntOptions) SetSearchEnabled(v bool) *IntOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSortEnabled sets the SortEnabled field's value.
+func (s *IntOptions) SetSortEnabled(v bool) *IntOptions {
+	s.SortEnabled = &v
+	return s
+}
+
+// SetSourceField sets the SourceField field's value.
+func (s *IntOptions) SetSourceField(v string) *IntOptions {
+	s.SourceField = &v
+	return s
 }
 
 // Options for a latlon field. A latlon field contains a location stored as
@@ -4077,6 +4917,42 @@ func (s *LatLonOptions) Validate() error {
 	return nil
 }
 
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *LatLonOptions) SetDefaultValue(v string) *LatLonOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *LatLonOptions) SetFacetEnabled(v bool) *LatLonOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *LatLonOptions) SetReturnEnabled(v bool) *LatLonOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *LatLonOptions) SetSearchEnabled(v bool) *LatLonOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSortEnabled sets the SortEnabled field's value.
+func (s *LatLonOptions) SetSortEnabled(v bool) *LatLonOptions {
+	s.SortEnabled = &v
+	return s
+}
+
+// SetSourceField sets the SourceField field's value.
+func (s *LatLonOptions) SetSourceField(v string) *LatLonOptions {
+	s.SourceField = &v
+	return s
+}
+
 type Limits struct {
 	_ struct{} `type:"structure"`
 
@@ -4095,6 +4971,18 @@ func (s Limits) String() string {
 // GoString returns the string representation
 func (s Limits) GoString() string {
 	return s.String()
+}
+
+// SetMaximumPartitionCount sets the MaximumPartitionCount field's value.
+func (s *Limits) SetMaximumPartitionCount(v int64) *Limits {
+	s.MaximumPartitionCount = &v
+	return s
+}
+
+// SetMaximumReplicationCount sets the MaximumReplicationCount field's value.
+func (s *Limits) SetMaximumReplicationCount(v int64) *Limits {
+	s.MaximumReplicationCount = &v
+	return s
 }
 
 type ListDomainNamesInput struct {
@@ -4130,6 +5018,12 @@ func (s ListDomainNamesOutput) GoString() string {
 	return s.String()
 }
 
+// SetDomainNames sets the DomainNames field's value.
+func (s *ListDomainNamesOutput) SetDomainNames(v map[string]*string) *ListDomainNamesOutput {
+	s.DomainNames = v
+	return s
+}
+
 // Options for a field that contains an array of literal strings. Present if
 // IndexFieldType specifies the field is of type literal-array. All options
 // are enabled by default.
@@ -4160,6 +5054,36 @@ func (s LiteralArrayOptions) String() string {
 // GoString returns the string representation
 func (s LiteralArrayOptions) GoString() string {
 	return s.String()
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *LiteralArrayOptions) SetDefaultValue(v string) *LiteralArrayOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *LiteralArrayOptions) SetFacetEnabled(v bool) *LiteralArrayOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *LiteralArrayOptions) SetReturnEnabled(v bool) *LiteralArrayOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *LiteralArrayOptions) SetSearchEnabled(v bool) *LiteralArrayOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSourceFields sets the SourceFields field's value.
+func (s *LiteralArrayOptions) SetSourceFields(v string) *LiteralArrayOptions {
+	s.SourceFields = &v
+	return s
 }
 
 // Options for literal field. Present if IndexFieldType specifies the field
@@ -4222,6 +5146,42 @@ func (s *LiteralOptions) Validate() error {
 	return nil
 }
 
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *LiteralOptions) SetDefaultValue(v string) *LiteralOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetFacetEnabled sets the FacetEnabled field's value.
+func (s *LiteralOptions) SetFacetEnabled(v bool) *LiteralOptions {
+	s.FacetEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *LiteralOptions) SetReturnEnabled(v bool) *LiteralOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSearchEnabled sets the SearchEnabled field's value.
+func (s *LiteralOptions) SetSearchEnabled(v bool) *LiteralOptions {
+	s.SearchEnabled = &v
+	return s
+}
+
+// SetSortEnabled sets the SortEnabled field's value.
+func (s *LiteralOptions) SetSortEnabled(v bool) *LiteralOptions {
+	s.SortEnabled = &v
+	return s
+}
+
+// SetSourceField sets the SourceField field's value.
+func (s *LiteralOptions) SetSourceField(v string) *LiteralOptions {
+	s.SourceField = &v
+	return s
+}
+
 // The status of domain configuration option.
 type OptionStatus struct {
 	_ struct{} `type:"structure"`
@@ -4267,6 +5227,36 @@ func (s OptionStatus) GoString() string {
 	return s.String()
 }
 
+// SetCreationDate sets the CreationDate field's value.
+func (s *OptionStatus) SetCreationDate(v time.Time) *OptionStatus {
+	s.CreationDate = &v
+	return s
+}
+
+// SetPendingDeletion sets the PendingDeletion field's value.
+func (s *OptionStatus) SetPendingDeletion(v bool) *OptionStatus {
+	s.PendingDeletion = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *OptionStatus) SetState(v string) *OptionStatus {
+	s.State = &v
+	return s
+}
+
+// SetUpdateDate sets the UpdateDate field's value.
+func (s *OptionStatus) SetUpdateDate(v time.Time) *OptionStatus {
+	s.UpdateDate = &v
+	return s
+}
+
+// SetUpdateVersion sets the UpdateVersion field's value.
+func (s *OptionStatus) SetUpdateVersion(v int64) *OptionStatus {
+	s.UpdateVersion = &v
+	return s
+}
+
 // The desired instance type and desired number of replicas of each index partition.
 type ScalingParameters struct {
 	_ struct{} `type:"structure"`
@@ -4291,6 +5281,24 @@ func (s ScalingParameters) String() string {
 // GoString returns the string representation
 func (s ScalingParameters) GoString() string {
 	return s.String()
+}
+
+// SetDesiredInstanceType sets the DesiredInstanceType field's value.
+func (s *ScalingParameters) SetDesiredInstanceType(v string) *ScalingParameters {
+	s.DesiredInstanceType = &v
+	return s
+}
+
+// SetDesiredPartitionCount sets the DesiredPartitionCount field's value.
+func (s *ScalingParameters) SetDesiredPartitionCount(v int64) *ScalingParameters {
+	s.DesiredPartitionCount = &v
+	return s
+}
+
+// SetDesiredReplicationCount sets the DesiredReplicationCount field's value.
+func (s *ScalingParameters) SetDesiredReplicationCount(v int64) *ScalingParameters {
+	s.DesiredReplicationCount = &v
+	return s
 }
 
 // The status and configuration of a search domain's scaling parameters.
@@ -4318,6 +5326,18 @@ func (s ScalingParametersStatus) GoString() string {
 	return s.String()
 }
 
+// SetOptions sets the Options field's value.
+func (s *ScalingParametersStatus) SetOptions(v *ScalingParameters) *ScalingParametersStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ScalingParametersStatus) SetStatus(v *OptionStatus) *ScalingParametersStatus {
+	s.Status = v
+	return s
+}
+
 // The endpoint to which service requests can be submitted.
 type ServiceEndpoint struct {
 	_ struct{} `type:"structure"`
@@ -4335,6 +5355,12 @@ func (s ServiceEndpoint) String() string {
 // GoString returns the string representation
 func (s ServiceEndpoint) GoString() string {
 	return s.String()
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *ServiceEndpoint) SetEndpoint(v string) *ServiceEndpoint {
+	s.Endpoint = &v
+	return s
 }
 
 // Configuration information for a search suggester. Each suggester has a unique
@@ -4389,6 +5415,18 @@ func (s *Suggester) Validate() error {
 	return nil
 }
 
+// SetDocumentSuggesterOptions sets the DocumentSuggesterOptions field's value.
+func (s *Suggester) SetDocumentSuggesterOptions(v *DocumentSuggesterOptions) *Suggester {
+	s.DocumentSuggesterOptions = v
+	return s
+}
+
+// SetSuggesterName sets the SuggesterName field's value.
+func (s *Suggester) SetSuggesterName(v string) *Suggester {
+	s.SuggesterName = &v
+	return s
+}
+
 // The value of a Suggester and its current status.
 type SuggesterStatus struct {
 	_ struct{} `type:"structure"`
@@ -4414,6 +5452,18 @@ func (s SuggesterStatus) String() string {
 // GoString returns the string representation
 func (s SuggesterStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *SuggesterStatus) SetOptions(v *Suggester) *SuggesterStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SuggesterStatus) SetStatus(v *OptionStatus) *SuggesterStatus {
+	s.Status = v
+	return s
 }
 
 // Options for a field that contains an array of text strings. Present if IndexFieldType
@@ -4446,6 +5496,36 @@ func (s TextArrayOptions) String() string {
 // GoString returns the string representation
 func (s TextArrayOptions) GoString() string {
 	return s.String()
+}
+
+// SetAnalysisScheme sets the AnalysisScheme field's value.
+func (s *TextArrayOptions) SetAnalysisScheme(v string) *TextArrayOptions {
+	s.AnalysisScheme = &v
+	return s
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *TextArrayOptions) SetDefaultValue(v string) *TextArrayOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetHighlightEnabled sets the HighlightEnabled field's value.
+func (s *TextArrayOptions) SetHighlightEnabled(v bool) *TextArrayOptions {
+	s.HighlightEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *TextArrayOptions) SetReturnEnabled(v bool) *TextArrayOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSourceFields sets the SourceFields field's value.
+func (s *TextArrayOptions) SetSourceFields(v string) *TextArrayOptions {
+	s.SourceFields = &v
+	return s
 }
 
 // Options for text field. Present if IndexFieldType specifies the field is
@@ -4509,6 +5589,42 @@ func (s *TextOptions) Validate() error {
 	return nil
 }
 
+// SetAnalysisScheme sets the AnalysisScheme field's value.
+func (s *TextOptions) SetAnalysisScheme(v string) *TextOptions {
+	s.AnalysisScheme = &v
+	return s
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *TextOptions) SetDefaultValue(v string) *TextOptions {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetHighlightEnabled sets the HighlightEnabled field's value.
+func (s *TextOptions) SetHighlightEnabled(v bool) *TextOptions {
+	s.HighlightEnabled = &v
+	return s
+}
+
+// SetReturnEnabled sets the ReturnEnabled field's value.
+func (s *TextOptions) SetReturnEnabled(v bool) *TextOptions {
+	s.ReturnEnabled = &v
+	return s
+}
+
+// SetSortEnabled sets the SortEnabled field's value.
+func (s *TextOptions) SetSortEnabled(v bool) *TextOptions {
+	s.SortEnabled = &v
+	return s
+}
+
+// SetSourceField sets the SourceField field's value.
+func (s *TextOptions) SetSourceField(v string) *TextOptions {
+	s.SourceField = &v
+	return s
+}
+
 // Container for the parameters to the UpdateAvailabilityOptions operation.
 // Specifies the name of the domain you want to update and the Multi-AZ availability
 // option.
@@ -4561,6 +5677,18 @@ func (s *UpdateAvailabilityOptionsInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateAvailabilityOptionsInput) SetDomainName(v string) *UpdateAvailabilityOptionsInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *UpdateAvailabilityOptionsInput) SetMultiAZ(v bool) *UpdateAvailabilityOptionsInput {
+	s.MultiAZ = &v
+	return s
+}
+
 // The result of a UpdateAvailabilityOptions request. Contains the status of
 // the domain's availability options.
 type UpdateAvailabilityOptionsOutput struct {
@@ -4579,6 +5707,12 @@ func (s UpdateAvailabilityOptionsOutput) String() string {
 // GoString returns the string representation
 func (s UpdateAvailabilityOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityOptions sets the AvailabilityOptions field's value.
+func (s *UpdateAvailabilityOptionsOutput) SetAvailabilityOptions(v *AvailabilityOptionsStatus) *UpdateAvailabilityOptionsOutput {
+	s.AvailabilityOptions = v
+	return s
 }
 
 // Container for the parameters to the UpdateScalingParameters operation. Specifies
@@ -4630,6 +5764,18 @@ func (s *UpdateScalingParametersInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateScalingParametersInput) SetDomainName(v string) *UpdateScalingParametersInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetScalingParameters sets the ScalingParameters field's value.
+func (s *UpdateScalingParametersInput) SetScalingParameters(v *ScalingParameters) *UpdateScalingParametersInput {
+	s.ScalingParameters = v
+	return s
+}
+
 // The result of a UpdateScalingParameters request. Contains the status of the
 // newly-configured scaling parameters.
 type UpdateScalingParametersOutput struct {
@@ -4649,6 +5795,12 @@ func (s UpdateScalingParametersOutput) String() string {
 // GoString returns the string representation
 func (s UpdateScalingParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetScalingParameters sets the ScalingParameters field's value.
+func (s *UpdateScalingParametersOutput) SetScalingParameters(v *ScalingParametersStatus) *UpdateScalingParametersOutput {
+	s.ScalingParameters = v
+	return s
 }
 
 // Container for the parameters to the UpdateServiceAccessPolicies operation.
@@ -4701,6 +5853,18 @@ func (s *UpdateServiceAccessPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetAccessPolicies sets the AccessPolicies field's value.
+func (s *UpdateServiceAccessPoliciesInput) SetAccessPolicies(v string) *UpdateServiceAccessPoliciesInput {
+	s.AccessPolicies = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateServiceAccessPoliciesInput) SetDomainName(v string) *UpdateServiceAccessPoliciesInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of an UpdateServiceAccessPolicies request. Contains the new access
 // policies.
 type UpdateServiceAccessPoliciesOutput struct {
@@ -4720,6 +5884,12 @@ func (s UpdateServiceAccessPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s UpdateServiceAccessPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccessPolicies sets the AccessPolicies field's value.
+func (s *UpdateServiceAccessPoliciesOutput) SetAccessPolicies(v *AccessPoliciesStatus) *UpdateServiceAccessPoliciesOutput {
+	s.AccessPolicies = v
+	return s
 }
 
 const (

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -280,6 +280,18 @@ func (s Bucket) GoString() string {
 	return s.String()
 }
 
+// SetCount sets the Count field's value.
+func (s *Bucket) SetCount(v int64) *Bucket {
+	s.Count = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Bucket) SetValue(v string) *Bucket {
+	s.Value = &v
+	return s
+}
+
 // A container for the calculated facet values and counts.
 type BucketInfo struct {
 	_ struct{} `type:"structure"`
@@ -296,6 +308,12 @@ func (s BucketInfo) String() string {
 // GoString returns the string representation
 func (s BucketInfo) GoString() string {
 	return s.String()
+}
+
+// SetBuckets sets the Buckets field's value.
+func (s *BucketInfo) SetBuckets(v []*Bucket) *BucketInfo {
+	s.Buckets = v
+	return s
 }
 
 // A warning returned by the document service when an issue is discovered while
@@ -315,6 +333,12 @@ func (s DocumentServiceWarning) String() string {
 // GoString returns the string representation
 func (s DocumentServiceWarning) GoString() string {
 	return s.String()
+}
+
+// SetMessage sets the Message field's value.
+func (s *DocumentServiceWarning) SetMessage(v string) *DocumentServiceWarning {
+	s.Message = &v
+	return s
 }
 
 // The statistics for a field calculated in the request.
@@ -378,6 +402,54 @@ func (s FieldStats) GoString() string {
 	return s.String()
 }
 
+// SetCount sets the Count field's value.
+func (s *FieldStats) SetCount(v int64) *FieldStats {
+	s.Count = &v
+	return s
+}
+
+// SetMax sets the Max field's value.
+func (s *FieldStats) SetMax(v string) *FieldStats {
+	s.Max = &v
+	return s
+}
+
+// SetMean sets the Mean field's value.
+func (s *FieldStats) SetMean(v string) *FieldStats {
+	s.Mean = &v
+	return s
+}
+
+// SetMin sets the Min field's value.
+func (s *FieldStats) SetMin(v string) *FieldStats {
+	s.Min = &v
+	return s
+}
+
+// SetMissing sets the Missing field's value.
+func (s *FieldStats) SetMissing(v int64) *FieldStats {
+	s.Missing = &v
+	return s
+}
+
+// SetStddev sets the Stddev field's value.
+func (s *FieldStats) SetStddev(v float64) *FieldStats {
+	s.Stddev = &v
+	return s
+}
+
+// SetSum sets the Sum field's value.
+func (s *FieldStats) SetSum(v float64) *FieldStats {
+	s.Sum = &v
+	return s
+}
+
+// SetSumOfSquares sets the SumOfSquares field's value.
+func (s *FieldStats) SetSumOfSquares(v float64) *FieldStats {
+	s.SumOfSquares = &v
+	return s
+}
+
 // Information about a document that matches the search request.
 type Hit struct {
 	_ struct{} `type:"structure"`
@@ -403,6 +475,30 @@ func (s Hit) String() string {
 // GoString returns the string representation
 func (s Hit) GoString() string {
 	return s.String()
+}
+
+// SetExprs sets the Exprs field's value.
+func (s *Hit) SetExprs(v map[string]*string) *Hit {
+	s.Exprs = v
+	return s
+}
+
+// SetFields sets the Fields field's value.
+func (s *Hit) SetFields(v map[string][]*string) *Hit {
+	s.Fields = v
+	return s
+}
+
+// SetHighlights sets the Highlights field's value.
+func (s *Hit) SetHighlights(v map[string]*string) *Hit {
+	s.Highlights = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Hit) SetId(v string) *Hit {
+	s.Id = &v
+	return s
 }
 
 // The collection of documents that match the search request.
@@ -431,6 +527,30 @@ func (s Hits) String() string {
 // GoString returns the string representation
 func (s Hits) GoString() string {
 	return s.String()
+}
+
+// SetCursor sets the Cursor field's value.
+func (s *Hits) SetCursor(v string) *Hits {
+	s.Cursor = &v
+	return s
+}
+
+// SetFound sets the Found field's value.
+func (s *Hits) SetFound(v int64) *Hits {
+	s.Found = &v
+	return s
+}
+
+// SetHit sets the Hit field's value.
+func (s *Hits) SetHit(v []*Hit) *Hits {
+	s.Hit = v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *Hits) SetStart(v int64) *Hits {
+	s.Start = &v
+	return s
 }
 
 // Container for the parameters to the Search request.
@@ -761,6 +881,90 @@ func (s *SearchInput) Validate() error {
 	return nil
 }
 
+// SetCursor sets the Cursor field's value.
+func (s *SearchInput) SetCursor(v string) *SearchInput {
+	s.Cursor = &v
+	return s
+}
+
+// SetExpr sets the Expr field's value.
+func (s *SearchInput) SetExpr(v string) *SearchInput {
+	s.Expr = &v
+	return s
+}
+
+// SetFacet sets the Facet field's value.
+func (s *SearchInput) SetFacet(v string) *SearchInput {
+	s.Facet = &v
+	return s
+}
+
+// SetFilterQuery sets the FilterQuery field's value.
+func (s *SearchInput) SetFilterQuery(v string) *SearchInput {
+	s.FilterQuery = &v
+	return s
+}
+
+// SetHighlight sets the Highlight field's value.
+func (s *SearchInput) SetHighlight(v string) *SearchInput {
+	s.Highlight = &v
+	return s
+}
+
+// SetPartial sets the Partial field's value.
+func (s *SearchInput) SetPartial(v bool) *SearchInput {
+	s.Partial = &v
+	return s
+}
+
+// SetQuery sets the Query field's value.
+func (s *SearchInput) SetQuery(v string) *SearchInput {
+	s.Query = &v
+	return s
+}
+
+// SetQueryOptions sets the QueryOptions field's value.
+func (s *SearchInput) SetQueryOptions(v string) *SearchInput {
+	s.QueryOptions = &v
+	return s
+}
+
+// SetQueryParser sets the QueryParser field's value.
+func (s *SearchInput) SetQueryParser(v string) *SearchInput {
+	s.QueryParser = &v
+	return s
+}
+
+// SetReturn sets the Return field's value.
+func (s *SearchInput) SetReturn(v string) *SearchInput {
+	s.Return = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *SearchInput) SetSize(v int64) *SearchInput {
+	s.Size = &v
+	return s
+}
+
+// SetSort sets the Sort field's value.
+func (s *SearchInput) SetSort(v string) *SearchInput {
+	s.Sort = &v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *SearchInput) SetStart(v int64) *SearchInput {
+	s.Start = &v
+	return s
+}
+
+// SetStats sets the Stats field's value.
+func (s *SearchInput) SetStats(v string) *SearchInput {
+	s.Stats = &v
+	return s
+}
+
 // The result of a Search request. Contains the documents that match the specified
 // search criteria and any requested fields, highlights, and facet information.
 type SearchOutput struct {
@@ -789,6 +993,30 @@ func (s SearchOutput) GoString() string {
 	return s.String()
 }
 
+// SetFacets sets the Facets field's value.
+func (s *SearchOutput) SetFacets(v map[string]*BucketInfo) *SearchOutput {
+	s.Facets = v
+	return s
+}
+
+// SetHits sets the Hits field's value.
+func (s *SearchOutput) SetHits(v *Hits) *SearchOutput {
+	s.Hits = v
+	return s
+}
+
+// SetStats sets the Stats field's value.
+func (s *SearchOutput) SetStats(v map[string]*FieldStats) *SearchOutput {
+	s.Stats = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SearchOutput) SetStatus(v *SearchStatus) *SearchOutput {
+	s.Status = v
+	return s
+}
+
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SearchStatus struct {
@@ -809,6 +1037,18 @@ func (s SearchStatus) String() string {
 // GoString returns the string representation
 func (s SearchStatus) GoString() string {
 	return s.String()
+}
+
+// SetRid sets the Rid field's value.
+func (s *SearchStatus) SetRid(v string) *SearchStatus {
+	s.Rid = &v
+	return s
+}
+
+// SetTimems sets the Timems field's value.
+func (s *SearchStatus) SetTimems(v int64) *SearchStatus {
+	s.Timems = &v
+	return s
 }
 
 // Container for the parameters to the Suggest request.
@@ -855,6 +1095,24 @@ func (s *SuggestInput) Validate() error {
 	return nil
 }
 
+// SetQuery sets the Query field's value.
+func (s *SuggestInput) SetQuery(v string) *SuggestInput {
+	s.Query = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *SuggestInput) SetSize(v int64) *SuggestInput {
+	s.Size = &v
+	return s
+}
+
+// SetSuggester sets the Suggester field's value.
+func (s *SuggestInput) SetSuggester(v string) *SuggestInput {
+	s.Suggester = &v
+	return s
+}
+
 // Container for the suggestion information returned in a SuggestResponse.
 type SuggestModel struct {
 	_ struct{} `type:"structure"`
@@ -879,6 +1137,24 @@ func (s SuggestModel) GoString() string {
 	return s.String()
 }
 
+// SetFound sets the Found field's value.
+func (s *SuggestModel) SetFound(v int64) *SuggestModel {
+	s.Found = &v
+	return s
+}
+
+// SetQuery sets the Query field's value.
+func (s *SuggestModel) SetQuery(v string) *SuggestModel {
+	s.Query = &v
+	return s
+}
+
+// SetSuggestions sets the Suggestions field's value.
+func (s *SuggestModel) SetSuggestions(v []*SuggestionMatch) *SuggestModel {
+	s.Suggestions = v
+	return s
+}
+
 // Contains the response to a Suggest request.
 type SuggestOutput struct {
 	_ struct{} `type:"structure"`
@@ -899,6 +1175,18 @@ func (s SuggestOutput) String() string {
 // GoString returns the string representation
 func (s SuggestOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *SuggestOutput) SetStatus(v *SuggestStatus) *SuggestOutput {
+	s.Status = v
+	return s
+}
+
+// SetSuggest sets the Suggest field's value.
+func (s *SuggestOutput) SetSuggest(v *SuggestModel) *SuggestOutput {
+	s.Suggest = v
+	return s
 }
 
 // Contains the resource id (rid) and the time it took to process the request
@@ -923,6 +1211,18 @@ func (s SuggestStatus) GoString() string {
 	return s.String()
 }
 
+// SetRid sets the Rid field's value.
+func (s *SuggestStatus) SetRid(v string) *SuggestStatus {
+	s.Rid = &v
+	return s
+}
+
+// SetTimems sets the Timems field's value.
+func (s *SuggestStatus) SetTimems(v int64) *SuggestStatus {
+	s.Timems = &v
+	return s
+}
+
 // An autocomplete suggestion that matches the query string specified in a SuggestRequest.
 type SuggestionMatch struct {
 	_ struct{} `type:"structure"`
@@ -945,6 +1245,24 @@ func (s SuggestionMatch) String() string {
 // GoString returns the string representation
 func (s SuggestionMatch) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *SuggestionMatch) SetId(v string) *SuggestionMatch {
+	s.Id = &v
+	return s
+}
+
+// SetScore sets the Score field's value.
+func (s *SuggestionMatch) SetScore(v int64) *SuggestionMatch {
+	s.Score = &v
+	return s
+}
+
+// SetSuggestion sets the Suggestion field's value.
+func (s *SuggestionMatch) SetSuggestion(v string) *SuggestionMatch {
+	s.Suggestion = &v
+	return s
 }
 
 // Container for the parameters to the UploadDocuments request.
@@ -992,6 +1310,18 @@ func (s *UploadDocumentsInput) Validate() error {
 	return nil
 }
 
+// SetContentType sets the ContentType field's value.
+func (s *UploadDocumentsInput) SetContentType(v string) *UploadDocumentsInput {
+	s.ContentType = &v
+	return s
+}
+
+// SetDocuments sets the Documents field's value.
+func (s *UploadDocumentsInput) SetDocuments(v io.ReadSeeker) *UploadDocumentsInput {
+	s.Documents = v
+	return s
+}
+
 // Contains the response to an UploadDocuments request.
 type UploadDocumentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1017,6 +1347,30 @@ func (s UploadDocumentsOutput) String() string {
 // GoString returns the string representation
 func (s UploadDocumentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAdds sets the Adds field's value.
+func (s *UploadDocumentsOutput) SetAdds(v int64) *UploadDocumentsOutput {
+	s.Adds = &v
+	return s
+}
+
+// SetDeletes sets the Deletes field's value.
+func (s *UploadDocumentsOutput) SetDeletes(v int64) *UploadDocumentsOutput {
+	s.Deletes = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UploadDocumentsOutput) SetStatus(v string) *UploadDocumentsOutput {
+	s.Status = &v
+	return s
+}
+
+// SetWarnings sets the Warnings field's value.
+func (s *UploadDocumentsOutput) SetWarnings(v []*DocumentServiceWarning) *UploadDocumentsOutput {
+	s.Warnings = v
+	return s
 }
 
 const (

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -1245,6 +1245,18 @@ func (s *AddTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *AddTagsInput) SetResourceId(v string) *AddTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTagsList sets the TagsList field's value.
+func (s *AddTagsInput) SetTagsList(v []*Tag) *AddTagsInput {
+	s.TagsList = v
+	return s
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type AddTagsOutput struct {
@@ -1370,6 +1382,66 @@ func (s *CreateTrailInput) Validate() error {
 	return nil
 }
 
+// SetCloudWatchLogsLogGroupArn sets the CloudWatchLogsLogGroupArn field's value.
+func (s *CreateTrailInput) SetCloudWatchLogsLogGroupArn(v string) *CreateTrailInput {
+	s.CloudWatchLogsLogGroupArn = &v
+	return s
+}
+
+// SetCloudWatchLogsRoleArn sets the CloudWatchLogsRoleArn field's value.
+func (s *CreateTrailInput) SetCloudWatchLogsRoleArn(v string) *CreateTrailInput {
+	s.CloudWatchLogsRoleArn = &v
+	return s
+}
+
+// SetEnableLogFileValidation sets the EnableLogFileValidation field's value.
+func (s *CreateTrailInput) SetEnableLogFileValidation(v bool) *CreateTrailInput {
+	s.EnableLogFileValidation = &v
+	return s
+}
+
+// SetIncludeGlobalServiceEvents sets the IncludeGlobalServiceEvents field's value.
+func (s *CreateTrailInput) SetIncludeGlobalServiceEvents(v bool) *CreateTrailInput {
+	s.IncludeGlobalServiceEvents = &v
+	return s
+}
+
+// SetIsMultiRegionTrail sets the IsMultiRegionTrail field's value.
+func (s *CreateTrailInput) SetIsMultiRegionTrail(v bool) *CreateTrailInput {
+	s.IsMultiRegionTrail = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateTrailInput) SetKmsKeyId(v string) *CreateTrailInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateTrailInput) SetName(v string) *CreateTrailInput {
+	s.Name = &v
+	return s
+}
+
+// SetS3BucketName sets the S3BucketName field's value.
+func (s *CreateTrailInput) SetS3BucketName(v string) *CreateTrailInput {
+	s.S3BucketName = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *CreateTrailInput) SetS3KeyPrefix(v string) *CreateTrailInput {
+	s.S3KeyPrefix = &v
+	return s
+}
+
+// SetSnsTopicName sets the SnsTopicName field's value.
+func (s *CreateTrailInput) SetSnsTopicName(v string) *CreateTrailInput {
+	s.SnsTopicName = &v
+	return s
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type CreateTrailOutput struct {
@@ -1437,6 +1509,78 @@ func (s CreateTrailOutput) GoString() string {
 	return s.String()
 }
 
+// SetCloudWatchLogsLogGroupArn sets the CloudWatchLogsLogGroupArn field's value.
+func (s *CreateTrailOutput) SetCloudWatchLogsLogGroupArn(v string) *CreateTrailOutput {
+	s.CloudWatchLogsLogGroupArn = &v
+	return s
+}
+
+// SetCloudWatchLogsRoleArn sets the CloudWatchLogsRoleArn field's value.
+func (s *CreateTrailOutput) SetCloudWatchLogsRoleArn(v string) *CreateTrailOutput {
+	s.CloudWatchLogsRoleArn = &v
+	return s
+}
+
+// SetIncludeGlobalServiceEvents sets the IncludeGlobalServiceEvents field's value.
+func (s *CreateTrailOutput) SetIncludeGlobalServiceEvents(v bool) *CreateTrailOutput {
+	s.IncludeGlobalServiceEvents = &v
+	return s
+}
+
+// SetIsMultiRegionTrail sets the IsMultiRegionTrail field's value.
+func (s *CreateTrailOutput) SetIsMultiRegionTrail(v bool) *CreateTrailOutput {
+	s.IsMultiRegionTrail = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateTrailOutput) SetKmsKeyId(v string) *CreateTrailOutput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLogFileValidationEnabled sets the LogFileValidationEnabled field's value.
+func (s *CreateTrailOutput) SetLogFileValidationEnabled(v bool) *CreateTrailOutput {
+	s.LogFileValidationEnabled = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateTrailOutput) SetName(v string) *CreateTrailOutput {
+	s.Name = &v
+	return s
+}
+
+// SetS3BucketName sets the S3BucketName field's value.
+func (s *CreateTrailOutput) SetS3BucketName(v string) *CreateTrailOutput {
+	s.S3BucketName = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *CreateTrailOutput) SetS3KeyPrefix(v string) *CreateTrailOutput {
+	s.S3KeyPrefix = &v
+	return s
+}
+
+// SetSnsTopicARN sets the SnsTopicARN field's value.
+func (s *CreateTrailOutput) SetSnsTopicARN(v string) *CreateTrailOutput {
+	s.SnsTopicARN = &v
+	return s
+}
+
+// SetSnsTopicName sets the SnsTopicName field's value.
+func (s *CreateTrailOutput) SetSnsTopicName(v string) *CreateTrailOutput {
+	s.SnsTopicName = &v
+	return s
+}
+
+// SetTrailARN sets the TrailARN field's value.
+func (s *CreateTrailOutput) SetTrailARN(v string) *CreateTrailOutput {
+	s.TrailARN = &v
+	return s
+}
+
 // The request that specifies the name of a trail to delete.
 type DeleteTrailInput struct {
 	_ struct{} `type:"structure"`
@@ -1471,6 +1615,12 @@ func (s *DeleteTrailInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteTrailInput) SetName(v string) *DeleteTrailInput {
+	s.Name = &v
+	return s
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns
@@ -1530,6 +1680,18 @@ func (s DescribeTrailsInput) GoString() string {
 	return s.String()
 }
 
+// SetIncludeShadowTrails sets the IncludeShadowTrails field's value.
+func (s *DescribeTrailsInput) SetIncludeShadowTrails(v bool) *DescribeTrailsInput {
+	s.IncludeShadowTrails = &v
+	return s
+}
+
+// SetTrailNameList sets the TrailNameList field's value.
+func (s *DescribeTrailsInput) SetTrailNameList(v []*string) *DescribeTrailsInput {
+	s.TrailNameList = v
+	return s
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type DescribeTrailsOutput struct {
@@ -1547,6 +1709,12 @@ func (s DescribeTrailsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTrailsOutput) GoString() string {
 	return s.String()
+}
+
+// SetTrailList sets the TrailList field's value.
+func (s *DescribeTrailsOutput) SetTrailList(v []*Trail) *DescribeTrailsOutput {
+	s.TrailList = v
+	return s
 }
 
 // Contains information about an event that was returned by a lookup request.
@@ -1584,6 +1752,42 @@ func (s Event) GoString() string {
 	return s.String()
 }
 
+// SetCloudTrailEvent sets the CloudTrailEvent field's value.
+func (s *Event) SetCloudTrailEvent(v string) *Event {
+	s.CloudTrailEvent = &v
+	return s
+}
+
+// SetEventId sets the EventId field's value.
+func (s *Event) SetEventId(v string) *Event {
+	s.EventId = &v
+	return s
+}
+
+// SetEventName sets the EventName field's value.
+func (s *Event) SetEventName(v string) *Event {
+	s.EventName = &v
+	return s
+}
+
+// SetEventTime sets the EventTime field's value.
+func (s *Event) SetEventTime(v time.Time) *Event {
+	s.EventTime = &v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *Event) SetResources(v []*Resource) *Event {
+	s.Resources = v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *Event) SetUsername(v string) *Event {
+	s.Username = &v
+	return s
+}
+
 // The name of a trail about which you want the current status.
 type GetTrailStatusInput struct {
 	_ struct{} `type:"structure"`
@@ -1619,6 +1823,12 @@ func (s *GetTrailStatusInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *GetTrailStatusInput) SetName(v string) *GetTrailStatusInput {
+	s.Name = &v
+	return s
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns
@@ -1713,6 +1923,108 @@ func (s GetTrailStatusOutput) GoString() string {
 	return s.String()
 }
 
+// SetIsLogging sets the IsLogging field's value.
+func (s *GetTrailStatusOutput) SetIsLogging(v bool) *GetTrailStatusOutput {
+	s.IsLogging = &v
+	return s
+}
+
+// SetLatestCloudWatchLogsDeliveryError sets the LatestCloudWatchLogsDeliveryError field's value.
+func (s *GetTrailStatusOutput) SetLatestCloudWatchLogsDeliveryError(v string) *GetTrailStatusOutput {
+	s.LatestCloudWatchLogsDeliveryError = &v
+	return s
+}
+
+// SetLatestCloudWatchLogsDeliveryTime sets the LatestCloudWatchLogsDeliveryTime field's value.
+func (s *GetTrailStatusOutput) SetLatestCloudWatchLogsDeliveryTime(v time.Time) *GetTrailStatusOutput {
+	s.LatestCloudWatchLogsDeliveryTime = &v
+	return s
+}
+
+// SetLatestDeliveryAttemptSucceeded sets the LatestDeliveryAttemptSucceeded field's value.
+func (s *GetTrailStatusOutput) SetLatestDeliveryAttemptSucceeded(v string) *GetTrailStatusOutput {
+	s.LatestDeliveryAttemptSucceeded = &v
+	return s
+}
+
+// SetLatestDeliveryAttemptTime sets the LatestDeliveryAttemptTime field's value.
+func (s *GetTrailStatusOutput) SetLatestDeliveryAttemptTime(v string) *GetTrailStatusOutput {
+	s.LatestDeliveryAttemptTime = &v
+	return s
+}
+
+// SetLatestDeliveryError sets the LatestDeliveryError field's value.
+func (s *GetTrailStatusOutput) SetLatestDeliveryError(v string) *GetTrailStatusOutput {
+	s.LatestDeliveryError = &v
+	return s
+}
+
+// SetLatestDeliveryTime sets the LatestDeliveryTime field's value.
+func (s *GetTrailStatusOutput) SetLatestDeliveryTime(v time.Time) *GetTrailStatusOutput {
+	s.LatestDeliveryTime = &v
+	return s
+}
+
+// SetLatestDigestDeliveryError sets the LatestDigestDeliveryError field's value.
+func (s *GetTrailStatusOutput) SetLatestDigestDeliveryError(v string) *GetTrailStatusOutput {
+	s.LatestDigestDeliveryError = &v
+	return s
+}
+
+// SetLatestDigestDeliveryTime sets the LatestDigestDeliveryTime field's value.
+func (s *GetTrailStatusOutput) SetLatestDigestDeliveryTime(v time.Time) *GetTrailStatusOutput {
+	s.LatestDigestDeliveryTime = &v
+	return s
+}
+
+// SetLatestNotificationAttemptSucceeded sets the LatestNotificationAttemptSucceeded field's value.
+func (s *GetTrailStatusOutput) SetLatestNotificationAttemptSucceeded(v string) *GetTrailStatusOutput {
+	s.LatestNotificationAttemptSucceeded = &v
+	return s
+}
+
+// SetLatestNotificationAttemptTime sets the LatestNotificationAttemptTime field's value.
+func (s *GetTrailStatusOutput) SetLatestNotificationAttemptTime(v string) *GetTrailStatusOutput {
+	s.LatestNotificationAttemptTime = &v
+	return s
+}
+
+// SetLatestNotificationError sets the LatestNotificationError field's value.
+func (s *GetTrailStatusOutput) SetLatestNotificationError(v string) *GetTrailStatusOutput {
+	s.LatestNotificationError = &v
+	return s
+}
+
+// SetLatestNotificationTime sets the LatestNotificationTime field's value.
+func (s *GetTrailStatusOutput) SetLatestNotificationTime(v time.Time) *GetTrailStatusOutput {
+	s.LatestNotificationTime = &v
+	return s
+}
+
+// SetStartLoggingTime sets the StartLoggingTime field's value.
+func (s *GetTrailStatusOutput) SetStartLoggingTime(v time.Time) *GetTrailStatusOutput {
+	s.StartLoggingTime = &v
+	return s
+}
+
+// SetStopLoggingTime sets the StopLoggingTime field's value.
+func (s *GetTrailStatusOutput) SetStopLoggingTime(v time.Time) *GetTrailStatusOutput {
+	s.StopLoggingTime = &v
+	return s
+}
+
+// SetTimeLoggingStarted sets the TimeLoggingStarted field's value.
+func (s *GetTrailStatusOutput) SetTimeLoggingStarted(v string) *GetTrailStatusOutput {
+	s.TimeLoggingStarted = &v
+	return s
+}
+
+// SetTimeLoggingStopped sets the TimeLoggingStopped field's value.
+func (s *GetTrailStatusOutput) SetTimeLoggingStopped(v string) *GetTrailStatusOutput {
+	s.TimeLoggingStopped = &v
+	return s
+}
+
 // Requests the public keys for a specified time range.
 type ListPublicKeysInput struct {
 	_ struct{} `type:"structure"`
@@ -1740,6 +2052,24 @@ func (s ListPublicKeysInput) GoString() string {
 	return s.String()
 }
 
+// SetEndTime sets the EndTime field's value.
+func (s *ListPublicKeysInput) SetEndTime(v time.Time) *ListPublicKeysInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPublicKeysInput) SetNextToken(v string) *ListPublicKeysInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ListPublicKeysInput) SetStartTime(v time.Time) *ListPublicKeysInput {
+	s.StartTime = &v
+	return s
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type ListPublicKeysOutput struct {
@@ -1762,6 +2092,18 @@ func (s ListPublicKeysOutput) String() string {
 // GoString returns the string representation
 func (s ListPublicKeysOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPublicKeysOutput) SetNextToken(v string) *ListPublicKeysOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPublicKeyList sets the PublicKeyList field's value.
+func (s *ListPublicKeysOutput) SetPublicKeyList(v []*PublicKey) *ListPublicKeysOutput {
+	s.PublicKeyList = v
+	return s
 }
 
 // Specifies a list of trail tags to return.
@@ -1803,6 +2145,18 @@ func (s *ListTagsInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListTagsInput) SetNextToken(v string) *ListTagsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceIdList sets the ResourceIdList field's value.
+func (s *ListTagsInput) SetResourceIdList(v []*string) *ListTagsInput {
+	s.ResourceIdList = v
+	return s
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type ListTagsOutput struct {
@@ -1823,6 +2177,18 @@ func (s ListTagsOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTagsOutput) SetNextToken(v string) *ListTagsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceTagList sets the ResourceTagList field's value.
+func (s *ListTagsOutput) SetResourceTagList(v []*ResourceTag) *ListTagsOutput {
+	s.ResourceTagList = v
+	return s
 }
 
 // Specifies an attribute and value that filter the events returned.
@@ -1864,6 +2230,18 @@ func (s *LookupAttribute) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributeKey sets the AttributeKey field's value.
+func (s *LookupAttribute) SetAttributeKey(v string) *LookupAttribute {
+	s.AttributeKey = &v
+	return s
+}
+
+// SetAttributeValue sets the AttributeValue field's value.
+func (s *LookupAttribute) SetAttributeValue(v string) *LookupAttribute {
+	s.AttributeValue = &v
+	return s
 }
 
 // Contains a request for LookupEvents.
@@ -1929,6 +2307,36 @@ func (s *LookupEventsInput) Validate() error {
 	return nil
 }
 
+// SetEndTime sets the EndTime field's value.
+func (s *LookupEventsInput) SetEndTime(v time.Time) *LookupEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetLookupAttributes sets the LookupAttributes field's value.
+func (s *LookupEventsInput) SetLookupAttributes(v []*LookupAttribute) *LookupEventsInput {
+	s.LookupAttributes = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *LookupEventsInput) SetMaxResults(v int64) *LookupEventsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *LookupEventsInput) SetNextToken(v string) *LookupEventsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *LookupEventsInput) SetStartTime(v time.Time) *LookupEventsInput {
+	s.StartTime = &v
+	return s
+}
+
 // Contains a response to a LookupEvents action.
 type LookupEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1954,6 +2362,18 @@ func (s LookupEventsOutput) String() string {
 // GoString returns the string representation
 func (s LookupEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *LookupEventsOutput) SetEvents(v []*Event) *LookupEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *LookupEventsOutput) SetNextToken(v string) *LookupEventsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains information about a returned public key.
@@ -1983,6 +2403,30 @@ func (s PublicKey) String() string {
 // GoString returns the string representation
 func (s PublicKey) GoString() string {
 	return s.String()
+}
+
+// SetFingerprint sets the Fingerprint field's value.
+func (s *PublicKey) SetFingerprint(v string) *PublicKey {
+	s.Fingerprint = &v
+	return s
+}
+
+// SetValidityEndTime sets the ValidityEndTime field's value.
+func (s *PublicKey) SetValidityEndTime(v time.Time) *PublicKey {
+	s.ValidityEndTime = &v
+	return s
+}
+
+// SetValidityStartTime sets the ValidityStartTime field's value.
+func (s *PublicKey) SetValidityStartTime(v time.Time) *PublicKey {
+	s.ValidityStartTime = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *PublicKey) SetValue(v []byte) *PublicKey {
+	s.Value = v
+	return s
 }
 
 // Specifies the tags to remove from a trail.
@@ -2034,6 +2478,18 @@ func (s *RemoveTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *RemoveTagsInput) SetResourceId(v string) *RemoveTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTagsList sets the TagsList field's value.
+func (s *RemoveTagsInput) SetTagsList(v []*Tag) *RemoveTagsInput {
+	s.TagsList = v
+	return s
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type RemoveTagsOutput struct {
@@ -2078,6 +2534,18 @@ func (s Resource) GoString() string {
 	return s.String()
 }
 
+// SetResourceName sets the ResourceName field's value.
+func (s *Resource) SetResourceName(v string) *Resource {
+	s.ResourceName = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *Resource) SetResourceType(v string) *Resource {
+	s.ResourceType = &v
+	return s
+}
+
 // A resource tag.
 type ResourceTag struct {
 	_ struct{} `type:"structure"`
@@ -2097,6 +2565,18 @@ func (s ResourceTag) String() string {
 // GoString returns the string representation
 func (s ResourceTag) GoString() string {
 	return s.String()
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ResourceTag) SetResourceId(v string) *ResourceTag {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTagsList sets the TagsList field's value.
+func (s *ResourceTag) SetTagsList(v []*Tag) *ResourceTag {
+	s.TagsList = v
+	return s
 }
 
 // The request to CloudTrail to start logging AWS API calls for an account.
@@ -2133,6 +2613,12 @@ func (s *StartLoggingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *StartLoggingInput) SetName(v string) *StartLoggingInput {
+	s.Name = &v
+	return s
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns
@@ -2188,6 +2674,12 @@ func (s *StopLoggingInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *StopLoggingInput) SetName(v string) *StopLoggingInput {
+	s.Name = &v
+	return s
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type StopLoggingOutput struct {
@@ -2240,6 +2732,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // The settings for a trail.
@@ -2309,6 +2813,84 @@ func (s Trail) String() string {
 // GoString returns the string representation
 func (s Trail) GoString() string {
 	return s.String()
+}
+
+// SetCloudWatchLogsLogGroupArn sets the CloudWatchLogsLogGroupArn field's value.
+func (s *Trail) SetCloudWatchLogsLogGroupArn(v string) *Trail {
+	s.CloudWatchLogsLogGroupArn = &v
+	return s
+}
+
+// SetCloudWatchLogsRoleArn sets the CloudWatchLogsRoleArn field's value.
+func (s *Trail) SetCloudWatchLogsRoleArn(v string) *Trail {
+	s.CloudWatchLogsRoleArn = &v
+	return s
+}
+
+// SetHomeRegion sets the HomeRegion field's value.
+func (s *Trail) SetHomeRegion(v string) *Trail {
+	s.HomeRegion = &v
+	return s
+}
+
+// SetIncludeGlobalServiceEvents sets the IncludeGlobalServiceEvents field's value.
+func (s *Trail) SetIncludeGlobalServiceEvents(v bool) *Trail {
+	s.IncludeGlobalServiceEvents = &v
+	return s
+}
+
+// SetIsMultiRegionTrail sets the IsMultiRegionTrail field's value.
+func (s *Trail) SetIsMultiRegionTrail(v bool) *Trail {
+	s.IsMultiRegionTrail = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *Trail) SetKmsKeyId(v string) *Trail {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLogFileValidationEnabled sets the LogFileValidationEnabled field's value.
+func (s *Trail) SetLogFileValidationEnabled(v bool) *Trail {
+	s.LogFileValidationEnabled = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Trail) SetName(v string) *Trail {
+	s.Name = &v
+	return s
+}
+
+// SetS3BucketName sets the S3BucketName field's value.
+func (s *Trail) SetS3BucketName(v string) *Trail {
+	s.S3BucketName = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *Trail) SetS3KeyPrefix(v string) *Trail {
+	s.S3KeyPrefix = &v
+	return s
+}
+
+// SetSnsTopicARN sets the SnsTopicARN field's value.
+func (s *Trail) SetSnsTopicARN(v string) *Trail {
+	s.SnsTopicARN = &v
+	return s
+}
+
+// SetSnsTopicName sets the SnsTopicName field's value.
+func (s *Trail) SetSnsTopicName(v string) *Trail {
+	s.SnsTopicName = &v
+	return s
+}
+
+// SetTrailARN sets the TrailARN field's value.
+func (s *Trail) SetTrailARN(v string) *Trail {
+	s.TrailARN = &v
+	return s
 }
 
 // Specifies settings to update for the trail.
@@ -2423,6 +3005,66 @@ func (s *UpdateTrailInput) Validate() error {
 	return nil
 }
 
+// SetCloudWatchLogsLogGroupArn sets the CloudWatchLogsLogGroupArn field's value.
+func (s *UpdateTrailInput) SetCloudWatchLogsLogGroupArn(v string) *UpdateTrailInput {
+	s.CloudWatchLogsLogGroupArn = &v
+	return s
+}
+
+// SetCloudWatchLogsRoleArn sets the CloudWatchLogsRoleArn field's value.
+func (s *UpdateTrailInput) SetCloudWatchLogsRoleArn(v string) *UpdateTrailInput {
+	s.CloudWatchLogsRoleArn = &v
+	return s
+}
+
+// SetEnableLogFileValidation sets the EnableLogFileValidation field's value.
+func (s *UpdateTrailInput) SetEnableLogFileValidation(v bool) *UpdateTrailInput {
+	s.EnableLogFileValidation = &v
+	return s
+}
+
+// SetIncludeGlobalServiceEvents sets the IncludeGlobalServiceEvents field's value.
+func (s *UpdateTrailInput) SetIncludeGlobalServiceEvents(v bool) *UpdateTrailInput {
+	s.IncludeGlobalServiceEvents = &v
+	return s
+}
+
+// SetIsMultiRegionTrail sets the IsMultiRegionTrail field's value.
+func (s *UpdateTrailInput) SetIsMultiRegionTrail(v bool) *UpdateTrailInput {
+	s.IsMultiRegionTrail = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *UpdateTrailInput) SetKmsKeyId(v string) *UpdateTrailInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateTrailInput) SetName(v string) *UpdateTrailInput {
+	s.Name = &v
+	return s
+}
+
+// SetS3BucketName sets the S3BucketName field's value.
+func (s *UpdateTrailInput) SetS3BucketName(v string) *UpdateTrailInput {
+	s.S3BucketName = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *UpdateTrailInput) SetS3KeyPrefix(v string) *UpdateTrailInput {
+	s.S3KeyPrefix = &v
+	return s
+}
+
+// SetSnsTopicName sets the SnsTopicName field's value.
+func (s *UpdateTrailInput) SetSnsTopicName(v string) *UpdateTrailInput {
+	s.SnsTopicName = &v
+	return s
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type UpdateTrailOutput struct {
@@ -2488,6 +3130,78 @@ func (s UpdateTrailOutput) String() string {
 // GoString returns the string representation
 func (s UpdateTrailOutput) GoString() string {
 	return s.String()
+}
+
+// SetCloudWatchLogsLogGroupArn sets the CloudWatchLogsLogGroupArn field's value.
+func (s *UpdateTrailOutput) SetCloudWatchLogsLogGroupArn(v string) *UpdateTrailOutput {
+	s.CloudWatchLogsLogGroupArn = &v
+	return s
+}
+
+// SetCloudWatchLogsRoleArn sets the CloudWatchLogsRoleArn field's value.
+func (s *UpdateTrailOutput) SetCloudWatchLogsRoleArn(v string) *UpdateTrailOutput {
+	s.CloudWatchLogsRoleArn = &v
+	return s
+}
+
+// SetIncludeGlobalServiceEvents sets the IncludeGlobalServiceEvents field's value.
+func (s *UpdateTrailOutput) SetIncludeGlobalServiceEvents(v bool) *UpdateTrailOutput {
+	s.IncludeGlobalServiceEvents = &v
+	return s
+}
+
+// SetIsMultiRegionTrail sets the IsMultiRegionTrail field's value.
+func (s *UpdateTrailOutput) SetIsMultiRegionTrail(v bool) *UpdateTrailOutput {
+	s.IsMultiRegionTrail = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *UpdateTrailOutput) SetKmsKeyId(v string) *UpdateTrailOutput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLogFileValidationEnabled sets the LogFileValidationEnabled field's value.
+func (s *UpdateTrailOutput) SetLogFileValidationEnabled(v bool) *UpdateTrailOutput {
+	s.LogFileValidationEnabled = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateTrailOutput) SetName(v string) *UpdateTrailOutput {
+	s.Name = &v
+	return s
+}
+
+// SetS3BucketName sets the S3BucketName field's value.
+func (s *UpdateTrailOutput) SetS3BucketName(v string) *UpdateTrailOutput {
+	s.S3BucketName = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *UpdateTrailOutput) SetS3KeyPrefix(v string) *UpdateTrailOutput {
+	s.S3KeyPrefix = &v
+	return s
+}
+
+// SetSnsTopicARN sets the SnsTopicARN field's value.
+func (s *UpdateTrailOutput) SetSnsTopicARN(v string) *UpdateTrailOutput {
+	s.SnsTopicARN = &v
+	return s
+}
+
+// SetSnsTopicName sets the SnsTopicName field's value.
+func (s *UpdateTrailOutput) SetSnsTopicName(v string) *UpdateTrailOutput {
+	s.SnsTopicName = &v
+	return s
+}
+
+// SetTrailARN sets the TrailARN field's value.
+func (s *UpdateTrailOutput) SetTrailARN(v string) *UpdateTrailOutput {
+	s.TrailARN = &v
+	return s
 }
 
 const (

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -977,6 +977,36 @@ func (s AlarmHistoryItem) GoString() string {
 	return s.String()
 }
 
+// SetAlarmName sets the AlarmName field's value.
+func (s *AlarmHistoryItem) SetAlarmName(v string) *AlarmHistoryItem {
+	s.AlarmName = &v
+	return s
+}
+
+// SetHistoryData sets the HistoryData field's value.
+func (s *AlarmHistoryItem) SetHistoryData(v string) *AlarmHistoryItem {
+	s.HistoryData = &v
+	return s
+}
+
+// SetHistoryItemType sets the HistoryItemType field's value.
+func (s *AlarmHistoryItem) SetHistoryItemType(v string) *AlarmHistoryItem {
+	s.HistoryItemType = &v
+	return s
+}
+
+// SetHistorySummary sets the HistorySummary field's value.
+func (s *AlarmHistoryItem) SetHistorySummary(v string) *AlarmHistoryItem {
+	s.HistorySummary = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *AlarmHistoryItem) SetTimestamp(v time.Time) *AlarmHistoryItem {
+	s.Timestamp = &v
+	return s
+}
+
 // The Datapoint data type encapsulates the statistical data that Amazon CloudWatch
 // computes from metric data.
 type Datapoint struct {
@@ -1015,6 +1045,48 @@ func (s Datapoint) GoString() string {
 	return s.String()
 }
 
+// SetAverage sets the Average field's value.
+func (s *Datapoint) SetAverage(v float64) *Datapoint {
+	s.Average = &v
+	return s
+}
+
+// SetMaximum sets the Maximum field's value.
+func (s *Datapoint) SetMaximum(v float64) *Datapoint {
+	s.Maximum = &v
+	return s
+}
+
+// SetMinimum sets the Minimum field's value.
+func (s *Datapoint) SetMinimum(v float64) *Datapoint {
+	s.Minimum = &v
+	return s
+}
+
+// SetSampleCount sets the SampleCount field's value.
+func (s *Datapoint) SetSampleCount(v float64) *Datapoint {
+	s.SampleCount = &v
+	return s
+}
+
+// SetSum sets the Sum field's value.
+func (s *Datapoint) SetSum(v float64) *Datapoint {
+	s.Sum = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *Datapoint) SetTimestamp(v time.Time) *Datapoint {
+	s.Timestamp = &v
+	return s
+}
+
+// SetUnit sets the Unit field's value.
+func (s *Datapoint) SetUnit(v string) *Datapoint {
+	s.Unit = &v
+	return s
+}
+
 // Describes the inputs for DeleteAlarms.
 type DeleteAlarmsInput struct {
 	_ struct{} `type:"structure"`
@@ -1046,6 +1118,12 @@ func (s *DeleteAlarmsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAlarmNames sets the AlarmNames field's value.
+func (s *DeleteAlarmsInput) SetAlarmNames(v []*string) *DeleteAlarmsInput {
+	s.AlarmNames = v
+	return s
 }
 
 type DeleteAlarmsOutput struct {
@@ -1112,6 +1190,42 @@ func (s *DescribeAlarmHistoryInput) Validate() error {
 	return nil
 }
 
+// SetAlarmName sets the AlarmName field's value.
+func (s *DescribeAlarmHistoryInput) SetAlarmName(v string) *DescribeAlarmHistoryInput {
+	s.AlarmName = &v
+	return s
+}
+
+// SetEndDate sets the EndDate field's value.
+func (s *DescribeAlarmHistoryInput) SetEndDate(v time.Time) *DescribeAlarmHistoryInput {
+	s.EndDate = &v
+	return s
+}
+
+// SetHistoryItemType sets the HistoryItemType field's value.
+func (s *DescribeAlarmHistoryInput) SetHistoryItemType(v string) *DescribeAlarmHistoryInput {
+	s.HistoryItemType = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeAlarmHistoryInput) SetMaxRecords(v int64) *DescribeAlarmHistoryInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAlarmHistoryInput) SetNextToken(v string) *DescribeAlarmHistoryInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *DescribeAlarmHistoryInput) SetStartDate(v time.Time) *DescribeAlarmHistoryInput {
+	s.StartDate = &v
+	return s
+}
+
 // The output for DescribeAlarmHistory.
 type DescribeAlarmHistoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -1131,6 +1245,18 @@ func (s DescribeAlarmHistoryOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAlarmHistoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetAlarmHistoryItems sets the AlarmHistoryItems field's value.
+func (s *DescribeAlarmHistoryOutput) SetAlarmHistoryItems(v []*AlarmHistoryItem) *DescribeAlarmHistoryOutput {
+	s.AlarmHistoryItems = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAlarmHistoryOutput) SetNextToken(v string) *DescribeAlarmHistoryOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Describes the inputs for DescribeAlarmsForMetric.
@@ -1207,6 +1333,42 @@ func (s *DescribeAlarmsForMetricInput) Validate() error {
 	return nil
 }
 
+// SetDimensions sets the Dimensions field's value.
+func (s *DescribeAlarmsForMetricInput) SetDimensions(v []*Dimension) *DescribeAlarmsForMetricInput {
+	s.Dimensions = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *DescribeAlarmsForMetricInput) SetMetricName(v string) *DescribeAlarmsForMetricInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *DescribeAlarmsForMetricInput) SetNamespace(v string) *DescribeAlarmsForMetricInput {
+	s.Namespace = &v
+	return s
+}
+
+// SetPeriod sets the Period field's value.
+func (s *DescribeAlarmsForMetricInput) SetPeriod(v int64) *DescribeAlarmsForMetricInput {
+	s.Period = &v
+	return s
+}
+
+// SetStatistic sets the Statistic field's value.
+func (s *DescribeAlarmsForMetricInput) SetStatistic(v string) *DescribeAlarmsForMetricInput {
+	s.Statistic = &v
+	return s
+}
+
+// SetUnit sets the Unit field's value.
+func (s *DescribeAlarmsForMetricInput) SetUnit(v string) *DescribeAlarmsForMetricInput {
+	s.Unit = &v
+	return s
+}
+
 // The output for DescribeAlarmsForMetric.
 type DescribeAlarmsForMetricOutput struct {
 	_ struct{} `type:"structure"`
@@ -1223,6 +1385,12 @@ func (s DescribeAlarmsForMetricOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAlarmsForMetricOutput) GoString() string {
 	return s.String()
+}
+
+// SetMetricAlarms sets the MetricAlarms field's value.
+func (s *DescribeAlarmsForMetricOutput) SetMetricAlarms(v []*MetricAlarm) *DescribeAlarmsForMetricOutput {
+	s.MetricAlarms = v
+	return s
 }
 
 // Describes the inputs for DescribeAlarms.
@@ -1279,6 +1447,42 @@ func (s *DescribeAlarmsInput) Validate() error {
 	return nil
 }
 
+// SetActionPrefix sets the ActionPrefix field's value.
+func (s *DescribeAlarmsInput) SetActionPrefix(v string) *DescribeAlarmsInput {
+	s.ActionPrefix = &v
+	return s
+}
+
+// SetAlarmNamePrefix sets the AlarmNamePrefix field's value.
+func (s *DescribeAlarmsInput) SetAlarmNamePrefix(v string) *DescribeAlarmsInput {
+	s.AlarmNamePrefix = &v
+	return s
+}
+
+// SetAlarmNames sets the AlarmNames field's value.
+func (s *DescribeAlarmsInput) SetAlarmNames(v []*string) *DescribeAlarmsInput {
+	s.AlarmNames = v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeAlarmsInput) SetMaxRecords(v int64) *DescribeAlarmsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAlarmsInput) SetNextToken(v string) *DescribeAlarmsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStateValue sets the StateValue field's value.
+func (s *DescribeAlarmsInput) SetStateValue(v string) *DescribeAlarmsInput {
+	s.StateValue = &v
+	return s
+}
+
 // The output for DescribeAlarms.
 type DescribeAlarmsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1298,6 +1502,18 @@ func (s DescribeAlarmsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAlarmsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMetricAlarms sets the MetricAlarms field's value.
+func (s *DescribeAlarmsOutput) SetMetricAlarms(v []*MetricAlarm) *DescribeAlarmsOutput {
+	s.MetricAlarms = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAlarmsOutput) SetNextToken(v string) *DescribeAlarmsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // The Dimension data type further expands on the identity of a metric using
@@ -1350,6 +1566,18 @@ func (s *Dimension) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *Dimension) SetName(v string) *Dimension {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Dimension) SetValue(v string) *Dimension {
+	s.Value = &v
+	return s
+}
+
 // The DimensionFilter data type is used to filter ListMetrics results.
 type DimensionFilter struct {
 	_ struct{} `type:"structure"`
@@ -1395,6 +1623,18 @@ func (s *DimensionFilter) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *DimensionFilter) SetName(v string) *DimensionFilter {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *DimensionFilter) SetValue(v string) *DimensionFilter {
+	s.Value = &v
+	return s
+}
+
 type DisableAlarmActionsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1425,6 +1665,12 @@ func (s *DisableAlarmActionsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAlarmNames sets the AlarmNames field's value.
+func (s *DisableAlarmActionsInput) SetAlarmNames(v []*string) *DisableAlarmActionsInput {
+	s.AlarmNames = v
+	return s
 }
 
 type DisableAlarmActionsOutput struct {
@@ -1472,6 +1718,12 @@ func (s *EnableAlarmActionsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAlarmNames sets the AlarmNames field's value.
+func (s *EnableAlarmActionsInput) SetAlarmNames(v []*string) *EnableAlarmActionsInput {
+	s.AlarmNames = v
+	return s
 }
 
 type EnableAlarmActionsOutput struct {
@@ -1607,6 +1859,54 @@ func (s *GetMetricStatisticsInput) Validate() error {
 	return nil
 }
 
+// SetDimensions sets the Dimensions field's value.
+func (s *GetMetricStatisticsInput) SetDimensions(v []*Dimension) *GetMetricStatisticsInput {
+	s.Dimensions = v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *GetMetricStatisticsInput) SetEndTime(v time.Time) *GetMetricStatisticsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *GetMetricStatisticsInput) SetMetricName(v string) *GetMetricStatisticsInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *GetMetricStatisticsInput) SetNamespace(v string) *GetMetricStatisticsInput {
+	s.Namespace = &v
+	return s
+}
+
+// SetPeriod sets the Period field's value.
+func (s *GetMetricStatisticsInput) SetPeriod(v int64) *GetMetricStatisticsInput {
+	s.Period = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *GetMetricStatisticsInput) SetStartTime(v time.Time) *GetMetricStatisticsInput {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatistics sets the Statistics field's value.
+func (s *GetMetricStatisticsInput) SetStatistics(v []*string) *GetMetricStatisticsInput {
+	s.Statistics = v
+	return s
+}
+
+// SetUnit sets the Unit field's value.
+func (s *GetMetricStatisticsInput) SetUnit(v string) *GetMetricStatisticsInput {
+	s.Unit = &v
+	return s
+}
+
 // The output for GetMetricStatistics.
 type GetMetricStatisticsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1626,6 +1926,18 @@ func (s GetMetricStatisticsOutput) String() string {
 // GoString returns the string representation
 func (s GetMetricStatisticsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDatapoints sets the Datapoints field's value.
+func (s *GetMetricStatisticsOutput) SetDatapoints(v []*Datapoint) *GetMetricStatisticsOutput {
+	s.Datapoints = v
+	return s
+}
+
+// SetLabel sets the Label field's value.
+func (s *GetMetricStatisticsOutput) SetLabel(v string) *GetMetricStatisticsOutput {
+	s.Label = &v
+	return s
 }
 
 // Describes the inputs for ListMetrics.
@@ -1682,6 +1994,30 @@ func (s *ListMetricsInput) Validate() error {
 	return nil
 }
 
+// SetDimensions sets the Dimensions field's value.
+func (s *ListMetricsInput) SetDimensions(v []*DimensionFilter) *ListMetricsInput {
+	s.Dimensions = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *ListMetricsInput) SetMetricName(v string) *ListMetricsInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *ListMetricsInput) SetNamespace(v string) *ListMetricsInput {
+	s.Namespace = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListMetricsInput) SetNextToken(v string) *ListMetricsInput {
+	s.NextToken = &v
+	return s
+}
+
 // The output for ListMetrics.
 type ListMetricsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1701,6 +2037,18 @@ func (s ListMetricsOutput) String() string {
 // GoString returns the string representation
 func (s ListMetricsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMetrics sets the Metrics field's value.
+func (s *ListMetricsOutput) SetMetrics(v []*Metric) *ListMetricsOutput {
+	s.Metrics = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListMetricsOutput) SetNextToken(v string) *ListMetricsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // The Metric data type contains information about a specific metric. If you
@@ -1731,6 +2079,24 @@ func (s Metric) String() string {
 // GoString returns the string representation
 func (s Metric) GoString() string {
 	return s.String()
+}
+
+// SetDimensions sets the Dimensions field's value.
+func (s *Metric) SetDimensions(v []*Dimension) *Metric {
+	s.Dimensions = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *Metric) SetMetricName(v string) *Metric {
+	s.MetricName = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *Metric) SetNamespace(v string) *Metric {
+	s.Namespace = &v
+	return s
 }
 
 // The MetricAlarm data type represents an alarm. You can use PutMetricAlarm
@@ -1822,6 +2188,132 @@ func (s MetricAlarm) GoString() string {
 	return s.String()
 }
 
+// SetActionsEnabled sets the ActionsEnabled field's value.
+func (s *MetricAlarm) SetActionsEnabled(v bool) *MetricAlarm {
+	s.ActionsEnabled = &v
+	return s
+}
+
+// SetAlarmActions sets the AlarmActions field's value.
+func (s *MetricAlarm) SetAlarmActions(v []*string) *MetricAlarm {
+	s.AlarmActions = v
+	return s
+}
+
+// SetAlarmArn sets the AlarmArn field's value.
+func (s *MetricAlarm) SetAlarmArn(v string) *MetricAlarm {
+	s.AlarmArn = &v
+	return s
+}
+
+// SetAlarmConfigurationUpdatedTimestamp sets the AlarmConfigurationUpdatedTimestamp field's value.
+func (s *MetricAlarm) SetAlarmConfigurationUpdatedTimestamp(v time.Time) *MetricAlarm {
+	s.AlarmConfigurationUpdatedTimestamp = &v
+	return s
+}
+
+// SetAlarmDescription sets the AlarmDescription field's value.
+func (s *MetricAlarm) SetAlarmDescription(v string) *MetricAlarm {
+	s.AlarmDescription = &v
+	return s
+}
+
+// SetAlarmName sets the AlarmName field's value.
+func (s *MetricAlarm) SetAlarmName(v string) *MetricAlarm {
+	s.AlarmName = &v
+	return s
+}
+
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *MetricAlarm) SetComparisonOperator(v string) *MetricAlarm {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetDimensions sets the Dimensions field's value.
+func (s *MetricAlarm) SetDimensions(v []*Dimension) *MetricAlarm {
+	s.Dimensions = v
+	return s
+}
+
+// SetEvaluationPeriods sets the EvaluationPeriods field's value.
+func (s *MetricAlarm) SetEvaluationPeriods(v int64) *MetricAlarm {
+	s.EvaluationPeriods = &v
+	return s
+}
+
+// SetInsufficientDataActions sets the InsufficientDataActions field's value.
+func (s *MetricAlarm) SetInsufficientDataActions(v []*string) *MetricAlarm {
+	s.InsufficientDataActions = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *MetricAlarm) SetMetricName(v string) *MetricAlarm {
+	s.MetricName = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *MetricAlarm) SetNamespace(v string) *MetricAlarm {
+	s.Namespace = &v
+	return s
+}
+
+// SetOKActions sets the OKActions field's value.
+func (s *MetricAlarm) SetOKActions(v []*string) *MetricAlarm {
+	s.OKActions = v
+	return s
+}
+
+// SetPeriod sets the Period field's value.
+func (s *MetricAlarm) SetPeriod(v int64) *MetricAlarm {
+	s.Period = &v
+	return s
+}
+
+// SetStateReason sets the StateReason field's value.
+func (s *MetricAlarm) SetStateReason(v string) *MetricAlarm {
+	s.StateReason = &v
+	return s
+}
+
+// SetStateReasonData sets the StateReasonData field's value.
+func (s *MetricAlarm) SetStateReasonData(v string) *MetricAlarm {
+	s.StateReasonData = &v
+	return s
+}
+
+// SetStateUpdatedTimestamp sets the StateUpdatedTimestamp field's value.
+func (s *MetricAlarm) SetStateUpdatedTimestamp(v time.Time) *MetricAlarm {
+	s.StateUpdatedTimestamp = &v
+	return s
+}
+
+// SetStateValue sets the StateValue field's value.
+func (s *MetricAlarm) SetStateValue(v string) *MetricAlarm {
+	s.StateValue = &v
+	return s
+}
+
+// SetStatistic sets the Statistic field's value.
+func (s *MetricAlarm) SetStatistic(v string) *MetricAlarm {
+	s.Statistic = &v
+	return s
+}
+
+// SetThreshold sets the Threshold field's value.
+func (s *MetricAlarm) SetThreshold(v float64) *MetricAlarm {
+	s.Threshold = &v
+	return s
+}
+
+// SetUnit sets the Unit field's value.
+func (s *MetricAlarm) SetUnit(v string) *MetricAlarm {
+	s.Unit = &v
+	return s
+}
+
 // The MetricDatum data type encapsulates the information sent with PutMetricData
 // to either create a new metric or add new values to be aggregated into an
 // existing metric.
@@ -1897,6 +2389,42 @@ func (s *MetricDatum) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDimensions sets the Dimensions field's value.
+func (s *MetricDatum) SetDimensions(v []*Dimension) *MetricDatum {
+	s.Dimensions = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *MetricDatum) SetMetricName(v string) *MetricDatum {
+	s.MetricName = &v
+	return s
+}
+
+// SetStatisticValues sets the StatisticValues field's value.
+func (s *MetricDatum) SetStatisticValues(v *StatisticSet) *MetricDatum {
+	s.StatisticValues = v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *MetricDatum) SetTimestamp(v time.Time) *MetricDatum {
+	s.Timestamp = &v
+	return s
+}
+
+// SetUnit sets the Unit field's value.
+func (s *MetricDatum) SetUnit(v string) *MetricDatum {
+	s.Unit = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *MetricDatum) SetValue(v float64) *MetricDatum {
+	s.Value = &v
+	return s
 }
 
 // Describes the inputs for PutMetricAlarm.
@@ -2088,6 +2616,96 @@ func (s *PutMetricAlarmInput) Validate() error {
 	return nil
 }
 
+// SetActionsEnabled sets the ActionsEnabled field's value.
+func (s *PutMetricAlarmInput) SetActionsEnabled(v bool) *PutMetricAlarmInput {
+	s.ActionsEnabled = &v
+	return s
+}
+
+// SetAlarmActions sets the AlarmActions field's value.
+func (s *PutMetricAlarmInput) SetAlarmActions(v []*string) *PutMetricAlarmInput {
+	s.AlarmActions = v
+	return s
+}
+
+// SetAlarmDescription sets the AlarmDescription field's value.
+func (s *PutMetricAlarmInput) SetAlarmDescription(v string) *PutMetricAlarmInput {
+	s.AlarmDescription = &v
+	return s
+}
+
+// SetAlarmName sets the AlarmName field's value.
+func (s *PutMetricAlarmInput) SetAlarmName(v string) *PutMetricAlarmInput {
+	s.AlarmName = &v
+	return s
+}
+
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *PutMetricAlarmInput) SetComparisonOperator(v string) *PutMetricAlarmInput {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetDimensions sets the Dimensions field's value.
+func (s *PutMetricAlarmInput) SetDimensions(v []*Dimension) *PutMetricAlarmInput {
+	s.Dimensions = v
+	return s
+}
+
+// SetEvaluationPeriods sets the EvaluationPeriods field's value.
+func (s *PutMetricAlarmInput) SetEvaluationPeriods(v int64) *PutMetricAlarmInput {
+	s.EvaluationPeriods = &v
+	return s
+}
+
+// SetInsufficientDataActions sets the InsufficientDataActions field's value.
+func (s *PutMetricAlarmInput) SetInsufficientDataActions(v []*string) *PutMetricAlarmInput {
+	s.InsufficientDataActions = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *PutMetricAlarmInput) SetMetricName(v string) *PutMetricAlarmInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *PutMetricAlarmInput) SetNamespace(v string) *PutMetricAlarmInput {
+	s.Namespace = &v
+	return s
+}
+
+// SetOKActions sets the OKActions field's value.
+func (s *PutMetricAlarmInput) SetOKActions(v []*string) *PutMetricAlarmInput {
+	s.OKActions = v
+	return s
+}
+
+// SetPeriod sets the Period field's value.
+func (s *PutMetricAlarmInput) SetPeriod(v int64) *PutMetricAlarmInput {
+	s.Period = &v
+	return s
+}
+
+// SetStatistic sets the Statistic field's value.
+func (s *PutMetricAlarmInput) SetStatistic(v string) *PutMetricAlarmInput {
+	s.Statistic = &v
+	return s
+}
+
+// SetThreshold sets the Threshold field's value.
+func (s *PutMetricAlarmInput) SetThreshold(v float64) *PutMetricAlarmInput {
+	s.Threshold = &v
+	return s
+}
+
+// SetUnit sets the Unit field's value.
+func (s *PutMetricAlarmInput) SetUnit(v string) *PutMetricAlarmInput {
+	s.Unit = &v
+	return s
+}
+
 type PutMetricAlarmOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2158,6 +2776,18 @@ func (s *PutMetricDataInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMetricData sets the MetricData field's value.
+func (s *PutMetricDataInput) SetMetricData(v []*MetricDatum) *PutMetricDataInput {
+	s.MetricData = v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *PutMetricDataInput) SetNamespace(v string) *PutMetricDataInput {
+	s.Namespace = &v
+	return s
 }
 
 type PutMetricDataOutput struct {
@@ -2232,6 +2862,30 @@ func (s *SetAlarmStateInput) Validate() error {
 	return nil
 }
 
+// SetAlarmName sets the AlarmName field's value.
+func (s *SetAlarmStateInput) SetAlarmName(v string) *SetAlarmStateInput {
+	s.AlarmName = &v
+	return s
+}
+
+// SetStateReason sets the StateReason field's value.
+func (s *SetAlarmStateInput) SetStateReason(v string) *SetAlarmStateInput {
+	s.StateReason = &v
+	return s
+}
+
+// SetStateReasonData sets the StateReasonData field's value.
+func (s *SetAlarmStateInput) SetStateReasonData(v string) *SetAlarmStateInput {
+	s.StateReasonData = &v
+	return s
+}
+
+// SetStateValue sets the StateValue field's value.
+func (s *SetAlarmStateInput) SetStateValue(v string) *SetAlarmStateInput {
+	s.StateValue = &v
+	return s
+}
+
 type SetAlarmStateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2302,6 +2956,30 @@ func (s *StatisticSet) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMaximum sets the Maximum field's value.
+func (s *StatisticSet) SetMaximum(v float64) *StatisticSet {
+	s.Maximum = &v
+	return s
+}
+
+// SetMinimum sets the Minimum field's value.
+func (s *StatisticSet) SetMinimum(v float64) *StatisticSet {
+	s.Minimum = &v
+	return s
+}
+
+// SetSampleCount sets the SampleCount field's value.
+func (s *StatisticSet) SetSampleCount(v float64) *StatisticSet {
+	s.SampleCount = &v
+	return s
+}
+
+// SetSum sets the Sum field's value.
+func (s *StatisticSet) SetSum(v float64) *StatisticSet {
+	s.Sum = &v
+	return s
 }
 
 const (

--- a/service/cloudwatchevents/api.go
+++ b/service/cloudwatchevents/api.go
@@ -948,6 +948,12 @@ func (s *DeleteRuleInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *DeleteRuleInput) SetName(v string) *DeleteRuleInput {
+	s.Name = &v
+	return s
+}
+
 type DeleteRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -998,6 +1004,12 @@ func (s *DescribeRuleInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *DescribeRuleInput) SetName(v string) *DescribeRuleInput {
+	s.Name = &v
+	return s
+}
+
 // The result of the DescribeRule operation.
 type DescribeRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -1034,6 +1046,48 @@ func (s DescribeRuleOutput) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *DescribeRuleOutput) SetArn(v string) *DescribeRuleOutput {
+	s.Arn = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DescribeRuleOutput) SetDescription(v string) *DescribeRuleOutput {
+	s.Description = &v
+	return s
+}
+
+// SetEventPattern sets the EventPattern field's value.
+func (s *DescribeRuleOutput) SetEventPattern(v string) *DescribeRuleOutput {
+	s.EventPattern = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DescribeRuleOutput) SetName(v string) *DescribeRuleOutput {
+	s.Name = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *DescribeRuleOutput) SetRoleArn(v string) *DescribeRuleOutput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetScheduleExpression sets the ScheduleExpression field's value.
+func (s *DescribeRuleOutput) SetScheduleExpression(v string) *DescribeRuleOutput {
+	s.ScheduleExpression = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *DescribeRuleOutput) SetState(v string) *DescribeRuleOutput {
+	s.State = &v
+	return s
+}
+
 // Container for the parameters to the DisableRule operation.
 type DisableRuleInput struct {
 	_ struct{} `type:"structure"`
@@ -1068,6 +1122,12 @@ func (s *DisableRuleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DisableRuleInput) SetName(v string) *DisableRuleInput {
+	s.Name = &v
+	return s
 }
 
 type DisableRuleOutput struct {
@@ -1118,6 +1178,12 @@ func (s *EnableRuleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *EnableRuleInput) SetName(v string) *EnableRuleInput {
+	s.Name = &v
+	return s
 }
 
 type EnableRuleOutput struct {
@@ -1184,6 +1250,24 @@ func (s *ListRuleNamesByTargetInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListRuleNamesByTargetInput) SetLimit(v int64) *ListRuleNamesByTargetInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRuleNamesByTargetInput) SetNextToken(v string) *ListRuleNamesByTargetInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTargetArn sets the TargetArn field's value.
+func (s *ListRuleNamesByTargetInput) SetTargetArn(v string) *ListRuleNamesByTargetInput {
+	s.TargetArn = &v
+	return s
+}
+
 // The result of the ListRuleNamesByTarget operation.
 type ListRuleNamesByTargetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1203,6 +1287,18 @@ func (s ListRuleNamesByTargetOutput) String() string {
 // GoString returns the string representation
 func (s ListRuleNamesByTargetOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRuleNamesByTargetOutput) SetNextToken(v string) *ListRuleNamesByTargetOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRuleNames sets the RuleNames field's value.
+func (s *ListRuleNamesByTargetOutput) SetRuleNames(v []*string) *ListRuleNamesByTargetOutput {
+	s.RuleNames = v
+	return s
 }
 
 // Container for the parameters to the ListRules operation.
@@ -1249,6 +1345,24 @@ func (s *ListRulesInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListRulesInput) SetLimit(v int64) *ListRulesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNamePrefix sets the NamePrefix field's value.
+func (s *ListRulesInput) SetNamePrefix(v string) *ListRulesInput {
+	s.NamePrefix = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRulesInput) SetNextToken(v string) *ListRulesInput {
+	s.NextToken = &v
+	return s
+}
+
 // The result of the ListRules operation.
 type ListRulesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1268,6 +1382,18 @@ func (s ListRulesOutput) String() string {
 // GoString returns the string representation
 func (s ListRulesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRulesOutput) SetNextToken(v string) *ListRulesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *ListRulesOutput) SetRules(v []*Rule) *ListRulesOutput {
+	s.Rules = v
+	return s
 }
 
 // Container for the parameters to the ListTargetsByRule operation.
@@ -1319,6 +1445,24 @@ func (s *ListTargetsByRuleInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListTargetsByRuleInput) SetLimit(v int64) *ListTargetsByRuleInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTargetsByRuleInput) SetNextToken(v string) *ListTargetsByRuleInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRule sets the Rule field's value.
+func (s *ListTargetsByRuleInput) SetRule(v string) *ListTargetsByRuleInput {
+	s.Rule = &v
+	return s
+}
+
 // The result of the ListTargetsByRule operation.
 type ListTargetsByRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -1338,6 +1482,18 @@ func (s ListTargetsByRuleOutput) String() string {
 // GoString returns the string representation
 func (s ListTargetsByRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTargetsByRuleOutput) SetNextToken(v string) *ListTargetsByRuleOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *ListTargetsByRuleOutput) SetTargets(v []*Target) *ListTargetsByRuleOutput {
+	s.Targets = v
+	return s
 }
 
 // Container for the parameters to the PutEvents operation.
@@ -1378,6 +1534,12 @@ func (s *PutEventsInput) Validate() error {
 	return nil
 }
 
+// SetEntries sets the Entries field's value.
+func (s *PutEventsInput) SetEntries(v []*PutEventsRequestEntry) *PutEventsInput {
+	s.Entries = v
+	return s
+}
+
 // The result of the PutEvents operation.
 type PutEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1400,6 +1562,18 @@ func (s PutEventsOutput) String() string {
 // GoString returns the string representation
 func (s PutEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEntries sets the Entries field's value.
+func (s *PutEventsOutput) SetEntries(v []*PutEventsResultEntry) *PutEventsOutput {
+	s.Entries = v
+	return s
+}
+
+// SetFailedEntryCount sets the FailedEntryCount field's value.
+func (s *PutEventsOutput) SetFailedEntryCount(v int64) *PutEventsOutput {
+	s.FailedEntryCount = &v
+	return s
 }
 
 // Contains information about the event to be used in PutEvents.
@@ -1436,6 +1610,36 @@ func (s PutEventsRequestEntry) GoString() string {
 	return s.String()
 }
 
+// SetDetail sets the Detail field's value.
+func (s *PutEventsRequestEntry) SetDetail(v string) *PutEventsRequestEntry {
+	s.Detail = &v
+	return s
+}
+
+// SetDetailType sets the DetailType field's value.
+func (s *PutEventsRequestEntry) SetDetailType(v string) *PutEventsRequestEntry {
+	s.DetailType = &v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *PutEventsRequestEntry) SetResources(v []*string) *PutEventsRequestEntry {
+	s.Resources = v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *PutEventsRequestEntry) SetSource(v string) *PutEventsRequestEntry {
+	s.Source = &v
+	return s
+}
+
+// SetTime sets the Time field's value.
+func (s *PutEventsRequestEntry) SetTime(v time.Time) *PutEventsRequestEntry {
+	s.Time = &v
+	return s
+}
+
 // A PutEventsResult contains a list of PutEventsResultEntry.
 type PutEventsResultEntry struct {
 	_ struct{} `type:"structure"`
@@ -1458,6 +1662,24 @@ func (s PutEventsResultEntry) String() string {
 // GoString returns the string representation
 func (s PutEventsResultEntry) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *PutEventsResultEntry) SetErrorCode(v string) *PutEventsResultEntry {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *PutEventsResultEntry) SetErrorMessage(v string) *PutEventsResultEntry {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetEventId sets the EventId field's value.
+func (s *PutEventsResultEntry) SetEventId(v string) *PutEventsResultEntry {
+	s.EventId = &v
+	return s
 }
 
 // Container for the parameters to the PutRule operation.
@@ -1514,6 +1736,42 @@ func (s *PutRuleInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *PutRuleInput) SetDescription(v string) *PutRuleInput {
+	s.Description = &v
+	return s
+}
+
+// SetEventPattern sets the EventPattern field's value.
+func (s *PutRuleInput) SetEventPattern(v string) *PutRuleInput {
+	s.EventPattern = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PutRuleInput) SetName(v string) *PutRuleInput {
+	s.Name = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *PutRuleInput) SetRoleArn(v string) *PutRuleInput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetScheduleExpression sets the ScheduleExpression field's value.
+func (s *PutRuleInput) SetScheduleExpression(v string) *PutRuleInput {
+	s.ScheduleExpression = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *PutRuleInput) SetState(v string) *PutRuleInput {
+	s.State = &v
+	return s
+}
+
 // The result of the PutRule operation.
 type PutRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -1530,6 +1788,12 @@ func (s PutRuleOutput) String() string {
 // GoString returns the string representation
 func (s PutRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetRuleArn sets the RuleArn field's value.
+func (s *PutRuleOutput) SetRuleArn(v string) *PutRuleOutput {
+	s.RuleArn = &v
+	return s
 }
 
 // Container for the parameters to the PutTargets operation.
@@ -1586,6 +1850,18 @@ func (s *PutTargetsInput) Validate() error {
 	return nil
 }
 
+// SetRule sets the Rule field's value.
+func (s *PutTargetsInput) SetRule(v string) *PutTargetsInput {
+	s.Rule = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *PutTargetsInput) SetTargets(v []*Target) *PutTargetsInput {
+	s.Targets = v
+	return s
+}
+
 // The result of the PutTargets operation.
 type PutTargetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1605,6 +1881,18 @@ func (s PutTargetsOutput) String() string {
 // GoString returns the string representation
 func (s PutTargetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedEntries sets the FailedEntries field's value.
+func (s *PutTargetsOutput) SetFailedEntries(v []*PutTargetsResultEntry) *PutTargetsOutput {
+	s.FailedEntries = v
+	return s
+}
+
+// SetFailedEntryCount sets the FailedEntryCount field's value.
+func (s *PutTargetsOutput) SetFailedEntryCount(v int64) *PutTargetsOutput {
+	s.FailedEntryCount = &v
+	return s
 }
 
 // A PutTargetsResult contains a list of PutTargetsResultEntry.
@@ -1629,6 +1917,24 @@ func (s PutTargetsResultEntry) String() string {
 // GoString returns the string representation
 func (s PutTargetsResultEntry) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *PutTargetsResultEntry) SetErrorCode(v string) *PutTargetsResultEntry {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *PutTargetsResultEntry) SetErrorMessage(v string) *PutTargetsResultEntry {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetTargetId sets the TargetId field's value.
+func (s *PutTargetsResultEntry) SetTargetId(v string) *PutTargetsResultEntry {
+	s.TargetId = &v
+	return s
 }
 
 // Container for the parameters to the RemoveTargets operation.
@@ -1678,6 +1984,18 @@ func (s *RemoveTargetsInput) Validate() error {
 	return nil
 }
 
+// SetIds sets the Ids field's value.
+func (s *RemoveTargetsInput) SetIds(v []*string) *RemoveTargetsInput {
+	s.Ids = v
+	return s
+}
+
+// SetRule sets the Rule field's value.
+func (s *RemoveTargetsInput) SetRule(v string) *RemoveTargetsInput {
+	s.Rule = &v
+	return s
+}
+
 // The result of the RemoveTargets operation.
 type RemoveTargetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1697,6 +2015,18 @@ func (s RemoveTargetsOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTargetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedEntries sets the FailedEntries field's value.
+func (s *RemoveTargetsOutput) SetFailedEntries(v []*RemoveTargetsResultEntry) *RemoveTargetsOutput {
+	s.FailedEntries = v
+	return s
+}
+
+// SetFailedEntryCount sets the FailedEntryCount field's value.
+func (s *RemoveTargetsOutput) SetFailedEntryCount(v int64) *RemoveTargetsOutput {
+	s.FailedEntryCount = &v
+	return s
 }
 
 // The ID of the target requested to be removed from the rule by Amazon CloudWatch
@@ -1722,6 +2052,24 @@ func (s RemoveTargetsResultEntry) String() string {
 // GoString returns the string representation
 func (s RemoveTargetsResultEntry) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *RemoveTargetsResultEntry) SetErrorCode(v string) *RemoveTargetsResultEntry {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *RemoveTargetsResultEntry) SetErrorMessage(v string) *RemoveTargetsResultEntry {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetTargetId sets the TargetId field's value.
+func (s *RemoveTargetsResultEntry) SetTargetId(v string) *RemoveTargetsResultEntry {
+	s.TargetId = &v
+	return s
 }
 
 // Contains information about a rule in Amazon CloudWatch Events. A ListRulesResult
@@ -1760,6 +2108,48 @@ func (s Rule) String() string {
 // GoString returns the string representation
 func (s Rule) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Rule) SetArn(v string) *Rule {
+	s.Arn = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Rule) SetDescription(v string) *Rule {
+	s.Description = &v
+	return s
+}
+
+// SetEventPattern sets the EventPattern field's value.
+func (s *Rule) SetEventPattern(v string) *Rule {
+	s.EventPattern = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Rule) SetName(v string) *Rule {
+	s.Name = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *Rule) SetRoleArn(v string) *Rule {
+	s.RoleArn = &v
+	return s
+}
+
+// SetScheduleExpression sets the ScheduleExpression field's value.
+func (s *Rule) SetScheduleExpression(v string) *Rule {
+	s.ScheduleExpression = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Rule) SetState(v string) *Rule {
+	s.State = &v
+	return s
 }
 
 // Targets are the resources that can be invoked when a rule is triggered. For
@@ -1830,6 +2220,30 @@ func (s *Target) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *Target) SetArn(v string) *Target {
+	s.Arn = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Target) SetId(v string) *Target {
+	s.Id = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *Target) SetInput(v string) *Target {
+	s.Input = &v
+	return s
+}
+
+// SetInputPath sets the InputPath field's value.
+func (s *Target) SetInputPath(v string) *Target {
+	s.InputPath = &v
+	return s
+}
+
 // Container for the parameters to the TestEventPattern operation.
 type TestEventPatternInput struct {
 	_ struct{} `type:"structure"`
@@ -1871,6 +2285,18 @@ func (s *TestEventPatternInput) Validate() error {
 	return nil
 }
 
+// SetEvent sets the Event field's value.
+func (s *TestEventPatternInput) SetEvent(v string) *TestEventPatternInput {
+	s.Event = &v
+	return s
+}
+
+// SetEventPattern sets the EventPattern field's value.
+func (s *TestEventPatternInput) SetEventPattern(v string) *TestEventPatternInput {
+	s.EventPattern = &v
+	return s
+}
+
 // The result of the TestEventPattern operation.
 type TestEventPatternOutput struct {
 	_ struct{} `type:"structure"`
@@ -1887,6 +2313,12 @@ func (s TestEventPatternOutput) String() string {
 // GoString returns the string representation
 func (s TestEventPatternOutput) GoString() string {
 	return s.String()
+}
+
+// SetResult sets the Result field's value.
+func (s *TestEventPatternOutput) SetResult(v bool) *TestEventPatternOutput {
+	s.Result = &v
+	return s
 }
 
 const (

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -2255,6 +2255,12 @@ func (s *CancelExportTaskInput) Validate() error {
 	return nil
 }
 
+// SetTaskId sets the TaskId field's value.
+func (s *CancelExportTaskInput) SetTaskId(v string) *CancelExportTaskInput {
+	s.TaskId = &v
+	return s
+}
+
 type CancelExportTaskOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2354,6 +2360,48 @@ func (s *CreateExportTaskInput) Validate() error {
 	return nil
 }
 
+// SetDestination sets the Destination field's value.
+func (s *CreateExportTaskInput) SetDestination(v string) *CreateExportTaskInput {
+	s.Destination = &v
+	return s
+}
+
+// SetDestinationPrefix sets the DestinationPrefix field's value.
+func (s *CreateExportTaskInput) SetDestinationPrefix(v string) *CreateExportTaskInput {
+	s.DestinationPrefix = &v
+	return s
+}
+
+// SetFrom sets the From field's value.
+func (s *CreateExportTaskInput) SetFrom(v int64) *CreateExportTaskInput {
+	s.From = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *CreateExportTaskInput) SetLogGroupName(v string) *CreateExportTaskInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetLogStreamNamePrefix sets the LogStreamNamePrefix field's value.
+func (s *CreateExportTaskInput) SetLogStreamNamePrefix(v string) *CreateExportTaskInput {
+	s.LogStreamNamePrefix = &v
+	return s
+}
+
+// SetTaskName sets the TaskName field's value.
+func (s *CreateExportTaskInput) SetTaskName(v string) *CreateExportTaskInput {
+	s.TaskName = &v
+	return s
+}
+
+// SetTo sets the To field's value.
+func (s *CreateExportTaskInput) SetTo(v int64) *CreateExportTaskInput {
+	s.To = &v
+	return s
+}
+
 type CreateExportTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2369,6 +2417,12 @@ func (s CreateExportTaskOutput) String() string {
 // GoString returns the string representation
 func (s CreateExportTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *CreateExportTaskOutput) SetTaskId(v string) *CreateExportTaskOutput {
+	s.TaskId = &v
+	return s
 }
 
 type CreateLogGroupInput struct {
@@ -2404,6 +2458,12 @@ func (s *CreateLogGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *CreateLogGroupInput) SetLogGroupName(v string) *CreateLogGroupInput {
+	s.LogGroupName = &v
+	return s
 }
 
 type CreateLogGroupOutput struct {
@@ -2466,6 +2526,18 @@ func (s *CreateLogStreamInput) Validate() error {
 	return nil
 }
 
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *CreateLogStreamInput) SetLogGroupName(v string) *CreateLogStreamInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetLogStreamName sets the LogStreamName field's value.
+func (s *CreateLogStreamInput) SetLogStreamName(v string) *CreateLogStreamInput {
+	s.LogStreamName = &v
+	return s
+}
+
 type CreateLogStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2515,6 +2587,12 @@ func (s *DeleteDestinationInput) Validate() error {
 	return nil
 }
 
+// SetDestinationName sets the DestinationName field's value.
+func (s *DeleteDestinationInput) SetDestinationName(v string) *DeleteDestinationInput {
+	s.DestinationName = &v
+	return s
+}
+
 type DeleteDestinationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2562,6 +2640,12 @@ func (s *DeleteLogGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DeleteLogGroupInput) SetLogGroupName(v string) *DeleteLogGroupInput {
+	s.LogGroupName = &v
+	return s
 }
 
 type DeleteLogGroupOutput struct {
@@ -2624,6 +2708,18 @@ func (s *DeleteLogStreamInput) Validate() error {
 	return nil
 }
 
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DeleteLogStreamInput) SetLogGroupName(v string) *DeleteLogStreamInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetLogStreamName sets the LogStreamName field's value.
+func (s *DeleteLogStreamInput) SetLogStreamName(v string) *DeleteLogStreamInput {
+	s.LogStreamName = &v
+	return s
+}
+
 type DeleteLogStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2684,6 +2780,18 @@ func (s *DeleteMetricFilterInput) Validate() error {
 	return nil
 }
 
+// SetFilterName sets the FilterName field's value.
+func (s *DeleteMetricFilterInput) SetFilterName(v string) *DeleteMetricFilterInput {
+	s.FilterName = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DeleteMetricFilterInput) SetLogGroupName(v string) *DeleteMetricFilterInput {
+	s.LogGroupName = &v
+	return s
+}
+
 type DeleteMetricFilterOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2732,6 +2840,12 @@ func (s *DeleteRetentionPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DeleteRetentionPolicyInput) SetLogGroupName(v string) *DeleteRetentionPolicyInput {
+	s.LogGroupName = &v
+	return s
 }
 
 type DeleteRetentionPolicyOutput struct {
@@ -2795,6 +2909,18 @@ func (s *DeleteSubscriptionFilterInput) Validate() error {
 	return nil
 }
 
+// SetFilterName sets the FilterName field's value.
+func (s *DeleteSubscriptionFilterInput) SetFilterName(v string) *DeleteSubscriptionFilterInput {
+	s.FilterName = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DeleteSubscriptionFilterInput) SetLogGroupName(v string) *DeleteSubscriptionFilterInput {
+	s.LogGroupName = &v
+	return s
+}
+
 type DeleteSubscriptionFilterOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2854,6 +2980,24 @@ func (s *DescribeDestinationsInput) Validate() error {
 	return nil
 }
 
+// SetDestinationNamePrefix sets the DestinationNamePrefix field's value.
+func (s *DescribeDestinationsInput) SetDestinationNamePrefix(v string) *DescribeDestinationsInput {
+	s.DestinationNamePrefix = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeDestinationsInput) SetLimit(v int64) *DescribeDestinationsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeDestinationsInput) SetNextToken(v string) *DescribeDestinationsInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeDestinationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2873,6 +3017,18 @@ func (s DescribeDestinationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDestinationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDestinations sets the Destinations field's value.
+func (s *DescribeDestinationsOutput) SetDestinations(v []*Destination) *DescribeDestinationsOutput {
+	s.Destinations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeDestinationsOutput) SetNextToken(v string) *DescribeDestinationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeExportTasksInput struct {
@@ -2925,6 +3081,30 @@ func (s *DescribeExportTasksInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *DescribeExportTasksInput) SetLimit(v int64) *DescribeExportTasksInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeExportTasksInput) SetNextToken(v string) *DescribeExportTasksInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *DescribeExportTasksInput) SetStatusCode(v string) *DescribeExportTasksInput {
+	s.StatusCode = &v
+	return s
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *DescribeExportTasksInput) SetTaskId(v string) *DescribeExportTasksInput {
+	s.TaskId = &v
+	return s
+}
+
 type DescribeExportTasksOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2945,6 +3125,18 @@ func (s DescribeExportTasksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeExportTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetExportTasks sets the ExportTasks field's value.
+func (s *DescribeExportTasksOutput) SetExportTasks(v []*ExportTask) *DescribeExportTasksOutput {
+	s.ExportTasks = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeExportTasksOutput) SetNextToken(v string) *DescribeExportTasksOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeLogGroupsInput struct {
@@ -2993,6 +3185,24 @@ func (s *DescribeLogGroupsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *DescribeLogGroupsInput) SetLimit(v int64) *DescribeLogGroupsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetLogGroupNamePrefix sets the LogGroupNamePrefix field's value.
+func (s *DescribeLogGroupsInput) SetLogGroupNamePrefix(v string) *DescribeLogGroupsInput {
+	s.LogGroupNamePrefix = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLogGroupsInput) SetNextToken(v string) *DescribeLogGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeLogGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3013,6 +3223,18 @@ func (s DescribeLogGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLogGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetLogGroups sets the LogGroups field's value.
+func (s *DescribeLogGroupsOutput) SetLogGroups(v []*LogGroup) *DescribeLogGroupsOutput {
+	s.LogGroups = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLogGroupsOutput) SetNextToken(v string) *DescribeLogGroupsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeLogStreamsInput struct {
@@ -3082,6 +3304,42 @@ func (s *DescribeLogStreamsInput) Validate() error {
 	return nil
 }
 
+// SetDescending sets the Descending field's value.
+func (s *DescribeLogStreamsInput) SetDescending(v bool) *DescribeLogStreamsInput {
+	s.Descending = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeLogStreamsInput) SetLimit(v int64) *DescribeLogStreamsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DescribeLogStreamsInput) SetLogGroupName(v string) *DescribeLogStreamsInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetLogStreamNamePrefix sets the LogStreamNamePrefix field's value.
+func (s *DescribeLogStreamsInput) SetLogStreamNamePrefix(v string) *DescribeLogStreamsInput {
+	s.LogStreamNamePrefix = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLogStreamsInput) SetNextToken(v string) *DescribeLogStreamsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOrderBy sets the OrderBy field's value.
+func (s *DescribeLogStreamsInput) SetOrderBy(v string) *DescribeLogStreamsInput {
+	s.OrderBy = &v
+	return s
+}
+
 type DescribeLogStreamsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3102,6 +3360,18 @@ func (s DescribeLogStreamsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLogStreamsOutput) GoString() string {
 	return s.String()
+}
+
+// SetLogStreams sets the LogStreams field's value.
+func (s *DescribeLogStreamsOutput) SetLogStreams(v []*LogStream) *DescribeLogStreamsOutput {
+	s.LogStreams = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeLogStreamsOutput) SetNextToken(v string) *DescribeLogStreamsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeMetricFiltersInput struct {
@@ -3161,6 +3431,30 @@ func (s *DescribeMetricFiltersInput) Validate() error {
 	return nil
 }
 
+// SetFilterNamePrefix sets the FilterNamePrefix field's value.
+func (s *DescribeMetricFiltersInput) SetFilterNamePrefix(v string) *DescribeMetricFiltersInput {
+	s.FilterNamePrefix = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeMetricFiltersInput) SetLimit(v int64) *DescribeMetricFiltersInput {
+	s.Limit = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DescribeMetricFiltersInput) SetLogGroupName(v string) *DescribeMetricFiltersInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeMetricFiltersInput) SetNextToken(v string) *DescribeMetricFiltersInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeMetricFiltersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3180,6 +3474,18 @@ func (s DescribeMetricFiltersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeMetricFiltersOutput) GoString() string {
 	return s.String()
+}
+
+// SetMetricFilters sets the MetricFilters field's value.
+func (s *DescribeMetricFiltersOutput) SetMetricFilters(v []*MetricFilter) *DescribeMetricFiltersOutput {
+	s.MetricFilters = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeMetricFiltersOutput) SetNextToken(v string) *DescribeMetricFiltersOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeSubscriptionFiltersInput struct {
@@ -3238,6 +3544,30 @@ func (s *DescribeSubscriptionFiltersInput) Validate() error {
 	return nil
 }
 
+// SetFilterNamePrefix sets the FilterNamePrefix field's value.
+func (s *DescribeSubscriptionFiltersInput) SetFilterNamePrefix(v string) *DescribeSubscriptionFiltersInput {
+	s.FilterNamePrefix = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeSubscriptionFiltersInput) SetLimit(v int64) *DescribeSubscriptionFiltersInput {
+	s.Limit = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DescribeSubscriptionFiltersInput) SetLogGroupName(v string) *DescribeSubscriptionFiltersInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSubscriptionFiltersInput) SetNextToken(v string) *DescribeSubscriptionFiltersInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeSubscriptionFiltersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3257,6 +3587,18 @@ func (s DescribeSubscriptionFiltersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSubscriptionFiltersOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSubscriptionFiltersOutput) SetNextToken(v string) *DescribeSubscriptionFiltersOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSubscriptionFilters sets the SubscriptionFilters field's value.
+func (s *DescribeSubscriptionFiltersOutput) SetSubscriptionFilters(v []*SubscriptionFilter) *DescribeSubscriptionFiltersOutput {
+	s.SubscriptionFilters = v
+	return s
 }
 
 // A cross account destination that is the recipient of subscription log events.
@@ -3293,6 +3635,42 @@ func (s Destination) String() string {
 // GoString returns the string representation
 func (s Destination) GoString() string {
 	return s.String()
+}
+
+// SetAccessPolicy sets the AccessPolicy field's value.
+func (s *Destination) SetAccessPolicy(v string) *Destination {
+	s.AccessPolicy = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *Destination) SetArn(v string) *Destination {
+	s.Arn = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *Destination) SetCreationTime(v int64) *Destination {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDestinationName sets the DestinationName field's value.
+func (s *Destination) SetDestinationName(v string) *Destination {
+	s.DestinationName = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *Destination) SetRoleArn(v string) *Destination {
+	s.RoleArn = &v
+	return s
+}
+
+// SetTargetArn sets the TargetArn field's value.
+func (s *Destination) SetTargetArn(v string) *Destination {
+	s.TargetArn = &v
+	return s
 }
 
 // Represents an export task.
@@ -3339,6 +3717,60 @@ func (s ExportTask) GoString() string {
 	return s.String()
 }
 
+// SetDestination sets the Destination field's value.
+func (s *ExportTask) SetDestination(v string) *ExportTask {
+	s.Destination = &v
+	return s
+}
+
+// SetDestinationPrefix sets the DestinationPrefix field's value.
+func (s *ExportTask) SetDestinationPrefix(v string) *ExportTask {
+	s.DestinationPrefix = &v
+	return s
+}
+
+// SetExecutionInfo sets the ExecutionInfo field's value.
+func (s *ExportTask) SetExecutionInfo(v *ExportTaskExecutionInfo) *ExportTask {
+	s.ExecutionInfo = v
+	return s
+}
+
+// SetFrom sets the From field's value.
+func (s *ExportTask) SetFrom(v int64) *ExportTask {
+	s.From = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *ExportTask) SetLogGroupName(v string) *ExportTask {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ExportTask) SetStatus(v *ExportTaskStatus) *ExportTask {
+	s.Status = v
+	return s
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *ExportTask) SetTaskId(v string) *ExportTask {
+	s.TaskId = &v
+	return s
+}
+
+// SetTaskName sets the TaskName field's value.
+func (s *ExportTask) SetTaskName(v string) *ExportTask {
+	s.TaskName = &v
+	return s
+}
+
+// SetTo sets the To field's value.
+func (s *ExportTask) SetTo(v int64) *ExportTask {
+	s.To = &v
+	return s
+}
+
 // Represents the status of an export task.
 type ExportTaskExecutionInfo struct {
 	_ struct{} `type:"structure"`
@@ -3360,6 +3792,18 @@ func (s ExportTaskExecutionInfo) GoString() string {
 	return s.String()
 }
 
+// SetCompletionTime sets the CompletionTime field's value.
+func (s *ExportTaskExecutionInfo) SetCompletionTime(v int64) *ExportTaskExecutionInfo {
+	s.CompletionTime = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *ExportTaskExecutionInfo) SetCreationTime(v int64) *ExportTaskExecutionInfo {
+	s.CreationTime = &v
+	return s
+}
+
 // Represents the status of an export task.
 type ExportTaskStatus struct {
 	_ struct{} `type:"structure"`
@@ -3379,6 +3823,18 @@ func (s ExportTaskStatus) String() string {
 // GoString returns the string representation
 func (s ExportTaskStatus) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *ExportTaskStatus) SetCode(v string) *ExportTaskStatus {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *ExportTaskStatus) SetMessage(v string) *ExportTaskStatus {
+	s.Message = &v
+	return s
 }
 
 type FilterLogEventsInput struct {
@@ -3458,6 +3914,54 @@ func (s *FilterLogEventsInput) Validate() error {
 	return nil
 }
 
+// SetEndTime sets the EndTime field's value.
+func (s *FilterLogEventsInput) SetEndTime(v int64) *FilterLogEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetFilterPattern sets the FilterPattern field's value.
+func (s *FilterLogEventsInput) SetFilterPattern(v string) *FilterLogEventsInput {
+	s.FilterPattern = &v
+	return s
+}
+
+// SetInterleaved sets the Interleaved field's value.
+func (s *FilterLogEventsInput) SetInterleaved(v bool) *FilterLogEventsInput {
+	s.Interleaved = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *FilterLogEventsInput) SetLimit(v int64) *FilterLogEventsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *FilterLogEventsInput) SetLogGroupName(v string) *FilterLogEventsInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetLogStreamNames sets the LogStreamNames field's value.
+func (s *FilterLogEventsInput) SetLogStreamNames(v []*string) *FilterLogEventsInput {
+	s.LogStreamNames = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *FilterLogEventsInput) SetNextToken(v string) *FilterLogEventsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *FilterLogEventsInput) SetStartTime(v int64) *FilterLogEventsInput {
+	s.StartTime = &v
+	return s
+}
+
 type FilterLogEventsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3484,6 +3988,24 @@ func (s FilterLogEventsOutput) String() string {
 // GoString returns the string representation
 func (s FilterLogEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *FilterLogEventsOutput) SetEvents(v []*FilteredLogEvent) *FilterLogEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *FilterLogEventsOutput) SetNextToken(v string) *FilterLogEventsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSearchedLogStreams sets the SearchedLogStreams field's value.
+func (s *FilterLogEventsOutput) SetSearchedLogStreams(v []*SearchedLogStream) *FilterLogEventsOutput {
+	s.SearchedLogStreams = v
+	return s
 }
 
 // Represents a matched event from a FilterLogEvents request.
@@ -3516,6 +4038,36 @@ func (s FilteredLogEvent) String() string {
 // GoString returns the string representation
 func (s FilteredLogEvent) GoString() string {
 	return s.String()
+}
+
+// SetEventId sets the EventId field's value.
+func (s *FilteredLogEvent) SetEventId(v string) *FilteredLogEvent {
+	s.EventId = &v
+	return s
+}
+
+// SetIngestionTime sets the IngestionTime field's value.
+func (s *FilteredLogEvent) SetIngestionTime(v int64) *FilteredLogEvent {
+	s.IngestionTime = &v
+	return s
+}
+
+// SetLogStreamName sets the LogStreamName field's value.
+func (s *FilteredLogEvent) SetLogStreamName(v string) *FilteredLogEvent {
+	s.LogStreamName = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *FilteredLogEvent) SetMessage(v string) *FilteredLogEvent {
+	s.Message = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *FilteredLogEvent) SetTimestamp(v int64) *FilteredLogEvent {
+	s.Timestamp = &v
+	return s
 }
 
 type GetLogEventsInput struct {
@@ -3592,6 +4144,48 @@ func (s *GetLogEventsInput) Validate() error {
 	return nil
 }
 
+// SetEndTime sets the EndTime field's value.
+func (s *GetLogEventsInput) SetEndTime(v int64) *GetLogEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *GetLogEventsInput) SetLimit(v int64) *GetLogEventsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *GetLogEventsInput) SetLogGroupName(v string) *GetLogEventsInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetLogStreamName sets the LogStreamName field's value.
+func (s *GetLogEventsInput) SetLogStreamName(v string) *GetLogEventsInput {
+	s.LogStreamName = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetLogEventsInput) SetNextToken(v string) *GetLogEventsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStartFromHead sets the StartFromHead field's value.
+func (s *GetLogEventsInput) SetStartFromHead(v bool) *GetLogEventsInput {
+	s.StartFromHead = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *GetLogEventsInput) SetStartTime(v int64) *GetLogEventsInput {
+	s.StartTime = &v
+	return s
+}
+
 type GetLogEventsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3616,6 +4210,24 @@ func (s GetLogEventsOutput) String() string {
 // GoString returns the string representation
 func (s GetLogEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *GetLogEventsOutput) SetEvents(v []*OutputLogEvent) *GetLogEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetNextBackwardToken sets the NextBackwardToken field's value.
+func (s *GetLogEventsOutput) SetNextBackwardToken(v string) *GetLogEventsOutput {
+	s.NextBackwardToken = &v
+	return s
+}
+
+// SetNextForwardToken sets the NextForwardToken field's value.
+func (s *GetLogEventsOutput) SetNextForwardToken(v string) *GetLogEventsOutput {
+	s.NextForwardToken = &v
+	return s
 }
 
 // A log event is a record of some activity that was recorded by the application
@@ -3664,6 +4276,18 @@ func (s *InputLogEvent) Validate() error {
 	return nil
 }
 
+// SetMessage sets the Message field's value.
+func (s *InputLogEvent) SetMessage(v string) *InputLogEvent {
+	s.Message = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *InputLogEvent) SetTimestamp(v int64) *InputLogEvent {
+	s.Timestamp = &v
+	return s
+}
+
 type LogGroup struct {
 	_ struct{} `type:"structure"`
 
@@ -3694,6 +4318,42 @@ func (s LogGroup) String() string {
 // GoString returns the string representation
 func (s LogGroup) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *LogGroup) SetArn(v string) *LogGroup {
+	s.Arn = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *LogGroup) SetCreationTime(v int64) *LogGroup {
+	s.CreationTime = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *LogGroup) SetLogGroupName(v string) *LogGroup {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetMetricFilterCount sets the MetricFilterCount field's value.
+func (s *LogGroup) SetMetricFilterCount(v int64) *LogGroup {
+	s.MetricFilterCount = &v
+	return s
+}
+
+// SetRetentionInDays sets the RetentionInDays field's value.
+func (s *LogGroup) SetRetentionInDays(v int64) *LogGroup {
+	s.RetentionInDays = &v
+	return s
+}
+
+// SetStoredBytes sets the StoredBytes field's value.
+func (s *LogGroup) SetStoredBytes(v int64) *LogGroup {
+	s.StoredBytes = &v
+	return s
 }
 
 // A log stream is sequence of log events from a single emitter of logs.
@@ -3738,6 +4398,54 @@ func (s LogStream) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *LogStream) SetArn(v string) *LogStream {
+	s.Arn = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *LogStream) SetCreationTime(v int64) *LogStream {
+	s.CreationTime = &v
+	return s
+}
+
+// SetFirstEventTimestamp sets the FirstEventTimestamp field's value.
+func (s *LogStream) SetFirstEventTimestamp(v int64) *LogStream {
+	s.FirstEventTimestamp = &v
+	return s
+}
+
+// SetLastEventTimestamp sets the LastEventTimestamp field's value.
+func (s *LogStream) SetLastEventTimestamp(v int64) *LogStream {
+	s.LastEventTimestamp = &v
+	return s
+}
+
+// SetLastIngestionTime sets the LastIngestionTime field's value.
+func (s *LogStream) SetLastIngestionTime(v int64) *LogStream {
+	s.LastIngestionTime = &v
+	return s
+}
+
+// SetLogStreamName sets the LogStreamName field's value.
+func (s *LogStream) SetLogStreamName(v string) *LogStream {
+	s.LogStreamName = &v
+	return s
+}
+
+// SetStoredBytes sets the StoredBytes field's value.
+func (s *LogStream) SetStoredBytes(v int64) *LogStream {
+	s.StoredBytes = &v
+	return s
+}
+
+// SetUploadSequenceToken sets the UploadSequenceToken field's value.
+func (s *LogStream) SetUploadSequenceToken(v string) *LogStream {
+	s.UploadSequenceToken = &v
+	return s
+}
+
 // Metric filters can be used to express how CloudWatch Logs would extract metric
 // observations from ingested log events and transform them to metric data in
 // a CloudWatch metric.
@@ -3770,6 +4478,30 @@ func (s MetricFilter) GoString() string {
 	return s.String()
 }
 
+// SetCreationTime sets the CreationTime field's value.
+func (s *MetricFilter) SetCreationTime(v int64) *MetricFilter {
+	s.CreationTime = &v
+	return s
+}
+
+// SetFilterName sets the FilterName field's value.
+func (s *MetricFilter) SetFilterName(v string) *MetricFilter {
+	s.FilterName = &v
+	return s
+}
+
+// SetFilterPattern sets the FilterPattern field's value.
+func (s *MetricFilter) SetFilterPattern(v string) *MetricFilter {
+	s.FilterPattern = &v
+	return s
+}
+
+// SetMetricTransformations sets the MetricTransformations field's value.
+func (s *MetricFilter) SetMetricTransformations(v []*MetricTransformation) *MetricFilter {
+	s.MetricTransformations = v
+	return s
+}
+
 type MetricFilterMatchRecord struct {
 	_ struct{} `type:"structure"`
 
@@ -3788,6 +4520,24 @@ func (s MetricFilterMatchRecord) String() string {
 // GoString returns the string representation
 func (s MetricFilterMatchRecord) GoString() string {
 	return s.String()
+}
+
+// SetEventMessage sets the EventMessage field's value.
+func (s *MetricFilterMatchRecord) SetEventMessage(v string) *MetricFilterMatchRecord {
+	s.EventMessage = &v
+	return s
+}
+
+// SetEventNumber sets the EventNumber field's value.
+func (s *MetricFilterMatchRecord) SetEventNumber(v int64) *MetricFilterMatchRecord {
+	s.EventNumber = &v
+	return s
+}
+
+// SetExtractedValues sets the ExtractedValues field's value.
+func (s *MetricFilterMatchRecord) SetExtractedValues(v map[string]*string) *MetricFilterMatchRecord {
+	s.ExtractedValues = v
+	return s
 }
 
 type MetricTransformation struct {
@@ -3843,6 +4593,30 @@ func (s *MetricTransformation) Validate() error {
 	return nil
 }
 
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *MetricTransformation) SetDefaultValue(v float64) *MetricTransformation {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *MetricTransformation) SetMetricName(v string) *MetricTransformation {
+	s.MetricName = &v
+	return s
+}
+
+// SetMetricNamespace sets the MetricNamespace field's value.
+func (s *MetricTransformation) SetMetricNamespace(v string) *MetricTransformation {
+	s.MetricNamespace = &v
+	return s
+}
+
+// SetMetricValue sets the MetricValue field's value.
+func (s *MetricTransformation) SetMetricValue(v string) *MetricTransformation {
+	s.MetricValue = &v
+	return s
+}
+
 type OutputLogEvent struct {
 	_ struct{} `type:"structure"`
 
@@ -3865,6 +4639,24 @@ func (s OutputLogEvent) String() string {
 // GoString returns the string representation
 func (s OutputLogEvent) GoString() string {
 	return s.String()
+}
+
+// SetIngestionTime sets the IngestionTime field's value.
+func (s *OutputLogEvent) SetIngestionTime(v int64) *OutputLogEvent {
+	s.IngestionTime = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *OutputLogEvent) SetMessage(v string) *OutputLogEvent {
+	s.Message = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *OutputLogEvent) SetTimestamp(v int64) *OutputLogEvent {
+	s.Timestamp = &v
+	return s
 }
 
 type PutDestinationInput struct {
@@ -3925,6 +4717,24 @@ func (s *PutDestinationInput) Validate() error {
 	return nil
 }
 
+// SetDestinationName sets the DestinationName field's value.
+func (s *PutDestinationInput) SetDestinationName(v string) *PutDestinationInput {
+	s.DestinationName = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *PutDestinationInput) SetRoleArn(v string) *PutDestinationInput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetTargetArn sets the TargetArn field's value.
+func (s *PutDestinationInput) SetTargetArn(v string) *PutDestinationInput {
+	s.TargetArn = &v
+	return s
+}
+
 type PutDestinationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3940,6 +4750,12 @@ func (s PutDestinationOutput) String() string {
 // GoString returns the string representation
 func (s PutDestinationOutput) GoString() string {
 	return s.String()
+}
+
+// SetDestination sets the Destination field's value.
+func (s *PutDestinationOutput) SetDestination(v *Destination) *PutDestinationOutput {
+	s.Destination = v
+	return s
 }
 
 type PutDestinationPolicyInput struct {
@@ -3987,6 +4803,18 @@ func (s *PutDestinationPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccessPolicy sets the AccessPolicy field's value.
+func (s *PutDestinationPolicyInput) SetAccessPolicy(v string) *PutDestinationPolicyInput {
+	s.AccessPolicy = &v
+	return s
+}
+
+// SetDestinationName sets the DestinationName field's value.
+func (s *PutDestinationPolicyInput) SetDestinationName(v string) *PutDestinationPolicyInput {
+	s.DestinationName = &v
+	return s
 }
 
 type PutDestinationPolicyOutput struct {
@@ -4077,6 +4905,30 @@ func (s *PutLogEventsInput) Validate() error {
 	return nil
 }
 
+// SetLogEvents sets the LogEvents field's value.
+func (s *PutLogEventsInput) SetLogEvents(v []*InputLogEvent) *PutLogEventsInput {
+	s.LogEvents = v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *PutLogEventsInput) SetLogGroupName(v string) *PutLogEventsInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetLogStreamName sets the LogStreamName field's value.
+func (s *PutLogEventsInput) SetLogStreamName(v string) *PutLogEventsInput {
+	s.LogStreamName = &v
+	return s
+}
+
+// SetSequenceToken sets the SequenceToken field's value.
+func (s *PutLogEventsInput) SetSequenceToken(v string) *PutLogEventsInput {
+	s.SequenceToken = &v
+	return s
+}
+
 type PutLogEventsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4096,6 +4948,18 @@ func (s PutLogEventsOutput) String() string {
 // GoString returns the string representation
 func (s PutLogEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextSequenceToken sets the NextSequenceToken field's value.
+func (s *PutLogEventsOutput) SetNextSequenceToken(v string) *PutLogEventsOutput {
+	s.NextSequenceToken = &v
+	return s
+}
+
+// SetRejectedLogEventsInfo sets the RejectedLogEventsInfo field's value.
+func (s *PutLogEventsOutput) SetRejectedLogEventsInfo(v *RejectedLogEventsInfo) *PutLogEventsOutput {
+	s.RejectedLogEventsInfo = v
+	return s
 }
 
 type PutMetricFilterInput struct {
@@ -4174,6 +5038,30 @@ func (s *PutMetricFilterInput) Validate() error {
 	return nil
 }
 
+// SetFilterName sets the FilterName field's value.
+func (s *PutMetricFilterInput) SetFilterName(v string) *PutMetricFilterInput {
+	s.FilterName = &v
+	return s
+}
+
+// SetFilterPattern sets the FilterPattern field's value.
+func (s *PutMetricFilterInput) SetFilterPattern(v string) *PutMetricFilterInput {
+	s.FilterPattern = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *PutMetricFilterInput) SetLogGroupName(v string) *PutMetricFilterInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetMetricTransformations sets the MetricTransformations field's value.
+func (s *PutMetricFilterInput) SetMetricTransformations(v []*MetricTransformation) *PutMetricFilterInput {
+	s.MetricTransformations = v
+	return s
+}
+
 type PutMetricFilterOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4231,6 +5119,18 @@ func (s *PutRetentionPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *PutRetentionPolicyInput) SetLogGroupName(v string) *PutRetentionPolicyInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetRetentionInDays sets the RetentionInDays field's value.
+func (s *PutRetentionPolicyInput) SetRetentionInDays(v int64) *PutRetentionPolicyInput {
+	s.RetentionInDays = &v
+	return s
 }
 
 type PutRetentionPolicyOutput struct {
@@ -4335,6 +5235,36 @@ func (s *PutSubscriptionFilterInput) Validate() error {
 	return nil
 }
 
+// SetDestinationArn sets the DestinationArn field's value.
+func (s *PutSubscriptionFilterInput) SetDestinationArn(v string) *PutSubscriptionFilterInput {
+	s.DestinationArn = &v
+	return s
+}
+
+// SetFilterName sets the FilterName field's value.
+func (s *PutSubscriptionFilterInput) SetFilterName(v string) *PutSubscriptionFilterInput {
+	s.FilterName = &v
+	return s
+}
+
+// SetFilterPattern sets the FilterPattern field's value.
+func (s *PutSubscriptionFilterInput) SetFilterPattern(v string) *PutSubscriptionFilterInput {
+	s.FilterPattern = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *PutSubscriptionFilterInput) SetLogGroupName(v string) *PutSubscriptionFilterInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *PutSubscriptionFilterInput) SetRoleArn(v string) *PutSubscriptionFilterInput {
+	s.RoleArn = &v
+	return s
+}
+
 type PutSubscriptionFilterOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4369,6 +5299,24 @@ func (s RejectedLogEventsInfo) GoString() string {
 	return s.String()
 }
 
+// SetExpiredLogEventEndIndex sets the ExpiredLogEventEndIndex field's value.
+func (s *RejectedLogEventsInfo) SetExpiredLogEventEndIndex(v int64) *RejectedLogEventsInfo {
+	s.ExpiredLogEventEndIndex = &v
+	return s
+}
+
+// SetTooNewLogEventStartIndex sets the TooNewLogEventStartIndex field's value.
+func (s *RejectedLogEventsInfo) SetTooNewLogEventStartIndex(v int64) *RejectedLogEventsInfo {
+	s.TooNewLogEventStartIndex = &v
+	return s
+}
+
+// SetTooOldLogEventEndIndex sets the TooOldLogEventEndIndex field's value.
+func (s *RejectedLogEventsInfo) SetTooOldLogEventEndIndex(v int64) *RejectedLogEventsInfo {
+	s.TooOldLogEventEndIndex = &v
+	return s
+}
+
 // An object indicating the search status of a log stream in a FilterLogEvents
 // request.
 type SearchedLogStream struct {
@@ -4390,6 +5338,18 @@ func (s SearchedLogStream) String() string {
 // GoString returns the string representation
 func (s SearchedLogStream) GoString() string {
 	return s.String()
+}
+
+// SetLogStreamName sets the LogStreamName field's value.
+func (s *SearchedLogStream) SetLogStreamName(v string) *SearchedLogStream {
+	s.LogStreamName = &v
+	return s
+}
+
+// SetSearchedCompletely sets the SearchedCompletely field's value.
+func (s *SearchedLogStream) SetSearchedCompletely(v bool) *SearchedLogStream {
+	s.SearchedCompletely = &v
+	return s
 }
 
 type SubscriptionFilter struct {
@@ -4423,6 +5383,42 @@ func (s SubscriptionFilter) String() string {
 // GoString returns the string representation
 func (s SubscriptionFilter) GoString() string {
 	return s.String()
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *SubscriptionFilter) SetCreationTime(v int64) *SubscriptionFilter {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDestinationArn sets the DestinationArn field's value.
+func (s *SubscriptionFilter) SetDestinationArn(v string) *SubscriptionFilter {
+	s.DestinationArn = &v
+	return s
+}
+
+// SetFilterName sets the FilterName field's value.
+func (s *SubscriptionFilter) SetFilterName(v string) *SubscriptionFilter {
+	s.FilterName = &v
+	return s
+}
+
+// SetFilterPattern sets the FilterPattern field's value.
+func (s *SubscriptionFilter) SetFilterPattern(v string) *SubscriptionFilter {
+	s.FilterPattern = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *SubscriptionFilter) SetLogGroupName(v string) *SubscriptionFilter {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *SubscriptionFilter) SetRoleArn(v string) *SubscriptionFilter {
+	s.RoleArn = &v
+	return s
 }
 
 type TestMetricFilterInput struct {
@@ -4471,6 +5467,18 @@ func (s *TestMetricFilterInput) Validate() error {
 	return nil
 }
 
+// SetFilterPattern sets the FilterPattern field's value.
+func (s *TestMetricFilterInput) SetFilterPattern(v string) *TestMetricFilterInput {
+	s.FilterPattern = &v
+	return s
+}
+
+// SetLogEventMessages sets the LogEventMessages field's value.
+func (s *TestMetricFilterInput) SetLogEventMessages(v []*string) *TestMetricFilterInput {
+	s.LogEventMessages = v
+	return s
+}
+
 type TestMetricFilterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4485,6 +5493,12 @@ func (s TestMetricFilterOutput) String() string {
 // GoString returns the string representation
 func (s TestMetricFilterOutput) GoString() string {
 	return s.String()
+}
+
+// SetMatches sets the Matches field's value.
+func (s *TestMetricFilterOutput) SetMatches(v []*MetricFilterMatchRecord) *TestMetricFilterOutput {
+	s.Matches = v
+	return s
 }
 
 const (

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -1606,6 +1606,12 @@ func (s *BatchGetRepositoriesInput) Validate() error {
 	return nil
 }
 
+// SetRepositoryNames sets the RepositoryNames field's value.
+func (s *BatchGetRepositoriesInput) SetRepositoryNames(v []*string) *BatchGetRepositoriesInput {
+	s.RepositoryNames = v
+	return s
+}
+
 // Represents the output of a batch get repositories operation.
 type BatchGetRepositoriesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1627,6 +1633,18 @@ func (s BatchGetRepositoriesOutput) GoString() string {
 	return s.String()
 }
 
+// SetRepositories sets the Repositories field's value.
+func (s *BatchGetRepositoriesOutput) SetRepositories(v []*RepositoryMetadata) *BatchGetRepositoriesOutput {
+	s.Repositories = v
+	return s
+}
+
+// SetRepositoriesNotFound sets the RepositoriesNotFound field's value.
+func (s *BatchGetRepositoriesOutput) SetRepositoriesNotFound(v []*string) *BatchGetRepositoriesOutput {
+	s.RepositoriesNotFound = v
+	return s
+}
+
 // Returns information about a branch.
 type BranchInfo struct {
 	_ struct{} `type:"structure"`
@@ -1646,6 +1664,18 @@ func (s BranchInfo) String() string {
 // GoString returns the string representation
 func (s BranchInfo) GoString() string {
 	return s.String()
+}
+
+// SetBranchName sets the BranchName field's value.
+func (s *BranchInfo) SetBranchName(v string) *BranchInfo {
+	s.BranchName = &v
+	return s
+}
+
+// SetCommitId sets the CommitId field's value.
+func (s *BranchInfo) SetCommitId(v string) *BranchInfo {
+	s.CommitId = &v
+	return s
 }
 
 // Returns information about a specific commit.
@@ -1682,6 +1712,42 @@ func (s Commit) String() string {
 // GoString returns the string representation
 func (s Commit) GoString() string {
 	return s.String()
+}
+
+// SetAdditionalData sets the AdditionalData field's value.
+func (s *Commit) SetAdditionalData(v string) *Commit {
+	s.AdditionalData = &v
+	return s
+}
+
+// SetAuthor sets the Author field's value.
+func (s *Commit) SetAuthor(v *UserInfo) *Commit {
+	s.Author = v
+	return s
+}
+
+// SetCommitter sets the Committer field's value.
+func (s *Commit) SetCommitter(v *UserInfo) *Commit {
+	s.Committer = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Commit) SetMessage(v string) *Commit {
+	s.Message = &v
+	return s
+}
+
+// SetParents sets the Parents field's value.
+func (s *Commit) SetParents(v []*string) *Commit {
+	s.Parents = v
+	return s
+}
+
+// SetTreeId sets the TreeId field's value.
+func (s *Commit) SetTreeId(v string) *Commit {
+	s.TreeId = &v
+	return s
 }
 
 // Represents the input of a create branch operation.
@@ -1737,6 +1803,24 @@ func (s *CreateBranchInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBranchName sets the BranchName field's value.
+func (s *CreateBranchInput) SetBranchName(v string) *CreateBranchInput {
+	s.BranchName = &v
+	return s
+}
+
+// SetCommitId sets the CommitId field's value.
+func (s *CreateBranchInput) SetCommitId(v string) *CreateBranchInput {
+	s.CommitId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *CreateBranchInput) SetRepositoryName(v string) *CreateBranchInput {
+	s.RepositoryName = &v
+	return s
 }
 
 type CreateBranchOutput struct {
@@ -1804,6 +1888,18 @@ func (s *CreateRepositoryInput) Validate() error {
 	return nil
 }
 
+// SetRepositoryDescription sets the RepositoryDescription field's value.
+func (s *CreateRepositoryInput) SetRepositoryDescription(v string) *CreateRepositoryInput {
+	s.RepositoryDescription = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *CreateRepositoryInput) SetRepositoryName(v string) *CreateRepositoryInput {
+	s.RepositoryName = &v
+	return s
+}
+
 // Represents the output of a create repository operation.
 type CreateRepositoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -1820,6 +1916,12 @@ func (s CreateRepositoryOutput) String() string {
 // GoString returns the string representation
 func (s CreateRepositoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetRepositoryMetadata sets the RepositoryMetadata field's value.
+func (s *CreateRepositoryOutput) SetRepositoryMetadata(v *RepositoryMetadata) *CreateRepositoryOutput {
+	s.RepositoryMetadata = v
+	return s
 }
 
 // Represents the input of a delete repository operation.
@@ -1858,6 +1960,12 @@ func (s *DeleteRepositoryInput) Validate() error {
 	return nil
 }
 
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DeleteRepositoryInput) SetRepositoryName(v string) *DeleteRepositoryInput {
+	s.RepositoryName = &v
+	return s
+}
+
 // Represents the output of a delete repository operation.
 type DeleteRepositoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -1874,6 +1982,12 @@ func (s DeleteRepositoryOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRepositoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetRepositoryId sets the RepositoryId field's value.
+func (s *DeleteRepositoryOutput) SetRepositoryId(v string) *DeleteRepositoryOutput {
+	s.RepositoryId = &v
+	return s
 }
 
 // Represents the input of a get branch operation.
@@ -1914,6 +2028,18 @@ func (s *GetBranchInput) Validate() error {
 	return nil
 }
 
+// SetBranchName sets the BranchName field's value.
+func (s *GetBranchInput) SetBranchName(v string) *GetBranchInput {
+	s.BranchName = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetBranchInput) SetRepositoryName(v string) *GetBranchInput {
+	s.RepositoryName = &v
+	return s
+}
+
 // Represents the output of a get branch operation.
 type GetBranchOutput struct {
 	_ struct{} `type:"structure"`
@@ -1930,6 +2056,12 @@ func (s GetBranchOutput) String() string {
 // GoString returns the string representation
 func (s GetBranchOutput) GoString() string {
 	return s.String()
+}
+
+// SetBranch sets the Branch field's value.
+func (s *GetBranchOutput) SetBranch(v *BranchInfo) *GetBranchOutput {
+	s.Branch = v
+	return s
 }
 
 // Represents the input of a get commit operation.
@@ -1976,6 +2108,18 @@ func (s *GetCommitInput) Validate() error {
 	return nil
 }
 
+// SetCommitId sets the CommitId field's value.
+func (s *GetCommitInput) SetCommitId(v string) *GetCommitInput {
+	s.CommitId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetCommitInput) SetRepositoryName(v string) *GetCommitInput {
+	s.RepositoryName = &v
+	return s
+}
+
 // Represents the output of a get commit operation.
 type GetCommitOutput struct {
 	_ struct{} `type:"structure"`
@@ -1994,6 +2138,12 @@ func (s GetCommitOutput) String() string {
 // GoString returns the string representation
 func (s GetCommitOutput) GoString() string {
 	return s.String()
+}
+
+// SetCommit sets the Commit field's value.
+func (s *GetCommitOutput) SetCommit(v *Commit) *GetCommitOutput {
+	s.Commit = v
+	return s
 }
 
 // Represents the input of a get repository operation.
@@ -2032,6 +2182,12 @@ func (s *GetRepositoryInput) Validate() error {
 	return nil
 }
 
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetRepositoryInput) SetRepositoryName(v string) *GetRepositoryInput {
+	s.RepositoryName = &v
+	return s
+}
+
 // Represents the output of a get repository operation.
 type GetRepositoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -2048,6 +2204,12 @@ func (s GetRepositoryOutput) String() string {
 // GoString returns the string representation
 func (s GetRepositoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetRepositoryMetadata sets the RepositoryMetadata field's value.
+func (s *GetRepositoryOutput) SetRepositoryMetadata(v *RepositoryMetadata) *GetRepositoryOutput {
+	s.RepositoryMetadata = v
+	return s
 }
 
 // Represents the input of a get repository triggers operation.
@@ -2081,6 +2243,12 @@ func (s *GetRepositoryTriggersInput) Validate() error {
 	return nil
 }
 
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetRepositoryTriggersInput) SetRepositoryName(v string) *GetRepositoryTriggersInput {
+	s.RepositoryName = &v
+	return s
+}
+
 // Represents the output of a get repository triggers operation.
 type GetRepositoryTriggersOutput struct {
 	_ struct{} `type:"structure"`
@@ -2100,6 +2268,18 @@ func (s GetRepositoryTriggersOutput) String() string {
 // GoString returns the string representation
 func (s GetRepositoryTriggersOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigurationId sets the ConfigurationId field's value.
+func (s *GetRepositoryTriggersOutput) SetConfigurationId(v string) *GetRepositoryTriggersOutput {
+	s.ConfigurationId = &v
+	return s
+}
+
+// SetTriggers sets the Triggers field's value.
+func (s *GetRepositoryTriggersOutput) SetTriggers(v []*RepositoryTrigger) *GetRepositoryTriggersOutput {
+	s.Triggers = v
+	return s
 }
 
 // Represents the input of a list branches operation.
@@ -2141,6 +2321,18 @@ func (s *ListBranchesInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListBranchesInput) SetNextToken(v string) *ListBranchesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *ListBranchesInput) SetRepositoryName(v string) *ListBranchesInput {
+	s.RepositoryName = &v
+	return s
+}
+
 // Represents the output of a list branches operation.
 type ListBranchesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2160,6 +2352,18 @@ func (s ListBranchesOutput) String() string {
 // GoString returns the string representation
 func (s ListBranchesOutput) GoString() string {
 	return s.String()
+}
+
+// SetBranches sets the Branches field's value.
+func (s *ListBranchesOutput) SetBranches(v []*string) *ListBranchesOutput {
+	s.Branches = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListBranchesOutput) SetNextToken(v string) *ListBranchesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input of a list repositories operation.
@@ -2189,6 +2393,24 @@ func (s ListRepositoriesInput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListRepositoriesInput) SetNextToken(v string) *ListRepositoriesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOrder sets the Order field's value.
+func (s *ListRepositoriesInput) SetOrder(v string) *ListRepositoriesInput {
+	s.Order = &v
+	return s
+}
+
+// SetSortBy sets the SortBy field's value.
+func (s *ListRepositoriesInput) SetSortBy(v string) *ListRepositoriesInput {
+	s.SortBy = &v
+	return s
+}
+
 // Represents the output of a list repositories operation.
 type ListRepositoriesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2211,6 +2433,18 @@ func (s ListRepositoriesOutput) String() string {
 // GoString returns the string representation
 func (s ListRepositoriesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRepositoriesOutput) SetNextToken(v string) *ListRepositoriesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRepositories sets the Repositories field's value.
+func (s *ListRepositoriesOutput) SetRepositories(v []*RepositoryNameIdPair) *ListRepositoriesOutput {
+	s.Repositories = v
+	return s
 }
 
 // Represents the input ofa put repository triggers operation.
@@ -2247,6 +2481,18 @@ func (s *PutRepositoryTriggersInput) Validate() error {
 	return nil
 }
 
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PutRepositoryTriggersInput) SetRepositoryName(v string) *PutRepositoryTriggersInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetTriggers sets the Triggers field's value.
+func (s *PutRepositoryTriggersInput) SetTriggers(v []*RepositoryTrigger) *PutRepositoryTriggersInput {
+	s.Triggers = v
+	return s
+}
+
 // Represents the output of a put repository triggers operation.
 type PutRepositoryTriggersOutput struct {
 	_ struct{} `type:"structure"`
@@ -2263,6 +2509,12 @@ func (s PutRepositoryTriggersOutput) String() string {
 // GoString returns the string representation
 func (s PutRepositoryTriggersOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigurationId sets the ConfigurationId field's value.
+func (s *PutRepositoryTriggersOutput) SetConfigurationId(v string) *PutRepositoryTriggersOutput {
+	s.ConfigurationId = &v
+	return s
 }
 
 // Information about a repository.
@@ -2310,6 +2562,66 @@ func (s RepositoryMetadata) GoString() string {
 	return s.String()
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *RepositoryMetadata) SetAccountId(v string) *RepositoryMetadata {
+	s.AccountId = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *RepositoryMetadata) SetArn(v string) *RepositoryMetadata {
+	s.Arn = &v
+	return s
+}
+
+// SetCloneUrlHttp sets the CloneUrlHttp field's value.
+func (s *RepositoryMetadata) SetCloneUrlHttp(v string) *RepositoryMetadata {
+	s.CloneUrlHttp = &v
+	return s
+}
+
+// SetCloneUrlSsh sets the CloneUrlSsh field's value.
+func (s *RepositoryMetadata) SetCloneUrlSsh(v string) *RepositoryMetadata {
+	s.CloneUrlSsh = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *RepositoryMetadata) SetCreationDate(v time.Time) *RepositoryMetadata {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDefaultBranch sets the DefaultBranch field's value.
+func (s *RepositoryMetadata) SetDefaultBranch(v string) *RepositoryMetadata {
+	s.DefaultBranch = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *RepositoryMetadata) SetLastModifiedDate(v time.Time) *RepositoryMetadata {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetRepositoryDescription sets the RepositoryDescription field's value.
+func (s *RepositoryMetadata) SetRepositoryDescription(v string) *RepositoryMetadata {
+	s.RepositoryDescription = &v
+	return s
+}
+
+// SetRepositoryId sets the RepositoryId field's value.
+func (s *RepositoryMetadata) SetRepositoryId(v string) *RepositoryMetadata {
+	s.RepositoryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *RepositoryMetadata) SetRepositoryName(v string) *RepositoryMetadata {
+	s.RepositoryName = &v
+	return s
+}
+
 // Information about a repository name and ID.
 type RepositoryNameIdPair struct {
 	_ struct{} `type:"structure"`
@@ -2329,6 +2641,18 @@ func (s RepositoryNameIdPair) String() string {
 // GoString returns the string representation
 func (s RepositoryNameIdPair) GoString() string {
 	return s.String()
+}
+
+// SetRepositoryId sets the RepositoryId field's value.
+func (s *RepositoryNameIdPair) SetRepositoryId(v string) *RepositoryNameIdPair {
+	s.RepositoryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *RepositoryNameIdPair) SetRepositoryName(v string) *RepositoryNameIdPair {
+	s.RepositoryName = &v
+	return s
 }
 
 // Information about a trigger for a repository.
@@ -2367,6 +2691,36 @@ func (s RepositoryTrigger) GoString() string {
 	return s.String()
 }
 
+// SetBranches sets the Branches field's value.
+func (s *RepositoryTrigger) SetBranches(v []*string) *RepositoryTrigger {
+	s.Branches = v
+	return s
+}
+
+// SetCustomData sets the CustomData field's value.
+func (s *RepositoryTrigger) SetCustomData(v string) *RepositoryTrigger {
+	s.CustomData = &v
+	return s
+}
+
+// SetDestinationArn sets the DestinationArn field's value.
+func (s *RepositoryTrigger) SetDestinationArn(v string) *RepositoryTrigger {
+	s.DestinationArn = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *RepositoryTrigger) SetEvents(v []*string) *RepositoryTrigger {
+	s.Events = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RepositoryTrigger) SetName(v string) *RepositoryTrigger {
+	s.Name = &v
+	return s
+}
+
 // A trigger failed to run.
 type RepositoryTriggerExecutionFailure struct {
 	_ struct{} `type:"structure"`
@@ -2386,6 +2740,18 @@ func (s RepositoryTriggerExecutionFailure) String() string {
 // GoString returns the string representation
 func (s RepositoryTriggerExecutionFailure) GoString() string {
 	return s.String()
+}
+
+// SetFailureMessage sets the FailureMessage field's value.
+func (s *RepositoryTriggerExecutionFailure) SetFailureMessage(v string) *RepositoryTriggerExecutionFailure {
+	s.FailureMessage = &v
+	return s
+}
+
+// SetTrigger sets the Trigger field's value.
+func (s *RepositoryTriggerExecutionFailure) SetTrigger(v string) *RepositoryTriggerExecutionFailure {
+	s.Trigger = &v
+	return s
 }
 
 // Represents the input of a test repository triggers operation.
@@ -2422,6 +2788,18 @@ func (s *TestRepositoryTriggersInput) Validate() error {
 	return nil
 }
 
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *TestRepositoryTriggersInput) SetRepositoryName(v string) *TestRepositoryTriggersInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetTriggers sets the Triggers field's value.
+func (s *TestRepositoryTriggersInput) SetTriggers(v []*RepositoryTrigger) *TestRepositoryTriggersInput {
+	s.Triggers = v
+	return s
+}
+
 // Represents the output of a test repository triggers operation.
 type TestRepositoryTriggersOutput struct {
 	_ struct{} `type:"structure"`
@@ -2443,6 +2821,18 @@ func (s TestRepositoryTriggersOutput) String() string {
 // GoString returns the string representation
 func (s TestRepositoryTriggersOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedExecutions sets the FailedExecutions field's value.
+func (s *TestRepositoryTriggersOutput) SetFailedExecutions(v []*RepositoryTriggerExecutionFailure) *TestRepositoryTriggersOutput {
+	s.FailedExecutions = v
+	return s
+}
+
+// SetSuccessfulExecutions sets the SuccessfulExecutions field's value.
+func (s *TestRepositoryTriggersOutput) SetSuccessfulExecutions(v []*string) *TestRepositoryTriggersOutput {
+	s.SuccessfulExecutions = v
+	return s
 }
 
 // Represents the input of an update default branch operation.
@@ -2490,6 +2880,18 @@ func (s *UpdateDefaultBranchInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDefaultBranchName sets the DefaultBranchName field's value.
+func (s *UpdateDefaultBranchInput) SetDefaultBranchName(v string) *UpdateDefaultBranchInput {
+	s.DefaultBranchName = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *UpdateDefaultBranchInput) SetRepositoryName(v string) *UpdateDefaultBranchInput {
+	s.RepositoryName = &v
+	return s
 }
 
 type UpdateDefaultBranchOutput struct {
@@ -2544,6 +2946,18 @@ func (s *UpdateRepositoryDescriptionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRepositoryDescription sets the RepositoryDescription field's value.
+func (s *UpdateRepositoryDescriptionInput) SetRepositoryDescription(v string) *UpdateRepositoryDescriptionInput {
+	s.RepositoryDescription = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *UpdateRepositoryDescriptionInput) SetRepositoryName(v string) *UpdateRepositoryDescriptionInput {
+	s.RepositoryName = &v
+	return s
 }
 
 type UpdateRepositoryDescriptionOutput struct {
@@ -2607,6 +3021,18 @@ func (s *UpdateRepositoryNameInput) Validate() error {
 	return nil
 }
 
+// SetNewName sets the NewName field's value.
+func (s *UpdateRepositoryNameInput) SetNewName(v string) *UpdateRepositoryNameInput {
+	s.NewName = &v
+	return s
+}
+
+// SetOldName sets the OldName field's value.
+func (s *UpdateRepositoryNameInput) SetOldName(v string) *UpdateRepositoryNameInput {
+	s.OldName = &v
+	return s
+}
+
 type UpdateRepositoryNameOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2643,6 +3069,24 @@ func (s UserInfo) String() string {
 // GoString returns the string representation
 func (s UserInfo) GoString() string {
 	return s.String()
+}
+
+// SetDate sets the Date field's value.
+func (s *UserInfo) SetDate(v string) *UserInfo {
+	s.Date = &v
+	return s
+}
+
+// SetEmail sets the Email field's value.
+func (s *UserInfo) SetEmail(v string) *UserInfo {
+	s.Email = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UserInfo) SetName(v string) *UserInfo {
+	s.Name = &v
+	return s
 }
 
 const (

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -3049,6 +3049,18 @@ func (s *AddTagsToOnPremisesInstancesInput) Validate() error {
 	return nil
 }
 
+// SetInstanceNames sets the InstanceNames field's value.
+func (s *AddTagsToOnPremisesInstancesInput) SetInstanceNames(v []*string) *AddTagsToOnPremisesInstancesInput {
+	s.InstanceNames = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToOnPremisesInstancesInput) SetTags(v []*Tag) *AddTagsToOnPremisesInstancesInput {
+	s.Tags = v
+	return s
+}
+
 type AddTagsToOnPremisesInstancesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3080,6 +3092,12 @@ func (s Alarm) String() string {
 // GoString returns the string representation
 func (s Alarm) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *Alarm) SetName(v string) *Alarm {
+	s.Name = &v
+	return s
 }
 
 // Information about alarms associated with the deployment group.
@@ -3115,6 +3133,24 @@ func (s AlarmConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetAlarms sets the Alarms field's value.
+func (s *AlarmConfiguration) SetAlarms(v []*Alarm) *AlarmConfiguration {
+	s.Alarms = v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *AlarmConfiguration) SetEnabled(v bool) *AlarmConfiguration {
+	s.Enabled = &v
+	return s
+}
+
+// SetIgnorePollAlarmFailure sets the IgnorePollAlarmFailure field's value.
+func (s *AlarmConfiguration) SetIgnorePollAlarmFailure(v bool) *AlarmConfiguration {
+	s.IgnorePollAlarmFailure = &v
+	return s
+}
+
 // Information about an application.
 type ApplicationInfo struct {
 	_ struct{} `type:"structure"`
@@ -3143,6 +3179,30 @@ func (s ApplicationInfo) GoString() string {
 	return s.String()
 }
 
+// SetApplicationId sets the ApplicationId field's value.
+func (s *ApplicationInfo) SetApplicationId(v string) *ApplicationInfo {
+	s.ApplicationId = &v
+	return s
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ApplicationInfo) SetApplicationName(v string) *ApplicationInfo {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCreateTime sets the CreateTime field's value.
+func (s *ApplicationInfo) SetCreateTime(v time.Time) *ApplicationInfo {
+	s.CreateTime = &v
+	return s
+}
+
+// SetLinkedToGitHub sets the LinkedToGitHub field's value.
+func (s *ApplicationInfo) SetLinkedToGitHub(v bool) *ApplicationInfo {
+	s.LinkedToGitHub = &v
+	return s
+}
+
 // Information about a configuration for automatically rolling back to a previous
 // version of an application revision when a deployment doesn't complete successfully.
 type AutoRollbackConfiguration struct {
@@ -3166,6 +3226,18 @@ func (s AutoRollbackConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *AutoRollbackConfiguration) SetEnabled(v bool) *AutoRollbackConfiguration {
+	s.Enabled = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *AutoRollbackConfiguration) SetEvents(v []*string) *AutoRollbackConfiguration {
+	s.Events = v
+	return s
+}
+
 // Information about an Auto Scaling group.
 type AutoScalingGroup struct {
 	_ struct{} `type:"structure"`
@@ -3185,6 +3257,18 @@ func (s AutoScalingGroup) String() string {
 // GoString returns the string representation
 func (s AutoScalingGroup) GoString() string {
 	return s.String()
+}
+
+// SetHook sets the Hook field's value.
+func (s *AutoScalingGroup) SetHook(v string) *AutoScalingGroup {
+	s.Hook = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AutoScalingGroup) SetName(v string) *AutoScalingGroup {
+	s.Name = &v
+	return s
 }
 
 // Represents the input of a batch get application revisions operation.
@@ -3231,6 +3315,18 @@ func (s *BatchGetApplicationRevisionsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *BatchGetApplicationRevisionsInput) SetApplicationName(v string) *BatchGetApplicationRevisionsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetRevisions sets the Revisions field's value.
+func (s *BatchGetApplicationRevisionsInput) SetRevisions(v []*RevisionLocation) *BatchGetApplicationRevisionsInput {
+	s.Revisions = v
+	return s
+}
+
 // Represents the output of a batch get application revisions operation.
 type BatchGetApplicationRevisionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3255,6 +3351,24 @@ func (s BatchGetApplicationRevisionsOutput) GoString() string {
 	return s.String()
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *BatchGetApplicationRevisionsOutput) SetApplicationName(v string) *BatchGetApplicationRevisionsOutput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *BatchGetApplicationRevisionsOutput) SetErrorMessage(v string) *BatchGetApplicationRevisionsOutput {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetRevisions sets the Revisions field's value.
+func (s *BatchGetApplicationRevisionsOutput) SetRevisions(v []*RevisionInfo) *BatchGetApplicationRevisionsOutput {
+	s.Revisions = v
+	return s
+}
+
 // Represents the input of a batch get applications operation.
 type BatchGetApplicationsInput struct {
 	_ struct{} `type:"structure"`
@@ -3273,6 +3387,12 @@ func (s BatchGetApplicationsInput) GoString() string {
 	return s.String()
 }
 
+// SetApplicationNames sets the ApplicationNames field's value.
+func (s *BatchGetApplicationsInput) SetApplicationNames(v []*string) *BatchGetApplicationsInput {
+	s.ApplicationNames = v
+	return s
+}
+
 // Represents the output of a batch get applications operation.
 type BatchGetApplicationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3289,6 +3409,12 @@ func (s BatchGetApplicationsOutput) String() string {
 // GoString returns the string representation
 func (s BatchGetApplicationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetApplicationsInfo sets the ApplicationsInfo field's value.
+func (s *BatchGetApplicationsOutput) SetApplicationsInfo(v []*ApplicationInfo) *BatchGetApplicationsOutput {
+	s.ApplicationsInfo = v
+	return s
 }
 
 // Represents the input of a batch get deployment groups operation.
@@ -3336,6 +3462,18 @@ func (s *BatchGetDeploymentGroupsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *BatchGetDeploymentGroupsInput) SetApplicationName(v string) *BatchGetDeploymentGroupsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDeploymentGroupNames sets the DeploymentGroupNames field's value.
+func (s *BatchGetDeploymentGroupsInput) SetDeploymentGroupNames(v []*string) *BatchGetDeploymentGroupsInput {
+	s.DeploymentGroupNames = v
+	return s
+}
+
 // Represents the output of a batch get deployment groups operation.
 type BatchGetDeploymentGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3355,6 +3493,18 @@ func (s BatchGetDeploymentGroupsOutput) String() string {
 // GoString returns the string representation
 func (s BatchGetDeploymentGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentGroupsInfo sets the DeploymentGroupsInfo field's value.
+func (s *BatchGetDeploymentGroupsOutput) SetDeploymentGroupsInfo(v []*DeploymentGroupInfo) *BatchGetDeploymentGroupsOutput {
+	s.DeploymentGroupsInfo = v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *BatchGetDeploymentGroupsOutput) SetErrorMessage(v string) *BatchGetDeploymentGroupsOutput {
+	s.ErrorMessage = &v
+	return s
 }
 
 // Represents the input of a batch get deployment instances operation.
@@ -3398,6 +3548,18 @@ func (s *BatchGetDeploymentInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *BatchGetDeploymentInstancesInput) SetDeploymentId(v string) *BatchGetDeploymentInstancesInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *BatchGetDeploymentInstancesInput) SetInstanceIds(v []*string) *BatchGetDeploymentInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
 // Represents the output of a batch get deployment instance operation.
 type BatchGetDeploymentInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3419,6 +3581,18 @@ func (s BatchGetDeploymentInstancesOutput) GoString() string {
 	return s.String()
 }
 
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *BatchGetDeploymentInstancesOutput) SetErrorMessage(v string) *BatchGetDeploymentInstancesOutput {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetInstancesSummary sets the InstancesSummary field's value.
+func (s *BatchGetDeploymentInstancesOutput) SetInstancesSummary(v []*InstanceSummary) *BatchGetDeploymentInstancesOutput {
+	s.InstancesSummary = v
+	return s
+}
+
 // Represents the input of a batch get deployments operation.
 type BatchGetDeploymentsInput struct {
 	_ struct{} `type:"structure"`
@@ -3435,6 +3609,12 @@ func (s BatchGetDeploymentsInput) String() string {
 // GoString returns the string representation
 func (s BatchGetDeploymentsInput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentIds sets the DeploymentIds field's value.
+func (s *BatchGetDeploymentsInput) SetDeploymentIds(v []*string) *BatchGetDeploymentsInput {
+	s.DeploymentIds = v
+	return s
 }
 
 // Represents the output of a batch get deployments operation.
@@ -3455,6 +3635,12 @@ func (s BatchGetDeploymentsOutput) GoString() string {
 	return s.String()
 }
 
+// SetDeploymentsInfo sets the DeploymentsInfo field's value.
+func (s *BatchGetDeploymentsOutput) SetDeploymentsInfo(v []*DeploymentInfo) *BatchGetDeploymentsOutput {
+	s.DeploymentsInfo = v
+	return s
+}
+
 // Represents the input of a batch get on-premises instances operation.
 type BatchGetOnPremisesInstancesInput struct {
 	_ struct{} `type:"structure"`
@@ -3473,6 +3659,12 @@ func (s BatchGetOnPremisesInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceNames sets the InstanceNames field's value.
+func (s *BatchGetOnPremisesInstancesInput) SetInstanceNames(v []*string) *BatchGetOnPremisesInstancesInput {
+	s.InstanceNames = v
+	return s
+}
+
 // Represents the output of a batch get on-premises instances operation.
 type BatchGetOnPremisesInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3489,6 +3681,12 @@ func (s BatchGetOnPremisesInstancesOutput) String() string {
 // GoString returns the string representation
 func (s BatchGetOnPremisesInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceInfos sets the InstanceInfos field's value.
+func (s *BatchGetOnPremisesInstancesOutput) SetInstanceInfos(v []*InstanceInfo) *BatchGetOnPremisesInstancesOutput {
+	s.InstanceInfos = v
+	return s
 }
 
 // Represents the input of a create application operation.
@@ -3528,6 +3726,12 @@ func (s *CreateApplicationInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *CreateApplicationInput) SetApplicationName(v string) *CreateApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
 // Represents the output of a create application operation.
 type CreateApplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -3544,6 +3748,12 @@ func (s CreateApplicationOutput) String() string {
 // GoString returns the string representation
 func (s CreateApplicationOutput) GoString() string {
 	return s.String()
+}
+
+// SetApplicationId sets the ApplicationId field's value.
+func (s *CreateApplicationOutput) SetApplicationId(v string) *CreateApplicationOutput {
+	s.ApplicationId = &v
+	return s
 }
 
 // Represents the input of a create deployment configuration operation.
@@ -3603,6 +3813,18 @@ func (s *CreateDeploymentConfigInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *CreateDeploymentConfigInput) SetDeploymentConfigName(v string) *CreateDeploymentConfigInput {
+	s.DeploymentConfigName = &v
+	return s
+}
+
+// SetMinimumHealthyHosts sets the MinimumHealthyHosts field's value.
+func (s *CreateDeploymentConfigInput) SetMinimumHealthyHosts(v *MinimumHealthyHosts) *CreateDeploymentConfigInput {
+	s.MinimumHealthyHosts = v
+	return s
+}
+
 // Represents the output of a create deployment configuration operation.
 type CreateDeploymentConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -3619,6 +3841,12 @@ func (s CreateDeploymentConfigOutput) String() string {
 // GoString returns the string representation
 func (s CreateDeploymentConfigOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentConfigId sets the DeploymentConfigId field's value.
+func (s *CreateDeploymentConfigOutput) SetDeploymentConfigId(v string) *CreateDeploymentConfigOutput {
+	s.DeploymentConfigId = &v
+	return s
 }
 
 // Represents the input of a create deployment group operation.
@@ -3757,6 +3985,66 @@ func (s *CreateDeploymentGroupInput) Validate() error {
 	return nil
 }
 
+// SetAlarmConfiguration sets the AlarmConfiguration field's value.
+func (s *CreateDeploymentGroupInput) SetAlarmConfiguration(v *AlarmConfiguration) *CreateDeploymentGroupInput {
+	s.AlarmConfiguration = v
+	return s
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *CreateDeploymentGroupInput) SetApplicationName(v string) *CreateDeploymentGroupInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetAutoRollbackConfiguration sets the AutoRollbackConfiguration field's value.
+func (s *CreateDeploymentGroupInput) SetAutoRollbackConfiguration(v *AutoRollbackConfiguration) *CreateDeploymentGroupInput {
+	s.AutoRollbackConfiguration = v
+	return s
+}
+
+// SetAutoScalingGroups sets the AutoScalingGroups field's value.
+func (s *CreateDeploymentGroupInput) SetAutoScalingGroups(v []*string) *CreateDeploymentGroupInput {
+	s.AutoScalingGroups = v
+	return s
+}
+
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *CreateDeploymentGroupInput) SetDeploymentConfigName(v string) *CreateDeploymentGroupInput {
+	s.DeploymentConfigName = &v
+	return s
+}
+
+// SetDeploymentGroupName sets the DeploymentGroupName field's value.
+func (s *CreateDeploymentGroupInput) SetDeploymentGroupName(v string) *CreateDeploymentGroupInput {
+	s.DeploymentGroupName = &v
+	return s
+}
+
+// SetEc2TagFilters sets the Ec2TagFilters field's value.
+func (s *CreateDeploymentGroupInput) SetEc2TagFilters(v []*EC2TagFilter) *CreateDeploymentGroupInput {
+	s.Ec2TagFilters = v
+	return s
+}
+
+// SetOnPremisesInstanceTagFilters sets the OnPremisesInstanceTagFilters field's value.
+func (s *CreateDeploymentGroupInput) SetOnPremisesInstanceTagFilters(v []*TagFilter) *CreateDeploymentGroupInput {
+	s.OnPremisesInstanceTagFilters = v
+	return s
+}
+
+// SetServiceRoleArn sets the ServiceRoleArn field's value.
+func (s *CreateDeploymentGroupInput) SetServiceRoleArn(v string) *CreateDeploymentGroupInput {
+	s.ServiceRoleArn = &v
+	return s
+}
+
+// SetTriggerConfigurations sets the TriggerConfigurations field's value.
+func (s *CreateDeploymentGroupInput) SetTriggerConfigurations(v []*TriggerConfig) *CreateDeploymentGroupInput {
+	s.TriggerConfigurations = v
+	return s
+}
+
 // Represents the output of a create deployment group operation.
 type CreateDeploymentGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -3773,6 +4061,12 @@ func (s CreateDeploymentGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateDeploymentGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentGroupId sets the DeploymentGroupId field's value.
+func (s *CreateDeploymentGroupOutput) SetDeploymentGroupId(v string) *CreateDeploymentGroupOutput {
+	s.DeploymentGroupId = &v
+	return s
 }
 
 // Represents the input of a create deployment operation.
@@ -3854,6 +4148,54 @@ func (s *CreateDeploymentInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *CreateDeploymentInput) SetApplicationName(v string) *CreateDeploymentInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetAutoRollbackConfiguration sets the AutoRollbackConfiguration field's value.
+func (s *CreateDeploymentInput) SetAutoRollbackConfiguration(v *AutoRollbackConfiguration) *CreateDeploymentInput {
+	s.AutoRollbackConfiguration = v
+	return s
+}
+
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *CreateDeploymentInput) SetDeploymentConfigName(v string) *CreateDeploymentInput {
+	s.DeploymentConfigName = &v
+	return s
+}
+
+// SetDeploymentGroupName sets the DeploymentGroupName field's value.
+func (s *CreateDeploymentInput) SetDeploymentGroupName(v string) *CreateDeploymentInput {
+	s.DeploymentGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateDeploymentInput) SetDescription(v string) *CreateDeploymentInput {
+	s.Description = &v
+	return s
+}
+
+// SetIgnoreApplicationStopFailures sets the IgnoreApplicationStopFailures field's value.
+func (s *CreateDeploymentInput) SetIgnoreApplicationStopFailures(v bool) *CreateDeploymentInput {
+	s.IgnoreApplicationStopFailures = &v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *CreateDeploymentInput) SetRevision(v *RevisionLocation) *CreateDeploymentInput {
+	s.Revision = v
+	return s
+}
+
+// SetUpdateOutdatedInstancesOnly sets the UpdateOutdatedInstancesOnly field's value.
+func (s *CreateDeploymentInput) SetUpdateOutdatedInstancesOnly(v bool) *CreateDeploymentInput {
+	s.UpdateOutdatedInstancesOnly = &v
+	return s
+}
+
 // Represents the output of a create deployment operation.
 type CreateDeploymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -3870,6 +4212,12 @@ func (s CreateDeploymentOutput) String() string {
 // GoString returns the string representation
 func (s CreateDeploymentOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *CreateDeploymentOutput) SetDeploymentId(v string) *CreateDeploymentOutput {
+	s.DeploymentId = &v
+	return s
 }
 
 // Represents the input of a delete application operation.
@@ -3907,6 +4255,12 @@ func (s *DeleteApplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteApplicationInput) SetApplicationName(v string) *DeleteApplicationInput {
+	s.ApplicationName = &v
+	return s
 }
 
 type DeleteApplicationOutput struct {
@@ -3958,6 +4312,12 @@ func (s *DeleteDeploymentConfigInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *DeleteDeploymentConfigInput) SetDeploymentConfigName(v string) *DeleteDeploymentConfigInput {
+	s.DeploymentConfigName = &v
+	return s
 }
 
 type DeleteDeploymentConfigOutput struct {
@@ -4022,6 +4382,18 @@ func (s *DeleteDeploymentGroupInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteDeploymentGroupInput) SetApplicationName(v string) *DeleteDeploymentGroupInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDeploymentGroupName sets the DeploymentGroupName field's value.
+func (s *DeleteDeploymentGroupInput) SetDeploymentGroupName(v string) *DeleteDeploymentGroupInput {
+	s.DeploymentGroupName = &v
+	return s
+}
+
 // Represents the output of a delete deployment group operation.
 type DeleteDeploymentGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -4043,6 +4415,12 @@ func (s DeleteDeploymentGroupOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDeploymentGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetHooksNotCleanedUp sets the HooksNotCleanedUp field's value.
+func (s *DeleteDeploymentGroupOutput) SetHooksNotCleanedUp(v []*AutoScalingGroup) *DeleteDeploymentGroupOutput {
+	s.HooksNotCleanedUp = v
+	return s
 }
 
 // Information about a deployment configuration.
@@ -4070,6 +4448,30 @@ func (s DeploymentConfigInfo) String() string {
 // GoString returns the string representation
 func (s DeploymentConfigInfo) GoString() string {
 	return s.String()
+}
+
+// SetCreateTime sets the CreateTime field's value.
+func (s *DeploymentConfigInfo) SetCreateTime(v time.Time) *DeploymentConfigInfo {
+	s.CreateTime = &v
+	return s
+}
+
+// SetDeploymentConfigId sets the DeploymentConfigId field's value.
+func (s *DeploymentConfigInfo) SetDeploymentConfigId(v string) *DeploymentConfigInfo {
+	s.DeploymentConfigId = &v
+	return s
+}
+
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *DeploymentConfigInfo) SetDeploymentConfigName(v string) *DeploymentConfigInfo {
+	s.DeploymentConfigName = &v
+	return s
+}
+
+// SetMinimumHealthyHosts sets the MinimumHealthyHosts field's value.
+func (s *DeploymentConfigInfo) SetMinimumHealthyHosts(v *MinimumHealthyHosts) *DeploymentConfigInfo {
+	s.MinimumHealthyHosts = v
+	return s
 }
 
 // Information about a deployment group.
@@ -4123,6 +4525,78 @@ func (s DeploymentGroupInfo) String() string {
 // GoString returns the string representation
 func (s DeploymentGroupInfo) GoString() string {
 	return s.String()
+}
+
+// SetAlarmConfiguration sets the AlarmConfiguration field's value.
+func (s *DeploymentGroupInfo) SetAlarmConfiguration(v *AlarmConfiguration) *DeploymentGroupInfo {
+	s.AlarmConfiguration = v
+	return s
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeploymentGroupInfo) SetApplicationName(v string) *DeploymentGroupInfo {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetAutoRollbackConfiguration sets the AutoRollbackConfiguration field's value.
+func (s *DeploymentGroupInfo) SetAutoRollbackConfiguration(v *AutoRollbackConfiguration) *DeploymentGroupInfo {
+	s.AutoRollbackConfiguration = v
+	return s
+}
+
+// SetAutoScalingGroups sets the AutoScalingGroups field's value.
+func (s *DeploymentGroupInfo) SetAutoScalingGroups(v []*AutoScalingGroup) *DeploymentGroupInfo {
+	s.AutoScalingGroups = v
+	return s
+}
+
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *DeploymentGroupInfo) SetDeploymentConfigName(v string) *DeploymentGroupInfo {
+	s.DeploymentConfigName = &v
+	return s
+}
+
+// SetDeploymentGroupId sets the DeploymentGroupId field's value.
+func (s *DeploymentGroupInfo) SetDeploymentGroupId(v string) *DeploymentGroupInfo {
+	s.DeploymentGroupId = &v
+	return s
+}
+
+// SetDeploymentGroupName sets the DeploymentGroupName field's value.
+func (s *DeploymentGroupInfo) SetDeploymentGroupName(v string) *DeploymentGroupInfo {
+	s.DeploymentGroupName = &v
+	return s
+}
+
+// SetEc2TagFilters sets the Ec2TagFilters field's value.
+func (s *DeploymentGroupInfo) SetEc2TagFilters(v []*EC2TagFilter) *DeploymentGroupInfo {
+	s.Ec2TagFilters = v
+	return s
+}
+
+// SetOnPremisesInstanceTagFilters sets the OnPremisesInstanceTagFilters field's value.
+func (s *DeploymentGroupInfo) SetOnPremisesInstanceTagFilters(v []*TagFilter) *DeploymentGroupInfo {
+	s.OnPremisesInstanceTagFilters = v
+	return s
+}
+
+// SetServiceRoleArn sets the ServiceRoleArn field's value.
+func (s *DeploymentGroupInfo) SetServiceRoleArn(v string) *DeploymentGroupInfo {
+	s.ServiceRoleArn = &v
+	return s
+}
+
+// SetTargetRevision sets the TargetRevision field's value.
+func (s *DeploymentGroupInfo) SetTargetRevision(v *RevisionLocation) *DeploymentGroupInfo {
+	s.TargetRevision = v
+	return s
+}
+
+// SetTriggerConfigurations sets the TriggerConfigurations field's value.
+func (s *DeploymentGroupInfo) SetTriggerConfigurations(v []*TriggerConfig) *DeploymentGroupInfo {
+	s.TriggerConfigurations = v
+	return s
 }
 
 // Information about a deployment.
@@ -4213,6 +4687,108 @@ func (s DeploymentInfo) GoString() string {
 	return s.String()
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeploymentInfo) SetApplicationName(v string) *DeploymentInfo {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetAutoRollbackConfiguration sets the AutoRollbackConfiguration field's value.
+func (s *DeploymentInfo) SetAutoRollbackConfiguration(v *AutoRollbackConfiguration) *DeploymentInfo {
+	s.AutoRollbackConfiguration = v
+	return s
+}
+
+// SetCompleteTime sets the CompleteTime field's value.
+func (s *DeploymentInfo) SetCompleteTime(v time.Time) *DeploymentInfo {
+	s.CompleteTime = &v
+	return s
+}
+
+// SetCreateTime sets the CreateTime field's value.
+func (s *DeploymentInfo) SetCreateTime(v time.Time) *DeploymentInfo {
+	s.CreateTime = &v
+	return s
+}
+
+// SetCreator sets the Creator field's value.
+func (s *DeploymentInfo) SetCreator(v string) *DeploymentInfo {
+	s.Creator = &v
+	return s
+}
+
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *DeploymentInfo) SetDeploymentConfigName(v string) *DeploymentInfo {
+	s.DeploymentConfigName = &v
+	return s
+}
+
+// SetDeploymentGroupName sets the DeploymentGroupName field's value.
+func (s *DeploymentInfo) SetDeploymentGroupName(v string) *DeploymentInfo {
+	s.DeploymentGroupName = &v
+	return s
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *DeploymentInfo) SetDeploymentId(v string) *DeploymentInfo {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetDeploymentOverview sets the DeploymentOverview field's value.
+func (s *DeploymentInfo) SetDeploymentOverview(v *DeploymentOverview) *DeploymentInfo {
+	s.DeploymentOverview = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DeploymentInfo) SetDescription(v string) *DeploymentInfo {
+	s.Description = &v
+	return s
+}
+
+// SetErrorInformation sets the ErrorInformation field's value.
+func (s *DeploymentInfo) SetErrorInformation(v *ErrorInformation) *DeploymentInfo {
+	s.ErrorInformation = v
+	return s
+}
+
+// SetIgnoreApplicationStopFailures sets the IgnoreApplicationStopFailures field's value.
+func (s *DeploymentInfo) SetIgnoreApplicationStopFailures(v bool) *DeploymentInfo {
+	s.IgnoreApplicationStopFailures = &v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *DeploymentInfo) SetRevision(v *RevisionLocation) *DeploymentInfo {
+	s.Revision = v
+	return s
+}
+
+// SetRollbackInfo sets the RollbackInfo field's value.
+func (s *DeploymentInfo) SetRollbackInfo(v *RollbackInfo) *DeploymentInfo {
+	s.RollbackInfo = v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DeploymentInfo) SetStartTime(v time.Time) *DeploymentInfo {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DeploymentInfo) SetStatus(v string) *DeploymentInfo {
+	s.Status = &v
+	return s
+}
+
+// SetUpdateOutdatedInstancesOnly sets the UpdateOutdatedInstancesOnly field's value.
+func (s *DeploymentInfo) SetUpdateOutdatedInstancesOnly(v bool) *DeploymentInfo {
+	s.UpdateOutdatedInstancesOnly = &v
+	return s
+}
+
 // Information about the deployment status of the instances in the deployment.
 type DeploymentOverview struct {
 	_ struct{} `type:"structure"`
@@ -4242,6 +4818,36 @@ func (s DeploymentOverview) String() string {
 // GoString returns the string representation
 func (s DeploymentOverview) GoString() string {
 	return s.String()
+}
+
+// SetFailed sets the Failed field's value.
+func (s *DeploymentOverview) SetFailed(v int64) *DeploymentOverview {
+	s.Failed = &v
+	return s
+}
+
+// SetInProgress sets the InProgress field's value.
+func (s *DeploymentOverview) SetInProgress(v int64) *DeploymentOverview {
+	s.InProgress = &v
+	return s
+}
+
+// SetPending sets the Pending field's value.
+func (s *DeploymentOverview) SetPending(v int64) *DeploymentOverview {
+	s.Pending = &v
+	return s
+}
+
+// SetSkipped sets the Skipped field's value.
+func (s *DeploymentOverview) SetSkipped(v int64) *DeploymentOverview {
+	s.Skipped = &v
+	return s
+}
+
+// SetSucceeded sets the Succeeded field's value.
+func (s *DeploymentOverview) SetSucceeded(v int64) *DeploymentOverview {
+	s.Succeeded = &v
+	return s
 }
 
 // Represents the input of a deregister on-premises instance operation.
@@ -4275,6 +4881,12 @@ func (s *DeregisterOnPremisesInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceName sets the InstanceName field's value.
+func (s *DeregisterOnPremisesInstanceInput) SetInstanceName(v string) *DeregisterOnPremisesInstanceInput {
+	s.InstanceName = &v
+	return s
 }
 
 type DeregisterOnPremisesInstanceOutput struct {
@@ -4335,6 +4947,30 @@ func (s Diagnostics) GoString() string {
 	return s.String()
 }
 
+// SetErrorCode sets the ErrorCode field's value.
+func (s *Diagnostics) SetErrorCode(v string) *Diagnostics {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetLogTail sets the LogTail field's value.
+func (s *Diagnostics) SetLogTail(v string) *Diagnostics {
+	s.LogTail = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Diagnostics) SetMessage(v string) *Diagnostics {
+	s.Message = &v
+	return s
+}
+
+// SetScriptName sets the ScriptName field's value.
+func (s *Diagnostics) SetScriptName(v string) *Diagnostics {
+	s.ScriptName = &v
+	return s
+}
+
 // Information about a tag filter.
 type EC2TagFilter struct {
 	_ struct{} `type:"structure"`
@@ -4363,6 +4999,24 @@ func (s EC2TagFilter) String() string {
 // GoString returns the string representation
 func (s EC2TagFilter) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *EC2TagFilter) SetKey(v string) *EC2TagFilter {
+	s.Key = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *EC2TagFilter) SetType(v string) *EC2TagFilter {
+	s.Type = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *EC2TagFilter) SetValue(v string) *EC2TagFilter {
+	s.Value = &v
+	return s
 }
 
 // Information about a deployment error.
@@ -4422,6 +5076,18 @@ func (s ErrorInformation) GoString() string {
 	return s.String()
 }
 
+// SetCode sets the Code field's value.
+func (s *ErrorInformation) SetCode(v string) *ErrorInformation {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *ErrorInformation) SetMessage(v string) *ErrorInformation {
+	s.Message = &v
+	return s
+}
+
 // Information about an application revision.
 type GenericRevisionInfo struct {
 	_ struct{} `type:"structure"`
@@ -4450,6 +5116,36 @@ func (s GenericRevisionInfo) String() string {
 // GoString returns the string representation
 func (s GenericRevisionInfo) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentGroups sets the DeploymentGroups field's value.
+func (s *GenericRevisionInfo) SetDeploymentGroups(v []*string) *GenericRevisionInfo {
+	s.DeploymentGroups = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *GenericRevisionInfo) SetDescription(v string) *GenericRevisionInfo {
+	s.Description = &v
+	return s
+}
+
+// SetFirstUsedTime sets the FirstUsedTime field's value.
+func (s *GenericRevisionInfo) SetFirstUsedTime(v time.Time) *GenericRevisionInfo {
+	s.FirstUsedTime = &v
+	return s
+}
+
+// SetLastUsedTime sets the LastUsedTime field's value.
+func (s *GenericRevisionInfo) SetLastUsedTime(v time.Time) *GenericRevisionInfo {
+	s.LastUsedTime = &v
+	return s
+}
+
+// SetRegisterTime sets the RegisterTime field's value.
+func (s *GenericRevisionInfo) SetRegisterTime(v time.Time) *GenericRevisionInfo {
+	s.RegisterTime = &v
+	return s
 }
 
 // Represents the input of a get application operation.
@@ -4489,6 +5185,12 @@ func (s *GetApplicationInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *GetApplicationInput) SetApplicationName(v string) *GetApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
 // Represents the output of a get application operation.
 type GetApplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -4505,6 +5207,12 @@ func (s GetApplicationOutput) String() string {
 // GoString returns the string representation
 func (s GetApplicationOutput) GoString() string {
 	return s.String()
+}
+
+// SetApplication sets the Application field's value.
+func (s *GetApplicationOutput) SetApplication(v *ApplicationInfo) *GetApplicationOutput {
+	s.Application = v
+	return s
 }
 
 // Represents the input of a get application revision operation.
@@ -4551,6 +5259,18 @@ func (s *GetApplicationRevisionInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *GetApplicationRevisionInput) SetApplicationName(v string) *GetApplicationRevisionInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *GetApplicationRevisionInput) SetRevision(v *RevisionLocation) *GetApplicationRevisionInput {
+	s.Revision = v
+	return s
+}
+
 // Represents the output of a get application revision operation.
 type GetApplicationRevisionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4573,6 +5293,24 @@ func (s GetApplicationRevisionOutput) String() string {
 // GoString returns the string representation
 func (s GetApplicationRevisionOutput) GoString() string {
 	return s.String()
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *GetApplicationRevisionOutput) SetApplicationName(v string) *GetApplicationRevisionOutput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *GetApplicationRevisionOutput) SetRevision(v *RevisionLocation) *GetApplicationRevisionOutput {
+	s.Revision = v
+	return s
+}
+
+// SetRevisionInfo sets the RevisionInfo field's value.
+func (s *GetApplicationRevisionOutput) SetRevisionInfo(v *GenericRevisionInfo) *GetApplicationRevisionOutput {
+	s.RevisionInfo = v
+	return s
 }
 
 // Represents the input of a get deployment configuration operation.
@@ -4612,6 +5350,12 @@ func (s *GetDeploymentConfigInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *GetDeploymentConfigInput) SetDeploymentConfigName(v string) *GetDeploymentConfigInput {
+	s.DeploymentConfigName = &v
+	return s
+}
+
 // Represents the output of a get deployment configuration operation.
 type GetDeploymentConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -4628,6 +5372,12 @@ func (s GetDeploymentConfigOutput) String() string {
 // GoString returns the string representation
 func (s GetDeploymentConfigOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentConfigInfo sets the DeploymentConfigInfo field's value.
+func (s *GetDeploymentConfigOutput) SetDeploymentConfigInfo(v *DeploymentConfigInfo) *GetDeploymentConfigOutput {
+	s.DeploymentConfigInfo = v
+	return s
 }
 
 // Represents the input of a get deployment group operation.
@@ -4678,6 +5428,18 @@ func (s *GetDeploymentGroupInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *GetDeploymentGroupInput) SetApplicationName(v string) *GetDeploymentGroupInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDeploymentGroupName sets the DeploymentGroupName field's value.
+func (s *GetDeploymentGroupInput) SetDeploymentGroupName(v string) *GetDeploymentGroupInput {
+	s.DeploymentGroupName = &v
+	return s
+}
+
 // Represents the output of a get deployment group operation.
 type GetDeploymentGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -4694,6 +5456,12 @@ func (s GetDeploymentGroupOutput) String() string {
 // GoString returns the string representation
 func (s GetDeploymentGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentGroupInfo sets the DeploymentGroupInfo field's value.
+func (s *GetDeploymentGroupOutput) SetDeploymentGroupInfo(v *DeploymentGroupInfo) *GetDeploymentGroupOutput {
+	s.DeploymentGroupInfo = v
+	return s
 }
 
 // Represents the input of a get deployment operation.
@@ -4727,6 +5495,12 @@ func (s *GetDeploymentInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *GetDeploymentInput) SetDeploymentId(v string) *GetDeploymentInput {
+	s.DeploymentId = &v
+	return s
 }
 
 // Represents the input of a get deployment instance operation.
@@ -4770,6 +5544,18 @@ func (s *GetDeploymentInstanceInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *GetDeploymentInstanceInput) SetDeploymentId(v string) *GetDeploymentInstanceInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *GetDeploymentInstanceInput) SetInstanceId(v string) *GetDeploymentInstanceInput {
+	s.InstanceId = &v
+	return s
+}
+
 // Represents the output of a get deployment instance operation.
 type GetDeploymentInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -4788,6 +5574,12 @@ func (s GetDeploymentInstanceOutput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceSummary sets the InstanceSummary field's value.
+func (s *GetDeploymentInstanceOutput) SetInstanceSummary(v *InstanceSummary) *GetDeploymentInstanceOutput {
+	s.InstanceSummary = v
+	return s
+}
+
 // Represents the output of a get deployment operation.
 type GetDeploymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -4804,6 +5596,12 @@ func (s GetDeploymentOutput) String() string {
 // GoString returns the string representation
 func (s GetDeploymentOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentInfo sets the DeploymentInfo field's value.
+func (s *GetDeploymentOutput) SetDeploymentInfo(v *DeploymentInfo) *GetDeploymentOutput {
+	s.DeploymentInfo = v
+	return s
 }
 
 // Represents the input of a get on-premises instance operation.
@@ -4839,6 +5637,12 @@ func (s *GetOnPremisesInstanceInput) Validate() error {
 	return nil
 }
 
+// SetInstanceName sets the InstanceName field's value.
+func (s *GetOnPremisesInstanceInput) SetInstanceName(v string) *GetOnPremisesInstanceInput {
+	s.InstanceName = &v
+	return s
+}
+
 // Represents the output of a get on-premises instance operation.
 type GetOnPremisesInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -4855,6 +5659,12 @@ func (s GetOnPremisesInstanceOutput) String() string {
 // GoString returns the string representation
 func (s GetOnPremisesInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceInfo sets the InstanceInfo field's value.
+func (s *GetOnPremisesInstanceOutput) SetInstanceInfo(v *InstanceInfo) *GetOnPremisesInstanceOutput {
+	s.InstanceInfo = v
+	return s
 }
 
 // Information about the location of application artifacts stored in GitHub.
@@ -4880,6 +5690,18 @@ func (s GitHubLocation) String() string {
 // GoString returns the string representation
 func (s GitHubLocation) GoString() string {
 	return s.String()
+}
+
+// SetCommitId sets the CommitId field's value.
+func (s *GitHubLocation) SetCommitId(v string) *GitHubLocation {
+	s.CommitId = &v
+	return s
+}
+
+// SetRepository sets the Repository field's value.
+func (s *GitHubLocation) SetRepository(v string) *GitHubLocation {
+	s.Repository = &v
+	return s
 }
 
 // Information about an on-premises instance.
@@ -4914,6 +5736,42 @@ func (s InstanceInfo) String() string {
 // GoString returns the string representation
 func (s InstanceInfo) GoString() string {
 	return s.String()
+}
+
+// SetDeregisterTime sets the DeregisterTime field's value.
+func (s *InstanceInfo) SetDeregisterTime(v time.Time) *InstanceInfo {
+	s.DeregisterTime = &v
+	return s
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *InstanceInfo) SetIamUserArn(v string) *InstanceInfo {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetInstanceArn sets the InstanceArn field's value.
+func (s *InstanceInfo) SetInstanceArn(v string) *InstanceInfo {
+	s.InstanceArn = &v
+	return s
+}
+
+// SetInstanceName sets the InstanceName field's value.
+func (s *InstanceInfo) SetInstanceName(v string) *InstanceInfo {
+	s.InstanceName = &v
+	return s
+}
+
+// SetRegisterTime sets the RegisterTime field's value.
+func (s *InstanceInfo) SetRegisterTime(v time.Time) *InstanceInfo {
+	s.RegisterTime = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *InstanceInfo) SetTags(v []*Tag) *InstanceInfo {
+	s.Tags = v
+	return s
 }
 
 // Information about an instance in a deployment.
@@ -4958,6 +5816,36 @@ func (s InstanceSummary) GoString() string {
 	return s.String()
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *InstanceSummary) SetDeploymentId(v string) *InstanceSummary {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceSummary) SetInstanceId(v string) *InstanceSummary {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *InstanceSummary) SetLastUpdatedAt(v time.Time) *InstanceSummary {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetLifecycleEvents sets the LifecycleEvents field's value.
+func (s *InstanceSummary) SetLifecycleEvents(v []*LifecycleEvent) *InstanceSummary {
+	s.LifecycleEvents = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *InstanceSummary) SetStatus(v string) *InstanceSummary {
+	s.Status = &v
+	return s
+}
+
 // Information about a deployment lifecycle event.
 type LifecycleEvent struct {
 	_ struct{} `type:"structure"`
@@ -4999,6 +5887,36 @@ func (s LifecycleEvent) String() string {
 // GoString returns the string representation
 func (s LifecycleEvent) GoString() string {
 	return s.String()
+}
+
+// SetDiagnostics sets the Diagnostics field's value.
+func (s *LifecycleEvent) SetDiagnostics(v *Diagnostics) *LifecycleEvent {
+	s.Diagnostics = v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *LifecycleEvent) SetEndTime(v time.Time) *LifecycleEvent {
+	s.EndTime = &v
+	return s
+}
+
+// SetLifecycleEventName sets the LifecycleEventName field's value.
+func (s *LifecycleEvent) SetLifecycleEventName(v string) *LifecycleEvent {
+	s.LifecycleEventName = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *LifecycleEvent) SetStartTime(v time.Time) *LifecycleEvent {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *LifecycleEvent) SetStatus(v string) *LifecycleEvent {
+	s.Status = &v
+	return s
 }
 
 // Represents the input of a list application revisions operation.
@@ -5085,6 +6003,48 @@ func (s *ListApplicationRevisionsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ListApplicationRevisionsInput) SetApplicationName(v string) *ListApplicationRevisionsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDeployed sets the Deployed field's value.
+func (s *ListApplicationRevisionsInput) SetDeployed(v string) *ListApplicationRevisionsInput {
+	s.Deployed = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListApplicationRevisionsInput) SetNextToken(v string) *ListApplicationRevisionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *ListApplicationRevisionsInput) SetS3Bucket(v string) *ListApplicationRevisionsInput {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *ListApplicationRevisionsInput) SetS3KeyPrefix(v string) *ListApplicationRevisionsInput {
+	s.S3KeyPrefix = &v
+	return s
+}
+
+// SetSortBy sets the SortBy field's value.
+func (s *ListApplicationRevisionsInput) SetSortBy(v string) *ListApplicationRevisionsInput {
+	s.SortBy = &v
+	return s
+}
+
+// SetSortOrder sets the SortOrder field's value.
+func (s *ListApplicationRevisionsInput) SetSortOrder(v string) *ListApplicationRevisionsInput {
+	s.SortOrder = &v
+	return s
+}
+
 // Represents the output of a list application revisions operation.
 type ListApplicationRevisionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5108,6 +6068,18 @@ func (s ListApplicationRevisionsOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListApplicationRevisionsOutput) SetNextToken(v string) *ListApplicationRevisionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRevisions sets the Revisions field's value.
+func (s *ListApplicationRevisionsOutput) SetRevisions(v []*RevisionLocation) *ListApplicationRevisionsOutput {
+	s.Revisions = v
+	return s
+}
+
 // Represents the input of a list applications operation.
 type ListApplicationsInput struct {
 	_ struct{} `type:"structure"`
@@ -5125,6 +6097,12 @@ func (s ListApplicationsInput) String() string {
 // GoString returns the string representation
 func (s ListApplicationsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListApplicationsInput) SetNextToken(v string) *ListApplicationsInput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the output of a list applications operation.
@@ -5150,6 +6128,18 @@ func (s ListApplicationsOutput) GoString() string {
 	return s.String()
 }
 
+// SetApplications sets the Applications field's value.
+func (s *ListApplicationsOutput) SetApplications(v []*string) *ListApplicationsOutput {
+	s.Applications = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListApplicationsOutput) SetNextToken(v string) *ListApplicationsOutput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the input of a list deployment configurations operation.
 type ListDeploymentConfigsInput struct {
 	_ struct{} `type:"structure"`
@@ -5168,6 +6158,12 @@ func (s ListDeploymentConfigsInput) String() string {
 // GoString returns the string representation
 func (s ListDeploymentConfigsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDeploymentConfigsInput) SetNextToken(v string) *ListDeploymentConfigsInput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the output of a list deployment configurations operation.
@@ -5192,6 +6188,18 @@ func (s ListDeploymentConfigsOutput) String() string {
 // GoString returns the string representation
 func (s ListDeploymentConfigsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentConfigsList sets the DeploymentConfigsList field's value.
+func (s *ListDeploymentConfigsOutput) SetDeploymentConfigsList(v []*string) *ListDeploymentConfigsOutput {
+	s.DeploymentConfigsList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDeploymentConfigsOutput) SetNextToken(v string) *ListDeploymentConfigsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input of a list deployment groups operation.
@@ -5235,6 +6243,18 @@ func (s *ListDeploymentGroupsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ListDeploymentGroupsInput) SetApplicationName(v string) *ListDeploymentGroupsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDeploymentGroupsInput) SetNextToken(v string) *ListDeploymentGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the output of a list deployment groups operation.
 type ListDeploymentGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5259,6 +6279,24 @@ func (s ListDeploymentGroupsOutput) String() string {
 // GoString returns the string representation
 func (s ListDeploymentGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ListDeploymentGroupsOutput) SetApplicationName(v string) *ListDeploymentGroupsOutput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDeploymentGroups sets the DeploymentGroups field's value.
+func (s *ListDeploymentGroupsOutput) SetDeploymentGroups(v []*string) *ListDeploymentGroupsOutput {
+	s.DeploymentGroups = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDeploymentGroupsOutput) SetNextToken(v string) *ListDeploymentGroupsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input of a list deployment instances operation.
@@ -5313,6 +6351,24 @@ func (s *ListDeploymentInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *ListDeploymentInstancesInput) SetDeploymentId(v string) *ListDeploymentInstancesInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetInstanceStatusFilter sets the InstanceStatusFilter field's value.
+func (s *ListDeploymentInstancesInput) SetInstanceStatusFilter(v []*string) *ListDeploymentInstancesInput {
+	s.InstanceStatusFilter = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDeploymentInstancesInput) SetNextToken(v string) *ListDeploymentInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the output of a list deployment instances operation.
 type ListDeploymentInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5334,6 +6390,18 @@ func (s ListDeploymentInstancesOutput) String() string {
 // GoString returns the string representation
 func (s ListDeploymentInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstancesList sets the InstancesList field's value.
+func (s *ListDeploymentInstancesOutput) SetInstancesList(v []*string) *ListDeploymentInstancesOutput {
+	s.InstancesList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDeploymentInstancesOutput) SetNextToken(v string) *ListDeploymentInstancesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input of a list deployments operation.
@@ -5396,6 +6464,36 @@ func (s *ListDeploymentsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ListDeploymentsInput) SetApplicationName(v string) *ListDeploymentsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCreateTimeRange sets the CreateTimeRange field's value.
+func (s *ListDeploymentsInput) SetCreateTimeRange(v *TimeRange) *ListDeploymentsInput {
+	s.CreateTimeRange = v
+	return s
+}
+
+// SetDeploymentGroupName sets the DeploymentGroupName field's value.
+func (s *ListDeploymentsInput) SetDeploymentGroupName(v string) *ListDeploymentsInput {
+	s.DeploymentGroupName = &v
+	return s
+}
+
+// SetIncludeOnlyStatuses sets the IncludeOnlyStatuses field's value.
+func (s *ListDeploymentsInput) SetIncludeOnlyStatuses(v []*string) *ListDeploymentsInput {
+	s.IncludeOnlyStatuses = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDeploymentsInput) SetNextToken(v string) *ListDeploymentsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the output of a list deployments operation.
 type ListDeploymentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5417,6 +6515,18 @@ func (s ListDeploymentsOutput) String() string {
 // GoString returns the string representation
 func (s ListDeploymentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeployments sets the Deployments field's value.
+func (s *ListDeploymentsOutput) SetDeployments(v []*string) *ListDeploymentsOutput {
+	s.Deployments = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDeploymentsOutput) SetNextToken(v string) *ListDeploymentsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input of a list on-premises instances operation.
@@ -5451,6 +6561,24 @@ func (s ListOnPremisesInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListOnPremisesInstancesInput) SetNextToken(v string) *ListOnPremisesInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRegistrationStatus sets the RegistrationStatus field's value.
+func (s *ListOnPremisesInstancesInput) SetRegistrationStatus(v string) *ListOnPremisesInstancesInput {
+	s.RegistrationStatus = &v
+	return s
+}
+
+// SetTagFilters sets the TagFilters field's value.
+func (s *ListOnPremisesInstancesInput) SetTagFilters(v []*TagFilter) *ListOnPremisesInstancesInput {
+	s.TagFilters = v
+	return s
+}
+
 // Represents the output of list on-premises instances operation.
 type ListOnPremisesInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5472,6 +6600,18 @@ func (s ListOnPremisesInstancesOutput) String() string {
 // GoString returns the string representation
 func (s ListOnPremisesInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceNames sets the InstanceNames field's value.
+func (s *ListOnPremisesInstancesOutput) SetInstanceNames(v []*string) *ListOnPremisesInstancesOutput {
+	s.InstanceNames = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListOnPremisesInstancesOutput) SetNextToken(v string) *ListOnPremisesInstancesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Information about minimum healthy instance.
@@ -5515,6 +6655,18 @@ func (s MinimumHealthyHosts) String() string {
 // GoString returns the string representation
 func (s MinimumHealthyHosts) GoString() string {
 	return s.String()
+}
+
+// SetType sets the Type field's value.
+func (s *MinimumHealthyHosts) SetType(v string) *MinimumHealthyHosts {
+	s.Type = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *MinimumHealthyHosts) SetValue(v int64) *MinimumHealthyHosts {
+	s.Value = &v
+	return s
 }
 
 // Represents the input of a register application revision operation.
@@ -5564,6 +6716,24 @@ func (s *RegisterApplicationRevisionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *RegisterApplicationRevisionInput) SetApplicationName(v string) *RegisterApplicationRevisionInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *RegisterApplicationRevisionInput) SetDescription(v string) *RegisterApplicationRevisionInput {
+	s.Description = &v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *RegisterApplicationRevisionInput) SetRevision(v *RevisionLocation) *RegisterApplicationRevisionInput {
+	s.Revision = v
+	return s
 }
 
 type RegisterApplicationRevisionOutput struct {
@@ -5621,6 +6791,18 @@ func (s *RegisterOnPremisesInstanceInput) Validate() error {
 	return nil
 }
 
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *RegisterOnPremisesInstanceInput) SetIamUserArn(v string) *RegisterOnPremisesInstanceInput {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetInstanceName sets the InstanceName field's value.
+func (s *RegisterOnPremisesInstanceInput) SetInstanceName(v string) *RegisterOnPremisesInstanceInput {
+	s.InstanceName = &v
+	return s
+}
+
 type RegisterOnPremisesInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5676,6 +6858,18 @@ func (s *RemoveTagsFromOnPremisesInstancesInput) Validate() error {
 	return nil
 }
 
+// SetInstanceNames sets the InstanceNames field's value.
+func (s *RemoveTagsFromOnPremisesInstancesInput) SetInstanceNames(v []*string) *RemoveTagsFromOnPremisesInstancesInput {
+	s.InstanceNames = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RemoveTagsFromOnPremisesInstancesInput) SetTags(v []*Tag) *RemoveTagsFromOnPremisesInstancesInput {
+	s.Tags = v
+	return s
+}
+
 type RemoveTagsFromOnPremisesInstancesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5711,6 +6905,18 @@ func (s RevisionInfo) GoString() string {
 	return s.String()
 }
 
+// SetGenericRevisionInfo sets the GenericRevisionInfo field's value.
+func (s *RevisionInfo) SetGenericRevisionInfo(v *GenericRevisionInfo) *RevisionInfo {
+	s.GenericRevisionInfo = v
+	return s
+}
+
+// SetRevisionLocation sets the RevisionLocation field's value.
+func (s *RevisionInfo) SetRevisionLocation(v *RevisionLocation) *RevisionInfo {
+	s.RevisionLocation = v
+	return s
+}
+
 // Information about the location of an application revision.
 type RevisionLocation struct {
 	_ struct{} `type:"structure"`
@@ -5740,6 +6946,24 @@ func (s RevisionLocation) GoString() string {
 	return s.String()
 }
 
+// SetGitHubLocation sets the GitHubLocation field's value.
+func (s *RevisionLocation) SetGitHubLocation(v *GitHubLocation) *RevisionLocation {
+	s.GitHubLocation = v
+	return s
+}
+
+// SetRevisionType sets the RevisionType field's value.
+func (s *RevisionLocation) SetRevisionType(v string) *RevisionLocation {
+	s.RevisionType = &v
+	return s
+}
+
+// SetS3Location sets the S3Location field's value.
+func (s *RevisionLocation) SetS3Location(v *S3Location) *RevisionLocation {
+	s.S3Location = v
+	return s
+}
+
 // Information about a deployment rollback.
 type RollbackInfo struct {
 	_ struct{} `type:"structure"`
@@ -5764,6 +6988,24 @@ func (s RollbackInfo) String() string {
 // GoString returns the string representation
 func (s RollbackInfo) GoString() string {
 	return s.String()
+}
+
+// SetRollbackDeploymentId sets the RollbackDeploymentId field's value.
+func (s *RollbackInfo) SetRollbackDeploymentId(v string) *RollbackInfo {
+	s.RollbackDeploymentId = &v
+	return s
+}
+
+// SetRollbackMessage sets the RollbackMessage field's value.
+func (s *RollbackInfo) SetRollbackMessage(v string) *RollbackInfo {
+	s.RollbackMessage = &v
+	return s
+}
+
+// SetRollbackTriggeringDeploymentId sets the RollbackTriggeringDeploymentId field's value.
+func (s *RollbackInfo) SetRollbackTriggeringDeploymentId(v string) *RollbackInfo {
+	s.RollbackTriggeringDeploymentId = &v
+	return s
 }
 
 // Information about the location of application artifacts stored in Amazon
@@ -5812,6 +7054,36 @@ func (s S3Location) GoString() string {
 	return s.String()
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *S3Location) SetBucket(v string) *S3Location {
+	s.Bucket = &v
+	return s
+}
+
+// SetBundleType sets the BundleType field's value.
+func (s *S3Location) SetBundleType(v string) *S3Location {
+	s.BundleType = &v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *S3Location) SetETag(v string) *S3Location {
+	s.ETag = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *S3Location) SetKey(v string) *S3Location {
+	s.Key = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *S3Location) SetVersion(v string) *S3Location {
+	s.Version = &v
+	return s
+}
+
 // Represents the input of a stop deployment operation.
 type StopDeploymentInput struct {
 	_ struct{} `type:"structure"`
@@ -5850,6 +7122,18 @@ func (s *StopDeploymentInput) Validate() error {
 	return nil
 }
 
+// SetAutoRollbackEnabled sets the AutoRollbackEnabled field's value.
+func (s *StopDeploymentInput) SetAutoRollbackEnabled(v bool) *StopDeploymentInput {
+	s.AutoRollbackEnabled = &v
+	return s
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *StopDeploymentInput) SetDeploymentId(v string) *StopDeploymentInput {
+	s.DeploymentId = &v
+	return s
+}
+
 // Represents the output of a stop deployment operation.
 type StopDeploymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5875,6 +7159,18 @@ func (s StopDeploymentOutput) GoString() string {
 	return s.String()
 }
 
+// SetStatus sets the Status field's value.
+func (s *StopDeploymentOutput) SetStatus(v string) *StopDeploymentOutput {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *StopDeploymentOutput) SetStatusMessage(v string) *StopDeploymentOutput {
+	s.StatusMessage = &v
+	return s
+}
+
 // Information about a tag.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -5894,6 +7190,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // Information about an on-premises instance tag filter.
@@ -5926,6 +7234,24 @@ func (s TagFilter) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *TagFilter) SetKey(v string) *TagFilter {
+	s.Key = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *TagFilter) SetType(v string) *TagFilter {
+	s.Type = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *TagFilter) SetValue(v string) *TagFilter {
+	s.Value = &v
+	return s
+}
+
 // Information about a time range.
 type TimeRange struct {
 	_ struct{} `type:"structure"`
@@ -5951,6 +7277,18 @@ func (s TimeRange) GoString() string {
 	return s.String()
 }
 
+// SetEnd sets the End field's value.
+func (s *TimeRange) SetEnd(v time.Time) *TimeRange {
+	s.End = &v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *TimeRange) SetStart(v time.Time) *TimeRange {
+	s.Start = &v
+	return s
+}
+
 // Information about notification triggers for the deployment group.
 type TriggerConfig struct {
 	_ struct{} `type:"structure"`
@@ -5974,6 +7312,24 @@ func (s TriggerConfig) String() string {
 // GoString returns the string representation
 func (s TriggerConfig) GoString() string {
 	return s.String()
+}
+
+// SetTriggerEvents sets the TriggerEvents field's value.
+func (s *TriggerConfig) SetTriggerEvents(v []*string) *TriggerConfig {
+	s.TriggerEvents = v
+	return s
+}
+
+// SetTriggerName sets the TriggerName field's value.
+func (s *TriggerConfig) SetTriggerName(v string) *TriggerConfig {
+	s.TriggerName = &v
+	return s
+}
+
+// SetTriggerTargetArn sets the TriggerTargetArn field's value.
+func (s *TriggerConfig) SetTriggerTargetArn(v string) *TriggerConfig {
+	s.TriggerTargetArn = &v
+	return s
 }
 
 // Represents the input of an update application operation.
@@ -6011,6 +7367,18 @@ func (s *UpdateApplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *UpdateApplicationInput) SetApplicationName(v string) *UpdateApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetNewApplicationName sets the NewApplicationName field's value.
+func (s *UpdateApplicationInput) SetNewApplicationName(v string) *UpdateApplicationInput {
+	s.NewApplicationName = &v
+	return s
 }
 
 type UpdateApplicationOutput struct {
@@ -6119,6 +7487,72 @@ func (s *UpdateDeploymentGroupInput) Validate() error {
 	return nil
 }
 
+// SetAlarmConfiguration sets the AlarmConfiguration field's value.
+func (s *UpdateDeploymentGroupInput) SetAlarmConfiguration(v *AlarmConfiguration) *UpdateDeploymentGroupInput {
+	s.AlarmConfiguration = v
+	return s
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *UpdateDeploymentGroupInput) SetApplicationName(v string) *UpdateDeploymentGroupInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetAutoRollbackConfiguration sets the AutoRollbackConfiguration field's value.
+func (s *UpdateDeploymentGroupInput) SetAutoRollbackConfiguration(v *AutoRollbackConfiguration) *UpdateDeploymentGroupInput {
+	s.AutoRollbackConfiguration = v
+	return s
+}
+
+// SetAutoScalingGroups sets the AutoScalingGroups field's value.
+func (s *UpdateDeploymentGroupInput) SetAutoScalingGroups(v []*string) *UpdateDeploymentGroupInput {
+	s.AutoScalingGroups = v
+	return s
+}
+
+// SetCurrentDeploymentGroupName sets the CurrentDeploymentGroupName field's value.
+func (s *UpdateDeploymentGroupInput) SetCurrentDeploymentGroupName(v string) *UpdateDeploymentGroupInput {
+	s.CurrentDeploymentGroupName = &v
+	return s
+}
+
+// SetDeploymentConfigName sets the DeploymentConfigName field's value.
+func (s *UpdateDeploymentGroupInput) SetDeploymentConfigName(v string) *UpdateDeploymentGroupInput {
+	s.DeploymentConfigName = &v
+	return s
+}
+
+// SetEc2TagFilters sets the Ec2TagFilters field's value.
+func (s *UpdateDeploymentGroupInput) SetEc2TagFilters(v []*EC2TagFilter) *UpdateDeploymentGroupInput {
+	s.Ec2TagFilters = v
+	return s
+}
+
+// SetNewDeploymentGroupName sets the NewDeploymentGroupName field's value.
+func (s *UpdateDeploymentGroupInput) SetNewDeploymentGroupName(v string) *UpdateDeploymentGroupInput {
+	s.NewDeploymentGroupName = &v
+	return s
+}
+
+// SetOnPremisesInstanceTagFilters sets the OnPremisesInstanceTagFilters field's value.
+func (s *UpdateDeploymentGroupInput) SetOnPremisesInstanceTagFilters(v []*TagFilter) *UpdateDeploymentGroupInput {
+	s.OnPremisesInstanceTagFilters = v
+	return s
+}
+
+// SetServiceRoleArn sets the ServiceRoleArn field's value.
+func (s *UpdateDeploymentGroupInput) SetServiceRoleArn(v string) *UpdateDeploymentGroupInput {
+	s.ServiceRoleArn = &v
+	return s
+}
+
+// SetTriggerConfigurations sets the TriggerConfigurations field's value.
+func (s *UpdateDeploymentGroupInput) SetTriggerConfigurations(v []*TriggerConfig) *UpdateDeploymentGroupInput {
+	s.TriggerConfigurations = v
+	return s
+}
+
 // Represents the output of an update deployment group operation.
 type UpdateDeploymentGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -6139,6 +7573,12 @@ func (s UpdateDeploymentGroupOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDeploymentGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetHooksNotCleanedUp sets the HooksNotCleanedUp field's value.
+func (s *UpdateDeploymentGroupOutput) SetHooksNotCleanedUp(v []*AutoScalingGroup) *UpdateDeploymentGroupOutput {
+	s.HooksNotCleanedUp = v
+	return s
 }
 
 const (

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -1945,6 +1945,24 @@ func (s AWSSessionCredentials) GoString() string {
 	return s.String()
 }
 
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *AWSSessionCredentials) SetAccessKeyId(v string) *AWSSessionCredentials {
+	s.AccessKeyId = &v
+	return s
+}
+
+// SetSecretAccessKey sets the SecretAccessKey field's value.
+func (s *AWSSessionCredentials) SetSecretAccessKey(v string) *AWSSessionCredentials {
+	s.SecretAccessKey = &v
+	return s
+}
+
+// SetSessionToken sets the SessionToken field's value.
+func (s *AWSSessionCredentials) SetSessionToken(v string) *AWSSessionCredentials {
+	s.SessionToken = &v
+	return s
+}
+
 // Represents the input of an acknowledge job action.
 type AcknowledgeJobInput struct {
 	_ struct{} `type:"structure"`
@@ -1988,6 +2006,18 @@ func (s *AcknowledgeJobInput) Validate() error {
 	return nil
 }
 
+// SetJobId sets the JobId field's value.
+func (s *AcknowledgeJobInput) SetJobId(v string) *AcknowledgeJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetNonce sets the Nonce field's value.
+func (s *AcknowledgeJobInput) SetNonce(v string) *AcknowledgeJobInput {
+	s.Nonce = &v
+	return s
+}
+
 // Represents the output of an acknowledge job action.
 type AcknowledgeJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -2004,6 +2034,12 @@ func (s AcknowledgeJobOutput) String() string {
 // GoString returns the string representation
 func (s AcknowledgeJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *AcknowledgeJobOutput) SetStatus(v string) *AcknowledgeJobOutput {
+	s.Status = &v
+	return s
 }
 
 // Represents the input of an acknowledge third party job action.
@@ -2061,6 +2097,24 @@ func (s *AcknowledgeThirdPartyJobInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *AcknowledgeThirdPartyJobInput) SetClientToken(v string) *AcknowledgeThirdPartyJobInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *AcknowledgeThirdPartyJobInput) SetJobId(v string) *AcknowledgeThirdPartyJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetNonce sets the Nonce field's value.
+func (s *AcknowledgeThirdPartyJobInput) SetNonce(v string) *AcknowledgeThirdPartyJobInput {
+	s.Nonce = &v
+	return s
+}
+
 // Represents the output of an acknowledge third party job action.
 type AcknowledgeThirdPartyJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -2079,6 +2133,12 @@ func (s AcknowledgeThirdPartyJobOutput) GoString() string {
 	return s.String()
 }
 
+// SetStatus sets the Status field's value.
+func (s *AcknowledgeThirdPartyJobOutput) SetStatus(v string) *AcknowledgeThirdPartyJobOutput {
+	s.Status = &v
+	return s
+}
+
 // Represents information about an action configuration.
 type ActionConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -2095,6 +2155,12 @@ func (s ActionConfiguration) String() string {
 // GoString returns the string representation
 func (s ActionConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *ActionConfiguration) SetConfiguration(v map[string]*string) *ActionConfiguration {
+	s.Configuration = v
+	return s
 }
 
 // Represents information about an action configuration property.
@@ -2183,6 +2249,48 @@ func (s *ActionConfigurationProperty) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *ActionConfigurationProperty) SetDescription(v string) *ActionConfigurationProperty {
+	s.Description = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *ActionConfigurationProperty) SetKey(v bool) *ActionConfigurationProperty {
+	s.Key = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ActionConfigurationProperty) SetName(v string) *ActionConfigurationProperty {
+	s.Name = &v
+	return s
+}
+
+// SetQueryable sets the Queryable field's value.
+func (s *ActionConfigurationProperty) SetQueryable(v bool) *ActionConfigurationProperty {
+	s.Queryable = &v
+	return s
+}
+
+// SetRequired sets the Required field's value.
+func (s *ActionConfigurationProperty) SetRequired(v bool) *ActionConfigurationProperty {
+	s.Required = &v
+	return s
+}
+
+// SetSecret sets the Secret field's value.
+func (s *ActionConfigurationProperty) SetSecret(v bool) *ActionConfigurationProperty {
+	s.Secret = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ActionConfigurationProperty) SetType(v string) *ActionConfigurationProperty {
+	s.Type = &v
+	return s
+}
+
 // Represents the context of an action within the stage of a pipeline to a job
 // worker.
 type ActionContext struct {
@@ -2200,6 +2308,12 @@ func (s ActionContext) String() string {
 // GoString returns the string representation
 func (s ActionContext) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *ActionContext) SetName(v string) *ActionContext {
+	s.Name = &v
+	return s
 }
 
 // Represents information about an action declaration.
@@ -2292,6 +2406,48 @@ func (s *ActionDeclaration) Validate() error {
 	return nil
 }
 
+// SetActionTypeId sets the ActionTypeId field's value.
+func (s *ActionDeclaration) SetActionTypeId(v *ActionTypeId) *ActionDeclaration {
+	s.ActionTypeId = v
+	return s
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *ActionDeclaration) SetConfiguration(v map[string]*string) *ActionDeclaration {
+	s.Configuration = v
+	return s
+}
+
+// SetInputArtifacts sets the InputArtifacts field's value.
+func (s *ActionDeclaration) SetInputArtifacts(v []*InputArtifact) *ActionDeclaration {
+	s.InputArtifacts = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ActionDeclaration) SetName(v string) *ActionDeclaration {
+	s.Name = &v
+	return s
+}
+
+// SetOutputArtifacts sets the OutputArtifacts field's value.
+func (s *ActionDeclaration) SetOutputArtifacts(v []*OutputArtifact) *ActionDeclaration {
+	s.OutputArtifacts = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *ActionDeclaration) SetRoleArn(v string) *ActionDeclaration {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRunOrder sets the RunOrder field's value.
+func (s *ActionDeclaration) SetRunOrder(v int64) *ActionDeclaration {
+	s.RunOrder = &v
+	return s
+}
+
 // Represents information about the run of an action.
 type ActionExecution struct {
 	_ struct{} `type:"structure"`
@@ -2337,6 +2493,60 @@ func (s ActionExecution) String() string {
 // GoString returns the string representation
 func (s ActionExecution) GoString() string {
 	return s.String()
+}
+
+// SetErrorDetails sets the ErrorDetails field's value.
+func (s *ActionExecution) SetErrorDetails(v *ErrorDetails) *ActionExecution {
+	s.ErrorDetails = v
+	return s
+}
+
+// SetExternalExecutionId sets the ExternalExecutionId field's value.
+func (s *ActionExecution) SetExternalExecutionId(v string) *ActionExecution {
+	s.ExternalExecutionId = &v
+	return s
+}
+
+// SetExternalExecutionUrl sets the ExternalExecutionUrl field's value.
+func (s *ActionExecution) SetExternalExecutionUrl(v string) *ActionExecution {
+	s.ExternalExecutionUrl = &v
+	return s
+}
+
+// SetLastStatusChange sets the LastStatusChange field's value.
+func (s *ActionExecution) SetLastStatusChange(v time.Time) *ActionExecution {
+	s.LastStatusChange = &v
+	return s
+}
+
+// SetLastUpdatedBy sets the LastUpdatedBy field's value.
+func (s *ActionExecution) SetLastUpdatedBy(v string) *ActionExecution {
+	s.LastUpdatedBy = &v
+	return s
+}
+
+// SetPercentComplete sets the PercentComplete field's value.
+func (s *ActionExecution) SetPercentComplete(v int64) *ActionExecution {
+	s.PercentComplete = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ActionExecution) SetStatus(v string) *ActionExecution {
+	s.Status = &v
+	return s
+}
+
+// SetSummary sets the Summary field's value.
+func (s *ActionExecution) SetSummary(v string) *ActionExecution {
+	s.Summary = &v
+	return s
+}
+
+// SetToken sets the Token field's value.
+func (s *ActionExecution) SetToken(v string) *ActionExecution {
+	s.Token = &v
+	return s
 }
 
 // Represents information about the version (or revision) of an action.
@@ -2397,6 +2607,24 @@ func (s *ActionRevision) Validate() error {
 	return nil
 }
 
+// SetCreated sets the Created field's value.
+func (s *ActionRevision) SetCreated(v time.Time) *ActionRevision {
+	s.Created = &v
+	return s
+}
+
+// SetRevisionChangeId sets the RevisionChangeId field's value.
+func (s *ActionRevision) SetRevisionChangeId(v string) *ActionRevision {
+	s.RevisionChangeId = &v
+	return s
+}
+
+// SetRevisionId sets the RevisionId field's value.
+func (s *ActionRevision) SetRevisionId(v string) *ActionRevision {
+	s.RevisionId = &v
+	return s
+}
+
 // Represents information about the state of an action.
 type ActionState struct {
 	_ struct{} `type:"structure"`
@@ -2427,6 +2655,36 @@ func (s ActionState) String() string {
 // GoString returns the string representation
 func (s ActionState) GoString() string {
 	return s.String()
+}
+
+// SetActionName sets the ActionName field's value.
+func (s *ActionState) SetActionName(v string) *ActionState {
+	s.ActionName = &v
+	return s
+}
+
+// SetCurrentRevision sets the CurrentRevision field's value.
+func (s *ActionState) SetCurrentRevision(v *ActionRevision) *ActionState {
+	s.CurrentRevision = v
+	return s
+}
+
+// SetEntityUrl sets the EntityUrl field's value.
+func (s *ActionState) SetEntityUrl(v string) *ActionState {
+	s.EntityUrl = &v
+	return s
+}
+
+// SetLatestExecution sets the LatestExecution field's value.
+func (s *ActionState) SetLatestExecution(v *ActionExecution) *ActionState {
+	s.LatestExecution = v
+	return s
+}
+
+// SetRevisionUrl sets the RevisionUrl field's value.
+func (s *ActionState) SetRevisionUrl(v string) *ActionState {
+	s.RevisionUrl = &v
+	return s
 }
 
 // Returns information about the details of an action type.
@@ -2463,6 +2721,36 @@ func (s ActionType) String() string {
 // GoString returns the string representation
 func (s ActionType) GoString() string {
 	return s.String()
+}
+
+// SetActionConfigurationProperties sets the ActionConfigurationProperties field's value.
+func (s *ActionType) SetActionConfigurationProperties(v []*ActionConfigurationProperty) *ActionType {
+	s.ActionConfigurationProperties = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ActionType) SetId(v *ActionTypeId) *ActionType {
+	s.Id = v
+	return s
+}
+
+// SetInputArtifactDetails sets the InputArtifactDetails field's value.
+func (s *ActionType) SetInputArtifactDetails(v *ArtifactDetails) *ActionType {
+	s.InputArtifactDetails = v
+	return s
+}
+
+// SetOutputArtifactDetails sets the OutputArtifactDetails field's value.
+func (s *ActionType) SetOutputArtifactDetails(v *ArtifactDetails) *ActionType {
+	s.OutputArtifactDetails = v
+	return s
+}
+
+// SetSettings sets the Settings field's value.
+func (s *ActionType) SetSettings(v *ActionTypeSettings) *ActionType {
+	s.Settings = v
+	return s
 }
 
 // Represents information about an action type.
@@ -2533,6 +2821,30 @@ func (s *ActionTypeId) Validate() error {
 	return nil
 }
 
+// SetCategory sets the Category field's value.
+func (s *ActionTypeId) SetCategory(v string) *ActionTypeId {
+	s.Category = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *ActionTypeId) SetOwner(v string) *ActionTypeId {
+	s.Owner = &v
+	return s
+}
+
+// SetProvider sets the Provider field's value.
+func (s *ActionTypeId) SetProvider(v string) *ActionTypeId {
+	s.Provider = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *ActionTypeId) SetVersion(v string) *ActionTypeId {
+	s.Version = &v
+	return s
+}
+
 // Returns information about the settings for an action type.
 type ActionTypeSettings struct {
 	_ struct{} `type:"structure"`
@@ -2592,6 +2904,30 @@ func (s *ActionTypeSettings) Validate() error {
 	return nil
 }
 
+// SetEntityUrlTemplate sets the EntityUrlTemplate field's value.
+func (s *ActionTypeSettings) SetEntityUrlTemplate(v string) *ActionTypeSettings {
+	s.EntityUrlTemplate = &v
+	return s
+}
+
+// SetExecutionUrlTemplate sets the ExecutionUrlTemplate field's value.
+func (s *ActionTypeSettings) SetExecutionUrlTemplate(v string) *ActionTypeSettings {
+	s.ExecutionUrlTemplate = &v
+	return s
+}
+
+// SetRevisionUrlTemplate sets the RevisionUrlTemplate field's value.
+func (s *ActionTypeSettings) SetRevisionUrlTemplate(v string) *ActionTypeSettings {
+	s.RevisionUrlTemplate = &v
+	return s
+}
+
+// SetThirdPartyConfigurationUrl sets the ThirdPartyConfigurationUrl field's value.
+func (s *ActionTypeSettings) SetThirdPartyConfigurationUrl(v string) *ActionTypeSettings {
+	s.ThirdPartyConfigurationUrl = &v
+	return s
+}
+
 // Represents information about the result of an approval request.
 type ApprovalResult struct {
 	_ struct{} `type:"structure"`
@@ -2633,6 +2969,18 @@ func (s *ApprovalResult) Validate() error {
 	return nil
 }
 
+// SetStatus sets the Status field's value.
+func (s *ApprovalResult) SetStatus(v string) *ApprovalResult {
+	s.Status = &v
+	return s
+}
+
+// SetSummary sets the Summary field's value.
+func (s *ApprovalResult) SetSummary(v string) *ApprovalResult {
+	s.Summary = &v
+	return s
+}
+
 // Represents information about an artifact that will be worked upon by actions
 // in the pipeline.
 type Artifact struct {
@@ -2657,6 +3005,24 @@ func (s Artifact) String() string {
 // GoString returns the string representation
 func (s Artifact) GoString() string {
 	return s.String()
+}
+
+// SetLocation sets the Location field's value.
+func (s *Artifact) SetLocation(v *ArtifactLocation) *Artifact {
+	s.Location = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Artifact) SetName(v string) *Artifact {
+	s.Name = &v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *Artifact) SetRevision(v string) *Artifact {
+	s.Revision = &v
+	return s
 }
 
 // Returns information about the details of an artifact.
@@ -2700,6 +3066,18 @@ func (s *ArtifactDetails) Validate() error {
 	return nil
 }
 
+// SetMaximumCount sets the MaximumCount field's value.
+func (s *ArtifactDetails) SetMaximumCount(v int64) *ArtifactDetails {
+	s.MaximumCount = &v
+	return s
+}
+
+// SetMinimumCount sets the MinimumCount field's value.
+func (s *ArtifactDetails) SetMinimumCount(v int64) *ArtifactDetails {
+	s.MinimumCount = &v
+	return s
+}
+
 // Represents information about the location of an artifact.
 type ArtifactLocation struct {
 	_ struct{} `type:"structure"`
@@ -2719,6 +3097,18 @@ func (s ArtifactLocation) String() string {
 // GoString returns the string representation
 func (s ArtifactLocation) GoString() string {
 	return s.String()
+}
+
+// SetS3Location sets the S3Location field's value.
+func (s *ArtifactLocation) SetS3Location(v *S3ArtifactLocation) *ArtifactLocation {
+	s.S3Location = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ArtifactLocation) SetType(v string) *ArtifactLocation {
+	s.Type = &v
+	return s
 }
 
 // Represents revision details of an artifact.
@@ -2760,6 +3150,42 @@ func (s ArtifactRevision) String() string {
 // GoString returns the string representation
 func (s ArtifactRevision) GoString() string {
 	return s.String()
+}
+
+// SetCreated sets the Created field's value.
+func (s *ArtifactRevision) SetCreated(v time.Time) *ArtifactRevision {
+	s.Created = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ArtifactRevision) SetName(v string) *ArtifactRevision {
+	s.Name = &v
+	return s
+}
+
+// SetRevisionChangeIdentifier sets the RevisionChangeIdentifier field's value.
+func (s *ArtifactRevision) SetRevisionChangeIdentifier(v string) *ArtifactRevision {
+	s.RevisionChangeIdentifier = &v
+	return s
+}
+
+// SetRevisionId sets the RevisionId field's value.
+func (s *ArtifactRevision) SetRevisionId(v string) *ArtifactRevision {
+	s.RevisionId = &v
+	return s
+}
+
+// SetRevisionSummary sets the RevisionSummary field's value.
+func (s *ArtifactRevision) SetRevisionSummary(v string) *ArtifactRevision {
+	s.RevisionSummary = &v
+	return s
+}
+
+// SetRevisionUrl sets the RevisionUrl field's value.
+func (s *ArtifactRevision) SetRevisionUrl(v string) *ArtifactRevision {
+	s.RevisionUrl = &v
+	return s
 }
 
 // The Amazon S3 location where artifacts are stored for the pipeline. If this
@@ -2819,6 +3245,24 @@ func (s *ArtifactStore) Validate() error {
 	return nil
 }
 
+// SetEncryptionKey sets the EncryptionKey field's value.
+func (s *ArtifactStore) SetEncryptionKey(v *EncryptionKey) *ArtifactStore {
+	s.EncryptionKey = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *ArtifactStore) SetLocation(v string) *ArtifactStore {
+	s.Location = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ArtifactStore) SetType(v string) *ArtifactStore {
+	s.Type = &v
+	return s
+}
+
 // Reserved for future use.
 type BlockerDeclaration struct {
 	_ struct{} `type:"structure"`
@@ -2861,6 +3305,18 @@ func (s *BlockerDeclaration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *BlockerDeclaration) SetName(v string) *BlockerDeclaration {
+	s.Name = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *BlockerDeclaration) SetType(v string) *BlockerDeclaration {
+	s.Type = &v
+	return s
 }
 
 // Represents the input of a create custom action operation.
@@ -2973,6 +3429,48 @@ func (s *CreateCustomActionTypeInput) Validate() error {
 	return nil
 }
 
+// SetCategory sets the Category field's value.
+func (s *CreateCustomActionTypeInput) SetCategory(v string) *CreateCustomActionTypeInput {
+	s.Category = &v
+	return s
+}
+
+// SetConfigurationProperties sets the ConfigurationProperties field's value.
+func (s *CreateCustomActionTypeInput) SetConfigurationProperties(v []*ActionConfigurationProperty) *CreateCustomActionTypeInput {
+	s.ConfigurationProperties = v
+	return s
+}
+
+// SetInputArtifactDetails sets the InputArtifactDetails field's value.
+func (s *CreateCustomActionTypeInput) SetInputArtifactDetails(v *ArtifactDetails) *CreateCustomActionTypeInput {
+	s.InputArtifactDetails = v
+	return s
+}
+
+// SetOutputArtifactDetails sets the OutputArtifactDetails field's value.
+func (s *CreateCustomActionTypeInput) SetOutputArtifactDetails(v *ArtifactDetails) *CreateCustomActionTypeInput {
+	s.OutputArtifactDetails = v
+	return s
+}
+
+// SetProvider sets the Provider field's value.
+func (s *CreateCustomActionTypeInput) SetProvider(v string) *CreateCustomActionTypeInput {
+	s.Provider = &v
+	return s
+}
+
+// SetSettings sets the Settings field's value.
+func (s *CreateCustomActionTypeInput) SetSettings(v *ActionTypeSettings) *CreateCustomActionTypeInput {
+	s.Settings = v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *CreateCustomActionTypeInput) SetVersion(v string) *CreateCustomActionTypeInput {
+	s.Version = &v
+	return s
+}
+
 // Represents the output of a create custom action operation.
 type CreateCustomActionTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -2991,6 +3489,12 @@ func (s CreateCustomActionTypeOutput) String() string {
 // GoString returns the string representation
 func (s CreateCustomActionTypeOutput) GoString() string {
 	return s.String()
+}
+
+// SetActionType sets the ActionType field's value.
+func (s *CreateCustomActionTypeOutput) SetActionType(v *ActionType) *CreateCustomActionTypeOutput {
+	s.ActionType = v
+	return s
 }
 
 // Represents the input of a create pipeline action.
@@ -3031,6 +3535,12 @@ func (s *CreatePipelineInput) Validate() error {
 	return nil
 }
 
+// SetPipeline sets the Pipeline field's value.
+func (s *CreatePipelineInput) SetPipeline(v *PipelineDeclaration) *CreatePipelineInput {
+	s.Pipeline = v
+	return s
+}
+
 // Represents the output of a create pipeline action.
 type CreatePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -3047,6 +3557,12 @@ func (s CreatePipelineOutput) String() string {
 // GoString returns the string representation
 func (s CreatePipelineOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipeline sets the Pipeline field's value.
+func (s *CreatePipelineOutput) SetPipeline(v *PipelineDeclaration) *CreatePipelineOutput {
+	s.Pipeline = v
+	return s
 }
 
 // Represents information about a current revision.
@@ -3106,6 +3622,30 @@ func (s *CurrentRevision) Validate() error {
 	return nil
 }
 
+// SetChangeIdentifier sets the ChangeIdentifier field's value.
+func (s *CurrentRevision) SetChangeIdentifier(v string) *CurrentRevision {
+	s.ChangeIdentifier = &v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *CurrentRevision) SetCreated(v time.Time) *CurrentRevision {
+	s.Created = &v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *CurrentRevision) SetRevision(v string) *CurrentRevision {
+	s.Revision = &v
+	return s
+}
+
+// SetRevisionSummary sets the RevisionSummary field's value.
+func (s *CurrentRevision) SetRevisionSummary(v string) *CurrentRevision {
+	s.RevisionSummary = &v
+	return s
+}
+
 // Represents the input of a delete custom action operation. The custom action
 // will be marked as deleted.
 type DeleteCustomActionTypeInput struct {
@@ -3163,6 +3703,24 @@ func (s *DeleteCustomActionTypeInput) Validate() error {
 	return nil
 }
 
+// SetCategory sets the Category field's value.
+func (s *DeleteCustomActionTypeInput) SetCategory(v string) *DeleteCustomActionTypeInput {
+	s.Category = &v
+	return s
+}
+
+// SetProvider sets the Provider field's value.
+func (s *DeleteCustomActionTypeInput) SetProvider(v string) *DeleteCustomActionTypeInput {
+	s.Provider = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *DeleteCustomActionTypeInput) SetVersion(v string) *DeleteCustomActionTypeInput {
+	s.Version = &v
+	return s
+}
+
 type DeleteCustomActionTypeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3211,6 +3769,12 @@ func (s *DeletePipelineInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DeletePipelineInput) SetName(v string) *DeletePipelineInput {
+	s.Name = &v
+	return s
 }
 
 type DeletePipelineOutput struct {
@@ -3300,6 +3864,30 @@ func (s *DisableStageTransitionInput) Validate() error {
 	return nil
 }
 
+// SetPipelineName sets the PipelineName field's value.
+func (s *DisableStageTransitionInput) SetPipelineName(v string) *DisableStageTransitionInput {
+	s.PipelineName = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *DisableStageTransitionInput) SetReason(v string) *DisableStageTransitionInput {
+	s.Reason = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *DisableStageTransitionInput) SetStageName(v string) *DisableStageTransitionInput {
+	s.StageName = &v
+	return s
+}
+
+// SetTransitionType sets the TransitionType field's value.
+func (s *DisableStageTransitionInput) SetTransitionType(v string) *DisableStageTransitionInput {
+	s.TransitionType = &v
+	return s
+}
+
 type DisableStageTransitionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3373,6 +3961,24 @@ func (s *EnableStageTransitionInput) Validate() error {
 	return nil
 }
 
+// SetPipelineName sets the PipelineName field's value.
+func (s *EnableStageTransitionInput) SetPipelineName(v string) *EnableStageTransitionInput {
+	s.PipelineName = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *EnableStageTransitionInput) SetStageName(v string) *EnableStageTransitionInput {
+	s.StageName = &v
+	return s
+}
+
+// SetTransitionType sets the TransitionType field's value.
+func (s *EnableStageTransitionInput) SetTransitionType(v string) *EnableStageTransitionInput {
+	s.TransitionType = &v
+	return s
+}
+
 type EnableStageTransitionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3434,6 +4040,18 @@ func (s *EncryptionKey) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *EncryptionKey) SetId(v string) *EncryptionKey {
+	s.Id = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *EncryptionKey) SetType(v string) *EncryptionKey {
+	s.Type = &v
+	return s
+}
+
 // Represents information about an error in AWS CodePipeline.
 type ErrorDetails struct {
 	_ struct{} `type:"structure"`
@@ -3453,6 +4071,18 @@ func (s ErrorDetails) String() string {
 // GoString returns the string representation
 func (s ErrorDetails) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *ErrorDetails) SetCode(v string) *ErrorDetails {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *ErrorDetails) SetMessage(v string) *ErrorDetails {
+	s.Message = &v
+	return s
 }
 
 // The details of the actions taken and results produced on an artifact as it
@@ -3493,6 +4123,24 @@ func (s *ExecutionDetails) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetExternalExecutionId sets the ExternalExecutionId field's value.
+func (s *ExecutionDetails) SetExternalExecutionId(v string) *ExecutionDetails {
+	s.ExternalExecutionId = &v
+	return s
+}
+
+// SetPercentComplete sets the PercentComplete field's value.
+func (s *ExecutionDetails) SetPercentComplete(v int64) *ExecutionDetails {
+	s.PercentComplete = &v
+	return s
+}
+
+// SetSummary sets the Summary field's value.
+func (s *ExecutionDetails) SetSummary(v string) *ExecutionDetails {
+	s.Summary = &v
+	return s
 }
 
 // Represents information about failure details.
@@ -3542,6 +4190,24 @@ func (s *FailureDetails) Validate() error {
 	return nil
 }
 
+// SetExternalExecutionId sets the ExternalExecutionId field's value.
+func (s *FailureDetails) SetExternalExecutionId(v string) *FailureDetails {
+	s.ExternalExecutionId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *FailureDetails) SetMessage(v string) *FailureDetails {
+	s.Message = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *FailureDetails) SetType(v string) *FailureDetails {
+	s.Type = &v
+	return s
+}
+
 // Represents the input of a get job details action.
 type GetJobDetailsInput struct {
 	_ struct{} `type:"structure"`
@@ -3575,6 +4241,12 @@ func (s *GetJobDetailsInput) Validate() error {
 	return nil
 }
 
+// SetJobId sets the JobId field's value.
+func (s *GetJobDetailsInput) SetJobId(v string) *GetJobDetailsInput {
+	s.JobId = &v
+	return s
+}
+
 // Represents the output of a get job details action.
 type GetJobDetailsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3594,6 +4266,12 @@ func (s GetJobDetailsOutput) String() string {
 // GoString returns the string representation
 func (s GetJobDetailsOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobDetails sets the JobDetails field's value.
+func (s *GetJobDetailsOutput) SetJobDetails(v *JobDetails) *GetJobDetailsOutput {
+	s.JobDetails = v
+	return s
 }
 
 // Represents the input of a get pipeline execution action.
@@ -3640,6 +4318,18 @@ func (s *GetPipelineExecutionInput) Validate() error {
 	return nil
 }
 
+// SetPipelineExecutionId sets the PipelineExecutionId field's value.
+func (s *GetPipelineExecutionInput) SetPipelineExecutionId(v string) *GetPipelineExecutionInput {
+	s.PipelineExecutionId = &v
+	return s
+}
+
+// SetPipelineName sets the PipelineName field's value.
+func (s *GetPipelineExecutionInput) SetPipelineName(v string) *GetPipelineExecutionInput {
+	s.PipelineName = &v
+	return s
+}
+
 // Represents the output of a get pipeline execution action.
 type GetPipelineExecutionOutput struct {
 	_ struct{} `type:"structure"`
@@ -3656,6 +4346,12 @@ func (s GetPipelineExecutionOutput) String() string {
 // GoString returns the string representation
 func (s GetPipelineExecutionOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipelineExecution sets the PipelineExecution field's value.
+func (s *GetPipelineExecutionOutput) SetPipelineExecution(v *PipelineExecution) *GetPipelineExecutionOutput {
+	s.PipelineExecution = v
+	return s
 }
 
 // Represents the input of a get pipeline action.
@@ -3702,6 +4398,18 @@ func (s *GetPipelineInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *GetPipelineInput) SetName(v string) *GetPipelineInput {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *GetPipelineInput) SetVersion(v int64) *GetPipelineInput {
+	s.Version = &v
+	return s
+}
+
 // Represents the output of a get pipeline action.
 type GetPipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -3718,6 +4426,12 @@ func (s GetPipelineOutput) String() string {
 // GoString returns the string representation
 func (s GetPipelineOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipeline sets the Pipeline field's value.
+func (s *GetPipelineOutput) SetPipeline(v *PipelineDeclaration) *GetPipelineOutput {
+	s.Pipeline = v
+	return s
 }
 
 // Represents the input of a get pipeline state action.
@@ -3756,6 +4470,12 @@ func (s *GetPipelineStateInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *GetPipelineStateInput) SetName(v string) *GetPipelineStateInput {
+	s.Name = &v
+	return s
+}
+
 // Represents the output of a get pipeline state action.
 type GetPipelineStateOutput struct {
 	_ struct{} `type:"structure"`
@@ -3787,6 +4507,36 @@ func (s GetPipelineStateOutput) String() string {
 // GoString returns the string representation
 func (s GetPipelineStateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCreated sets the Created field's value.
+func (s *GetPipelineStateOutput) SetCreated(v time.Time) *GetPipelineStateOutput {
+	s.Created = &v
+	return s
+}
+
+// SetPipelineName sets the PipelineName field's value.
+func (s *GetPipelineStateOutput) SetPipelineName(v string) *GetPipelineStateOutput {
+	s.PipelineName = &v
+	return s
+}
+
+// SetPipelineVersion sets the PipelineVersion field's value.
+func (s *GetPipelineStateOutput) SetPipelineVersion(v int64) *GetPipelineStateOutput {
+	s.PipelineVersion = &v
+	return s
+}
+
+// SetStageStates sets the StageStates field's value.
+func (s *GetPipelineStateOutput) SetStageStates(v []*StageState) *GetPipelineStateOutput {
+	s.StageStates = v
+	return s
+}
+
+// SetUpdated sets the Updated field's value.
+func (s *GetPipelineStateOutput) SetUpdated(v time.Time) *GetPipelineStateOutput {
+	s.Updated = &v
+	return s
 }
 
 // Represents the input of a get third party job details action.
@@ -3834,6 +4584,18 @@ func (s *GetThirdPartyJobDetailsInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *GetThirdPartyJobDetailsInput) SetClientToken(v string) *GetThirdPartyJobDetailsInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *GetThirdPartyJobDetailsInput) SetJobId(v string) *GetThirdPartyJobDetailsInput {
+	s.JobId = &v
+	return s
+}
+
 // Represents the output of a get third party job details action.
 type GetThirdPartyJobDetailsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3850,6 +4612,12 @@ func (s GetThirdPartyJobDetailsOutput) String() string {
 // GoString returns the string representation
 func (s GetThirdPartyJobDetailsOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobDetails sets the JobDetails field's value.
+func (s *GetThirdPartyJobDetailsOutput) SetJobDetails(v *ThirdPartyJobDetails) *GetThirdPartyJobDetailsOutput {
+	s.JobDetails = v
+	return s
 }
 
 // Represents information about an artifact to be worked on, such as a test
@@ -3895,6 +4663,12 @@ func (s *InputArtifact) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *InputArtifact) SetName(v string) *InputArtifact {
+	s.Name = &v
+	return s
+}
+
 // Represents information about a job.
 type Job struct {
 	_ struct{} `type:"structure"`
@@ -3922,6 +4696,30 @@ func (s Job) String() string {
 // GoString returns the string representation
 func (s Job) GoString() string {
 	return s.String()
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *Job) SetAccountId(v string) *Job {
+	s.AccountId = &v
+	return s
+}
+
+// SetData sets the Data field's value.
+func (s *Job) SetData(v *JobData) *Job {
+	s.Data = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Job) SetId(v string) *Job {
+	s.Id = &v
+	return s
+}
+
+// SetNonce sets the Nonce field's value.
+func (s *Job) SetNonce(v string) *Job {
+	s.Nonce = &v
+	return s
 }
 
 // Represents additional information about a job required for a job worker to
@@ -3969,6 +4767,54 @@ func (s JobData) GoString() string {
 	return s.String()
 }
 
+// SetActionConfiguration sets the ActionConfiguration field's value.
+func (s *JobData) SetActionConfiguration(v *ActionConfiguration) *JobData {
+	s.ActionConfiguration = v
+	return s
+}
+
+// SetActionTypeId sets the ActionTypeId field's value.
+func (s *JobData) SetActionTypeId(v *ActionTypeId) *JobData {
+	s.ActionTypeId = v
+	return s
+}
+
+// SetArtifactCredentials sets the ArtifactCredentials field's value.
+func (s *JobData) SetArtifactCredentials(v *AWSSessionCredentials) *JobData {
+	s.ArtifactCredentials = v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *JobData) SetContinuationToken(v string) *JobData {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetEncryptionKey sets the EncryptionKey field's value.
+func (s *JobData) SetEncryptionKey(v *EncryptionKey) *JobData {
+	s.EncryptionKey = v
+	return s
+}
+
+// SetInputArtifacts sets the InputArtifacts field's value.
+func (s *JobData) SetInputArtifacts(v []*Artifact) *JobData {
+	s.InputArtifacts = v
+	return s
+}
+
+// SetOutputArtifacts sets the OutputArtifacts field's value.
+func (s *JobData) SetOutputArtifacts(v []*Artifact) *JobData {
+	s.OutputArtifacts = v
+	return s
+}
+
+// SetPipelineContext sets the PipelineContext field's value.
+func (s *JobData) SetPipelineContext(v *PipelineContext) *JobData {
+	s.PipelineContext = v
+	return s
+}
+
 // Represents information about the details of a job.
 type JobDetails struct {
 	_ struct{} `type:"structure"`
@@ -3994,6 +4840,24 @@ func (s JobDetails) GoString() string {
 	return s.String()
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *JobDetails) SetAccountId(v string) *JobDetails {
+	s.AccountId = &v
+	return s
+}
+
+// SetData sets the Data field's value.
+func (s *JobDetails) SetData(v *JobData) *JobDetails {
+	s.Data = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *JobDetails) SetId(v string) *JobDetails {
+	s.Id = &v
+	return s
+}
+
 // Represents the input of a list action types action.
 type ListActionTypesInput struct {
 	_ struct{} `type:"structure"`
@@ -4014,6 +4878,18 @@ func (s ListActionTypesInput) String() string {
 // GoString returns the string representation
 func (s ListActionTypesInput) GoString() string {
 	return s.String()
+}
+
+// SetActionOwnerFilter sets the ActionOwnerFilter field's value.
+func (s *ListActionTypesInput) SetActionOwnerFilter(v string) *ListActionTypesInput {
+	s.ActionOwnerFilter = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListActionTypesInput) SetNextToken(v string) *ListActionTypesInput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the output of a list action types action.
@@ -4041,6 +4917,18 @@ func (s ListActionTypesOutput) GoString() string {
 	return s.String()
 }
 
+// SetActionTypes sets the ActionTypes field's value.
+func (s *ListActionTypesOutput) SetActionTypes(v []*ActionType) *ListActionTypesOutput {
+	s.ActionTypes = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListActionTypesOutput) SetNextToken(v string) *ListActionTypesOutput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the input of a list pipelines action.
 type ListPipelinesInput struct {
 	_ struct{} `type:"structure"`
@@ -4058,6 +4946,12 @@ func (s ListPipelinesInput) String() string {
 // GoString returns the string representation
 func (s ListPipelinesInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPipelinesInput) SetNextToken(v string) *ListPipelinesInput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the output of a list pipelines action.
@@ -4081,6 +4975,18 @@ func (s ListPipelinesOutput) String() string {
 // GoString returns the string representation
 func (s ListPipelinesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPipelinesOutput) SetNextToken(v string) *ListPipelinesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPipelines sets the Pipelines field's value.
+func (s *ListPipelinesOutput) SetPipelines(v []*PipelineSummary) *ListPipelinesOutput {
+	s.Pipelines = v
+	return s
 }
 
 // Represents information about the output of an action.
@@ -4127,6 +5033,12 @@ func (s *OutputArtifact) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *OutputArtifact) SetName(v string) *OutputArtifact {
+	s.Name = &v
+	return s
+}
+
 // Represents information about a pipeline to a job worker.
 type PipelineContext struct {
 	_ struct{} `type:"structure"`
@@ -4151,6 +5063,24 @@ func (s PipelineContext) String() string {
 // GoString returns the string representation
 func (s PipelineContext) GoString() string {
 	return s.String()
+}
+
+// SetAction sets the Action field's value.
+func (s *PipelineContext) SetAction(v *ActionContext) *PipelineContext {
+	s.Action = v
+	return s
+}
+
+// SetPipelineName sets the PipelineName field's value.
+func (s *PipelineContext) SetPipelineName(v string) *PipelineContext {
+	s.PipelineName = &v
+	return s
+}
+
+// SetStage sets the Stage field's value.
+func (s *PipelineContext) SetStage(v *StageContext) *PipelineContext {
+	s.Stage = v
+	return s
 }
 
 // Represents the structure of actions and stages to be performed in the pipeline.
@@ -4239,6 +5169,36 @@ func (s *PipelineDeclaration) Validate() error {
 	return nil
 }
 
+// SetArtifactStore sets the ArtifactStore field's value.
+func (s *PipelineDeclaration) SetArtifactStore(v *ArtifactStore) *PipelineDeclaration {
+	s.ArtifactStore = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PipelineDeclaration) SetName(v string) *PipelineDeclaration {
+	s.Name = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *PipelineDeclaration) SetRoleArn(v string) *PipelineDeclaration {
+	s.RoleArn = &v
+	return s
+}
+
+// SetStages sets the Stages field's value.
+func (s *PipelineDeclaration) SetStages(v []*StageDeclaration) *PipelineDeclaration {
+	s.Stages = v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *PipelineDeclaration) SetVersion(v int64) *PipelineDeclaration {
+	s.Version = &v
+	return s
+}
+
 // Represents information about an execution of a pipeline.
 type PipelineExecution struct {
 	_ struct{} `type:"structure"`
@@ -4279,6 +5239,36 @@ func (s PipelineExecution) GoString() string {
 	return s.String()
 }
 
+// SetArtifactRevisions sets the ArtifactRevisions field's value.
+func (s *PipelineExecution) SetArtifactRevisions(v []*ArtifactRevision) *PipelineExecution {
+	s.ArtifactRevisions = v
+	return s
+}
+
+// SetPipelineExecutionId sets the PipelineExecutionId field's value.
+func (s *PipelineExecution) SetPipelineExecutionId(v string) *PipelineExecution {
+	s.PipelineExecutionId = &v
+	return s
+}
+
+// SetPipelineName sets the PipelineName field's value.
+func (s *PipelineExecution) SetPipelineName(v string) *PipelineExecution {
+	s.PipelineName = &v
+	return s
+}
+
+// SetPipelineVersion sets the PipelineVersion field's value.
+func (s *PipelineExecution) SetPipelineVersion(v int64) *PipelineExecution {
+	s.PipelineVersion = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *PipelineExecution) SetStatus(v string) *PipelineExecution {
+	s.Status = &v
+	return s
+}
+
 // Returns a summary of a pipeline.
 type PipelineSummary struct {
 	_ struct{} `type:"structure"`
@@ -4304,6 +5294,30 @@ func (s PipelineSummary) String() string {
 // GoString returns the string representation
 func (s PipelineSummary) GoString() string {
 	return s.String()
+}
+
+// SetCreated sets the Created field's value.
+func (s *PipelineSummary) SetCreated(v time.Time) *PipelineSummary {
+	s.Created = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PipelineSummary) SetName(v string) *PipelineSummary {
+	s.Name = &v
+	return s
+}
+
+// SetUpdated sets the Updated field's value.
+func (s *PipelineSummary) SetUpdated(v time.Time) *PipelineSummary {
+	s.Updated = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *PipelineSummary) SetVersion(v int64) *PipelineSummary {
+	s.Version = &v
+	return s
 }
 
 // Represents the input of a poll for jobs action.
@@ -4356,6 +5370,24 @@ func (s *PollForJobsInput) Validate() error {
 	return nil
 }
 
+// SetActionTypeId sets the ActionTypeId field's value.
+func (s *PollForJobsInput) SetActionTypeId(v *ActionTypeId) *PollForJobsInput {
+	s.ActionTypeId = v
+	return s
+}
+
+// SetMaxBatchSize sets the MaxBatchSize field's value.
+func (s *PollForJobsInput) SetMaxBatchSize(v int64) *PollForJobsInput {
+	s.MaxBatchSize = &v
+	return s
+}
+
+// SetQueryParam sets the QueryParam field's value.
+func (s *PollForJobsInput) SetQueryParam(v map[string]*string) *PollForJobsInput {
+	s.QueryParam = v
+	return s
+}
+
 // Represents the output of a poll for jobs action.
 type PollForJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4372,6 +5404,12 @@ func (s PollForJobsOutput) String() string {
 // GoString returns the string representation
 func (s PollForJobsOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobs sets the Jobs field's value.
+func (s *PollForJobsOutput) SetJobs(v []*Job) *PollForJobsOutput {
+	s.Jobs = v
+	return s
 }
 
 // Represents the input of a poll for third party jobs action.
@@ -4418,6 +5456,18 @@ func (s *PollForThirdPartyJobsInput) Validate() error {
 	return nil
 }
 
+// SetActionTypeId sets the ActionTypeId field's value.
+func (s *PollForThirdPartyJobsInput) SetActionTypeId(v *ActionTypeId) *PollForThirdPartyJobsInput {
+	s.ActionTypeId = v
+	return s
+}
+
+// SetMaxBatchSize sets the MaxBatchSize field's value.
+func (s *PollForThirdPartyJobsInput) SetMaxBatchSize(v int64) *PollForThirdPartyJobsInput {
+	s.MaxBatchSize = &v
+	return s
+}
+
 // Represents the output of a poll for third party jobs action.
 type PollForThirdPartyJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4434,6 +5484,12 @@ func (s PollForThirdPartyJobsOutput) String() string {
 // GoString returns the string representation
 func (s PollForThirdPartyJobsOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobs sets the Jobs field's value.
+func (s *PollForThirdPartyJobsOutput) SetJobs(v []*ThirdPartyJob) *PollForThirdPartyJobsOutput {
+	s.Jobs = v
+	return s
 }
 
 // Represents the input of a put action revision action.
@@ -4507,6 +5563,30 @@ func (s *PutActionRevisionInput) Validate() error {
 	return nil
 }
 
+// SetActionName sets the ActionName field's value.
+func (s *PutActionRevisionInput) SetActionName(v string) *PutActionRevisionInput {
+	s.ActionName = &v
+	return s
+}
+
+// SetActionRevision sets the ActionRevision field's value.
+func (s *PutActionRevisionInput) SetActionRevision(v *ActionRevision) *PutActionRevisionInput {
+	s.ActionRevision = v
+	return s
+}
+
+// SetPipelineName sets the PipelineName field's value.
+func (s *PutActionRevisionInput) SetPipelineName(v string) *PutActionRevisionInput {
+	s.PipelineName = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *PutActionRevisionInput) SetStageName(v string) *PutActionRevisionInput {
+	s.StageName = &v
+	return s
+}
+
 // Represents the output of a put action revision action.
 type PutActionRevisionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4527,6 +5607,18 @@ func (s PutActionRevisionOutput) String() string {
 // GoString returns the string representation
 func (s PutActionRevisionOutput) GoString() string {
 	return s.String()
+}
+
+// SetNewRevision sets the NewRevision field's value.
+func (s *PutActionRevisionOutput) SetNewRevision(v bool) *PutActionRevisionOutput {
+	s.NewRevision = &v
+	return s
+}
+
+// SetPipelineExecutionId sets the PipelineExecutionId field's value.
+func (s *PutActionRevisionOutput) SetPipelineExecutionId(v string) *PutActionRevisionOutput {
+	s.PipelineExecutionId = &v
+	return s
 }
 
 // Represents the input of a put approval result action.
@@ -4611,6 +5703,36 @@ func (s *PutApprovalResultInput) Validate() error {
 	return nil
 }
 
+// SetActionName sets the ActionName field's value.
+func (s *PutApprovalResultInput) SetActionName(v string) *PutApprovalResultInput {
+	s.ActionName = &v
+	return s
+}
+
+// SetPipelineName sets the PipelineName field's value.
+func (s *PutApprovalResultInput) SetPipelineName(v string) *PutApprovalResultInput {
+	s.PipelineName = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *PutApprovalResultInput) SetResult(v *ApprovalResult) *PutApprovalResultInput {
+	s.Result = v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *PutApprovalResultInput) SetStageName(v string) *PutApprovalResultInput {
+	s.StageName = &v
+	return s
+}
+
+// SetToken sets the Token field's value.
+func (s *PutApprovalResultInput) SetToken(v string) *PutApprovalResultInput {
+	s.Token = &v
+	return s
+}
+
 // Represents the output of a put approval result action.
 type PutApprovalResultOutput struct {
 	_ struct{} `type:"structure"`
@@ -4627,6 +5749,12 @@ func (s PutApprovalResultOutput) String() string {
 // GoString returns the string representation
 func (s PutApprovalResultOutput) GoString() string {
 	return s.String()
+}
+
+// SetApprovedAt sets the ApprovedAt field's value.
+func (s *PutApprovalResultOutput) SetApprovedAt(v time.Time) *PutApprovalResultOutput {
+	s.ApprovedAt = &v
+	return s
 }
 
 // Represents the input of a put job failure result action.
@@ -4674,6 +5802,18 @@ func (s *PutJobFailureResultInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFailureDetails sets the FailureDetails field's value.
+func (s *PutJobFailureResultInput) SetFailureDetails(v *FailureDetails) *PutJobFailureResultInput {
+	s.FailureDetails = v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *PutJobFailureResultInput) SetJobId(v string) *PutJobFailureResultInput {
+	s.JobId = &v
+	return s
 }
 
 type PutJobFailureResultOutput struct {
@@ -4750,6 +5890,30 @@ func (s *PutJobSuccessResultInput) Validate() error {
 	return nil
 }
 
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *PutJobSuccessResultInput) SetContinuationToken(v string) *PutJobSuccessResultInput {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetCurrentRevision sets the CurrentRevision field's value.
+func (s *PutJobSuccessResultInput) SetCurrentRevision(v *CurrentRevision) *PutJobSuccessResultInput {
+	s.CurrentRevision = v
+	return s
+}
+
+// SetExecutionDetails sets the ExecutionDetails field's value.
+func (s *PutJobSuccessResultInput) SetExecutionDetails(v *ExecutionDetails) *PutJobSuccessResultInput {
+	s.ExecutionDetails = v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *PutJobSuccessResultInput) SetJobId(v string) *PutJobSuccessResultInput {
+	s.JobId = &v
+	return s
+}
+
 type PutJobSuccessResultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4820,6 +5984,24 @@ func (s *PutThirdPartyJobFailureResultInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *PutThirdPartyJobFailureResultInput) SetClientToken(v string) *PutThirdPartyJobFailureResultInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetFailureDetails sets the FailureDetails field's value.
+func (s *PutThirdPartyJobFailureResultInput) SetFailureDetails(v *FailureDetails) *PutThirdPartyJobFailureResultInput {
+	s.FailureDetails = v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *PutThirdPartyJobFailureResultInput) SetJobId(v string) *PutThirdPartyJobFailureResultInput {
+	s.JobId = &v
+	return s
 }
 
 type PutThirdPartyJobFailureResultOutput struct {
@@ -4907,6 +6089,36 @@ func (s *PutThirdPartyJobSuccessResultInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *PutThirdPartyJobSuccessResultInput) SetClientToken(v string) *PutThirdPartyJobSuccessResultInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *PutThirdPartyJobSuccessResultInput) SetContinuationToken(v string) *PutThirdPartyJobSuccessResultInput {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetCurrentRevision sets the CurrentRevision field's value.
+func (s *PutThirdPartyJobSuccessResultInput) SetCurrentRevision(v *CurrentRevision) *PutThirdPartyJobSuccessResultInput {
+	s.CurrentRevision = v
+	return s
+}
+
+// SetExecutionDetails sets the ExecutionDetails field's value.
+func (s *PutThirdPartyJobSuccessResultInput) SetExecutionDetails(v *ExecutionDetails) *PutThirdPartyJobSuccessResultInput {
+	s.ExecutionDetails = v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *PutThirdPartyJobSuccessResultInput) SetJobId(v string) *PutThirdPartyJobSuccessResultInput {
+	s.JobId = &v
+	return s
+}
+
 type PutThirdPartyJobSuccessResultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4986,6 +6198,30 @@ func (s *RetryStageExecutionInput) Validate() error {
 	return nil
 }
 
+// SetPipelineExecutionId sets the PipelineExecutionId field's value.
+func (s *RetryStageExecutionInput) SetPipelineExecutionId(v string) *RetryStageExecutionInput {
+	s.PipelineExecutionId = &v
+	return s
+}
+
+// SetPipelineName sets the PipelineName field's value.
+func (s *RetryStageExecutionInput) SetPipelineName(v string) *RetryStageExecutionInput {
+	s.PipelineName = &v
+	return s
+}
+
+// SetRetryMode sets the RetryMode field's value.
+func (s *RetryStageExecutionInput) SetRetryMode(v string) *RetryStageExecutionInput {
+	s.RetryMode = &v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *RetryStageExecutionInput) SetStageName(v string) *RetryStageExecutionInput {
+	s.StageName = &v
+	return s
+}
+
 // Represents the output of a retry stage execution action.
 type RetryStageExecutionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5002,6 +6238,12 @@ func (s RetryStageExecutionOutput) String() string {
 // GoString returns the string representation
 func (s RetryStageExecutionOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipelineExecutionId sets the PipelineExecutionId field's value.
+func (s *RetryStageExecutionOutput) SetPipelineExecutionId(v string) *RetryStageExecutionOutput {
+	s.PipelineExecutionId = &v
+	return s
 }
 
 // The location of the Amazon S3 bucket that contains a revision.
@@ -5030,6 +6272,18 @@ func (s S3ArtifactLocation) GoString() string {
 	return s.String()
 }
 
+// SetBucketName sets the BucketName field's value.
+func (s *S3ArtifactLocation) SetBucketName(v string) *S3ArtifactLocation {
+	s.BucketName = &v
+	return s
+}
+
+// SetObjectKey sets the ObjectKey field's value.
+func (s *S3ArtifactLocation) SetObjectKey(v string) *S3ArtifactLocation {
+	s.ObjectKey = &v
+	return s
+}
+
 // Represents information about a stage to a job worker.
 type StageContext struct {
 	_ struct{} `type:"structure"`
@@ -5046,6 +6300,12 @@ func (s StageContext) String() string {
 // GoString returns the string representation
 func (s StageContext) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *StageContext) SetName(v string) *StageContext {
+	s.Name = &v
+	return s
 }
 
 // Represents information about a stage and its definition.
@@ -5115,6 +6375,24 @@ func (s *StageDeclaration) Validate() error {
 	return nil
 }
 
+// SetActions sets the Actions field's value.
+func (s *StageDeclaration) SetActions(v []*ActionDeclaration) *StageDeclaration {
+	s.Actions = v
+	return s
+}
+
+// SetBlockers sets the Blockers field's value.
+func (s *StageDeclaration) SetBlockers(v []*BlockerDeclaration) *StageDeclaration {
+	s.Blockers = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *StageDeclaration) SetName(v string) *StageDeclaration {
+	s.Name = &v
+	return s
+}
+
 // Represents information about the run of a stage.
 type StageExecution struct {
 	_ struct{} `type:"structure"`
@@ -5139,6 +6417,18 @@ func (s StageExecution) String() string {
 // GoString returns the string representation
 func (s StageExecution) GoString() string {
 	return s.String()
+}
+
+// SetPipelineExecutionId sets the PipelineExecutionId field's value.
+func (s *StageExecution) SetPipelineExecutionId(v string) *StageExecution {
+	s.PipelineExecutionId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *StageExecution) SetStatus(v string) *StageExecution {
+	s.Status = &v
+	return s
 }
 
 // Represents information about the state of the stage.
@@ -5167,6 +6457,30 @@ func (s StageState) String() string {
 // GoString returns the string representation
 func (s StageState) GoString() string {
 	return s.String()
+}
+
+// SetActionStates sets the ActionStates field's value.
+func (s *StageState) SetActionStates(v []*ActionState) *StageState {
+	s.ActionStates = v
+	return s
+}
+
+// SetInboundTransitionState sets the InboundTransitionState field's value.
+func (s *StageState) SetInboundTransitionState(v *TransitionState) *StageState {
+	s.InboundTransitionState = v
+	return s
+}
+
+// SetLatestExecution sets the LatestExecution field's value.
+func (s *StageState) SetLatestExecution(v *StageExecution) *StageState {
+	s.LatestExecution = v
+	return s
+}
+
+// SetStageName sets the StageName field's value.
+func (s *StageState) SetStageName(v string) *StageState {
+	s.StageName = &v
+	return s
 }
 
 // Represents the input of a start pipeline execution action.
@@ -5205,6 +6519,12 @@ func (s *StartPipelineExecutionInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *StartPipelineExecutionInput) SetName(v string) *StartPipelineExecutionInput {
+	s.Name = &v
+	return s
+}
+
 // Represents the output of a start pipeline execution action.
 type StartPipelineExecutionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5221,6 +6541,12 @@ func (s StartPipelineExecutionOutput) String() string {
 // GoString returns the string representation
 func (s StartPipelineExecutionOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipelineExecutionId sets the PipelineExecutionId field's value.
+func (s *StartPipelineExecutionOutput) SetPipelineExecutionId(v string) *StartPipelineExecutionOutput {
+	s.PipelineExecutionId = &v
+	return s
 }
 
 // A response to a PollForThirdPartyJobs request returned by AWS CodePipeline
@@ -5244,6 +6570,18 @@ func (s ThirdPartyJob) String() string {
 // GoString returns the string representation
 func (s ThirdPartyJob) GoString() string {
 	return s.String()
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *ThirdPartyJob) SetClientId(v string) *ThirdPartyJob {
+	s.ClientId = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *ThirdPartyJob) SetJobId(v string) *ThirdPartyJob {
+	s.JobId = &v
+	return s
 }
 
 // Represents information about the job data for a partner action.
@@ -5297,6 +6635,54 @@ func (s ThirdPartyJobData) GoString() string {
 	return s.String()
 }
 
+// SetActionConfiguration sets the ActionConfiguration field's value.
+func (s *ThirdPartyJobData) SetActionConfiguration(v *ActionConfiguration) *ThirdPartyJobData {
+	s.ActionConfiguration = v
+	return s
+}
+
+// SetActionTypeId sets the ActionTypeId field's value.
+func (s *ThirdPartyJobData) SetActionTypeId(v *ActionTypeId) *ThirdPartyJobData {
+	s.ActionTypeId = v
+	return s
+}
+
+// SetArtifactCredentials sets the ArtifactCredentials field's value.
+func (s *ThirdPartyJobData) SetArtifactCredentials(v *AWSSessionCredentials) *ThirdPartyJobData {
+	s.ArtifactCredentials = v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ThirdPartyJobData) SetContinuationToken(v string) *ThirdPartyJobData {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetEncryptionKey sets the EncryptionKey field's value.
+func (s *ThirdPartyJobData) SetEncryptionKey(v *EncryptionKey) *ThirdPartyJobData {
+	s.EncryptionKey = v
+	return s
+}
+
+// SetInputArtifacts sets the InputArtifacts field's value.
+func (s *ThirdPartyJobData) SetInputArtifacts(v []*Artifact) *ThirdPartyJobData {
+	s.InputArtifacts = v
+	return s
+}
+
+// SetOutputArtifacts sets the OutputArtifacts field's value.
+func (s *ThirdPartyJobData) SetOutputArtifacts(v []*Artifact) *ThirdPartyJobData {
+	s.OutputArtifacts = v
+	return s
+}
+
+// SetPipelineContext sets the PipelineContext field's value.
+func (s *ThirdPartyJobData) SetPipelineContext(v *PipelineContext) *ThirdPartyJobData {
+	s.PipelineContext = v
+	return s
+}
+
 // The details of a job sent in response to a GetThirdPartyJobDetails request.
 type ThirdPartyJobDetails struct {
 	_ struct{} `type:"structure"`
@@ -5321,6 +6707,24 @@ func (s ThirdPartyJobDetails) String() string {
 // GoString returns the string representation
 func (s ThirdPartyJobDetails) GoString() string {
 	return s.String()
+}
+
+// SetData sets the Data field's value.
+func (s *ThirdPartyJobDetails) SetData(v *ThirdPartyJobData) *ThirdPartyJobDetails {
+	s.Data = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ThirdPartyJobDetails) SetId(v string) *ThirdPartyJobDetails {
+	s.Id = &v
+	return s
+}
+
+// SetNonce sets the Nonce field's value.
+func (s *ThirdPartyJobDetails) SetNonce(v string) *ThirdPartyJobDetails {
+	s.Nonce = &v
+	return s
 }
 
 // Represents information about the state of transitions between one stage and
@@ -5350,6 +6754,30 @@ func (s TransitionState) String() string {
 // GoString returns the string representation
 func (s TransitionState) GoString() string {
 	return s.String()
+}
+
+// SetDisabledReason sets the DisabledReason field's value.
+func (s *TransitionState) SetDisabledReason(v string) *TransitionState {
+	s.DisabledReason = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *TransitionState) SetEnabled(v bool) *TransitionState {
+	s.Enabled = &v
+	return s
+}
+
+// SetLastChangedAt sets the LastChangedAt field's value.
+func (s *TransitionState) SetLastChangedAt(v time.Time) *TransitionState {
+	s.LastChangedAt = &v
+	return s
+}
+
+// SetLastChangedBy sets the LastChangedBy field's value.
+func (s *TransitionState) SetLastChangedBy(v string) *TransitionState {
+	s.LastChangedBy = &v
+	return s
 }
 
 // Represents the input of an update pipeline action.
@@ -5390,6 +6818,12 @@ func (s *UpdatePipelineInput) Validate() error {
 	return nil
 }
 
+// SetPipeline sets the Pipeline field's value.
+func (s *UpdatePipelineInput) SetPipeline(v *PipelineDeclaration) *UpdatePipelineInput {
+	s.Pipeline = v
+	return s
+}
+
 // Represents the output of an update pipeline action.
 type UpdatePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -5406,6 +6840,12 @@ func (s UpdatePipelineOutput) String() string {
 // GoString returns the string representation
 func (s UpdatePipelineOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipeline sets the Pipeline field's value.
+func (s *UpdatePipelineOutput) SetPipeline(v *PipelineDeclaration) *UpdatePipelineOutput {
+	s.Pipeline = v
+	return s
 }
 
 const (

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -1644,6 +1644,48 @@ func (s *CreateIdentityPoolInput) Validate() error {
 	return nil
 }
 
+// SetAllowUnauthenticatedIdentities sets the AllowUnauthenticatedIdentities field's value.
+func (s *CreateIdentityPoolInput) SetAllowUnauthenticatedIdentities(v bool) *CreateIdentityPoolInput {
+	s.AllowUnauthenticatedIdentities = &v
+	return s
+}
+
+// SetCognitoIdentityProviders sets the CognitoIdentityProviders field's value.
+func (s *CreateIdentityPoolInput) SetCognitoIdentityProviders(v []*Provider) *CreateIdentityPoolInput {
+	s.CognitoIdentityProviders = v
+	return s
+}
+
+// SetDeveloperProviderName sets the DeveloperProviderName field's value.
+func (s *CreateIdentityPoolInput) SetDeveloperProviderName(v string) *CreateIdentityPoolInput {
+	s.DeveloperProviderName = &v
+	return s
+}
+
+// SetIdentityPoolName sets the IdentityPoolName field's value.
+func (s *CreateIdentityPoolInput) SetIdentityPoolName(v string) *CreateIdentityPoolInput {
+	s.IdentityPoolName = &v
+	return s
+}
+
+// SetOpenIdConnectProviderARNs sets the OpenIdConnectProviderARNs field's value.
+func (s *CreateIdentityPoolInput) SetOpenIdConnectProviderARNs(v []*string) *CreateIdentityPoolInput {
+	s.OpenIdConnectProviderARNs = v
+	return s
+}
+
+// SetSamlProviderARNs sets the SamlProviderARNs field's value.
+func (s *CreateIdentityPoolInput) SetSamlProviderARNs(v []*string) *CreateIdentityPoolInput {
+	s.SamlProviderARNs = v
+	return s
+}
+
+// SetSupportedLoginProviders sets the SupportedLoginProviders field's value.
+func (s *CreateIdentityPoolInput) SetSupportedLoginProviders(v map[string]*string) *CreateIdentityPoolInput {
+	s.SupportedLoginProviders = v
+	return s
+}
+
 // Credentials for the provided identity ID.
 type Credentials struct {
 	_ struct{} `type:"structure"`
@@ -1669,6 +1711,30 @@ func (s Credentials) String() string {
 // GoString returns the string representation
 func (s Credentials) GoString() string {
 	return s.String()
+}
+
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *Credentials) SetAccessKeyId(v string) *Credentials {
+	s.AccessKeyId = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *Credentials) SetExpiration(v time.Time) *Credentials {
+	s.Expiration = &v
+	return s
+}
+
+// SetSecretKey sets the SecretKey field's value.
+func (s *Credentials) SetSecretKey(v string) *Credentials {
+	s.SecretKey = &v
+	return s
+}
+
+// SetSessionToken sets the SessionToken field's value.
+func (s *Credentials) SetSessionToken(v string) *Credentials {
+	s.SessionToken = &v
+	return s
 }
 
 // Input to the DeleteIdentities action.
@@ -1707,6 +1773,12 @@ func (s *DeleteIdentitiesInput) Validate() error {
 	return nil
 }
 
+// SetIdentityIdsToDelete sets the IdentityIdsToDelete field's value.
+func (s *DeleteIdentitiesInput) SetIdentityIdsToDelete(v []*string) *DeleteIdentitiesInput {
+	s.IdentityIdsToDelete = v
+	return s
+}
+
 // Returned in response to a successful DeleteIdentities operation.
 type DeleteIdentitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1724,6 +1796,12 @@ func (s DeleteIdentitiesOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIdentitiesOutput) GoString() string {
 	return s.String()
+}
+
+// SetUnprocessedIdentityIds sets the UnprocessedIdentityIds field's value.
+func (s *DeleteIdentitiesOutput) SetUnprocessedIdentityIds(v []*UnprocessedIdentityId) *DeleteIdentitiesOutput {
+	s.UnprocessedIdentityIds = v
+	return s
 }
 
 // Input to the DeleteIdentityPool action.
@@ -1760,6 +1838,12 @@ func (s *DeleteIdentityPoolInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *DeleteIdentityPoolInput) SetIdentityPoolId(v string) *DeleteIdentityPoolInput {
+	s.IdentityPoolId = &v
+	return s
 }
 
 type DeleteIdentityPoolOutput struct {
@@ -1812,6 +1896,12 @@ func (s *DescribeIdentityInput) Validate() error {
 	return nil
 }
 
+// SetIdentityId sets the IdentityId field's value.
+func (s *DescribeIdentityInput) SetIdentityId(v string) *DescribeIdentityInput {
+	s.IdentityId = &v
+	return s
+}
+
 // Input to the DescribeIdentityPool action.
 type DescribeIdentityPoolInput struct {
 	_ struct{} `type:"structure"`
@@ -1846,6 +1936,12 @@ func (s *DescribeIdentityPoolInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *DescribeIdentityPoolInput) SetIdentityPoolId(v string) *DescribeIdentityPoolInput {
+	s.IdentityPoolId = &v
+	return s
 }
 
 // Input to the GetCredentialsForIdentity action.
@@ -1896,6 +1992,24 @@ func (s *GetCredentialsForIdentityInput) Validate() error {
 	return nil
 }
 
+// SetCustomRoleArn sets the CustomRoleArn field's value.
+func (s *GetCredentialsForIdentityInput) SetCustomRoleArn(v string) *GetCredentialsForIdentityInput {
+	s.CustomRoleArn = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *GetCredentialsForIdentityInput) SetIdentityId(v string) *GetCredentialsForIdentityInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetLogins sets the Logins field's value.
+func (s *GetCredentialsForIdentityInput) SetLogins(v map[string]*string) *GetCredentialsForIdentityInput {
+	s.Logins = v
+	return s
+}
+
 // Returned in response to a successful GetCredentialsForIdentity operation.
 type GetCredentialsForIdentityOutput struct {
 	_ struct{} `type:"structure"`
@@ -1915,6 +2029,18 @@ func (s GetCredentialsForIdentityOutput) String() string {
 // GoString returns the string representation
 func (s GetCredentialsForIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// SetCredentials sets the Credentials field's value.
+func (s *GetCredentialsForIdentityOutput) SetCredentials(v *Credentials) *GetCredentialsForIdentityOutput {
+	s.Credentials = v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *GetCredentialsForIdentityOutput) SetIdentityId(v string) *GetCredentialsForIdentityOutput {
+	s.IdentityId = &v
+	return s
 }
 
 // Input to the GetId action.
@@ -1969,6 +2095,24 @@ func (s *GetIdInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *GetIdInput) SetAccountId(v string) *GetIdInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetIdInput) SetIdentityPoolId(v string) *GetIdInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetLogins sets the Logins field's value.
+func (s *GetIdInput) SetLogins(v map[string]*string) *GetIdInput {
+	s.Logins = v
+	return s
+}
+
 // Returned in response to a GetId request.
 type GetIdOutput struct {
 	_ struct{} `type:"structure"`
@@ -1985,6 +2129,12 @@ func (s GetIdOutput) String() string {
 // GoString returns the string representation
 func (s GetIdOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *GetIdOutput) SetIdentityId(v string) *GetIdOutput {
+	s.IdentityId = &v
+	return s
 }
 
 // Input to the GetIdentityPoolRoles action.
@@ -2023,6 +2173,12 @@ func (s *GetIdentityPoolRolesInput) Validate() error {
 	return nil
 }
 
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetIdentityPoolRolesInput) SetIdentityPoolId(v string) *GetIdentityPoolRolesInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // Returned in response to a successful GetIdentityPoolRoles operation.
 type GetIdentityPoolRolesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2043,6 +2199,18 @@ func (s GetIdentityPoolRolesOutput) String() string {
 // GoString returns the string representation
 func (s GetIdentityPoolRolesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetIdentityPoolRolesOutput) SetIdentityPoolId(v string) *GetIdentityPoolRolesOutput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetRoles sets the Roles field's value.
+func (s *GetIdentityPoolRolesOutput) SetRoles(v map[string]*string) *GetIdentityPoolRolesOutput {
+	s.Roles = v
+	return s
 }
 
 // Input to the GetOpenIdTokenForDeveloperIdentity action.
@@ -2116,6 +2284,30 @@ func (s *GetOpenIdTokenForDeveloperIdentityInput) Validate() error {
 	return nil
 }
 
+// SetIdentityId sets the IdentityId field's value.
+func (s *GetOpenIdTokenForDeveloperIdentityInput) SetIdentityId(v string) *GetOpenIdTokenForDeveloperIdentityInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetOpenIdTokenForDeveloperIdentityInput) SetIdentityPoolId(v string) *GetOpenIdTokenForDeveloperIdentityInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetLogins sets the Logins field's value.
+func (s *GetOpenIdTokenForDeveloperIdentityInput) SetLogins(v map[string]*string) *GetOpenIdTokenForDeveloperIdentityInput {
+	s.Logins = v
+	return s
+}
+
+// SetTokenDuration sets the TokenDuration field's value.
+func (s *GetOpenIdTokenForDeveloperIdentityInput) SetTokenDuration(v int64) *GetOpenIdTokenForDeveloperIdentityInput {
+	s.TokenDuration = &v
+	return s
+}
+
 // Returned in response to a successful GetOpenIdTokenForDeveloperIdentity request.
 type GetOpenIdTokenForDeveloperIdentityOutput struct {
 	_ struct{} `type:"structure"`
@@ -2135,6 +2327,18 @@ func (s GetOpenIdTokenForDeveloperIdentityOutput) String() string {
 // GoString returns the string representation
 func (s GetOpenIdTokenForDeveloperIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *GetOpenIdTokenForDeveloperIdentityOutput) SetIdentityId(v string) *GetOpenIdTokenForDeveloperIdentityOutput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetToken sets the Token field's value.
+func (s *GetOpenIdTokenForDeveloperIdentityOutput) SetToken(v string) *GetOpenIdTokenForDeveloperIdentityOutput {
+	s.Token = &v
+	return s
 }
 
 // Input to the GetOpenIdToken action.
@@ -2179,6 +2383,18 @@ func (s *GetOpenIdTokenInput) Validate() error {
 	return nil
 }
 
+// SetIdentityId sets the IdentityId field's value.
+func (s *GetOpenIdTokenInput) SetIdentityId(v string) *GetOpenIdTokenInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetLogins sets the Logins field's value.
+func (s *GetOpenIdTokenInput) SetLogins(v map[string]*string) *GetOpenIdTokenInput {
+	s.Logins = v
+	return s
+}
+
 // Returned in response to a successful GetOpenIdToken request.
 type GetOpenIdTokenOutput struct {
 	_ struct{} `type:"structure"`
@@ -2199,6 +2415,18 @@ func (s GetOpenIdTokenOutput) String() string {
 // GoString returns the string representation
 func (s GetOpenIdTokenOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *GetOpenIdTokenOutput) SetIdentityId(v string) *GetOpenIdTokenOutput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetToken sets the Token field's value.
+func (s *GetOpenIdTokenOutput) SetToken(v string) *GetOpenIdTokenOutput {
+	s.Token = &v
+	return s
 }
 
 // A description of the identity.
@@ -2226,6 +2454,30 @@ func (s IdentityDescription) String() string {
 // GoString returns the string representation
 func (s IdentityDescription) GoString() string {
 	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *IdentityDescription) SetCreationDate(v time.Time) *IdentityDescription {
+	s.CreationDate = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *IdentityDescription) SetIdentityId(v string) *IdentityDescription {
+	s.IdentityId = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *IdentityDescription) SetLastModifiedDate(v time.Time) *IdentityDescription {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetLogins sets the Logins field's value.
+func (s *IdentityDescription) SetLogins(v []*string) *IdentityDescription {
+	s.Logins = v
+	return s
 }
 
 // An object representing a Cognito identity pool.
@@ -2312,6 +2564,54 @@ func (s *IdentityPool) Validate() error {
 	return nil
 }
 
+// SetAllowUnauthenticatedIdentities sets the AllowUnauthenticatedIdentities field's value.
+func (s *IdentityPool) SetAllowUnauthenticatedIdentities(v bool) *IdentityPool {
+	s.AllowUnauthenticatedIdentities = &v
+	return s
+}
+
+// SetCognitoIdentityProviders sets the CognitoIdentityProviders field's value.
+func (s *IdentityPool) SetCognitoIdentityProviders(v []*Provider) *IdentityPool {
+	s.CognitoIdentityProviders = v
+	return s
+}
+
+// SetDeveloperProviderName sets the DeveloperProviderName field's value.
+func (s *IdentityPool) SetDeveloperProviderName(v string) *IdentityPool {
+	s.DeveloperProviderName = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *IdentityPool) SetIdentityPoolId(v string) *IdentityPool {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetIdentityPoolName sets the IdentityPoolName field's value.
+func (s *IdentityPool) SetIdentityPoolName(v string) *IdentityPool {
+	s.IdentityPoolName = &v
+	return s
+}
+
+// SetOpenIdConnectProviderARNs sets the OpenIdConnectProviderARNs field's value.
+func (s *IdentityPool) SetOpenIdConnectProviderARNs(v []*string) *IdentityPool {
+	s.OpenIdConnectProviderARNs = v
+	return s
+}
+
+// SetSamlProviderARNs sets the SamlProviderARNs field's value.
+func (s *IdentityPool) SetSamlProviderARNs(v []*string) *IdentityPool {
+	s.SamlProviderARNs = v
+	return s
+}
+
+// SetSupportedLoginProviders sets the SupportedLoginProviders field's value.
+func (s *IdentityPool) SetSupportedLoginProviders(v map[string]*string) *IdentityPool {
+	s.SupportedLoginProviders = v
+	return s
+}
+
 // A description of the identity pool.
 type IdentityPoolShortDescription struct {
 	_ struct{} `type:"structure"`
@@ -2331,6 +2631,18 @@ func (s IdentityPoolShortDescription) String() string {
 // GoString returns the string representation
 func (s IdentityPoolShortDescription) GoString() string {
 	return s.String()
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *IdentityPoolShortDescription) SetIdentityPoolId(v string) *IdentityPoolShortDescription {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetIdentityPoolName sets the IdentityPoolName field's value.
+func (s *IdentityPoolShortDescription) SetIdentityPoolName(v string) *IdentityPoolShortDescription {
+	s.IdentityPoolName = &v
+	return s
 }
 
 // Input to the ListIdentities action.
@@ -2391,6 +2703,30 @@ func (s *ListIdentitiesInput) Validate() error {
 	return nil
 }
 
+// SetHideDisabled sets the HideDisabled field's value.
+func (s *ListIdentitiesInput) SetHideDisabled(v bool) *ListIdentitiesInput {
+	s.HideDisabled = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *ListIdentitiesInput) SetIdentityPoolId(v string) *ListIdentitiesInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListIdentitiesInput) SetMaxResults(v int64) *ListIdentitiesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIdentitiesInput) SetNextToken(v string) *ListIdentitiesInput {
+	s.NextToken = &v
+	return s
+}
+
 // The response to a ListIdentities request.
 type ListIdentitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2413,6 +2749,24 @@ func (s ListIdentitiesOutput) String() string {
 // GoString returns the string representation
 func (s ListIdentitiesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentities sets the Identities field's value.
+func (s *ListIdentitiesOutput) SetIdentities(v []*IdentityDescription) *ListIdentitiesOutput {
+	s.Identities = v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *ListIdentitiesOutput) SetIdentityPoolId(v string) *ListIdentitiesOutput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIdentitiesOutput) SetNextToken(v string) *ListIdentitiesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Input to the ListIdentityPools action.
@@ -2457,6 +2811,18 @@ func (s *ListIdentityPoolsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListIdentityPoolsInput) SetMaxResults(v int64) *ListIdentityPoolsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIdentityPoolsInput) SetNextToken(v string) *ListIdentityPoolsInput {
+	s.NextToken = &v
+	return s
+}
+
 // The result of a successful ListIdentityPools action.
 type ListIdentityPoolsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2476,6 +2842,18 @@ func (s ListIdentityPoolsOutput) String() string {
 // GoString returns the string representation
 func (s ListIdentityPoolsOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityPools sets the IdentityPools field's value.
+func (s *ListIdentityPoolsOutput) SetIdentityPools(v []*IdentityPoolShortDescription) *ListIdentityPoolsOutput {
+	s.IdentityPools = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIdentityPoolsOutput) SetNextToken(v string) *ListIdentityPoolsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Input to the LookupDeveloperIdentityInput action.
@@ -2545,6 +2923,36 @@ func (s *LookupDeveloperIdentityInput) Validate() error {
 	return nil
 }
 
+// SetDeveloperUserIdentifier sets the DeveloperUserIdentifier field's value.
+func (s *LookupDeveloperIdentityInput) SetDeveloperUserIdentifier(v string) *LookupDeveloperIdentityInput {
+	s.DeveloperUserIdentifier = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *LookupDeveloperIdentityInput) SetIdentityId(v string) *LookupDeveloperIdentityInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *LookupDeveloperIdentityInput) SetIdentityPoolId(v string) *LookupDeveloperIdentityInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *LookupDeveloperIdentityInput) SetMaxResults(v int64) *LookupDeveloperIdentityInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *LookupDeveloperIdentityInput) SetNextToken(v string) *LookupDeveloperIdentityInput {
+	s.NextToken = &v
+	return s
+}
+
 // Returned in response to a successful LookupDeveloperIdentity action.
 type LookupDeveloperIdentityOutput struct {
 	_ struct{} `type:"structure"`
@@ -2574,6 +2982,24 @@ func (s LookupDeveloperIdentityOutput) String() string {
 // GoString returns the string representation
 func (s LookupDeveloperIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeveloperUserIdentifierList sets the DeveloperUserIdentifierList field's value.
+func (s *LookupDeveloperIdentityOutput) SetDeveloperUserIdentifierList(v []*string) *LookupDeveloperIdentityOutput {
+	s.DeveloperUserIdentifierList = v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *LookupDeveloperIdentityOutput) SetIdentityId(v string) *LookupDeveloperIdentityOutput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *LookupDeveloperIdentityOutput) SetNextToken(v string) *LookupDeveloperIdentityOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Input to the MergeDeveloperIdentities action.
@@ -2649,6 +3075,30 @@ func (s *MergeDeveloperIdentitiesInput) Validate() error {
 	return nil
 }
 
+// SetDestinationUserIdentifier sets the DestinationUserIdentifier field's value.
+func (s *MergeDeveloperIdentitiesInput) SetDestinationUserIdentifier(v string) *MergeDeveloperIdentitiesInput {
+	s.DestinationUserIdentifier = &v
+	return s
+}
+
+// SetDeveloperProviderName sets the DeveloperProviderName field's value.
+func (s *MergeDeveloperIdentitiesInput) SetDeveloperProviderName(v string) *MergeDeveloperIdentitiesInput {
+	s.DeveloperProviderName = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *MergeDeveloperIdentitiesInput) SetIdentityPoolId(v string) *MergeDeveloperIdentitiesInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetSourceUserIdentifier sets the SourceUserIdentifier field's value.
+func (s *MergeDeveloperIdentitiesInput) SetSourceUserIdentifier(v string) *MergeDeveloperIdentitiesInput {
+	s.SourceUserIdentifier = &v
+	return s
+}
+
 // Returned in response to a successful MergeDeveloperIdentities action.
 type MergeDeveloperIdentitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2665,6 +3115,12 @@ func (s MergeDeveloperIdentitiesOutput) String() string {
 // GoString returns the string representation
 func (s MergeDeveloperIdentitiesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *MergeDeveloperIdentitiesOutput) SetIdentityId(v string) *MergeDeveloperIdentitiesOutput {
+	s.IdentityId = &v
+	return s
 }
 
 // A provider representing an Amazon Cognito Identity User Pool and its client
@@ -2704,6 +3160,18 @@ func (s *Provider) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *Provider) SetClientId(v string) *Provider {
+	s.ClientId = &v
+	return s
+}
+
+// SetProviderName sets the ProviderName field's value.
+func (s *Provider) SetProviderName(v string) *Provider {
+	s.ProviderName = &v
+	return s
 }
 
 // Input to the SetIdentityPoolRoles action.
@@ -2750,6 +3218,18 @@ func (s *SetIdentityPoolRolesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *SetIdentityPoolRolesInput) SetIdentityPoolId(v string) *SetIdentityPoolRolesInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetRoles sets the Roles field's value.
+func (s *SetIdentityPoolRolesInput) SetRoles(v map[string]*string) *SetIdentityPoolRolesInput {
+	s.Roles = v
+	return s
 }
 
 type SetIdentityPoolRolesOutput struct {
@@ -2835,6 +3315,30 @@ func (s *UnlinkDeveloperIdentityInput) Validate() error {
 	return nil
 }
 
+// SetDeveloperProviderName sets the DeveloperProviderName field's value.
+func (s *UnlinkDeveloperIdentityInput) SetDeveloperProviderName(v string) *UnlinkDeveloperIdentityInput {
+	s.DeveloperProviderName = &v
+	return s
+}
+
+// SetDeveloperUserIdentifier sets the DeveloperUserIdentifier field's value.
+func (s *UnlinkDeveloperIdentityInput) SetDeveloperUserIdentifier(v string) *UnlinkDeveloperIdentityInput {
+	s.DeveloperUserIdentifier = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *UnlinkDeveloperIdentityInput) SetIdentityId(v string) *UnlinkDeveloperIdentityInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *UnlinkDeveloperIdentityInput) SetIdentityPoolId(v string) *UnlinkDeveloperIdentityInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 type UnlinkDeveloperIdentityOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2901,6 +3405,24 @@ func (s *UnlinkIdentityInput) Validate() error {
 	return nil
 }
 
+// SetIdentityId sets the IdentityId field's value.
+func (s *UnlinkIdentityInput) SetIdentityId(v string) *UnlinkIdentityInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetLogins sets the Logins field's value.
+func (s *UnlinkIdentityInput) SetLogins(v map[string]*string) *UnlinkIdentityInput {
+	s.Logins = v
+	return s
+}
+
+// SetLoginsToRemove sets the LoginsToRemove field's value.
+func (s *UnlinkIdentityInput) SetLoginsToRemove(v []*string) *UnlinkIdentityInput {
+	s.LoginsToRemove = v
+	return s
+}
+
 type UnlinkIdentityOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2935,6 +3457,18 @@ func (s UnprocessedIdentityId) String() string {
 // GoString returns the string representation
 func (s UnprocessedIdentityId) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *UnprocessedIdentityId) SetErrorCode(v string) *UnprocessedIdentityId {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *UnprocessedIdentityId) SetIdentityId(v string) *UnprocessedIdentityId {
+	s.IdentityId = &v
+	return s
 }
 
 const (

--- a/service/cognitoidentityprovider/api.go
+++ b/service/cognitoidentityprovider/api.go
@@ -5346,6 +5346,18 @@ func (s *AddCustomAttributesInput) Validate() error {
 	return nil
 }
 
+// SetCustomAttributes sets the CustomAttributes field's value.
+func (s *AddCustomAttributesInput) SetCustomAttributes(v []*SchemaAttributeType) *AddCustomAttributesInput {
+	s.CustomAttributes = v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AddCustomAttributesInput) SetUserPoolId(v string) *AddCustomAttributesInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server for the request to add custom attributes.
 type AddCustomAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5408,6 +5420,18 @@ func (s *AdminConfirmSignUpInput) Validate() error {
 	return nil
 }
 
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminConfirmSignUpInput) SetUserPoolId(v string) *AdminConfirmSignUpInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminConfirmSignUpInput) SetUsername(v string) *AdminConfirmSignUpInput {
+	s.Username = &v
+	return s
+}
+
 // Represents the response from the server for the request to confirm registration.
 type AdminConfirmSignUpOutput struct {
 	_ struct{} `type:"structure"`
@@ -5463,6 +5487,24 @@ func (s *AdminCreateUserConfigType) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAllowAdminCreateUserOnly sets the AllowAdminCreateUserOnly field's value.
+func (s *AdminCreateUserConfigType) SetAllowAdminCreateUserOnly(v bool) *AdminCreateUserConfigType {
+	s.AllowAdminCreateUserOnly = &v
+	return s
+}
+
+// SetInviteMessageTemplate sets the InviteMessageTemplate field's value.
+func (s *AdminCreateUserConfigType) SetInviteMessageTemplate(v *MessageTemplateType) *AdminCreateUserConfigType {
+	s.InviteMessageTemplate = v
+	return s
+}
+
+// SetUnusedAccountValidityDays sets the UnusedAccountValidityDays field's value.
+func (s *AdminCreateUserConfigType) SetUnusedAccountValidityDays(v int64) *AdminCreateUserConfigType {
+	s.UnusedAccountValidityDays = &v
+	return s
 }
 
 // Represents the request to create a user in the specified user pool.
@@ -5617,6 +5659,54 @@ func (s *AdminCreateUserInput) Validate() error {
 	return nil
 }
 
+// SetDesiredDeliveryMediums sets the DesiredDeliveryMediums field's value.
+func (s *AdminCreateUserInput) SetDesiredDeliveryMediums(v []*string) *AdminCreateUserInput {
+	s.DesiredDeliveryMediums = v
+	return s
+}
+
+// SetForceAliasCreation sets the ForceAliasCreation field's value.
+func (s *AdminCreateUserInput) SetForceAliasCreation(v bool) *AdminCreateUserInput {
+	s.ForceAliasCreation = &v
+	return s
+}
+
+// SetMessageAction sets the MessageAction field's value.
+func (s *AdminCreateUserInput) SetMessageAction(v string) *AdminCreateUserInput {
+	s.MessageAction = &v
+	return s
+}
+
+// SetTemporaryPassword sets the TemporaryPassword field's value.
+func (s *AdminCreateUserInput) SetTemporaryPassword(v string) *AdminCreateUserInput {
+	s.TemporaryPassword = &v
+	return s
+}
+
+// SetUserAttributes sets the UserAttributes field's value.
+func (s *AdminCreateUserInput) SetUserAttributes(v []*AttributeType) *AdminCreateUserInput {
+	s.UserAttributes = v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminCreateUserInput) SetUserPoolId(v string) *AdminCreateUserInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminCreateUserInput) SetUsername(v string) *AdminCreateUserInput {
+	s.Username = &v
+	return s
+}
+
+// SetValidationData sets the ValidationData field's value.
+func (s *AdminCreateUserInput) SetValidationData(v []*AttributeType) *AdminCreateUserInput {
+	s.ValidationData = v
+	return s
+}
+
 // Represents the response from the server to the request to create the user.
 type AdminCreateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -5633,6 +5723,12 @@ func (s AdminCreateUserOutput) String() string {
 // GoString returns the string representation
 func (s AdminCreateUserOutput) GoString() string {
 	return s.String()
+}
+
+// SetUser sets the User field's value.
+func (s *AdminCreateUserOutput) SetUser(v *UserType) *AdminCreateUserOutput {
+	s.User = v
+	return s
 }
 
 // Represents the request to delete user attributes as an administrator.
@@ -5688,6 +5784,24 @@ func (s *AdminDeleteUserAttributesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUserAttributeNames sets the UserAttributeNames field's value.
+func (s *AdminDeleteUserAttributesInput) SetUserAttributeNames(v []*string) *AdminDeleteUserAttributesInput {
+	s.UserAttributeNames = v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminDeleteUserAttributesInput) SetUserPoolId(v string) *AdminDeleteUserAttributesInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminDeleteUserAttributesInput) SetUsername(v string) *AdminDeleteUserAttributesInput {
+	s.Username = &v
+	return s
 }
 
 // Represents the response received from the server for a request to delete
@@ -5753,6 +5867,18 @@ func (s *AdminDeleteUserInput) Validate() error {
 	return nil
 }
 
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminDeleteUserInput) SetUserPoolId(v string) *AdminDeleteUserInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminDeleteUserInput) SetUsername(v string) *AdminDeleteUserInput {
+	s.Username = &v
+	return s
+}
+
 type AdminDeleteUserOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5812,6 +5938,18 @@ func (s *AdminDisableUserInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminDisableUserInput) SetUserPoolId(v string) *AdminDisableUserInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminDisableUserInput) SetUsername(v string) *AdminDisableUserInput {
+	s.Username = &v
+	return s
 }
 
 // Represents the response received from the server to disable the user as an
@@ -5875,6 +6013,18 @@ func (s *AdminEnableUserInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminEnableUserInput) SetUserPoolId(v string) *AdminEnableUserInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminEnableUserInput) SetUsername(v string) *AdminEnableUserInput {
+	s.Username = &v
+	return s
 }
 
 // Represents the response from the server for the request to enable a user
@@ -5951,6 +6101,24 @@ func (s *AdminForgetDeviceInput) Validate() error {
 	return nil
 }
 
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *AdminForgetDeviceInput) SetDeviceKey(v string) *AdminForgetDeviceInput {
+	s.DeviceKey = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminForgetDeviceInput) SetUserPoolId(v string) *AdminForgetDeviceInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminForgetDeviceInput) SetUsername(v string) *AdminForgetDeviceInput {
+	s.Username = &v
+	return s
+}
+
 type AdminForgetDeviceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6023,6 +6191,24 @@ func (s *AdminGetDeviceInput) Validate() error {
 	return nil
 }
 
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *AdminGetDeviceInput) SetDeviceKey(v string) *AdminGetDeviceInput {
+	s.DeviceKey = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminGetDeviceInput) SetUserPoolId(v string) *AdminGetDeviceInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminGetDeviceInput) SetUsername(v string) *AdminGetDeviceInput {
+	s.Username = &v
+	return s
+}
+
 // Gets the device response, as an administrator.
 type AdminGetDeviceOutput struct {
 	_ struct{} `type:"structure"`
@@ -6041,6 +6227,12 @@ func (s AdminGetDeviceOutput) String() string {
 // GoString returns the string representation
 func (s AdminGetDeviceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevice sets the Device field's value.
+func (s *AdminGetDeviceOutput) SetDevice(v *DeviceType) *AdminGetDeviceOutput {
+	s.Device = v
+	return s
 }
 
 // Represents the request to get the specified user as an administrator.
@@ -6091,6 +6283,18 @@ func (s *AdminGetUserInput) Validate() error {
 	return nil
 }
 
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminGetUserInput) SetUserPoolId(v string) *AdminGetUserInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminGetUserInput) SetUsername(v string) *AdminGetUserInput {
+	s.Username = &v
+	return s
+}
+
 // Represents the response from the server from the request to get the specified
 // user as an administrator.
 type AdminGetUserOutput struct {
@@ -6138,6 +6342,48 @@ func (s AdminGetUserOutput) String() string {
 // GoString returns the string representation
 func (s AdminGetUserOutput) GoString() string {
 	return s.String()
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *AdminGetUserOutput) SetEnabled(v bool) *AdminGetUserOutput {
+	s.Enabled = &v
+	return s
+}
+
+// SetMFAOptions sets the MFAOptions field's value.
+func (s *AdminGetUserOutput) SetMFAOptions(v []*MFAOptionType) *AdminGetUserOutput {
+	s.MFAOptions = v
+	return s
+}
+
+// SetUserAttributes sets the UserAttributes field's value.
+func (s *AdminGetUserOutput) SetUserAttributes(v []*AttributeType) *AdminGetUserOutput {
+	s.UserAttributes = v
+	return s
+}
+
+// SetUserCreateDate sets the UserCreateDate field's value.
+func (s *AdminGetUserOutput) SetUserCreateDate(v time.Time) *AdminGetUserOutput {
+	s.UserCreateDate = &v
+	return s
+}
+
+// SetUserLastModifiedDate sets the UserLastModifiedDate field's value.
+func (s *AdminGetUserOutput) SetUserLastModifiedDate(v time.Time) *AdminGetUserOutput {
+	s.UserLastModifiedDate = &v
+	return s
+}
+
+// SetUserStatus sets the UserStatus field's value.
+func (s *AdminGetUserOutput) SetUserStatus(v string) *AdminGetUserOutput {
+	s.UserStatus = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminGetUserOutput) SetUsername(v string) *AdminGetUserOutput {
+	s.Username = &v
+	return s
 }
 
 // Initiates the authorization request, as an administrator.
@@ -6201,6 +6447,36 @@ func (s *AdminInitiateAuthInput) Validate() error {
 	return nil
 }
 
+// SetAuthFlow sets the AuthFlow field's value.
+func (s *AdminInitiateAuthInput) SetAuthFlow(v string) *AdminInitiateAuthInput {
+	s.AuthFlow = &v
+	return s
+}
+
+// SetAuthParameters sets the AuthParameters field's value.
+func (s *AdminInitiateAuthInput) SetAuthParameters(v map[string]*string) *AdminInitiateAuthInput {
+	s.AuthParameters = v
+	return s
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *AdminInitiateAuthInput) SetClientId(v string) *AdminInitiateAuthInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetClientMetadata sets the ClientMetadata field's value.
+func (s *AdminInitiateAuthInput) SetClientMetadata(v map[string]*string) *AdminInitiateAuthInput {
+	s.ClientMetadata = v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminInitiateAuthInput) SetUserPoolId(v string) *AdminInitiateAuthInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Initiates the authentication response, as an administrator.
 type AdminInitiateAuthOutput struct {
 	_ struct{} `type:"structure"`
@@ -6226,6 +6502,30 @@ func (s AdminInitiateAuthOutput) String() string {
 // GoString returns the string representation
 func (s AdminInitiateAuthOutput) GoString() string {
 	return s.String()
+}
+
+// SetAuthenticationResult sets the AuthenticationResult field's value.
+func (s *AdminInitiateAuthOutput) SetAuthenticationResult(v *AuthenticationResultType) *AdminInitiateAuthOutput {
+	s.AuthenticationResult = v
+	return s
+}
+
+// SetChallengeName sets the ChallengeName field's value.
+func (s *AdminInitiateAuthOutput) SetChallengeName(v string) *AdminInitiateAuthOutput {
+	s.ChallengeName = &v
+	return s
+}
+
+// SetChallengeParameters sets the ChallengeParameters field's value.
+func (s *AdminInitiateAuthOutput) SetChallengeParameters(v map[string]*string) *AdminInitiateAuthOutput {
+	s.ChallengeParameters = v
+	return s
+}
+
+// SetSession sets the Session field's value.
+func (s *AdminInitiateAuthOutput) SetSession(v string) *AdminInitiateAuthOutput {
+	s.Session = &v
+	return s
 }
 
 // Represents the request to list devices, as an administrator.
@@ -6284,6 +6584,30 @@ func (s *AdminListDevicesInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *AdminListDevicesInput) SetLimit(v int64) *AdminListDevicesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPaginationToken sets the PaginationToken field's value.
+func (s *AdminListDevicesInput) SetPaginationToken(v string) *AdminListDevicesInput {
+	s.PaginationToken = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminListDevicesInput) SetUserPoolId(v string) *AdminListDevicesInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminListDevicesInput) SetUsername(v string) *AdminListDevicesInput {
+	s.Username = &v
+	return s
+}
+
 // Lists the device's response, as an administrator.
 type AdminListDevicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6303,6 +6627,18 @@ func (s AdminListDevicesOutput) String() string {
 // GoString returns the string representation
 func (s AdminListDevicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevices sets the Devices field's value.
+func (s *AdminListDevicesOutput) SetDevices(v []*DeviceType) *AdminListDevicesOutput {
+	s.Devices = v
+	return s
+}
+
+// SetPaginationToken sets the PaginationToken field's value.
+func (s *AdminListDevicesOutput) SetPaginationToken(v string) *AdminListDevicesOutput {
+	s.PaginationToken = &v
+	return s
 }
 
 // Represents the request to reset a user's password as an administrator.
@@ -6350,6 +6686,18 @@ func (s *AdminResetUserPasswordInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminResetUserPasswordInput) SetUserPoolId(v string) *AdminResetUserPasswordInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminResetUserPasswordInput) SetUsername(v string) *AdminResetUserPasswordInput {
+	s.Username = &v
+	return s
 }
 
 // Represents the response from the server to reset a user password as an administrator.
@@ -6431,6 +6779,36 @@ func (s *AdminRespondToAuthChallengeInput) Validate() error {
 	return nil
 }
 
+// SetChallengeName sets the ChallengeName field's value.
+func (s *AdminRespondToAuthChallengeInput) SetChallengeName(v string) *AdminRespondToAuthChallengeInput {
+	s.ChallengeName = &v
+	return s
+}
+
+// SetChallengeResponses sets the ChallengeResponses field's value.
+func (s *AdminRespondToAuthChallengeInput) SetChallengeResponses(v map[string]*string) *AdminRespondToAuthChallengeInput {
+	s.ChallengeResponses = v
+	return s
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *AdminRespondToAuthChallengeInput) SetClientId(v string) *AdminRespondToAuthChallengeInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetSession sets the Session field's value.
+func (s *AdminRespondToAuthChallengeInput) SetSession(v string) *AdminRespondToAuthChallengeInput {
+	s.Session = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminRespondToAuthChallengeInput) SetUserPoolId(v string) *AdminRespondToAuthChallengeInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Responds to the authentication challenge, as an administrator.
 type AdminRespondToAuthChallengeOutput struct {
 	_ struct{} `type:"structure"`
@@ -6456,6 +6834,30 @@ func (s AdminRespondToAuthChallengeOutput) String() string {
 // GoString returns the string representation
 func (s AdminRespondToAuthChallengeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAuthenticationResult sets the AuthenticationResult field's value.
+func (s *AdminRespondToAuthChallengeOutput) SetAuthenticationResult(v *AuthenticationResultType) *AdminRespondToAuthChallengeOutput {
+	s.AuthenticationResult = v
+	return s
+}
+
+// SetChallengeName sets the ChallengeName field's value.
+func (s *AdminRespondToAuthChallengeOutput) SetChallengeName(v string) *AdminRespondToAuthChallengeOutput {
+	s.ChallengeName = &v
+	return s
+}
+
+// SetChallengeParameters sets the ChallengeParameters field's value.
+func (s *AdminRespondToAuthChallengeOutput) SetChallengeParameters(v map[string]*string) *AdminRespondToAuthChallengeOutput {
+	s.ChallengeParameters = v
+	return s
+}
+
+// SetSession sets the Session field's value.
+func (s *AdminRespondToAuthChallengeOutput) SetSession(v string) *AdminRespondToAuthChallengeOutput {
+	s.Session = &v
+	return s
 }
 
 // Represents the request to set user settings as an administrator.
@@ -6522,6 +6924,24 @@ func (s *AdminSetUserSettingsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMFAOptions sets the MFAOptions field's value.
+func (s *AdminSetUserSettingsInput) SetMFAOptions(v []*MFAOptionType) *AdminSetUserSettingsInput {
+	s.MFAOptions = v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminSetUserSettingsInput) SetUserPoolId(v string) *AdminSetUserSettingsInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminSetUserSettingsInput) SetUsername(v string) *AdminSetUserSettingsInput {
+	s.Username = &v
+	return s
 }
 
 // Represents the response from the server to set user settings as an administrator.
@@ -6598,6 +7018,30 @@ func (s *AdminUpdateDeviceStatusInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *AdminUpdateDeviceStatusInput) SetDeviceKey(v string) *AdminUpdateDeviceStatusInput {
+	s.DeviceKey = &v
+	return s
+}
+
+// SetDeviceRememberedStatus sets the DeviceRememberedStatus field's value.
+func (s *AdminUpdateDeviceStatusInput) SetDeviceRememberedStatus(v string) *AdminUpdateDeviceStatusInput {
+	s.DeviceRememberedStatus = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminUpdateDeviceStatusInput) SetUserPoolId(v string) *AdminUpdateDeviceStatusInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminUpdateDeviceStatusInput) SetUsername(v string) *AdminUpdateDeviceStatusInput {
+	s.Username = &v
+	return s
 }
 
 // The status response from the request to update the device, as an administrator.
@@ -6680,6 +7124,24 @@ func (s *AdminUpdateUserAttributesInput) Validate() error {
 	return nil
 }
 
+// SetUserAttributes sets the UserAttributes field's value.
+func (s *AdminUpdateUserAttributesInput) SetUserAttributes(v []*AttributeType) *AdminUpdateUserAttributesInput {
+	s.UserAttributes = v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminUpdateUserAttributesInput) SetUserPoolId(v string) *AdminUpdateUserAttributesInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminUpdateUserAttributesInput) SetUsername(v string) *AdminUpdateUserAttributesInput {
+	s.Username = &v
+	return s
+}
+
 // Represents the response from the server for the request to update user attributes
 // as an administrator.
 type AdminUpdateUserAttributesOutput struct {
@@ -6743,6 +7205,18 @@ func (s *AdminUserGlobalSignOutInput) Validate() error {
 	return nil
 }
 
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *AdminUserGlobalSignOutInput) SetUserPoolId(v string) *AdminUserGlobalSignOutInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *AdminUserGlobalSignOutInput) SetUsername(v string) *AdminUserGlobalSignOutInput {
+	s.Username = &v
+	return s
+}
+
 // The global sign-out response, as an administrator.
 type AdminUserGlobalSignOutOutput struct {
 	_ struct{} `type:"structure"`
@@ -6797,6 +7271,18 @@ func (s *AttributeType) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *AttributeType) SetName(v string) *AttributeType {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *AttributeType) SetValue(v string) *AttributeType {
+	s.Value = &v
+	return s
+}
+
 // The result type of the authentication result.
 type AuthenticationResultType struct {
 	_ struct{} `type:"structure"`
@@ -6828,6 +7314,42 @@ func (s AuthenticationResultType) String() string {
 // GoString returns the string representation
 func (s AuthenticationResultType) GoString() string {
 	return s.String()
+}
+
+// SetAccessToken sets the AccessToken field's value.
+func (s *AuthenticationResultType) SetAccessToken(v string) *AuthenticationResultType {
+	s.AccessToken = &v
+	return s
+}
+
+// SetExpiresIn sets the ExpiresIn field's value.
+func (s *AuthenticationResultType) SetExpiresIn(v int64) *AuthenticationResultType {
+	s.ExpiresIn = &v
+	return s
+}
+
+// SetIdToken sets the IdToken field's value.
+func (s *AuthenticationResultType) SetIdToken(v string) *AuthenticationResultType {
+	s.IdToken = &v
+	return s
+}
+
+// SetNewDeviceMetadata sets the NewDeviceMetadata field's value.
+func (s *AuthenticationResultType) SetNewDeviceMetadata(v *NewDeviceMetadataType) *AuthenticationResultType {
+	s.NewDeviceMetadata = v
+	return s
+}
+
+// SetRefreshToken sets the RefreshToken field's value.
+func (s *AuthenticationResultType) SetRefreshToken(v string) *AuthenticationResultType {
+	s.RefreshToken = &v
+	return s
+}
+
+// SetTokenType sets the TokenType field's value.
+func (s *AuthenticationResultType) SetTokenType(v string) *AuthenticationResultType {
+	s.TokenType = &v
+	return s
 }
 
 // Represents the request to change a user password.
@@ -6880,6 +7402,24 @@ func (s *ChangePasswordInput) Validate() error {
 	return nil
 }
 
+// SetAccessToken sets the AccessToken field's value.
+func (s *ChangePasswordInput) SetAccessToken(v string) *ChangePasswordInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetPreviousPassword sets the PreviousPassword field's value.
+func (s *ChangePasswordInput) SetPreviousPassword(v string) *ChangePasswordInput {
+	s.PreviousPassword = &v
+	return s
+}
+
+// SetProposedPassword sets the ProposedPassword field's value.
+func (s *ChangePasswordInput) SetProposedPassword(v string) *ChangePasswordInput {
+	s.ProposedPassword = &v
+	return s
+}
+
 // The response from the server to the change password request.
 type ChangePasswordOutput struct {
 	_ struct{} `type:"structure"`
@@ -6917,6 +7457,24 @@ func (s CodeDeliveryDetailsType) String() string {
 // GoString returns the string representation
 func (s CodeDeliveryDetailsType) GoString() string {
 	return s.String()
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *CodeDeliveryDetailsType) SetAttributeName(v string) *CodeDeliveryDetailsType {
+	s.AttributeName = &v
+	return s
+}
+
+// SetDeliveryMedium sets the DeliveryMedium field's value.
+func (s *CodeDeliveryDetailsType) SetDeliveryMedium(v string) *CodeDeliveryDetailsType {
+	s.DeliveryMedium = &v
+	return s
+}
+
+// SetDestination sets the Destination field's value.
+func (s *CodeDeliveryDetailsType) SetDestination(v string) *CodeDeliveryDetailsType {
+	s.Destination = &v
+	return s
 }
 
 // Confirms the device request.
@@ -6972,6 +7530,30 @@ func (s *ConfirmDeviceInput) Validate() error {
 	return nil
 }
 
+// SetAccessToken sets the AccessToken field's value.
+func (s *ConfirmDeviceInput) SetAccessToken(v string) *ConfirmDeviceInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *ConfirmDeviceInput) SetDeviceKey(v string) *ConfirmDeviceInput {
+	s.DeviceKey = &v
+	return s
+}
+
+// SetDeviceName sets the DeviceName field's value.
+func (s *ConfirmDeviceInput) SetDeviceName(v string) *ConfirmDeviceInput {
+	s.DeviceName = &v
+	return s
+}
+
+// SetDeviceSecretVerifierConfig sets the DeviceSecretVerifierConfig field's value.
+func (s *ConfirmDeviceInput) SetDeviceSecretVerifierConfig(v *DeviceSecretVerifierConfigType) *ConfirmDeviceInput {
+	s.DeviceSecretVerifierConfig = v
+	return s
+}
+
 // Confirms the device response.
 type ConfirmDeviceOutput struct {
 	_ struct{} `type:"structure"`
@@ -6989,6 +7571,12 @@ func (s ConfirmDeviceOutput) String() string {
 // GoString returns the string representation
 func (s ConfirmDeviceOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserConfirmationNecessary sets the UserConfirmationNecessary field's value.
+func (s *ConfirmDeviceOutput) SetUserConfirmationNecessary(v bool) *ConfirmDeviceOutput {
+	s.UserConfirmationNecessary = &v
+	return s
 }
 
 // The request representing the confirmation for a password reset.
@@ -7066,6 +7654,36 @@ func (s *ConfirmForgotPasswordInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *ConfirmForgotPasswordInput) SetClientId(v string) *ConfirmForgotPasswordInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetConfirmationCode sets the ConfirmationCode field's value.
+func (s *ConfirmForgotPasswordInput) SetConfirmationCode(v string) *ConfirmForgotPasswordInput {
+	s.ConfirmationCode = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *ConfirmForgotPasswordInput) SetPassword(v string) *ConfirmForgotPasswordInput {
+	s.Password = &v
+	return s
+}
+
+// SetSecretHash sets the SecretHash field's value.
+func (s *ConfirmForgotPasswordInput) SetSecretHash(v string) *ConfirmForgotPasswordInput {
+	s.SecretHash = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *ConfirmForgotPasswordInput) SetUsername(v string) *ConfirmForgotPasswordInput {
+	s.Username = &v
+	return s
 }
 
 // The response from the server that results from a user's request to retrieve
@@ -7157,6 +7775,36 @@ func (s *ConfirmSignUpInput) Validate() error {
 	return nil
 }
 
+// SetClientId sets the ClientId field's value.
+func (s *ConfirmSignUpInput) SetClientId(v string) *ConfirmSignUpInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetConfirmationCode sets the ConfirmationCode field's value.
+func (s *ConfirmSignUpInput) SetConfirmationCode(v string) *ConfirmSignUpInput {
+	s.ConfirmationCode = &v
+	return s
+}
+
+// SetForceAliasCreation sets the ForceAliasCreation field's value.
+func (s *ConfirmSignUpInput) SetForceAliasCreation(v bool) *ConfirmSignUpInput {
+	s.ForceAliasCreation = &v
+	return s
+}
+
+// SetSecretHash sets the SecretHash field's value.
+func (s *ConfirmSignUpInput) SetSecretHash(v string) *ConfirmSignUpInput {
+	s.SecretHash = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *ConfirmSignUpInput) SetUsername(v string) *ConfirmSignUpInput {
+	s.Username = &v
+	return s
+}
+
 // Represents the response from the server for the registration confirmation.
 type ConfirmSignUpOutput struct {
 	_ struct{} `type:"structure"`
@@ -7230,6 +7878,24 @@ func (s *CreateUserImportJobInput) Validate() error {
 	return nil
 }
 
+// SetCloudWatchLogsRoleArn sets the CloudWatchLogsRoleArn field's value.
+func (s *CreateUserImportJobInput) SetCloudWatchLogsRoleArn(v string) *CreateUserImportJobInput {
+	s.CloudWatchLogsRoleArn = &v
+	return s
+}
+
+// SetJobName sets the JobName field's value.
+func (s *CreateUserImportJobInput) SetJobName(v string) *CreateUserImportJobInput {
+	s.JobName = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *CreateUserImportJobInput) SetUserPoolId(v string) *CreateUserImportJobInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server to the request to create the user
 // import job.
 type CreateUserImportJobOutput struct {
@@ -7247,6 +7913,12 @@ func (s CreateUserImportJobOutput) String() string {
 // GoString returns the string representation
 func (s CreateUserImportJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserImportJob sets the UserImportJob field's value.
+func (s *CreateUserImportJobOutput) SetUserImportJob(v *UserImportJobType) *CreateUserImportJobOutput {
+	s.UserImportJob = v
+	return s
 }
 
 // Represents the request to create a user pool client.
@@ -7312,6 +7984,48 @@ func (s *CreateUserPoolClientInput) Validate() error {
 	return nil
 }
 
+// SetClientName sets the ClientName field's value.
+func (s *CreateUserPoolClientInput) SetClientName(v string) *CreateUserPoolClientInput {
+	s.ClientName = &v
+	return s
+}
+
+// SetExplicitAuthFlows sets the ExplicitAuthFlows field's value.
+func (s *CreateUserPoolClientInput) SetExplicitAuthFlows(v []*string) *CreateUserPoolClientInput {
+	s.ExplicitAuthFlows = v
+	return s
+}
+
+// SetGenerateSecret sets the GenerateSecret field's value.
+func (s *CreateUserPoolClientInput) SetGenerateSecret(v bool) *CreateUserPoolClientInput {
+	s.GenerateSecret = &v
+	return s
+}
+
+// SetReadAttributes sets the ReadAttributes field's value.
+func (s *CreateUserPoolClientInput) SetReadAttributes(v []*string) *CreateUserPoolClientInput {
+	s.ReadAttributes = v
+	return s
+}
+
+// SetRefreshTokenValidity sets the RefreshTokenValidity field's value.
+func (s *CreateUserPoolClientInput) SetRefreshTokenValidity(v int64) *CreateUserPoolClientInput {
+	s.RefreshTokenValidity = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *CreateUserPoolClientInput) SetUserPoolId(v string) *CreateUserPoolClientInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetWriteAttributes sets the WriteAttributes field's value.
+func (s *CreateUserPoolClientInput) SetWriteAttributes(v []*string) *CreateUserPoolClientInput {
+	s.WriteAttributes = v
+	return s
+}
+
 // Represents the response from the server to create a user pool client.
 type CreateUserPoolClientOutput struct {
 	_ struct{} `type:"structure"`
@@ -7328,6 +8042,12 @@ func (s CreateUserPoolClientOutput) String() string {
 // GoString returns the string representation
 func (s CreateUserPoolClientOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserPoolClient sets the UserPoolClient field's value.
+func (s *CreateUserPoolClientOutput) SetUserPoolClient(v *UserPoolClientType) *CreateUserPoolClientOutput {
+	s.UserPoolClient = v
+	return s
 }
 
 // Represents the request to create a user pool.
@@ -7443,6 +8163,90 @@ func (s *CreateUserPoolInput) Validate() error {
 	return nil
 }
 
+// SetAdminCreateUserConfig sets the AdminCreateUserConfig field's value.
+func (s *CreateUserPoolInput) SetAdminCreateUserConfig(v *AdminCreateUserConfigType) *CreateUserPoolInput {
+	s.AdminCreateUserConfig = v
+	return s
+}
+
+// SetAliasAttributes sets the AliasAttributes field's value.
+func (s *CreateUserPoolInput) SetAliasAttributes(v []*string) *CreateUserPoolInput {
+	s.AliasAttributes = v
+	return s
+}
+
+// SetAutoVerifiedAttributes sets the AutoVerifiedAttributes field's value.
+func (s *CreateUserPoolInput) SetAutoVerifiedAttributes(v []*string) *CreateUserPoolInput {
+	s.AutoVerifiedAttributes = v
+	return s
+}
+
+// SetDeviceConfiguration sets the DeviceConfiguration field's value.
+func (s *CreateUserPoolInput) SetDeviceConfiguration(v *DeviceConfigurationType) *CreateUserPoolInput {
+	s.DeviceConfiguration = v
+	return s
+}
+
+// SetEmailConfiguration sets the EmailConfiguration field's value.
+func (s *CreateUserPoolInput) SetEmailConfiguration(v *EmailConfigurationType) *CreateUserPoolInput {
+	s.EmailConfiguration = v
+	return s
+}
+
+// SetEmailVerificationMessage sets the EmailVerificationMessage field's value.
+func (s *CreateUserPoolInput) SetEmailVerificationMessage(v string) *CreateUserPoolInput {
+	s.EmailVerificationMessage = &v
+	return s
+}
+
+// SetEmailVerificationSubject sets the EmailVerificationSubject field's value.
+func (s *CreateUserPoolInput) SetEmailVerificationSubject(v string) *CreateUserPoolInput {
+	s.EmailVerificationSubject = &v
+	return s
+}
+
+// SetLambdaConfig sets the LambdaConfig field's value.
+func (s *CreateUserPoolInput) SetLambdaConfig(v *LambdaConfigType) *CreateUserPoolInput {
+	s.LambdaConfig = v
+	return s
+}
+
+// SetMfaConfiguration sets the MfaConfiguration field's value.
+func (s *CreateUserPoolInput) SetMfaConfiguration(v string) *CreateUserPoolInput {
+	s.MfaConfiguration = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *CreateUserPoolInput) SetPolicies(v *UserPoolPolicyType) *CreateUserPoolInput {
+	s.Policies = v
+	return s
+}
+
+// SetPoolName sets the PoolName field's value.
+func (s *CreateUserPoolInput) SetPoolName(v string) *CreateUserPoolInput {
+	s.PoolName = &v
+	return s
+}
+
+// SetSmsAuthenticationMessage sets the SmsAuthenticationMessage field's value.
+func (s *CreateUserPoolInput) SetSmsAuthenticationMessage(v string) *CreateUserPoolInput {
+	s.SmsAuthenticationMessage = &v
+	return s
+}
+
+// SetSmsConfiguration sets the SmsConfiguration field's value.
+func (s *CreateUserPoolInput) SetSmsConfiguration(v *SmsConfigurationType) *CreateUserPoolInput {
+	s.SmsConfiguration = v
+	return s
+}
+
+// SetSmsVerificationMessage sets the SmsVerificationMessage field's value.
+func (s *CreateUserPoolInput) SetSmsVerificationMessage(v string) *CreateUserPoolInput {
+	s.SmsVerificationMessage = &v
+	return s
+}
+
 // Represents the response from the server for the request to create a user
 // pool.
 type CreateUserPoolOutput struct {
@@ -7460,6 +8264,12 @@ func (s CreateUserPoolOutput) String() string {
 // GoString returns the string representation
 func (s CreateUserPoolOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserPool sets the UserPool field's value.
+func (s *CreateUserPoolOutput) SetUserPool(v *UserPoolType) *CreateUserPoolOutput {
+	s.UserPool = v
+	return s
 }
 
 // Represents the request to delete user attributes.
@@ -7498,6 +8308,18 @@ func (s *DeleteUserAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAccessToken sets the AccessToken field's value.
+func (s *DeleteUserAttributesInput) SetAccessToken(v string) *DeleteUserAttributesInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetUserAttributeNames sets the UserAttributeNames field's value.
+func (s *DeleteUserAttributesInput) SetUserAttributeNames(v []*string) *DeleteUserAttributesInput {
+	s.UserAttributeNames = v
+	return s
+}
+
 // Represents the response from the server to delete user attributes.
 type DeleteUserAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7529,6 +8351,12 @@ func (s DeleteUserInput) String() string {
 // GoString returns the string representation
 func (s DeleteUserInput) GoString() string {
 	return s.String()
+}
+
+// SetAccessToken sets the AccessToken field's value.
+func (s *DeleteUserInput) SetAccessToken(v string) *DeleteUserInput {
+	s.AccessToken = &v
+	return s
 }
 
 type DeleteUserOutput struct {
@@ -7592,6 +8420,18 @@ func (s *DeleteUserPoolClientInput) Validate() error {
 	return nil
 }
 
+// SetClientId sets the ClientId field's value.
+func (s *DeleteUserPoolClientInput) SetClientId(v string) *DeleteUserPoolClientInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *DeleteUserPoolClientInput) SetUserPoolId(v string) *DeleteUserPoolClientInput {
+	s.UserPoolId = &v
+	return s
+}
+
 type DeleteUserPoolClientOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7640,6 +8480,12 @@ func (s *DeleteUserPoolInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *DeleteUserPoolInput) SetUserPoolId(v string) *DeleteUserPoolInput {
+	s.UserPoolId = &v
+	return s
 }
 
 type DeleteUserPoolOutput struct {
@@ -7703,6 +8549,18 @@ func (s *DescribeUserImportJobInput) Validate() error {
 	return nil
 }
 
+// SetJobId sets the JobId field's value.
+func (s *DescribeUserImportJobInput) SetJobId(v string) *DescribeUserImportJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *DescribeUserImportJobInput) SetUserPoolId(v string) *DescribeUserImportJobInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server to the request to describe the user
 // import job.
 type DescribeUserImportJobOutput struct {
@@ -7720,6 +8578,12 @@ func (s DescribeUserImportJobOutput) String() string {
 // GoString returns the string representation
 func (s DescribeUserImportJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserImportJob sets the UserImportJob field's value.
+func (s *DescribeUserImportJobOutput) SetUserImportJob(v *UserImportJobType) *DescribeUserImportJobOutput {
+	s.UserImportJob = v
+	return s
 }
 
 // Represents the request to describe a user pool client.
@@ -7769,6 +8633,18 @@ func (s *DescribeUserPoolClientInput) Validate() error {
 	return nil
 }
 
+// SetClientId sets the ClientId field's value.
+func (s *DescribeUserPoolClientInput) SetClientId(v string) *DescribeUserPoolClientInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *DescribeUserPoolClientInput) SetUserPoolId(v string) *DescribeUserPoolClientInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server from a request to describe the user
 // pool client.
 type DescribeUserPoolClientOutput struct {
@@ -7786,6 +8662,12 @@ func (s DescribeUserPoolClientOutput) String() string {
 // GoString returns the string representation
 func (s DescribeUserPoolClientOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserPoolClient sets the UserPoolClient field's value.
+func (s *DescribeUserPoolClientOutput) SetUserPoolClient(v *UserPoolClientType) *DescribeUserPoolClientOutput {
+	s.UserPoolClient = v
+	return s
 }
 
 // Represents the request to describe the user pool.
@@ -7824,6 +8706,12 @@ func (s *DescribeUserPoolInput) Validate() error {
 	return nil
 }
 
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *DescribeUserPoolInput) SetUserPoolId(v string) *DescribeUserPoolInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response to describe the user pool.
 type DescribeUserPoolOutput struct {
 	_ struct{} `type:"structure"`
@@ -7840,6 +8728,12 @@ func (s DescribeUserPoolOutput) String() string {
 // GoString returns the string representation
 func (s DescribeUserPoolOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserPool sets the UserPool field's value.
+func (s *DescribeUserPoolOutput) SetUserPool(v *UserPoolType) *DescribeUserPoolOutput {
+	s.UserPool = v
+	return s
 }
 
 // The type of configuration for the user pool's device tracking.
@@ -7864,6 +8758,18 @@ func (s DeviceConfigurationType) GoString() string {
 	return s.String()
 }
 
+// SetChallengeRequiredOnNewDevice sets the ChallengeRequiredOnNewDevice field's value.
+func (s *DeviceConfigurationType) SetChallengeRequiredOnNewDevice(v bool) *DeviceConfigurationType {
+	s.ChallengeRequiredOnNewDevice = &v
+	return s
+}
+
+// SetDeviceOnlyRememberedOnUserPrompt sets the DeviceOnlyRememberedOnUserPrompt field's value.
+func (s *DeviceConfigurationType) SetDeviceOnlyRememberedOnUserPrompt(v bool) *DeviceConfigurationType {
+	s.DeviceOnlyRememberedOnUserPrompt = &v
+	return s
+}
+
 // The device verifier against which it will be authenticated.
 type DeviceSecretVerifierConfigType struct {
 	_ struct{} `type:"structure"`
@@ -7883,6 +8789,18 @@ func (s DeviceSecretVerifierConfigType) String() string {
 // GoString returns the string representation
 func (s DeviceSecretVerifierConfigType) GoString() string {
 	return s.String()
+}
+
+// SetPasswordVerifier sets the PasswordVerifier field's value.
+func (s *DeviceSecretVerifierConfigType) SetPasswordVerifier(v string) *DeviceSecretVerifierConfigType {
+	s.PasswordVerifier = &v
+	return s
+}
+
+// SetSalt sets the Salt field's value.
+func (s *DeviceSecretVerifierConfigType) SetSalt(v string) *DeviceSecretVerifierConfigType {
+	s.Salt = &v
+	return s
 }
 
 // The device type.
@@ -7913,6 +8831,36 @@ func (s DeviceType) String() string {
 // GoString returns the string representation
 func (s DeviceType) GoString() string {
 	return s.String()
+}
+
+// SetDeviceAttributes sets the DeviceAttributes field's value.
+func (s *DeviceType) SetDeviceAttributes(v []*AttributeType) *DeviceType {
+	s.DeviceAttributes = v
+	return s
+}
+
+// SetDeviceCreateDate sets the DeviceCreateDate field's value.
+func (s *DeviceType) SetDeviceCreateDate(v time.Time) *DeviceType {
+	s.DeviceCreateDate = &v
+	return s
+}
+
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *DeviceType) SetDeviceKey(v string) *DeviceType {
+	s.DeviceKey = &v
+	return s
+}
+
+// SetDeviceLastAuthenticatedDate sets the DeviceLastAuthenticatedDate field's value.
+func (s *DeviceType) SetDeviceLastAuthenticatedDate(v time.Time) *DeviceType {
+	s.DeviceLastAuthenticatedDate = &v
+	return s
+}
+
+// SetDeviceLastModifiedDate sets the DeviceLastModifiedDate field's value.
+func (s *DeviceType) SetDeviceLastModifiedDate(v time.Time) *DeviceType {
+	s.DeviceLastModifiedDate = &v
+	return s
 }
 
 // The email configuration type.
@@ -7947,6 +8895,18 @@ func (s *EmailConfigurationType) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetReplyToEmailAddress sets the ReplyToEmailAddress field's value.
+func (s *EmailConfigurationType) SetReplyToEmailAddress(v string) *EmailConfigurationType {
+	s.ReplyToEmailAddress = &v
+	return s
+}
+
+// SetSourceArn sets the SourceArn field's value.
+func (s *EmailConfigurationType) SetSourceArn(v string) *EmailConfigurationType {
+	s.SourceArn = &v
+	return s
 }
 
 // Represents the request to forget the device.
@@ -7986,6 +8946,18 @@ func (s *ForgetDeviceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccessToken sets the AccessToken field's value.
+func (s *ForgetDeviceInput) SetAccessToken(v string) *ForgetDeviceInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *ForgetDeviceInput) SetDeviceKey(v string) *ForgetDeviceInput {
+	s.DeviceKey = &v
+	return s
 }
 
 type ForgetDeviceOutput struct {
@@ -8057,6 +9029,24 @@ func (s *ForgotPasswordInput) Validate() error {
 	return nil
 }
 
+// SetClientId sets the ClientId field's value.
+func (s *ForgotPasswordInput) SetClientId(v string) *ForgotPasswordInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetSecretHash sets the SecretHash field's value.
+func (s *ForgotPasswordInput) SetSecretHash(v string) *ForgotPasswordInput {
+	s.SecretHash = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *ForgotPasswordInput) SetUsername(v string) *ForgotPasswordInput {
+	s.Username = &v
+	return s
+}
+
 // Respresents the response from the server regarding the request to reset a
 // password.
 type ForgotPasswordOutput struct {
@@ -8074,6 +9064,12 @@ func (s ForgotPasswordOutput) String() string {
 // GoString returns the string representation
 func (s ForgotPasswordOutput) GoString() string {
 	return s.String()
+}
+
+// SetCodeDeliveryDetails sets the CodeDeliveryDetails field's value.
+func (s *ForgotPasswordOutput) SetCodeDeliveryDetails(v *CodeDeliveryDetailsType) *ForgotPasswordOutput {
+	s.CodeDeliveryDetails = v
+	return s
 }
 
 // Represents the request to get the header information for the .csv file for
@@ -8113,6 +9109,12 @@ func (s *GetCSVHeaderInput) Validate() error {
 	return nil
 }
 
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *GetCSVHeaderInput) SetUserPoolId(v string) *GetCSVHeaderInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server to the request to get the header
 // information for the .csv file for the user import job.
 type GetCSVHeaderOutput struct {
@@ -8133,6 +9135,18 @@ func (s GetCSVHeaderOutput) String() string {
 // GoString returns the string representation
 func (s GetCSVHeaderOutput) GoString() string {
 	return s.String()
+}
+
+// SetCSVHeader sets the CSVHeader field's value.
+func (s *GetCSVHeaderOutput) SetCSVHeader(v []*string) *GetCSVHeaderOutput {
+	s.CSVHeader = v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *GetCSVHeaderOutput) SetUserPoolId(v string) *GetCSVHeaderOutput {
+	s.UserPoolId = &v
+	return s
 }
 
 // Represents the request to get the device.
@@ -8174,6 +9188,18 @@ func (s *GetDeviceInput) Validate() error {
 	return nil
 }
 
+// SetAccessToken sets the AccessToken field's value.
+func (s *GetDeviceInput) SetAccessToken(v string) *GetDeviceInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *GetDeviceInput) SetDeviceKey(v string) *GetDeviceInput {
+	s.DeviceKey = &v
+	return s
+}
+
 // Gets the device response.
 type GetDeviceOutput struct {
 	_ struct{} `type:"structure"`
@@ -8192,6 +9218,12 @@ func (s GetDeviceOutput) String() string {
 // GoString returns the string representation
 func (s GetDeviceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevice sets the Device field's value.
+func (s *GetDeviceOutput) SetDevice(v *DeviceType) *GetDeviceOutput {
+	s.Device = v
+	return s
 }
 
 // Represents the request to get user attribute verification.
@@ -8235,6 +9267,18 @@ func (s *GetUserAttributeVerificationCodeInput) Validate() error {
 	return nil
 }
 
+// SetAccessToken sets the AccessToken field's value.
+func (s *GetUserAttributeVerificationCodeInput) SetAccessToken(v string) *GetUserAttributeVerificationCodeInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *GetUserAttributeVerificationCodeInput) SetAttributeName(v string) *GetUserAttributeVerificationCodeInput {
+	s.AttributeName = &v
+	return s
+}
+
 // The verification code response returned by the server response to get the
 // user attribute verification code.
 type GetUserAttributeVerificationCodeOutput struct {
@@ -8255,6 +9299,12 @@ func (s GetUserAttributeVerificationCodeOutput) GoString() string {
 	return s.String()
 }
 
+// SetCodeDeliveryDetails sets the CodeDeliveryDetails field's value.
+func (s *GetUserAttributeVerificationCodeOutput) SetCodeDeliveryDetails(v *CodeDeliveryDetailsType) *GetUserAttributeVerificationCodeOutput {
+	s.CodeDeliveryDetails = v
+	return s
+}
+
 // Represents the request to get information about the user.
 type GetUserInput struct {
 	_ struct{} `type:"structure"`
@@ -8272,6 +9322,12 @@ func (s GetUserInput) String() string {
 // GoString returns the string representation
 func (s GetUserInput) GoString() string {
 	return s.String()
+}
+
+// SetAccessToken sets the AccessToken field's value.
+func (s *GetUserInput) SetAccessToken(v string) *GetUserInput {
+	s.AccessToken = &v
+	return s
 }
 
 // Represents the response from the server from the request to get information
@@ -8303,6 +9359,24 @@ func (s GetUserOutput) GoString() string {
 	return s.String()
 }
 
+// SetMFAOptions sets the MFAOptions field's value.
+func (s *GetUserOutput) SetMFAOptions(v []*MFAOptionType) *GetUserOutput {
+	s.MFAOptions = v
+	return s
+}
+
+// SetUserAttributes sets the UserAttributes field's value.
+func (s *GetUserOutput) SetUserAttributes(v []*AttributeType) *GetUserOutput {
+	s.UserAttributes = v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *GetUserOutput) SetUsername(v string) *GetUserOutput {
+	s.Username = &v
+	return s
+}
+
 // Represents the request to sign out all devices.
 type GlobalSignOutInput struct {
 	_ struct{} `type:"structure"`
@@ -8319,6 +9393,12 @@ func (s GlobalSignOutInput) String() string {
 // GoString returns the string representation
 func (s GlobalSignOutInput) GoString() string {
 	return s.String()
+}
+
+// SetAccessToken sets the AccessToken field's value.
+func (s *GlobalSignOutInput) SetAccessToken(v string) *GlobalSignOutInput {
+	s.AccessToken = &v
+	return s
 }
 
 // The response to the request to sign out all devices.
@@ -8386,6 +9466,30 @@ func (s *InitiateAuthInput) Validate() error {
 	return nil
 }
 
+// SetAuthFlow sets the AuthFlow field's value.
+func (s *InitiateAuthInput) SetAuthFlow(v string) *InitiateAuthInput {
+	s.AuthFlow = &v
+	return s
+}
+
+// SetAuthParameters sets the AuthParameters field's value.
+func (s *InitiateAuthInput) SetAuthParameters(v map[string]*string) *InitiateAuthInput {
+	s.AuthParameters = v
+	return s
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *InitiateAuthInput) SetClientId(v string) *InitiateAuthInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetClientMetadata sets the ClientMetadata field's value.
+func (s *InitiateAuthInput) SetClientMetadata(v map[string]*string) *InitiateAuthInput {
+	s.ClientMetadata = v
+	return s
+}
+
 // Initiates the authentication response.
 type InitiateAuthOutput struct {
 	_ struct{} `type:"structure"`
@@ -8411,6 +9515,30 @@ func (s InitiateAuthOutput) String() string {
 // GoString returns the string representation
 func (s InitiateAuthOutput) GoString() string {
 	return s.String()
+}
+
+// SetAuthenticationResult sets the AuthenticationResult field's value.
+func (s *InitiateAuthOutput) SetAuthenticationResult(v *AuthenticationResultType) *InitiateAuthOutput {
+	s.AuthenticationResult = v
+	return s
+}
+
+// SetChallengeName sets the ChallengeName field's value.
+func (s *InitiateAuthOutput) SetChallengeName(v string) *InitiateAuthOutput {
+	s.ChallengeName = &v
+	return s
+}
+
+// SetChallengeParameters sets the ChallengeParameters field's value.
+func (s *InitiateAuthOutput) SetChallengeParameters(v map[string]*string) *InitiateAuthOutput {
+	s.ChallengeParameters = v
+	return s
+}
+
+// SetSession sets the Session field's value.
+func (s *InitiateAuthOutput) SetSession(v string) *InitiateAuthOutput {
+	s.Session = &v
+	return s
 }
 
 // Specifies the type of configuration for AWS Lambda triggers.
@@ -8486,6 +9614,54 @@ func (s *LambdaConfigType) Validate() error {
 	return nil
 }
 
+// SetCreateAuthChallenge sets the CreateAuthChallenge field's value.
+func (s *LambdaConfigType) SetCreateAuthChallenge(v string) *LambdaConfigType {
+	s.CreateAuthChallenge = &v
+	return s
+}
+
+// SetCustomMessage sets the CustomMessage field's value.
+func (s *LambdaConfigType) SetCustomMessage(v string) *LambdaConfigType {
+	s.CustomMessage = &v
+	return s
+}
+
+// SetDefineAuthChallenge sets the DefineAuthChallenge field's value.
+func (s *LambdaConfigType) SetDefineAuthChallenge(v string) *LambdaConfigType {
+	s.DefineAuthChallenge = &v
+	return s
+}
+
+// SetPostAuthentication sets the PostAuthentication field's value.
+func (s *LambdaConfigType) SetPostAuthentication(v string) *LambdaConfigType {
+	s.PostAuthentication = &v
+	return s
+}
+
+// SetPostConfirmation sets the PostConfirmation field's value.
+func (s *LambdaConfigType) SetPostConfirmation(v string) *LambdaConfigType {
+	s.PostConfirmation = &v
+	return s
+}
+
+// SetPreAuthentication sets the PreAuthentication field's value.
+func (s *LambdaConfigType) SetPreAuthentication(v string) *LambdaConfigType {
+	s.PreAuthentication = &v
+	return s
+}
+
+// SetPreSignUp sets the PreSignUp field's value.
+func (s *LambdaConfigType) SetPreSignUp(v string) *LambdaConfigType {
+	s.PreSignUp = &v
+	return s
+}
+
+// SetVerifyAuthChallengeResponse sets the VerifyAuthChallengeResponse field's value.
+func (s *LambdaConfigType) SetVerifyAuthChallengeResponse(v string) *LambdaConfigType {
+	s.VerifyAuthChallengeResponse = &v
+	return s
+}
+
 // Represents the request to list the devices.
 type ListDevicesInput struct {
 	_ struct{} `type:"structure"`
@@ -8528,6 +9704,24 @@ func (s *ListDevicesInput) Validate() error {
 	return nil
 }
 
+// SetAccessToken sets the AccessToken field's value.
+func (s *ListDevicesInput) SetAccessToken(v string) *ListDevicesInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListDevicesInput) SetLimit(v int64) *ListDevicesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPaginationToken sets the PaginationToken field's value.
+func (s *ListDevicesInput) SetPaginationToken(v string) *ListDevicesInput {
+	s.PaginationToken = &v
+	return s
+}
+
 // Represents the response to list devices.
 type ListDevicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8547,6 +9741,18 @@ func (s ListDevicesOutput) String() string {
 // GoString returns the string representation
 func (s ListDevicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevices sets the Devices field's value.
+func (s *ListDevicesOutput) SetDevices(v []*DeviceType) *ListDevicesOutput {
+	s.Devices = v
+	return s
+}
+
+// SetPaginationToken sets the PaginationToken field's value.
+func (s *ListDevicesOutput) SetPaginationToken(v string) *ListDevicesOutput {
+	s.PaginationToken = &v
+	return s
 }
 
 // Represents the request to list the user import jobs.
@@ -8603,6 +9809,24 @@ func (s *ListUserImportJobsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListUserImportJobsInput) SetMaxResults(v int64) *ListUserImportJobsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetPaginationToken sets the PaginationToken field's value.
+func (s *ListUserImportJobsInput) SetPaginationToken(v string) *ListUserImportJobsInput {
+	s.PaginationToken = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *ListUserImportJobsInput) SetUserPoolId(v string) *ListUserImportJobsInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server to the request to list the user import
 // jobs.
 type ListUserImportJobsOutput struct {
@@ -8624,6 +9848,18 @@ func (s ListUserImportJobsOutput) String() string {
 // GoString returns the string representation
 func (s ListUserImportJobsOutput) GoString() string {
 	return s.String()
+}
+
+// SetPaginationToken sets the PaginationToken field's value.
+func (s *ListUserImportJobsOutput) SetPaginationToken(v string) *ListUserImportJobsOutput {
+	s.PaginationToken = &v
+	return s
+}
+
+// SetUserImportJobs sets the UserImportJobs field's value.
+func (s *ListUserImportJobsOutput) SetUserImportJobs(v []*UserImportJobType) *ListUserImportJobsOutput {
+	s.UserImportJobs = v
+	return s
 }
 
 // Represents the request to list the user pool clients.
@@ -8676,6 +9912,24 @@ func (s *ListUserPoolClientsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListUserPoolClientsInput) SetMaxResults(v int64) *ListUserPoolClientsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListUserPoolClientsInput) SetNextToken(v string) *ListUserPoolClientsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *ListUserPoolClientsInput) SetUserPoolId(v string) *ListUserPoolClientsInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server that lists user pool clients.
 type ListUserPoolClientsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8696,6 +9950,18 @@ func (s ListUserPoolClientsOutput) String() string {
 // GoString returns the string representation
 func (s ListUserPoolClientsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListUserPoolClientsOutput) SetNextToken(v string) *ListUserPoolClientsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetUserPoolClients sets the UserPoolClients field's value.
+func (s *ListUserPoolClientsOutput) SetUserPoolClients(v []*UserPoolClientDescription) *ListUserPoolClientsOutput {
+	s.UserPoolClients = v
+	return s
 }
 
 // Represents the request to list user pools.
@@ -8742,6 +10008,18 @@ func (s *ListUserPoolsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListUserPoolsInput) SetMaxResults(v int64) *ListUserPoolsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListUserPoolsInput) SetNextToken(v string) *ListUserPoolsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the response to list user pools.
 type ListUserPoolsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8762,6 +10040,18 @@ func (s ListUserPoolsOutput) String() string {
 // GoString returns the string representation
 func (s ListUserPoolsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListUserPoolsOutput) SetNextToken(v string) *ListUserPoolsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetUserPools sets the UserPools field's value.
+func (s *ListUserPoolsOutput) SetUserPools(v []*UserPoolDescriptionType) *ListUserPoolsOutput {
+	s.UserPools = v
+	return s
 }
 
 // Represents the request to list users.
@@ -8816,6 +10106,36 @@ func (s *ListUsersInput) Validate() error {
 	return nil
 }
 
+// SetAttributesToGet sets the AttributesToGet field's value.
+func (s *ListUsersInput) SetAttributesToGet(v []*string) *ListUsersInput {
+	s.AttributesToGet = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *ListUsersInput) SetFilter(v string) *ListUsersInput {
+	s.Filter = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListUsersInput) SetLimit(v int64) *ListUsersInput {
+	s.Limit = &v
+	return s
+}
+
+// SetPaginationToken sets the PaginationToken field's value.
+func (s *ListUsersInput) SetPaginationToken(v string) *ListUsersInput {
+	s.PaginationToken = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *ListUsersInput) SetUserPoolId(v string) *ListUsersInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // The response from the request to list users.
 type ListUsersOutput struct {
 	_ struct{} `type:"structure"`
@@ -8836,6 +10156,18 @@ func (s ListUsersOutput) String() string {
 // GoString returns the string representation
 func (s ListUsersOutput) GoString() string {
 	return s.String()
+}
+
+// SetPaginationToken sets the PaginationToken field's value.
+func (s *ListUsersOutput) SetPaginationToken(v string) *ListUsersOutput {
+	s.PaginationToken = &v
+	return s
+}
+
+// SetUsers sets the Users field's value.
+func (s *ListUsersOutput) SetUsers(v []*UserType) *ListUsersOutput {
+	s.Users = v
+	return s
 }
 
 // Specifies the different settings for multi-factor authentication (MFA).
@@ -8870,6 +10202,18 @@ func (s *MFAOptionType) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *MFAOptionType) SetAttributeName(v string) *MFAOptionType {
+	s.AttributeName = &v
+	return s
+}
+
+// SetDeliveryMedium sets the DeliveryMedium field's value.
+func (s *MFAOptionType) SetDeliveryMedium(v string) *MFAOptionType {
+	s.DeliveryMedium = &v
+	return s
 }
 
 // The message template structure.
@@ -8915,6 +10259,24 @@ func (s *MessageTemplateType) Validate() error {
 	return nil
 }
 
+// SetEmailMessage sets the EmailMessage field's value.
+func (s *MessageTemplateType) SetEmailMessage(v string) *MessageTemplateType {
+	s.EmailMessage = &v
+	return s
+}
+
+// SetEmailSubject sets the EmailSubject field's value.
+func (s *MessageTemplateType) SetEmailSubject(v string) *MessageTemplateType {
+	s.EmailSubject = &v
+	return s
+}
+
+// SetSMSMessage sets the SMSMessage field's value.
+func (s *MessageTemplateType) SetSMSMessage(v string) *MessageTemplateType {
+	s.SMSMessage = &v
+	return s
+}
+
 // The new device metadata type.
 type NewDeviceMetadataType struct {
 	_ struct{} `type:"structure"`
@@ -8934,6 +10296,18 @@ func (s NewDeviceMetadataType) String() string {
 // GoString returns the string representation
 func (s NewDeviceMetadataType) GoString() string {
 	return s.String()
+}
+
+// SetDeviceGroupKey sets the DeviceGroupKey field's value.
+func (s *NewDeviceMetadataType) SetDeviceGroupKey(v string) *NewDeviceMetadataType {
+	s.DeviceGroupKey = &v
+	return s
+}
+
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *NewDeviceMetadataType) SetDeviceKey(v string) *NewDeviceMetadataType {
+	s.DeviceKey = &v
+	return s
 }
 
 // The minimum and maximum value of an attribute that is of the number data
@@ -8956,6 +10330,18 @@ func (s NumberAttributeConstraintsType) String() string {
 // GoString returns the string representation
 func (s NumberAttributeConstraintsType) GoString() string {
 	return s.String()
+}
+
+// SetMaxValue sets the MaxValue field's value.
+func (s *NumberAttributeConstraintsType) SetMaxValue(v string) *NumberAttributeConstraintsType {
+	s.MaxValue = &v
+	return s
+}
+
+// SetMinValue sets the MinValue field's value.
+func (s *NumberAttributeConstraintsType) SetMinValue(v string) *NumberAttributeConstraintsType {
+	s.MinValue = &v
+	return s
 }
 
 // The password policy type.
@@ -9004,6 +10390,36 @@ func (s *PasswordPolicyType) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMinimumLength sets the MinimumLength field's value.
+func (s *PasswordPolicyType) SetMinimumLength(v int64) *PasswordPolicyType {
+	s.MinimumLength = &v
+	return s
+}
+
+// SetRequireLowercase sets the RequireLowercase field's value.
+func (s *PasswordPolicyType) SetRequireLowercase(v bool) *PasswordPolicyType {
+	s.RequireLowercase = &v
+	return s
+}
+
+// SetRequireNumbers sets the RequireNumbers field's value.
+func (s *PasswordPolicyType) SetRequireNumbers(v bool) *PasswordPolicyType {
+	s.RequireNumbers = &v
+	return s
+}
+
+// SetRequireSymbols sets the RequireSymbols field's value.
+func (s *PasswordPolicyType) SetRequireSymbols(v bool) *PasswordPolicyType {
+	s.RequireSymbols = &v
+	return s
+}
+
+// SetRequireUppercase sets the RequireUppercase field's value.
+func (s *PasswordPolicyType) SetRequireUppercase(v bool) *PasswordPolicyType {
+	s.RequireUppercase = &v
+	return s
 }
 
 // Represents the request to resend the confirmation code.
@@ -9060,6 +10476,24 @@ func (s *ResendConfirmationCodeInput) Validate() error {
 	return nil
 }
 
+// SetClientId sets the ClientId field's value.
+func (s *ResendConfirmationCodeInput) SetClientId(v string) *ResendConfirmationCodeInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetSecretHash sets the SecretHash field's value.
+func (s *ResendConfirmationCodeInput) SetSecretHash(v string) *ResendConfirmationCodeInput {
+	s.SecretHash = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *ResendConfirmationCodeInput) SetUsername(v string) *ResendConfirmationCodeInput {
+	s.Username = &v
+	return s
+}
+
 // The response from the server when the Amazon Cognito service makes the request
 // to resend a confirmation code.
 type ResendConfirmationCodeOutput struct {
@@ -9077,6 +10511,12 @@ func (s ResendConfirmationCodeOutput) String() string {
 // GoString returns the string representation
 func (s ResendConfirmationCodeOutput) GoString() string {
 	return s.String()
+}
+
+// SetCodeDeliveryDetails sets the CodeDeliveryDetails field's value.
+func (s *ResendConfirmationCodeOutput) SetCodeDeliveryDetails(v *CodeDeliveryDetailsType) *ResendConfirmationCodeOutput {
+	s.CodeDeliveryDetails = v
+	return s
 }
 
 // The request to respond to an authentication challenge.
@@ -9132,6 +10572,30 @@ func (s *RespondToAuthChallengeInput) Validate() error {
 	return nil
 }
 
+// SetChallengeName sets the ChallengeName field's value.
+func (s *RespondToAuthChallengeInput) SetChallengeName(v string) *RespondToAuthChallengeInput {
+	s.ChallengeName = &v
+	return s
+}
+
+// SetChallengeResponses sets the ChallengeResponses field's value.
+func (s *RespondToAuthChallengeInput) SetChallengeResponses(v map[string]*string) *RespondToAuthChallengeInput {
+	s.ChallengeResponses = v
+	return s
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *RespondToAuthChallengeInput) SetClientId(v string) *RespondToAuthChallengeInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetSession sets the Session field's value.
+func (s *RespondToAuthChallengeInput) SetSession(v string) *RespondToAuthChallengeInput {
+	s.Session = &v
+	return s
+}
+
 // The response to respond to the authentication challenge.
 type RespondToAuthChallengeOutput struct {
 	_ struct{} `type:"structure"`
@@ -9157,6 +10621,30 @@ func (s RespondToAuthChallengeOutput) String() string {
 // GoString returns the string representation
 func (s RespondToAuthChallengeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAuthenticationResult sets the AuthenticationResult field's value.
+func (s *RespondToAuthChallengeOutput) SetAuthenticationResult(v *AuthenticationResultType) *RespondToAuthChallengeOutput {
+	s.AuthenticationResult = v
+	return s
+}
+
+// SetChallengeName sets the ChallengeName field's value.
+func (s *RespondToAuthChallengeOutput) SetChallengeName(v string) *RespondToAuthChallengeOutput {
+	s.ChallengeName = &v
+	return s
+}
+
+// SetChallengeParameters sets the ChallengeParameters field's value.
+func (s *RespondToAuthChallengeOutput) SetChallengeParameters(v map[string]*string) *RespondToAuthChallengeOutput {
+	s.ChallengeParameters = v
+	return s
+}
+
+// SetSession sets the Session field's value.
+func (s *RespondToAuthChallengeOutput) SetSession(v string) *RespondToAuthChallengeOutput {
+	s.Session = &v
+	return s
 }
 
 // Contains information about the schema attribute.
@@ -9210,6 +10698,48 @@ func (s *SchemaAttributeType) Validate() error {
 	return nil
 }
 
+// SetAttributeDataType sets the AttributeDataType field's value.
+func (s *SchemaAttributeType) SetAttributeDataType(v string) *SchemaAttributeType {
+	s.AttributeDataType = &v
+	return s
+}
+
+// SetDeveloperOnlyAttribute sets the DeveloperOnlyAttribute field's value.
+func (s *SchemaAttributeType) SetDeveloperOnlyAttribute(v bool) *SchemaAttributeType {
+	s.DeveloperOnlyAttribute = &v
+	return s
+}
+
+// SetMutable sets the Mutable field's value.
+func (s *SchemaAttributeType) SetMutable(v bool) *SchemaAttributeType {
+	s.Mutable = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *SchemaAttributeType) SetName(v string) *SchemaAttributeType {
+	s.Name = &v
+	return s
+}
+
+// SetNumberAttributeConstraints sets the NumberAttributeConstraints field's value.
+func (s *SchemaAttributeType) SetNumberAttributeConstraints(v *NumberAttributeConstraintsType) *SchemaAttributeType {
+	s.NumberAttributeConstraints = v
+	return s
+}
+
+// SetRequired sets the Required field's value.
+func (s *SchemaAttributeType) SetRequired(v bool) *SchemaAttributeType {
+	s.Required = &v
+	return s
+}
+
+// SetStringAttributeConstraints sets the StringAttributeConstraints field's value.
+func (s *SchemaAttributeType) SetStringAttributeConstraints(v *StringAttributeConstraintsType) *SchemaAttributeType {
+	s.StringAttributeConstraints = v
+	return s
+}
+
 // Represents the request to set user settings.
 type SetUserSettingsInput struct {
 	_ struct{} `type:"structure"`
@@ -9259,6 +10789,18 @@ func (s *SetUserSettingsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccessToken sets the AccessToken field's value.
+func (s *SetUserSettingsInput) SetAccessToken(v string) *SetUserSettingsInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetMFAOptions sets the MFAOptions field's value.
+func (s *SetUserSettingsInput) SetMFAOptions(v []*MFAOptionType) *SetUserSettingsInput {
+	s.MFAOptions = v
+	return s
 }
 
 // The response from the server for a set user settings request.
@@ -9367,6 +10909,42 @@ func (s *SignUpInput) Validate() error {
 	return nil
 }
 
+// SetClientId sets the ClientId field's value.
+func (s *SignUpInput) SetClientId(v string) *SignUpInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *SignUpInput) SetPassword(v string) *SignUpInput {
+	s.Password = &v
+	return s
+}
+
+// SetSecretHash sets the SecretHash field's value.
+func (s *SignUpInput) SetSecretHash(v string) *SignUpInput {
+	s.SecretHash = &v
+	return s
+}
+
+// SetUserAttributes sets the UserAttributes field's value.
+func (s *SignUpInput) SetUserAttributes(v []*AttributeType) *SignUpInput {
+	s.UserAttributes = v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *SignUpInput) SetUsername(v string) *SignUpInput {
+	s.Username = &v
+	return s
+}
+
+// SetValidationData sets the ValidationData field's value.
+func (s *SignUpInput) SetValidationData(v []*AttributeType) *SignUpInput {
+	s.ValidationData = v
+	return s
+}
+
 // The response from the server for a registration request.
 type SignUpOutput struct {
 	_ struct{} `type:"structure"`
@@ -9386,6 +10964,18 @@ func (s SignUpOutput) String() string {
 // GoString returns the string representation
 func (s SignUpOutput) GoString() string {
 	return s.String()
+}
+
+// SetCodeDeliveryDetails sets the CodeDeliveryDetails field's value.
+func (s *SignUpOutput) SetCodeDeliveryDetails(v *CodeDeliveryDetailsType) *SignUpOutput {
+	s.CodeDeliveryDetails = v
+	return s
+}
+
+// SetUserConfirmed sets the UserConfirmed field's value.
+func (s *SignUpOutput) SetUserConfirmed(v bool) *SignUpOutput {
+	s.UserConfirmed = &v
+	return s
 }
 
 // The SMS configuratoin type.
@@ -9421,6 +11011,18 @@ func (s *SmsConfigurationType) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetExternalId sets the ExternalId field's value.
+func (s *SmsConfigurationType) SetExternalId(v string) *SmsConfigurationType {
+	s.ExternalId = &v
+	return s
+}
+
+// SetSnsCallerArn sets the SnsCallerArn field's value.
+func (s *SmsConfigurationType) SetSnsCallerArn(v string) *SmsConfigurationType {
+	s.SnsCallerArn = &v
+	return s
 }
 
 // Represents the request to start the user import job.
@@ -9470,6 +11072,18 @@ func (s *StartUserImportJobInput) Validate() error {
 	return nil
 }
 
+// SetJobId sets the JobId field's value.
+func (s *StartUserImportJobInput) SetJobId(v string) *StartUserImportJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *StartUserImportJobInput) SetUserPoolId(v string) *StartUserImportJobInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server to the request to start the user
 // import job.
 type StartUserImportJobOutput struct {
@@ -9487,6 +11101,12 @@ func (s StartUserImportJobOutput) String() string {
 // GoString returns the string representation
 func (s StartUserImportJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserImportJob sets the UserImportJob field's value.
+func (s *StartUserImportJobOutput) SetUserImportJob(v *UserImportJobType) *StartUserImportJobOutput {
+	s.UserImportJob = v
+	return s
 }
 
 // Represents the request to stop the user import job.
@@ -9536,6 +11156,18 @@ func (s *StopUserImportJobInput) Validate() error {
 	return nil
 }
 
+// SetJobId sets the JobId field's value.
+func (s *StopUserImportJobInput) SetJobId(v string) *StopUserImportJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *StopUserImportJobInput) SetUserPoolId(v string) *StopUserImportJobInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server to the request to stop the user import
 // job.
 type StopUserImportJobOutput struct {
@@ -9553,6 +11185,12 @@ func (s StopUserImportJobOutput) String() string {
 // GoString returns the string representation
 func (s StopUserImportJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserImportJob sets the UserImportJob field's value.
+func (s *StopUserImportJobOutput) SetUserImportJob(v *UserImportJobType) *StopUserImportJobOutput {
+	s.UserImportJob = v
+	return s
 }
 
 // The type of constraints associated with an attribute of the string type.
@@ -9574,6 +11212,18 @@ func (s StringAttributeConstraintsType) String() string {
 // GoString returns the string representation
 func (s StringAttributeConstraintsType) GoString() string {
 	return s.String()
+}
+
+// SetMaxLength sets the MaxLength field's value.
+func (s *StringAttributeConstraintsType) SetMaxLength(v string) *StringAttributeConstraintsType {
+	s.MaxLength = &v
+	return s
+}
+
+// SetMinLength sets the MinLength field's value.
+func (s *StringAttributeConstraintsType) SetMinLength(v string) *StringAttributeConstraintsType {
+	s.MinLength = &v
+	return s
 }
 
 // Represents the request to update the device status.
@@ -9621,6 +11271,24 @@ func (s *UpdateDeviceStatusInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccessToken sets the AccessToken field's value.
+func (s *UpdateDeviceStatusInput) SetAccessToken(v string) *UpdateDeviceStatusInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetDeviceKey sets the DeviceKey field's value.
+func (s *UpdateDeviceStatusInput) SetDeviceKey(v string) *UpdateDeviceStatusInput {
+	s.DeviceKey = &v
+	return s
+}
+
+// SetDeviceRememberedStatus sets the DeviceRememberedStatus field's value.
+func (s *UpdateDeviceStatusInput) SetDeviceRememberedStatus(v string) *UpdateDeviceStatusInput {
+	s.DeviceRememberedStatus = &v
+	return s
 }
 
 // The response to the request to update the device status.
@@ -9684,6 +11352,18 @@ func (s *UpdateUserAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAccessToken sets the AccessToken field's value.
+func (s *UpdateUserAttributesInput) SetAccessToken(v string) *UpdateUserAttributesInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetUserAttributes sets the UserAttributes field's value.
+func (s *UpdateUserAttributesInput) SetUserAttributes(v []*AttributeType) *UpdateUserAttributesInput {
+	s.UserAttributes = v
+	return s
+}
+
 // Represents the response from the server for the request to update user attributes.
 type UpdateUserAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9701,6 +11381,12 @@ func (s UpdateUserAttributesOutput) String() string {
 // GoString returns the string representation
 func (s UpdateUserAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCodeDeliveryDetailsList sets the CodeDeliveryDetailsList field's value.
+func (s *UpdateUserAttributesOutput) SetCodeDeliveryDetailsList(v []*CodeDeliveryDetailsType) *UpdateUserAttributesOutput {
+	s.CodeDeliveryDetailsList = v
+	return s
 }
 
 // Represents the request to update the user pool client.
@@ -9769,6 +11455,48 @@ func (s *UpdateUserPoolClientInput) Validate() error {
 	return nil
 }
 
+// SetClientId sets the ClientId field's value.
+func (s *UpdateUserPoolClientInput) SetClientId(v string) *UpdateUserPoolClientInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetClientName sets the ClientName field's value.
+func (s *UpdateUserPoolClientInput) SetClientName(v string) *UpdateUserPoolClientInput {
+	s.ClientName = &v
+	return s
+}
+
+// SetExplicitAuthFlows sets the ExplicitAuthFlows field's value.
+func (s *UpdateUserPoolClientInput) SetExplicitAuthFlows(v []*string) *UpdateUserPoolClientInput {
+	s.ExplicitAuthFlows = v
+	return s
+}
+
+// SetReadAttributes sets the ReadAttributes field's value.
+func (s *UpdateUserPoolClientInput) SetReadAttributes(v []*string) *UpdateUserPoolClientInput {
+	s.ReadAttributes = v
+	return s
+}
+
+// SetRefreshTokenValidity sets the RefreshTokenValidity field's value.
+func (s *UpdateUserPoolClientInput) SetRefreshTokenValidity(v int64) *UpdateUserPoolClientInput {
+	s.RefreshTokenValidity = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *UpdateUserPoolClientInput) SetUserPoolId(v string) *UpdateUserPoolClientInput {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetWriteAttributes sets the WriteAttributes field's value.
+func (s *UpdateUserPoolClientInput) SetWriteAttributes(v []*string) *UpdateUserPoolClientInput {
+	s.WriteAttributes = v
+	return s
+}
+
 // Represents the response from the server to the request to update the user
 // pool client.
 type UpdateUserPoolClientOutput struct {
@@ -9787,6 +11515,12 @@ func (s UpdateUserPoolClientOutput) String() string {
 // GoString returns the string representation
 func (s UpdateUserPoolClientOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserPoolClient sets the UserPoolClient field's value.
+func (s *UpdateUserPoolClientOutput) SetUserPoolClient(v *UserPoolClientType) *UpdateUserPoolClientOutput {
+	s.UserPoolClient = v
+	return s
 }
 
 // Represents the request to update the user pool.
@@ -9908,6 +11642,84 @@ func (s *UpdateUserPoolInput) Validate() error {
 	return nil
 }
 
+// SetAdminCreateUserConfig sets the AdminCreateUserConfig field's value.
+func (s *UpdateUserPoolInput) SetAdminCreateUserConfig(v *AdminCreateUserConfigType) *UpdateUserPoolInput {
+	s.AdminCreateUserConfig = v
+	return s
+}
+
+// SetAutoVerifiedAttributes sets the AutoVerifiedAttributes field's value.
+func (s *UpdateUserPoolInput) SetAutoVerifiedAttributes(v []*string) *UpdateUserPoolInput {
+	s.AutoVerifiedAttributes = v
+	return s
+}
+
+// SetDeviceConfiguration sets the DeviceConfiguration field's value.
+func (s *UpdateUserPoolInput) SetDeviceConfiguration(v *DeviceConfigurationType) *UpdateUserPoolInput {
+	s.DeviceConfiguration = v
+	return s
+}
+
+// SetEmailConfiguration sets the EmailConfiguration field's value.
+func (s *UpdateUserPoolInput) SetEmailConfiguration(v *EmailConfigurationType) *UpdateUserPoolInput {
+	s.EmailConfiguration = v
+	return s
+}
+
+// SetEmailVerificationMessage sets the EmailVerificationMessage field's value.
+func (s *UpdateUserPoolInput) SetEmailVerificationMessage(v string) *UpdateUserPoolInput {
+	s.EmailVerificationMessage = &v
+	return s
+}
+
+// SetEmailVerificationSubject sets the EmailVerificationSubject field's value.
+func (s *UpdateUserPoolInput) SetEmailVerificationSubject(v string) *UpdateUserPoolInput {
+	s.EmailVerificationSubject = &v
+	return s
+}
+
+// SetLambdaConfig sets the LambdaConfig field's value.
+func (s *UpdateUserPoolInput) SetLambdaConfig(v *LambdaConfigType) *UpdateUserPoolInput {
+	s.LambdaConfig = v
+	return s
+}
+
+// SetMfaConfiguration sets the MfaConfiguration field's value.
+func (s *UpdateUserPoolInput) SetMfaConfiguration(v string) *UpdateUserPoolInput {
+	s.MfaConfiguration = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *UpdateUserPoolInput) SetPolicies(v *UserPoolPolicyType) *UpdateUserPoolInput {
+	s.Policies = v
+	return s
+}
+
+// SetSmsAuthenticationMessage sets the SmsAuthenticationMessage field's value.
+func (s *UpdateUserPoolInput) SetSmsAuthenticationMessage(v string) *UpdateUserPoolInput {
+	s.SmsAuthenticationMessage = &v
+	return s
+}
+
+// SetSmsConfiguration sets the SmsConfiguration field's value.
+func (s *UpdateUserPoolInput) SetSmsConfiguration(v *SmsConfigurationType) *UpdateUserPoolInput {
+	s.SmsConfiguration = v
+	return s
+}
+
+// SetSmsVerificationMessage sets the SmsVerificationMessage field's value.
+func (s *UpdateUserPoolInput) SetSmsVerificationMessage(v string) *UpdateUserPoolInput {
+	s.SmsVerificationMessage = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *UpdateUserPoolInput) SetUserPoolId(v string) *UpdateUserPoolInput {
+	s.UserPoolId = &v
+	return s
+}
+
 // Represents the response from the server when you make a request to update
 // the user pool.
 type UpdateUserPoolOutput struct {
@@ -10001,6 +11813,84 @@ func (s UserImportJobType) GoString() string {
 	return s.String()
 }
 
+// SetCloudWatchLogsRoleArn sets the CloudWatchLogsRoleArn field's value.
+func (s *UserImportJobType) SetCloudWatchLogsRoleArn(v string) *UserImportJobType {
+	s.CloudWatchLogsRoleArn = &v
+	return s
+}
+
+// SetCompletionDate sets the CompletionDate field's value.
+func (s *UserImportJobType) SetCompletionDate(v time.Time) *UserImportJobType {
+	s.CompletionDate = &v
+	return s
+}
+
+// SetCompletionMessage sets the CompletionMessage field's value.
+func (s *UserImportJobType) SetCompletionMessage(v string) *UserImportJobType {
+	s.CompletionMessage = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *UserImportJobType) SetCreationDate(v time.Time) *UserImportJobType {
+	s.CreationDate = &v
+	return s
+}
+
+// SetFailedUsers sets the FailedUsers field's value.
+func (s *UserImportJobType) SetFailedUsers(v int64) *UserImportJobType {
+	s.FailedUsers = &v
+	return s
+}
+
+// SetImportedUsers sets the ImportedUsers field's value.
+func (s *UserImportJobType) SetImportedUsers(v int64) *UserImportJobType {
+	s.ImportedUsers = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *UserImportJobType) SetJobId(v string) *UserImportJobType {
+	s.JobId = &v
+	return s
+}
+
+// SetJobName sets the JobName field's value.
+func (s *UserImportJobType) SetJobName(v string) *UserImportJobType {
+	s.JobName = &v
+	return s
+}
+
+// SetPreSignedUrl sets the PreSignedUrl field's value.
+func (s *UserImportJobType) SetPreSignedUrl(v string) *UserImportJobType {
+	s.PreSignedUrl = &v
+	return s
+}
+
+// SetSkippedUsers sets the SkippedUsers field's value.
+func (s *UserImportJobType) SetSkippedUsers(v int64) *UserImportJobType {
+	s.SkippedUsers = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *UserImportJobType) SetStartDate(v time.Time) *UserImportJobType {
+	s.StartDate = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UserImportJobType) SetStatus(v string) *UserImportJobType {
+	s.Status = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *UserImportJobType) SetUserPoolId(v string) *UserImportJobType {
+	s.UserPoolId = &v
+	return s
+}
+
 // The description of the user poool client.
 type UserPoolClientDescription struct {
 	_ struct{} `type:"structure"`
@@ -10024,6 +11914,24 @@ func (s UserPoolClientDescription) String() string {
 // GoString returns the string representation
 func (s UserPoolClientDescription) GoString() string {
 	return s.String()
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *UserPoolClientDescription) SetClientId(v string) *UserPoolClientDescription {
+	s.ClientId = &v
+	return s
+}
+
+// SetClientName sets the ClientName field's value.
+func (s *UserPoolClientDescription) SetClientName(v string) *UserPoolClientDescription {
+	s.ClientName = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *UserPoolClientDescription) SetUserPoolId(v string) *UserPoolClientDescription {
+	s.UserPoolId = &v
+	return s
 }
 
 // A user pool of the client type.
@@ -10071,6 +11979,66 @@ func (s UserPoolClientType) GoString() string {
 	return s.String()
 }
 
+// SetClientId sets the ClientId field's value.
+func (s *UserPoolClientType) SetClientId(v string) *UserPoolClientType {
+	s.ClientId = &v
+	return s
+}
+
+// SetClientName sets the ClientName field's value.
+func (s *UserPoolClientType) SetClientName(v string) *UserPoolClientType {
+	s.ClientName = &v
+	return s
+}
+
+// SetClientSecret sets the ClientSecret field's value.
+func (s *UserPoolClientType) SetClientSecret(v string) *UserPoolClientType {
+	s.ClientSecret = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *UserPoolClientType) SetCreationDate(v time.Time) *UserPoolClientType {
+	s.CreationDate = &v
+	return s
+}
+
+// SetExplicitAuthFlows sets the ExplicitAuthFlows field's value.
+func (s *UserPoolClientType) SetExplicitAuthFlows(v []*string) *UserPoolClientType {
+	s.ExplicitAuthFlows = v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *UserPoolClientType) SetLastModifiedDate(v time.Time) *UserPoolClientType {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetReadAttributes sets the ReadAttributes field's value.
+func (s *UserPoolClientType) SetReadAttributes(v []*string) *UserPoolClientType {
+	s.ReadAttributes = v
+	return s
+}
+
+// SetRefreshTokenValidity sets the RefreshTokenValidity field's value.
+func (s *UserPoolClientType) SetRefreshTokenValidity(v int64) *UserPoolClientType {
+	s.RefreshTokenValidity = &v
+	return s
+}
+
+// SetUserPoolId sets the UserPoolId field's value.
+func (s *UserPoolClientType) SetUserPoolId(v string) *UserPoolClientType {
+	s.UserPoolId = &v
+	return s
+}
+
+// SetWriteAttributes sets the WriteAttributes field's value.
+func (s *UserPoolClientType) SetWriteAttributes(v []*string) *UserPoolClientType {
+	s.WriteAttributes = v
+	return s
+}
+
 // A user pool description.
 type UserPoolDescriptionType struct {
 	_ struct{} `type:"structure"`
@@ -10104,6 +12072,42 @@ func (s UserPoolDescriptionType) GoString() string {
 	return s.String()
 }
 
+// SetCreationDate sets the CreationDate field's value.
+func (s *UserPoolDescriptionType) SetCreationDate(v time.Time) *UserPoolDescriptionType {
+	s.CreationDate = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UserPoolDescriptionType) SetId(v string) *UserPoolDescriptionType {
+	s.Id = &v
+	return s
+}
+
+// SetLambdaConfig sets the LambdaConfig field's value.
+func (s *UserPoolDescriptionType) SetLambdaConfig(v *LambdaConfigType) *UserPoolDescriptionType {
+	s.LambdaConfig = v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *UserPoolDescriptionType) SetLastModifiedDate(v time.Time) *UserPoolDescriptionType {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UserPoolDescriptionType) SetName(v string) *UserPoolDescriptionType {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UserPoolDescriptionType) SetStatus(v string) *UserPoolDescriptionType {
+	s.Status = &v
+	return s
+}
+
 // The type of policy in a user pool.
 type UserPoolPolicyType struct {
 	_ struct{} `type:"structure"`
@@ -10135,6 +12139,12 @@ func (s *UserPoolPolicyType) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPasswordPolicy sets the PasswordPolicy field's value.
+func (s *UserPoolPolicyType) SetPasswordPolicy(v *PasswordPolicyType) *UserPoolPolicyType {
+	s.PasswordPolicy = v
+	return s
 }
 
 // A container with information about the user pool type.
@@ -10226,6 +12236,138 @@ func (s UserPoolType) GoString() string {
 	return s.String()
 }
 
+// SetAdminCreateUserConfig sets the AdminCreateUserConfig field's value.
+func (s *UserPoolType) SetAdminCreateUserConfig(v *AdminCreateUserConfigType) *UserPoolType {
+	s.AdminCreateUserConfig = v
+	return s
+}
+
+// SetAliasAttributes sets the AliasAttributes field's value.
+func (s *UserPoolType) SetAliasAttributes(v []*string) *UserPoolType {
+	s.AliasAttributes = v
+	return s
+}
+
+// SetAutoVerifiedAttributes sets the AutoVerifiedAttributes field's value.
+func (s *UserPoolType) SetAutoVerifiedAttributes(v []*string) *UserPoolType {
+	s.AutoVerifiedAttributes = v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *UserPoolType) SetCreationDate(v time.Time) *UserPoolType {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDeviceConfiguration sets the DeviceConfiguration field's value.
+func (s *UserPoolType) SetDeviceConfiguration(v *DeviceConfigurationType) *UserPoolType {
+	s.DeviceConfiguration = v
+	return s
+}
+
+// SetEmailConfiguration sets the EmailConfiguration field's value.
+func (s *UserPoolType) SetEmailConfiguration(v *EmailConfigurationType) *UserPoolType {
+	s.EmailConfiguration = v
+	return s
+}
+
+// SetEmailConfigurationFailure sets the EmailConfigurationFailure field's value.
+func (s *UserPoolType) SetEmailConfigurationFailure(v string) *UserPoolType {
+	s.EmailConfigurationFailure = &v
+	return s
+}
+
+// SetEmailVerificationMessage sets the EmailVerificationMessage field's value.
+func (s *UserPoolType) SetEmailVerificationMessage(v string) *UserPoolType {
+	s.EmailVerificationMessage = &v
+	return s
+}
+
+// SetEmailVerificationSubject sets the EmailVerificationSubject field's value.
+func (s *UserPoolType) SetEmailVerificationSubject(v string) *UserPoolType {
+	s.EmailVerificationSubject = &v
+	return s
+}
+
+// SetEstimatedNumberOfUsers sets the EstimatedNumberOfUsers field's value.
+func (s *UserPoolType) SetEstimatedNumberOfUsers(v int64) *UserPoolType {
+	s.EstimatedNumberOfUsers = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UserPoolType) SetId(v string) *UserPoolType {
+	s.Id = &v
+	return s
+}
+
+// SetLambdaConfig sets the LambdaConfig field's value.
+func (s *UserPoolType) SetLambdaConfig(v *LambdaConfigType) *UserPoolType {
+	s.LambdaConfig = v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *UserPoolType) SetLastModifiedDate(v time.Time) *UserPoolType {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetMfaConfiguration sets the MfaConfiguration field's value.
+func (s *UserPoolType) SetMfaConfiguration(v string) *UserPoolType {
+	s.MfaConfiguration = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UserPoolType) SetName(v string) *UserPoolType {
+	s.Name = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *UserPoolType) SetPolicies(v *UserPoolPolicyType) *UserPoolType {
+	s.Policies = v
+	return s
+}
+
+// SetSchemaAttributes sets the SchemaAttributes field's value.
+func (s *UserPoolType) SetSchemaAttributes(v []*SchemaAttributeType) *UserPoolType {
+	s.SchemaAttributes = v
+	return s
+}
+
+// SetSmsAuthenticationMessage sets the SmsAuthenticationMessage field's value.
+func (s *UserPoolType) SetSmsAuthenticationMessage(v string) *UserPoolType {
+	s.SmsAuthenticationMessage = &v
+	return s
+}
+
+// SetSmsConfiguration sets the SmsConfiguration field's value.
+func (s *UserPoolType) SetSmsConfiguration(v *SmsConfigurationType) *UserPoolType {
+	s.SmsConfiguration = v
+	return s
+}
+
+// SetSmsConfigurationFailure sets the SmsConfigurationFailure field's value.
+func (s *UserPoolType) SetSmsConfigurationFailure(v string) *UserPoolType {
+	s.SmsConfigurationFailure = &v
+	return s
+}
+
+// SetSmsVerificationMessage sets the SmsVerificationMessage field's value.
+func (s *UserPoolType) SetSmsVerificationMessage(v string) *UserPoolType {
+	s.SmsVerificationMessage = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UserPoolType) SetStatus(v string) *UserPoolType {
+	s.Status = &v
+	return s
+}
+
 // The user type.
 type UserType struct {
 	_ struct{} `type:"structure"`
@@ -10270,6 +12412,48 @@ func (s UserType) String() string {
 // GoString returns the string representation
 func (s UserType) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *UserType) SetAttributes(v []*AttributeType) *UserType {
+	s.Attributes = v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *UserType) SetEnabled(v bool) *UserType {
+	s.Enabled = &v
+	return s
+}
+
+// SetMFAOptions sets the MFAOptions field's value.
+func (s *UserType) SetMFAOptions(v []*MFAOptionType) *UserType {
+	s.MFAOptions = v
+	return s
+}
+
+// SetUserCreateDate sets the UserCreateDate field's value.
+func (s *UserType) SetUserCreateDate(v time.Time) *UserType {
+	s.UserCreateDate = &v
+	return s
+}
+
+// SetUserLastModifiedDate sets the UserLastModifiedDate field's value.
+func (s *UserType) SetUserLastModifiedDate(v time.Time) *UserType {
+	s.UserLastModifiedDate = &v
+	return s
+}
+
+// SetUserStatus sets the UserStatus field's value.
+func (s *UserType) SetUserStatus(v string) *UserType {
+	s.UserStatus = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *UserType) SetUsername(v string) *UserType {
+	s.Username = &v
+	return s
 }
 
 // Represents the request to verify user attributes.
@@ -10320,6 +12504,24 @@ func (s *VerifyUserAttributeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccessToken sets the AccessToken field's value.
+func (s *VerifyUserAttributeInput) SetAccessToken(v string) *VerifyUserAttributeInput {
+	s.AccessToken = &v
+	return s
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *VerifyUserAttributeInput) SetAttributeName(v string) *VerifyUserAttributeInput {
+	s.AttributeName = &v
+	return s
+}
+
+// SetCode sets the Code field's value.
+func (s *VerifyUserAttributeInput) SetCode(v string) *VerifyUserAttributeInput {
+	s.Code = &v
+	return s
 }
 
 // A container representing the response from the server from the request to

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -1454,6 +1454,12 @@ func (s *BulkPublishInput) Validate() error {
 	return nil
 }
 
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *BulkPublishInput) SetIdentityPoolId(v string) *BulkPublishInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // The output for the BulkPublish operation.
 type BulkPublishOutput struct {
 	_ struct{} `type:"structure"`
@@ -1471,6 +1477,12 @@ func (s BulkPublishOutput) String() string {
 // GoString returns the string representation
 func (s BulkPublishOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *BulkPublishOutput) SetIdentityPoolId(v string) *BulkPublishOutput {
+	s.IdentityPoolId = &v
+	return s
 }
 
 // Configuration options for configure Cognito streams.
@@ -1520,6 +1532,24 @@ func (s *CognitoStreams) Validate() error {
 	return nil
 }
 
+// SetRoleArn sets the RoleArn field's value.
+func (s *CognitoStreams) SetRoleArn(v string) *CognitoStreams {
+	s.RoleArn = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *CognitoStreams) SetStreamName(v string) *CognitoStreams {
+	s.StreamName = &v
+	return s
+}
+
+// SetStreamingStatus sets the StreamingStatus field's value.
+func (s *CognitoStreams) SetStreamingStatus(v string) *CognitoStreams {
+	s.StreamingStatus = &v
+	return s
+}
+
 // A collection of data for an identity pool. An identity pool can have multiple
 // datasets. A dataset is per identity and can be general or associated with
 // a particular entity in an application (like a saved game). Datasets are automatically
@@ -1560,6 +1590,48 @@ func (s Dataset) String() string {
 // GoString returns the string representation
 func (s Dataset) GoString() string {
 	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *Dataset) SetCreationDate(v time.Time) *Dataset {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDataStorage sets the DataStorage field's value.
+func (s *Dataset) SetDataStorage(v int64) *Dataset {
+	s.DataStorage = &v
+	return s
+}
+
+// SetDatasetName sets the DatasetName field's value.
+func (s *Dataset) SetDatasetName(v string) *Dataset {
+	s.DatasetName = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *Dataset) SetIdentityId(v string) *Dataset {
+	s.IdentityId = &v
+	return s
+}
+
+// SetLastModifiedBy sets the LastModifiedBy field's value.
+func (s *Dataset) SetLastModifiedBy(v string) *Dataset {
+	s.LastModifiedBy = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *Dataset) SetLastModifiedDate(v time.Time) *Dataset {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetNumRecords sets the NumRecords field's value.
+func (s *Dataset) SetNumRecords(v int64) *Dataset {
+	s.NumRecords = &v
+	return s
 }
 
 // A request to delete the specific dataset.
@@ -1623,6 +1695,24 @@ func (s *DeleteDatasetInput) Validate() error {
 	return nil
 }
 
+// SetDatasetName sets the DatasetName field's value.
+func (s *DeleteDatasetInput) SetDatasetName(v string) *DeleteDatasetInput {
+	s.DatasetName = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *DeleteDatasetInput) SetIdentityId(v string) *DeleteDatasetInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *DeleteDatasetInput) SetIdentityPoolId(v string) *DeleteDatasetInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // Response to a successful DeleteDataset request.
 type DeleteDatasetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1643,6 +1733,12 @@ func (s DeleteDatasetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDatasetOutput) GoString() string {
 	return s.String()
+}
+
+// SetDataset sets the Dataset field's value.
+func (s *DeleteDatasetOutput) SetDataset(v *Dataset) *DeleteDatasetOutput {
+	s.Dataset = v
+	return s
 }
 
 // A request for meta data about a dataset (creation date, number of records,
@@ -1707,6 +1803,24 @@ func (s *DescribeDatasetInput) Validate() error {
 	return nil
 }
 
+// SetDatasetName sets the DatasetName field's value.
+func (s *DescribeDatasetInput) SetDatasetName(v string) *DescribeDatasetInput {
+	s.DatasetName = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *DescribeDatasetInput) SetIdentityId(v string) *DescribeDatasetInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *DescribeDatasetInput) SetIdentityPoolId(v string) *DescribeDatasetInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // Response to a successful DescribeDataset request.
 type DescribeDatasetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1727,6 +1841,12 @@ func (s DescribeDatasetOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDatasetOutput) GoString() string {
 	return s.String()
+}
+
+// SetDataset sets the Dataset field's value.
+func (s *DescribeDatasetOutput) SetDataset(v *Dataset) *DescribeDatasetOutput {
+	s.Dataset = v
+	return s
 }
 
 // A request for usage information about the identity pool.
@@ -1766,6 +1886,12 @@ func (s *DescribeIdentityPoolUsageInput) Validate() error {
 	return nil
 }
 
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *DescribeIdentityPoolUsageInput) SetIdentityPoolId(v string) *DescribeIdentityPoolUsageInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // Response to a successful DescribeIdentityPoolUsage request.
 type DescribeIdentityPoolUsageOutput struct {
 	_ struct{} `type:"structure"`
@@ -1782,6 +1908,12 @@ func (s DescribeIdentityPoolUsageOutput) String() string {
 // GoString returns the string representation
 func (s DescribeIdentityPoolUsageOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityPoolUsage sets the IdentityPoolUsage field's value.
+func (s *DescribeIdentityPoolUsageOutput) SetIdentityPoolUsage(v *IdentityPoolUsage) *DescribeIdentityPoolUsageOutput {
+	s.IdentityPoolUsage = v
+	return s
 }
 
 // A request for information about the usage of an identity pool.
@@ -1833,6 +1965,18 @@ func (s *DescribeIdentityUsageInput) Validate() error {
 	return nil
 }
 
+// SetIdentityId sets the IdentityId field's value.
+func (s *DescribeIdentityUsageInput) SetIdentityId(v string) *DescribeIdentityUsageInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *DescribeIdentityUsageInput) SetIdentityPoolId(v string) *DescribeIdentityUsageInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // The response to a successful DescribeIdentityUsage request.
 type DescribeIdentityUsageOutput struct {
 	_ struct{} `type:"structure"`
@@ -1849,6 +1993,12 @@ func (s DescribeIdentityUsageOutput) String() string {
 // GoString returns the string representation
 func (s DescribeIdentityUsageOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentityUsage sets the IdentityUsage field's value.
+func (s *DescribeIdentityUsageOutput) SetIdentityUsage(v *IdentityUsage) *DescribeIdentityUsageOutput {
+	s.IdentityUsage = v
+	return s
 }
 
 // The input for the GetBulkPublishDetails operation.
@@ -1886,6 +2036,12 @@ func (s *GetBulkPublishDetailsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetBulkPublishDetailsInput) SetIdentityPoolId(v string) *GetBulkPublishDetailsInput {
+	s.IdentityPoolId = &v
+	return s
 }
 
 // The output for the GetBulkPublishDetails operation.
@@ -1930,6 +2086,36 @@ func (s GetBulkPublishDetailsOutput) GoString() string {
 	return s.String()
 }
 
+// SetBulkPublishCompleteTime sets the BulkPublishCompleteTime field's value.
+func (s *GetBulkPublishDetailsOutput) SetBulkPublishCompleteTime(v time.Time) *GetBulkPublishDetailsOutput {
+	s.BulkPublishCompleteTime = &v
+	return s
+}
+
+// SetBulkPublishStartTime sets the BulkPublishStartTime field's value.
+func (s *GetBulkPublishDetailsOutput) SetBulkPublishStartTime(v time.Time) *GetBulkPublishDetailsOutput {
+	s.BulkPublishStartTime = &v
+	return s
+}
+
+// SetBulkPublishStatus sets the BulkPublishStatus field's value.
+func (s *GetBulkPublishDetailsOutput) SetBulkPublishStatus(v string) *GetBulkPublishDetailsOutput {
+	s.BulkPublishStatus = &v
+	return s
+}
+
+// SetFailureMessage sets the FailureMessage field's value.
+func (s *GetBulkPublishDetailsOutput) SetFailureMessage(v string) *GetBulkPublishDetailsOutput {
+	s.FailureMessage = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetBulkPublishDetailsOutput) SetIdentityPoolId(v string) *GetBulkPublishDetailsOutput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // A request for a list of the configured Cognito Events
 type GetCognitoEventsInput struct {
 	_ struct{} `type:"structure"`
@@ -1966,6 +2152,12 @@ func (s *GetCognitoEventsInput) Validate() error {
 	return nil
 }
 
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetCognitoEventsInput) SetIdentityPoolId(v string) *GetCognitoEventsInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // The response from the GetCognitoEvents request
 type GetCognitoEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1982,6 +2174,12 @@ func (s GetCognitoEventsOutput) String() string {
 // GoString returns the string representation
 func (s GetCognitoEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *GetCognitoEventsOutput) SetEvents(v map[string]*string) *GetCognitoEventsOutput {
+	s.Events = v
+	return s
 }
 
 // The input for the GetIdentityPoolConfiguration operation.
@@ -2022,6 +2220,12 @@ func (s *GetIdentityPoolConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetIdentityPoolConfigurationInput) SetIdentityPoolId(v string) *GetIdentityPoolConfigurationInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
 // The output for the GetIdentityPoolConfiguration operation.
 type GetIdentityPoolConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -2045,6 +2249,24 @@ func (s GetIdentityPoolConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s GetIdentityPoolConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetCognitoStreams sets the CognitoStreams field's value.
+func (s *GetIdentityPoolConfigurationOutput) SetCognitoStreams(v *CognitoStreams) *GetIdentityPoolConfigurationOutput {
+	s.CognitoStreams = v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *GetIdentityPoolConfigurationOutput) SetIdentityPoolId(v string) *GetIdentityPoolConfigurationOutput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetPushSync sets the PushSync field's value.
+func (s *GetIdentityPoolConfigurationOutput) SetPushSync(v *PushSync) *GetIdentityPoolConfigurationOutput {
+	s.PushSync = v
+	return s
 }
 
 // Usage information for the identity pool.
@@ -2073,6 +2295,30 @@ func (s IdentityPoolUsage) String() string {
 // GoString returns the string representation
 func (s IdentityPoolUsage) GoString() string {
 	return s.String()
+}
+
+// SetDataStorage sets the DataStorage field's value.
+func (s *IdentityPoolUsage) SetDataStorage(v int64) *IdentityPoolUsage {
+	s.DataStorage = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *IdentityPoolUsage) SetIdentityPoolId(v string) *IdentityPoolUsage {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *IdentityPoolUsage) SetLastModifiedDate(v time.Time) *IdentityPoolUsage {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetSyncSessionsCount sets the SyncSessionsCount field's value.
+func (s *IdentityPoolUsage) SetSyncSessionsCount(v int64) *IdentityPoolUsage {
+	s.SyncSessionsCount = &v
+	return s
 }
 
 // Usage information for the identity.
@@ -2105,6 +2351,36 @@ func (s IdentityUsage) String() string {
 // GoString returns the string representation
 func (s IdentityUsage) GoString() string {
 	return s.String()
+}
+
+// SetDataStorage sets the DataStorage field's value.
+func (s *IdentityUsage) SetDataStorage(v int64) *IdentityUsage {
+	s.DataStorage = &v
+	return s
+}
+
+// SetDatasetCount sets the DatasetCount field's value.
+func (s *IdentityUsage) SetDatasetCount(v int64) *IdentityUsage {
+	s.DatasetCount = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *IdentityUsage) SetIdentityId(v string) *IdentityUsage {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *IdentityUsage) SetIdentityPoolId(v string) *IdentityUsage {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *IdentityUsage) SetLastModifiedDate(v time.Time) *IdentityUsage {
+	s.LastModifiedDate = &v
+	return s
 }
 
 // Request for a list of datasets for an identity.
@@ -2162,6 +2438,30 @@ func (s *ListDatasetsInput) Validate() error {
 	return nil
 }
 
+// SetIdentityId sets the IdentityId field's value.
+func (s *ListDatasetsInput) SetIdentityId(v string) *ListDatasetsInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *ListDatasetsInput) SetIdentityPoolId(v string) *ListDatasetsInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListDatasetsInput) SetMaxResults(v int64) *ListDatasetsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDatasetsInput) SetNextToken(v string) *ListDatasetsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Returned for a successful ListDatasets request.
 type ListDatasetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2186,6 +2486,24 @@ func (s ListDatasetsOutput) GoString() string {
 	return s.String()
 }
 
+// SetCount sets the Count field's value.
+func (s *ListDatasetsOutput) SetCount(v int64) *ListDatasetsOutput {
+	s.Count = &v
+	return s
+}
+
+// SetDatasets sets the Datasets field's value.
+func (s *ListDatasetsOutput) SetDatasets(v []*Dataset) *ListDatasetsOutput {
+	s.Datasets = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDatasetsOutput) SetNextToken(v string) *ListDatasetsOutput {
+	s.NextToken = &v
+	return s
+}
+
 // A request for usage information on an identity pool.
 type ListIdentityPoolUsageInput struct {
 	_ struct{} `type:"structure"`
@@ -2205,6 +2523,18 @@ func (s ListIdentityPoolUsageInput) String() string {
 // GoString returns the string representation
 func (s ListIdentityPoolUsageInput) GoString() string {
 	return s.String()
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListIdentityPoolUsageInput) SetMaxResults(v int64) *ListIdentityPoolUsageInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIdentityPoolUsageInput) SetNextToken(v string) *ListIdentityPoolUsageInput {
+	s.NextToken = &v
+	return s
 }
 
 // Returned for a successful ListIdentityPoolUsage request.
@@ -2232,6 +2562,30 @@ func (s ListIdentityPoolUsageOutput) String() string {
 // GoString returns the string representation
 func (s ListIdentityPoolUsageOutput) GoString() string {
 	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *ListIdentityPoolUsageOutput) SetCount(v int64) *ListIdentityPoolUsageOutput {
+	s.Count = &v
+	return s
+}
+
+// SetIdentityPoolUsages sets the IdentityPoolUsages field's value.
+func (s *ListIdentityPoolUsageOutput) SetIdentityPoolUsages(v []*IdentityPoolUsage) *ListIdentityPoolUsageOutput {
+	s.IdentityPoolUsages = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListIdentityPoolUsageOutput) SetMaxResults(v int64) *ListIdentityPoolUsageOutput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIdentityPoolUsageOutput) SetNextToken(v string) *ListIdentityPoolUsageOutput {
+	s.NextToken = &v
+	return s
 }
 
 // A request for a list of records.
@@ -2307,6 +2661,48 @@ func (s *ListRecordsInput) Validate() error {
 	return nil
 }
 
+// SetDatasetName sets the DatasetName field's value.
+func (s *ListRecordsInput) SetDatasetName(v string) *ListRecordsInput {
+	s.DatasetName = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *ListRecordsInput) SetIdentityId(v string) *ListRecordsInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *ListRecordsInput) SetIdentityPoolId(v string) *ListRecordsInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetLastSyncCount sets the LastSyncCount field's value.
+func (s *ListRecordsInput) SetLastSyncCount(v int64) *ListRecordsInput {
+	s.LastSyncCount = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListRecordsInput) SetMaxResults(v int64) *ListRecordsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRecordsInput) SetNextToken(v string) *ListRecordsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSyncSessionToken sets the SyncSessionToken field's value.
+func (s *ListRecordsInput) SetSyncSessionToken(v string) *ListRecordsInput {
+	s.SyncSessionToken = &v
+	return s
+}
+
 // Returned for a successful ListRecordsRequest.
 type ListRecordsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2349,6 +2745,60 @@ func (s ListRecordsOutput) GoString() string {
 	return s.String()
 }
 
+// SetCount sets the Count field's value.
+func (s *ListRecordsOutput) SetCount(v int64) *ListRecordsOutput {
+	s.Count = &v
+	return s
+}
+
+// SetDatasetDeletedAfterRequestedSyncCount sets the DatasetDeletedAfterRequestedSyncCount field's value.
+func (s *ListRecordsOutput) SetDatasetDeletedAfterRequestedSyncCount(v bool) *ListRecordsOutput {
+	s.DatasetDeletedAfterRequestedSyncCount = &v
+	return s
+}
+
+// SetDatasetExists sets the DatasetExists field's value.
+func (s *ListRecordsOutput) SetDatasetExists(v bool) *ListRecordsOutput {
+	s.DatasetExists = &v
+	return s
+}
+
+// SetDatasetSyncCount sets the DatasetSyncCount field's value.
+func (s *ListRecordsOutput) SetDatasetSyncCount(v int64) *ListRecordsOutput {
+	s.DatasetSyncCount = &v
+	return s
+}
+
+// SetLastModifiedBy sets the LastModifiedBy field's value.
+func (s *ListRecordsOutput) SetLastModifiedBy(v string) *ListRecordsOutput {
+	s.LastModifiedBy = &v
+	return s
+}
+
+// SetMergedDatasetNames sets the MergedDatasetNames field's value.
+func (s *ListRecordsOutput) SetMergedDatasetNames(v []*string) *ListRecordsOutput {
+	s.MergedDatasetNames = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRecordsOutput) SetNextToken(v string) *ListRecordsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRecords sets the Records field's value.
+func (s *ListRecordsOutput) SetRecords(v []*Record) *ListRecordsOutput {
+	s.Records = v
+	return s
+}
+
+// SetSyncSessionToken sets the SyncSessionToken field's value.
+func (s *ListRecordsOutput) SetSyncSessionToken(v string) *ListRecordsOutput {
+	s.SyncSessionToken = &v
+	return s
+}
+
 // Configuration options to be applied to the identity pool.
 type PushSync struct {
 	_ struct{} `type:"structure"`
@@ -2383,6 +2833,18 @@ func (s *PushSync) Validate() error {
 	return nil
 }
 
+// SetApplicationArns sets the ApplicationArns field's value.
+func (s *PushSync) SetApplicationArns(v []*string) *PushSync {
+	s.ApplicationArns = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *PushSync) SetRoleArn(v string) *PushSync {
+	s.RoleArn = &v
+	return s
+}
+
 // The basic data structure of a dataset.
 type Record struct {
 	_ struct{} `type:"structure"`
@@ -2414,6 +2876,42 @@ func (s Record) String() string {
 // GoString returns the string representation
 func (s Record) GoString() string {
 	return s.String()
+}
+
+// SetDeviceLastModifiedDate sets the DeviceLastModifiedDate field's value.
+func (s *Record) SetDeviceLastModifiedDate(v time.Time) *Record {
+	s.DeviceLastModifiedDate = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *Record) SetKey(v string) *Record {
+	s.Key = &v
+	return s
+}
+
+// SetLastModifiedBy sets the LastModifiedBy field's value.
+func (s *Record) SetLastModifiedBy(v string) *Record {
+	s.LastModifiedBy = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *Record) SetLastModifiedDate(v time.Time) *Record {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetSyncCount sets the SyncCount field's value.
+func (s *Record) SetSyncCount(v int64) *Record {
+	s.SyncCount = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Record) SetValue(v string) *Record {
+	s.Value = &v
+	return s
 }
 
 // An update operation for a record.
@@ -2472,6 +2970,36 @@ func (s *RecordPatch) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDeviceLastModifiedDate sets the DeviceLastModifiedDate field's value.
+func (s *RecordPatch) SetDeviceLastModifiedDate(v time.Time) *RecordPatch {
+	s.DeviceLastModifiedDate = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *RecordPatch) SetKey(v string) *RecordPatch {
+	s.Key = &v
+	return s
+}
+
+// SetOp sets the Op field's value.
+func (s *RecordPatch) SetOp(v string) *RecordPatch {
+	s.Op = &v
+	return s
+}
+
+// SetSyncCount sets the SyncCount field's value.
+func (s *RecordPatch) SetSyncCount(v int64) *RecordPatch {
+	s.SyncCount = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *RecordPatch) SetValue(v string) *RecordPatch {
+	s.Value = &v
+	return s
 }
 
 // A request to RegisterDevice.
@@ -2539,6 +3067,30 @@ func (s *RegisterDeviceInput) Validate() error {
 	return nil
 }
 
+// SetIdentityId sets the IdentityId field's value.
+func (s *RegisterDeviceInput) SetIdentityId(v string) *RegisterDeviceInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *RegisterDeviceInput) SetIdentityPoolId(v string) *RegisterDeviceInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *RegisterDeviceInput) SetPlatform(v string) *RegisterDeviceInput {
+	s.Platform = &v
+	return s
+}
+
+// SetToken sets the Token field's value.
+func (s *RegisterDeviceInput) SetToken(v string) *RegisterDeviceInput {
+	s.Token = &v
+	return s
+}
+
 // Response to a RegisterDevice request.
 type RegisterDeviceOutput struct {
 	_ struct{} `type:"structure"`
@@ -2555,6 +3107,12 @@ func (s RegisterDeviceOutput) String() string {
 // GoString returns the string representation
 func (s RegisterDeviceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeviceId sets the DeviceId field's value.
+func (s *RegisterDeviceOutput) SetDeviceId(v string) *RegisterDeviceOutput {
+	s.DeviceId = &v
+	return s
 }
 
 // A request to configure Cognito Events"
@@ -2599,6 +3157,18 @@ func (s *SetCognitoEventsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEvents sets the Events field's value.
+func (s *SetCognitoEventsInput) SetEvents(v map[string]*string) *SetCognitoEventsInput {
+	s.Events = v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *SetCognitoEventsInput) SetIdentityPoolId(v string) *SetCognitoEventsInput {
+	s.IdentityPoolId = &v
+	return s
 }
 
 type SetCognitoEventsOutput struct {
@@ -2668,6 +3238,24 @@ func (s *SetIdentityPoolConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetCognitoStreams sets the CognitoStreams field's value.
+func (s *SetIdentityPoolConfigurationInput) SetCognitoStreams(v *CognitoStreams) *SetIdentityPoolConfigurationInput {
+	s.CognitoStreams = v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *SetIdentityPoolConfigurationInput) SetIdentityPoolId(v string) *SetIdentityPoolConfigurationInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetPushSync sets the PushSync field's value.
+func (s *SetIdentityPoolConfigurationInput) SetPushSync(v *PushSync) *SetIdentityPoolConfigurationInput {
+	s.PushSync = v
+	return s
+}
+
 // The output for the SetIdentityPoolConfiguration operation
 type SetIdentityPoolConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -2691,6 +3279,24 @@ func (s SetIdentityPoolConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s SetIdentityPoolConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetCognitoStreams sets the CognitoStreams field's value.
+func (s *SetIdentityPoolConfigurationOutput) SetCognitoStreams(v *CognitoStreams) *SetIdentityPoolConfigurationOutput {
+	s.CognitoStreams = v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *SetIdentityPoolConfigurationOutput) SetIdentityPoolId(v string) *SetIdentityPoolConfigurationOutput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetPushSync sets the PushSync field's value.
+func (s *SetIdentityPoolConfigurationOutput) SetPushSync(v *PushSync) *SetIdentityPoolConfigurationOutput {
+	s.PushSync = v
+	return s
 }
 
 // A request to SubscribeToDatasetRequest.
@@ -2761,6 +3367,30 @@ func (s *SubscribeToDatasetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDatasetName sets the DatasetName field's value.
+func (s *SubscribeToDatasetInput) SetDatasetName(v string) *SubscribeToDatasetInput {
+	s.DatasetName = &v
+	return s
+}
+
+// SetDeviceId sets the DeviceId field's value.
+func (s *SubscribeToDatasetInput) SetDeviceId(v string) *SubscribeToDatasetInput {
+	s.DeviceId = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *SubscribeToDatasetInput) SetIdentityId(v string) *SubscribeToDatasetInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *SubscribeToDatasetInput) SetIdentityPoolId(v string) *SubscribeToDatasetInput {
+	s.IdentityPoolId = &v
+	return s
 }
 
 // Response to a SubscribeToDataset request.
@@ -2846,6 +3476,30 @@ func (s *UnsubscribeFromDatasetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDatasetName sets the DatasetName field's value.
+func (s *UnsubscribeFromDatasetInput) SetDatasetName(v string) *UnsubscribeFromDatasetInput {
+	s.DatasetName = &v
+	return s
+}
+
+// SetDeviceId sets the DeviceId field's value.
+func (s *UnsubscribeFromDatasetInput) SetDeviceId(v string) *UnsubscribeFromDatasetInput {
+	s.DeviceId = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *UnsubscribeFromDatasetInput) SetIdentityId(v string) *UnsubscribeFromDatasetInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *UnsubscribeFromDatasetInput) SetIdentityPoolId(v string) *UnsubscribeFromDatasetInput {
+	s.IdentityPoolId = &v
+	return s
 }
 
 // Response to an UnsubscribeFromDataset request.
@@ -2957,6 +3611,48 @@ func (s *UpdateRecordsInput) Validate() error {
 	return nil
 }
 
+// SetClientContext sets the ClientContext field's value.
+func (s *UpdateRecordsInput) SetClientContext(v string) *UpdateRecordsInput {
+	s.ClientContext = &v
+	return s
+}
+
+// SetDatasetName sets the DatasetName field's value.
+func (s *UpdateRecordsInput) SetDatasetName(v string) *UpdateRecordsInput {
+	s.DatasetName = &v
+	return s
+}
+
+// SetDeviceId sets the DeviceId field's value.
+func (s *UpdateRecordsInput) SetDeviceId(v string) *UpdateRecordsInput {
+	s.DeviceId = &v
+	return s
+}
+
+// SetIdentityId sets the IdentityId field's value.
+func (s *UpdateRecordsInput) SetIdentityId(v string) *UpdateRecordsInput {
+	s.IdentityId = &v
+	return s
+}
+
+// SetIdentityPoolId sets the IdentityPoolId field's value.
+func (s *UpdateRecordsInput) SetIdentityPoolId(v string) *UpdateRecordsInput {
+	s.IdentityPoolId = &v
+	return s
+}
+
+// SetRecordPatches sets the RecordPatches field's value.
+func (s *UpdateRecordsInput) SetRecordPatches(v []*RecordPatch) *UpdateRecordsInput {
+	s.RecordPatches = v
+	return s
+}
+
+// SetSyncSessionToken sets the SyncSessionToken field's value.
+func (s *UpdateRecordsInput) SetSyncSessionToken(v string) *UpdateRecordsInput {
+	s.SyncSessionToken = &v
+	return s
+}
+
 // Returned for a successful UpdateRecordsRequest.
 type UpdateRecordsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2973,6 +3669,12 @@ func (s UpdateRecordsOutput) String() string {
 // GoString returns the string representation
 func (s UpdateRecordsOutput) GoString() string {
 	return s.String()
+}
+
+// SetRecords sets the Records field's value.
+func (s *UpdateRecordsOutput) SetRecords(v []*Record) *UpdateRecordsOutput {
+	s.Records = v
+	return s
 }
 
 const (

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -2118,6 +2118,18 @@ func (s Compliance) GoString() string {
 	return s.String()
 }
 
+// SetComplianceContributorCount sets the ComplianceContributorCount field's value.
+func (s *Compliance) SetComplianceContributorCount(v *ComplianceContributorCount) *Compliance {
+	s.ComplianceContributorCount = v
+	return s
+}
+
+// SetComplianceType sets the ComplianceType field's value.
+func (s *Compliance) SetComplianceType(v string) *Compliance {
+	s.ComplianceType = &v
+	return s
+}
+
 // Indicates whether an AWS Config rule is compliant. A rule is compliant if
 // all of the resources that the rule evaluated comply with it, and it is noncompliant
 // if any of these resources do not comply.
@@ -2139,6 +2151,18 @@ func (s ComplianceByConfigRule) String() string {
 // GoString returns the string representation
 func (s ComplianceByConfigRule) GoString() string {
 	return s.String()
+}
+
+// SetCompliance sets the Compliance field's value.
+func (s *ComplianceByConfigRule) SetCompliance(v *Compliance) *ComplianceByConfigRule {
+	s.Compliance = v
+	return s
+}
+
+// SetConfigRuleName sets the ConfigRuleName field's value.
+func (s *ComplianceByConfigRule) SetConfigRuleName(v string) *ComplianceByConfigRule {
+	s.ConfigRuleName = &v
+	return s
 }
 
 // Indicates whether an AWS resource that is evaluated according to one or more
@@ -2169,6 +2193,24 @@ func (s ComplianceByResource) GoString() string {
 	return s.String()
 }
 
+// SetCompliance sets the Compliance field's value.
+func (s *ComplianceByResource) SetCompliance(v *Compliance) *ComplianceByResource {
+	s.Compliance = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ComplianceByResource) SetResourceId(v string) *ComplianceByResource {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ComplianceByResource) SetResourceType(v string) *ComplianceByResource {
+	s.ResourceType = &v
+	return s
+}
+
 // The number of AWS resources or AWS Config rules responsible for the current
 // compliance of the item, up to a maximum number.
 type ComplianceContributorCount struct {
@@ -2190,6 +2232,18 @@ func (s ComplianceContributorCount) String() string {
 // GoString returns the string representation
 func (s ComplianceContributorCount) GoString() string {
 	return s.String()
+}
+
+// SetCapExceeded sets the CapExceeded field's value.
+func (s *ComplianceContributorCount) SetCapExceeded(v bool) *ComplianceContributorCount {
+	s.CapExceeded = &v
+	return s
+}
+
+// SetCappedCount sets the CappedCount field's value.
+func (s *ComplianceContributorCount) SetCappedCount(v int64) *ComplianceContributorCount {
+	s.CappedCount = &v
+	return s
 }
 
 // The number of AWS Config rules or AWS resources that are compliant and noncompliant,
@@ -2219,6 +2273,24 @@ func (s ComplianceSummary) GoString() string {
 	return s.String()
 }
 
+// SetComplianceSummaryTimestamp sets the ComplianceSummaryTimestamp field's value.
+func (s *ComplianceSummary) SetComplianceSummaryTimestamp(v time.Time) *ComplianceSummary {
+	s.ComplianceSummaryTimestamp = &v
+	return s
+}
+
+// SetCompliantResourceCount sets the CompliantResourceCount field's value.
+func (s *ComplianceSummary) SetCompliantResourceCount(v *ComplianceContributorCount) *ComplianceSummary {
+	s.CompliantResourceCount = v
+	return s
+}
+
+// SetNonCompliantResourceCount sets the NonCompliantResourceCount field's value.
+func (s *ComplianceSummary) SetNonCompliantResourceCount(v *ComplianceContributorCount) *ComplianceSummary {
+	s.NonCompliantResourceCount = v
+	return s
+}
+
 // The number of AWS resources of a specific type that are compliant or noncompliant,
 // up to a maximum of 100 for each compliance.
 type ComplianceSummaryByResourceType struct {
@@ -2240,6 +2312,18 @@ func (s ComplianceSummaryByResourceType) String() string {
 // GoString returns the string representation
 func (s ComplianceSummaryByResourceType) GoString() string {
 	return s.String()
+}
+
+// SetComplianceSummary sets the ComplianceSummary field's value.
+func (s *ComplianceSummaryByResourceType) SetComplianceSummary(v *ComplianceSummary) *ComplianceSummaryByResourceType {
+	s.ComplianceSummary = v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ComplianceSummaryByResourceType) SetResourceType(v string) *ComplianceSummaryByResourceType {
+	s.ResourceType = &v
+	return s
 }
 
 // A list that contains the status of the delivery of either the snapshot or
@@ -2274,6 +2358,42 @@ func (s ConfigExportDeliveryInfo) String() string {
 // GoString returns the string representation
 func (s ConfigExportDeliveryInfo) GoString() string {
 	return s.String()
+}
+
+// SetLastAttemptTime sets the LastAttemptTime field's value.
+func (s *ConfigExportDeliveryInfo) SetLastAttemptTime(v time.Time) *ConfigExportDeliveryInfo {
+	s.LastAttemptTime = &v
+	return s
+}
+
+// SetLastErrorCode sets the LastErrorCode field's value.
+func (s *ConfigExportDeliveryInfo) SetLastErrorCode(v string) *ConfigExportDeliveryInfo {
+	s.LastErrorCode = &v
+	return s
+}
+
+// SetLastErrorMessage sets the LastErrorMessage field's value.
+func (s *ConfigExportDeliveryInfo) SetLastErrorMessage(v string) *ConfigExportDeliveryInfo {
+	s.LastErrorMessage = &v
+	return s
+}
+
+// SetLastStatus sets the LastStatus field's value.
+func (s *ConfigExportDeliveryInfo) SetLastStatus(v string) *ConfigExportDeliveryInfo {
+	s.LastStatus = &v
+	return s
+}
+
+// SetLastSuccessfulTime sets the LastSuccessfulTime field's value.
+func (s *ConfigExportDeliveryInfo) SetLastSuccessfulTime(v time.Time) *ConfigExportDeliveryInfo {
+	s.LastSuccessfulTime = &v
+	return s
+}
+
+// SetNextDeliveryTime sets the NextDeliveryTime field's value.
+func (s *ConfigExportDeliveryInfo) SetNextDeliveryTime(v time.Time) *ConfigExportDeliveryInfo {
+	s.NextDeliveryTime = &v
+	return s
 }
 
 // An AWS Config rule represents an AWS Lambda function that you create for
@@ -2392,6 +2512,60 @@ func (s *ConfigRule) Validate() error {
 	return nil
 }
 
+// SetConfigRuleArn sets the ConfigRuleArn field's value.
+func (s *ConfigRule) SetConfigRuleArn(v string) *ConfigRule {
+	s.ConfigRuleArn = &v
+	return s
+}
+
+// SetConfigRuleId sets the ConfigRuleId field's value.
+func (s *ConfigRule) SetConfigRuleId(v string) *ConfigRule {
+	s.ConfigRuleId = &v
+	return s
+}
+
+// SetConfigRuleName sets the ConfigRuleName field's value.
+func (s *ConfigRule) SetConfigRuleName(v string) *ConfigRule {
+	s.ConfigRuleName = &v
+	return s
+}
+
+// SetConfigRuleState sets the ConfigRuleState field's value.
+func (s *ConfigRule) SetConfigRuleState(v string) *ConfigRule {
+	s.ConfigRuleState = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ConfigRule) SetDescription(v string) *ConfigRule {
+	s.Description = &v
+	return s
+}
+
+// SetInputParameters sets the InputParameters field's value.
+func (s *ConfigRule) SetInputParameters(v string) *ConfigRule {
+	s.InputParameters = &v
+	return s
+}
+
+// SetMaximumExecutionFrequency sets the MaximumExecutionFrequency field's value.
+func (s *ConfigRule) SetMaximumExecutionFrequency(v string) *ConfigRule {
+	s.MaximumExecutionFrequency = &v
+	return s
+}
+
+// SetScope sets the Scope field's value.
+func (s *ConfigRule) SetScope(v *Scope) *ConfigRule {
+	s.Scope = v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *ConfigRule) SetSource(v *Source) *ConfigRule {
+	s.Source = v
+	return s
+}
+
 // Status information for your AWS managed Config rules. The status includes
 // information such as the last time the rule ran, the last time it failed,
 // and the related error for the last failure.
@@ -2455,6 +2629,72 @@ func (s ConfigRuleEvaluationStatus) GoString() string {
 	return s.String()
 }
 
+// SetConfigRuleArn sets the ConfigRuleArn field's value.
+func (s *ConfigRuleEvaluationStatus) SetConfigRuleArn(v string) *ConfigRuleEvaluationStatus {
+	s.ConfigRuleArn = &v
+	return s
+}
+
+// SetConfigRuleId sets the ConfigRuleId field's value.
+func (s *ConfigRuleEvaluationStatus) SetConfigRuleId(v string) *ConfigRuleEvaluationStatus {
+	s.ConfigRuleId = &v
+	return s
+}
+
+// SetConfigRuleName sets the ConfigRuleName field's value.
+func (s *ConfigRuleEvaluationStatus) SetConfigRuleName(v string) *ConfigRuleEvaluationStatus {
+	s.ConfigRuleName = &v
+	return s
+}
+
+// SetFirstActivatedTime sets the FirstActivatedTime field's value.
+func (s *ConfigRuleEvaluationStatus) SetFirstActivatedTime(v time.Time) *ConfigRuleEvaluationStatus {
+	s.FirstActivatedTime = &v
+	return s
+}
+
+// SetFirstEvaluationStarted sets the FirstEvaluationStarted field's value.
+func (s *ConfigRuleEvaluationStatus) SetFirstEvaluationStarted(v bool) *ConfigRuleEvaluationStatus {
+	s.FirstEvaluationStarted = &v
+	return s
+}
+
+// SetLastErrorCode sets the LastErrorCode field's value.
+func (s *ConfigRuleEvaluationStatus) SetLastErrorCode(v string) *ConfigRuleEvaluationStatus {
+	s.LastErrorCode = &v
+	return s
+}
+
+// SetLastErrorMessage sets the LastErrorMessage field's value.
+func (s *ConfigRuleEvaluationStatus) SetLastErrorMessage(v string) *ConfigRuleEvaluationStatus {
+	s.LastErrorMessage = &v
+	return s
+}
+
+// SetLastFailedEvaluationTime sets the LastFailedEvaluationTime field's value.
+func (s *ConfigRuleEvaluationStatus) SetLastFailedEvaluationTime(v time.Time) *ConfigRuleEvaluationStatus {
+	s.LastFailedEvaluationTime = &v
+	return s
+}
+
+// SetLastFailedInvocationTime sets the LastFailedInvocationTime field's value.
+func (s *ConfigRuleEvaluationStatus) SetLastFailedInvocationTime(v time.Time) *ConfigRuleEvaluationStatus {
+	s.LastFailedInvocationTime = &v
+	return s
+}
+
+// SetLastSuccessfulEvaluationTime sets the LastSuccessfulEvaluationTime field's value.
+func (s *ConfigRuleEvaluationStatus) SetLastSuccessfulEvaluationTime(v time.Time) *ConfigRuleEvaluationStatus {
+	s.LastSuccessfulEvaluationTime = &v
+	return s
+}
+
+// SetLastSuccessfulInvocationTime sets the LastSuccessfulInvocationTime field's value.
+func (s *ConfigRuleEvaluationStatus) SetLastSuccessfulInvocationTime(v time.Time) *ConfigRuleEvaluationStatus {
+	s.LastSuccessfulInvocationTime = &v
+	return s
+}
+
 // Provides options for how often AWS Config delivers configuration snapshots
 // to the Amazon S3 bucket in your delivery channel.
 //
@@ -2511,6 +2751,12 @@ func (s ConfigSnapshotDeliveryProperties) GoString() string {
 	return s.String()
 }
 
+// SetDeliveryFrequency sets the DeliveryFrequency field's value.
+func (s *ConfigSnapshotDeliveryProperties) SetDeliveryFrequency(v string) *ConfigSnapshotDeliveryProperties {
+	s.DeliveryFrequency = &v
+	return s
+}
+
 // A list that contains the status of the delivery of the configuration stream
 // notification to the Amazon SNS topic.
 type ConfigStreamDeliveryInfo struct {
@@ -2541,6 +2787,30 @@ func (s ConfigStreamDeliveryInfo) String() string {
 // GoString returns the string representation
 func (s ConfigStreamDeliveryInfo) GoString() string {
 	return s.String()
+}
+
+// SetLastErrorCode sets the LastErrorCode field's value.
+func (s *ConfigStreamDeliveryInfo) SetLastErrorCode(v string) *ConfigStreamDeliveryInfo {
+	s.LastErrorCode = &v
+	return s
+}
+
+// SetLastErrorMessage sets the LastErrorMessage field's value.
+func (s *ConfigStreamDeliveryInfo) SetLastErrorMessage(v string) *ConfigStreamDeliveryInfo {
+	s.LastErrorMessage = &v
+	return s
+}
+
+// SetLastStatus sets the LastStatus field's value.
+func (s *ConfigStreamDeliveryInfo) SetLastStatus(v string) *ConfigStreamDeliveryInfo {
+	s.LastStatus = &v
+	return s
+}
+
+// SetLastStatusChangeTime sets the LastStatusChangeTime field's value.
+func (s *ConfigStreamDeliveryInfo) SetLastStatusChangeTime(v time.Time) *ConfigStreamDeliveryInfo {
+	s.LastStatusChangeTime = &v
+	return s
 }
 
 // A list that contains detailed configurations of a specified resource.
@@ -2627,6 +2897,114 @@ func (s ConfigurationItem) GoString() string {
 	return s.String()
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *ConfigurationItem) SetAccountId(v string) *ConfigurationItem {
+	s.AccountId = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *ConfigurationItem) SetArn(v string) *ConfigurationItem {
+	s.Arn = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ConfigurationItem) SetAvailabilityZone(v string) *ConfigurationItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetAwsRegion sets the AwsRegion field's value.
+func (s *ConfigurationItem) SetAwsRegion(v string) *ConfigurationItem {
+	s.AwsRegion = &v
+	return s
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *ConfigurationItem) SetConfiguration(v string) *ConfigurationItem {
+	s.Configuration = &v
+	return s
+}
+
+// SetConfigurationItemCaptureTime sets the ConfigurationItemCaptureTime field's value.
+func (s *ConfigurationItem) SetConfigurationItemCaptureTime(v time.Time) *ConfigurationItem {
+	s.ConfigurationItemCaptureTime = &v
+	return s
+}
+
+// SetConfigurationItemMD5Hash sets the ConfigurationItemMD5Hash field's value.
+func (s *ConfigurationItem) SetConfigurationItemMD5Hash(v string) *ConfigurationItem {
+	s.ConfigurationItemMD5Hash = &v
+	return s
+}
+
+// SetConfigurationItemStatus sets the ConfigurationItemStatus field's value.
+func (s *ConfigurationItem) SetConfigurationItemStatus(v string) *ConfigurationItem {
+	s.ConfigurationItemStatus = &v
+	return s
+}
+
+// SetConfigurationStateId sets the ConfigurationStateId field's value.
+func (s *ConfigurationItem) SetConfigurationStateId(v string) *ConfigurationItem {
+	s.ConfigurationStateId = &v
+	return s
+}
+
+// SetRelatedEvents sets the RelatedEvents field's value.
+func (s *ConfigurationItem) SetRelatedEvents(v []*string) *ConfigurationItem {
+	s.RelatedEvents = v
+	return s
+}
+
+// SetRelationships sets the Relationships field's value.
+func (s *ConfigurationItem) SetRelationships(v []*Relationship) *ConfigurationItem {
+	s.Relationships = v
+	return s
+}
+
+// SetResourceCreationTime sets the ResourceCreationTime field's value.
+func (s *ConfigurationItem) SetResourceCreationTime(v time.Time) *ConfigurationItem {
+	s.ResourceCreationTime = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ConfigurationItem) SetResourceId(v string) *ConfigurationItem {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *ConfigurationItem) SetResourceName(v string) *ConfigurationItem {
+	s.ResourceName = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ConfigurationItem) SetResourceType(v string) *ConfigurationItem {
+	s.ResourceType = &v
+	return s
+}
+
+// SetSupplementaryConfiguration sets the SupplementaryConfiguration field's value.
+func (s *ConfigurationItem) SetSupplementaryConfiguration(v map[string]*string) *ConfigurationItem {
+	s.SupplementaryConfiguration = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ConfigurationItem) SetTags(v map[string]*string) *ConfigurationItem {
+	s.Tags = v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *ConfigurationItem) SetVersion(v string) *ConfigurationItem {
+	s.Version = &v
+	return s
+}
+
 // An object that represents the recording of configuration changes of an AWS
 // resource.
 type ConfigurationRecorder struct {
@@ -2669,6 +3047,24 @@ func (s *ConfigurationRecorder) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *ConfigurationRecorder) SetName(v string) *ConfigurationRecorder {
+	s.Name = &v
+	return s
+}
+
+// SetRecordingGroup sets the RecordingGroup field's value.
+func (s *ConfigurationRecorder) SetRecordingGroup(v *RecordingGroup) *ConfigurationRecorder {
+	s.RecordingGroup = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *ConfigurationRecorder) SetRoleARN(v string) *ConfigurationRecorder {
+	s.RoleARN = &v
+	return s
+}
+
 // The current status of the configuration recorder.
 type ConfigurationRecorderStatus struct {
 	_ struct{} `type:"structure"`
@@ -2708,6 +3104,54 @@ func (s ConfigurationRecorderStatus) GoString() string {
 	return s.String()
 }
 
+// SetLastErrorCode sets the LastErrorCode field's value.
+func (s *ConfigurationRecorderStatus) SetLastErrorCode(v string) *ConfigurationRecorderStatus {
+	s.LastErrorCode = &v
+	return s
+}
+
+// SetLastErrorMessage sets the LastErrorMessage field's value.
+func (s *ConfigurationRecorderStatus) SetLastErrorMessage(v string) *ConfigurationRecorderStatus {
+	s.LastErrorMessage = &v
+	return s
+}
+
+// SetLastStartTime sets the LastStartTime field's value.
+func (s *ConfigurationRecorderStatus) SetLastStartTime(v time.Time) *ConfigurationRecorderStatus {
+	s.LastStartTime = &v
+	return s
+}
+
+// SetLastStatus sets the LastStatus field's value.
+func (s *ConfigurationRecorderStatus) SetLastStatus(v string) *ConfigurationRecorderStatus {
+	s.LastStatus = &v
+	return s
+}
+
+// SetLastStatusChangeTime sets the LastStatusChangeTime field's value.
+func (s *ConfigurationRecorderStatus) SetLastStatusChangeTime(v time.Time) *ConfigurationRecorderStatus {
+	s.LastStatusChangeTime = &v
+	return s
+}
+
+// SetLastStopTime sets the LastStopTime field's value.
+func (s *ConfigurationRecorderStatus) SetLastStopTime(v time.Time) *ConfigurationRecorderStatus {
+	s.LastStopTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ConfigurationRecorderStatus) SetName(v string) *ConfigurationRecorderStatus {
+	s.Name = &v
+	return s
+}
+
+// SetRecording sets the Recording field's value.
+func (s *ConfigurationRecorderStatus) SetRecording(v bool) *ConfigurationRecorderStatus {
+	s.Recording = &v
+	return s
+}
+
 type DeleteConfigRuleInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2741,6 +3185,12 @@ func (s *DeleteConfigRuleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConfigRuleName sets the ConfigRuleName field's value.
+func (s *DeleteConfigRuleInput) SetConfigRuleName(v string) *DeleteConfigRuleInput {
+	s.ConfigRuleName = &v
+	return s
 }
 
 type DeleteConfigRuleOutput struct {
@@ -2795,6 +3245,12 @@ func (s *DeleteConfigurationRecorderInput) Validate() error {
 	return nil
 }
 
+// SetConfigurationRecorderName sets the ConfigurationRecorderName field's value.
+func (s *DeleteConfigurationRecorderInput) SetConfigurationRecorderName(v string) *DeleteConfigurationRecorderInput {
+	s.ConfigurationRecorderName = &v
+	return s
+}
+
 type DeleteConfigurationRecorderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2846,6 +3302,12 @@ func (s *DeleteDeliveryChannelInput) Validate() error {
 	return nil
 }
 
+// SetDeliveryChannelName sets the DeliveryChannelName field's value.
+func (s *DeleteDeliveryChannelInput) SetDeliveryChannelName(v string) *DeleteDeliveryChannelInput {
+	s.DeliveryChannelName = &v
+	return s
+}
+
 type DeleteDeliveryChannelOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2893,6 +3355,12 @@ func (s *DeleteEvaluationResultsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConfigRuleName sets the ConfigRuleName field's value.
+func (s *DeleteEvaluationResultsInput) SetConfigRuleName(v string) *DeleteEvaluationResultsInput {
+	s.ConfigRuleName = &v
+	return s
 }
 
 // The output when you delete the evaluation results for the specified Config
@@ -2947,6 +3415,12 @@ func (s *DeliverConfigSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDeliveryChannelName sets the DeliveryChannelName field's value.
+func (s *DeliverConfigSnapshotInput) SetDeliveryChannelName(v string) *DeliverConfigSnapshotInput {
+	s.DeliveryChannelName = &v
+	return s
+}
+
 // The output for the DeliverConfigSnapshot action in JSON format.
 type DeliverConfigSnapshotOutput struct {
 	_ struct{} `type:"structure"`
@@ -2963,6 +3437,12 @@ func (s DeliverConfigSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s DeliverConfigSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigSnapshotId sets the ConfigSnapshotId field's value.
+func (s *DeliverConfigSnapshotOutput) SetConfigSnapshotId(v string) *DeliverConfigSnapshotOutput {
+	s.ConfigSnapshotId = &v
+	return s
 }
 
 // The channel through which AWS Config delivers notifications and updated configuration
@@ -3063,6 +3543,36 @@ func (s *DeliveryChannel) Validate() error {
 	return nil
 }
 
+// SetConfigSnapshotDeliveryProperties sets the ConfigSnapshotDeliveryProperties field's value.
+func (s *DeliveryChannel) SetConfigSnapshotDeliveryProperties(v *ConfigSnapshotDeliveryProperties) *DeliveryChannel {
+	s.ConfigSnapshotDeliveryProperties = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeliveryChannel) SetName(v string) *DeliveryChannel {
+	s.Name = &v
+	return s
+}
+
+// SetS3BucketName sets the S3BucketName field's value.
+func (s *DeliveryChannel) SetS3BucketName(v string) *DeliveryChannel {
+	s.S3BucketName = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *DeliveryChannel) SetS3KeyPrefix(v string) *DeliveryChannel {
+	s.S3KeyPrefix = &v
+	return s
+}
+
+// SetSnsTopicARN sets the SnsTopicARN field's value.
+func (s *DeliveryChannel) SetSnsTopicARN(v string) *DeliveryChannel {
+	s.SnsTopicARN = &v
+	return s
+}
+
 // The status of a specified delivery channel.
 //
 // Valid values: Success | Failure
@@ -3095,6 +3605,30 @@ func (s DeliveryChannelStatus) GoString() string {
 	return s.String()
 }
 
+// SetConfigHistoryDeliveryInfo sets the ConfigHistoryDeliveryInfo field's value.
+func (s *DeliveryChannelStatus) SetConfigHistoryDeliveryInfo(v *ConfigExportDeliveryInfo) *DeliveryChannelStatus {
+	s.ConfigHistoryDeliveryInfo = v
+	return s
+}
+
+// SetConfigSnapshotDeliveryInfo sets the ConfigSnapshotDeliveryInfo field's value.
+func (s *DeliveryChannelStatus) SetConfigSnapshotDeliveryInfo(v *ConfigExportDeliveryInfo) *DeliveryChannelStatus {
+	s.ConfigSnapshotDeliveryInfo = v
+	return s
+}
+
+// SetConfigStreamDeliveryInfo sets the ConfigStreamDeliveryInfo field's value.
+func (s *DeliveryChannelStatus) SetConfigStreamDeliveryInfo(v *ConfigStreamDeliveryInfo) *DeliveryChannelStatus {
+	s.ConfigStreamDeliveryInfo = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeliveryChannelStatus) SetName(v string) *DeliveryChannelStatus {
+	s.Name = &v
+	return s
+}
+
 type DescribeComplianceByConfigRuleInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3121,6 +3655,24 @@ func (s DescribeComplianceByConfigRuleInput) GoString() string {
 	return s.String()
 }
 
+// SetComplianceTypes sets the ComplianceTypes field's value.
+func (s *DescribeComplianceByConfigRuleInput) SetComplianceTypes(v []*string) *DescribeComplianceByConfigRuleInput {
+	s.ComplianceTypes = v
+	return s
+}
+
+// SetConfigRuleNames sets the ConfigRuleNames field's value.
+func (s *DescribeComplianceByConfigRuleInput) SetConfigRuleNames(v []*string) *DescribeComplianceByConfigRuleInput {
+	s.ConfigRuleNames = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeComplianceByConfigRuleInput) SetNextToken(v string) *DescribeComplianceByConfigRuleInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeComplianceByConfigRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3140,6 +3692,18 @@ func (s DescribeComplianceByConfigRuleOutput) String() string {
 // GoString returns the string representation
 func (s DescribeComplianceByConfigRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetComplianceByConfigRules sets the ComplianceByConfigRules field's value.
+func (s *DescribeComplianceByConfigRuleOutput) SetComplianceByConfigRules(v []*ComplianceByConfigRule) *DescribeComplianceByConfigRuleOutput {
+	s.ComplianceByConfigRules = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeComplianceByConfigRuleOutput) SetNextToken(v string) *DescribeComplianceByConfigRuleOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeComplianceByResourceInput struct {
@@ -3196,6 +3760,36 @@ func (s *DescribeComplianceByResourceInput) Validate() error {
 	return nil
 }
 
+// SetComplianceTypes sets the ComplianceTypes field's value.
+func (s *DescribeComplianceByResourceInput) SetComplianceTypes(v []*string) *DescribeComplianceByResourceInput {
+	s.ComplianceTypes = v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeComplianceByResourceInput) SetLimit(v int64) *DescribeComplianceByResourceInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeComplianceByResourceInput) SetNextToken(v string) *DescribeComplianceByResourceInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DescribeComplianceByResourceInput) SetResourceId(v string) *DescribeComplianceByResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *DescribeComplianceByResourceInput) SetResourceType(v string) *DescribeComplianceByResourceInput {
+	s.ResourceType = &v
+	return s
+}
+
 type DescribeComplianceByResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3218,6 +3812,18 @@ func (s DescribeComplianceByResourceOutput) GoString() string {
 	return s.String()
 }
 
+// SetComplianceByResources sets the ComplianceByResources field's value.
+func (s *DescribeComplianceByResourceOutput) SetComplianceByResources(v []*ComplianceByResource) *DescribeComplianceByResourceOutput {
+	s.ComplianceByResources = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeComplianceByResourceOutput) SetNextToken(v string) *DescribeComplianceByResourceOutput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeConfigRuleEvaluationStatusInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3237,6 +3843,12 @@ func (s DescribeConfigRuleEvaluationStatusInput) GoString() string {
 	return s.String()
 }
 
+// SetConfigRuleNames sets the ConfigRuleNames field's value.
+func (s *DescribeConfigRuleEvaluationStatusInput) SetConfigRuleNames(v []*string) *DescribeConfigRuleEvaluationStatusInput {
+	s.ConfigRuleNames = v
+	return s
+}
+
 type DescribeConfigRuleEvaluationStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3252,6 +3864,12 @@ func (s DescribeConfigRuleEvaluationStatusOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConfigRuleEvaluationStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigRulesEvaluationStatus sets the ConfigRulesEvaluationStatus field's value.
+func (s *DescribeConfigRuleEvaluationStatusOutput) SetConfigRulesEvaluationStatus(v []*ConfigRuleEvaluationStatus) *DescribeConfigRuleEvaluationStatusOutput {
+	s.ConfigRulesEvaluationStatus = v
+	return s
 }
 
 type DescribeConfigRulesInput struct {
@@ -3276,6 +3894,18 @@ func (s DescribeConfigRulesInput) GoString() string {
 	return s.String()
 }
 
+// SetConfigRuleNames sets the ConfigRuleNames field's value.
+func (s *DescribeConfigRulesInput) SetConfigRuleNames(v []*string) *DescribeConfigRulesInput {
+	s.ConfigRuleNames = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeConfigRulesInput) SetNextToken(v string) *DescribeConfigRulesInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeConfigRulesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3295,6 +3925,18 @@ func (s DescribeConfigRulesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConfigRulesOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigRules sets the ConfigRules field's value.
+func (s *DescribeConfigRulesOutput) SetConfigRules(v []*ConfigRule) *DescribeConfigRulesOutput {
+	s.ConfigRules = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeConfigRulesOutput) SetNextToken(v string) *DescribeConfigRulesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // The input for the DescribeConfigurationRecorderStatus action.
@@ -3317,6 +3959,12 @@ func (s DescribeConfigurationRecorderStatusInput) GoString() string {
 	return s.String()
 }
 
+// SetConfigurationRecorderNames sets the ConfigurationRecorderNames field's value.
+func (s *DescribeConfigurationRecorderStatusInput) SetConfigurationRecorderNames(v []*string) *DescribeConfigurationRecorderStatusInput {
+	s.ConfigurationRecorderNames = v
+	return s
+}
+
 // The output for the DescribeConfigurationRecorderStatus action in JSON format.
 type DescribeConfigurationRecorderStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -3333,6 +3981,12 @@ func (s DescribeConfigurationRecorderStatusOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConfigurationRecorderStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigurationRecordersStatus sets the ConfigurationRecordersStatus field's value.
+func (s *DescribeConfigurationRecorderStatusOutput) SetConfigurationRecordersStatus(v []*ConfigurationRecorderStatus) *DescribeConfigurationRecorderStatusOutput {
+	s.ConfigurationRecordersStatus = v
+	return s
 }
 
 // The input for the DescribeConfigurationRecorders action.
@@ -3353,6 +4007,12 @@ func (s DescribeConfigurationRecordersInput) GoString() string {
 	return s.String()
 }
 
+// SetConfigurationRecorderNames sets the ConfigurationRecorderNames field's value.
+func (s *DescribeConfigurationRecordersInput) SetConfigurationRecorderNames(v []*string) *DescribeConfigurationRecordersInput {
+	s.ConfigurationRecorderNames = v
+	return s
+}
+
 // The output for the DescribeConfigurationRecorders action.
 type DescribeConfigurationRecordersOutput struct {
 	_ struct{} `type:"structure"`
@@ -3369,6 +4029,12 @@ func (s DescribeConfigurationRecordersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConfigurationRecordersOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigurationRecorders sets the ConfigurationRecorders field's value.
+func (s *DescribeConfigurationRecordersOutput) SetConfigurationRecorders(v []*ConfigurationRecorder) *DescribeConfigurationRecordersOutput {
+	s.ConfigurationRecorders = v
+	return s
 }
 
 // The input for the DeliveryChannelStatus action.
@@ -3389,6 +4055,12 @@ func (s DescribeDeliveryChannelStatusInput) GoString() string {
 	return s.String()
 }
 
+// SetDeliveryChannelNames sets the DeliveryChannelNames field's value.
+func (s *DescribeDeliveryChannelStatusInput) SetDeliveryChannelNames(v []*string) *DescribeDeliveryChannelStatusInput {
+	s.DeliveryChannelNames = v
+	return s
+}
+
 // The output for the DescribeDeliveryChannelStatus action.
 type DescribeDeliveryChannelStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -3405,6 +4077,12 @@ func (s DescribeDeliveryChannelStatusOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDeliveryChannelStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeliveryChannelsStatus sets the DeliveryChannelsStatus field's value.
+func (s *DescribeDeliveryChannelStatusOutput) SetDeliveryChannelsStatus(v []*DeliveryChannelStatus) *DescribeDeliveryChannelStatusOutput {
+	s.DeliveryChannelsStatus = v
+	return s
 }
 
 // The input for the DescribeDeliveryChannels action.
@@ -3425,6 +4103,12 @@ func (s DescribeDeliveryChannelsInput) GoString() string {
 	return s.String()
 }
 
+// SetDeliveryChannelNames sets the DeliveryChannelNames field's value.
+func (s *DescribeDeliveryChannelsInput) SetDeliveryChannelNames(v []*string) *DescribeDeliveryChannelsInput {
+	s.DeliveryChannelNames = v
+	return s
+}
+
 // The output for the DescribeDeliveryChannels action.
 type DescribeDeliveryChannelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3441,6 +4125,12 @@ func (s DescribeDeliveryChannelsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDeliveryChannelsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeliveryChannels sets the DeliveryChannels field's value.
+func (s *DescribeDeliveryChannelsOutput) SetDeliveryChannels(v []*DeliveryChannel) *DescribeDeliveryChannelsOutput {
+	s.DeliveryChannels = v
+	return s
 }
 
 // Identifies an AWS resource and indicates whether it complies with the AWS
@@ -3526,6 +4216,36 @@ func (s *Evaluation) Validate() error {
 	return nil
 }
 
+// SetAnnotation sets the Annotation field's value.
+func (s *Evaluation) SetAnnotation(v string) *Evaluation {
+	s.Annotation = &v
+	return s
+}
+
+// SetComplianceResourceId sets the ComplianceResourceId field's value.
+func (s *Evaluation) SetComplianceResourceId(v string) *Evaluation {
+	s.ComplianceResourceId = &v
+	return s
+}
+
+// SetComplianceResourceType sets the ComplianceResourceType field's value.
+func (s *Evaluation) SetComplianceResourceType(v string) *Evaluation {
+	s.ComplianceResourceType = &v
+	return s
+}
+
+// SetComplianceType sets the ComplianceType field's value.
+func (s *Evaluation) SetComplianceType(v string) *Evaluation {
+	s.ComplianceType = &v
+	return s
+}
+
+// SetOrderingTimestamp sets the OrderingTimestamp field's value.
+func (s *Evaluation) SetOrderingTimestamp(v time.Time) *Evaluation {
+	s.OrderingTimestamp = &v
+	return s
+}
+
 // The details of an AWS Config evaluation. Provides the AWS resource that was
 // evaluated, the compliance of the resource, related timestamps, and supplementary
 // information.
@@ -3568,6 +4288,42 @@ func (s EvaluationResult) GoString() string {
 	return s.String()
 }
 
+// SetAnnotation sets the Annotation field's value.
+func (s *EvaluationResult) SetAnnotation(v string) *EvaluationResult {
+	s.Annotation = &v
+	return s
+}
+
+// SetComplianceType sets the ComplianceType field's value.
+func (s *EvaluationResult) SetComplianceType(v string) *EvaluationResult {
+	s.ComplianceType = &v
+	return s
+}
+
+// SetConfigRuleInvokedTime sets the ConfigRuleInvokedTime field's value.
+func (s *EvaluationResult) SetConfigRuleInvokedTime(v time.Time) *EvaluationResult {
+	s.ConfigRuleInvokedTime = &v
+	return s
+}
+
+// SetEvaluationResultIdentifier sets the EvaluationResultIdentifier field's value.
+func (s *EvaluationResult) SetEvaluationResultIdentifier(v *EvaluationResultIdentifier) *EvaluationResult {
+	s.EvaluationResultIdentifier = v
+	return s
+}
+
+// SetResultRecordedTime sets the ResultRecordedTime field's value.
+func (s *EvaluationResult) SetResultRecordedTime(v time.Time) *EvaluationResult {
+	s.ResultRecordedTime = &v
+	return s
+}
+
+// SetResultToken sets the ResultToken field's value.
+func (s *EvaluationResult) SetResultToken(v string) *EvaluationResult {
+	s.ResultToken = &v
+	return s
+}
+
 // Uniquely identifies an evaluation result.
 type EvaluationResultIdentifier struct {
 	_ struct{} `type:"structure"`
@@ -3593,6 +4349,18 @@ func (s EvaluationResultIdentifier) GoString() string {
 	return s.String()
 }
 
+// SetEvaluationResultQualifier sets the EvaluationResultQualifier field's value.
+func (s *EvaluationResultIdentifier) SetEvaluationResultQualifier(v *EvaluationResultQualifier) *EvaluationResultIdentifier {
+	s.EvaluationResultQualifier = v
+	return s
+}
+
+// SetOrderingTimestamp sets the OrderingTimestamp field's value.
+func (s *EvaluationResultIdentifier) SetOrderingTimestamp(v time.Time) *EvaluationResultIdentifier {
+	s.OrderingTimestamp = &v
+	return s
+}
+
 // Identifies an AWS Config rule that evaluated an AWS resource, and provides
 // the type and ID of the resource that the rule evaluated.
 type EvaluationResultQualifier struct {
@@ -3616,6 +4384,24 @@ func (s EvaluationResultQualifier) String() string {
 // GoString returns the string representation
 func (s EvaluationResultQualifier) GoString() string {
 	return s.String()
+}
+
+// SetConfigRuleName sets the ConfigRuleName field's value.
+func (s *EvaluationResultQualifier) SetConfigRuleName(v string) *EvaluationResultQualifier {
+	s.ConfigRuleName = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *EvaluationResultQualifier) SetResourceId(v string) *EvaluationResultQualifier {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *EvaluationResultQualifier) SetResourceType(v string) *EvaluationResultQualifier {
+	s.ResourceType = &v
+	return s
 }
 
 type GetComplianceDetailsByConfigRuleInput struct {
@@ -3667,6 +4453,30 @@ func (s *GetComplianceDetailsByConfigRuleInput) Validate() error {
 	return nil
 }
 
+// SetComplianceTypes sets the ComplianceTypes field's value.
+func (s *GetComplianceDetailsByConfigRuleInput) SetComplianceTypes(v []*string) *GetComplianceDetailsByConfigRuleInput {
+	s.ComplianceTypes = v
+	return s
+}
+
+// SetConfigRuleName sets the ConfigRuleName field's value.
+func (s *GetComplianceDetailsByConfigRuleInput) SetConfigRuleName(v string) *GetComplianceDetailsByConfigRuleInput {
+	s.ConfigRuleName = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *GetComplianceDetailsByConfigRuleInput) SetLimit(v int64) *GetComplianceDetailsByConfigRuleInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetComplianceDetailsByConfigRuleInput) SetNextToken(v string) *GetComplianceDetailsByConfigRuleInput {
+	s.NextToken = &v
+	return s
+}
+
 type GetComplianceDetailsByConfigRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3687,6 +4497,18 @@ func (s GetComplianceDetailsByConfigRuleOutput) String() string {
 // GoString returns the string representation
 func (s GetComplianceDetailsByConfigRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvaluationResults sets the EvaluationResults field's value.
+func (s *GetComplianceDetailsByConfigRuleOutput) SetEvaluationResults(v []*EvaluationResult) *GetComplianceDetailsByConfigRuleOutput {
+	s.EvaluationResults = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetComplianceDetailsByConfigRuleOutput) SetNextToken(v string) *GetComplianceDetailsByConfigRuleOutput {
+	s.NextToken = &v
+	return s
 }
 
 type GetComplianceDetailsByResourceInput struct {
@@ -3744,6 +4566,30 @@ func (s *GetComplianceDetailsByResourceInput) Validate() error {
 	return nil
 }
 
+// SetComplianceTypes sets the ComplianceTypes field's value.
+func (s *GetComplianceDetailsByResourceInput) SetComplianceTypes(v []*string) *GetComplianceDetailsByResourceInput {
+	s.ComplianceTypes = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetComplianceDetailsByResourceInput) SetNextToken(v string) *GetComplianceDetailsByResourceInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *GetComplianceDetailsByResourceInput) SetResourceId(v string) *GetComplianceDetailsByResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *GetComplianceDetailsByResourceInput) SetResourceType(v string) *GetComplianceDetailsByResourceInput {
+	s.ResourceType = &v
+	return s
+}
+
 type GetComplianceDetailsByResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3763,6 +4609,18 @@ func (s GetComplianceDetailsByResourceOutput) String() string {
 // GoString returns the string representation
 func (s GetComplianceDetailsByResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvaluationResults sets the EvaluationResults field's value.
+func (s *GetComplianceDetailsByResourceOutput) SetEvaluationResults(v []*EvaluationResult) *GetComplianceDetailsByResourceOutput {
+	s.EvaluationResults = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetComplianceDetailsByResourceOutput) SetNextToken(v string) *GetComplianceDetailsByResourceOutput {
+	s.NextToken = &v
+	return s
 }
 
 type GetComplianceSummaryByConfigRuleInput struct {
@@ -3797,6 +4655,12 @@ func (s GetComplianceSummaryByConfigRuleOutput) GoString() string {
 	return s.String()
 }
 
+// SetComplianceSummary sets the ComplianceSummary field's value.
+func (s *GetComplianceSummaryByConfigRuleOutput) SetComplianceSummary(v *ComplianceSummary) *GetComplianceSummaryByConfigRuleOutput {
+	s.ComplianceSummary = v
+	return s
+}
+
 type GetComplianceSummaryByResourceTypeInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3819,6 +4683,12 @@ func (s GetComplianceSummaryByResourceTypeInput) GoString() string {
 	return s.String()
 }
 
+// SetResourceTypes sets the ResourceTypes field's value.
+func (s *GetComplianceSummaryByResourceTypeInput) SetResourceTypes(v []*string) *GetComplianceSummaryByResourceTypeInput {
+	s.ResourceTypes = v
+	return s
+}
+
 type GetComplianceSummaryByResourceTypeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3836,6 +4706,12 @@ func (s GetComplianceSummaryByResourceTypeOutput) String() string {
 // GoString returns the string representation
 func (s GetComplianceSummaryByResourceTypeOutput) GoString() string {
 	return s.String()
+}
+
+// SetComplianceSummariesByResourceType sets the ComplianceSummariesByResourceType field's value.
+func (s *GetComplianceSummaryByResourceTypeOutput) SetComplianceSummariesByResourceType(v []*ComplianceSummaryByResourceType) *GetComplianceSummaryByResourceTypeOutput {
+	s.ComplianceSummariesByResourceType = v
+	return s
 }
 
 // The input for the GetResourceConfigHistory action.
@@ -3901,6 +4777,48 @@ func (s *GetResourceConfigHistoryInput) Validate() error {
 	return nil
 }
 
+// SetChronologicalOrder sets the ChronologicalOrder field's value.
+func (s *GetResourceConfigHistoryInput) SetChronologicalOrder(v string) *GetResourceConfigHistoryInput {
+	s.ChronologicalOrder = &v
+	return s
+}
+
+// SetEarlierTime sets the EarlierTime field's value.
+func (s *GetResourceConfigHistoryInput) SetEarlierTime(v time.Time) *GetResourceConfigHistoryInput {
+	s.EarlierTime = &v
+	return s
+}
+
+// SetLaterTime sets the LaterTime field's value.
+func (s *GetResourceConfigHistoryInput) SetLaterTime(v time.Time) *GetResourceConfigHistoryInput {
+	s.LaterTime = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *GetResourceConfigHistoryInput) SetLimit(v int64) *GetResourceConfigHistoryInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetResourceConfigHistoryInput) SetNextToken(v string) *GetResourceConfigHistoryInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *GetResourceConfigHistoryInput) SetResourceId(v string) *GetResourceConfigHistoryInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *GetResourceConfigHistoryInput) SetResourceType(v string) *GetResourceConfigHistoryInput {
+	s.ResourceType = &v
+	return s
+}
+
 // The output for the GetResourceConfigHistory action.
 type GetResourceConfigHistoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -3921,6 +4839,18 @@ func (s GetResourceConfigHistoryOutput) String() string {
 // GoString returns the string representation
 func (s GetResourceConfigHistoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigurationItems sets the ConfigurationItems field's value.
+func (s *GetResourceConfigHistoryOutput) SetConfigurationItems(v []*ConfigurationItem) *GetResourceConfigHistoryOutput {
+	s.ConfigurationItems = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetResourceConfigHistoryOutput) SetNextToken(v string) *GetResourceConfigHistoryOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListDiscoveredResourcesInput struct {
@@ -3978,6 +4908,42 @@ func (s *ListDiscoveredResourcesInput) Validate() error {
 	return nil
 }
 
+// SetIncludeDeletedResources sets the IncludeDeletedResources field's value.
+func (s *ListDiscoveredResourcesInput) SetIncludeDeletedResources(v bool) *ListDiscoveredResourcesInput {
+	s.IncludeDeletedResources = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListDiscoveredResourcesInput) SetLimit(v int64) *ListDiscoveredResourcesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDiscoveredResourcesInput) SetNextToken(v string) *ListDiscoveredResourcesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceIds sets the ResourceIds field's value.
+func (s *ListDiscoveredResourcesInput) SetResourceIds(v []*string) *ListDiscoveredResourcesInput {
+	s.ResourceIds = v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *ListDiscoveredResourcesInput) SetResourceName(v string) *ListDiscoveredResourcesInput {
+	s.ResourceName = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ListDiscoveredResourcesInput) SetResourceType(v string) *ListDiscoveredResourcesInput {
+	s.ResourceType = &v
+	return s
+}
+
 type ListDiscoveredResourcesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3998,6 +4964,18 @@ func (s ListDiscoveredResourcesOutput) String() string {
 // GoString returns the string representation
 func (s ListDiscoveredResourcesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDiscoveredResourcesOutput) SetNextToken(v string) *ListDiscoveredResourcesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceIdentifiers sets the ResourceIdentifiers field's value.
+func (s *ListDiscoveredResourcesOutput) SetResourceIdentifiers(v []*ResourceIdentifier) *ListDiscoveredResourcesOutput {
+	s.ResourceIdentifiers = v
+	return s
 }
 
 type PutConfigRuleInput struct {
@@ -4048,6 +5026,12 @@ func (s *PutConfigRuleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConfigRule sets the ConfigRule field's value.
+func (s *PutConfigRuleInput) SetConfigRule(v *ConfigRule) *PutConfigRuleInput {
+	s.ConfigRule = v
+	return s
 }
 
 type PutConfigRuleOutput struct {
@@ -4103,6 +5087,12 @@ func (s *PutConfigurationRecorderInput) Validate() error {
 	return nil
 }
 
+// SetConfigurationRecorder sets the ConfigurationRecorder field's value.
+func (s *PutConfigurationRecorderInput) SetConfigurationRecorder(v *ConfigurationRecorder) *PutConfigurationRecorderInput {
+	s.ConfigurationRecorder = v
+	return s
+}
+
 type PutConfigurationRecorderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4154,6 +5144,12 @@ func (s *PutDeliveryChannelInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDeliveryChannel sets the DeliveryChannel field's value.
+func (s *PutDeliveryChannelInput) SetDeliveryChannel(v *DeliveryChannel) *PutDeliveryChannelInput {
+	s.DeliveryChannel = v
+	return s
 }
 
 type PutDeliveryChannelOutput struct {
@@ -4218,6 +5214,18 @@ func (s *PutEvaluationsInput) Validate() error {
 	return nil
 }
 
+// SetEvaluations sets the Evaluations field's value.
+func (s *PutEvaluationsInput) SetEvaluations(v []*Evaluation) *PutEvaluationsInput {
+	s.Evaluations = v
+	return s
+}
+
+// SetResultToken sets the ResultToken field's value.
+func (s *PutEvaluationsInput) SetResultToken(v string) *PutEvaluationsInput {
+	s.ResultToken = &v
+	return s
+}
+
 type PutEvaluationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4233,6 +5241,12 @@ func (s PutEvaluationsOutput) String() string {
 // GoString returns the string representation
 func (s PutEvaluationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedEvaluations sets the FailedEvaluations field's value.
+func (s *PutEvaluationsOutput) SetFailedEvaluations(v []*Evaluation) *PutEvaluationsOutput {
+	s.FailedEvaluations = v
+	return s
 }
 
 // Specifies the types of AWS resource for which AWS Config records configuration
@@ -4318,6 +5332,24 @@ func (s RecordingGroup) GoString() string {
 	return s.String()
 }
 
+// SetAllSupported sets the AllSupported field's value.
+func (s *RecordingGroup) SetAllSupported(v bool) *RecordingGroup {
+	s.AllSupported = &v
+	return s
+}
+
+// SetIncludeGlobalResourceTypes sets the IncludeGlobalResourceTypes field's value.
+func (s *RecordingGroup) SetIncludeGlobalResourceTypes(v bool) *RecordingGroup {
+	s.IncludeGlobalResourceTypes = &v
+	return s
+}
+
+// SetResourceTypes sets the ResourceTypes field's value.
+func (s *RecordingGroup) SetResourceTypes(v []*string) *RecordingGroup {
+	s.ResourceTypes = v
+	return s
+}
+
 // The relationship of the related resource to the main resource.
 type Relationship struct {
 	_ struct{} `type:"structure"`
@@ -4343,6 +5375,30 @@ func (s Relationship) String() string {
 // GoString returns the string representation
 func (s Relationship) GoString() string {
 	return s.String()
+}
+
+// SetRelationshipName sets the RelationshipName field's value.
+func (s *Relationship) SetRelationshipName(v string) *Relationship {
+	s.RelationshipName = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *Relationship) SetResourceId(v string) *Relationship {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *Relationship) SetResourceName(v string) *Relationship {
+	s.ResourceName = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *Relationship) SetResourceType(v string) *Relationship {
+	s.ResourceType = &v
+	return s
 }
 
 // The details that identify a resource that is discovered by AWS Config, including
@@ -4371,6 +5427,30 @@ func (s ResourceIdentifier) String() string {
 // GoString returns the string representation
 func (s ResourceIdentifier) GoString() string {
 	return s.String()
+}
+
+// SetResourceDeletionTime sets the ResourceDeletionTime field's value.
+func (s *ResourceIdentifier) SetResourceDeletionTime(v time.Time) *ResourceIdentifier {
+	s.ResourceDeletionTime = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ResourceIdentifier) SetResourceId(v string) *ResourceIdentifier {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *ResourceIdentifier) SetResourceName(v string) *ResourceIdentifier {
+	s.ResourceName = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ResourceIdentifier) SetResourceType(v string) *ResourceIdentifier {
+	s.ResourceType = &v
+	return s
 }
 
 // Defines which resources trigger an evaluation for an AWS Config rule. The
@@ -4431,6 +5511,30 @@ func (s *Scope) Validate() error {
 	return nil
 }
 
+// SetComplianceResourceId sets the ComplianceResourceId field's value.
+func (s *Scope) SetComplianceResourceId(v string) *Scope {
+	s.ComplianceResourceId = &v
+	return s
+}
+
+// SetComplianceResourceTypes sets the ComplianceResourceTypes field's value.
+func (s *Scope) SetComplianceResourceTypes(v []*string) *Scope {
+	s.ComplianceResourceTypes = v
+	return s
+}
+
+// SetTagKey sets the TagKey field's value.
+func (s *Scope) SetTagKey(v string) *Scope {
+	s.TagKey = &v
+	return s
+}
+
+// SetTagValue sets the TagValue field's value.
+func (s *Scope) SetTagValue(v string) *Scope {
+	s.TagValue = &v
+	return s
+}
+
 // Provides the AWS Config rule owner (AWS or customer), the rule identifier,
 // and the events that trigger the evaluation of your AWS resources.
 type Source struct {
@@ -4475,6 +5579,24 @@ func (s *Source) Validate() error {
 	return nil
 }
 
+// SetOwner sets the Owner field's value.
+func (s *Source) SetOwner(v string) *Source {
+	s.Owner = &v
+	return s
+}
+
+// SetSourceDetails sets the SourceDetails field's value.
+func (s *Source) SetSourceDetails(v []*SourceDetail) *Source {
+	s.SourceDetails = v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *Source) SetSourceIdentifier(v string) *Source {
+	s.SourceIdentifier = &v
+	return s
+}
+
 // Provides the source and the message types that trigger AWS Config to evaluate
 // your AWS resources against a rule. It also provides the frequency with which
 // you want AWS Config to run evaluations for the rule if the trigger type is
@@ -4516,6 +5638,24 @@ func (s SourceDetail) GoString() string {
 	return s.String()
 }
 
+// SetEventSource sets the EventSource field's value.
+func (s *SourceDetail) SetEventSource(v string) *SourceDetail {
+	s.EventSource = &v
+	return s
+}
+
+// SetMaximumExecutionFrequency sets the MaximumExecutionFrequency field's value.
+func (s *SourceDetail) SetMaximumExecutionFrequency(v string) *SourceDetail {
+	s.MaximumExecutionFrequency = &v
+	return s
+}
+
+// SetMessageType sets the MessageType field's value.
+func (s *SourceDetail) SetMessageType(v string) *SourceDetail {
+	s.MessageType = &v
+	return s
+}
+
 type StartConfigRulesEvaluationInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4544,6 +5684,12 @@ func (s *StartConfigRulesEvaluationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConfigRuleNames sets the ConfigRuleNames field's value.
+func (s *StartConfigRulesEvaluationInput) SetConfigRuleNames(v []*string) *StartConfigRulesEvaluationInput {
+	s.ConfigRuleNames = v
+	return s
 }
 
 // The output when you start the evaluation for the specified Config rule.
@@ -4598,6 +5744,12 @@ func (s *StartConfigurationRecorderInput) Validate() error {
 	return nil
 }
 
+// SetConfigurationRecorderName sets the ConfigurationRecorderName field's value.
+func (s *StartConfigurationRecorderInput) SetConfigurationRecorderName(v string) *StartConfigurationRecorderInput {
+	s.ConfigurationRecorderName = &v
+	return s
+}
+
 type StartConfigurationRecorderOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4647,6 +5799,12 @@ func (s *StopConfigurationRecorderInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConfigurationRecorderName sets the ConfigurationRecorderName field's value.
+func (s *StopConfigurationRecorderInput) SetConfigurationRecorderName(v string) *StopConfigurationRecorderInput {
+	s.ConfigurationRecorderName = &v
+	return s
 }
 
 type StopConfigurationRecorderOutput struct {

--- a/service/databasemigrationservice/api.go
+++ b/service/databasemigrationservice/api.go
@@ -2270,6 +2270,24 @@ func (s AccountQuota) GoString() string {
 	return s.String()
 }
 
+// SetAccountQuotaName sets the AccountQuotaName field's value.
+func (s *AccountQuota) SetAccountQuotaName(v string) *AccountQuota {
+	s.AccountQuotaName = &v
+	return s
+}
+
+// SetMax sets the Max field's value.
+func (s *AccountQuota) SetMax(v int64) *AccountQuota {
+	s.Max = &v
+	return s
+}
+
+// SetUsed sets the Used field's value.
+func (s *AccountQuota) SetUsed(v int64) *AccountQuota {
+	s.Used = &v
+	return s
+}
+
 type AddTagsToResourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2312,6 +2330,18 @@ func (s *AddTagsToResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceArn sets the ResourceArn field's value.
+func (s *AddTagsToResourceInput) SetResourceArn(v string) *AddTagsToResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToResourceInput) SetTags(v []*Tag) *AddTagsToResourceInput {
+	s.Tags = v
+	return s
+}
+
 type AddTagsToResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2341,6 +2371,12 @@ func (s AvailabilityZone) String() string {
 // GoString returns the string representation
 func (s AvailabilityZone) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *AvailabilityZone) SetName(v string) *AvailabilityZone {
+	s.Name = &v
+	return s
 }
 
 // The SSL certificate that can be used to encrypt connections between the endpoints
@@ -2386,6 +2422,60 @@ func (s Certificate) GoString() string {
 	return s.String()
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *Certificate) SetCertificateArn(v string) *Certificate {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateCreationDate sets the CertificateCreationDate field's value.
+func (s *Certificate) SetCertificateCreationDate(v time.Time) *Certificate {
+	s.CertificateCreationDate = &v
+	return s
+}
+
+// SetCertificateIdentifier sets the CertificateIdentifier field's value.
+func (s *Certificate) SetCertificateIdentifier(v string) *Certificate {
+	s.CertificateIdentifier = &v
+	return s
+}
+
+// SetCertificateOwner sets the CertificateOwner field's value.
+func (s *Certificate) SetCertificateOwner(v string) *Certificate {
+	s.CertificateOwner = &v
+	return s
+}
+
+// SetCertificatePem sets the CertificatePem field's value.
+func (s *Certificate) SetCertificatePem(v string) *Certificate {
+	s.CertificatePem = &v
+	return s
+}
+
+// SetKeyLength sets the KeyLength field's value.
+func (s *Certificate) SetKeyLength(v int64) *Certificate {
+	s.KeyLength = &v
+	return s
+}
+
+// SetSigningAlgorithm sets the SigningAlgorithm field's value.
+func (s *Certificate) SetSigningAlgorithm(v string) *Certificate {
+	s.SigningAlgorithm = &v
+	return s
+}
+
+// SetValidFromDate sets the ValidFromDate field's value.
+func (s *Certificate) SetValidFromDate(v time.Time) *Certificate {
+	s.ValidFromDate = &v
+	return s
+}
+
+// SetValidToDate sets the ValidToDate field's value.
+func (s *Certificate) SetValidToDate(v time.Time) *Certificate {
+	s.ValidToDate = &v
+	return s
+}
+
 type Connection struct {
 	_ struct{} `type:"structure"`
 
@@ -2419,6 +2509,42 @@ func (s Connection) String() string {
 // GoString returns the string representation
 func (s Connection) GoString() string {
 	return s.String()
+}
+
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *Connection) SetEndpointArn(v string) *Connection {
+	s.EndpointArn = &v
+	return s
+}
+
+// SetEndpointIdentifier sets the EndpointIdentifier field's value.
+func (s *Connection) SetEndpointIdentifier(v string) *Connection {
+	s.EndpointIdentifier = &v
+	return s
+}
+
+// SetLastFailureMessage sets the LastFailureMessage field's value.
+func (s *Connection) SetLastFailureMessage(v string) *Connection {
+	s.LastFailureMessage = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *Connection) SetReplicationInstanceArn(v string) *Connection {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+// SetReplicationInstanceIdentifier sets the ReplicationInstanceIdentifier field's value.
+func (s *Connection) SetReplicationInstanceIdentifier(v string) *Connection {
+	s.ReplicationInstanceIdentifier = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Connection) SetStatus(v string) *Connection {
+	s.Status = &v
+	return s
 }
 
 type CreateEndpointInput struct {
@@ -2530,6 +2656,84 @@ func (s *CreateEndpointInput) Validate() error {
 	return nil
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *CreateEndpointInput) SetCertificateArn(v string) *CreateEndpointInput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *CreateEndpointInput) SetDatabaseName(v string) *CreateEndpointInput {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetEndpointIdentifier sets the EndpointIdentifier field's value.
+func (s *CreateEndpointInput) SetEndpointIdentifier(v string) *CreateEndpointInput {
+	s.EndpointIdentifier = &v
+	return s
+}
+
+// SetEndpointType sets the EndpointType field's value.
+func (s *CreateEndpointInput) SetEndpointType(v string) *CreateEndpointInput {
+	s.EndpointType = &v
+	return s
+}
+
+// SetEngineName sets the EngineName field's value.
+func (s *CreateEndpointInput) SetEngineName(v string) *CreateEndpointInput {
+	s.EngineName = &v
+	return s
+}
+
+// SetExtraConnectionAttributes sets the ExtraConnectionAttributes field's value.
+func (s *CreateEndpointInput) SetExtraConnectionAttributes(v string) *CreateEndpointInput {
+	s.ExtraConnectionAttributes = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateEndpointInput) SetKmsKeyId(v string) *CreateEndpointInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *CreateEndpointInput) SetPassword(v string) *CreateEndpointInput {
+	s.Password = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateEndpointInput) SetPort(v int64) *CreateEndpointInput {
+	s.Port = &v
+	return s
+}
+
+// SetServerName sets the ServerName field's value.
+func (s *CreateEndpointInput) SetServerName(v string) *CreateEndpointInput {
+	s.ServerName = &v
+	return s
+}
+
+// SetSslMode sets the SslMode field's value.
+func (s *CreateEndpointInput) SetSslMode(v string) *CreateEndpointInput {
+	s.SslMode = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateEndpointInput) SetTags(v []*Tag) *CreateEndpointInput {
+	s.Tags = v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *CreateEndpointInput) SetUsername(v string) *CreateEndpointInput {
+	s.Username = &v
+	return s
+}
+
 type CreateEndpointOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2545,6 +2749,12 @@ func (s CreateEndpointOutput) String() string {
 // GoString returns the string representation
 func (s CreateEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *CreateEndpointOutput) SetEndpoint(v *Endpoint) *CreateEndpointOutput {
+	s.Endpoint = v
+	return s
 }
 
 type CreateReplicationInstanceInput struct {
@@ -2662,6 +2872,84 @@ func (s *CreateReplicationInstanceInput) Validate() error {
 	return nil
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *CreateReplicationInstanceInput) SetAllocatedStorage(v int64) *CreateReplicationInstanceInput {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *CreateReplicationInstanceInput) SetAutoMinorVersionUpgrade(v bool) *CreateReplicationInstanceInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *CreateReplicationInstanceInput) SetAvailabilityZone(v string) *CreateReplicationInstanceInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *CreateReplicationInstanceInput) SetEngineVersion(v string) *CreateReplicationInstanceInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateReplicationInstanceInput) SetKmsKeyId(v string) *CreateReplicationInstanceInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *CreateReplicationInstanceInput) SetMultiAZ(v bool) *CreateReplicationInstanceInput {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *CreateReplicationInstanceInput) SetPreferredMaintenanceWindow(v string) *CreateReplicationInstanceInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *CreateReplicationInstanceInput) SetPubliclyAccessible(v bool) *CreateReplicationInstanceInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetReplicationInstanceClass sets the ReplicationInstanceClass field's value.
+func (s *CreateReplicationInstanceInput) SetReplicationInstanceClass(v string) *CreateReplicationInstanceInput {
+	s.ReplicationInstanceClass = &v
+	return s
+}
+
+// SetReplicationInstanceIdentifier sets the ReplicationInstanceIdentifier field's value.
+func (s *CreateReplicationInstanceInput) SetReplicationInstanceIdentifier(v string) *CreateReplicationInstanceInput {
+	s.ReplicationInstanceIdentifier = &v
+	return s
+}
+
+// SetReplicationSubnetGroupIdentifier sets the ReplicationSubnetGroupIdentifier field's value.
+func (s *CreateReplicationInstanceInput) SetReplicationSubnetGroupIdentifier(v string) *CreateReplicationInstanceInput {
+	s.ReplicationSubnetGroupIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateReplicationInstanceInput) SetTags(v []*Tag) *CreateReplicationInstanceInput {
+	s.Tags = v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *CreateReplicationInstanceInput) SetVpcSecurityGroupIds(v []*string) *CreateReplicationInstanceInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type CreateReplicationInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2677,6 +2965,12 @@ func (s CreateReplicationInstanceOutput) String() string {
 // GoString returns the string representation
 func (s CreateReplicationInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationInstance sets the ReplicationInstance field's value.
+func (s *CreateReplicationInstanceOutput) SetReplicationInstance(v *ReplicationInstance) *CreateReplicationInstanceOutput {
+	s.ReplicationInstance = v
+	return s
 }
 
 type CreateReplicationSubnetGroupInput struct {
@@ -2736,6 +3030,30 @@ func (s *CreateReplicationSubnetGroupInput) Validate() error {
 	return nil
 }
 
+// SetReplicationSubnetGroupDescription sets the ReplicationSubnetGroupDescription field's value.
+func (s *CreateReplicationSubnetGroupInput) SetReplicationSubnetGroupDescription(v string) *CreateReplicationSubnetGroupInput {
+	s.ReplicationSubnetGroupDescription = &v
+	return s
+}
+
+// SetReplicationSubnetGroupIdentifier sets the ReplicationSubnetGroupIdentifier field's value.
+func (s *CreateReplicationSubnetGroupInput) SetReplicationSubnetGroupIdentifier(v string) *CreateReplicationSubnetGroupInput {
+	s.ReplicationSubnetGroupIdentifier = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *CreateReplicationSubnetGroupInput) SetSubnetIds(v []*string) *CreateReplicationSubnetGroupInput {
+	s.SubnetIds = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateReplicationSubnetGroupInput) SetTags(v []*Tag) *CreateReplicationSubnetGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateReplicationSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2751,6 +3069,12 @@ func (s CreateReplicationSubnetGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateReplicationSubnetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationSubnetGroup sets the ReplicationSubnetGroup field's value.
+func (s *CreateReplicationSubnetGroupOutput) SetReplicationSubnetGroup(v *ReplicationSubnetGroup) *CreateReplicationSubnetGroupOutput {
+	s.ReplicationSubnetGroup = v
+	return s
 }
 
 type CreateReplicationTaskInput struct {
@@ -2845,6 +3169,60 @@ func (s *CreateReplicationTaskInput) Validate() error {
 	return nil
 }
 
+// SetCdcStartTime sets the CdcStartTime field's value.
+func (s *CreateReplicationTaskInput) SetCdcStartTime(v time.Time) *CreateReplicationTaskInput {
+	s.CdcStartTime = &v
+	return s
+}
+
+// SetMigrationType sets the MigrationType field's value.
+func (s *CreateReplicationTaskInput) SetMigrationType(v string) *CreateReplicationTaskInput {
+	s.MigrationType = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *CreateReplicationTaskInput) SetReplicationInstanceArn(v string) *CreateReplicationTaskInput {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+// SetReplicationTaskIdentifier sets the ReplicationTaskIdentifier field's value.
+func (s *CreateReplicationTaskInput) SetReplicationTaskIdentifier(v string) *CreateReplicationTaskInput {
+	s.ReplicationTaskIdentifier = &v
+	return s
+}
+
+// SetReplicationTaskSettings sets the ReplicationTaskSettings field's value.
+func (s *CreateReplicationTaskInput) SetReplicationTaskSettings(v string) *CreateReplicationTaskInput {
+	s.ReplicationTaskSettings = &v
+	return s
+}
+
+// SetSourceEndpointArn sets the SourceEndpointArn field's value.
+func (s *CreateReplicationTaskInput) SetSourceEndpointArn(v string) *CreateReplicationTaskInput {
+	s.SourceEndpointArn = &v
+	return s
+}
+
+// SetTableMappings sets the TableMappings field's value.
+func (s *CreateReplicationTaskInput) SetTableMappings(v string) *CreateReplicationTaskInput {
+	s.TableMappings = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateReplicationTaskInput) SetTags(v []*Tag) *CreateReplicationTaskInput {
+	s.Tags = v
+	return s
+}
+
+// SetTargetEndpointArn sets the TargetEndpointArn field's value.
+func (s *CreateReplicationTaskInput) SetTargetEndpointArn(v string) *CreateReplicationTaskInput {
+	s.TargetEndpointArn = &v
+	return s
+}
+
 type CreateReplicationTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2860,6 +3238,12 @@ func (s CreateReplicationTaskOutput) String() string {
 // GoString returns the string representation
 func (s CreateReplicationTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationTask sets the ReplicationTask field's value.
+func (s *CreateReplicationTaskOutput) SetReplicationTask(v *ReplicationTask) *CreateReplicationTaskOutput {
+	s.ReplicationTask = v
+	return s
 }
 
 type DeleteCertificateInput struct {
@@ -2894,6 +3278,12 @@ func (s *DeleteCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *DeleteCertificateInput) SetCertificateArn(v string) *DeleteCertificateInput {
+	s.CertificateArn = &v
+	return s
+}
+
 type DeleteCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2909,6 +3299,12 @@ func (s DeleteCertificateOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificate sets the Certificate field's value.
+func (s *DeleteCertificateOutput) SetCertificate(v *Certificate) *DeleteCertificateOutput {
+	s.Certificate = v
+	return s
 }
 
 type DeleteEndpointInput struct {
@@ -2943,6 +3339,12 @@ func (s *DeleteEndpointInput) Validate() error {
 	return nil
 }
 
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *DeleteEndpointInput) SetEndpointArn(v string) *DeleteEndpointInput {
+	s.EndpointArn = &v
+	return s
+}
+
 type DeleteEndpointOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2958,6 +3360,12 @@ func (s DeleteEndpointOutput) String() string {
 // GoString returns the string representation
 func (s DeleteEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *DeleteEndpointOutput) SetEndpoint(v *Endpoint) *DeleteEndpointOutput {
+	s.Endpoint = v
+	return s
 }
 
 type DeleteReplicationInstanceInput struct {
@@ -2992,6 +3400,12 @@ func (s *DeleteReplicationInstanceInput) Validate() error {
 	return nil
 }
 
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *DeleteReplicationInstanceInput) SetReplicationInstanceArn(v string) *DeleteReplicationInstanceInput {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
 type DeleteReplicationInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3007,6 +3421,12 @@ func (s DeleteReplicationInstanceOutput) String() string {
 // GoString returns the string representation
 func (s DeleteReplicationInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationInstance sets the ReplicationInstance field's value.
+func (s *DeleteReplicationInstanceOutput) SetReplicationInstance(v *ReplicationInstance) *DeleteReplicationInstanceOutput {
+	s.ReplicationInstance = v
+	return s
 }
 
 type DeleteReplicationSubnetGroupInput struct {
@@ -3039,6 +3459,12 @@ func (s *DeleteReplicationSubnetGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetReplicationSubnetGroupIdentifier sets the ReplicationSubnetGroupIdentifier field's value.
+func (s *DeleteReplicationSubnetGroupInput) SetReplicationSubnetGroupIdentifier(v string) *DeleteReplicationSubnetGroupInput {
+	s.ReplicationSubnetGroupIdentifier = &v
+	return s
 }
 
 type DeleteReplicationSubnetGroupOutput struct {
@@ -3087,6 +3513,12 @@ func (s *DeleteReplicationTaskInput) Validate() error {
 	return nil
 }
 
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *DeleteReplicationTaskInput) SetReplicationTaskArn(v string) *DeleteReplicationTaskInput {
+	s.ReplicationTaskArn = &v
+	return s
+}
+
 type DeleteReplicationTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3102,6 +3534,12 @@ func (s DeleteReplicationTaskOutput) String() string {
 // GoString returns the string representation
 func (s DeleteReplicationTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationTask sets the ReplicationTask field's value.
+func (s *DeleteReplicationTaskOutput) SetReplicationTask(v *ReplicationTask) *DeleteReplicationTaskOutput {
+	s.ReplicationTask = v
+	return s
 }
 
 type DescribeAccountAttributesInput struct {
@@ -3133,6 +3571,12 @@ func (s DescribeAccountAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAccountAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccountQuotas sets the AccountQuotas field's value.
+func (s *DescribeAccountAttributesOutput) SetAccountQuotas(v []*AccountQuota) *DescribeAccountAttributesOutput {
+	s.AccountQuotas = v
+	return s
 }
 
 type DescribeCertificatesInput struct {
@@ -3184,6 +3628,24 @@ func (s *DescribeCertificatesInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeCertificatesInput) SetFilters(v []*Filter) *DescribeCertificatesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCertificatesInput) SetMarker(v string) *DescribeCertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeCertificatesInput) SetMaxRecords(v int64) *DescribeCertificatesInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeCertificatesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3202,6 +3664,18 @@ func (s DescribeCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *DescribeCertificatesOutput) SetCertificates(v []*Certificate) *DescribeCertificatesOutput {
+	s.Certificates = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCertificatesOutput) SetMarker(v string) *DescribeCertificatesOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeConnectionsInput struct {
@@ -3257,6 +3731,24 @@ func (s *DescribeConnectionsInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeConnectionsInput) SetFilters(v []*Filter) *DescribeConnectionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeConnectionsInput) SetMarker(v string) *DescribeConnectionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeConnectionsInput) SetMaxRecords(v int64) *DescribeConnectionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeConnectionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3277,6 +3769,18 @@ func (s DescribeConnectionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConnectionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetConnections sets the Connections field's value.
+func (s *DescribeConnectionsOutput) SetConnections(v []*Connection) *DescribeConnectionsOutput {
+	s.Connections = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeConnectionsOutput) SetMarker(v string) *DescribeConnectionsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeEndpointTypesInput struct {
@@ -3332,6 +3836,24 @@ func (s *DescribeEndpointTypesInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeEndpointTypesInput) SetFilters(v []*Filter) *DescribeEndpointTypesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEndpointTypesInput) SetMarker(v string) *DescribeEndpointTypesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEndpointTypesInput) SetMaxRecords(v int64) *DescribeEndpointTypesInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeEndpointTypesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3352,6 +3874,18 @@ func (s DescribeEndpointTypesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEndpointTypesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEndpointTypesOutput) SetMarker(v string) *DescribeEndpointTypesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSupportedEndpointTypes sets the SupportedEndpointTypes field's value.
+func (s *DescribeEndpointTypesOutput) SetSupportedEndpointTypes(v []*SupportedEndpointType) *DescribeEndpointTypesOutput {
+	s.SupportedEndpointTypes = v
+	return s
 }
 
 type DescribeEndpointsInput struct {
@@ -3407,6 +3941,24 @@ func (s *DescribeEndpointsInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeEndpointsInput) SetFilters(v []*Filter) *DescribeEndpointsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEndpointsInput) SetMarker(v string) *DescribeEndpointsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEndpointsInput) SetMaxRecords(v int64) *DescribeEndpointsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeEndpointsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3427,6 +3979,18 @@ func (s DescribeEndpointsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEndpointsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEndpoints sets the Endpoints field's value.
+func (s *DescribeEndpointsOutput) SetEndpoints(v []*Endpoint) *DescribeEndpointsOutput {
+	s.Endpoints = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEndpointsOutput) SetMarker(v string) *DescribeEndpointsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeOrderableReplicationInstancesInput struct {
@@ -3457,6 +4021,18 @@ func (s DescribeOrderableReplicationInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeOrderableReplicationInstancesInput) SetMarker(v string) *DescribeOrderableReplicationInstancesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeOrderableReplicationInstancesInput) SetMaxRecords(v int64) *DescribeOrderableReplicationInstancesInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeOrderableReplicationInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3477,6 +4053,18 @@ func (s DescribeOrderableReplicationInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeOrderableReplicationInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOrderableReplicationInstancesOutput) SetMarker(v string) *DescribeOrderableReplicationInstancesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetOrderableReplicationInstances sets the OrderableReplicationInstances field's value.
+func (s *DescribeOrderableReplicationInstancesOutput) SetOrderableReplicationInstances(v []*OrderableReplicationInstance) *DescribeOrderableReplicationInstancesOutput {
+	s.OrderableReplicationInstances = v
+	return s
 }
 
 type DescribeRefreshSchemasStatusInput struct {
@@ -3511,6 +4099,12 @@ func (s *DescribeRefreshSchemasStatusInput) Validate() error {
 	return nil
 }
 
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *DescribeRefreshSchemasStatusInput) SetEndpointArn(v string) *DescribeRefreshSchemasStatusInput {
+	s.EndpointArn = &v
+	return s
+}
+
 type DescribeRefreshSchemasStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3526,6 +4120,12 @@ func (s DescribeRefreshSchemasStatusOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRefreshSchemasStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetRefreshSchemasStatus sets the RefreshSchemasStatus field's value.
+func (s *DescribeRefreshSchemasStatusOutput) SetRefreshSchemasStatus(v *RefreshSchemasStatus) *DescribeRefreshSchemasStatusOutput {
+	s.RefreshSchemasStatus = v
+	return s
 }
 
 type DescribeReplicationInstancesInput struct {
@@ -3582,6 +4182,24 @@ func (s *DescribeReplicationInstancesInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeReplicationInstancesInput) SetFilters(v []*Filter) *DescribeReplicationInstancesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationInstancesInput) SetMarker(v string) *DescribeReplicationInstancesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReplicationInstancesInput) SetMaxRecords(v int64) *DescribeReplicationInstancesInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeReplicationInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3602,6 +4220,18 @@ func (s DescribeReplicationInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReplicationInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationInstancesOutput) SetMarker(v string) *DescribeReplicationInstancesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReplicationInstances sets the ReplicationInstances field's value.
+func (s *DescribeReplicationInstancesOutput) SetReplicationInstances(v []*ReplicationInstance) *DescribeReplicationInstancesOutput {
+	s.ReplicationInstances = v
+	return s
 }
 
 type DescribeReplicationSubnetGroupsInput struct {
@@ -3655,6 +4285,24 @@ func (s *DescribeReplicationSubnetGroupsInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeReplicationSubnetGroupsInput) SetFilters(v []*Filter) *DescribeReplicationSubnetGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationSubnetGroupsInput) SetMarker(v string) *DescribeReplicationSubnetGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReplicationSubnetGroupsInput) SetMaxRecords(v int64) *DescribeReplicationSubnetGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeReplicationSubnetGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3675,6 +4323,18 @@ func (s DescribeReplicationSubnetGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReplicationSubnetGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationSubnetGroupsOutput) SetMarker(v string) *DescribeReplicationSubnetGroupsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReplicationSubnetGroups sets the ReplicationSubnetGroups field's value.
+func (s *DescribeReplicationSubnetGroupsOutput) SetReplicationSubnetGroups(v []*ReplicationSubnetGroup) *DescribeReplicationSubnetGroupsOutput {
+	s.ReplicationSubnetGroups = v
+	return s
 }
 
 type DescribeReplicationTasksInput struct {
@@ -3731,6 +4391,24 @@ func (s *DescribeReplicationTasksInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeReplicationTasksInput) SetFilters(v []*Filter) *DescribeReplicationTasksInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationTasksInput) SetMarker(v string) *DescribeReplicationTasksInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReplicationTasksInput) SetMaxRecords(v int64) *DescribeReplicationTasksInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeReplicationTasksOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3751,6 +4429,18 @@ func (s DescribeReplicationTasksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReplicationTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationTasksOutput) SetMarker(v string) *DescribeReplicationTasksOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReplicationTasks sets the ReplicationTasks field's value.
+func (s *DescribeReplicationTasksOutput) SetReplicationTasks(v []*ReplicationTask) *DescribeReplicationTasksOutput {
+	s.ReplicationTasks = v
+	return s
 }
 
 type DescribeSchemasInput struct {
@@ -3799,6 +4489,24 @@ func (s *DescribeSchemasInput) Validate() error {
 	return nil
 }
 
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *DescribeSchemasInput) SetEndpointArn(v string) *DescribeSchemasInput {
+	s.EndpointArn = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeSchemasInput) SetMarker(v string) *DescribeSchemasInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeSchemasInput) SetMaxRecords(v int64) *DescribeSchemasInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeSchemasOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3819,6 +4527,18 @@ func (s DescribeSchemasOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSchemasOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeSchemasOutput) SetMarker(v string) *DescribeSchemasOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSchemas sets the Schemas field's value.
+func (s *DescribeSchemasOutput) SetSchemas(v []*string) *DescribeSchemasOutput {
+	s.Schemas = v
+	return s
 }
 
 type DescribeTableStatisticsInput struct {
@@ -3867,6 +4587,24 @@ func (s *DescribeTableStatisticsInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeTableStatisticsInput) SetMarker(v string) *DescribeTableStatisticsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeTableStatisticsInput) SetMaxRecords(v int64) *DescribeTableStatisticsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *DescribeTableStatisticsInput) SetReplicationTaskArn(v string) *DescribeTableStatisticsInput {
+	s.ReplicationTaskArn = &v
+	return s
+}
+
 type DescribeTableStatisticsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3890,6 +4628,24 @@ func (s DescribeTableStatisticsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTableStatisticsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTableStatisticsOutput) SetMarker(v string) *DescribeTableStatisticsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *DescribeTableStatisticsOutput) SetReplicationTaskArn(v string) *DescribeTableStatisticsOutput {
+	s.ReplicationTaskArn = &v
+	return s
+}
+
+// SetTableStatistics sets the TableStatistics field's value.
+func (s *DescribeTableStatisticsOutput) SetTableStatistics(v []*TableStatistics) *DescribeTableStatisticsOutput {
+	s.TableStatistics = v
+	return s
 }
 
 type Endpoint struct {
@@ -3955,6 +4711,84 @@ func (s Endpoint) GoString() string {
 	return s.String()
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *Endpoint) SetCertificateArn(v string) *Endpoint {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *Endpoint) SetDatabaseName(v string) *Endpoint {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *Endpoint) SetEndpointArn(v string) *Endpoint {
+	s.EndpointArn = &v
+	return s
+}
+
+// SetEndpointIdentifier sets the EndpointIdentifier field's value.
+func (s *Endpoint) SetEndpointIdentifier(v string) *Endpoint {
+	s.EndpointIdentifier = &v
+	return s
+}
+
+// SetEndpointType sets the EndpointType field's value.
+func (s *Endpoint) SetEndpointType(v string) *Endpoint {
+	s.EndpointType = &v
+	return s
+}
+
+// SetEngineName sets the EngineName field's value.
+func (s *Endpoint) SetEngineName(v string) *Endpoint {
+	s.EngineName = &v
+	return s
+}
+
+// SetExtraConnectionAttributes sets the ExtraConnectionAttributes field's value.
+func (s *Endpoint) SetExtraConnectionAttributes(v string) *Endpoint {
+	s.ExtraConnectionAttributes = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *Endpoint) SetKmsKeyId(v string) *Endpoint {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *Endpoint) SetPort(v int64) *Endpoint {
+	s.Port = &v
+	return s
+}
+
+// SetServerName sets the ServerName field's value.
+func (s *Endpoint) SetServerName(v string) *Endpoint {
+	s.ServerName = &v
+	return s
+}
+
+// SetSslMode sets the SslMode field's value.
+func (s *Endpoint) SetSslMode(v string) *Endpoint {
+	s.SslMode = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Endpoint) SetStatus(v string) *Endpoint {
+	s.Status = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *Endpoint) SetUsername(v string) *Endpoint {
+	s.Username = &v
+	return s
+}
+
 type Filter struct {
 	_ struct{} `type:"structure"`
 
@@ -3995,6 +4829,18 @@ func (s *Filter) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *Filter) SetName(v string) *Filter {
+	s.Name = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *Filter) SetValues(v []*string) *Filter {
+	s.Values = v
+	return s
+}
+
 type ImportCertificateInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4030,6 +4876,18 @@ func (s *ImportCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateIdentifier sets the CertificateIdentifier field's value.
+func (s *ImportCertificateInput) SetCertificateIdentifier(v string) *ImportCertificateInput {
+	s.CertificateIdentifier = &v
+	return s
+}
+
+// SetCertificatePem sets the CertificatePem field's value.
+func (s *ImportCertificateInput) SetCertificatePem(v string) *ImportCertificateInput {
+	s.CertificatePem = &v
+	return s
+}
+
 type ImportCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4045,6 +4903,12 @@ func (s ImportCertificateOutput) String() string {
 // GoString returns the string representation
 func (s ImportCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificate sets the Certificate field's value.
+func (s *ImportCertificateOutput) SetCertificate(v *Certificate) *ImportCertificateOutput {
+	s.Certificate = v
+	return s
 }
 
 type ListTagsForResourceInput struct {
@@ -4080,6 +4944,12 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceArn sets the ResourceArn field's value.
+func (s *ListTagsForResourceInput) SetResourceArn(v string) *ListTagsForResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4095,6 +4965,12 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagList sets the TagList field's value.
+func (s *ListTagsForResourceOutput) SetTagList(v []*Tag) *ListTagsForResourceOutput {
+	s.TagList = v
+	return s
 }
 
 type ModifyEndpointInput struct {
@@ -4169,6 +5045,78 @@ func (s *ModifyEndpointInput) Validate() error {
 	return nil
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *ModifyEndpointInput) SetCertificateArn(v string) *ModifyEndpointInput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *ModifyEndpointInput) SetDatabaseName(v string) *ModifyEndpointInput {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *ModifyEndpointInput) SetEndpointArn(v string) *ModifyEndpointInput {
+	s.EndpointArn = &v
+	return s
+}
+
+// SetEndpointIdentifier sets the EndpointIdentifier field's value.
+func (s *ModifyEndpointInput) SetEndpointIdentifier(v string) *ModifyEndpointInput {
+	s.EndpointIdentifier = &v
+	return s
+}
+
+// SetEndpointType sets the EndpointType field's value.
+func (s *ModifyEndpointInput) SetEndpointType(v string) *ModifyEndpointInput {
+	s.EndpointType = &v
+	return s
+}
+
+// SetEngineName sets the EngineName field's value.
+func (s *ModifyEndpointInput) SetEngineName(v string) *ModifyEndpointInput {
+	s.EngineName = &v
+	return s
+}
+
+// SetExtraConnectionAttributes sets the ExtraConnectionAttributes field's value.
+func (s *ModifyEndpointInput) SetExtraConnectionAttributes(v string) *ModifyEndpointInput {
+	s.ExtraConnectionAttributes = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *ModifyEndpointInput) SetPassword(v string) *ModifyEndpointInput {
+	s.Password = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *ModifyEndpointInput) SetPort(v int64) *ModifyEndpointInput {
+	s.Port = &v
+	return s
+}
+
+// SetServerName sets the ServerName field's value.
+func (s *ModifyEndpointInput) SetServerName(v string) *ModifyEndpointInput {
+	s.ServerName = &v
+	return s
+}
+
+// SetSslMode sets the SslMode field's value.
+func (s *ModifyEndpointInput) SetSslMode(v string) *ModifyEndpointInput {
+	s.SslMode = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *ModifyEndpointInput) SetUsername(v string) *ModifyEndpointInput {
+	s.Username = &v
+	return s
+}
+
 type ModifyEndpointOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4184,6 +5132,12 @@ func (s ModifyEndpointOutput) String() string {
 // GoString returns the string representation
 func (s ModifyEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *ModifyEndpointOutput) SetEndpoint(v *Endpoint) *ModifyEndpointOutput {
+	s.Endpoint = v
+	return s
 }
 
 type ModifyReplicationInstanceInput struct {
@@ -4282,6 +5236,72 @@ func (s *ModifyReplicationInstanceInput) Validate() error {
 	return nil
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *ModifyReplicationInstanceInput) SetAllocatedStorage(v int64) *ModifyReplicationInstanceInput {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAllowMajorVersionUpgrade sets the AllowMajorVersionUpgrade field's value.
+func (s *ModifyReplicationInstanceInput) SetAllowMajorVersionUpgrade(v bool) *ModifyReplicationInstanceInput {
+	s.AllowMajorVersionUpgrade = &v
+	return s
+}
+
+// SetApplyImmediately sets the ApplyImmediately field's value.
+func (s *ModifyReplicationInstanceInput) SetApplyImmediately(v bool) *ModifyReplicationInstanceInput {
+	s.ApplyImmediately = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *ModifyReplicationInstanceInput) SetAutoMinorVersionUpgrade(v bool) *ModifyReplicationInstanceInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *ModifyReplicationInstanceInput) SetEngineVersion(v string) *ModifyReplicationInstanceInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *ModifyReplicationInstanceInput) SetMultiAZ(v bool) *ModifyReplicationInstanceInput {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *ModifyReplicationInstanceInput) SetPreferredMaintenanceWindow(v string) *ModifyReplicationInstanceInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *ModifyReplicationInstanceInput) SetReplicationInstanceArn(v string) *ModifyReplicationInstanceInput {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+// SetReplicationInstanceClass sets the ReplicationInstanceClass field's value.
+func (s *ModifyReplicationInstanceInput) SetReplicationInstanceClass(v string) *ModifyReplicationInstanceInput {
+	s.ReplicationInstanceClass = &v
+	return s
+}
+
+// SetReplicationInstanceIdentifier sets the ReplicationInstanceIdentifier field's value.
+func (s *ModifyReplicationInstanceInput) SetReplicationInstanceIdentifier(v string) *ModifyReplicationInstanceInput {
+	s.ReplicationInstanceIdentifier = &v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *ModifyReplicationInstanceInput) SetVpcSecurityGroupIds(v []*string) *ModifyReplicationInstanceInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type ModifyReplicationInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4297,6 +5317,12 @@ func (s ModifyReplicationInstanceOutput) String() string {
 // GoString returns the string representation
 func (s ModifyReplicationInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationInstance sets the ReplicationInstance field's value.
+func (s *ModifyReplicationInstanceOutput) SetReplicationInstance(v *ReplicationInstance) *ModifyReplicationInstanceOutput {
+	s.ReplicationInstance = v
+	return s
 }
 
 type ModifyReplicationSubnetGroupInput struct {
@@ -4342,6 +5368,24 @@ func (s *ModifyReplicationSubnetGroupInput) Validate() error {
 	return nil
 }
 
+// SetReplicationSubnetGroupDescription sets the ReplicationSubnetGroupDescription field's value.
+func (s *ModifyReplicationSubnetGroupInput) SetReplicationSubnetGroupDescription(v string) *ModifyReplicationSubnetGroupInput {
+	s.ReplicationSubnetGroupDescription = &v
+	return s
+}
+
+// SetReplicationSubnetGroupIdentifier sets the ReplicationSubnetGroupIdentifier field's value.
+func (s *ModifyReplicationSubnetGroupInput) SetReplicationSubnetGroupIdentifier(v string) *ModifyReplicationSubnetGroupInput {
+	s.ReplicationSubnetGroupIdentifier = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *ModifyReplicationSubnetGroupInput) SetSubnetIds(v []*string) *ModifyReplicationSubnetGroupInput {
+	s.SubnetIds = v
+	return s
+}
+
 type ModifyReplicationSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4357,6 +5401,12 @@ func (s ModifyReplicationSubnetGroupOutput) String() string {
 // GoString returns the string representation
 func (s ModifyReplicationSubnetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationSubnetGroup sets the ReplicationSubnetGroup field's value.
+func (s *ModifyReplicationSubnetGroupOutput) SetReplicationSubnetGroup(v *ReplicationSubnetGroup) *ModifyReplicationSubnetGroupOutput {
+	s.ReplicationSubnetGroup = v
+	return s
 }
 
 type OrderableReplicationInstance struct {
@@ -4401,6 +5451,48 @@ func (s OrderableReplicationInstance) GoString() string {
 	return s.String()
 }
 
+// SetDefaultAllocatedStorage sets the DefaultAllocatedStorage field's value.
+func (s *OrderableReplicationInstance) SetDefaultAllocatedStorage(v int64) *OrderableReplicationInstance {
+	s.DefaultAllocatedStorage = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *OrderableReplicationInstance) SetEngineVersion(v string) *OrderableReplicationInstance {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetIncludedAllocatedStorage sets the IncludedAllocatedStorage field's value.
+func (s *OrderableReplicationInstance) SetIncludedAllocatedStorage(v int64) *OrderableReplicationInstance {
+	s.IncludedAllocatedStorage = &v
+	return s
+}
+
+// SetMaxAllocatedStorage sets the MaxAllocatedStorage field's value.
+func (s *OrderableReplicationInstance) SetMaxAllocatedStorage(v int64) *OrderableReplicationInstance {
+	s.MaxAllocatedStorage = &v
+	return s
+}
+
+// SetMinAllocatedStorage sets the MinAllocatedStorage field's value.
+func (s *OrderableReplicationInstance) SetMinAllocatedStorage(v int64) *OrderableReplicationInstance {
+	s.MinAllocatedStorage = &v
+	return s
+}
+
+// SetReplicationInstanceClass sets the ReplicationInstanceClass field's value.
+func (s *OrderableReplicationInstance) SetReplicationInstanceClass(v string) *OrderableReplicationInstance {
+	s.ReplicationInstanceClass = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *OrderableReplicationInstance) SetStorageType(v string) *OrderableReplicationInstance {
+	s.StorageType = &v
+	return s
+}
+
 type RefreshSchemasInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4441,6 +5533,18 @@ func (s *RefreshSchemasInput) Validate() error {
 	return nil
 }
 
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *RefreshSchemasInput) SetEndpointArn(v string) *RefreshSchemasInput {
+	s.EndpointArn = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *RefreshSchemasInput) SetReplicationInstanceArn(v string) *RefreshSchemasInput {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
 type RefreshSchemasOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4456,6 +5560,12 @@ func (s RefreshSchemasOutput) String() string {
 // GoString returns the string representation
 func (s RefreshSchemasOutput) GoString() string {
 	return s.String()
+}
+
+// SetRefreshSchemasStatus sets the RefreshSchemasStatus field's value.
+func (s *RefreshSchemasOutput) SetRefreshSchemasStatus(v *RefreshSchemasStatus) *RefreshSchemasOutput {
+	s.RefreshSchemasStatus = v
+	return s
 }
 
 type RefreshSchemasStatus struct {
@@ -4485,6 +5595,36 @@ func (s RefreshSchemasStatus) String() string {
 // GoString returns the string representation
 func (s RefreshSchemasStatus) GoString() string {
 	return s.String()
+}
+
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *RefreshSchemasStatus) SetEndpointArn(v string) *RefreshSchemasStatus {
+	s.EndpointArn = &v
+	return s
+}
+
+// SetLastFailureMessage sets the LastFailureMessage field's value.
+func (s *RefreshSchemasStatus) SetLastFailureMessage(v string) *RefreshSchemasStatus {
+	s.LastFailureMessage = &v
+	return s
+}
+
+// SetLastRefreshDate sets the LastRefreshDate field's value.
+func (s *RefreshSchemasStatus) SetLastRefreshDate(v time.Time) *RefreshSchemasStatus {
+	s.LastRefreshDate = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *RefreshSchemasStatus) SetReplicationInstanceArn(v string) *RefreshSchemasStatus {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *RefreshSchemasStatus) SetStatus(v string) *RefreshSchemasStatus {
+	s.Status = &v
+	return s
 }
 
 type RemoveTagsFromResourceInput struct {
@@ -4526,6 +5666,18 @@ func (s *RemoveTagsFromResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *RemoveTagsFromResourceInput) SetResourceArn(v string) *RemoveTagsFromResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsFromResourceInput) SetTagKeys(v []*string) *RemoveTagsFromResourceInput {
+	s.TagKeys = v
+	return s
 }
 
 type RemoveTagsFromResourceOutput struct {
@@ -4639,6 +5791,126 @@ func (s ReplicationInstance) GoString() string {
 	return s.String()
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *ReplicationInstance) SetAllocatedStorage(v int64) *ReplicationInstance {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *ReplicationInstance) SetAutoMinorVersionUpgrade(v bool) *ReplicationInstance {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ReplicationInstance) SetAvailabilityZone(v string) *ReplicationInstance {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *ReplicationInstance) SetEngineVersion(v string) *ReplicationInstance {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetInstanceCreateTime sets the InstanceCreateTime field's value.
+func (s *ReplicationInstance) SetInstanceCreateTime(v time.Time) *ReplicationInstance {
+	s.InstanceCreateTime = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *ReplicationInstance) SetKmsKeyId(v string) *ReplicationInstance {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *ReplicationInstance) SetMultiAZ(v bool) *ReplicationInstance {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetPendingModifiedValues sets the PendingModifiedValues field's value.
+func (s *ReplicationInstance) SetPendingModifiedValues(v *ReplicationPendingModifiedValues) *ReplicationInstance {
+	s.PendingModifiedValues = v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *ReplicationInstance) SetPreferredMaintenanceWindow(v string) *ReplicationInstance {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *ReplicationInstance) SetPubliclyAccessible(v bool) *ReplicationInstance {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *ReplicationInstance) SetReplicationInstanceArn(v string) *ReplicationInstance {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+// SetReplicationInstanceClass sets the ReplicationInstanceClass field's value.
+func (s *ReplicationInstance) SetReplicationInstanceClass(v string) *ReplicationInstance {
+	s.ReplicationInstanceClass = &v
+	return s
+}
+
+// SetReplicationInstanceIdentifier sets the ReplicationInstanceIdentifier field's value.
+func (s *ReplicationInstance) SetReplicationInstanceIdentifier(v string) *ReplicationInstance {
+	s.ReplicationInstanceIdentifier = &v
+	return s
+}
+
+// SetReplicationInstancePrivateIpAddress sets the ReplicationInstancePrivateIpAddress field's value.
+func (s *ReplicationInstance) SetReplicationInstancePrivateIpAddress(v string) *ReplicationInstance {
+	s.ReplicationInstancePrivateIpAddress = &v
+	return s
+}
+
+// SetReplicationInstancePrivateIpAddresses sets the ReplicationInstancePrivateIpAddresses field's value.
+func (s *ReplicationInstance) SetReplicationInstancePrivateIpAddresses(v []*string) *ReplicationInstance {
+	s.ReplicationInstancePrivateIpAddresses = v
+	return s
+}
+
+// SetReplicationInstancePublicIpAddress sets the ReplicationInstancePublicIpAddress field's value.
+func (s *ReplicationInstance) SetReplicationInstancePublicIpAddress(v string) *ReplicationInstance {
+	s.ReplicationInstancePublicIpAddress = &v
+	return s
+}
+
+// SetReplicationInstancePublicIpAddresses sets the ReplicationInstancePublicIpAddresses field's value.
+func (s *ReplicationInstance) SetReplicationInstancePublicIpAddresses(v []*string) *ReplicationInstance {
+	s.ReplicationInstancePublicIpAddresses = v
+	return s
+}
+
+// SetReplicationInstanceStatus sets the ReplicationInstanceStatus field's value.
+func (s *ReplicationInstance) SetReplicationInstanceStatus(v string) *ReplicationInstance {
+	s.ReplicationInstanceStatus = &v
+	return s
+}
+
+// SetReplicationSubnetGroup sets the ReplicationSubnetGroup field's value.
+func (s *ReplicationInstance) SetReplicationSubnetGroup(v *ReplicationSubnetGroup) *ReplicationInstance {
+	s.ReplicationSubnetGroup = v
+	return s
+}
+
+// SetVpcSecurityGroups sets the VpcSecurityGroups field's value.
+func (s *ReplicationInstance) SetVpcSecurityGroups(v []*VpcSecurityGroupMembership) *ReplicationInstance {
+	s.VpcSecurityGroups = v
+	return s
+}
+
 type ReplicationPendingModifiedValues struct {
 	_ struct{} `type:"structure"`
 
@@ -4670,6 +5942,30 @@ func (s ReplicationPendingModifiedValues) GoString() string {
 	return s.String()
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *ReplicationPendingModifiedValues) SetAllocatedStorage(v int64) *ReplicationPendingModifiedValues {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *ReplicationPendingModifiedValues) SetEngineVersion(v string) *ReplicationPendingModifiedValues {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *ReplicationPendingModifiedValues) SetMultiAZ(v bool) *ReplicationPendingModifiedValues {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetReplicationInstanceClass sets the ReplicationInstanceClass field's value.
+func (s *ReplicationPendingModifiedValues) SetReplicationInstanceClass(v string) *ReplicationPendingModifiedValues {
+	s.ReplicationInstanceClass = &v
+	return s
+}
+
 type ReplicationSubnetGroup struct {
 	_ struct{} `type:"structure"`
 
@@ -4697,6 +5993,36 @@ func (s ReplicationSubnetGroup) String() string {
 // GoString returns the string representation
 func (s ReplicationSubnetGroup) GoString() string {
 	return s.String()
+}
+
+// SetReplicationSubnetGroupDescription sets the ReplicationSubnetGroupDescription field's value.
+func (s *ReplicationSubnetGroup) SetReplicationSubnetGroupDescription(v string) *ReplicationSubnetGroup {
+	s.ReplicationSubnetGroupDescription = &v
+	return s
+}
+
+// SetReplicationSubnetGroupIdentifier sets the ReplicationSubnetGroupIdentifier field's value.
+func (s *ReplicationSubnetGroup) SetReplicationSubnetGroupIdentifier(v string) *ReplicationSubnetGroup {
+	s.ReplicationSubnetGroupIdentifier = &v
+	return s
+}
+
+// SetSubnetGroupStatus sets the SubnetGroupStatus field's value.
+func (s *ReplicationSubnetGroup) SetSubnetGroupStatus(v string) *ReplicationSubnetGroup {
+	s.SubnetGroupStatus = &v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *ReplicationSubnetGroup) SetSubnets(v []*Subnet) *ReplicationSubnetGroup {
+	s.Subnets = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *ReplicationSubnetGroup) SetVpcId(v string) *ReplicationSubnetGroup {
+	s.VpcId = &v
+	return s
 }
 
 type ReplicationTask struct {
@@ -4761,6 +6087,84 @@ func (s ReplicationTask) GoString() string {
 	return s.String()
 }
 
+// SetLastFailureMessage sets the LastFailureMessage field's value.
+func (s *ReplicationTask) SetLastFailureMessage(v string) *ReplicationTask {
+	s.LastFailureMessage = &v
+	return s
+}
+
+// SetMigrationType sets the MigrationType field's value.
+func (s *ReplicationTask) SetMigrationType(v string) *ReplicationTask {
+	s.MigrationType = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *ReplicationTask) SetReplicationInstanceArn(v string) *ReplicationTask {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *ReplicationTask) SetReplicationTaskArn(v string) *ReplicationTask {
+	s.ReplicationTaskArn = &v
+	return s
+}
+
+// SetReplicationTaskCreationDate sets the ReplicationTaskCreationDate field's value.
+func (s *ReplicationTask) SetReplicationTaskCreationDate(v time.Time) *ReplicationTask {
+	s.ReplicationTaskCreationDate = &v
+	return s
+}
+
+// SetReplicationTaskIdentifier sets the ReplicationTaskIdentifier field's value.
+func (s *ReplicationTask) SetReplicationTaskIdentifier(v string) *ReplicationTask {
+	s.ReplicationTaskIdentifier = &v
+	return s
+}
+
+// SetReplicationTaskSettings sets the ReplicationTaskSettings field's value.
+func (s *ReplicationTask) SetReplicationTaskSettings(v string) *ReplicationTask {
+	s.ReplicationTaskSettings = &v
+	return s
+}
+
+// SetReplicationTaskStartDate sets the ReplicationTaskStartDate field's value.
+func (s *ReplicationTask) SetReplicationTaskStartDate(v time.Time) *ReplicationTask {
+	s.ReplicationTaskStartDate = &v
+	return s
+}
+
+// SetReplicationTaskStats sets the ReplicationTaskStats field's value.
+func (s *ReplicationTask) SetReplicationTaskStats(v *ReplicationTaskStats) *ReplicationTask {
+	s.ReplicationTaskStats = v
+	return s
+}
+
+// SetSourceEndpointArn sets the SourceEndpointArn field's value.
+func (s *ReplicationTask) SetSourceEndpointArn(v string) *ReplicationTask {
+	s.SourceEndpointArn = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ReplicationTask) SetStatus(v string) *ReplicationTask {
+	s.Status = &v
+	return s
+}
+
+// SetTableMappings sets the TableMappings field's value.
+func (s *ReplicationTask) SetTableMappings(v string) *ReplicationTask {
+	s.TableMappings = &v
+	return s
+}
+
+// SetTargetEndpointArn sets the TargetEndpointArn field's value.
+func (s *ReplicationTask) SetTargetEndpointArn(v string) *ReplicationTask {
+	s.TargetEndpointArn = &v
+	return s
+}
+
 type ReplicationTaskStats struct {
 	_ struct{} `type:"structure"`
 
@@ -4791,6 +6195,42 @@ func (s ReplicationTaskStats) String() string {
 // GoString returns the string representation
 func (s ReplicationTaskStats) GoString() string {
 	return s.String()
+}
+
+// SetElapsedTimeMillis sets the ElapsedTimeMillis field's value.
+func (s *ReplicationTaskStats) SetElapsedTimeMillis(v int64) *ReplicationTaskStats {
+	s.ElapsedTimeMillis = &v
+	return s
+}
+
+// SetFullLoadProgressPercent sets the FullLoadProgressPercent field's value.
+func (s *ReplicationTaskStats) SetFullLoadProgressPercent(v int64) *ReplicationTaskStats {
+	s.FullLoadProgressPercent = &v
+	return s
+}
+
+// SetTablesErrored sets the TablesErrored field's value.
+func (s *ReplicationTaskStats) SetTablesErrored(v int64) *ReplicationTaskStats {
+	s.TablesErrored = &v
+	return s
+}
+
+// SetTablesLoaded sets the TablesLoaded field's value.
+func (s *ReplicationTaskStats) SetTablesLoaded(v int64) *ReplicationTaskStats {
+	s.TablesLoaded = &v
+	return s
+}
+
+// SetTablesLoading sets the TablesLoading field's value.
+func (s *ReplicationTaskStats) SetTablesLoading(v int64) *ReplicationTaskStats {
+	s.TablesLoading = &v
+	return s
+}
+
+// SetTablesQueued sets the TablesQueued field's value.
+func (s *ReplicationTaskStats) SetTablesQueued(v int64) *ReplicationTaskStats {
+	s.TablesQueued = &v
+	return s
 }
 
 type StartReplicationTaskInput struct {
@@ -4836,6 +6276,24 @@ func (s *StartReplicationTaskInput) Validate() error {
 	return nil
 }
 
+// SetCdcStartTime sets the CdcStartTime field's value.
+func (s *StartReplicationTaskInput) SetCdcStartTime(v time.Time) *StartReplicationTaskInput {
+	s.CdcStartTime = &v
+	return s
+}
+
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *StartReplicationTaskInput) SetReplicationTaskArn(v string) *StartReplicationTaskInput {
+	s.ReplicationTaskArn = &v
+	return s
+}
+
+// SetStartReplicationTaskType sets the StartReplicationTaskType field's value.
+func (s *StartReplicationTaskInput) SetStartReplicationTaskType(v string) *StartReplicationTaskInput {
+	s.StartReplicationTaskType = &v
+	return s
+}
+
 type StartReplicationTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4851,6 +6309,12 @@ func (s StartReplicationTaskOutput) String() string {
 // GoString returns the string representation
 func (s StartReplicationTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationTask sets the ReplicationTask field's value.
+func (s *StartReplicationTaskOutput) SetReplicationTask(v *ReplicationTask) *StartReplicationTaskOutput {
+	s.ReplicationTask = v
+	return s
 }
 
 type StopReplicationTaskInput struct {
@@ -4885,6 +6349,12 @@ func (s *StopReplicationTaskInput) Validate() error {
 	return nil
 }
 
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *StopReplicationTaskInput) SetReplicationTaskArn(v string) *StopReplicationTaskInput {
+	s.ReplicationTaskArn = &v
+	return s
+}
+
 type StopReplicationTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4900,6 +6370,12 @@ func (s StopReplicationTaskOutput) String() string {
 // GoString returns the string representation
 func (s StopReplicationTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationTask sets the ReplicationTask field's value.
+func (s *StopReplicationTaskOutput) SetReplicationTask(v *ReplicationTask) *StopReplicationTaskOutput {
+	s.ReplicationTask = v
+	return s
 }
 
 type Subnet struct {
@@ -4925,6 +6401,24 @@ func (s Subnet) GoString() string {
 	return s.String()
 }
 
+// SetSubnetAvailabilityZone sets the SubnetAvailabilityZone field's value.
+func (s *Subnet) SetSubnetAvailabilityZone(v *AvailabilityZone) *Subnet {
+	s.SubnetAvailabilityZone = v
+	return s
+}
+
+// SetSubnetIdentifier sets the SubnetIdentifier field's value.
+func (s *Subnet) SetSubnetIdentifier(v string) *Subnet {
+	s.SubnetIdentifier = &v
+	return s
+}
+
+// SetSubnetStatus sets the SubnetStatus field's value.
+func (s *Subnet) SetSubnetStatus(v string) *Subnet {
+	s.SubnetStatus = &v
+	return s
+}
+
 type SupportedEndpointType struct {
 	_ struct{} `type:"structure"`
 
@@ -4946,6 +6440,24 @@ func (s SupportedEndpointType) String() string {
 // GoString returns the string representation
 func (s SupportedEndpointType) GoString() string {
 	return s.String()
+}
+
+// SetEndpointType sets the EndpointType field's value.
+func (s *SupportedEndpointType) SetEndpointType(v string) *SupportedEndpointType {
+	s.EndpointType = &v
+	return s
+}
+
+// SetEngineName sets the EngineName field's value.
+func (s *SupportedEndpointType) SetEngineName(v string) *SupportedEndpointType {
+	s.EngineName = &v
+	return s
+}
+
+// SetSupportsCDC sets the SupportsCDC field's value.
+func (s *SupportedEndpointType) SetSupportsCDC(v bool) *SupportedEndpointType {
+	s.SupportsCDC = &v
+	return s
 }
 
 type TableStatistics struct {
@@ -4990,6 +6502,60 @@ func (s TableStatistics) GoString() string {
 	return s.String()
 }
 
+// SetDdls sets the Ddls field's value.
+func (s *TableStatistics) SetDdls(v int64) *TableStatistics {
+	s.Ddls = &v
+	return s
+}
+
+// SetDeletes sets the Deletes field's value.
+func (s *TableStatistics) SetDeletes(v int64) *TableStatistics {
+	s.Deletes = &v
+	return s
+}
+
+// SetFullLoadRows sets the FullLoadRows field's value.
+func (s *TableStatistics) SetFullLoadRows(v int64) *TableStatistics {
+	s.FullLoadRows = &v
+	return s
+}
+
+// SetInserts sets the Inserts field's value.
+func (s *TableStatistics) SetInserts(v int64) *TableStatistics {
+	s.Inserts = &v
+	return s
+}
+
+// SetLastUpdateTime sets the LastUpdateTime field's value.
+func (s *TableStatistics) SetLastUpdateTime(v time.Time) *TableStatistics {
+	s.LastUpdateTime = &v
+	return s
+}
+
+// SetSchemaName sets the SchemaName field's value.
+func (s *TableStatistics) SetSchemaName(v string) *TableStatistics {
+	s.SchemaName = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *TableStatistics) SetTableName(v string) *TableStatistics {
+	s.TableName = &v
+	return s
+}
+
+// SetTableState sets the TableState field's value.
+func (s *TableStatistics) SetTableState(v string) *TableStatistics {
+	s.TableState = &v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *TableStatistics) SetUpdates(v int64) *TableStatistics {
+	s.Updates = &v
+	return s
+}
+
 type Tag struct {
 	_ struct{} `type:"structure"`
 
@@ -5014,6 +6580,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 type TestConnectionInput struct {
@@ -5056,6 +6634,18 @@ func (s *TestConnectionInput) Validate() error {
 	return nil
 }
 
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *TestConnectionInput) SetEndpointArn(v string) *TestConnectionInput {
+	s.EndpointArn = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *TestConnectionInput) SetReplicationInstanceArn(v string) *TestConnectionInput {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
 type TestConnectionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5071,6 +6661,12 @@ func (s TestConnectionOutput) String() string {
 // GoString returns the string representation
 func (s TestConnectionOutput) GoString() string {
 	return s.String()
+}
+
+// SetConnection sets the Connection field's value.
+func (s *TestConnectionOutput) SetConnection(v *Connection) *TestConnectionOutput {
+	s.Connection = v
+	return s
 }
 
 type VpcSecurityGroupMembership struct {
@@ -5091,6 +6687,18 @@ func (s VpcSecurityGroupMembership) String() string {
 // GoString returns the string representation
 func (s VpcSecurityGroupMembership) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *VpcSecurityGroupMembership) SetStatus(v string) *VpcSecurityGroupMembership {
+	s.Status = &v
+	return s
+}
+
+// SetVpcSecurityGroupId sets the VpcSecurityGroupId field's value.
+func (s *VpcSecurityGroupMembership) SetVpcSecurityGroupId(v string) *VpcSecurityGroupMembership {
+	s.VpcSecurityGroupId = &v
+	return s
 }
 
 const (

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -1673,6 +1673,24 @@ func (s *ActivatePipelineInput) Validate() error {
 	return nil
 }
 
+// SetParameterValues sets the ParameterValues field's value.
+func (s *ActivatePipelineInput) SetParameterValues(v []*ParameterValue) *ActivatePipelineInput {
+	s.ParameterValues = v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *ActivatePipelineInput) SetPipelineId(v string) *ActivatePipelineInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetStartTimestamp sets the StartTimestamp field's value.
+func (s *ActivatePipelineInput) SetStartTimestamp(v time.Time) *ActivatePipelineInput {
+	s.StartTimestamp = &v
+	return s
+}
+
 // Contains the output of ActivatePipeline.
 type ActivatePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -1740,6 +1758,18 @@ func (s *AddTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *AddTagsInput) SetPipelineId(v string) *AddTagsInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsInput) SetTags(v []*Tag) *AddTagsInput {
+	s.Tags = v
+	return s
 }
 
 // Contains the output of AddTags.
@@ -1835,6 +1865,30 @@ func (s *CreatePipelineInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreatePipelineInput) SetDescription(v string) *CreatePipelineInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreatePipelineInput) SetName(v string) *CreatePipelineInput {
+	s.Name = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreatePipelineInput) SetTags(v []*Tag) *CreatePipelineInput {
+	s.Tags = v
+	return s
+}
+
+// SetUniqueId sets the UniqueId field's value.
+func (s *CreatePipelineInput) SetUniqueId(v string) *CreatePipelineInput {
+	s.UniqueId = &v
+	return s
+}
+
 // Contains the output of CreatePipeline.
 type CreatePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -1854,6 +1908,12 @@ func (s CreatePipelineOutput) String() string {
 // GoString returns the string representation
 func (s CreatePipelineOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *CreatePipelineOutput) SetPipelineId(v string) *CreatePipelineOutput {
+	s.PipelineId = &v
+	return s
 }
 
 // Contains the parameters for DeactivatePipeline.
@@ -1895,6 +1955,18 @@ func (s *DeactivatePipelineInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCancelActive sets the CancelActive field's value.
+func (s *DeactivatePipelineInput) SetCancelActive(v bool) *DeactivatePipelineInput {
+	s.CancelActive = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *DeactivatePipelineInput) SetPipelineId(v string) *DeactivatePipelineInput {
+	s.PipelineId = &v
+	return s
 }
 
 // Contains the output of DeactivatePipeline.
@@ -1946,6 +2018,12 @@ func (s *DeletePipelineInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *DeletePipelineInput) SetPipelineId(v string) *DeletePipelineInput {
+	s.PipelineId = &v
+	return s
 }
 
 type DeletePipelineOutput struct {
@@ -2017,6 +2095,30 @@ func (s *DescribeObjectsInput) Validate() error {
 	return nil
 }
 
+// SetEvaluateExpressions sets the EvaluateExpressions field's value.
+func (s *DescribeObjectsInput) SetEvaluateExpressions(v bool) *DescribeObjectsInput {
+	s.EvaluateExpressions = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeObjectsInput) SetMarker(v string) *DescribeObjectsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetObjectIds sets the ObjectIds field's value.
+func (s *DescribeObjectsInput) SetObjectIds(v []*string) *DescribeObjectsInput {
+	s.ObjectIds = v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *DescribeObjectsInput) SetPipelineId(v string) *DescribeObjectsInput {
+	s.PipelineId = &v
+	return s
+}
+
 // Contains the output of DescribeObjects.
 type DescribeObjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2043,6 +2145,24 @@ func (s DescribeObjectsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeObjectsOutput) GoString() string {
 	return s.String()
+}
+
+// SetHasMoreResults sets the HasMoreResults field's value.
+func (s *DescribeObjectsOutput) SetHasMoreResults(v bool) *DescribeObjectsOutput {
+	s.HasMoreResults = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeObjectsOutput) SetMarker(v string) *DescribeObjectsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPipelineObjects sets the PipelineObjects field's value.
+func (s *DescribeObjectsOutput) SetPipelineObjects(v []*PipelineObject) *DescribeObjectsOutput {
+	s.PipelineObjects = v
+	return s
 }
 
 // Contains the parameters for DescribePipelines.
@@ -2079,6 +2199,12 @@ func (s *DescribePipelinesInput) Validate() error {
 	return nil
 }
 
+// SetPipelineIds sets the PipelineIds field's value.
+func (s *DescribePipelinesInput) SetPipelineIds(v []*string) *DescribePipelinesInput {
+	s.PipelineIds = v
+	return s
+}
+
 // Contains the output of DescribePipelines.
 type DescribePipelinesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2097,6 +2223,12 @@ func (s DescribePipelinesOutput) String() string {
 // GoString returns the string representation
 func (s DescribePipelinesOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipelineDescriptionList sets the PipelineDescriptionList field's value.
+func (s *DescribePipelinesOutput) SetPipelineDescriptionList(v []*PipelineDescription) *DescribePipelinesOutput {
+	s.PipelineDescriptionList = v
+	return s
 }
 
 // Contains the parameters for EvaluateExpression.
@@ -2154,6 +2286,24 @@ func (s *EvaluateExpressionInput) Validate() error {
 	return nil
 }
 
+// SetExpression sets the Expression field's value.
+func (s *EvaluateExpressionInput) SetExpression(v string) *EvaluateExpressionInput {
+	s.Expression = &v
+	return s
+}
+
+// SetObjectId sets the ObjectId field's value.
+func (s *EvaluateExpressionInput) SetObjectId(v string) *EvaluateExpressionInput {
+	s.ObjectId = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *EvaluateExpressionInput) SetPipelineId(v string) *EvaluateExpressionInput {
+	s.PipelineId = &v
+	return s
+}
+
 // Contains the output of EvaluateExpression.
 type EvaluateExpressionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2172,6 +2322,12 @@ func (s EvaluateExpressionOutput) String() string {
 // GoString returns the string representation
 func (s EvaluateExpressionOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvaluatedExpression sets the EvaluatedExpression field's value.
+func (s *EvaluateExpressionOutput) SetEvaluatedExpression(v string) *EvaluateExpressionOutput {
+	s.EvaluatedExpression = &v
+	return s
 }
 
 // A key-value pair that describes a property of a pipeline object. The value
@@ -2221,6 +2377,24 @@ func (s *Field) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Field) SetKey(v string) *Field {
+	s.Key = &v
+	return s
+}
+
+// SetRefValue sets the RefValue field's value.
+func (s *Field) SetRefValue(v string) *Field {
+	s.RefValue = &v
+	return s
+}
+
+// SetStringValue sets the StringValue field's value.
+func (s *Field) SetStringValue(v string) *Field {
+	s.StringValue = &v
+	return s
+}
+
 // Contains the parameters for GetPipelineDefinition.
 type GetPipelineDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -2262,6 +2436,18 @@ func (s *GetPipelineDefinitionInput) Validate() error {
 	return nil
 }
 
+// SetPipelineId sets the PipelineId field's value.
+func (s *GetPipelineDefinitionInput) SetPipelineId(v string) *GetPipelineDefinitionInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *GetPipelineDefinitionInput) SetVersion(v string) *GetPipelineDefinitionInput {
+	s.Version = &v
+	return s
+}
+
 // Contains the output of GetPipelineDefinition.
 type GetPipelineDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2284,6 +2470,24 @@ func (s GetPipelineDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s GetPipelineDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// SetParameterObjects sets the ParameterObjects field's value.
+func (s *GetPipelineDefinitionOutput) SetParameterObjects(v []*ParameterObject) *GetPipelineDefinitionOutput {
+	s.ParameterObjects = v
+	return s
+}
+
+// SetParameterValues sets the ParameterValues field's value.
+func (s *GetPipelineDefinitionOutput) SetParameterValues(v []*ParameterValue) *GetPipelineDefinitionOutput {
+	s.ParameterValues = v
+	return s
+}
+
+// SetPipelineObjects sets the PipelineObjects field's value.
+func (s *GetPipelineDefinitionOutput) SetPipelineObjects(v []*PipelineObject) *GetPipelineDefinitionOutput {
+	s.PipelineObjects = v
+	return s
 }
 
 // Identity information for the EC2 instance that is hosting the task runner.
@@ -2315,6 +2519,18 @@ func (s InstanceIdentity) GoString() string {
 	return s.String()
 }
 
+// SetDocument sets the Document field's value.
+func (s *InstanceIdentity) SetDocument(v string) *InstanceIdentity {
+	s.Document = &v
+	return s
+}
+
+// SetSignature sets the Signature field's value.
+func (s *InstanceIdentity) SetSignature(v string) *InstanceIdentity {
+	s.Signature = &v
+	return s
+}
+
 // Contains the parameters for ListPipelines.
 type ListPipelinesInput struct {
 	_ struct{} `type:"structure"`
@@ -2334,6 +2550,12 @@ func (s ListPipelinesInput) String() string {
 // GoString returns the string representation
 func (s ListPipelinesInput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPipelinesInput) SetMarker(v string) *ListPipelinesInput {
+	s.Marker = &v
+	return s
 }
 
 // Contains the output of ListPipelines.
@@ -2364,6 +2586,24 @@ func (s ListPipelinesOutput) String() string {
 // GoString returns the string representation
 func (s ListPipelinesOutput) GoString() string {
 	return s.String()
+}
+
+// SetHasMoreResults sets the HasMoreResults field's value.
+func (s *ListPipelinesOutput) SetHasMoreResults(v bool) *ListPipelinesOutput {
+	s.HasMoreResults = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPipelinesOutput) SetMarker(v string) *ListPipelinesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPipelineIdList sets the PipelineIdList field's value.
+func (s *ListPipelinesOutput) SetPipelineIdList(v []*PipelineIdName) *ListPipelinesOutput {
+	s.PipelineIdList = v
+	return s
 }
 
 // Contains a logical operation for comparing the value of a field with a specified
@@ -2416,6 +2656,18 @@ func (s Operator) GoString() string {
 	return s.String()
 }
 
+// SetType sets the Type field's value.
+func (s *Operator) SetType(v string) *Operator {
+	s.Type = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *Operator) SetValues(v []*string) *Operator {
+	s.Values = v
+	return s
+}
+
 // The attributes allowed or specified with a parameter object.
 type ParameterAttribute struct {
 	_ struct{} `type:"structure"`
@@ -2458,6 +2710,18 @@ func (s *ParameterAttribute) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *ParameterAttribute) SetKey(v string) *ParameterAttribute {
+	s.Key = &v
+	return s
+}
+
+// SetStringValue sets the StringValue field's value.
+func (s *ParameterAttribute) SetStringValue(v string) *ParameterAttribute {
+	s.StringValue = &v
+	return s
 }
 
 // Contains information about a parameter object.
@@ -2514,6 +2778,18 @@ func (s *ParameterObject) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *ParameterObject) SetAttributes(v []*ParameterAttribute) *ParameterObject {
+	s.Attributes = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ParameterObject) SetId(v string) *ParameterObject {
+	s.Id = &v
+	return s
+}
+
 // A value or list of parameter values.
 type ParameterValue struct {
 	_ struct{} `type:"structure"`
@@ -2558,6 +2834,18 @@ func (s *ParameterValue) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *ParameterValue) SetId(v string) *ParameterValue {
+	s.Id = &v
+	return s
+}
+
+// SetStringValue sets the StringValue field's value.
+func (s *ParameterValue) SetStringValue(v string) *ParameterValue {
+	s.StringValue = &v
+	return s
+}
+
 // Contains pipeline metadata.
 type PipelineDescription struct {
 	_ struct{} `type:"structure"`
@@ -2599,6 +2887,36 @@ func (s PipelineDescription) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *PipelineDescription) SetDescription(v string) *PipelineDescription {
+	s.Description = &v
+	return s
+}
+
+// SetFields sets the Fields field's value.
+func (s *PipelineDescription) SetFields(v []*Field) *PipelineDescription {
+	s.Fields = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PipelineDescription) SetName(v string) *PipelineDescription {
+	s.Name = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *PipelineDescription) SetPipelineId(v string) *PipelineDescription {
+	s.PipelineId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *PipelineDescription) SetTags(v []*Tag) *PipelineDescription {
+	s.Tags = v
+	return s
+}
+
 // Contains the name and identifier of a pipeline.
 type PipelineIdName struct {
 	_ struct{} `type:"structure"`
@@ -2619,6 +2937,18 @@ func (s PipelineIdName) String() string {
 // GoString returns the string representation
 func (s PipelineIdName) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *PipelineIdName) SetId(v string) *PipelineIdName {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PipelineIdName) SetName(v string) *PipelineIdName {
+	s.Name = &v
+	return s
 }
 
 // Contains information about a pipeline object. This can be a logical, physical,
@@ -2688,6 +3018,24 @@ func (s *PipelineObject) Validate() error {
 	return nil
 }
 
+// SetFields sets the Fields field's value.
+func (s *PipelineObject) SetFields(v []*Field) *PipelineObject {
+	s.Fields = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *PipelineObject) SetId(v string) *PipelineObject {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PipelineObject) SetName(v string) *PipelineObject {
+	s.Name = &v
+	return s
+}
+
 // Contains the parameters for PollForTask.
 type PollForTaskInput struct {
 	_ struct{} `type:"structure"`
@@ -2739,6 +3087,24 @@ func (s *PollForTaskInput) Validate() error {
 	return nil
 }
 
+// SetHostname sets the Hostname field's value.
+func (s *PollForTaskInput) SetHostname(v string) *PollForTaskInput {
+	s.Hostname = &v
+	return s
+}
+
+// SetInstanceIdentity sets the InstanceIdentity field's value.
+func (s *PollForTaskInput) SetInstanceIdentity(v *InstanceIdentity) *PollForTaskInput {
+	s.InstanceIdentity = v
+	return s
+}
+
+// SetWorkerGroup sets the WorkerGroup field's value.
+func (s *PollForTaskInput) SetWorkerGroup(v string) *PollForTaskInput {
+	s.WorkerGroup = &v
+	return s
+}
+
 // Contains the output of PollForTask.
 type PollForTaskOutput struct {
 	_ struct{} `type:"structure"`
@@ -2758,6 +3124,12 @@ func (s PollForTaskOutput) String() string {
 // GoString returns the string representation
 func (s PollForTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetTaskObject sets the TaskObject field's value.
+func (s *PollForTaskOutput) SetTaskObject(v *TaskObject) *PollForTaskOutput {
+	s.TaskObject = v
+	return s
 }
 
 // Contains the parameters for PutPipelineDefinition.
@@ -2841,6 +3213,30 @@ func (s *PutPipelineDefinitionInput) Validate() error {
 	return nil
 }
 
+// SetParameterObjects sets the ParameterObjects field's value.
+func (s *PutPipelineDefinitionInput) SetParameterObjects(v []*ParameterObject) *PutPipelineDefinitionInput {
+	s.ParameterObjects = v
+	return s
+}
+
+// SetParameterValues sets the ParameterValues field's value.
+func (s *PutPipelineDefinitionInput) SetParameterValues(v []*ParameterValue) *PutPipelineDefinitionInput {
+	s.ParameterValues = v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *PutPipelineDefinitionInput) SetPipelineId(v string) *PutPipelineDefinitionInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetPipelineObjects sets the PipelineObjects field's value.
+func (s *PutPipelineDefinitionInput) SetPipelineObjects(v []*PipelineObject) *PutPipelineDefinitionInput {
+	s.PipelineObjects = v
+	return s
+}
+
 // Contains the output of PutPipelineDefinition.
 type PutPipelineDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2869,6 +3265,24 @@ func (s PutPipelineDefinitionOutput) GoString() string {
 	return s.String()
 }
 
+// SetErrored sets the Errored field's value.
+func (s *PutPipelineDefinitionOutput) SetErrored(v bool) *PutPipelineDefinitionOutput {
+	s.Errored = &v
+	return s
+}
+
+// SetValidationErrors sets the ValidationErrors field's value.
+func (s *PutPipelineDefinitionOutput) SetValidationErrors(v []*ValidationError) *PutPipelineDefinitionOutput {
+	s.ValidationErrors = v
+	return s
+}
+
+// SetValidationWarnings sets the ValidationWarnings field's value.
+func (s *PutPipelineDefinitionOutput) SetValidationWarnings(v []*ValidationWarning) *PutPipelineDefinitionOutput {
+	s.ValidationWarnings = v
+	return s
+}
+
 // Defines the query to run against an object.
 type Query struct {
 	_ struct{} `type:"structure"`
@@ -2886,6 +3300,12 @@ func (s Query) String() string {
 // GoString returns the string representation
 func (s Query) GoString() string {
 	return s.String()
+}
+
+// SetSelectors sets the Selectors field's value.
+func (s *Query) SetSelectors(v []*Selector) *Query {
+	s.Selectors = v
+	return s
 }
 
 // Contains the parameters for QueryObjects.
@@ -2949,6 +3369,36 @@ func (s *QueryObjectsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *QueryObjectsInput) SetLimit(v int64) *QueryObjectsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *QueryObjectsInput) SetMarker(v string) *QueryObjectsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *QueryObjectsInput) SetPipelineId(v string) *QueryObjectsInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetQuery sets the Query field's value.
+func (s *QueryObjectsInput) SetQuery(v *Query) *QueryObjectsInput {
+	s.Query = v
+	return s
+}
+
+// SetSphere sets the Sphere field's value.
+func (s *QueryObjectsInput) SetSphere(v string) *QueryObjectsInput {
+	s.Sphere = &v
+	return s
+}
+
 // Contains the output of QueryObjects.
 type QueryObjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2974,6 +3424,24 @@ func (s QueryObjectsOutput) String() string {
 // GoString returns the string representation
 func (s QueryObjectsOutput) GoString() string {
 	return s.String()
+}
+
+// SetHasMoreResults sets the HasMoreResults field's value.
+func (s *QueryObjectsOutput) SetHasMoreResults(v bool) *QueryObjectsOutput {
+	s.HasMoreResults = &v
+	return s
+}
+
+// SetIds sets the Ids field's value.
+func (s *QueryObjectsOutput) SetIds(v []*string) *QueryObjectsOutput {
+	s.Ids = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *QueryObjectsOutput) SetMarker(v string) *QueryObjectsOutput {
+	s.Marker = &v
+	return s
 }
 
 // Contains the parameters for RemoveTags.
@@ -3018,6 +3486,18 @@ func (s *RemoveTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *RemoveTagsInput) SetPipelineId(v string) *RemoveTagsInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsInput) SetTagKeys(v []*string) *RemoveTagsInput {
+	s.TagKeys = v
+	return s
 }
 
 // Contains the output of RemoveTags.
@@ -3086,6 +3566,18 @@ func (s *ReportTaskProgressInput) Validate() error {
 	return nil
 }
 
+// SetFields sets the Fields field's value.
+func (s *ReportTaskProgressInput) SetFields(v []*Field) *ReportTaskProgressInput {
+	s.Fields = v
+	return s
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *ReportTaskProgressInput) SetTaskId(v string) *ReportTaskProgressInput {
+	s.TaskId = &v
+	return s
+}
+
 // Contains the output of ReportTaskProgress.
 type ReportTaskProgressOutput struct {
 	_ struct{} `type:"structure"`
@@ -3105,6 +3597,12 @@ func (s ReportTaskProgressOutput) String() string {
 // GoString returns the string representation
 func (s ReportTaskProgressOutput) GoString() string {
 	return s.String()
+}
+
+// SetCanceled sets the Canceled field's value.
+func (s *ReportTaskProgressOutput) SetCanceled(v bool) *ReportTaskProgressOutput {
+	s.Canceled = &v
+	return s
 }
 
 // Contains the parameters for ReportTaskRunnerHeartbeat.
@@ -3160,6 +3658,24 @@ func (s *ReportTaskRunnerHeartbeatInput) Validate() error {
 	return nil
 }
 
+// SetHostname sets the Hostname field's value.
+func (s *ReportTaskRunnerHeartbeatInput) SetHostname(v string) *ReportTaskRunnerHeartbeatInput {
+	s.Hostname = &v
+	return s
+}
+
+// SetTaskrunnerId sets the TaskrunnerId field's value.
+func (s *ReportTaskRunnerHeartbeatInput) SetTaskrunnerId(v string) *ReportTaskRunnerHeartbeatInput {
+	s.TaskrunnerId = &v
+	return s
+}
+
+// SetWorkerGroup sets the WorkerGroup field's value.
+func (s *ReportTaskRunnerHeartbeatInput) SetWorkerGroup(v string) *ReportTaskRunnerHeartbeatInput {
+	s.WorkerGroup = &v
+	return s
+}
+
 // Contains the output of ReportTaskRunnerHeartbeat.
 type ReportTaskRunnerHeartbeatOutput struct {
 	_ struct{} `type:"structure"`
@@ -3178,6 +3694,12 @@ func (s ReportTaskRunnerHeartbeatOutput) String() string {
 // GoString returns the string representation
 func (s ReportTaskRunnerHeartbeatOutput) GoString() string {
 	return s.String()
+}
+
+// SetTerminate sets the Terminate field's value.
+func (s *ReportTaskRunnerHeartbeatOutput) SetTerminate(v bool) *ReportTaskRunnerHeartbeatOutput {
+	s.Terminate = &v
+	return s
 }
 
 // A comparision that is used to determine whether a query should return this
@@ -3204,6 +3726,18 @@ func (s Selector) String() string {
 // GoString returns the string representation
 func (s Selector) GoString() string {
 	return s.String()
+}
+
+// SetFieldName sets the FieldName field's value.
+func (s *Selector) SetFieldName(v string) *Selector {
+	s.FieldName = &v
+	return s
+}
+
+// SetOperator sets the Operator field's value.
+func (s *Selector) SetOperator(v *Operator) *Selector {
+	s.Operator = v
+	return s
 }
 
 // Contains the parameters for SetStatus.
@@ -3258,6 +3792,24 @@ func (s *SetStatusInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetObjectIds sets the ObjectIds field's value.
+func (s *SetStatusInput) SetObjectIds(v []*string) *SetStatusInput {
+	s.ObjectIds = v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *SetStatusInput) SetPipelineId(v string) *SetStatusInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SetStatusInput) SetStatus(v string) *SetStatusInput {
+	s.Status = &v
+	return s
 }
 
 type SetStatusOutput struct {
@@ -3338,6 +3890,36 @@ func (s *SetTaskStatusInput) Validate() error {
 	return nil
 }
 
+// SetErrorId sets the ErrorId field's value.
+func (s *SetTaskStatusInput) SetErrorId(v string) *SetTaskStatusInput {
+	s.ErrorId = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *SetTaskStatusInput) SetErrorMessage(v string) *SetTaskStatusInput {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetErrorStackTrace sets the ErrorStackTrace field's value.
+func (s *SetTaskStatusInput) SetErrorStackTrace(v string) *SetTaskStatusInput {
+	s.ErrorStackTrace = &v
+	return s
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *SetTaskStatusInput) SetTaskId(v string) *SetTaskStatusInput {
+	s.TaskId = &v
+	return s
+}
+
+// SetTaskStatus sets the TaskStatus field's value.
+func (s *SetTaskStatusInput) SetTaskStatus(v string) *SetTaskStatusInput {
+	s.TaskStatus = &v
+	return s
+}
+
 // Contains the output of SetTaskStatus.
 type SetTaskStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -3405,6 +3987,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // Contains information about a pipeline task that is assigned to a task runner.
 type TaskObject struct {
 	_ struct{} `type:"structure"`
@@ -3433,6 +4027,30 @@ func (s TaskObject) String() string {
 // GoString returns the string representation
 func (s TaskObject) GoString() string {
 	return s.String()
+}
+
+// SetAttemptId sets the AttemptId field's value.
+func (s *TaskObject) SetAttemptId(v string) *TaskObject {
+	s.AttemptId = &v
+	return s
+}
+
+// SetObjects sets the Objects field's value.
+func (s *TaskObject) SetObjects(v map[string]*PipelineObject) *TaskObject {
+	s.Objects = v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *TaskObject) SetPipelineId(v string) *TaskObject {
+	s.PipelineId = &v
+	return s
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *TaskObject) SetTaskId(v string) *TaskObject {
+	s.TaskId = &v
+	return s
 }
 
 // Contains the parameters for ValidatePipelineDefinition.
@@ -3515,6 +4133,30 @@ func (s *ValidatePipelineDefinitionInput) Validate() error {
 	return nil
 }
 
+// SetParameterObjects sets the ParameterObjects field's value.
+func (s *ValidatePipelineDefinitionInput) SetParameterObjects(v []*ParameterObject) *ValidatePipelineDefinitionInput {
+	s.ParameterObjects = v
+	return s
+}
+
+// SetParameterValues sets the ParameterValues field's value.
+func (s *ValidatePipelineDefinitionInput) SetParameterValues(v []*ParameterValue) *ValidatePipelineDefinitionInput {
+	s.ParameterValues = v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *ValidatePipelineDefinitionInput) SetPipelineId(v string) *ValidatePipelineDefinitionInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetPipelineObjects sets the PipelineObjects field's value.
+func (s *ValidatePipelineDefinitionInput) SetPipelineObjects(v []*PipelineObject) *ValidatePipelineDefinitionInput {
+	s.PipelineObjects = v
+	return s
+}
+
 // Contains the output of ValidatePipelineDefinition.
 type ValidatePipelineDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -3541,6 +4183,24 @@ func (s ValidatePipelineDefinitionOutput) GoString() string {
 	return s.String()
 }
 
+// SetErrored sets the Errored field's value.
+func (s *ValidatePipelineDefinitionOutput) SetErrored(v bool) *ValidatePipelineDefinitionOutput {
+	s.Errored = &v
+	return s
+}
+
+// SetValidationErrors sets the ValidationErrors field's value.
+func (s *ValidatePipelineDefinitionOutput) SetValidationErrors(v []*ValidationError) *ValidatePipelineDefinitionOutput {
+	s.ValidationErrors = v
+	return s
+}
+
+// SetValidationWarnings sets the ValidationWarnings field's value.
+func (s *ValidatePipelineDefinitionOutput) SetValidationWarnings(v []*ValidationWarning) *ValidatePipelineDefinitionOutput {
+	s.ValidationWarnings = v
+	return s
+}
+
 // Defines a validation error. Validation errors prevent pipeline activation.
 // The set of validation errors that can be returned are defined by AWS Data
 // Pipeline.
@@ -3564,6 +4224,18 @@ func (s ValidationError) GoString() string {
 	return s.String()
 }
 
+// SetErrors sets the Errors field's value.
+func (s *ValidationError) SetErrors(v []*string) *ValidationError {
+	s.Errors = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ValidationError) SetId(v string) *ValidationError {
+	s.Id = &v
+	return s
+}
+
 // Defines a validation warning. Validation warnings do not prevent pipeline
 // activation. The set of validation warnings that can be returned are defined
 // by AWS Data Pipeline.
@@ -3585,6 +4257,18 @@ func (s ValidationWarning) String() string {
 // GoString returns the string representation
 func (s ValidationWarning) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *ValidationWarning) SetId(v string) *ValidationWarning {
+	s.Id = &v
+	return s
+}
+
+// SetWarnings sets the Warnings field's value.
+func (s *ValidationWarning) SetWarnings(v []*string) *ValidationWarning {
+	s.Warnings = v
+	return s
 }
 
 const (

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -3670,6 +3670,24 @@ func (s AccountSettings) GoString() string {
 	return s.String()
 }
 
+// SetAwsAccountNumber sets the AwsAccountNumber field's value.
+func (s *AccountSettings) SetAwsAccountNumber(v string) *AccountSettings {
+	s.AwsAccountNumber = &v
+	return s
+}
+
+// SetUnmeteredDevices sets the UnmeteredDevices field's value.
+func (s *AccountSettings) SetUnmeteredDevices(v map[string]*int64) *AccountSettings {
+	s.UnmeteredDevices = v
+	return s
+}
+
+// SetUnmeteredRemoteAccessDevices sets the UnmeteredRemoteAccessDevices field's value.
+func (s *AccountSettings) SetUnmeteredRemoteAccessDevices(v map[string]*int64) *AccountSettings {
+	s.UnmeteredRemoteAccessDevices = v
+	return s
+}
+
 // Represents the output of a test. Examples of artifacts include logs and screenshots.
 type Artifact struct {
 	_ struct{} `type:"structure"`
@@ -3750,6 +3768,36 @@ func (s Artifact) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Artifact) SetArn(v string) *Artifact {
+	s.Arn = &v
+	return s
+}
+
+// SetExtension sets the Extension field's value.
+func (s *Artifact) SetExtension(v string) *Artifact {
+	s.Extension = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Artifact) SetName(v string) *Artifact {
+	s.Name = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Artifact) SetType(v string) *Artifact {
+	s.Type = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *Artifact) SetUrl(v string) *Artifact {
+	s.Url = &v
+	return s
+}
+
 // Represents the amount of CPU that an app is using on a physical device.
 //
 // Note that this does not represent system-wide CPU usage.
@@ -3775,6 +3823,24 @@ func (s CPU) String() string {
 // GoString returns the string representation
 func (s CPU) GoString() string {
 	return s.String()
+}
+
+// SetArchitecture sets the Architecture field's value.
+func (s *CPU) SetArchitecture(v string) *CPU {
+	s.Architecture = &v
+	return s
+}
+
+// SetClock sets the Clock field's value.
+func (s *CPU) SetClock(v float64) *CPU {
+	s.Clock = &v
+	return s
+}
+
+// SetFrequency sets the Frequency field's value.
+func (s *CPU) SetFrequency(v string) *CPU {
+	s.Frequency = &v
+	return s
 }
 
 // Represents entity counters.
@@ -3811,6 +3877,48 @@ func (s Counters) String() string {
 // GoString returns the string representation
 func (s Counters) GoString() string {
 	return s.String()
+}
+
+// SetErrored sets the Errored field's value.
+func (s *Counters) SetErrored(v int64) *Counters {
+	s.Errored = &v
+	return s
+}
+
+// SetFailed sets the Failed field's value.
+func (s *Counters) SetFailed(v int64) *Counters {
+	s.Failed = &v
+	return s
+}
+
+// SetPassed sets the Passed field's value.
+func (s *Counters) SetPassed(v int64) *Counters {
+	s.Passed = &v
+	return s
+}
+
+// SetSkipped sets the Skipped field's value.
+func (s *Counters) SetSkipped(v int64) *Counters {
+	s.Skipped = &v
+	return s
+}
+
+// SetStopped sets the Stopped field's value.
+func (s *Counters) SetStopped(v int64) *Counters {
+	s.Stopped = &v
+	return s
+}
+
+// SetTotal sets the Total field's value.
+func (s *Counters) SetTotal(v int64) *Counters {
+	s.Total = &v
+	return s
+}
+
+// SetWarned sets the Warned field's value.
+func (s *Counters) SetWarned(v int64) *Counters {
+	s.Warned = &v
+	return s
 }
 
 // Represents a request to the create device pool operation.
@@ -3868,6 +3976,30 @@ func (s *CreateDevicePoolInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateDevicePoolInput) SetDescription(v string) *CreateDevicePoolInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateDevicePoolInput) SetName(v string) *CreateDevicePoolInput {
+	s.Name = &v
+	return s
+}
+
+// SetProjectArn sets the ProjectArn field's value.
+func (s *CreateDevicePoolInput) SetProjectArn(v string) *CreateDevicePoolInput {
+	s.ProjectArn = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *CreateDevicePoolInput) SetRules(v []*Rule) *CreateDevicePoolInput {
+	s.Rules = v
+	return s
+}
+
 // Represents the result of a create device pool request.
 type CreateDevicePoolOutput struct {
 	_ struct{} `type:"structure"`
@@ -3884,6 +4016,12 @@ func (s CreateDevicePoolOutput) String() string {
 // GoString returns the string representation
 func (s CreateDevicePoolOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevicePool sets the DevicePool field's value.
+func (s *CreateDevicePoolOutput) SetDevicePool(v *DevicePool) *CreateDevicePoolOutput {
+	s.DevicePool = v
+	return s
 }
 
 // Represents a request to the create project operation.
@@ -3919,6 +4057,12 @@ func (s *CreateProjectInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *CreateProjectInput) SetName(v string) *CreateProjectInput {
+	s.Name = &v
+	return s
+}
+
 // Represents the result of a create project request.
 type CreateProjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -3935,6 +4079,12 @@ func (s CreateProjectOutput) String() string {
 // GoString returns the string representation
 func (s CreateProjectOutput) GoString() string {
 	return s.String()
+}
+
+// SetProject sets the Project field's value.
+func (s *CreateProjectOutput) SetProject(v *Project) *CreateProjectOutput {
+	s.Project = v
+	return s
 }
 
 // Creates the configuration settings for a remote access session, including
@@ -3954,6 +4104,12 @@ func (s CreateRemoteAccessSessionConfiguration) String() string {
 // GoString returns the string representation
 func (s CreateRemoteAccessSessionConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetBillingMethod sets the BillingMethod field's value.
+func (s *CreateRemoteAccessSessionConfiguration) SetBillingMethod(v string) *CreateRemoteAccessSessionConfiguration {
+	s.BillingMethod = &v
+	return s
 }
 
 // Creates and submits a request to start a remote access session.
@@ -4011,6 +4167,30 @@ func (s *CreateRemoteAccessSessionInput) Validate() error {
 	return nil
 }
 
+// SetConfiguration sets the Configuration field's value.
+func (s *CreateRemoteAccessSessionInput) SetConfiguration(v *CreateRemoteAccessSessionConfiguration) *CreateRemoteAccessSessionInput {
+	s.Configuration = v
+	return s
+}
+
+// SetDeviceArn sets the DeviceArn field's value.
+func (s *CreateRemoteAccessSessionInput) SetDeviceArn(v string) *CreateRemoteAccessSessionInput {
+	s.DeviceArn = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateRemoteAccessSessionInput) SetName(v string) *CreateRemoteAccessSessionInput {
+	s.Name = &v
+	return s
+}
+
+// SetProjectArn sets the ProjectArn field's value.
+func (s *CreateRemoteAccessSessionInput) SetProjectArn(v string) *CreateRemoteAccessSessionInput {
+	s.ProjectArn = &v
+	return s
+}
+
 // Represents the server response from a request to create a remote access session.
 type CreateRemoteAccessSessionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4028,6 +4208,12 @@ func (s CreateRemoteAccessSessionOutput) String() string {
 // GoString returns the string representation
 func (s CreateRemoteAccessSessionOutput) GoString() string {
 	return s.String()
+}
+
+// SetRemoteAccessSession sets the RemoteAccessSession field's value.
+func (s *CreateRemoteAccessSessionOutput) SetRemoteAccessSession(v *RemoteAccessSession) *CreateRemoteAccessSessionOutput {
+	s.RemoteAccessSession = v
+	return s
 }
 
 // Represents a request to the create upload operation.
@@ -4128,6 +4314,30 @@ func (s *CreateUploadInput) Validate() error {
 	return nil
 }
 
+// SetContentType sets the ContentType field's value.
+func (s *CreateUploadInput) SetContentType(v string) *CreateUploadInput {
+	s.ContentType = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateUploadInput) SetName(v string) *CreateUploadInput {
+	s.Name = &v
+	return s
+}
+
+// SetProjectArn sets the ProjectArn field's value.
+func (s *CreateUploadInput) SetProjectArn(v string) *CreateUploadInput {
+	s.ProjectArn = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CreateUploadInput) SetType(v string) *CreateUploadInput {
+	s.Type = &v
+	return s
+}
+
 // Represents the result of a create upload request.
 type CreateUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -4144,6 +4354,12 @@ func (s CreateUploadOutput) String() string {
 // GoString returns the string representation
 func (s CreateUploadOutput) GoString() string {
 	return s.String()
+}
+
+// SetUpload sets the Upload field's value.
+func (s *CreateUploadOutput) SetUpload(v *Upload) *CreateUploadOutput {
+	s.Upload = v
+	return s
 }
 
 // Represents a request to the delete device pool operation.
@@ -4181,6 +4397,12 @@ func (s *DeleteDevicePoolInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetArn sets the Arn field's value.
+func (s *DeleteDevicePoolInput) SetArn(v string) *DeleteDevicePoolInput {
+	s.Arn = &v
+	return s
 }
 
 // Represents the result of a delete device pool request.
@@ -4235,6 +4457,12 @@ func (s *DeleteProjectInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *DeleteProjectInput) SetArn(v string) *DeleteProjectInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a delete project request.
 type DeleteProjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -4285,6 +4513,12 @@ func (s *DeleteRemoteAccessSessionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetArn sets the Arn field's value.
+func (s *DeleteRemoteAccessSessionInput) SetArn(v string) *DeleteRemoteAccessSessionInput {
+	s.Arn = &v
+	return s
 }
 
 // The response from the server when a request is made to delete the remote
@@ -4339,6 +4573,12 @@ func (s *DeleteRunInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *DeleteRunInput) SetArn(v string) *DeleteRunInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a delete run request.
 type DeleteRunOutput struct {
 	_ struct{} `type:"structure"`
@@ -4389,6 +4629,12 @@ func (s *DeleteUploadInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetArn sets the Arn field's value.
+func (s *DeleteUploadInput) SetArn(v string) *DeleteUploadInput {
+	s.Arn = &v
+	return s
 }
 
 // Represents the result of a delete upload request.
@@ -4486,6 +4732,108 @@ func (s Device) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Device) SetArn(v string) *Device {
+	s.Arn = &v
+	return s
+}
+
+// SetCarrier sets the Carrier field's value.
+func (s *Device) SetCarrier(v string) *Device {
+	s.Carrier = &v
+	return s
+}
+
+// SetCpu sets the Cpu field's value.
+func (s *Device) SetCpu(v *CPU) *Device {
+	s.Cpu = v
+	return s
+}
+
+// SetFleetName sets the FleetName field's value.
+func (s *Device) SetFleetName(v string) *Device {
+	s.FleetName = &v
+	return s
+}
+
+// SetFleetType sets the FleetType field's value.
+func (s *Device) SetFleetType(v string) *Device {
+	s.FleetType = &v
+	return s
+}
+
+// SetFormFactor sets the FormFactor field's value.
+func (s *Device) SetFormFactor(v string) *Device {
+	s.FormFactor = &v
+	return s
+}
+
+// SetHeapSize sets the HeapSize field's value.
+func (s *Device) SetHeapSize(v int64) *Device {
+	s.HeapSize = &v
+	return s
+}
+
+// SetImage sets the Image field's value.
+func (s *Device) SetImage(v string) *Device {
+	s.Image = &v
+	return s
+}
+
+// SetManufacturer sets the Manufacturer field's value.
+func (s *Device) SetManufacturer(v string) *Device {
+	s.Manufacturer = &v
+	return s
+}
+
+// SetMemory sets the Memory field's value.
+func (s *Device) SetMemory(v int64) *Device {
+	s.Memory = &v
+	return s
+}
+
+// SetModel sets the Model field's value.
+func (s *Device) SetModel(v string) *Device {
+	s.Model = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Device) SetName(v string) *Device {
+	s.Name = &v
+	return s
+}
+
+// SetOs sets the Os field's value.
+func (s *Device) SetOs(v string) *Device {
+	s.Os = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *Device) SetPlatform(v string) *Device {
+	s.Platform = &v
+	return s
+}
+
+// SetRadio sets the Radio field's value.
+func (s *Device) SetRadio(v string) *Device {
+	s.Radio = &v
+	return s
+}
+
+// SetRemoteAccessEnabled sets the RemoteAccessEnabled field's value.
+func (s *Device) SetRemoteAccessEnabled(v bool) *Device {
+	s.RemoteAccessEnabled = &v
+	return s
+}
+
+// SetResolution sets the Resolution field's value.
+func (s *Device) SetResolution(v *Resolution) *Device {
+	s.Resolution = v
+	return s
+}
+
 // Represents the total (metered or unmetered) minutes used by the resource
 // to run tests. Contains the sum of minutes consumed by all children.
 type DeviceMinutes struct {
@@ -4512,6 +4860,24 @@ func (s DeviceMinutes) String() string {
 // GoString returns the string representation
 func (s DeviceMinutes) GoString() string {
 	return s.String()
+}
+
+// SetMetered sets the Metered field's value.
+func (s *DeviceMinutes) SetMetered(v float64) *DeviceMinutes {
+	s.Metered = &v
+	return s
+}
+
+// SetTotal sets the Total field's value.
+func (s *DeviceMinutes) SetTotal(v float64) *DeviceMinutes {
+	s.Total = &v
+	return s
+}
+
+// SetUnmetered sets the Unmetered field's value.
+func (s *DeviceMinutes) SetUnmetered(v float64) *DeviceMinutes {
+	s.Unmetered = &v
+	return s
 }
 
 // Represents a collection of device types.
@@ -4551,6 +4917,36 @@ func (s DevicePool) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *DevicePool) SetArn(v string) *DevicePool {
+	s.Arn = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DevicePool) SetDescription(v string) *DevicePool {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DevicePool) SetName(v string) *DevicePool {
+	s.Name = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *DevicePool) SetRules(v []*Rule) *DevicePool {
+	s.Rules = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *DevicePool) SetType(v string) *DevicePool {
+	s.Type = &v
+	return s
+}
+
 // Represents a device pool compatibility result.
 type DevicePoolCompatibilityResult struct {
 	_ struct{} `type:"structure"`
@@ -4573,6 +4969,24 @@ func (s DevicePoolCompatibilityResult) String() string {
 // GoString returns the string representation
 func (s DevicePoolCompatibilityResult) GoString() string {
 	return s.String()
+}
+
+// SetCompatible sets the Compatible field's value.
+func (s *DevicePoolCompatibilityResult) SetCompatible(v bool) *DevicePoolCompatibilityResult {
+	s.Compatible = &v
+	return s
+}
+
+// SetDevice sets the Device field's value.
+func (s *DevicePoolCompatibilityResult) SetDevice(v *Device) *DevicePoolCompatibilityResult {
+	s.Device = v
+	return s
+}
+
+// SetIncompatibilityMessages sets the IncompatibilityMessages field's value.
+func (s *DevicePoolCompatibilityResult) SetIncompatibilityMessages(v []*IncompatibilityMessage) *DevicePoolCompatibilityResult {
+	s.IncompatibilityMessages = v
+	return s
 }
 
 // Represents the request sent to retrieve the account settings.
@@ -4607,6 +5021,12 @@ func (s GetAccountSettingsOutput) String() string {
 // GoString returns the string representation
 func (s GetAccountSettingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccountSettings sets the AccountSettings field's value.
+func (s *GetAccountSettingsOutput) SetAccountSettings(v *AccountSettings) *GetAccountSettingsOutput {
+	s.AccountSettings = v
+	return s
 }
 
 // Represents a request to the get device request.
@@ -4645,6 +5065,12 @@ func (s *GetDeviceInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetDeviceInput) SetArn(v string) *GetDeviceInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a get device request.
 type GetDeviceOutput struct {
 	_ struct{} `type:"structure"`
@@ -4661,6 +5087,12 @@ func (s GetDeviceOutput) String() string {
 // GoString returns the string representation
 func (s GetDeviceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevice sets the Device field's value.
+func (s *GetDeviceOutput) SetDevice(v *Device) *GetDeviceOutput {
+	s.Device = v
+	return s
 }
 
 // Represents a request to the get device pool compatibility operation.
@@ -4740,6 +5172,24 @@ func (s *GetDevicePoolCompatibilityInput) Validate() error {
 	return nil
 }
 
+// SetAppArn sets the AppArn field's value.
+func (s *GetDevicePoolCompatibilityInput) SetAppArn(v string) *GetDevicePoolCompatibilityInput {
+	s.AppArn = &v
+	return s
+}
+
+// SetDevicePoolArn sets the DevicePoolArn field's value.
+func (s *GetDevicePoolCompatibilityInput) SetDevicePoolArn(v string) *GetDevicePoolCompatibilityInput {
+	s.DevicePoolArn = &v
+	return s
+}
+
+// SetTestType sets the TestType field's value.
+func (s *GetDevicePoolCompatibilityInput) SetTestType(v string) *GetDevicePoolCompatibilityInput {
+	s.TestType = &v
+	return s
+}
+
 // Represents the result of describe device pool compatibility request.
 type GetDevicePoolCompatibilityOutput struct {
 	_ struct{} `type:"structure"`
@@ -4759,6 +5209,18 @@ func (s GetDevicePoolCompatibilityOutput) String() string {
 // GoString returns the string representation
 func (s GetDevicePoolCompatibilityOutput) GoString() string {
 	return s.String()
+}
+
+// SetCompatibleDevices sets the CompatibleDevices field's value.
+func (s *GetDevicePoolCompatibilityOutput) SetCompatibleDevices(v []*DevicePoolCompatibilityResult) *GetDevicePoolCompatibilityOutput {
+	s.CompatibleDevices = v
+	return s
+}
+
+// SetIncompatibleDevices sets the IncompatibleDevices field's value.
+func (s *GetDevicePoolCompatibilityOutput) SetIncompatibleDevices(v []*DevicePoolCompatibilityResult) *GetDevicePoolCompatibilityOutput {
+	s.IncompatibleDevices = v
+	return s
 }
 
 // Represents a request to the get device pool operation.
@@ -4797,6 +5259,12 @@ func (s *GetDevicePoolInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetDevicePoolInput) SetArn(v string) *GetDevicePoolInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a get device pool request.
 type GetDevicePoolOutput struct {
 	_ struct{} `type:"structure"`
@@ -4813,6 +5281,12 @@ func (s GetDevicePoolOutput) String() string {
 // GoString returns the string representation
 func (s GetDevicePoolOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevicePool sets the DevicePool field's value.
+func (s *GetDevicePoolOutput) SetDevicePool(v *DevicePool) *GetDevicePoolOutput {
+	s.DevicePool = v
+	return s
 }
 
 // Represents a request to the get job operation.
@@ -4851,6 +5325,12 @@ func (s *GetJobInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetJobInput) SetArn(v string) *GetJobInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a get job request.
 type GetJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -4867,6 +5347,12 @@ func (s GetJobOutput) String() string {
 // GoString returns the string representation
 func (s GetJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetJob sets the Job field's value.
+func (s *GetJobOutput) SetJob(v *Job) *GetJobOutput {
+	s.Job = v
+	return s
 }
 
 // Represents the request to retrieve the offering status for the specified
@@ -4902,6 +5388,12 @@ func (s *GetOfferingStatusInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *GetOfferingStatusInput) SetNextToken(v string) *GetOfferingStatusInput {
+	s.NextToken = &v
+	return s
+}
+
 // Returns the status result for a device offering.
 type GetOfferingStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -4925,6 +5417,24 @@ func (s GetOfferingStatusOutput) String() string {
 // GoString returns the string representation
 func (s GetOfferingStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetCurrent sets the Current field's value.
+func (s *GetOfferingStatusOutput) SetCurrent(v map[string]*OfferingStatus) *GetOfferingStatusOutput {
+	s.Current = v
+	return s
+}
+
+// SetNextPeriod sets the NextPeriod field's value.
+func (s *GetOfferingStatusOutput) SetNextPeriod(v map[string]*OfferingStatus) *GetOfferingStatusOutput {
+	s.NextPeriod = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetOfferingStatusOutput) SetNextToken(v string) *GetOfferingStatusOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents a request to the get project operation.
@@ -4963,6 +5473,12 @@ func (s *GetProjectInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetProjectInput) SetArn(v string) *GetProjectInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a get project request.
 type GetProjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -4980,6 +5496,12 @@ func (s GetProjectOutput) String() string {
 // GoString returns the string representation
 func (s GetProjectOutput) GoString() string {
 	return s.String()
+}
+
+// SetProject sets the Project field's value.
+func (s *GetProjectOutput) SetProject(v *Project) *GetProjectOutput {
+	s.Project = v
+	return s
 }
 
 // Represents the request to get information about the specified remote access
@@ -5020,6 +5542,12 @@ func (s *GetRemoteAccessSessionInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetRemoteAccessSessionInput) SetArn(v string) *GetRemoteAccessSessionInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the response from the server that lists detailed information about
 // the remote access session.
 type GetRemoteAccessSessionOutput struct {
@@ -5037,6 +5565,12 @@ func (s GetRemoteAccessSessionOutput) String() string {
 // GoString returns the string representation
 func (s GetRemoteAccessSessionOutput) GoString() string {
 	return s.String()
+}
+
+// SetRemoteAccessSession sets the RemoteAccessSession field's value.
+func (s *GetRemoteAccessSessionOutput) SetRemoteAccessSession(v *RemoteAccessSession) *GetRemoteAccessSessionOutput {
+	s.RemoteAccessSession = v
+	return s
 }
 
 // Represents a request to the get run operation.
@@ -5075,6 +5609,12 @@ func (s *GetRunInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetRunInput) SetArn(v string) *GetRunInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a get run request.
 type GetRunOutput struct {
 	_ struct{} `type:"structure"`
@@ -5091,6 +5631,12 @@ func (s GetRunOutput) String() string {
 // GoString returns the string representation
 func (s GetRunOutput) GoString() string {
 	return s.String()
+}
+
+// SetRun sets the Run field's value.
+func (s *GetRunOutput) SetRun(v *Run) *GetRunOutput {
+	s.Run = v
+	return s
 }
 
 // Represents a request to the get suite operation.
@@ -5129,6 +5675,12 @@ func (s *GetSuiteInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetSuiteInput) SetArn(v string) *GetSuiteInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a get suite request.
 type GetSuiteOutput struct {
 	_ struct{} `type:"structure"`
@@ -5145,6 +5697,12 @@ func (s GetSuiteOutput) String() string {
 // GoString returns the string representation
 func (s GetSuiteOutput) GoString() string {
 	return s.String()
+}
+
+// SetSuite sets the Suite field's value.
+func (s *GetSuiteOutput) SetSuite(v *Suite) *GetSuiteOutput {
+	s.Suite = v
+	return s
 }
 
 // Represents a request to the get test operation.
@@ -5183,6 +5741,12 @@ func (s *GetTestInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetTestInput) SetArn(v string) *GetTestInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a get test request.
 type GetTestOutput struct {
 	_ struct{} `type:"structure"`
@@ -5199,6 +5763,12 @@ func (s GetTestOutput) String() string {
 // GoString returns the string representation
 func (s GetTestOutput) GoString() string {
 	return s.String()
+}
+
+// SetTest sets the Test field's value.
+func (s *GetTestOutput) SetTest(v *Test) *GetTestOutput {
+	s.Test = v
+	return s
 }
 
 // Represents a request to the get upload operation.
@@ -5237,6 +5807,12 @@ func (s *GetUploadInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *GetUploadInput) SetArn(v string) *GetUploadInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the result of a get upload request.
 type GetUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -5253,6 +5829,12 @@ func (s GetUploadOutput) String() string {
 // GoString returns the string representation
 func (s GetUploadOutput) GoString() string {
 	return s.String()
+}
+
+// SetUpload sets the Upload field's value.
+func (s *GetUploadOutput) SetUpload(v *Upload) *GetUploadOutput {
+	s.Upload = v
+	return s
 }
 
 // Represents information about incompatibility.
@@ -5284,6 +5866,18 @@ func (s IncompatibilityMessage) String() string {
 // GoString returns the string representation
 func (s IncompatibilityMessage) GoString() string {
 	return s.String()
+}
+
+// SetMessage sets the Message field's value.
+func (s *IncompatibilityMessage) SetMessage(v string) *IncompatibilityMessage {
+	s.Message = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *IncompatibilityMessage) SetType(v string) *IncompatibilityMessage {
+	s.Type = &v
+	return s
 }
 
 // Represents the request to install an Android application (in .apk format)
@@ -5336,6 +5930,18 @@ func (s *InstallToRemoteAccessSessionInput) Validate() error {
 	return nil
 }
 
+// SetAppArn sets the AppArn field's value.
+func (s *InstallToRemoteAccessSessionInput) SetAppArn(v string) *InstallToRemoteAccessSessionInput {
+	s.AppArn = &v
+	return s
+}
+
+// SetRemoteAccessSessionArn sets the RemoteAccessSessionArn field's value.
+func (s *InstallToRemoteAccessSessionInput) SetRemoteAccessSessionArn(v string) *InstallToRemoteAccessSessionInput {
+	s.RemoteAccessSessionArn = &v
+	return s
+}
+
 // Represents the response from the server after AWS Device Farm makes a request
 // to install to a remote access session.
 type InstallToRemoteAccessSessionOutput struct {
@@ -5353,6 +5959,12 @@ func (s InstallToRemoteAccessSessionOutput) String() string {
 // GoString returns the string representation
 func (s InstallToRemoteAccessSessionOutput) GoString() string {
 	return s.String()
+}
+
+// SetAppUpload sets the AppUpload field's value.
+func (s *InstallToRemoteAccessSessionOutput) SetAppUpload(v *Upload) *InstallToRemoteAccessSessionOutput {
+	s.AppUpload = v
+	return s
 }
 
 // Represents a device.
@@ -5474,6 +6086,78 @@ func (s Job) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Job) SetArn(v string) *Job {
+	s.Arn = &v
+	return s
+}
+
+// SetCounters sets the Counters field's value.
+func (s *Job) SetCounters(v *Counters) *Job {
+	s.Counters = v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *Job) SetCreated(v time.Time) *Job {
+	s.Created = &v
+	return s
+}
+
+// SetDevice sets the Device field's value.
+func (s *Job) SetDevice(v *Device) *Job {
+	s.Device = v
+	return s
+}
+
+// SetDeviceMinutes sets the DeviceMinutes field's value.
+func (s *Job) SetDeviceMinutes(v *DeviceMinutes) *Job {
+	s.DeviceMinutes = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Job) SetMessage(v string) *Job {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Job) SetName(v string) *Job {
+	s.Name = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *Job) SetResult(v string) *Job {
+	s.Result = &v
+	return s
+}
+
+// SetStarted sets the Started field's value.
+func (s *Job) SetStarted(v time.Time) *Job {
+	s.Started = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Job) SetStatus(v string) *Job {
+	s.Status = &v
+	return s
+}
+
+// SetStopped sets the Stopped field's value.
+func (s *Job) SetStopped(v time.Time) *Job {
+	s.Stopped = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Job) SetType(v string) *Job {
+	s.Type = &v
+	return s
+}
+
 // Represents a request to the list artifacts operation.
 type ListArtifactsInput struct {
 	_ struct{} `type:"structure"`
@@ -5533,6 +6217,24 @@ func (s *ListArtifactsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListArtifactsInput) SetArn(v string) *ListArtifactsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListArtifactsInput) SetNextToken(v string) *ListArtifactsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ListArtifactsInput) SetType(v string) *ListArtifactsInput {
+	s.Type = &v
+	return s
+}
+
 // Represents the result of a list artifacts operation.
 type ListArtifactsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5554,6 +6256,18 @@ func (s ListArtifactsOutput) String() string {
 // GoString returns the string representation
 func (s ListArtifactsOutput) GoString() string {
 	return s.String()
+}
+
+// SetArtifacts sets the Artifacts field's value.
+func (s *ListArtifactsOutput) SetArtifacts(v []*Artifact) *ListArtifactsOutput {
+	s.Artifacts = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListArtifactsOutput) SetNextToken(v string) *ListArtifactsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the result of a list device pools request.
@@ -5609,6 +6323,24 @@ func (s *ListDevicePoolsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListDevicePoolsInput) SetArn(v string) *ListDevicePoolsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDevicePoolsInput) SetNextToken(v string) *ListDevicePoolsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ListDevicePoolsInput) SetType(v string) *ListDevicePoolsInput {
+	s.Type = &v
+	return s
+}
+
 // Represents the result of a list device pools request.
 type ListDevicePoolsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5630,6 +6362,18 @@ func (s ListDevicePoolsOutput) String() string {
 // GoString returns the string representation
 func (s ListDevicePoolsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevicePools sets the DevicePools field's value.
+func (s *ListDevicePoolsOutput) SetDevicePools(v []*DevicePool) *ListDevicePoolsOutput {
+	s.DevicePools = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDevicePoolsOutput) SetNextToken(v string) *ListDevicePoolsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the result of a list devices request.
@@ -5670,6 +6414,18 @@ func (s *ListDevicesInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListDevicesInput) SetArn(v string) *ListDevicesInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDevicesInput) SetNextToken(v string) *ListDevicesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list devices operation.
 type ListDevicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5691,6 +6447,18 @@ func (s ListDevicesOutput) String() string {
 // GoString returns the string representation
 func (s ListDevicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevices sets the Devices field's value.
+func (s *ListDevicesOutput) SetDevices(v []*Device) *ListDevicesOutput {
+	s.Devices = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDevicesOutput) SetNextToken(v string) *ListDevicesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents a request to the list jobs operation.
@@ -5736,6 +6504,18 @@ func (s *ListJobsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListJobsInput) SetArn(v string) *ListJobsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobsInput) SetNextToken(v string) *ListJobsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list jobs request.
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5757,6 +6537,18 @@ func (s ListJobsOutput) String() string {
 // GoString returns the string representation
 func (s ListJobsOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobs sets the Jobs field's value.
+func (s *ListJobsOutput) SetJobs(v []*Job) *ListJobsOutput {
+	s.Jobs = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobsOutput) SetNextToken(v string) *ListJobsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the request to list the offering transaction history.
@@ -5791,6 +6583,12 @@ func (s *ListOfferingTransactionsInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListOfferingTransactionsInput) SetNextToken(v string) *ListOfferingTransactionsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Returns the transaction log of the specified offerings.
 type ListOfferingTransactionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5812,6 +6610,18 @@ func (s ListOfferingTransactionsOutput) String() string {
 // GoString returns the string representation
 func (s ListOfferingTransactionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListOfferingTransactionsOutput) SetNextToken(v string) *ListOfferingTransactionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOfferingTransactions sets the OfferingTransactions field's value.
+func (s *ListOfferingTransactionsOutput) SetOfferingTransactions(v []*OfferingTransaction) *ListOfferingTransactionsOutput {
+	s.OfferingTransactions = v
+	return s
 }
 
 // Represents the request to list all offerings.
@@ -5846,6 +6656,12 @@ func (s *ListOfferingsInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListOfferingsInput) SetNextToken(v string) *ListOfferingsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the return values of the list of offerings.
 type ListOfferingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5866,6 +6682,18 @@ func (s ListOfferingsOutput) String() string {
 // GoString returns the string representation
 func (s ListOfferingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListOfferingsOutput) SetNextToken(v string) *ListOfferingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOfferings sets the Offerings field's value.
+func (s *ListOfferingsOutput) SetOfferings(v []*Offering) *ListOfferingsOutput {
+	s.Offerings = v
+	return s
 }
 
 // Represents a request to the list projects operation.
@@ -5908,6 +6736,18 @@ func (s *ListProjectsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListProjectsInput) SetArn(v string) *ListProjectsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListProjectsInput) SetNextToken(v string) *ListProjectsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list projects request.
 type ListProjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5929,6 +6769,18 @@ func (s ListProjectsOutput) String() string {
 // GoString returns the string representation
 func (s ListProjectsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListProjectsOutput) SetNextToken(v string) *ListProjectsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetProjects sets the Projects field's value.
+func (s *ListProjectsOutput) SetProjects(v []*Project) *ListProjectsOutput {
+	s.Projects = v
+	return s
 }
 
 // Represents the request to return information about the remote access session.
@@ -5975,6 +6827,18 @@ func (s *ListRemoteAccessSessionsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListRemoteAccessSessionsInput) SetArn(v string) *ListRemoteAccessSessionsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRemoteAccessSessionsInput) SetNextToken(v string) *ListRemoteAccessSessionsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the response from the server after AWS Device Farm makes a request
 // to return information about the remote access session.
 type ListRemoteAccessSessionsOutput struct {
@@ -5997,6 +6861,18 @@ func (s ListRemoteAccessSessionsOutput) String() string {
 // GoString returns the string representation
 func (s ListRemoteAccessSessionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRemoteAccessSessionsOutput) SetNextToken(v string) *ListRemoteAccessSessionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRemoteAccessSessions sets the RemoteAccessSessions field's value.
+func (s *ListRemoteAccessSessionsOutput) SetRemoteAccessSessions(v []*RemoteAccessSession) *ListRemoteAccessSessionsOutput {
+	s.RemoteAccessSessions = v
+	return s
 }
 
 // Represents a request to the list runs operation.
@@ -6043,6 +6919,18 @@ func (s *ListRunsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListRunsInput) SetArn(v string) *ListRunsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRunsInput) SetNextToken(v string) *ListRunsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list runs request.
 type ListRunsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6064,6 +6952,18 @@ func (s ListRunsOutput) String() string {
 // GoString returns the string representation
 func (s ListRunsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRunsOutput) SetNextToken(v string) *ListRunsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRuns sets the Runs field's value.
+func (s *ListRunsOutput) SetRuns(v []*Run) *ListRunsOutput {
+	s.Runs = v
+	return s
 }
 
 // Represents a request to the list samples operation.
@@ -6110,6 +7010,18 @@ func (s *ListSamplesInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListSamplesInput) SetArn(v string) *ListSamplesInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListSamplesInput) SetNextToken(v string) *ListSamplesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list samples request.
 type ListSamplesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6131,6 +7043,18 @@ func (s ListSamplesOutput) String() string {
 // GoString returns the string representation
 func (s ListSamplesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListSamplesOutput) SetNextToken(v string) *ListSamplesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSamples sets the Samples field's value.
+func (s *ListSamplesOutput) SetSamples(v []*Sample) *ListSamplesOutput {
+	s.Samples = v
+	return s
 }
 
 // Represents a request to the list suites operation.
@@ -6176,6 +7100,18 @@ func (s *ListSuitesInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListSuitesInput) SetArn(v string) *ListSuitesInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListSuitesInput) SetNextToken(v string) *ListSuitesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list suites request.
 type ListSuitesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6197,6 +7133,18 @@ func (s ListSuitesOutput) String() string {
 // GoString returns the string representation
 func (s ListSuitesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListSuitesOutput) SetNextToken(v string) *ListSuitesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSuites sets the Suites field's value.
+func (s *ListSuitesOutput) SetSuites(v []*Suite) *ListSuitesOutput {
+	s.Suites = v
+	return s
 }
 
 // Represents a request to the list tests operation.
@@ -6242,6 +7190,18 @@ func (s *ListTestsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListTestsInput) SetArn(v string) *ListTestsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTestsInput) SetNextToken(v string) *ListTestsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list tests request.
 type ListTestsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6263,6 +7223,18 @@ func (s ListTestsOutput) String() string {
 // GoString returns the string representation
 func (s ListTestsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTestsOutput) SetNextToken(v string) *ListTestsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTests sets the Tests field's value.
+func (s *ListTestsOutput) SetTests(v []*Test) *ListTestsOutput {
+	s.Tests = v
+	return s
 }
 
 // Represents a request to the list unique problems operation.
@@ -6308,6 +7280,18 @@ func (s *ListUniqueProblemsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListUniqueProblemsInput) SetArn(v string) *ListUniqueProblemsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListUniqueProblemsInput) SetNextToken(v string) *ListUniqueProblemsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list unique problems request.
 type ListUniqueProblemsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6345,6 +7329,18 @@ func (s ListUniqueProblemsOutput) String() string {
 // GoString returns the string representation
 func (s ListUniqueProblemsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListUniqueProblemsOutput) SetNextToken(v string) *ListUniqueProblemsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetUniqueProblems sets the UniqueProblems field's value.
+func (s *ListUniqueProblemsOutput) SetUniqueProblems(v map[string][]*UniqueProblem) *ListUniqueProblemsOutput {
+	s.UniqueProblems = v
+	return s
 }
 
 // Represents a request to the list uploads operation.
@@ -6391,6 +7387,18 @@ func (s *ListUploadsInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *ListUploadsInput) SetArn(v string) *ListUploadsInput {
+	s.Arn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListUploadsInput) SetNextToken(v string) *ListUploadsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the result of a list uploads request.
 type ListUploadsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6412,6 +7420,18 @@ func (s ListUploadsOutput) String() string {
 // GoString returns the string representation
 func (s ListUploadsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListUploadsOutput) SetNextToken(v string) *ListUploadsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetUploads sets the Uploads field's value.
+func (s *ListUploadsOutput) SetUploads(v []*Upload) *ListUploadsOutput {
+	s.Uploads = v
+	return s
 }
 
 // Represents a latitude and longitude pair, expressed in geographic coordinate
@@ -6458,6 +7478,18 @@ func (s *Location) Validate() error {
 	return nil
 }
 
+// SetLatitude sets the Latitude field's value.
+func (s *Location) SetLatitude(v float64) *Location {
+	s.Latitude = &v
+	return s
+}
+
+// SetLongitude sets the Longitude field's value.
+func (s *Location) SetLongitude(v float64) *Location {
+	s.Longitude = &v
+	return s
+}
+
 // A number representing the monetary amount for an offering or transaction.
 type MonetaryAmount struct {
 	_ struct{} `type:"structure"`
@@ -6477,6 +7509,18 @@ func (s MonetaryAmount) String() string {
 // GoString returns the string representation
 func (s MonetaryAmount) GoString() string {
 	return s.String()
+}
+
+// SetAmount sets the Amount field's value.
+func (s *MonetaryAmount) SetAmount(v float64) *MonetaryAmount {
+	s.Amount = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *MonetaryAmount) SetCurrencyCode(v string) *MonetaryAmount {
+	s.CurrencyCode = &v
+	return s
 }
 
 // Represents the metadata of a device offering.
@@ -6509,6 +7553,36 @@ func (s Offering) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *Offering) SetDescription(v string) *Offering {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Offering) SetId(v string) *Offering {
+	s.Id = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *Offering) SetPlatform(v string) *Offering {
+	s.Platform = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *Offering) SetRecurringCharges(v []*RecurringCharge) *Offering {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Offering) SetType(v string) *Offering {
+	s.Type = &v
+	return s
+}
+
 // The status of the offering.
 type OfferingStatus struct {
 	_ struct{} `type:"structure"`
@@ -6536,6 +7610,30 @@ func (s OfferingStatus) GoString() string {
 	return s.String()
 }
 
+// SetEffectiveOn sets the EffectiveOn field's value.
+func (s *OfferingStatus) SetEffectiveOn(v time.Time) *OfferingStatus {
+	s.EffectiveOn = &v
+	return s
+}
+
+// SetOffering sets the Offering field's value.
+func (s *OfferingStatus) SetOffering(v *Offering) *OfferingStatus {
+	s.Offering = v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *OfferingStatus) SetQuantity(v int64) *OfferingStatus {
+	s.Quantity = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *OfferingStatus) SetType(v string) *OfferingStatus {
+	s.Type = &v
+	return s
+}
+
 // Represents the metadata of an offering transaction.
 type OfferingTransaction struct {
 	_ struct{} `type:"structure"`
@@ -6561,6 +7659,30 @@ func (s OfferingTransaction) String() string {
 // GoString returns the string representation
 func (s OfferingTransaction) GoString() string {
 	return s.String()
+}
+
+// SetCost sets the Cost field's value.
+func (s *OfferingTransaction) SetCost(v *MonetaryAmount) *OfferingTransaction {
+	s.Cost = v
+	return s
+}
+
+// SetCreatedOn sets the CreatedOn field's value.
+func (s *OfferingTransaction) SetCreatedOn(v time.Time) *OfferingTransaction {
+	s.CreatedOn = &v
+	return s
+}
+
+// SetOfferingStatus sets the OfferingStatus field's value.
+func (s *OfferingTransaction) SetOfferingStatus(v *OfferingStatus) *OfferingTransaction {
+	s.OfferingStatus = v
+	return s
+}
+
+// SetTransactionId sets the TransactionId field's value.
+func (s *OfferingTransaction) SetTransactionId(v string) *OfferingTransaction {
+	s.TransactionId = &v
+	return s
 }
 
 // Represents a specific warning or failure.
@@ -6615,6 +7737,48 @@ func (s Problem) GoString() string {
 	return s.String()
 }
 
+// SetDevice sets the Device field's value.
+func (s *Problem) SetDevice(v *Device) *Problem {
+	s.Device = v
+	return s
+}
+
+// SetJob sets the Job field's value.
+func (s *Problem) SetJob(v *ProblemDetail) *Problem {
+	s.Job = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Problem) SetMessage(v string) *Problem {
+	s.Message = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *Problem) SetResult(v string) *Problem {
+	s.Result = &v
+	return s
+}
+
+// SetRun sets the Run field's value.
+func (s *Problem) SetRun(v *ProblemDetail) *Problem {
+	s.Run = v
+	return s
+}
+
+// SetSuite sets the Suite field's value.
+func (s *Problem) SetSuite(v *ProblemDetail) *Problem {
+	s.Suite = v
+	return s
+}
+
+// SetTest sets the Test field's value.
+func (s *Problem) SetTest(v *ProblemDetail) *Problem {
+	s.Test = v
+	return s
+}
+
 // Information about a problem detail.
 type ProblemDetail struct {
 	_ struct{} `type:"structure"`
@@ -6634,6 +7798,18 @@ func (s ProblemDetail) String() string {
 // GoString returns the string representation
 func (s ProblemDetail) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *ProblemDetail) SetArn(v string) *ProblemDetail {
+	s.Arn = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ProblemDetail) SetName(v string) *ProblemDetail {
+	s.Name = &v
+	return s
 }
 
 // Represents an operating-system neutral workspace for running and managing
@@ -6659,6 +7835,24 @@ func (s Project) String() string {
 // GoString returns the string representation
 func (s Project) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Project) SetArn(v string) *Project {
+	s.Arn = &v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *Project) SetCreated(v time.Time) *Project {
+	s.Created = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Project) SetName(v string) *Project {
+	s.Name = &v
+	return s
 }
 
 // Represents a request for a purchase offering.
@@ -6695,6 +7889,18 @@ func (s *PurchaseOfferingInput) Validate() error {
 	return nil
 }
 
+// SetOfferingId sets the OfferingId field's value.
+func (s *PurchaseOfferingInput) SetOfferingId(v string) *PurchaseOfferingInput {
+	s.OfferingId = &v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *PurchaseOfferingInput) SetQuantity(v int64) *PurchaseOfferingInput {
+	s.Quantity = &v
+	return s
+}
+
 // The result of the purchase offering (e.g., success or failure).
 type PurchaseOfferingOutput struct {
 	_ struct{} `type:"structure"`
@@ -6711,6 +7917,12 @@ func (s PurchaseOfferingOutput) String() string {
 // GoString returns the string representation
 func (s PurchaseOfferingOutput) GoString() string {
 	return s.String()
+}
+
+// SetOfferingTransaction sets the OfferingTransaction field's value.
+func (s *PurchaseOfferingOutput) SetOfferingTransaction(v *OfferingTransaction) *PurchaseOfferingOutput {
+	s.OfferingTransaction = v
+	return s
 }
 
 // Represents the set of radios and their states on a device. Examples of radios
@@ -6741,6 +7953,30 @@ func (s Radios) GoString() string {
 	return s.String()
 }
 
+// SetBluetooth sets the Bluetooth field's value.
+func (s *Radios) SetBluetooth(v bool) *Radios {
+	s.Bluetooth = &v
+	return s
+}
+
+// SetGps sets the Gps field's value.
+func (s *Radios) SetGps(v bool) *Radios {
+	s.Gps = &v
+	return s
+}
+
+// SetNfc sets the Nfc field's value.
+func (s *Radios) SetNfc(v bool) *Radios {
+	s.Nfc = &v
+	return s
+}
+
+// SetWifi sets the Wifi field's value.
+func (s *Radios) SetWifi(v bool) *Radios {
+	s.Wifi = &v
+	return s
+}
+
 // Specifies whether charges for devices will be recurring.
 type RecurringCharge struct {
 	_ struct{} `type:"structure"`
@@ -6760,6 +7996,18 @@ func (s RecurringCharge) String() string {
 // GoString returns the string representation
 func (s RecurringCharge) GoString() string {
 	return s.String()
+}
+
+// SetCost sets the Cost field's value.
+func (s *RecurringCharge) SetCost(v *MonetaryAmount) *RecurringCharge {
+	s.Cost = v
+	return s
+}
+
+// SetFrequency sets the Frequency field's value.
+func (s *RecurringCharge) SetFrequency(v string) *RecurringCharge {
+	s.Frequency = &v
+	return s
 }
 
 // Represents information about the remote access session.
@@ -6848,6 +8096,78 @@ func (s RemoteAccessSession) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *RemoteAccessSession) SetArn(v string) *RemoteAccessSession {
+	s.Arn = &v
+	return s
+}
+
+// SetBillingMethod sets the BillingMethod field's value.
+func (s *RemoteAccessSession) SetBillingMethod(v string) *RemoteAccessSession {
+	s.BillingMethod = &v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *RemoteAccessSession) SetCreated(v time.Time) *RemoteAccessSession {
+	s.Created = &v
+	return s
+}
+
+// SetDevice sets the Device field's value.
+func (s *RemoteAccessSession) SetDevice(v *Device) *RemoteAccessSession {
+	s.Device = v
+	return s
+}
+
+// SetDeviceMinutes sets the DeviceMinutes field's value.
+func (s *RemoteAccessSession) SetDeviceMinutes(v *DeviceMinutes) *RemoteAccessSession {
+	s.DeviceMinutes = v
+	return s
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *RemoteAccessSession) SetEndpoint(v string) *RemoteAccessSession {
+	s.Endpoint = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *RemoteAccessSession) SetMessage(v string) *RemoteAccessSession {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RemoteAccessSession) SetName(v string) *RemoteAccessSession {
+	s.Name = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *RemoteAccessSession) SetResult(v string) *RemoteAccessSession {
+	s.Result = &v
+	return s
+}
+
+// SetStarted sets the Started field's value.
+func (s *RemoteAccessSession) SetStarted(v time.Time) *RemoteAccessSession {
+	s.Started = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *RemoteAccessSession) SetStatus(v string) *RemoteAccessSession {
+	s.Status = &v
+	return s
+}
+
+// SetStopped sets the Stopped field's value.
+func (s *RemoteAccessSession) SetStopped(v time.Time) *RemoteAccessSession {
+	s.Stopped = &v
+	return s
+}
+
 // A request representing an offering renewal.
 type RenewOfferingInput struct {
 	_ struct{} `type:"structure"`
@@ -6882,6 +8202,18 @@ func (s *RenewOfferingInput) Validate() error {
 	return nil
 }
 
+// SetOfferingId sets the OfferingId field's value.
+func (s *RenewOfferingInput) SetOfferingId(v string) *RenewOfferingInput {
+	s.OfferingId = &v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *RenewOfferingInput) SetQuantity(v int64) *RenewOfferingInput {
+	s.Quantity = &v
+	return s
+}
+
 // The result of a renewal offering.
 type RenewOfferingOutput struct {
 	_ struct{} `type:"structure"`
@@ -6898,6 +8230,12 @@ func (s RenewOfferingOutput) String() string {
 // GoString returns the string representation
 func (s RenewOfferingOutput) GoString() string {
 	return s.String()
+}
+
+// SetOfferingTransaction sets the OfferingTransaction field's value.
+func (s *RenewOfferingOutput) SetOfferingTransaction(v *OfferingTransaction) *RenewOfferingOutput {
+	s.OfferingTransaction = v
+	return s
 }
 
 // Represents the screen resolution of a device in height and width, expressed
@@ -6920,6 +8258,18 @@ func (s Resolution) String() string {
 // GoString returns the string representation
 func (s Resolution) GoString() string {
 	return s.String()
+}
+
+// SetHeight sets the Height field's value.
+func (s *Resolution) SetHeight(v int64) *Resolution {
+	s.Height = &v
+	return s
+}
+
+// SetWidth sets the Width field's value.
+func (s *Resolution) SetWidth(v int64) *Resolution {
+	s.Width = &v
+	return s
 }
 
 // Represents a condition for a device pool.
@@ -6964,6 +8314,24 @@ func (s Rule) String() string {
 // GoString returns the string representation
 func (s Rule) GoString() string {
 	return s.String()
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *Rule) SetAttribute(v string) *Rule {
+	s.Attribute = &v
+	return s
+}
+
+// SetOperator sets the Operator field's value.
+func (s *Rule) SetOperator(v string) *Rule {
+	s.Operator = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Rule) SetValue(v string) *Rule {
+	s.Value = &v
+	return s
 }
 
 // Represents an app on a set of devices with a specific test and configuration.
@@ -7101,6 +8469,96 @@ func (s Run) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Run) SetArn(v string) *Run {
+	s.Arn = &v
+	return s
+}
+
+// SetBillingMethod sets the BillingMethod field's value.
+func (s *Run) SetBillingMethod(v string) *Run {
+	s.BillingMethod = &v
+	return s
+}
+
+// SetCompletedJobs sets the CompletedJobs field's value.
+func (s *Run) SetCompletedJobs(v int64) *Run {
+	s.CompletedJobs = &v
+	return s
+}
+
+// SetCounters sets the Counters field's value.
+func (s *Run) SetCounters(v *Counters) *Run {
+	s.Counters = v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *Run) SetCreated(v time.Time) *Run {
+	s.Created = &v
+	return s
+}
+
+// SetDeviceMinutes sets the DeviceMinutes field's value.
+func (s *Run) SetDeviceMinutes(v *DeviceMinutes) *Run {
+	s.DeviceMinutes = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Run) SetMessage(v string) *Run {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Run) SetName(v string) *Run {
+	s.Name = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *Run) SetPlatform(v string) *Run {
+	s.Platform = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *Run) SetResult(v string) *Run {
+	s.Result = &v
+	return s
+}
+
+// SetStarted sets the Started field's value.
+func (s *Run) SetStarted(v time.Time) *Run {
+	s.Started = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Run) SetStatus(v string) *Run {
+	s.Status = &v
+	return s
+}
+
+// SetStopped sets the Stopped field's value.
+func (s *Run) SetStopped(v time.Time) *Run {
+	s.Stopped = &v
+	return s
+}
+
+// SetTotalJobs sets the TotalJobs field's value.
+func (s *Run) SetTotalJobs(v int64) *Run {
+	s.TotalJobs = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Run) SetType(v string) *Run {
+	s.Type = &v
+	return s
+}
+
 // Represents a sample of performance data.
 type Sample struct {
 	_ struct{} `type:"structure"`
@@ -7167,6 +8625,24 @@ func (s Sample) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Sample) SetArn(v string) *Sample {
+	s.Arn = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Sample) SetType(v string) *Sample {
+	s.Type = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *Sample) SetUrl(v string) *Sample {
+	s.Url = &v
+	return s
+}
+
 // Represents the settings for a run. Includes things like location, radio states,
 // auxiliary apps, and network profiles.
 type ScheduleRunConfiguration struct {
@@ -7226,6 +8702,48 @@ func (s *ScheduleRunConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAuxiliaryApps sets the AuxiliaryApps field's value.
+func (s *ScheduleRunConfiguration) SetAuxiliaryApps(v []*string) *ScheduleRunConfiguration {
+	s.AuxiliaryApps = v
+	return s
+}
+
+// SetBillingMethod sets the BillingMethod field's value.
+func (s *ScheduleRunConfiguration) SetBillingMethod(v string) *ScheduleRunConfiguration {
+	s.BillingMethod = &v
+	return s
+}
+
+// SetExtraDataPackageArn sets the ExtraDataPackageArn field's value.
+func (s *ScheduleRunConfiguration) SetExtraDataPackageArn(v string) *ScheduleRunConfiguration {
+	s.ExtraDataPackageArn = &v
+	return s
+}
+
+// SetLocale sets the Locale field's value.
+func (s *ScheduleRunConfiguration) SetLocale(v string) *ScheduleRunConfiguration {
+	s.Locale = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *ScheduleRunConfiguration) SetLocation(v *Location) *ScheduleRunConfiguration {
+	s.Location = v
+	return s
+}
+
+// SetNetworkProfileArn sets the NetworkProfileArn field's value.
+func (s *ScheduleRunConfiguration) SetNetworkProfileArn(v string) *ScheduleRunConfiguration {
+	s.NetworkProfileArn = &v
+	return s
+}
+
+// SetRadios sets the Radios field's value.
+func (s *ScheduleRunConfiguration) SetRadios(v *Radios) *ScheduleRunConfiguration {
+	s.Radios = v
+	return s
 }
 
 // Represents a request to the schedule run operation.
@@ -7305,6 +8823,42 @@ func (s *ScheduleRunInput) Validate() error {
 	return nil
 }
 
+// SetAppArn sets the AppArn field's value.
+func (s *ScheduleRunInput) SetAppArn(v string) *ScheduleRunInput {
+	s.AppArn = &v
+	return s
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *ScheduleRunInput) SetConfiguration(v *ScheduleRunConfiguration) *ScheduleRunInput {
+	s.Configuration = v
+	return s
+}
+
+// SetDevicePoolArn sets the DevicePoolArn field's value.
+func (s *ScheduleRunInput) SetDevicePoolArn(v string) *ScheduleRunInput {
+	s.DevicePoolArn = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ScheduleRunInput) SetName(v string) *ScheduleRunInput {
+	s.Name = &v
+	return s
+}
+
+// SetProjectArn sets the ProjectArn field's value.
+func (s *ScheduleRunInput) SetProjectArn(v string) *ScheduleRunInput {
+	s.ProjectArn = &v
+	return s
+}
+
+// SetTest sets the Test field's value.
+func (s *ScheduleRunInput) SetTest(v *ScheduleRunTest) *ScheduleRunInput {
+	s.Test = v
+	return s
+}
+
 // Represents the result of a schedule run request.
 type ScheduleRunOutput struct {
 	_ struct{} `type:"structure"`
@@ -7321,6 +8875,12 @@ func (s ScheduleRunOutput) String() string {
 // GoString returns the string representation
 func (s ScheduleRunOutput) GoString() string {
 	return s.String()
+}
+
+// SetRun sets the Run field's value.
+func (s *ScheduleRunOutput) SetRun(v *Run) *ScheduleRunOutput {
+	s.Run = v
+	return s
 }
 
 // Represents additional test settings.
@@ -7400,6 +8960,30 @@ func (s *ScheduleRunTest) Validate() error {
 	return nil
 }
 
+// SetFilter sets the Filter field's value.
+func (s *ScheduleRunTest) SetFilter(v string) *ScheduleRunTest {
+	s.Filter = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ScheduleRunTest) SetParameters(v map[string]*string) *ScheduleRunTest {
+	s.Parameters = v
+	return s
+}
+
+// SetTestPackageArn sets the TestPackageArn field's value.
+func (s *ScheduleRunTest) SetTestPackageArn(v string) *ScheduleRunTest {
+	s.TestPackageArn = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ScheduleRunTest) SetType(v string) *ScheduleRunTest {
+	s.Type = &v
+	return s
+}
+
 // Represents the request to stop the remote access session.
 type StopRemoteAccessSessionInput struct {
 	_ struct{} `type:"structure"`
@@ -7436,6 +9020,12 @@ func (s *StopRemoteAccessSessionInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *StopRemoteAccessSessionInput) SetArn(v string) *StopRemoteAccessSessionInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the response from the server that describes the remote access
 // session when AWS Device Farm stops the session.
 type StopRemoteAccessSessionOutput struct {
@@ -7454,6 +9044,12 @@ func (s StopRemoteAccessSessionOutput) String() string {
 // GoString returns the string representation
 func (s StopRemoteAccessSessionOutput) GoString() string {
 	return s.String()
+}
+
+// SetRemoteAccessSession sets the RemoteAccessSession field's value.
+func (s *StopRemoteAccessSessionOutput) SetRemoteAccessSession(v *RemoteAccessSession) *StopRemoteAccessSessionOutput {
+	s.RemoteAccessSession = v
+	return s
 }
 
 // Represents the request to stop a specific run.
@@ -7493,6 +9089,12 @@ func (s *StopRunInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *StopRunInput) SetArn(v string) *StopRunInput {
+	s.Arn = &v
+	return s
+}
+
 // Represents the results of your stop run attempt.
 type StopRunOutput struct {
 	_ struct{} `type:"structure"`
@@ -7509,6 +9111,12 @@ func (s StopRunOutput) String() string {
 // GoString returns the string representation
 func (s StopRunOutput) GoString() string {
 	return s.String()
+}
+
+// SetRun sets the Run field's value.
+func (s *StopRunOutput) SetRun(v *Run) *StopRunOutput {
+	s.Run = v
+	return s
 }
 
 // Represents a collection of one or more tests.
@@ -7627,6 +9235,72 @@ func (s Suite) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Suite) SetArn(v string) *Suite {
+	s.Arn = &v
+	return s
+}
+
+// SetCounters sets the Counters field's value.
+func (s *Suite) SetCounters(v *Counters) *Suite {
+	s.Counters = v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *Suite) SetCreated(v time.Time) *Suite {
+	s.Created = &v
+	return s
+}
+
+// SetDeviceMinutes sets the DeviceMinutes field's value.
+func (s *Suite) SetDeviceMinutes(v *DeviceMinutes) *Suite {
+	s.DeviceMinutes = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Suite) SetMessage(v string) *Suite {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Suite) SetName(v string) *Suite {
+	s.Name = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *Suite) SetResult(v string) *Suite {
+	s.Result = &v
+	return s
+}
+
+// SetStarted sets the Started field's value.
+func (s *Suite) SetStarted(v time.Time) *Suite {
+	s.Started = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Suite) SetStatus(v string) *Suite {
+	s.Status = &v
+	return s
+}
+
+// SetStopped sets the Stopped field's value.
+func (s *Suite) SetStopped(v time.Time) *Suite {
+	s.Stopped = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Suite) SetType(v string) *Suite {
+	s.Type = &v
+	return s
+}
+
 // Represents a condition that is evaluated.
 type Test struct {
 	_ struct{} `type:"structure"`
@@ -7743,6 +9417,72 @@ func (s Test) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Test) SetArn(v string) *Test {
+	s.Arn = &v
+	return s
+}
+
+// SetCounters sets the Counters field's value.
+func (s *Test) SetCounters(v *Counters) *Test {
+	s.Counters = v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *Test) SetCreated(v time.Time) *Test {
+	s.Created = &v
+	return s
+}
+
+// SetDeviceMinutes sets the DeviceMinutes field's value.
+func (s *Test) SetDeviceMinutes(v *DeviceMinutes) *Test {
+	s.DeviceMinutes = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Test) SetMessage(v string) *Test {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Test) SetName(v string) *Test {
+	s.Name = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *Test) SetResult(v string) *Test {
+	s.Result = &v
+	return s
+}
+
+// SetStarted sets the Started field's value.
+func (s *Test) SetStarted(v time.Time) *Test {
+	s.Started = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Test) SetStatus(v string) *Test {
+	s.Status = &v
+	return s
+}
+
+// SetStopped sets the Stopped field's value.
+func (s *Test) SetStopped(v time.Time) *Test {
+	s.Stopped = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Test) SetType(v string) *Test {
+	s.Type = &v
+	return s
+}
+
 // A collection of one or more problems, grouped by their result.
 type UniqueProblem struct {
 	_ struct{} `type:"structure"`
@@ -7762,6 +9502,18 @@ func (s UniqueProblem) String() string {
 // GoString returns the string representation
 func (s UniqueProblem) GoString() string {
 	return s.String()
+}
+
+// SetMessage sets the Message field's value.
+func (s *UniqueProblem) SetMessage(v string) *UniqueProblem {
+	s.Message = &v
+	return s
+}
+
+// SetProblems sets the Problems field's value.
+func (s *UniqueProblem) SetProblems(v []*Problem) *UniqueProblem {
+	s.Problems = v
+	return s
 }
 
 // Represents a request to the update device pool operation.
@@ -7812,6 +9564,30 @@ func (s *UpdateDevicePoolInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *UpdateDevicePoolInput) SetArn(v string) *UpdateDevicePoolInput {
+	s.Arn = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateDevicePoolInput) SetDescription(v string) *UpdateDevicePoolInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateDevicePoolInput) SetName(v string) *UpdateDevicePoolInput {
+	s.Name = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *UpdateDevicePoolInput) SetRules(v []*Rule) *UpdateDevicePoolInput {
+	s.Rules = v
+	return s
+}
+
 // Represents the result of an update device pool request.
 type UpdateDevicePoolOutput struct {
 	_ struct{} `type:"structure"`
@@ -7828,6 +9604,12 @@ func (s UpdateDevicePoolOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDevicePoolOutput) GoString() string {
 	return s.String()
+}
+
+// SetDevicePool sets the DevicePool field's value.
+func (s *UpdateDevicePoolOutput) SetDevicePool(v *DevicePool) *UpdateDevicePoolOutput {
+	s.DevicePool = v
+	return s
 }
 
 // Represents a request to the update project operation.
@@ -7869,6 +9651,18 @@ func (s *UpdateProjectInput) Validate() error {
 	return nil
 }
 
+// SetArn sets the Arn field's value.
+func (s *UpdateProjectInput) SetArn(v string) *UpdateProjectInput {
+	s.Arn = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateProjectInput) SetName(v string) *UpdateProjectInput {
+	s.Name = &v
+	return s
+}
+
 // Represents the result of an update project request.
 type UpdateProjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -7886,6 +9680,12 @@ func (s UpdateProjectOutput) String() string {
 // GoString returns the string representation
 func (s UpdateProjectOutput) GoString() string {
 	return s.String()
+}
+
+// SetProject sets the Project field's value.
+func (s *UpdateProjectOutput) SetProject(v *Project) *UpdateProjectOutput {
+	s.Project = v
+	return s
 }
 
 // An app or a set of one or more tests to upload or that have been uploaded.
@@ -7978,6 +9778,60 @@ func (s Upload) String() string {
 // GoString returns the string representation
 func (s Upload) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Upload) SetArn(v string) *Upload {
+	s.Arn = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *Upload) SetContentType(v string) *Upload {
+	s.ContentType = &v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *Upload) SetCreated(v time.Time) *Upload {
+	s.Created = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Upload) SetMessage(v string) *Upload {
+	s.Message = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *Upload) SetMetadata(v string) *Upload {
+	s.Metadata = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Upload) SetName(v string) *Upload {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Upload) SetStatus(v string) *Upload {
+	s.Status = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Upload) SetType(v string) *Upload {
+	s.Type = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *Upload) SetUrl(v string) *Upload {
+	s.Url = &v
+	return s
 }
 
 const (

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -1653,6 +1653,36 @@ func (s *AllocateConnectionOnInterconnectInput) Validate() error {
 	return nil
 }
 
+// SetBandwidth sets the Bandwidth field's value.
+func (s *AllocateConnectionOnInterconnectInput) SetBandwidth(v string) *AllocateConnectionOnInterconnectInput {
+	s.Bandwidth = &v
+	return s
+}
+
+// SetConnectionName sets the ConnectionName field's value.
+func (s *AllocateConnectionOnInterconnectInput) SetConnectionName(v string) *AllocateConnectionOnInterconnectInput {
+	s.ConnectionName = &v
+	return s
+}
+
+// SetInterconnectId sets the InterconnectId field's value.
+func (s *AllocateConnectionOnInterconnectInput) SetInterconnectId(v string) *AllocateConnectionOnInterconnectInput {
+	s.InterconnectId = &v
+	return s
+}
+
+// SetOwnerAccount sets the OwnerAccount field's value.
+func (s *AllocateConnectionOnInterconnectInput) SetOwnerAccount(v string) *AllocateConnectionOnInterconnectInput {
+	s.OwnerAccount = &v
+	return s
+}
+
+// SetVlan sets the Vlan field's value.
+func (s *AllocateConnectionOnInterconnectInput) SetVlan(v int64) *AllocateConnectionOnInterconnectInput {
+	s.Vlan = &v
+	return s
+}
+
 // Container for the parameters to the AllocatePrivateVirtualInterface operation.
 type AllocatePrivateVirtualInterfaceInput struct {
 	_ struct{} `type:"structure"`
@@ -1711,6 +1741,24 @@ func (s *AllocatePrivateVirtualInterfaceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConnectionId sets the ConnectionId field's value.
+func (s *AllocatePrivateVirtualInterfaceInput) SetConnectionId(v string) *AllocatePrivateVirtualInterfaceInput {
+	s.ConnectionId = &v
+	return s
+}
+
+// SetNewPrivateVirtualInterfaceAllocation sets the NewPrivateVirtualInterfaceAllocation field's value.
+func (s *AllocatePrivateVirtualInterfaceInput) SetNewPrivateVirtualInterfaceAllocation(v *NewPrivateVirtualInterfaceAllocation) *AllocatePrivateVirtualInterfaceInput {
+	s.NewPrivateVirtualInterfaceAllocation = v
+	return s
+}
+
+// SetOwnerAccount sets the OwnerAccount field's value.
+func (s *AllocatePrivateVirtualInterfaceInput) SetOwnerAccount(v string) *AllocatePrivateVirtualInterfaceInput {
+	s.OwnerAccount = &v
+	return s
 }
 
 // Container for the parameters to the AllocatePublicVirtualInterface operation.
@@ -1773,6 +1821,24 @@ func (s *AllocatePublicVirtualInterfaceInput) Validate() error {
 	return nil
 }
 
+// SetConnectionId sets the ConnectionId field's value.
+func (s *AllocatePublicVirtualInterfaceInput) SetConnectionId(v string) *AllocatePublicVirtualInterfaceInput {
+	s.ConnectionId = &v
+	return s
+}
+
+// SetNewPublicVirtualInterfaceAllocation sets the NewPublicVirtualInterfaceAllocation field's value.
+func (s *AllocatePublicVirtualInterfaceInput) SetNewPublicVirtualInterfaceAllocation(v *NewPublicVirtualInterfaceAllocation) *AllocatePublicVirtualInterfaceInput {
+	s.NewPublicVirtualInterfaceAllocation = v
+	return s
+}
+
+// SetOwnerAccount sets the OwnerAccount field's value.
+func (s *AllocatePublicVirtualInterfaceInput) SetOwnerAccount(v string) *AllocatePublicVirtualInterfaceInput {
+	s.OwnerAccount = &v
+	return s
+}
+
 // Container for the parameters to the ConfirmConnection operation.
 type ConfirmConnectionInput struct {
 	_ struct{} `type:"structure"`
@@ -1808,6 +1874,12 @@ func (s *ConfirmConnectionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConnectionId sets the ConnectionId field's value.
+func (s *ConfirmConnectionInput) SetConnectionId(v string) *ConfirmConnectionInput {
+	s.ConnectionId = &v
+	return s
 }
 
 // The response received when ConfirmConnection is called.
@@ -1847,6 +1919,12 @@ func (s ConfirmConnectionOutput) String() string {
 // GoString returns the string representation
 func (s ConfirmConnectionOutput) GoString() string {
 	return s.String()
+}
+
+// SetConnectionState sets the ConnectionState field's value.
+func (s *ConfirmConnectionOutput) SetConnectionState(v string) *ConfirmConnectionOutput {
+	s.ConnectionState = &v
+	return s
 }
 
 // Container for the parameters to the ConfirmPrivateVirtualInterface operation.
@@ -1900,6 +1978,18 @@ func (s *ConfirmPrivateVirtualInterfaceInput) Validate() error {
 	return nil
 }
 
+// SetVirtualGatewayId sets the VirtualGatewayId field's value.
+func (s *ConfirmPrivateVirtualInterfaceInput) SetVirtualGatewayId(v string) *ConfirmPrivateVirtualInterfaceInput {
+	s.VirtualGatewayId = &v
+	return s
+}
+
+// SetVirtualInterfaceId sets the VirtualInterfaceId field's value.
+func (s *ConfirmPrivateVirtualInterfaceInput) SetVirtualInterfaceId(v string) *ConfirmPrivateVirtualInterfaceInput {
+	s.VirtualInterfaceId = &v
+	return s
+}
+
 // The response received when ConfirmPrivateVirtualInterface is called.
 type ConfirmPrivateVirtualInterfaceOutput struct {
 	_ struct{} `type:"structure"`
@@ -1945,6 +2035,12 @@ func (s ConfirmPrivateVirtualInterfaceOutput) GoString() string {
 	return s.String()
 }
 
+// SetVirtualInterfaceState sets the VirtualInterfaceState field's value.
+func (s *ConfirmPrivateVirtualInterfaceOutput) SetVirtualInterfaceState(v string) *ConfirmPrivateVirtualInterfaceOutput {
+	s.VirtualInterfaceState = &v
+	return s
+}
+
 // Container for the parameters to the ConfirmPublicVirtualInterface operation.
 type ConfirmPublicVirtualInterfaceInput struct {
 	_ struct{} `type:"structure"`
@@ -1980,6 +2076,12 @@ func (s *ConfirmPublicVirtualInterfaceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetVirtualInterfaceId sets the VirtualInterfaceId field's value.
+func (s *ConfirmPublicVirtualInterfaceInput) SetVirtualInterfaceId(v string) *ConfirmPublicVirtualInterfaceInput {
+	s.VirtualInterfaceId = &v
+	return s
 }
 
 // The response received when ConfirmPublicVirtualInterface is called.
@@ -2025,6 +2127,12 @@ func (s ConfirmPublicVirtualInterfaceOutput) String() string {
 // GoString returns the string representation
 func (s ConfirmPublicVirtualInterfaceOutput) GoString() string {
 	return s.String()
+}
+
+// SetVirtualInterfaceState sets the VirtualInterfaceState field's value.
+func (s *ConfirmPublicVirtualInterfaceOutput) SetVirtualInterfaceState(v string) *ConfirmPublicVirtualInterfaceOutput {
+	s.VirtualInterfaceState = &v
+	return s
 }
 
 // A connection represents the physical network connection between the AWS Direct
@@ -2116,6 +2224,66 @@ func (s Connection) GoString() string {
 	return s.String()
 }
 
+// SetBandwidth sets the Bandwidth field's value.
+func (s *Connection) SetBandwidth(v string) *Connection {
+	s.Bandwidth = &v
+	return s
+}
+
+// SetConnectionId sets the ConnectionId field's value.
+func (s *Connection) SetConnectionId(v string) *Connection {
+	s.ConnectionId = &v
+	return s
+}
+
+// SetConnectionName sets the ConnectionName field's value.
+func (s *Connection) SetConnectionName(v string) *Connection {
+	s.ConnectionName = &v
+	return s
+}
+
+// SetConnectionState sets the ConnectionState field's value.
+func (s *Connection) SetConnectionState(v string) *Connection {
+	s.ConnectionState = &v
+	return s
+}
+
+// SetLoaIssueTime sets the LoaIssueTime field's value.
+func (s *Connection) SetLoaIssueTime(v time.Time) *Connection {
+	s.LoaIssueTime = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *Connection) SetLocation(v string) *Connection {
+	s.Location = &v
+	return s
+}
+
+// SetOwnerAccount sets the OwnerAccount field's value.
+func (s *Connection) SetOwnerAccount(v string) *Connection {
+	s.OwnerAccount = &v
+	return s
+}
+
+// SetPartnerName sets the PartnerName field's value.
+func (s *Connection) SetPartnerName(v string) *Connection {
+	s.PartnerName = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *Connection) SetRegion(v string) *Connection {
+	s.Region = &v
+	return s
+}
+
+// SetVlan sets the Vlan field's value.
+func (s *Connection) SetVlan(v int64) *Connection {
+	s.Vlan = &v
+	return s
+}
+
 // A structure containing a list of connections.
 type Connections struct {
 	_ struct{} `type:"structure"`
@@ -2132,6 +2300,12 @@ func (s Connections) String() string {
 // GoString returns the string representation
 func (s Connections) GoString() string {
 	return s.String()
+}
+
+// SetConnections sets the Connections field's value.
+func (s *Connections) SetConnections(v []*Connection) *Connections {
+	s.Connections = v
+	return s
 }
 
 // Container for the parameters to the CreateConnection operation.
@@ -2193,6 +2367,24 @@ func (s *CreateConnectionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBandwidth sets the Bandwidth field's value.
+func (s *CreateConnectionInput) SetBandwidth(v string) *CreateConnectionInput {
+	s.Bandwidth = &v
+	return s
+}
+
+// SetConnectionName sets the ConnectionName field's value.
+func (s *CreateConnectionInput) SetConnectionName(v string) *CreateConnectionInput {
+	s.ConnectionName = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateConnectionInput) SetLocation(v string) *CreateConnectionInput {
+	s.Location = &v
+	return s
 }
 
 // Container for the parameters to the CreateInterconnect operation.
@@ -2258,6 +2450,24 @@ func (s *CreateInterconnectInput) Validate() error {
 	return nil
 }
 
+// SetBandwidth sets the Bandwidth field's value.
+func (s *CreateInterconnectInput) SetBandwidth(v string) *CreateInterconnectInput {
+	s.Bandwidth = &v
+	return s
+}
+
+// SetInterconnectName sets the InterconnectName field's value.
+func (s *CreateInterconnectInput) SetInterconnectName(v string) *CreateInterconnectInput {
+	s.InterconnectName = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateInterconnectInput) SetLocation(v string) *CreateInterconnectInput {
+	s.Location = &v
+	return s
+}
+
 // Container for the parameters to the CreatePrivateVirtualInterface operation.
 type CreatePrivateVirtualInterfaceInput struct {
 	_ struct{} `type:"structure"`
@@ -2308,6 +2518,18 @@ func (s *CreatePrivateVirtualInterfaceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConnectionId sets the ConnectionId field's value.
+func (s *CreatePrivateVirtualInterfaceInput) SetConnectionId(v string) *CreatePrivateVirtualInterfaceInput {
+	s.ConnectionId = &v
+	return s
+}
+
+// SetNewPrivateVirtualInterface sets the NewPrivateVirtualInterface field's value.
+func (s *CreatePrivateVirtualInterfaceInput) SetNewPrivateVirtualInterface(v *NewPrivateVirtualInterface) *CreatePrivateVirtualInterfaceInput {
+	s.NewPrivateVirtualInterface = v
+	return s
 }
 
 // Container for the parameters to the CreatePublicVirtualInterface operation.
@@ -2362,6 +2584,18 @@ func (s *CreatePublicVirtualInterfaceInput) Validate() error {
 	return nil
 }
 
+// SetConnectionId sets the ConnectionId field's value.
+func (s *CreatePublicVirtualInterfaceInput) SetConnectionId(v string) *CreatePublicVirtualInterfaceInput {
+	s.ConnectionId = &v
+	return s
+}
+
+// SetNewPublicVirtualInterface sets the NewPublicVirtualInterface field's value.
+func (s *CreatePublicVirtualInterfaceInput) SetNewPublicVirtualInterface(v *NewPublicVirtualInterface) *CreatePublicVirtualInterfaceInput {
+	s.NewPublicVirtualInterface = v
+	return s
+}
+
 // Container for the parameters to the DeleteConnection operation.
 type DeleteConnectionInput struct {
 	_ struct{} `type:"structure"`
@@ -2399,6 +2633,12 @@ func (s *DeleteConnectionInput) Validate() error {
 	return nil
 }
 
+// SetConnectionId sets the ConnectionId field's value.
+func (s *DeleteConnectionInput) SetConnectionId(v string) *DeleteConnectionInput {
+	s.ConnectionId = &v
+	return s
+}
+
 // Container for the parameters to the DeleteInterconnect operation.
 type DeleteInterconnectInput struct {
 	_ struct{} `type:"structure"`
@@ -2434,6 +2674,12 @@ func (s *DeleteInterconnectInput) Validate() error {
 	return nil
 }
 
+// SetInterconnectId sets the InterconnectId field's value.
+func (s *DeleteInterconnectInput) SetInterconnectId(v string) *DeleteInterconnectInput {
+	s.InterconnectId = &v
+	return s
+}
+
 // The response received when DeleteInterconnect is called.
 type DeleteInterconnectOutput struct {
 	_ struct{} `type:"structure"`
@@ -2465,6 +2711,12 @@ func (s DeleteInterconnectOutput) String() string {
 // GoString returns the string representation
 func (s DeleteInterconnectOutput) GoString() string {
 	return s.String()
+}
+
+// SetInterconnectState sets the InterconnectState field's value.
+func (s *DeleteInterconnectOutput) SetInterconnectState(v string) *DeleteInterconnectOutput {
+	s.InterconnectState = &v
+	return s
 }
 
 // Container for the parameters to the DeleteVirtualInterface operation.
@@ -2502,6 +2754,12 @@ func (s *DeleteVirtualInterfaceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetVirtualInterfaceId sets the VirtualInterfaceId field's value.
+func (s *DeleteVirtualInterfaceInput) SetVirtualInterfaceId(v string) *DeleteVirtualInterfaceInput {
+	s.VirtualInterfaceId = &v
+	return s
 }
 
 // The response received when DeleteVirtualInterface is called.
@@ -2547,6 +2805,12 @@ func (s DeleteVirtualInterfaceOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVirtualInterfaceOutput) GoString() string {
 	return s.String()
+}
+
+// SetVirtualInterfaceState sets the VirtualInterfaceState field's value.
+func (s *DeleteVirtualInterfaceOutput) SetVirtualInterfaceState(v string) *DeleteVirtualInterfaceOutput {
+	s.VirtualInterfaceState = &v
+	return s
 }
 
 // Container for the parameters to the DescribeConnectionLoa operation.
@@ -2599,6 +2863,24 @@ func (s *DescribeConnectionLoaInput) Validate() error {
 	return nil
 }
 
+// SetConnectionId sets the ConnectionId field's value.
+func (s *DescribeConnectionLoaInput) SetConnectionId(v string) *DescribeConnectionLoaInput {
+	s.ConnectionId = &v
+	return s
+}
+
+// SetLoaContentType sets the LoaContentType field's value.
+func (s *DescribeConnectionLoaInput) SetLoaContentType(v string) *DescribeConnectionLoaInput {
+	s.LoaContentType = &v
+	return s
+}
+
+// SetProviderName sets the ProviderName field's value.
+func (s *DescribeConnectionLoaInput) SetProviderName(v string) *DescribeConnectionLoaInput {
+	s.ProviderName = &v
+	return s
+}
+
 // The response received when DescribeConnectionLoa is called.
 type DescribeConnectionLoaOutput struct {
 	_ struct{} `type:"structure"`
@@ -2616,6 +2898,12 @@ func (s DescribeConnectionLoaOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConnectionLoaOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoa sets the Loa field's value.
+func (s *DescribeConnectionLoaOutput) SetLoa(v *Loa) *DescribeConnectionLoaOutput {
+	s.Loa = v
+	return s
 }
 
 // Container for the parameters to the DescribeConnections operation.
@@ -2638,6 +2926,12 @@ func (s DescribeConnectionsInput) String() string {
 // GoString returns the string representation
 func (s DescribeConnectionsInput) GoString() string {
 	return s.String()
+}
+
+// SetConnectionId sets the ConnectionId field's value.
+func (s *DescribeConnectionsInput) SetConnectionId(v string) *DescribeConnectionsInput {
+	s.ConnectionId = &v
+	return s
 }
 
 // Container for the parameters to the DescribeConnectionsOnInterconnect operation.
@@ -2675,6 +2969,12 @@ func (s *DescribeConnectionsOnInterconnectInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInterconnectId sets the InterconnectId field's value.
+func (s *DescribeConnectionsOnInterconnectInput) SetInterconnectId(v string) *DescribeConnectionsOnInterconnectInput {
+	s.InterconnectId = &v
+	return s
 }
 
 // Container for the parameters to the DescribeInterconnectLoa operation.
@@ -2725,6 +3025,24 @@ func (s *DescribeInterconnectLoaInput) Validate() error {
 	return nil
 }
 
+// SetInterconnectId sets the InterconnectId field's value.
+func (s *DescribeInterconnectLoaInput) SetInterconnectId(v string) *DescribeInterconnectLoaInput {
+	s.InterconnectId = &v
+	return s
+}
+
+// SetLoaContentType sets the LoaContentType field's value.
+func (s *DescribeInterconnectLoaInput) SetLoaContentType(v string) *DescribeInterconnectLoaInput {
+	s.LoaContentType = &v
+	return s
+}
+
+// SetProviderName sets the ProviderName field's value.
+func (s *DescribeInterconnectLoaInput) SetProviderName(v string) *DescribeInterconnectLoaInput {
+	s.ProviderName = &v
+	return s
+}
+
 // The response received when DescribeInterconnectLoa is called.
 type DescribeInterconnectLoaOutput struct {
 	_ struct{} `type:"structure"`
@@ -2742,6 +3060,12 @@ func (s DescribeInterconnectLoaOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInterconnectLoaOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoa sets the Loa field's value.
+func (s *DescribeInterconnectLoaOutput) SetLoa(v *Loa) *DescribeInterconnectLoaOutput {
+	s.Loa = v
+	return s
 }
 
 // Container for the parameters to the DescribeInterconnects operation.
@@ -2764,6 +3088,12 @@ func (s DescribeInterconnectsInput) GoString() string {
 	return s.String()
 }
 
+// SetInterconnectId sets the InterconnectId field's value.
+func (s *DescribeInterconnectsInput) SetInterconnectId(v string) *DescribeInterconnectsInput {
+	s.InterconnectId = &v
+	return s
+}
+
 // A structure containing a list of interconnects.
 type DescribeInterconnectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2780,6 +3110,12 @@ func (s DescribeInterconnectsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInterconnectsOutput) GoString() string {
 	return s.String()
+}
+
+// SetInterconnects sets the Interconnects field's value.
+func (s *DescribeInterconnectsOutput) SetInterconnects(v []*Interconnect) *DescribeInterconnectsOutput {
+	s.Interconnects = v
+	return s
 }
 
 type DescribeLocationsInput struct {
@@ -2818,6 +3154,12 @@ func (s DescribeLocationsOutput) GoString() string {
 	return s.String()
 }
 
+// SetLocations sets the Locations field's value.
+func (s *DescribeLocationsOutput) SetLocations(v []*Location) *DescribeLocationsOutput {
+	s.Locations = v
+	return s
+}
+
 type DescribeVirtualGatewaysInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2850,6 +3192,12 @@ func (s DescribeVirtualGatewaysOutput) GoString() string {
 	return s.String()
 }
 
+// SetVirtualGateways sets the VirtualGateways field's value.
+func (s *DescribeVirtualGatewaysOutput) SetVirtualGateways(v []*VirtualGateway) *DescribeVirtualGatewaysOutput {
+	s.VirtualGateways = v
+	return s
+}
+
 // Container for the parameters to the DescribeVirtualInterfaces operation.
 type DescribeVirtualInterfacesInput struct {
 	_ struct{} `type:"structure"`
@@ -2879,6 +3227,18 @@ func (s DescribeVirtualInterfacesInput) GoString() string {
 	return s.String()
 }
 
+// SetConnectionId sets the ConnectionId field's value.
+func (s *DescribeVirtualInterfacesInput) SetConnectionId(v string) *DescribeVirtualInterfacesInput {
+	s.ConnectionId = &v
+	return s
+}
+
+// SetVirtualInterfaceId sets the VirtualInterfaceId field's value.
+func (s *DescribeVirtualInterfacesInput) SetVirtualInterfaceId(v string) *DescribeVirtualInterfacesInput {
+	s.VirtualInterfaceId = &v
+	return s
+}
+
 // A structure containing a list of virtual interfaces.
 type DescribeVirtualInterfacesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2895,6 +3255,12 @@ func (s DescribeVirtualInterfacesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVirtualInterfacesOutput) GoString() string {
 	return s.String()
+}
+
+// SetVirtualInterfaces sets the VirtualInterfaces field's value.
+func (s *DescribeVirtualInterfacesOutput) SetVirtualInterfaces(v []*VirtualInterface) *DescribeVirtualInterfacesOutput {
+	s.VirtualInterfaces = v
+	return s
 }
 
 // An interconnect is a connection that can host other connections.
@@ -2975,6 +3341,48 @@ func (s Interconnect) GoString() string {
 	return s.String()
 }
 
+// SetBandwidth sets the Bandwidth field's value.
+func (s *Interconnect) SetBandwidth(v string) *Interconnect {
+	s.Bandwidth = &v
+	return s
+}
+
+// SetInterconnectId sets the InterconnectId field's value.
+func (s *Interconnect) SetInterconnectId(v string) *Interconnect {
+	s.InterconnectId = &v
+	return s
+}
+
+// SetInterconnectName sets the InterconnectName field's value.
+func (s *Interconnect) SetInterconnectName(v string) *Interconnect {
+	s.InterconnectName = &v
+	return s
+}
+
+// SetInterconnectState sets the InterconnectState field's value.
+func (s *Interconnect) SetInterconnectState(v string) *Interconnect {
+	s.InterconnectState = &v
+	return s
+}
+
+// SetLoaIssueTime sets the LoaIssueTime field's value.
+func (s *Interconnect) SetLoaIssueTime(v time.Time) *Interconnect {
+	s.LoaIssueTime = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *Interconnect) SetLocation(v string) *Interconnect {
+	s.Location = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *Interconnect) SetRegion(v string) *Interconnect {
+	s.Region = &v
+	return s
+}
+
 // A structure containing the Letter of Authorization - Connecting Facility
 // Assignment (LOA-CFA) for a connection.
 type Loa struct {
@@ -3002,6 +3410,18 @@ func (s Loa) GoString() string {
 	return s.String()
 }
 
+// SetLoaContent sets the LoaContent field's value.
+func (s *Loa) SetLoaContent(v []byte) *Loa {
+	s.LoaContent = v
+	return s
+}
+
+// SetLoaContentType sets the LoaContentType field's value.
+func (s *Loa) SetLoaContentType(v string) *Loa {
+	s.LoaContentType = &v
+	return s
+}
+
 // An AWS Direct Connect location where connections and interconnects can be
 // requested.
 type Location struct {
@@ -3023,6 +3443,18 @@ func (s Location) String() string {
 // GoString returns the string representation
 func (s Location) GoString() string {
 	return s.String()
+}
+
+// SetLocationCode sets the LocationCode field's value.
+func (s *Location) SetLocationCode(v string) *Location {
+	s.LocationCode = &v
+	return s
+}
+
+// SetLocationName sets the LocationName field's value.
+func (s *Location) SetLocationName(v string) *Location {
+	s.LocationName = &v
+	return s
 }
 
 // A structure containing information about a new private virtual interface.
@@ -3106,6 +3538,48 @@ func (s *NewPrivateVirtualInterface) Validate() error {
 	return nil
 }
 
+// SetAmazonAddress sets the AmazonAddress field's value.
+func (s *NewPrivateVirtualInterface) SetAmazonAddress(v string) *NewPrivateVirtualInterface {
+	s.AmazonAddress = &v
+	return s
+}
+
+// SetAsn sets the Asn field's value.
+func (s *NewPrivateVirtualInterface) SetAsn(v int64) *NewPrivateVirtualInterface {
+	s.Asn = &v
+	return s
+}
+
+// SetAuthKey sets the AuthKey field's value.
+func (s *NewPrivateVirtualInterface) SetAuthKey(v string) *NewPrivateVirtualInterface {
+	s.AuthKey = &v
+	return s
+}
+
+// SetCustomerAddress sets the CustomerAddress field's value.
+func (s *NewPrivateVirtualInterface) SetCustomerAddress(v string) *NewPrivateVirtualInterface {
+	s.CustomerAddress = &v
+	return s
+}
+
+// SetVirtualGatewayId sets the VirtualGatewayId field's value.
+func (s *NewPrivateVirtualInterface) SetVirtualGatewayId(v string) *NewPrivateVirtualInterface {
+	s.VirtualGatewayId = &v
+	return s
+}
+
+// SetVirtualInterfaceName sets the VirtualInterfaceName field's value.
+func (s *NewPrivateVirtualInterface) SetVirtualInterfaceName(v string) *NewPrivateVirtualInterface {
+	s.VirtualInterfaceName = &v
+	return s
+}
+
+// SetVlan sets the Vlan field's value.
+func (s *NewPrivateVirtualInterface) SetVlan(v int64) *NewPrivateVirtualInterface {
+	s.Vlan = &v
+	return s
+}
+
 // A structure containing information about a private virtual interface that
 // will be provisioned on a connection.
 type NewPrivateVirtualInterfaceAllocation struct {
@@ -3175,6 +3649,42 @@ func (s *NewPrivateVirtualInterfaceAllocation) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAmazonAddress sets the AmazonAddress field's value.
+func (s *NewPrivateVirtualInterfaceAllocation) SetAmazonAddress(v string) *NewPrivateVirtualInterfaceAllocation {
+	s.AmazonAddress = &v
+	return s
+}
+
+// SetAsn sets the Asn field's value.
+func (s *NewPrivateVirtualInterfaceAllocation) SetAsn(v int64) *NewPrivateVirtualInterfaceAllocation {
+	s.Asn = &v
+	return s
+}
+
+// SetAuthKey sets the AuthKey field's value.
+func (s *NewPrivateVirtualInterfaceAllocation) SetAuthKey(v string) *NewPrivateVirtualInterfaceAllocation {
+	s.AuthKey = &v
+	return s
+}
+
+// SetCustomerAddress sets the CustomerAddress field's value.
+func (s *NewPrivateVirtualInterfaceAllocation) SetCustomerAddress(v string) *NewPrivateVirtualInterfaceAllocation {
+	s.CustomerAddress = &v
+	return s
+}
+
+// SetVirtualInterfaceName sets the VirtualInterfaceName field's value.
+func (s *NewPrivateVirtualInterfaceAllocation) SetVirtualInterfaceName(v string) *NewPrivateVirtualInterfaceAllocation {
+	s.VirtualInterfaceName = &v
+	return s
+}
+
+// SetVlan sets the Vlan field's value.
+func (s *NewPrivateVirtualInterfaceAllocation) SetVlan(v int64) *NewPrivateVirtualInterfaceAllocation {
+	s.Vlan = &v
+	return s
 }
 
 // A structure containing information about a new public virtual interface.
@@ -3264,6 +3774,48 @@ func (s *NewPublicVirtualInterface) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAmazonAddress sets the AmazonAddress field's value.
+func (s *NewPublicVirtualInterface) SetAmazonAddress(v string) *NewPublicVirtualInterface {
+	s.AmazonAddress = &v
+	return s
+}
+
+// SetAsn sets the Asn field's value.
+func (s *NewPublicVirtualInterface) SetAsn(v int64) *NewPublicVirtualInterface {
+	s.Asn = &v
+	return s
+}
+
+// SetAuthKey sets the AuthKey field's value.
+func (s *NewPublicVirtualInterface) SetAuthKey(v string) *NewPublicVirtualInterface {
+	s.AuthKey = &v
+	return s
+}
+
+// SetCustomerAddress sets the CustomerAddress field's value.
+func (s *NewPublicVirtualInterface) SetCustomerAddress(v string) *NewPublicVirtualInterface {
+	s.CustomerAddress = &v
+	return s
+}
+
+// SetRouteFilterPrefixes sets the RouteFilterPrefixes field's value.
+func (s *NewPublicVirtualInterface) SetRouteFilterPrefixes(v []*RouteFilterPrefix) *NewPublicVirtualInterface {
+	s.RouteFilterPrefixes = v
+	return s
+}
+
+// SetVirtualInterfaceName sets the VirtualInterfaceName field's value.
+func (s *NewPublicVirtualInterface) SetVirtualInterfaceName(v string) *NewPublicVirtualInterface {
+	s.VirtualInterfaceName = &v
+	return s
+}
+
+// SetVlan sets the Vlan field's value.
+func (s *NewPublicVirtualInterface) SetVlan(v int64) *NewPublicVirtualInterface {
+	s.Vlan = &v
+	return s
 }
 
 // A structure containing information about a public virtual interface that
@@ -3356,6 +3908,48 @@ func (s *NewPublicVirtualInterfaceAllocation) Validate() error {
 	return nil
 }
 
+// SetAmazonAddress sets the AmazonAddress field's value.
+func (s *NewPublicVirtualInterfaceAllocation) SetAmazonAddress(v string) *NewPublicVirtualInterfaceAllocation {
+	s.AmazonAddress = &v
+	return s
+}
+
+// SetAsn sets the Asn field's value.
+func (s *NewPublicVirtualInterfaceAllocation) SetAsn(v int64) *NewPublicVirtualInterfaceAllocation {
+	s.Asn = &v
+	return s
+}
+
+// SetAuthKey sets the AuthKey field's value.
+func (s *NewPublicVirtualInterfaceAllocation) SetAuthKey(v string) *NewPublicVirtualInterfaceAllocation {
+	s.AuthKey = &v
+	return s
+}
+
+// SetCustomerAddress sets the CustomerAddress field's value.
+func (s *NewPublicVirtualInterfaceAllocation) SetCustomerAddress(v string) *NewPublicVirtualInterfaceAllocation {
+	s.CustomerAddress = &v
+	return s
+}
+
+// SetRouteFilterPrefixes sets the RouteFilterPrefixes field's value.
+func (s *NewPublicVirtualInterfaceAllocation) SetRouteFilterPrefixes(v []*RouteFilterPrefix) *NewPublicVirtualInterfaceAllocation {
+	s.RouteFilterPrefixes = v
+	return s
+}
+
+// SetVirtualInterfaceName sets the VirtualInterfaceName field's value.
+func (s *NewPublicVirtualInterfaceAllocation) SetVirtualInterfaceName(v string) *NewPublicVirtualInterfaceAllocation {
+	s.VirtualInterfaceName = &v
+	return s
+}
+
+// SetVlan sets the Vlan field's value.
+func (s *NewPublicVirtualInterfaceAllocation) SetVlan(v int64) *NewPublicVirtualInterfaceAllocation {
+	s.Vlan = &v
+	return s
+}
+
 // A route filter prefix that the customer can advertise through Border Gateway
 // Protocol (BGP) over a public virtual interface.
 type RouteFilterPrefix struct {
@@ -3376,6 +3970,12 @@ func (s RouteFilterPrefix) String() string {
 // GoString returns the string representation
 func (s RouteFilterPrefix) GoString() string {
 	return s.String()
+}
+
+// SetCidr sets the Cidr field's value.
+func (s *RouteFilterPrefix) SetCidr(v string) *RouteFilterPrefix {
+	s.Cidr = &v
+	return s
 }
 
 // You can create one or more AWS Direct Connect private virtual interfaces
@@ -3413,6 +4013,18 @@ func (s VirtualGateway) String() string {
 // GoString returns the string representation
 func (s VirtualGateway) GoString() string {
 	return s.String()
+}
+
+// SetVirtualGatewayId sets the VirtualGatewayId field's value.
+func (s *VirtualGateway) SetVirtualGatewayId(v string) *VirtualGateway {
+	s.VirtualGatewayId = &v
+	return s
+}
+
+// SetVirtualGatewayState sets the VirtualGatewayState field's value.
+func (s *VirtualGateway) SetVirtualGatewayState(v string) *VirtualGateway {
+	s.VirtualGatewayState = &v
+	return s
 }
 
 // A virtual interface (VLAN) transmits the traffic between the AWS Direct Connect
@@ -3532,6 +4144,96 @@ func (s VirtualInterface) String() string {
 // GoString returns the string representation
 func (s VirtualInterface) GoString() string {
 	return s.String()
+}
+
+// SetAmazonAddress sets the AmazonAddress field's value.
+func (s *VirtualInterface) SetAmazonAddress(v string) *VirtualInterface {
+	s.AmazonAddress = &v
+	return s
+}
+
+// SetAsn sets the Asn field's value.
+func (s *VirtualInterface) SetAsn(v int64) *VirtualInterface {
+	s.Asn = &v
+	return s
+}
+
+// SetAuthKey sets the AuthKey field's value.
+func (s *VirtualInterface) SetAuthKey(v string) *VirtualInterface {
+	s.AuthKey = &v
+	return s
+}
+
+// SetConnectionId sets the ConnectionId field's value.
+func (s *VirtualInterface) SetConnectionId(v string) *VirtualInterface {
+	s.ConnectionId = &v
+	return s
+}
+
+// SetCustomerAddress sets the CustomerAddress field's value.
+func (s *VirtualInterface) SetCustomerAddress(v string) *VirtualInterface {
+	s.CustomerAddress = &v
+	return s
+}
+
+// SetCustomerRouterConfig sets the CustomerRouterConfig field's value.
+func (s *VirtualInterface) SetCustomerRouterConfig(v string) *VirtualInterface {
+	s.CustomerRouterConfig = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *VirtualInterface) SetLocation(v string) *VirtualInterface {
+	s.Location = &v
+	return s
+}
+
+// SetOwnerAccount sets the OwnerAccount field's value.
+func (s *VirtualInterface) SetOwnerAccount(v string) *VirtualInterface {
+	s.OwnerAccount = &v
+	return s
+}
+
+// SetRouteFilterPrefixes sets the RouteFilterPrefixes field's value.
+func (s *VirtualInterface) SetRouteFilterPrefixes(v []*RouteFilterPrefix) *VirtualInterface {
+	s.RouteFilterPrefixes = v
+	return s
+}
+
+// SetVirtualGatewayId sets the VirtualGatewayId field's value.
+func (s *VirtualInterface) SetVirtualGatewayId(v string) *VirtualInterface {
+	s.VirtualGatewayId = &v
+	return s
+}
+
+// SetVirtualInterfaceId sets the VirtualInterfaceId field's value.
+func (s *VirtualInterface) SetVirtualInterfaceId(v string) *VirtualInterface {
+	s.VirtualInterfaceId = &v
+	return s
+}
+
+// SetVirtualInterfaceName sets the VirtualInterfaceName field's value.
+func (s *VirtualInterface) SetVirtualInterfaceName(v string) *VirtualInterface {
+	s.VirtualInterfaceName = &v
+	return s
+}
+
+// SetVirtualInterfaceState sets the VirtualInterfaceState field's value.
+func (s *VirtualInterface) SetVirtualInterfaceState(v string) *VirtualInterface {
+	s.VirtualInterfaceState = &v
+	return s
+}
+
+// SetVirtualInterfaceType sets the VirtualInterfaceType field's value.
+func (s *VirtualInterface) SetVirtualInterfaceType(v string) *VirtualInterface {
+	s.VirtualInterfaceType = &v
+	return s
+}
+
+// SetVlan sets the Vlan field's value.
+func (s *VirtualInterface) SetVlan(v int64) *VirtualInterface {
+	s.Vlan = &v
+	return s
 }
 
 // State of the connection.

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -2823,6 +2823,24 @@ func (s *AddIpRoutesInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *AddIpRoutesInput) SetDirectoryId(v string) *AddIpRoutesInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetIpRoutes sets the IpRoutes field's value.
+func (s *AddIpRoutesInput) SetIpRoutes(v []*IpRoute) *AddIpRoutesInput {
+	s.IpRoutes = v
+	return s
+}
+
+// SetUpdateSecurityGroupForDirectoryControllers sets the UpdateSecurityGroupForDirectoryControllers field's value.
+func (s *AddIpRoutesInput) SetUpdateSecurityGroupForDirectoryControllers(v bool) *AddIpRoutesInput {
+	s.UpdateSecurityGroupForDirectoryControllers = &v
+	return s
+}
+
 type AddIpRoutesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2887,6 +2905,18 @@ func (s *AddTagsToResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *AddTagsToResourceInput) SetResourceId(v string) *AddTagsToResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToResourceInput) SetTags(v []*Tag) *AddTagsToResourceInput {
+	s.Tags = v
+	return s
+}
+
 type AddTagsToResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2935,6 +2965,18 @@ func (s *Attribute) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *Attribute) SetName(v string) *Attribute {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Attribute) SetValue(v string) *Attribute {
+	s.Value = &v
+	return s
+}
+
 // Contains information about a computer account in a directory.
 type Computer struct {
 	_ struct{} `type:"structure"`
@@ -2958,6 +3000,24 @@ func (s Computer) String() string {
 // GoString returns the string representation
 func (s Computer) GoString() string {
 	return s.String()
+}
+
+// SetComputerAttributes sets the ComputerAttributes field's value.
+func (s *Computer) SetComputerAttributes(v []*Attribute) *Computer {
+	s.ComputerAttributes = v
+	return s
+}
+
+// SetComputerId sets the ComputerId field's value.
+func (s *Computer) SetComputerId(v string) *Computer {
+	s.ComputerId = &v
+	return s
+}
+
+// SetComputerName sets the ComputerName field's value.
+func (s *Computer) SetComputerName(v string) *Computer {
+	s.ComputerName = &v
+	return s
 }
 
 // Points to a remote domain with which you are setting up a trust relationship.
@@ -2989,6 +3049,24 @@ func (s ConditionalForwarder) String() string {
 // GoString returns the string representation
 func (s ConditionalForwarder) GoString() string {
 	return s.String()
+}
+
+// SetDnsIpAddrs sets the DnsIpAddrs field's value.
+func (s *ConditionalForwarder) SetDnsIpAddrs(v []*string) *ConditionalForwarder {
+	s.DnsIpAddrs = v
+	return s
+}
+
+// SetRemoteDomainName sets the RemoteDomainName field's value.
+func (s *ConditionalForwarder) SetRemoteDomainName(v string) *ConditionalForwarder {
+	s.RemoteDomainName = &v
+	return s
+}
+
+// SetReplicationScope sets the ReplicationScope field's value.
+func (s *ConditionalForwarder) SetReplicationScope(v string) *ConditionalForwarder {
+	s.ReplicationScope = &v
+	return s
 }
 
 // Contains the inputs for the ConnectDirectory operation.
@@ -3063,6 +3141,42 @@ func (s *ConnectDirectoryInput) Validate() error {
 	return nil
 }
 
+// SetConnectSettings sets the ConnectSettings field's value.
+func (s *ConnectDirectoryInput) SetConnectSettings(v *DirectoryConnectSettings) *ConnectDirectoryInput {
+	s.ConnectSettings = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ConnectDirectoryInput) SetDescription(v string) *ConnectDirectoryInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ConnectDirectoryInput) SetName(v string) *ConnectDirectoryInput {
+	s.Name = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *ConnectDirectoryInput) SetPassword(v string) *ConnectDirectoryInput {
+	s.Password = &v
+	return s
+}
+
+// SetShortName sets the ShortName field's value.
+func (s *ConnectDirectoryInput) SetShortName(v string) *ConnectDirectoryInput {
+	s.ShortName = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *ConnectDirectoryInput) SetSize(v string) *ConnectDirectoryInput {
+	s.Size = &v
+	return s
+}
+
 // Contains the results of the ConnectDirectory operation.
 type ConnectDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -3079,6 +3193,12 @@ func (s ConnectDirectoryOutput) String() string {
 // GoString returns the string representation
 func (s ConnectDirectoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *ConnectDirectoryOutput) SetDirectoryId(v string) *ConnectDirectoryOutput {
+	s.DirectoryId = &v
+	return s
 }
 
 // Contains the inputs for the CreateAlias operation.
@@ -3128,6 +3248,18 @@ func (s *CreateAliasInput) Validate() error {
 	return nil
 }
 
+// SetAlias sets the Alias field's value.
+func (s *CreateAliasInput) SetAlias(v string) *CreateAliasInput {
+	s.Alias = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *CreateAliasInput) SetDirectoryId(v string) *CreateAliasInput {
+	s.DirectoryId = &v
+	return s
+}
+
 // Contains the results of the CreateAlias operation.
 type CreateAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -3147,6 +3279,18 @@ func (s CreateAliasOutput) String() string {
 // GoString returns the string representation
 func (s CreateAliasOutput) GoString() string {
 	return s.String()
+}
+
+// SetAlias sets the Alias field's value.
+func (s *CreateAliasOutput) SetAlias(v string) *CreateAliasOutput {
+	s.Alias = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *CreateAliasOutput) SetDirectoryId(v string) *CreateAliasOutput {
+	s.DirectoryId = &v
+	return s
 }
 
 // Contains the inputs for the CreateComputer operation.
@@ -3226,6 +3370,36 @@ func (s *CreateComputerInput) Validate() error {
 	return nil
 }
 
+// SetComputerAttributes sets the ComputerAttributes field's value.
+func (s *CreateComputerInput) SetComputerAttributes(v []*Attribute) *CreateComputerInput {
+	s.ComputerAttributes = v
+	return s
+}
+
+// SetComputerName sets the ComputerName field's value.
+func (s *CreateComputerInput) SetComputerName(v string) *CreateComputerInput {
+	s.ComputerName = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *CreateComputerInput) SetDirectoryId(v string) *CreateComputerInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetOrganizationalUnitDistinguishedName sets the OrganizationalUnitDistinguishedName field's value.
+func (s *CreateComputerInput) SetOrganizationalUnitDistinguishedName(v string) *CreateComputerInput {
+	s.OrganizationalUnitDistinguishedName = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *CreateComputerInput) SetPassword(v string) *CreateComputerInput {
+	s.Password = &v
+	return s
+}
+
 // Contains the results for the CreateComputer operation.
 type CreateComputerOutput struct {
 	_ struct{} `type:"structure"`
@@ -3242,6 +3416,12 @@ func (s CreateComputerOutput) String() string {
 // GoString returns the string representation
 func (s CreateComputerOutput) GoString() string {
 	return s.String()
+}
+
+// SetComputer sets the Computer field's value.
+func (s *CreateComputerOutput) SetComputer(v *Computer) *CreateComputerOutput {
+	s.Computer = v
+	return s
 }
 
 // Initiates the creation of a conditional forwarder for your AWS Directory
@@ -3295,6 +3475,24 @@ func (s *CreateConditionalForwarderInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *CreateConditionalForwarderInput) SetDirectoryId(v string) *CreateConditionalForwarderInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetDnsIpAddrs sets the DnsIpAddrs field's value.
+func (s *CreateConditionalForwarderInput) SetDnsIpAddrs(v []*string) *CreateConditionalForwarderInput {
+	s.DnsIpAddrs = v
+	return s
+}
+
+// SetRemoteDomainName sets the RemoteDomainName field's value.
+func (s *CreateConditionalForwarderInput) SetRemoteDomainName(v string) *CreateConditionalForwarderInput {
+	s.RemoteDomainName = &v
+	return s
 }
 
 // The result of a CreateConditinalForwarder request.
@@ -3378,6 +3576,42 @@ func (s *CreateDirectoryInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateDirectoryInput) SetDescription(v string) *CreateDirectoryInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateDirectoryInput) SetName(v string) *CreateDirectoryInput {
+	s.Name = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *CreateDirectoryInput) SetPassword(v string) *CreateDirectoryInput {
+	s.Password = &v
+	return s
+}
+
+// SetShortName sets the ShortName field's value.
+func (s *CreateDirectoryInput) SetShortName(v string) *CreateDirectoryInput {
+	s.ShortName = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *CreateDirectoryInput) SetSize(v string) *CreateDirectoryInput {
+	s.Size = &v
+	return s
+}
+
+// SetVpcSettings sets the VpcSettings field's value.
+func (s *CreateDirectoryInput) SetVpcSettings(v *DirectoryVpcSettings) *CreateDirectoryInput {
+	s.VpcSettings = v
+	return s
+}
+
 // Contains the results of the CreateDirectory operation.
 type CreateDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -3394,6 +3628,12 @@ func (s CreateDirectoryOutput) String() string {
 // GoString returns the string representation
 func (s CreateDirectoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *CreateDirectoryOutput) SetDirectoryId(v string) *CreateDirectoryOutput {
+	s.DirectoryId = &v
+	return s
 }
 
 // Creates a Microsoft AD in the AWS cloud.
@@ -3461,6 +3701,36 @@ func (s *CreateMicrosoftADInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateMicrosoftADInput) SetDescription(v string) *CreateMicrosoftADInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateMicrosoftADInput) SetName(v string) *CreateMicrosoftADInput {
+	s.Name = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *CreateMicrosoftADInput) SetPassword(v string) *CreateMicrosoftADInput {
+	s.Password = &v
+	return s
+}
+
+// SetShortName sets the ShortName field's value.
+func (s *CreateMicrosoftADInput) SetShortName(v string) *CreateMicrosoftADInput {
+	s.ShortName = &v
+	return s
+}
+
+// SetVpcSettings sets the VpcSettings field's value.
+func (s *CreateMicrosoftADInput) SetVpcSettings(v *DirectoryVpcSettings) *CreateMicrosoftADInput {
+	s.VpcSettings = v
+	return s
+}
+
 // Result of a CreateMicrosoftAD request.
 type CreateMicrosoftADOutput struct {
 	_ struct{} `type:"structure"`
@@ -3477,6 +3747,12 @@ func (s CreateMicrosoftADOutput) String() string {
 // GoString returns the string representation
 func (s CreateMicrosoftADOutput) GoString() string {
 	return s.String()
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *CreateMicrosoftADOutput) SetDirectoryId(v string) *CreateMicrosoftADOutput {
+	s.DirectoryId = &v
+	return s
 }
 
 // Contains the inputs for the CreateSnapshot operation.
@@ -3515,6 +3791,18 @@ func (s *CreateSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *CreateSnapshotInput) SetDirectoryId(v string) *CreateSnapshotInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateSnapshotInput) SetName(v string) *CreateSnapshotInput {
+	s.Name = &v
+	return s
+}
+
 // Contains the results of the CreateSnapshot operation.
 type CreateSnapshotOutput struct {
 	_ struct{} `type:"structure"`
@@ -3531,6 +3819,12 @@ func (s CreateSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *CreateSnapshotOutput) SetSnapshotId(v string) *CreateSnapshotOutput {
+	s.SnapshotId = &v
+	return s
 }
 
 // AWS Directory Service for Microsoft Active Directory allows you to configure
@@ -3609,6 +3903,42 @@ func (s *CreateTrustInput) Validate() error {
 	return nil
 }
 
+// SetConditionalForwarderIpAddrs sets the ConditionalForwarderIpAddrs field's value.
+func (s *CreateTrustInput) SetConditionalForwarderIpAddrs(v []*string) *CreateTrustInput {
+	s.ConditionalForwarderIpAddrs = v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *CreateTrustInput) SetDirectoryId(v string) *CreateTrustInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetRemoteDomainName sets the RemoteDomainName field's value.
+func (s *CreateTrustInput) SetRemoteDomainName(v string) *CreateTrustInput {
+	s.RemoteDomainName = &v
+	return s
+}
+
+// SetTrustDirection sets the TrustDirection field's value.
+func (s *CreateTrustInput) SetTrustDirection(v string) *CreateTrustInput {
+	s.TrustDirection = &v
+	return s
+}
+
+// SetTrustPassword sets the TrustPassword field's value.
+func (s *CreateTrustInput) SetTrustPassword(v string) *CreateTrustInput {
+	s.TrustPassword = &v
+	return s
+}
+
+// SetTrustType sets the TrustType field's value.
+func (s *CreateTrustInput) SetTrustType(v string) *CreateTrustInput {
+	s.TrustType = &v
+	return s
+}
+
 // The result of a CreateTrust request.
 type CreateTrustOutput struct {
 	_ struct{} `type:"structure"`
@@ -3625,6 +3955,12 @@ func (s CreateTrustOutput) String() string {
 // GoString returns the string representation
 func (s CreateTrustOutput) GoString() string {
 	return s.String()
+}
+
+// SetTrustId sets the TrustId field's value.
+func (s *CreateTrustOutput) SetTrustId(v string) *CreateTrustOutput {
+	s.TrustId = &v
+	return s
 }
 
 // Deletes a conditional forwarder.
@@ -3667,6 +4003,18 @@ func (s *DeleteConditionalForwarderInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DeleteConditionalForwarderInput) SetDirectoryId(v string) *DeleteConditionalForwarderInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetRemoteDomainName sets the RemoteDomainName field's value.
+func (s *DeleteConditionalForwarderInput) SetRemoteDomainName(v string) *DeleteConditionalForwarderInput {
+	s.RemoteDomainName = &v
+	return s
 }
 
 // The result of a DeleteConditionalForwarder request.
@@ -3717,6 +4065,12 @@ func (s *DeleteDirectoryInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DeleteDirectoryInput) SetDirectoryId(v string) *DeleteDirectoryInput {
+	s.DirectoryId = &v
+	return s
+}
+
 // Contains the results of the DeleteDirectory operation.
 type DeleteDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -3733,6 +4087,12 @@ func (s DeleteDirectoryOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDirectoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DeleteDirectoryOutput) SetDirectoryId(v string) *DeleteDirectoryOutput {
+	s.DirectoryId = &v
+	return s
 }
 
 // Contains the inputs for the DeleteSnapshot operation.
@@ -3768,6 +4128,12 @@ func (s *DeleteSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *DeleteSnapshotInput) SetSnapshotId(v string) *DeleteSnapshotInput {
+	s.SnapshotId = &v
+	return s
+}
+
 // Contains the results of the DeleteSnapshot operation.
 type DeleteSnapshotOutput struct {
 	_ struct{} `type:"structure"`
@@ -3784,6 +4150,12 @@ func (s DeleteSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *DeleteSnapshotOutput) SetSnapshotId(v string) *DeleteSnapshotOutput {
+	s.SnapshotId = &v
+	return s
 }
 
 // Deletes the local side of an existing trust relationship between the Microsoft
@@ -3823,6 +4195,18 @@ func (s *DeleteTrustInput) Validate() error {
 	return nil
 }
 
+// SetDeleteAssociatedConditionalForwarder sets the DeleteAssociatedConditionalForwarder field's value.
+func (s *DeleteTrustInput) SetDeleteAssociatedConditionalForwarder(v bool) *DeleteTrustInput {
+	s.DeleteAssociatedConditionalForwarder = &v
+	return s
+}
+
+// SetTrustId sets the TrustId field's value.
+func (s *DeleteTrustInput) SetTrustId(v string) *DeleteTrustInput {
+	s.TrustId = &v
+	return s
+}
+
 // The result of a DeleteTrust request.
 type DeleteTrustOutput struct {
 	_ struct{} `type:"structure"`
@@ -3839,6 +4223,12 @@ func (s DeleteTrustOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTrustOutput) GoString() string {
 	return s.String()
+}
+
+// SetTrustId sets the TrustId field's value.
+func (s *DeleteTrustOutput) SetTrustId(v string) *DeleteTrustOutput {
+	s.TrustId = &v
+	return s
 }
 
 // Removes the specified directory as a publisher to the specified SNS topic.
@@ -3884,6 +4274,18 @@ func (s *DeregisterEventTopicInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DeregisterEventTopicInput) SetDirectoryId(v string) *DeregisterEventTopicInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetTopicName sets the TopicName field's value.
+func (s *DeregisterEventTopicInput) SetTopicName(v string) *DeregisterEventTopicInput {
+	s.TopicName = &v
+	return s
 }
 
 // The result of a DeregisterEventTopic request.
@@ -3939,6 +4341,18 @@ func (s *DescribeConditionalForwardersInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DescribeConditionalForwardersInput) SetDirectoryId(v string) *DescribeConditionalForwardersInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetRemoteDomainNames sets the RemoteDomainNames field's value.
+func (s *DescribeConditionalForwardersInput) SetRemoteDomainNames(v []*string) *DescribeConditionalForwardersInput {
+	s.RemoteDomainNames = v
+	return s
+}
+
 // The result of a DescribeConditionalForwarder request.
 type DescribeConditionalForwardersOutput struct {
 	_ struct{} `type:"structure"`
@@ -3955,6 +4369,12 @@ func (s DescribeConditionalForwardersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConditionalForwardersOutput) GoString() string {
 	return s.String()
+}
+
+// SetConditionalForwarders sets the ConditionalForwarders field's value.
+func (s *DescribeConditionalForwardersOutput) SetConditionalForwarders(v []*ConditionalForwarder) *DescribeConditionalForwardersOutput {
+	s.ConditionalForwarders = v
+	return s
 }
 
 // Contains the inputs for the DescribeDirectories operation.
@@ -3987,6 +4407,24 @@ func (s DescribeDirectoriesInput) GoString() string {
 	return s.String()
 }
 
+// SetDirectoryIds sets the DirectoryIds field's value.
+func (s *DescribeDirectoriesInput) SetDirectoryIds(v []*string) *DescribeDirectoriesInput {
+	s.DirectoryIds = v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeDirectoriesInput) SetLimit(v int64) *DescribeDirectoriesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeDirectoriesInput) SetNextToken(v string) *DescribeDirectoriesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the results of the DescribeDirectories operation.
 type DescribeDirectoriesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4015,6 +4453,18 @@ func (s DescribeDirectoriesOutput) GoString() string {
 	return s.String()
 }
 
+// SetDirectoryDescriptions sets the DirectoryDescriptions field's value.
+func (s *DescribeDirectoriesOutput) SetDirectoryDescriptions(v []*DirectoryDescription) *DescribeDirectoriesOutput {
+	s.DirectoryDescriptions = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeDirectoriesOutput) SetNextToken(v string) *DescribeDirectoriesOutput {
+	s.NextToken = &v
+	return s
+}
+
 // Describes event topics.
 type DescribeEventTopicsInput struct {
 	_ struct{} `type:"structure"`
@@ -4040,6 +4490,18 @@ func (s DescribeEventTopicsInput) GoString() string {
 	return s.String()
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DescribeEventTopicsInput) SetDirectoryId(v string) *DescribeEventTopicsInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetTopicNames sets the TopicNames field's value.
+func (s *DescribeEventTopicsInput) SetTopicNames(v []*string) *DescribeEventTopicsInput {
+	s.TopicNames = v
+	return s
+}
+
 // The result of a DescribeEventTopic request.
 type DescribeEventTopicsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4057,6 +4519,12 @@ func (s DescribeEventTopicsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventTopicsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventTopics sets the EventTopics field's value.
+func (s *DescribeEventTopicsOutput) SetEventTopics(v []*EventTopic) *DescribeEventTopicsOutput {
+	s.EventTopics = v
+	return s
 }
 
 // Contains the inputs for the DescribeSnapshots operation.
@@ -4089,6 +4557,30 @@ func (s DescribeSnapshotsInput) GoString() string {
 	return s.String()
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DescribeSnapshotsInput) SetDirectoryId(v string) *DescribeSnapshotsInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeSnapshotsInput) SetLimit(v int64) *DescribeSnapshotsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSnapshotsInput) SetNextToken(v string) *DescribeSnapshotsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSnapshotIds sets the SnapshotIds field's value.
+func (s *DescribeSnapshotsInput) SetSnapshotIds(v []*string) *DescribeSnapshotsInput {
+	s.SnapshotIds = v
+	return s
+}
+
 // Contains the results of the DescribeSnapshots operation.
 type DescribeSnapshotsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4114,6 +4606,18 @@ func (s DescribeSnapshotsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSnapshotsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSnapshotsOutput) SetNextToken(v string) *DescribeSnapshotsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSnapshots sets the Snapshots field's value.
+func (s *DescribeSnapshotsOutput) SetSnapshots(v []*Snapshot) *DescribeSnapshotsOutput {
+	s.Snapshots = v
+	return s
 }
 
 // Describes the trust relationships for a particular Microsoft AD in the AWS
@@ -4151,6 +4655,30 @@ func (s DescribeTrustsInput) GoString() string {
 	return s.String()
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DescribeTrustsInput) SetDirectoryId(v string) *DescribeTrustsInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeTrustsInput) SetLimit(v int64) *DescribeTrustsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTrustsInput) SetNextToken(v string) *DescribeTrustsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTrustIds sets the TrustIds field's value.
+func (s *DescribeTrustsInput) SetTrustIds(v []*string) *DescribeTrustsInput {
+	s.TrustIds = v
+	return s
+}
+
 // The result of a DescribeTrust request.
 type DescribeTrustsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4177,6 +4705,18 @@ func (s DescribeTrustsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTrustsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTrustsOutput) SetNextToken(v string) *DescribeTrustsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTrusts sets the Trusts field's value.
+func (s *DescribeTrustsOutput) SetTrusts(v []*Trust) *DescribeTrustsOutput {
+	s.Trusts = v
+	return s
 }
 
 // Contains information for the ConnectDirectory operation when an AD Connector
@@ -4248,6 +4788,30 @@ func (s *DirectoryConnectSettings) Validate() error {
 	return nil
 }
 
+// SetCustomerDnsIps sets the CustomerDnsIps field's value.
+func (s *DirectoryConnectSettings) SetCustomerDnsIps(v []*string) *DirectoryConnectSettings {
+	s.CustomerDnsIps = v
+	return s
+}
+
+// SetCustomerUserName sets the CustomerUserName field's value.
+func (s *DirectoryConnectSettings) SetCustomerUserName(v string) *DirectoryConnectSettings {
+	s.CustomerUserName = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *DirectoryConnectSettings) SetSubnetIds(v []*string) *DirectoryConnectSettings {
+	s.SubnetIds = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DirectoryConnectSettings) SetVpcId(v string) *DirectoryConnectSettings {
+	s.VpcId = &v
+	return s
+}
+
 // Contains information about an AD Connector directory.
 type DirectoryConnectSettingsDescription struct {
 	_ struct{} `type:"structure"`
@@ -4279,6 +4843,42 @@ func (s DirectoryConnectSettingsDescription) String() string {
 // GoString returns the string representation
 func (s DirectoryConnectSettingsDescription) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *DirectoryConnectSettingsDescription) SetAvailabilityZones(v []*string) *DirectoryConnectSettingsDescription {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetConnectIps sets the ConnectIps field's value.
+func (s *DirectoryConnectSettingsDescription) SetConnectIps(v []*string) *DirectoryConnectSettingsDescription {
+	s.ConnectIps = v
+	return s
+}
+
+// SetCustomerUserName sets the CustomerUserName field's value.
+func (s *DirectoryConnectSettingsDescription) SetCustomerUserName(v string) *DirectoryConnectSettingsDescription {
+	s.CustomerUserName = &v
+	return s
+}
+
+// SetSecurityGroupId sets the SecurityGroupId field's value.
+func (s *DirectoryConnectSettingsDescription) SetSecurityGroupId(v string) *DirectoryConnectSettingsDescription {
+	s.SecurityGroupId = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *DirectoryConnectSettingsDescription) SetSubnetIds(v []*string) *DirectoryConnectSettingsDescription {
+	s.SubnetIds = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DirectoryConnectSettingsDescription) SetVpcId(v string) *DirectoryConnectSettingsDescription {
+	s.VpcId = &v
+	return s
 }
 
 // Contains information about an AWS Directory Service directory.
@@ -4363,6 +4963,114 @@ func (s DirectoryDescription) GoString() string {
 	return s.String()
 }
 
+// SetAccessUrl sets the AccessUrl field's value.
+func (s *DirectoryDescription) SetAccessUrl(v string) *DirectoryDescription {
+	s.AccessUrl = &v
+	return s
+}
+
+// SetAlias sets the Alias field's value.
+func (s *DirectoryDescription) SetAlias(v string) *DirectoryDescription {
+	s.Alias = &v
+	return s
+}
+
+// SetConnectSettings sets the ConnectSettings field's value.
+func (s *DirectoryDescription) SetConnectSettings(v *DirectoryConnectSettingsDescription) *DirectoryDescription {
+	s.ConnectSettings = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DirectoryDescription) SetDescription(v string) *DirectoryDescription {
+	s.Description = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DirectoryDescription) SetDirectoryId(v string) *DirectoryDescription {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetDnsIpAddrs sets the DnsIpAddrs field's value.
+func (s *DirectoryDescription) SetDnsIpAddrs(v []*string) *DirectoryDescription {
+	s.DnsIpAddrs = v
+	return s
+}
+
+// SetLaunchTime sets the LaunchTime field's value.
+func (s *DirectoryDescription) SetLaunchTime(v time.Time) *DirectoryDescription {
+	s.LaunchTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DirectoryDescription) SetName(v string) *DirectoryDescription {
+	s.Name = &v
+	return s
+}
+
+// SetRadiusSettings sets the RadiusSettings field's value.
+func (s *DirectoryDescription) SetRadiusSettings(v *RadiusSettings) *DirectoryDescription {
+	s.RadiusSettings = v
+	return s
+}
+
+// SetRadiusStatus sets the RadiusStatus field's value.
+func (s *DirectoryDescription) SetRadiusStatus(v string) *DirectoryDescription {
+	s.RadiusStatus = &v
+	return s
+}
+
+// SetShortName sets the ShortName field's value.
+func (s *DirectoryDescription) SetShortName(v string) *DirectoryDescription {
+	s.ShortName = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *DirectoryDescription) SetSize(v string) *DirectoryDescription {
+	s.Size = &v
+	return s
+}
+
+// SetSsoEnabled sets the SsoEnabled field's value.
+func (s *DirectoryDescription) SetSsoEnabled(v bool) *DirectoryDescription {
+	s.SsoEnabled = &v
+	return s
+}
+
+// SetStage sets the Stage field's value.
+func (s *DirectoryDescription) SetStage(v string) *DirectoryDescription {
+	s.Stage = &v
+	return s
+}
+
+// SetStageLastUpdatedDateTime sets the StageLastUpdatedDateTime field's value.
+func (s *DirectoryDescription) SetStageLastUpdatedDateTime(v time.Time) *DirectoryDescription {
+	s.StageLastUpdatedDateTime = &v
+	return s
+}
+
+// SetStageReason sets the StageReason field's value.
+func (s *DirectoryDescription) SetStageReason(v string) *DirectoryDescription {
+	s.StageReason = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *DirectoryDescription) SetType(v string) *DirectoryDescription {
+	s.Type = &v
+	return s
+}
+
+// SetVpcSettings sets the VpcSettings field's value.
+func (s *DirectoryDescription) SetVpcSettings(v *DirectoryVpcSettingsDescription) *DirectoryDescription {
+	s.VpcSettings = v
+	return s
+}
+
 // Contains directory limit information for a region.
 type DirectoryLimits struct {
 	_ struct{} `type:"structure"`
@@ -4403,6 +5111,60 @@ func (s DirectoryLimits) String() string {
 // GoString returns the string representation
 func (s DirectoryLimits) GoString() string {
 	return s.String()
+}
+
+// SetCloudOnlyDirectoriesCurrentCount sets the CloudOnlyDirectoriesCurrentCount field's value.
+func (s *DirectoryLimits) SetCloudOnlyDirectoriesCurrentCount(v int64) *DirectoryLimits {
+	s.CloudOnlyDirectoriesCurrentCount = &v
+	return s
+}
+
+// SetCloudOnlyDirectoriesLimit sets the CloudOnlyDirectoriesLimit field's value.
+func (s *DirectoryLimits) SetCloudOnlyDirectoriesLimit(v int64) *DirectoryLimits {
+	s.CloudOnlyDirectoriesLimit = &v
+	return s
+}
+
+// SetCloudOnlyDirectoriesLimitReached sets the CloudOnlyDirectoriesLimitReached field's value.
+func (s *DirectoryLimits) SetCloudOnlyDirectoriesLimitReached(v bool) *DirectoryLimits {
+	s.CloudOnlyDirectoriesLimitReached = &v
+	return s
+}
+
+// SetCloudOnlyMicrosoftADCurrentCount sets the CloudOnlyMicrosoftADCurrentCount field's value.
+func (s *DirectoryLimits) SetCloudOnlyMicrosoftADCurrentCount(v int64) *DirectoryLimits {
+	s.CloudOnlyMicrosoftADCurrentCount = &v
+	return s
+}
+
+// SetCloudOnlyMicrosoftADLimit sets the CloudOnlyMicrosoftADLimit field's value.
+func (s *DirectoryLimits) SetCloudOnlyMicrosoftADLimit(v int64) *DirectoryLimits {
+	s.CloudOnlyMicrosoftADLimit = &v
+	return s
+}
+
+// SetCloudOnlyMicrosoftADLimitReached sets the CloudOnlyMicrosoftADLimitReached field's value.
+func (s *DirectoryLimits) SetCloudOnlyMicrosoftADLimitReached(v bool) *DirectoryLimits {
+	s.CloudOnlyMicrosoftADLimitReached = &v
+	return s
+}
+
+// SetConnectedDirectoriesCurrentCount sets the ConnectedDirectoriesCurrentCount field's value.
+func (s *DirectoryLimits) SetConnectedDirectoriesCurrentCount(v int64) *DirectoryLimits {
+	s.ConnectedDirectoriesCurrentCount = &v
+	return s
+}
+
+// SetConnectedDirectoriesLimit sets the ConnectedDirectoriesLimit field's value.
+func (s *DirectoryLimits) SetConnectedDirectoriesLimit(v int64) *DirectoryLimits {
+	s.ConnectedDirectoriesLimit = &v
+	return s
+}
+
+// SetConnectedDirectoriesLimitReached sets the ConnectedDirectoriesLimitReached field's value.
+func (s *DirectoryLimits) SetConnectedDirectoriesLimitReached(v bool) *DirectoryLimits {
+	s.ConnectedDirectoriesLimitReached = &v
+	return s
 }
 
 // Contains VPC information for the CreateDirectory or CreateMicrosoftAD operation.
@@ -4448,6 +5210,18 @@ func (s *DirectoryVpcSettings) Validate() error {
 	return nil
 }
 
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *DirectoryVpcSettings) SetSubnetIds(v []*string) *DirectoryVpcSettings {
+	s.SubnetIds = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DirectoryVpcSettings) SetVpcId(v string) *DirectoryVpcSettings {
+	s.VpcId = &v
+	return s
+}
+
 // Contains information about the directory.
 type DirectoryVpcSettingsDescription struct {
 	_ struct{} `type:"structure"`
@@ -4476,6 +5250,30 @@ func (s DirectoryVpcSettingsDescription) String() string {
 // GoString returns the string representation
 func (s DirectoryVpcSettingsDescription) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *DirectoryVpcSettingsDescription) SetAvailabilityZones(v []*string) *DirectoryVpcSettingsDescription {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetSecurityGroupId sets the SecurityGroupId field's value.
+func (s *DirectoryVpcSettingsDescription) SetSecurityGroupId(v string) *DirectoryVpcSettingsDescription {
+	s.SecurityGroupId = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *DirectoryVpcSettingsDescription) SetSubnetIds(v []*string) *DirectoryVpcSettingsDescription {
+	s.SubnetIds = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DirectoryVpcSettingsDescription) SetVpcId(v string) *DirectoryVpcSettingsDescription {
+	s.VpcId = &v
+	return s
 }
 
 // Contains the inputs for the DisableRadius operation.
@@ -4509,6 +5307,12 @@ func (s *DisableRadiusInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DisableRadiusInput) SetDirectoryId(v string) *DisableRadiusInput {
+	s.DirectoryId = &v
+	return s
 }
 
 // Contains the results of the DisableRadius operation.
@@ -4581,6 +5385,24 @@ func (s *DisableSsoInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DisableSsoInput) SetDirectoryId(v string) *DisableSsoInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *DisableSsoInput) SetPassword(v string) *DisableSsoInput {
+	s.Password = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DisableSsoInput) SetUserName(v string) *DisableSsoInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the results of the DisableSso operation.
 type DisableSsoOutput struct {
 	_ struct{} `type:"structure"`
@@ -4640,6 +5462,18 @@ func (s *EnableRadiusInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *EnableRadiusInput) SetDirectoryId(v string) *EnableRadiusInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetRadiusSettings sets the RadiusSettings field's value.
+func (s *EnableRadiusInput) SetRadiusSettings(v *RadiusSettings) *EnableRadiusInput {
+	s.RadiusSettings = v
+	return s
 }
 
 // Contains the results of the EnableRadius operation.
@@ -4712,6 +5546,24 @@ func (s *EnableSsoInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *EnableSsoInput) SetDirectoryId(v string) *EnableSsoInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *EnableSsoInput) SetPassword(v string) *EnableSsoInput {
+	s.Password = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *EnableSsoInput) SetUserName(v string) *EnableSsoInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the results of the EnableSso operation.
 type EnableSsoOutput struct {
 	_ struct{} `type:"structure"`
@@ -4758,6 +5610,36 @@ func (s EventTopic) GoString() string {
 	return s.String()
 }
 
+// SetCreatedDateTime sets the CreatedDateTime field's value.
+func (s *EventTopic) SetCreatedDateTime(v time.Time) *EventTopic {
+	s.CreatedDateTime = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *EventTopic) SetDirectoryId(v string) *EventTopic {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EventTopic) SetStatus(v string) *EventTopic {
+	s.Status = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *EventTopic) SetTopicArn(v string) *EventTopic {
+	s.TopicArn = &v
+	return s
+}
+
+// SetTopicName sets the TopicName field's value.
+func (s *EventTopic) SetTopicName(v string) *EventTopic {
+	s.TopicName = &v
+	return s
+}
+
 // Contains the inputs for the GetDirectoryLimits operation.
 type GetDirectoryLimitsInput struct {
 	_ struct{} `type:"structure"`
@@ -4790,6 +5672,12 @@ func (s GetDirectoryLimitsOutput) String() string {
 // GoString returns the string representation
 func (s GetDirectoryLimitsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDirectoryLimits sets the DirectoryLimits field's value.
+func (s *GetDirectoryLimitsOutput) SetDirectoryLimits(v *DirectoryLimits) *GetDirectoryLimitsOutput {
+	s.DirectoryLimits = v
+	return s
 }
 
 // Contains the inputs for the GetSnapshotLimits operation.
@@ -4825,6 +5713,12 @@ func (s *GetSnapshotLimitsInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *GetSnapshotLimitsInput) SetDirectoryId(v string) *GetSnapshotLimitsInput {
+	s.DirectoryId = &v
+	return s
+}
+
 // Contains the results of the GetSnapshotLimits operation.
 type GetSnapshotLimitsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4842,6 +5736,12 @@ func (s GetSnapshotLimitsOutput) String() string {
 // GoString returns the string representation
 func (s GetSnapshotLimitsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshotLimits sets the SnapshotLimits field's value.
+func (s *GetSnapshotLimitsOutput) SetSnapshotLimits(v *SnapshotLimits) *GetSnapshotLimitsOutput {
+	s.SnapshotLimits = v
+	return s
 }
 
 // IP address block. This is often the address block of the DNS server used
@@ -4866,6 +5766,18 @@ func (s IpRoute) String() string {
 // GoString returns the string representation
 func (s IpRoute) GoString() string {
 	return s.String()
+}
+
+// SetCidrIp sets the CidrIp field's value.
+func (s *IpRoute) SetCidrIp(v string) *IpRoute {
+	s.CidrIp = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *IpRoute) SetDescription(v string) *IpRoute {
+	s.Description = &v
+	return s
 }
 
 // Information about one or more IP address blocks.
@@ -4899,6 +5811,42 @@ func (s IpRouteInfo) String() string {
 // GoString returns the string representation
 func (s IpRouteInfo) GoString() string {
 	return s.String()
+}
+
+// SetAddedDateTime sets the AddedDateTime field's value.
+func (s *IpRouteInfo) SetAddedDateTime(v time.Time) *IpRouteInfo {
+	s.AddedDateTime = &v
+	return s
+}
+
+// SetCidrIp sets the CidrIp field's value.
+func (s *IpRouteInfo) SetCidrIp(v string) *IpRouteInfo {
+	s.CidrIp = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *IpRouteInfo) SetDescription(v string) *IpRouteInfo {
+	s.Description = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *IpRouteInfo) SetDirectoryId(v string) *IpRouteInfo {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetIpRouteStatusMsg sets the IpRouteStatusMsg field's value.
+func (s *IpRouteInfo) SetIpRouteStatusMsg(v string) *IpRouteInfo {
+	s.IpRouteStatusMsg = &v
+	return s
+}
+
+// SetIpRouteStatusReason sets the IpRouteStatusReason field's value.
+func (s *IpRouteInfo) SetIpRouteStatusReason(v string) *IpRouteInfo {
+	s.IpRouteStatusReason = &v
+	return s
 }
 
 type ListIpRoutesInput struct {
@@ -4941,6 +5889,24 @@ func (s *ListIpRoutesInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *ListIpRoutesInput) SetDirectoryId(v string) *ListIpRoutesInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListIpRoutesInput) SetLimit(v int64) *ListIpRoutesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIpRoutesInput) SetNextToken(v string) *ListIpRoutesInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListIpRoutesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4961,6 +5927,18 @@ func (s ListIpRoutesOutput) String() string {
 // GoString returns the string representation
 func (s ListIpRoutesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIpRoutesInfo sets the IpRoutesInfo field's value.
+func (s *ListIpRoutesOutput) SetIpRoutesInfo(v []*IpRouteInfo) *ListIpRoutesOutput {
+	s.IpRoutesInfo = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIpRoutesOutput) SetNextToken(v string) *ListIpRoutesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListTagsForResourceInput struct {
@@ -5001,6 +5979,24 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListTagsForResourceInput) SetLimit(v int64) *ListTagsForResourceInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTagsForResourceInput) SetNextToken(v string) *ListTagsForResourceInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ListTagsForResourceInput) SetResourceId(v string) *ListTagsForResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5019,6 +6015,18 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTagsForResourceOutput) SetNextToken(v string) *ListTagsForResourceOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput {
+	s.Tags = v
+	return s
 }
 
 // Contains information about a Remote Authentication Dial In User Service (RADIUS)
@@ -5087,6 +6095,54 @@ func (s *RadiusSettings) Validate() error {
 	return nil
 }
 
+// SetAuthenticationProtocol sets the AuthenticationProtocol field's value.
+func (s *RadiusSettings) SetAuthenticationProtocol(v string) *RadiusSettings {
+	s.AuthenticationProtocol = &v
+	return s
+}
+
+// SetDisplayLabel sets the DisplayLabel field's value.
+func (s *RadiusSettings) SetDisplayLabel(v string) *RadiusSettings {
+	s.DisplayLabel = &v
+	return s
+}
+
+// SetRadiusPort sets the RadiusPort field's value.
+func (s *RadiusSettings) SetRadiusPort(v int64) *RadiusSettings {
+	s.RadiusPort = &v
+	return s
+}
+
+// SetRadiusRetries sets the RadiusRetries field's value.
+func (s *RadiusSettings) SetRadiusRetries(v int64) *RadiusSettings {
+	s.RadiusRetries = &v
+	return s
+}
+
+// SetRadiusServers sets the RadiusServers field's value.
+func (s *RadiusSettings) SetRadiusServers(v []*string) *RadiusSettings {
+	s.RadiusServers = v
+	return s
+}
+
+// SetRadiusTimeout sets the RadiusTimeout field's value.
+func (s *RadiusSettings) SetRadiusTimeout(v int64) *RadiusSettings {
+	s.RadiusTimeout = &v
+	return s
+}
+
+// SetSharedSecret sets the SharedSecret field's value.
+func (s *RadiusSettings) SetSharedSecret(v string) *RadiusSettings {
+	s.SharedSecret = &v
+	return s
+}
+
+// SetUseSameUsername sets the UseSameUsername field's value.
+func (s *RadiusSettings) SetUseSameUsername(v bool) *RadiusSettings {
+	s.UseSameUsername = &v
+	return s
+}
+
 // Registers a new event topic.
 type RegisterEventTopicInput struct {
 	_ struct{} `type:"structure"`
@@ -5130,6 +6186,18 @@ func (s *RegisterEventTopicInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *RegisterEventTopicInput) SetDirectoryId(v string) *RegisterEventTopicInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetTopicName sets the TopicName field's value.
+func (s *RegisterEventTopicInput) SetTopicName(v string) *RegisterEventTopicInput {
+	s.TopicName = &v
+	return s
 }
 
 // The result of a RegisterEventTopic request.
@@ -5187,6 +6255,18 @@ func (s *RemoveIpRoutesInput) Validate() error {
 	return nil
 }
 
+// SetCidrIps sets the CidrIps field's value.
+func (s *RemoveIpRoutesInput) SetCidrIps(v []*string) *RemoveIpRoutesInput {
+	s.CidrIps = v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *RemoveIpRoutesInput) SetDirectoryId(v string) *RemoveIpRoutesInput {
+	s.DirectoryId = &v
+	return s
+}
+
 type RemoveIpRoutesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5241,6 +6321,18 @@ func (s *RemoveTagsFromResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *RemoveTagsFromResourceInput) SetResourceId(v string) *RemoveTagsFromResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsFromResourceInput) SetTagKeys(v []*string) *RemoveTagsFromResourceInput {
+	s.TagKeys = v
+	return s
+}
+
 type RemoveTagsFromResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5286,6 +6378,12 @@ func (s *RestoreFromSnapshotInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *RestoreFromSnapshotInput) SetSnapshotId(v string) *RestoreFromSnapshotInput {
+	s.SnapshotId = &v
+	return s
 }
 
 // Contains the results of the RestoreFromSnapshot operation.
@@ -5336,6 +6434,42 @@ func (s Snapshot) GoString() string {
 	return s.String()
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *Snapshot) SetDirectoryId(v string) *Snapshot {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Snapshot) SetName(v string) *Snapshot {
+	s.Name = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *Snapshot) SetSnapshotId(v string) *Snapshot {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *Snapshot) SetStartTime(v time.Time) *Snapshot {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Snapshot) SetStatus(v string) *Snapshot {
+	s.Status = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Snapshot) SetType(v string) *Snapshot {
+	s.Type = &v
+	return s
+}
+
 // Contains manual snapshot limit information for a directory.
 type SnapshotLimits struct {
 	_ struct{} `type:"structure"`
@@ -5358,6 +6492,24 @@ func (s SnapshotLimits) String() string {
 // GoString returns the string representation
 func (s SnapshotLimits) GoString() string {
 	return s.String()
+}
+
+// SetManualSnapshotsCurrentCount sets the ManualSnapshotsCurrentCount field's value.
+func (s *SnapshotLimits) SetManualSnapshotsCurrentCount(v int64) *SnapshotLimits {
+	s.ManualSnapshotsCurrentCount = &v
+	return s
+}
+
+// SetManualSnapshotsLimit sets the ManualSnapshotsLimit field's value.
+func (s *SnapshotLimits) SetManualSnapshotsLimit(v int64) *SnapshotLimits {
+	s.ManualSnapshotsLimit = &v
+	return s
+}
+
+// SetManualSnapshotsLimitReached sets the ManualSnapshotsLimitReached field's value.
+func (s *SnapshotLimits) SetManualSnapshotsLimitReached(v bool) *SnapshotLimits {
+	s.ManualSnapshotsLimitReached = &v
+	return s
 }
 
 // Metadata assigned to an Amazon Directory Services directory consisting of
@@ -5409,6 +6561,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // Describes a trust relationship between an Microsoft AD in the AWS cloud and
 // an external domain.
 type Trust struct {
@@ -5454,6 +6618,66 @@ func (s Trust) String() string {
 // GoString returns the string representation
 func (s Trust) GoString() string {
 	return s.String()
+}
+
+// SetCreatedDateTime sets the CreatedDateTime field's value.
+func (s *Trust) SetCreatedDateTime(v time.Time) *Trust {
+	s.CreatedDateTime = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *Trust) SetDirectoryId(v string) *Trust {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetLastUpdatedDateTime sets the LastUpdatedDateTime field's value.
+func (s *Trust) SetLastUpdatedDateTime(v time.Time) *Trust {
+	s.LastUpdatedDateTime = &v
+	return s
+}
+
+// SetRemoteDomainName sets the RemoteDomainName field's value.
+func (s *Trust) SetRemoteDomainName(v string) *Trust {
+	s.RemoteDomainName = &v
+	return s
+}
+
+// SetStateLastUpdatedDateTime sets the StateLastUpdatedDateTime field's value.
+func (s *Trust) SetStateLastUpdatedDateTime(v time.Time) *Trust {
+	s.StateLastUpdatedDateTime = &v
+	return s
+}
+
+// SetTrustDirection sets the TrustDirection field's value.
+func (s *Trust) SetTrustDirection(v string) *Trust {
+	s.TrustDirection = &v
+	return s
+}
+
+// SetTrustId sets the TrustId field's value.
+func (s *Trust) SetTrustId(v string) *Trust {
+	s.TrustId = &v
+	return s
+}
+
+// SetTrustState sets the TrustState field's value.
+func (s *Trust) SetTrustState(v string) *Trust {
+	s.TrustState = &v
+	return s
+}
+
+// SetTrustStateReason sets the TrustStateReason field's value.
+func (s *Trust) SetTrustStateReason(v string) *Trust {
+	s.TrustStateReason = &v
+	return s
+}
+
+// SetTrustType sets the TrustType field's value.
+func (s *Trust) SetTrustType(v string) *Trust {
+	s.TrustType = &v
+	return s
 }
 
 // Updates a conditional forwarder.
@@ -5506,6 +6730,24 @@ func (s *UpdateConditionalForwarderInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *UpdateConditionalForwarderInput) SetDirectoryId(v string) *UpdateConditionalForwarderInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetDnsIpAddrs sets the DnsIpAddrs field's value.
+func (s *UpdateConditionalForwarderInput) SetDnsIpAddrs(v []*string) *UpdateConditionalForwarderInput {
+	s.DnsIpAddrs = v
+	return s
+}
+
+// SetRemoteDomainName sets the RemoteDomainName field's value.
+func (s *UpdateConditionalForwarderInput) SetRemoteDomainName(v string) *UpdateConditionalForwarderInput {
+	s.RemoteDomainName = &v
+	return s
 }
 
 // The result of an UpdateConditionalForwarder request.
@@ -5569,6 +6811,18 @@ func (s *UpdateRadiusInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *UpdateRadiusInput) SetDirectoryId(v string) *UpdateRadiusInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetRadiusSettings sets the RadiusSettings field's value.
+func (s *UpdateRadiusInput) SetRadiusSettings(v *RadiusSettings) *UpdateRadiusInput {
+	s.RadiusSettings = v
+	return s
+}
+
 // Contains the results of the UpdateRadius operation.
 type UpdateRadiusOutput struct {
 	_ struct{} `type:"structure"`
@@ -5618,6 +6872,12 @@ func (s *VerifyTrustInput) Validate() error {
 	return nil
 }
 
+// SetTrustId sets the TrustId field's value.
+func (s *VerifyTrustInput) SetTrustId(v string) *VerifyTrustInput {
+	s.TrustId = &v
+	return s
+}
+
 // Result of a VerifyTrust request.
 type VerifyTrustOutput struct {
 	_ struct{} `type:"structure"`
@@ -5634,6 +6894,12 @@ func (s VerifyTrustOutput) String() string {
 // GoString returns the string representation
 func (s VerifyTrustOutput) GoString() string {
 	return s.String()
+}
+
+// SetTrustId sets the TrustId field's value.
+func (s *VerifyTrustOutput) SetTrustId(v string) *VerifyTrustOutput {
+	s.TrustId = &v
+	return s
 }
 
 const (

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -1586,6 +1586,18 @@ func (s *AttributeDefinition) Validate() error {
 	return nil
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *AttributeDefinition) SetAttributeName(v string) *AttributeDefinition {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeType sets the AttributeType field's value.
+func (s *AttributeDefinition) SetAttributeType(v string) *AttributeDefinition {
+	s.AttributeType = &v
+	return s
+}
+
 // Represents the data for an attribute. You can set one, and only one, of the
 // elements.
 //
@@ -1637,6 +1649,66 @@ func (s AttributeValue) String() string {
 // GoString returns the string representation
 func (s AttributeValue) GoString() string {
 	return s.String()
+}
+
+// SetB sets the B field's value.
+func (s *AttributeValue) SetB(v []byte) *AttributeValue {
+	s.B = v
+	return s
+}
+
+// SetBOOL sets the BOOL field's value.
+func (s *AttributeValue) SetBOOL(v bool) *AttributeValue {
+	s.BOOL = &v
+	return s
+}
+
+// SetBS sets the BS field's value.
+func (s *AttributeValue) SetBS(v [][]byte) *AttributeValue {
+	s.BS = v
+	return s
+}
+
+// SetL sets the L field's value.
+func (s *AttributeValue) SetL(v []*AttributeValue) *AttributeValue {
+	s.L = v
+	return s
+}
+
+// SetM sets the M field's value.
+func (s *AttributeValue) SetM(v map[string]*AttributeValue) *AttributeValue {
+	s.M = v
+	return s
+}
+
+// SetN sets the N field's value.
+func (s *AttributeValue) SetN(v string) *AttributeValue {
+	s.N = &v
+	return s
+}
+
+// SetNS sets the NS field's value.
+func (s *AttributeValue) SetNS(v []*string) *AttributeValue {
+	s.NS = v
+	return s
+}
+
+// SetNULL sets the NULL field's value.
+func (s *AttributeValue) SetNULL(v bool) *AttributeValue {
+	s.NULL = &v
+	return s
+}
+
+// SetS sets the S field's value.
+func (s *AttributeValue) SetS(v string) *AttributeValue {
+	s.S = &v
+	return s
+}
+
+// SetSS sets the SS field's value.
+func (s *AttributeValue) SetSS(v []*string) *AttributeValue {
+	s.SS = v
+	return s
 }
 
 // For the UpdateItem operation, represents the attributes to be modified, the
@@ -1735,6 +1807,18 @@ func (s AttributeValueUpdate) String() string {
 // GoString returns the string representation
 func (s AttributeValueUpdate) GoString() string {
 	return s.String()
+}
+
+// SetAction sets the Action field's value.
+func (s *AttributeValueUpdate) SetAction(v string) *AttributeValueUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *AttributeValueUpdate) SetValue(v *AttributeValue) *AttributeValueUpdate {
+	s.Value = v
+	return s
 }
 
 // Represents the input of a BatchGetItem operation.
@@ -1879,6 +1963,18 @@ func (s *BatchGetItemInput) Validate() error {
 	return nil
 }
 
+// SetRequestItems sets the RequestItems field's value.
+func (s *BatchGetItemInput) SetRequestItems(v map[string]*KeysAndAttributes) *BatchGetItemInput {
+	s.RequestItems = v
+	return s
+}
+
+// SetReturnConsumedCapacity sets the ReturnConsumedCapacity field's value.
+func (s *BatchGetItemInput) SetReturnConsumedCapacity(v string) *BatchGetItemInput {
+	s.ReturnConsumedCapacity = &v
+	return s
+}
+
 // Represents the output of a BatchGetItem operation.
 type BatchGetItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -1928,6 +2024,24 @@ func (s BatchGetItemOutput) String() string {
 // GoString returns the string representation
 func (s BatchGetItemOutput) GoString() string {
 	return s.String()
+}
+
+// SetConsumedCapacity sets the ConsumedCapacity field's value.
+func (s *BatchGetItemOutput) SetConsumedCapacity(v []*ConsumedCapacity) *BatchGetItemOutput {
+	s.ConsumedCapacity = v
+	return s
+}
+
+// SetResponses sets the Responses field's value.
+func (s *BatchGetItemOutput) SetResponses(v map[string][]map[string]*AttributeValue) *BatchGetItemOutput {
+	s.Responses = v
+	return s
+}
+
+// SetUnprocessedKeys sets the UnprocessedKeys field's value.
+func (s *BatchGetItemOutput) SetUnprocessedKeys(v map[string]*KeysAndAttributes) *BatchGetItemOutput {
+	s.UnprocessedKeys = v
+	return s
 }
 
 // Represents the input of a BatchWriteItem operation.
@@ -2014,6 +2128,24 @@ func (s *BatchWriteItemInput) Validate() error {
 	return nil
 }
 
+// SetRequestItems sets the RequestItems field's value.
+func (s *BatchWriteItemInput) SetRequestItems(v map[string][]*WriteRequest) *BatchWriteItemInput {
+	s.RequestItems = v
+	return s
+}
+
+// SetReturnConsumedCapacity sets the ReturnConsumedCapacity field's value.
+func (s *BatchWriteItemInput) SetReturnConsumedCapacity(v string) *BatchWriteItemInput {
+	s.ReturnConsumedCapacity = &v
+	return s
+}
+
+// SetReturnItemCollectionMetrics sets the ReturnItemCollectionMetrics field's value.
+func (s *BatchWriteItemInput) SetReturnItemCollectionMetrics(v string) *BatchWriteItemInput {
+	s.ReturnItemCollectionMetrics = &v
+	return s
+}
+
 // Represents the output of a BatchWriteItem operation.
 type BatchWriteItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -2090,6 +2222,24 @@ func (s BatchWriteItemOutput) GoString() string {
 	return s.String()
 }
 
+// SetConsumedCapacity sets the ConsumedCapacity field's value.
+func (s *BatchWriteItemOutput) SetConsumedCapacity(v []*ConsumedCapacity) *BatchWriteItemOutput {
+	s.ConsumedCapacity = v
+	return s
+}
+
+// SetItemCollectionMetrics sets the ItemCollectionMetrics field's value.
+func (s *BatchWriteItemOutput) SetItemCollectionMetrics(v map[string][]*ItemCollectionMetrics) *BatchWriteItemOutput {
+	s.ItemCollectionMetrics = v
+	return s
+}
+
+// SetUnprocessedItems sets the UnprocessedItems field's value.
+func (s *BatchWriteItemOutput) SetUnprocessedItems(v map[string][]*WriteRequest) *BatchWriteItemOutput {
+	s.UnprocessedItems = v
+	return s
+}
+
 // Represents the amount of provisioned throughput capacity consumed on a table
 // or an index.
 type Capacity struct {
@@ -2107,6 +2257,12 @@ func (s Capacity) String() string {
 // GoString returns the string representation
 func (s Capacity) GoString() string {
 	return s.String()
+}
+
+// SetCapacityUnits sets the CapacityUnits field's value.
+func (s *Capacity) SetCapacityUnits(v float64) *Capacity {
+	s.CapacityUnits = &v
+	return s
 }
 
 // Represents the selection criteria for a Query or Scan operation:
@@ -2207,6 +2363,18 @@ func (s *Condition) Validate() error {
 	return nil
 }
 
+// SetAttributeValueList sets the AttributeValueList field's value.
+func (s *Condition) SetAttributeValueList(v []*AttributeValue) *Condition {
+	s.AttributeValueList = v
+	return s
+}
+
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *Condition) SetComparisonOperator(v string) *Condition {
+	s.ComparisonOperator = &v
+	return s
+}
+
 // The capacity units consumed by an operation. The data returned includes the
 // total provisioned throughput consumed, along with statistics for the table
 // and any indexes involved in the operation. ConsumedCapacity is only returned
@@ -2240,6 +2408,36 @@ func (s ConsumedCapacity) String() string {
 // GoString returns the string representation
 func (s ConsumedCapacity) GoString() string {
 	return s.String()
+}
+
+// SetCapacityUnits sets the CapacityUnits field's value.
+func (s *ConsumedCapacity) SetCapacityUnits(v float64) *ConsumedCapacity {
+	s.CapacityUnits = &v
+	return s
+}
+
+// SetGlobalSecondaryIndexes sets the GlobalSecondaryIndexes field's value.
+func (s *ConsumedCapacity) SetGlobalSecondaryIndexes(v map[string]*Capacity) *ConsumedCapacity {
+	s.GlobalSecondaryIndexes = v
+	return s
+}
+
+// SetLocalSecondaryIndexes sets the LocalSecondaryIndexes field's value.
+func (s *ConsumedCapacity) SetLocalSecondaryIndexes(v map[string]*Capacity) *ConsumedCapacity {
+	s.LocalSecondaryIndexes = v
+	return s
+}
+
+// SetTable sets the Table field's value.
+func (s *ConsumedCapacity) SetTable(v *Capacity) *ConsumedCapacity {
+	s.Table = v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *ConsumedCapacity) SetTableName(v string) *ConsumedCapacity {
+	s.TableName = &v
+	return s
 }
 
 // Represents a new global secondary index to be added to an existing table.
@@ -2330,6 +2528,30 @@ func (s *CreateGlobalSecondaryIndexAction) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *CreateGlobalSecondaryIndexAction) SetIndexName(v string) *CreateGlobalSecondaryIndexAction {
+	s.IndexName = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *CreateGlobalSecondaryIndexAction) SetKeySchema(v []*KeySchemaElement) *CreateGlobalSecondaryIndexAction {
+	s.KeySchema = v
+	return s
+}
+
+// SetProjection sets the Projection field's value.
+func (s *CreateGlobalSecondaryIndexAction) SetProjection(v *Projection) *CreateGlobalSecondaryIndexAction {
+	s.Projection = v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *CreateGlobalSecondaryIndexAction) SetProvisionedThroughput(v *ProvisionedThroughput) *CreateGlobalSecondaryIndexAction {
+	s.ProvisionedThroughput = v
+	return s
 }
 
 // Represents the input of a CreateTable operation.
@@ -2565,6 +2787,48 @@ func (s *CreateTableInput) Validate() error {
 	return nil
 }
 
+// SetAttributeDefinitions sets the AttributeDefinitions field's value.
+func (s *CreateTableInput) SetAttributeDefinitions(v []*AttributeDefinition) *CreateTableInput {
+	s.AttributeDefinitions = v
+	return s
+}
+
+// SetGlobalSecondaryIndexes sets the GlobalSecondaryIndexes field's value.
+func (s *CreateTableInput) SetGlobalSecondaryIndexes(v []*GlobalSecondaryIndex) *CreateTableInput {
+	s.GlobalSecondaryIndexes = v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *CreateTableInput) SetKeySchema(v []*KeySchemaElement) *CreateTableInput {
+	s.KeySchema = v
+	return s
+}
+
+// SetLocalSecondaryIndexes sets the LocalSecondaryIndexes field's value.
+func (s *CreateTableInput) SetLocalSecondaryIndexes(v []*LocalSecondaryIndex) *CreateTableInput {
+	s.LocalSecondaryIndexes = v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *CreateTableInput) SetProvisionedThroughput(v *ProvisionedThroughput) *CreateTableInput {
+	s.ProvisionedThroughput = v
+	return s
+}
+
+// SetStreamSpecification sets the StreamSpecification field's value.
+func (s *CreateTableInput) SetStreamSpecification(v *StreamSpecification) *CreateTableInput {
+	s.StreamSpecification = v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *CreateTableInput) SetTableName(v string) *CreateTableInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of a CreateTable operation.
 type CreateTableOutput struct {
 	_ struct{} `type:"structure"`
@@ -2581,6 +2845,12 @@ func (s CreateTableOutput) String() string {
 // GoString returns the string representation
 func (s CreateTableOutput) GoString() string {
 	return s.String()
+}
+
+// SetTableDescription sets the TableDescription field's value.
+func (s *CreateTableOutput) SetTableDescription(v *TableDescription) *CreateTableOutput {
+	s.TableDescription = v
+	return s
 }
 
 // Represents a global secondary index to be deleted from an existing table.
@@ -2617,6 +2887,12 @@ func (s *DeleteGlobalSecondaryIndexAction) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *DeleteGlobalSecondaryIndexAction) SetIndexName(v string) *DeleteGlobalSecondaryIndexAction {
+	s.IndexName = &v
+	return s
 }
 
 // Represents the input of a DeleteItem operation.
@@ -2915,6 +3191,66 @@ func (s *DeleteItemInput) Validate() error {
 	return nil
 }
 
+// SetConditionExpression sets the ConditionExpression field's value.
+func (s *DeleteItemInput) SetConditionExpression(v string) *DeleteItemInput {
+	s.ConditionExpression = &v
+	return s
+}
+
+// SetConditionalOperator sets the ConditionalOperator field's value.
+func (s *DeleteItemInput) SetConditionalOperator(v string) *DeleteItemInput {
+	s.ConditionalOperator = &v
+	return s
+}
+
+// SetExpected sets the Expected field's value.
+func (s *DeleteItemInput) SetExpected(v map[string]*ExpectedAttributeValue) *DeleteItemInput {
+	s.Expected = v
+	return s
+}
+
+// SetExpressionAttributeNames sets the ExpressionAttributeNames field's value.
+func (s *DeleteItemInput) SetExpressionAttributeNames(v map[string]*string) *DeleteItemInput {
+	s.ExpressionAttributeNames = v
+	return s
+}
+
+// SetExpressionAttributeValues sets the ExpressionAttributeValues field's value.
+func (s *DeleteItemInput) SetExpressionAttributeValues(v map[string]*AttributeValue) *DeleteItemInput {
+	s.ExpressionAttributeValues = v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *DeleteItemInput) SetKey(v map[string]*AttributeValue) *DeleteItemInput {
+	s.Key = v
+	return s
+}
+
+// SetReturnConsumedCapacity sets the ReturnConsumedCapacity field's value.
+func (s *DeleteItemInput) SetReturnConsumedCapacity(v string) *DeleteItemInput {
+	s.ReturnConsumedCapacity = &v
+	return s
+}
+
+// SetReturnItemCollectionMetrics sets the ReturnItemCollectionMetrics field's value.
+func (s *DeleteItemInput) SetReturnItemCollectionMetrics(v string) *DeleteItemInput {
+	s.ReturnItemCollectionMetrics = &v
+	return s
+}
+
+// SetReturnValues sets the ReturnValues field's value.
+func (s *DeleteItemInput) SetReturnValues(v string) *DeleteItemInput {
+	s.ReturnValues = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *DeleteItemInput) SetTableName(v string) *DeleteItemInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of a DeleteItem operation.
 type DeleteItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -2964,6 +3300,24 @@ func (s DeleteItemOutput) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *DeleteItemOutput) SetAttributes(v map[string]*AttributeValue) *DeleteItemOutput {
+	s.Attributes = v
+	return s
+}
+
+// SetConsumedCapacity sets the ConsumedCapacity field's value.
+func (s *DeleteItemOutput) SetConsumedCapacity(v *ConsumedCapacity) *DeleteItemOutput {
+	s.ConsumedCapacity = v
+	return s
+}
+
+// SetItemCollectionMetrics sets the ItemCollectionMetrics field's value.
+func (s *DeleteItemOutput) SetItemCollectionMetrics(v *ItemCollectionMetrics) *DeleteItemOutput {
+	s.ItemCollectionMetrics = v
+	return s
+}
+
 // Represents a request to perform a DeleteItem operation on an item.
 type DeleteRequest struct {
 	_ struct{} `type:"structure"`
@@ -2984,6 +3338,12 @@ func (s DeleteRequest) String() string {
 // GoString returns the string representation
 func (s DeleteRequest) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *DeleteRequest) SetKey(v map[string]*AttributeValue) *DeleteRequest {
+	s.Key = v
+	return s
 }
 
 // Represents the input of a DeleteTable operation.
@@ -3022,6 +3382,12 @@ func (s *DeleteTableInput) Validate() error {
 	return nil
 }
 
+// SetTableName sets the TableName field's value.
+func (s *DeleteTableInput) SetTableName(v string) *DeleteTableInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of a DeleteTable operation.
 type DeleteTableOutput struct {
 	_ struct{} `type:"structure"`
@@ -3038,6 +3404,12 @@ func (s DeleteTableOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTableOutput) GoString() string {
 	return s.String()
+}
+
+// SetTableDescription sets the TableDescription field's value.
+func (s *DeleteTableOutput) SetTableDescription(v *TableDescription) *DeleteTableOutput {
+	s.TableDescription = v
+	return s
 }
 
 // Represents the input of a DescribeLimits operation. Has no content.
@@ -3088,6 +3460,30 @@ func (s DescribeLimitsOutput) GoString() string {
 	return s.String()
 }
 
+// SetAccountMaxReadCapacityUnits sets the AccountMaxReadCapacityUnits field's value.
+func (s *DescribeLimitsOutput) SetAccountMaxReadCapacityUnits(v int64) *DescribeLimitsOutput {
+	s.AccountMaxReadCapacityUnits = &v
+	return s
+}
+
+// SetAccountMaxWriteCapacityUnits sets the AccountMaxWriteCapacityUnits field's value.
+func (s *DescribeLimitsOutput) SetAccountMaxWriteCapacityUnits(v int64) *DescribeLimitsOutput {
+	s.AccountMaxWriteCapacityUnits = &v
+	return s
+}
+
+// SetTableMaxReadCapacityUnits sets the TableMaxReadCapacityUnits field's value.
+func (s *DescribeLimitsOutput) SetTableMaxReadCapacityUnits(v int64) *DescribeLimitsOutput {
+	s.TableMaxReadCapacityUnits = &v
+	return s
+}
+
+// SetTableMaxWriteCapacityUnits sets the TableMaxWriteCapacityUnits field's value.
+func (s *DescribeLimitsOutput) SetTableMaxWriteCapacityUnits(v int64) *DescribeLimitsOutput {
+	s.TableMaxWriteCapacityUnits = &v
+	return s
+}
+
 // Represents the input of a DescribeTable operation.
 type DescribeTableInput struct {
 	_ struct{} `type:"structure"`
@@ -3124,6 +3520,12 @@ func (s *DescribeTableInput) Validate() error {
 	return nil
 }
 
+// SetTableName sets the TableName field's value.
+func (s *DescribeTableInput) SetTableName(v string) *DescribeTableInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of a DescribeTable operation.
 type DescribeTableOutput struct {
 	_ struct{} `type:"structure"`
@@ -3140,6 +3542,12 @@ func (s DescribeTableOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTableOutput) GoString() string {
 	return s.String()
+}
+
+// SetTable sets the Table field's value.
+func (s *DescribeTableOutput) SetTable(v *TableDescription) *DescribeTableOutput {
+	s.Table = v
+	return s
 }
 
 // Represents a condition to be compared with an attribute value. This condition
@@ -3266,6 +3674,30 @@ func (s ExpectedAttributeValue) String() string {
 // GoString returns the string representation
 func (s ExpectedAttributeValue) GoString() string {
 	return s.String()
+}
+
+// SetAttributeValueList sets the AttributeValueList field's value.
+func (s *ExpectedAttributeValue) SetAttributeValueList(v []*AttributeValue) *ExpectedAttributeValue {
+	s.AttributeValueList = v
+	return s
+}
+
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *ExpectedAttributeValue) SetComparisonOperator(v string) *ExpectedAttributeValue {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetExists sets the Exists field's value.
+func (s *ExpectedAttributeValue) SetExists(v bool) *ExpectedAttributeValue {
+	s.Exists = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ExpectedAttributeValue) SetValue(v *AttributeValue) *ExpectedAttributeValue {
+	s.Value = v
+	return s
 }
 
 // Represents the input of a GetItem operation.
@@ -3411,6 +3843,48 @@ func (s *GetItemInput) Validate() error {
 	return nil
 }
 
+// SetAttributesToGet sets the AttributesToGet field's value.
+func (s *GetItemInput) SetAttributesToGet(v []*string) *GetItemInput {
+	s.AttributesToGet = v
+	return s
+}
+
+// SetConsistentRead sets the ConsistentRead field's value.
+func (s *GetItemInput) SetConsistentRead(v bool) *GetItemInput {
+	s.ConsistentRead = &v
+	return s
+}
+
+// SetExpressionAttributeNames sets the ExpressionAttributeNames field's value.
+func (s *GetItemInput) SetExpressionAttributeNames(v map[string]*string) *GetItemInput {
+	s.ExpressionAttributeNames = v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *GetItemInput) SetKey(v map[string]*AttributeValue) *GetItemInput {
+	s.Key = v
+	return s
+}
+
+// SetProjectionExpression sets the ProjectionExpression field's value.
+func (s *GetItemInput) SetProjectionExpression(v string) *GetItemInput {
+	s.ProjectionExpression = &v
+	return s
+}
+
+// SetReturnConsumedCapacity sets the ReturnConsumedCapacity field's value.
+func (s *GetItemInput) SetReturnConsumedCapacity(v string) *GetItemInput {
+	s.ReturnConsumedCapacity = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *GetItemInput) SetTableName(v string) *GetItemInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of a GetItem operation.
 type GetItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -3435,6 +3909,18 @@ func (s GetItemOutput) String() string {
 // GoString returns the string representation
 func (s GetItemOutput) GoString() string {
 	return s.String()
+}
+
+// SetConsumedCapacity sets the ConsumedCapacity field's value.
+func (s *GetItemOutput) SetConsumedCapacity(v *ConsumedCapacity) *GetItemOutput {
+	s.ConsumedCapacity = v
+	return s
+}
+
+// SetItem sets the Item field's value.
+func (s *GetItemOutput) SetItem(v map[string]*AttributeValue) *GetItemOutput {
+	s.Item = v
+	return s
 }
 
 // Represents the properties of a global secondary index.
@@ -3542,6 +4028,30 @@ func (s *GlobalSecondaryIndex) Validate() error {
 	return nil
 }
 
+// SetIndexName sets the IndexName field's value.
+func (s *GlobalSecondaryIndex) SetIndexName(v string) *GlobalSecondaryIndex {
+	s.IndexName = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *GlobalSecondaryIndex) SetKeySchema(v []*KeySchemaElement) *GlobalSecondaryIndex {
+	s.KeySchema = v
+	return s
+}
+
+// SetProjection sets the Projection field's value.
+func (s *GlobalSecondaryIndex) SetProjection(v *Projection) *GlobalSecondaryIndex {
+	s.Projection = v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *GlobalSecondaryIndex) SetProvisionedThroughput(v *ProvisionedThroughput) *GlobalSecondaryIndex {
+	s.ProvisionedThroughput = v
+	return s
+}
+
 // Represents the properties of a global secondary index.
 type GlobalSecondaryIndexDescription struct {
 	_ struct{} `type:"structure"`
@@ -3620,6 +4130,60 @@ func (s GlobalSecondaryIndexDescription) GoString() string {
 	return s.String()
 }
 
+// SetBackfilling sets the Backfilling field's value.
+func (s *GlobalSecondaryIndexDescription) SetBackfilling(v bool) *GlobalSecondaryIndexDescription {
+	s.Backfilling = &v
+	return s
+}
+
+// SetIndexArn sets the IndexArn field's value.
+func (s *GlobalSecondaryIndexDescription) SetIndexArn(v string) *GlobalSecondaryIndexDescription {
+	s.IndexArn = &v
+	return s
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *GlobalSecondaryIndexDescription) SetIndexName(v string) *GlobalSecondaryIndexDescription {
+	s.IndexName = &v
+	return s
+}
+
+// SetIndexSizeBytes sets the IndexSizeBytes field's value.
+func (s *GlobalSecondaryIndexDescription) SetIndexSizeBytes(v int64) *GlobalSecondaryIndexDescription {
+	s.IndexSizeBytes = &v
+	return s
+}
+
+// SetIndexStatus sets the IndexStatus field's value.
+func (s *GlobalSecondaryIndexDescription) SetIndexStatus(v string) *GlobalSecondaryIndexDescription {
+	s.IndexStatus = &v
+	return s
+}
+
+// SetItemCount sets the ItemCount field's value.
+func (s *GlobalSecondaryIndexDescription) SetItemCount(v int64) *GlobalSecondaryIndexDescription {
+	s.ItemCount = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *GlobalSecondaryIndexDescription) SetKeySchema(v []*KeySchemaElement) *GlobalSecondaryIndexDescription {
+	s.KeySchema = v
+	return s
+}
+
+// SetProjection sets the Projection field's value.
+func (s *GlobalSecondaryIndexDescription) SetProjection(v *Projection) *GlobalSecondaryIndexDescription {
+	s.Projection = v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *GlobalSecondaryIndexDescription) SetProvisionedThroughput(v *ProvisionedThroughputDescription) *GlobalSecondaryIndexDescription {
+	s.ProvisionedThroughput = v
+	return s
+}
+
 // Represents one of the following:
 //
 //    * A new global secondary index to be added to an existing table.
@@ -3688,6 +4252,24 @@ func (s *GlobalSecondaryIndexUpdate) Validate() error {
 	return nil
 }
 
+// SetCreate sets the Create field's value.
+func (s *GlobalSecondaryIndexUpdate) SetCreate(v *CreateGlobalSecondaryIndexAction) *GlobalSecondaryIndexUpdate {
+	s.Create = v
+	return s
+}
+
+// SetDelete sets the Delete field's value.
+func (s *GlobalSecondaryIndexUpdate) SetDelete(v *DeleteGlobalSecondaryIndexAction) *GlobalSecondaryIndexUpdate {
+	s.Delete = v
+	return s
+}
+
+// SetUpdate sets the Update field's value.
+func (s *GlobalSecondaryIndexUpdate) SetUpdate(v *UpdateGlobalSecondaryIndexAction) *GlobalSecondaryIndexUpdate {
+	s.Update = v
+	return s
+}
+
 // Information about item collections, if any, that were affected by the operation.
 // ItemCollectionMetrics is only returned if the request asked for it. If the
 // table does not have any local secondary indexes, this information is not
@@ -3719,6 +4301,18 @@ func (s ItemCollectionMetrics) String() string {
 // GoString returns the string representation
 func (s ItemCollectionMetrics) GoString() string {
 	return s.String()
+}
+
+// SetItemCollectionKey sets the ItemCollectionKey field's value.
+func (s *ItemCollectionMetrics) SetItemCollectionKey(v map[string]*AttributeValue) *ItemCollectionMetrics {
+	s.ItemCollectionKey = v
+	return s
+}
+
+// SetSizeEstimateRangeGB sets the SizeEstimateRangeGB field's value.
+func (s *ItemCollectionMetrics) SetSizeEstimateRangeGB(v []*float64) *ItemCollectionMetrics {
+	s.SizeEstimateRangeGB = v
+	return s
 }
 
 // Represents a single element of a key schema. A key schema specifies the attributes
@@ -3786,6 +4380,18 @@ func (s *KeySchemaElement) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *KeySchemaElement) SetAttributeName(v string) *KeySchemaElement {
+	s.AttributeName = &v
+	return s
+}
+
+// SetKeyType sets the KeyType field's value.
+func (s *KeySchemaElement) SetKeyType(v string) *KeySchemaElement {
+	s.KeyType = &v
+	return s
 }
 
 // Represents a set of primary keys and, for each key, the attributes to retrieve
@@ -3894,6 +4500,36 @@ func (s *KeysAndAttributes) Validate() error {
 	return nil
 }
 
+// SetAttributesToGet sets the AttributesToGet field's value.
+func (s *KeysAndAttributes) SetAttributesToGet(v []*string) *KeysAndAttributes {
+	s.AttributesToGet = v
+	return s
+}
+
+// SetConsistentRead sets the ConsistentRead field's value.
+func (s *KeysAndAttributes) SetConsistentRead(v bool) *KeysAndAttributes {
+	s.ConsistentRead = &v
+	return s
+}
+
+// SetExpressionAttributeNames sets the ExpressionAttributeNames field's value.
+func (s *KeysAndAttributes) SetExpressionAttributeNames(v map[string]*string) *KeysAndAttributes {
+	s.ExpressionAttributeNames = v
+	return s
+}
+
+// SetKeys sets the Keys field's value.
+func (s *KeysAndAttributes) SetKeys(v []map[string]*AttributeValue) *KeysAndAttributes {
+	s.Keys = v
+	return s
+}
+
+// SetProjectionExpression sets the ProjectionExpression field's value.
+func (s *KeysAndAttributes) SetProjectionExpression(v string) *KeysAndAttributes {
+	s.ProjectionExpression = &v
+	return s
+}
+
 // Represents the input of a ListTables operation.
 type ListTablesInput struct {
 	_ struct{} `type:"structure"`
@@ -3934,6 +4570,18 @@ func (s *ListTablesInput) Validate() error {
 	return nil
 }
 
+// SetExclusiveStartTableName sets the ExclusiveStartTableName field's value.
+func (s *ListTablesInput) SetExclusiveStartTableName(v string) *ListTablesInput {
+	s.ExclusiveStartTableName = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListTablesInput) SetLimit(v int64) *ListTablesInput {
+	s.Limit = &v
+	return s
+}
+
 // Represents the output of a ListTables operation.
 type ListTablesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3963,6 +4611,18 @@ func (s ListTablesOutput) String() string {
 // GoString returns the string representation
 func (s ListTablesOutput) GoString() string {
 	return s.String()
+}
+
+// SetLastEvaluatedTableName sets the LastEvaluatedTableName field's value.
+func (s *ListTablesOutput) SetLastEvaluatedTableName(v string) *ListTablesOutput {
+	s.LastEvaluatedTableName = &v
+	return s
+}
+
+// SetTableNames sets the TableNames field's value.
+func (s *ListTablesOutput) SetTableNames(v []*string) *ListTablesOutput {
+	s.TableNames = v
+	return s
 }
 
 // Represents the properties of a local secondary index.
@@ -4052,6 +4712,24 @@ func (s *LocalSecondaryIndex) Validate() error {
 	return nil
 }
 
+// SetIndexName sets the IndexName field's value.
+func (s *LocalSecondaryIndex) SetIndexName(v string) *LocalSecondaryIndex {
+	s.IndexName = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *LocalSecondaryIndex) SetKeySchema(v []*KeySchemaElement) *LocalSecondaryIndex {
+	s.KeySchema = v
+	return s
+}
+
+// SetProjection sets the Projection field's value.
+func (s *LocalSecondaryIndex) SetProjection(v *Projection) *LocalSecondaryIndex {
+	s.Projection = v
+	return s
+}
+
 // Represents the properties of a local secondary index.
 type LocalSecondaryIndexDescription struct {
 	_ struct{} `type:"structure"`
@@ -4104,6 +4782,42 @@ func (s LocalSecondaryIndexDescription) GoString() string {
 	return s.String()
 }
 
+// SetIndexArn sets the IndexArn field's value.
+func (s *LocalSecondaryIndexDescription) SetIndexArn(v string) *LocalSecondaryIndexDescription {
+	s.IndexArn = &v
+	return s
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *LocalSecondaryIndexDescription) SetIndexName(v string) *LocalSecondaryIndexDescription {
+	s.IndexName = &v
+	return s
+}
+
+// SetIndexSizeBytes sets the IndexSizeBytes field's value.
+func (s *LocalSecondaryIndexDescription) SetIndexSizeBytes(v int64) *LocalSecondaryIndexDescription {
+	s.IndexSizeBytes = &v
+	return s
+}
+
+// SetItemCount sets the ItemCount field's value.
+func (s *LocalSecondaryIndexDescription) SetItemCount(v int64) *LocalSecondaryIndexDescription {
+	s.ItemCount = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *LocalSecondaryIndexDescription) SetKeySchema(v []*KeySchemaElement) *LocalSecondaryIndexDescription {
+	s.KeySchema = v
+	return s
+}
+
+// SetProjection sets the Projection field's value.
+func (s *LocalSecondaryIndexDescription) SetProjection(v *Projection) *LocalSecondaryIndexDescription {
+	s.Projection = v
+	return s
+}
+
 // Represents attributes that are copied (projected) from the table into an
 // index. These are in addition to the primary key attributes and index key
 // attributes, which are automatically projected.
@@ -4150,6 +4864,18 @@ func (s *Projection) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetNonKeyAttributes sets the NonKeyAttributes field's value.
+func (s *Projection) SetNonKeyAttributes(v []*string) *Projection {
+	s.NonKeyAttributes = v
+	return s
+}
+
+// SetProjectionType sets the ProjectionType field's value.
+func (s *Projection) SetProjectionType(v string) *Projection {
+	s.ProjectionType = &v
+	return s
 }
 
 // Represents the provisioned throughput settings for a specified table or index.
@@ -4210,6 +4936,18 @@ func (s *ProvisionedThroughput) Validate() error {
 	return nil
 }
 
+// SetReadCapacityUnits sets the ReadCapacityUnits field's value.
+func (s *ProvisionedThroughput) SetReadCapacityUnits(v int64) *ProvisionedThroughput {
+	s.ReadCapacityUnits = &v
+	return s
+}
+
+// SetWriteCapacityUnits sets the WriteCapacityUnits field's value.
+func (s *ProvisionedThroughput) SetWriteCapacityUnits(v int64) *ProvisionedThroughput {
+	s.WriteCapacityUnits = &v
+	return s
+}
+
 // Represents the provisioned throughput settings for the table, consisting
 // of read and write capacity units, along with data about increases and decreases.
 type ProvisionedThroughputDescription struct {
@@ -4246,6 +4984,36 @@ func (s ProvisionedThroughputDescription) String() string {
 // GoString returns the string representation
 func (s ProvisionedThroughputDescription) GoString() string {
 	return s.String()
+}
+
+// SetLastDecreaseDateTime sets the LastDecreaseDateTime field's value.
+func (s *ProvisionedThroughputDescription) SetLastDecreaseDateTime(v time.Time) *ProvisionedThroughputDescription {
+	s.LastDecreaseDateTime = &v
+	return s
+}
+
+// SetLastIncreaseDateTime sets the LastIncreaseDateTime field's value.
+func (s *ProvisionedThroughputDescription) SetLastIncreaseDateTime(v time.Time) *ProvisionedThroughputDescription {
+	s.LastIncreaseDateTime = &v
+	return s
+}
+
+// SetNumberOfDecreasesToday sets the NumberOfDecreasesToday field's value.
+func (s *ProvisionedThroughputDescription) SetNumberOfDecreasesToday(v int64) *ProvisionedThroughputDescription {
+	s.NumberOfDecreasesToday = &v
+	return s
+}
+
+// SetReadCapacityUnits sets the ReadCapacityUnits field's value.
+func (s *ProvisionedThroughputDescription) SetReadCapacityUnits(v int64) *ProvisionedThroughputDescription {
+	s.ReadCapacityUnits = &v
+	return s
+}
+
+// SetWriteCapacityUnits sets the WriteCapacityUnits field's value.
+func (s *ProvisionedThroughputDescription) SetWriteCapacityUnits(v int64) *ProvisionedThroughputDescription {
+	s.WriteCapacityUnits = &v
+	return s
 }
 
 // Represents the input of a PutItem operation.
@@ -4558,6 +5326,66 @@ func (s *PutItemInput) Validate() error {
 	return nil
 }
 
+// SetConditionExpression sets the ConditionExpression field's value.
+func (s *PutItemInput) SetConditionExpression(v string) *PutItemInput {
+	s.ConditionExpression = &v
+	return s
+}
+
+// SetConditionalOperator sets the ConditionalOperator field's value.
+func (s *PutItemInput) SetConditionalOperator(v string) *PutItemInput {
+	s.ConditionalOperator = &v
+	return s
+}
+
+// SetExpected sets the Expected field's value.
+func (s *PutItemInput) SetExpected(v map[string]*ExpectedAttributeValue) *PutItemInput {
+	s.Expected = v
+	return s
+}
+
+// SetExpressionAttributeNames sets the ExpressionAttributeNames field's value.
+func (s *PutItemInput) SetExpressionAttributeNames(v map[string]*string) *PutItemInput {
+	s.ExpressionAttributeNames = v
+	return s
+}
+
+// SetExpressionAttributeValues sets the ExpressionAttributeValues field's value.
+func (s *PutItemInput) SetExpressionAttributeValues(v map[string]*AttributeValue) *PutItemInput {
+	s.ExpressionAttributeValues = v
+	return s
+}
+
+// SetItem sets the Item field's value.
+func (s *PutItemInput) SetItem(v map[string]*AttributeValue) *PutItemInput {
+	s.Item = v
+	return s
+}
+
+// SetReturnConsumedCapacity sets the ReturnConsumedCapacity field's value.
+func (s *PutItemInput) SetReturnConsumedCapacity(v string) *PutItemInput {
+	s.ReturnConsumedCapacity = &v
+	return s
+}
+
+// SetReturnItemCollectionMetrics sets the ReturnItemCollectionMetrics field's value.
+func (s *PutItemInput) SetReturnItemCollectionMetrics(v string) *PutItemInput {
+	s.ReturnItemCollectionMetrics = &v
+	return s
+}
+
+// SetReturnValues sets the ReturnValues field's value.
+func (s *PutItemInput) SetReturnValues(v string) *PutItemInput {
+	s.ReturnValues = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *PutItemInput) SetTableName(v string) *PutItemInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of a PutItem operation.
 type PutItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -4607,6 +5435,24 @@ func (s PutItemOutput) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *PutItemOutput) SetAttributes(v map[string]*AttributeValue) *PutItemOutput {
+	s.Attributes = v
+	return s
+}
+
+// SetConsumedCapacity sets the ConsumedCapacity field's value.
+func (s *PutItemOutput) SetConsumedCapacity(v *ConsumedCapacity) *PutItemOutput {
+	s.ConsumedCapacity = v
+	return s
+}
+
+// SetItemCollectionMetrics sets the ItemCollectionMetrics field's value.
+func (s *PutItemOutput) SetItemCollectionMetrics(v *ItemCollectionMetrics) *PutItemOutput {
+	s.ItemCollectionMetrics = v
+	return s
+}
+
 // Represents a request to perform a PutItem operation on an item.
 type PutRequest struct {
 	_ struct{} `type:"structure"`
@@ -4629,6 +5475,12 @@ func (s PutRequest) String() string {
 // GoString returns the string representation
 func (s PutRequest) GoString() string {
 	return s.String()
+}
+
+// SetItem sets the Item field's value.
+func (s *PutRequest) SetItem(v map[string]*AttributeValue) *PutRequest {
+	s.Item = v
+	return s
 }
 
 // Represents the input of a Query operation.
@@ -5162,6 +6014,108 @@ func (s *QueryInput) Validate() error {
 	return nil
 }
 
+// SetAttributesToGet sets the AttributesToGet field's value.
+func (s *QueryInput) SetAttributesToGet(v []*string) *QueryInput {
+	s.AttributesToGet = v
+	return s
+}
+
+// SetConditionalOperator sets the ConditionalOperator field's value.
+func (s *QueryInput) SetConditionalOperator(v string) *QueryInput {
+	s.ConditionalOperator = &v
+	return s
+}
+
+// SetConsistentRead sets the ConsistentRead field's value.
+func (s *QueryInput) SetConsistentRead(v bool) *QueryInput {
+	s.ConsistentRead = &v
+	return s
+}
+
+// SetExclusiveStartKey sets the ExclusiveStartKey field's value.
+func (s *QueryInput) SetExclusiveStartKey(v map[string]*AttributeValue) *QueryInput {
+	s.ExclusiveStartKey = v
+	return s
+}
+
+// SetExpressionAttributeNames sets the ExpressionAttributeNames field's value.
+func (s *QueryInput) SetExpressionAttributeNames(v map[string]*string) *QueryInput {
+	s.ExpressionAttributeNames = v
+	return s
+}
+
+// SetExpressionAttributeValues sets the ExpressionAttributeValues field's value.
+func (s *QueryInput) SetExpressionAttributeValues(v map[string]*AttributeValue) *QueryInput {
+	s.ExpressionAttributeValues = v
+	return s
+}
+
+// SetFilterExpression sets the FilterExpression field's value.
+func (s *QueryInput) SetFilterExpression(v string) *QueryInput {
+	s.FilterExpression = &v
+	return s
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *QueryInput) SetIndexName(v string) *QueryInput {
+	s.IndexName = &v
+	return s
+}
+
+// SetKeyConditionExpression sets the KeyConditionExpression field's value.
+func (s *QueryInput) SetKeyConditionExpression(v string) *QueryInput {
+	s.KeyConditionExpression = &v
+	return s
+}
+
+// SetKeyConditions sets the KeyConditions field's value.
+func (s *QueryInput) SetKeyConditions(v map[string]*Condition) *QueryInput {
+	s.KeyConditions = v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *QueryInput) SetLimit(v int64) *QueryInput {
+	s.Limit = &v
+	return s
+}
+
+// SetProjectionExpression sets the ProjectionExpression field's value.
+func (s *QueryInput) SetProjectionExpression(v string) *QueryInput {
+	s.ProjectionExpression = &v
+	return s
+}
+
+// SetQueryFilter sets the QueryFilter field's value.
+func (s *QueryInput) SetQueryFilter(v map[string]*Condition) *QueryInput {
+	s.QueryFilter = v
+	return s
+}
+
+// SetReturnConsumedCapacity sets the ReturnConsumedCapacity field's value.
+func (s *QueryInput) SetReturnConsumedCapacity(v string) *QueryInput {
+	s.ReturnConsumedCapacity = &v
+	return s
+}
+
+// SetScanIndexForward sets the ScanIndexForward field's value.
+func (s *QueryInput) SetScanIndexForward(v bool) *QueryInput {
+	s.ScanIndexForward = &v
+	return s
+}
+
+// SetSelect sets the Select field's value.
+func (s *QueryInput) SetSelect(v string) *QueryInput {
+	s.Select = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *QueryInput) SetTableName(v string) *QueryInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of a Query operation.
 type QueryOutput struct {
 	_ struct{} `type:"structure"`
@@ -5218,6 +6172,36 @@ func (s QueryOutput) String() string {
 // GoString returns the string representation
 func (s QueryOutput) GoString() string {
 	return s.String()
+}
+
+// SetConsumedCapacity sets the ConsumedCapacity field's value.
+func (s *QueryOutput) SetConsumedCapacity(v *ConsumedCapacity) *QueryOutput {
+	s.ConsumedCapacity = v
+	return s
+}
+
+// SetCount sets the Count field's value.
+func (s *QueryOutput) SetCount(v int64) *QueryOutput {
+	s.Count = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *QueryOutput) SetItems(v []map[string]*AttributeValue) *QueryOutput {
+	s.Items = v
+	return s
+}
+
+// SetLastEvaluatedKey sets the LastEvaluatedKey field's value.
+func (s *QueryOutput) SetLastEvaluatedKey(v map[string]*AttributeValue) *QueryOutput {
+	s.LastEvaluatedKey = v
+	return s
+}
+
+// SetScannedCount sets the ScannedCount field's value.
+func (s *QueryOutput) SetScannedCount(v int64) *QueryOutput {
+	s.ScannedCount = &v
+	return s
 }
 
 // Represents the input of a Scan operation.
@@ -5564,6 +6548,102 @@ func (s *ScanInput) Validate() error {
 	return nil
 }
 
+// SetAttributesToGet sets the AttributesToGet field's value.
+func (s *ScanInput) SetAttributesToGet(v []*string) *ScanInput {
+	s.AttributesToGet = v
+	return s
+}
+
+// SetConditionalOperator sets the ConditionalOperator field's value.
+func (s *ScanInput) SetConditionalOperator(v string) *ScanInput {
+	s.ConditionalOperator = &v
+	return s
+}
+
+// SetConsistentRead sets the ConsistentRead field's value.
+func (s *ScanInput) SetConsistentRead(v bool) *ScanInput {
+	s.ConsistentRead = &v
+	return s
+}
+
+// SetExclusiveStartKey sets the ExclusiveStartKey field's value.
+func (s *ScanInput) SetExclusiveStartKey(v map[string]*AttributeValue) *ScanInput {
+	s.ExclusiveStartKey = v
+	return s
+}
+
+// SetExpressionAttributeNames sets the ExpressionAttributeNames field's value.
+func (s *ScanInput) SetExpressionAttributeNames(v map[string]*string) *ScanInput {
+	s.ExpressionAttributeNames = v
+	return s
+}
+
+// SetExpressionAttributeValues sets the ExpressionAttributeValues field's value.
+func (s *ScanInput) SetExpressionAttributeValues(v map[string]*AttributeValue) *ScanInput {
+	s.ExpressionAttributeValues = v
+	return s
+}
+
+// SetFilterExpression sets the FilterExpression field's value.
+func (s *ScanInput) SetFilterExpression(v string) *ScanInput {
+	s.FilterExpression = &v
+	return s
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *ScanInput) SetIndexName(v string) *ScanInput {
+	s.IndexName = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ScanInput) SetLimit(v int64) *ScanInput {
+	s.Limit = &v
+	return s
+}
+
+// SetProjectionExpression sets the ProjectionExpression field's value.
+func (s *ScanInput) SetProjectionExpression(v string) *ScanInput {
+	s.ProjectionExpression = &v
+	return s
+}
+
+// SetReturnConsumedCapacity sets the ReturnConsumedCapacity field's value.
+func (s *ScanInput) SetReturnConsumedCapacity(v string) *ScanInput {
+	s.ReturnConsumedCapacity = &v
+	return s
+}
+
+// SetScanFilter sets the ScanFilter field's value.
+func (s *ScanInput) SetScanFilter(v map[string]*Condition) *ScanInput {
+	s.ScanFilter = v
+	return s
+}
+
+// SetSegment sets the Segment field's value.
+func (s *ScanInput) SetSegment(v int64) *ScanInput {
+	s.Segment = &v
+	return s
+}
+
+// SetSelect sets the Select field's value.
+func (s *ScanInput) SetSelect(v string) *ScanInput {
+	s.Select = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *ScanInput) SetTableName(v string) *ScanInput {
+	s.TableName = &v
+	return s
+}
+
+// SetTotalSegments sets the TotalSegments field's value.
+func (s *ScanInput) SetTotalSegments(v int64) *ScanInput {
+	s.TotalSegments = &v
+	return s
+}
+
 // Represents the output of a Scan operation.
 type ScanOutput struct {
 	_ struct{} `type:"structure"`
@@ -5621,6 +6701,36 @@ func (s ScanOutput) GoString() string {
 	return s.String()
 }
 
+// SetConsumedCapacity sets the ConsumedCapacity field's value.
+func (s *ScanOutput) SetConsumedCapacity(v *ConsumedCapacity) *ScanOutput {
+	s.ConsumedCapacity = v
+	return s
+}
+
+// SetCount sets the Count field's value.
+func (s *ScanOutput) SetCount(v int64) *ScanOutput {
+	s.Count = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *ScanOutput) SetItems(v []map[string]*AttributeValue) *ScanOutput {
+	s.Items = v
+	return s
+}
+
+// SetLastEvaluatedKey sets the LastEvaluatedKey field's value.
+func (s *ScanOutput) SetLastEvaluatedKey(v map[string]*AttributeValue) *ScanOutput {
+	s.LastEvaluatedKey = v
+	return s
+}
+
+// SetScannedCount sets the ScannedCount field's value.
+func (s *ScanOutput) SetScannedCount(v int64) *ScanOutput {
+	s.ScannedCount = &v
+	return s
+}
+
 // Represents the DynamoDB Streams configuration for a table in DynamoDB.
 type StreamSpecification struct {
 	_ struct{} `type:"structure"`
@@ -5660,6 +6770,18 @@ func (s StreamSpecification) String() string {
 // GoString returns the string representation
 func (s StreamSpecification) GoString() string {
 	return s.String()
+}
+
+// SetStreamEnabled sets the StreamEnabled field's value.
+func (s *StreamSpecification) SetStreamEnabled(v bool) *StreamSpecification {
+	s.StreamEnabled = &v
+	return s
+}
+
+// SetStreamViewType sets the StreamViewType field's value.
+func (s *StreamSpecification) SetStreamViewType(v string) *StreamSpecification {
+	s.StreamViewType = &v
+	return s
 }
 
 // Represents the properties of a table.
@@ -5870,6 +6992,90 @@ func (s TableDescription) GoString() string {
 	return s.String()
 }
 
+// SetAttributeDefinitions sets the AttributeDefinitions field's value.
+func (s *TableDescription) SetAttributeDefinitions(v []*AttributeDefinition) *TableDescription {
+	s.AttributeDefinitions = v
+	return s
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *TableDescription) SetCreationDateTime(v time.Time) *TableDescription {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetGlobalSecondaryIndexes sets the GlobalSecondaryIndexes field's value.
+func (s *TableDescription) SetGlobalSecondaryIndexes(v []*GlobalSecondaryIndexDescription) *TableDescription {
+	s.GlobalSecondaryIndexes = v
+	return s
+}
+
+// SetItemCount sets the ItemCount field's value.
+func (s *TableDescription) SetItemCount(v int64) *TableDescription {
+	s.ItemCount = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *TableDescription) SetKeySchema(v []*KeySchemaElement) *TableDescription {
+	s.KeySchema = v
+	return s
+}
+
+// SetLatestStreamArn sets the LatestStreamArn field's value.
+func (s *TableDescription) SetLatestStreamArn(v string) *TableDescription {
+	s.LatestStreamArn = &v
+	return s
+}
+
+// SetLatestStreamLabel sets the LatestStreamLabel field's value.
+func (s *TableDescription) SetLatestStreamLabel(v string) *TableDescription {
+	s.LatestStreamLabel = &v
+	return s
+}
+
+// SetLocalSecondaryIndexes sets the LocalSecondaryIndexes field's value.
+func (s *TableDescription) SetLocalSecondaryIndexes(v []*LocalSecondaryIndexDescription) *TableDescription {
+	s.LocalSecondaryIndexes = v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *TableDescription) SetProvisionedThroughput(v *ProvisionedThroughputDescription) *TableDescription {
+	s.ProvisionedThroughput = v
+	return s
+}
+
+// SetStreamSpecification sets the StreamSpecification field's value.
+func (s *TableDescription) SetStreamSpecification(v *StreamSpecification) *TableDescription {
+	s.StreamSpecification = v
+	return s
+}
+
+// SetTableArn sets the TableArn field's value.
+func (s *TableDescription) SetTableArn(v string) *TableDescription {
+	s.TableArn = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *TableDescription) SetTableName(v string) *TableDescription {
+	s.TableName = &v
+	return s
+}
+
+// SetTableSizeBytes sets the TableSizeBytes field's value.
+func (s *TableDescription) SetTableSizeBytes(v int64) *TableDescription {
+	s.TableSizeBytes = &v
+	return s
+}
+
+// SetTableStatus sets the TableStatus field's value.
+func (s *TableDescription) SetTableStatus(v string) *TableDescription {
+	s.TableStatus = &v
+	return s
+}
+
 // Represents the new provisioned throughput settings to be applied to a global
 // secondary index.
 type UpdateGlobalSecondaryIndexAction struct {
@@ -5923,6 +7129,18 @@ func (s *UpdateGlobalSecondaryIndexAction) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *UpdateGlobalSecondaryIndexAction) SetIndexName(v string) *UpdateGlobalSecondaryIndexAction {
+	s.IndexName = &v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *UpdateGlobalSecondaryIndexAction) SetProvisionedThroughput(v *ProvisionedThroughput) *UpdateGlobalSecondaryIndexAction {
+	s.ProvisionedThroughput = v
+	return s
 }
 
 // Represents the input of an UpdateItem operation.
@@ -6397,6 +7615,78 @@ func (s *UpdateItemInput) Validate() error {
 	return nil
 }
 
+// SetAttributeUpdates sets the AttributeUpdates field's value.
+func (s *UpdateItemInput) SetAttributeUpdates(v map[string]*AttributeValueUpdate) *UpdateItemInput {
+	s.AttributeUpdates = v
+	return s
+}
+
+// SetConditionExpression sets the ConditionExpression field's value.
+func (s *UpdateItemInput) SetConditionExpression(v string) *UpdateItemInput {
+	s.ConditionExpression = &v
+	return s
+}
+
+// SetConditionalOperator sets the ConditionalOperator field's value.
+func (s *UpdateItemInput) SetConditionalOperator(v string) *UpdateItemInput {
+	s.ConditionalOperator = &v
+	return s
+}
+
+// SetExpected sets the Expected field's value.
+func (s *UpdateItemInput) SetExpected(v map[string]*ExpectedAttributeValue) *UpdateItemInput {
+	s.Expected = v
+	return s
+}
+
+// SetExpressionAttributeNames sets the ExpressionAttributeNames field's value.
+func (s *UpdateItemInput) SetExpressionAttributeNames(v map[string]*string) *UpdateItemInput {
+	s.ExpressionAttributeNames = v
+	return s
+}
+
+// SetExpressionAttributeValues sets the ExpressionAttributeValues field's value.
+func (s *UpdateItemInput) SetExpressionAttributeValues(v map[string]*AttributeValue) *UpdateItemInput {
+	s.ExpressionAttributeValues = v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *UpdateItemInput) SetKey(v map[string]*AttributeValue) *UpdateItemInput {
+	s.Key = v
+	return s
+}
+
+// SetReturnConsumedCapacity sets the ReturnConsumedCapacity field's value.
+func (s *UpdateItemInput) SetReturnConsumedCapacity(v string) *UpdateItemInput {
+	s.ReturnConsumedCapacity = &v
+	return s
+}
+
+// SetReturnItemCollectionMetrics sets the ReturnItemCollectionMetrics field's value.
+func (s *UpdateItemInput) SetReturnItemCollectionMetrics(v string) *UpdateItemInput {
+	s.ReturnItemCollectionMetrics = &v
+	return s
+}
+
+// SetReturnValues sets the ReturnValues field's value.
+func (s *UpdateItemInput) SetReturnValues(v string) *UpdateItemInput {
+	s.ReturnValues = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *UpdateItemInput) SetTableName(v string) *UpdateItemInput {
+	s.TableName = &v
+	return s
+}
+
+// SetUpdateExpression sets the UpdateExpression field's value.
+func (s *UpdateItemInput) SetUpdateExpression(v string) *UpdateItemInput {
+	s.UpdateExpression = &v
+	return s
+}
+
 // Represents the output of an UpdateItem operation.
 type UpdateItemOutput struct {
 	_ struct{} `type:"structure"`
@@ -6429,6 +7719,24 @@ func (s UpdateItemOutput) String() string {
 // GoString returns the string representation
 func (s UpdateItemOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *UpdateItemOutput) SetAttributes(v map[string]*AttributeValue) *UpdateItemOutput {
+	s.Attributes = v
+	return s
+}
+
+// SetConsumedCapacity sets the ConsumedCapacity field's value.
+func (s *UpdateItemOutput) SetConsumedCapacity(v *ConsumedCapacity) *UpdateItemOutput {
+	s.ConsumedCapacity = v
+	return s
+}
+
+// SetItemCollectionMetrics sets the ItemCollectionMetrics field's value.
+func (s *UpdateItemOutput) SetItemCollectionMetrics(v *ItemCollectionMetrics) *UpdateItemOutput {
+	s.ItemCollectionMetrics = v
+	return s
 }
 
 // Represents the input of an UpdateTable operation.
@@ -6526,6 +7834,36 @@ func (s *UpdateTableInput) Validate() error {
 	return nil
 }
 
+// SetAttributeDefinitions sets the AttributeDefinitions field's value.
+func (s *UpdateTableInput) SetAttributeDefinitions(v []*AttributeDefinition) *UpdateTableInput {
+	s.AttributeDefinitions = v
+	return s
+}
+
+// SetGlobalSecondaryIndexUpdates sets the GlobalSecondaryIndexUpdates field's value.
+func (s *UpdateTableInput) SetGlobalSecondaryIndexUpdates(v []*GlobalSecondaryIndexUpdate) *UpdateTableInput {
+	s.GlobalSecondaryIndexUpdates = v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *UpdateTableInput) SetProvisionedThroughput(v *ProvisionedThroughput) *UpdateTableInput {
+	s.ProvisionedThroughput = v
+	return s
+}
+
+// SetStreamSpecification sets the StreamSpecification field's value.
+func (s *UpdateTableInput) SetStreamSpecification(v *StreamSpecification) *UpdateTableInput {
+	s.StreamSpecification = v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *UpdateTableInput) SetTableName(v string) *UpdateTableInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of an UpdateTable operation.
 type UpdateTableOutput struct {
 	_ struct{} `type:"structure"`
@@ -6542,6 +7880,12 @@ func (s UpdateTableOutput) String() string {
 // GoString returns the string representation
 func (s UpdateTableOutput) GoString() string {
 	return s.String()
+}
+
+// SetTableDescription sets the TableDescription field's value.
+func (s *UpdateTableOutput) SetTableDescription(v *TableDescription) *UpdateTableOutput {
+	s.TableDescription = v
+	return s
 }
 
 // Represents an operation to perform - either DeleteItem or PutItem. You can
@@ -6566,6 +7910,18 @@ func (s WriteRequest) String() string {
 // GoString returns the string representation
 func (s WriteRequest) GoString() string {
 	return s.String()
+}
+
+// SetDeleteRequest sets the DeleteRequest field's value.
+func (s *WriteRequest) SetDeleteRequest(v *DeleteRequest) *WriteRequest {
+	s.DeleteRequest = v
+	return s
+}
+
+// SetPutRequest sets the PutRequest field's value.
+func (s *WriteRequest) SetPutRequest(v *PutRequest) *WriteRequest {
+	s.PutRequest = v
+	return s
 }
 
 const (

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -397,6 +397,24 @@ func (s *DescribeStreamInput) Validate() error {
 	return nil
 }
 
+// SetExclusiveStartShardId sets the ExclusiveStartShardId field's value.
+func (s *DescribeStreamInput) SetExclusiveStartShardId(v string) *DescribeStreamInput {
+	s.ExclusiveStartShardId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeStreamInput) SetLimit(v int64) *DescribeStreamInput {
+	s.Limit = &v
+	return s
+}
+
+// SetStreamArn sets the StreamArn field's value.
+func (s *DescribeStreamInput) SetStreamArn(v string) *DescribeStreamInput {
+	s.StreamArn = &v
+	return s
+}
+
 // Represents the output of a DescribeStream operation.
 type DescribeStreamOutput struct {
 	_ struct{} `type:"structure"`
@@ -416,6 +434,12 @@ func (s DescribeStreamOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStreamOutput) GoString() string {
 	return s.String()
+}
+
+// SetStreamDescription sets the StreamDescription field's value.
+func (s *DescribeStreamOutput) SetStreamDescription(v *StreamDescription) *DescribeStreamOutput {
+	s.StreamDescription = v
+	return s
 }
 
 // Represents the input of a GetRecords operation.
@@ -462,6 +486,18 @@ func (s *GetRecordsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetRecordsInput) SetLimit(v int64) *GetRecordsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetShardIterator sets the ShardIterator field's value.
+func (s *GetRecordsInput) SetShardIterator(v string) *GetRecordsInput {
+	s.ShardIterator = &v
+	return s
+}
+
 // Represents the output of a GetRecords operation.
 type GetRecordsOutput struct {
 	_ struct{} `type:"structure"`
@@ -483,6 +519,18 @@ func (s GetRecordsOutput) String() string {
 // GoString returns the string representation
 func (s GetRecordsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextShardIterator sets the NextShardIterator field's value.
+func (s *GetRecordsOutput) SetNextShardIterator(v string) *GetRecordsOutput {
+	s.NextShardIterator = &v
+	return s
+}
+
+// SetRecords sets the Records field's value.
+func (s *GetRecordsOutput) SetRecords(v []*Record) *GetRecordsOutput {
+	s.Records = v
+	return s
 }
 
 // Represents the input of a GetShardIterator operation.
@@ -562,6 +610,30 @@ func (s *GetShardIteratorInput) Validate() error {
 	return nil
 }
 
+// SetSequenceNumber sets the SequenceNumber field's value.
+func (s *GetShardIteratorInput) SetSequenceNumber(v string) *GetShardIteratorInput {
+	s.SequenceNumber = &v
+	return s
+}
+
+// SetShardId sets the ShardId field's value.
+func (s *GetShardIteratorInput) SetShardId(v string) *GetShardIteratorInput {
+	s.ShardId = &v
+	return s
+}
+
+// SetShardIteratorType sets the ShardIteratorType field's value.
+func (s *GetShardIteratorInput) SetShardIteratorType(v string) *GetShardIteratorInput {
+	s.ShardIteratorType = &v
+	return s
+}
+
+// SetStreamArn sets the StreamArn field's value.
+func (s *GetShardIteratorInput) SetStreamArn(v string) *GetShardIteratorInput {
+	s.StreamArn = &v
+	return s
+}
+
 // Represents the output of a GetShardIterator operation.
 type GetShardIteratorOutput struct {
 	_ struct{} `type:"structure"`
@@ -580,6 +652,12 @@ func (s GetShardIteratorOutput) String() string {
 // GoString returns the string representation
 func (s GetShardIteratorOutput) GoString() string {
 	return s.String()
+}
+
+// SetShardIterator sets the ShardIterator field's value.
+func (s *GetShardIteratorOutput) SetShardIterator(v string) *GetShardIteratorOutput {
+	s.ShardIterator = &v
+	return s
 }
 
 // Represents the input of a ListStreams operation.
@@ -628,6 +706,24 @@ func (s *ListStreamsInput) Validate() error {
 	return nil
 }
 
+// SetExclusiveStartStreamArn sets the ExclusiveStartStreamArn field's value.
+func (s *ListStreamsInput) SetExclusiveStartStreamArn(v string) *ListStreamsInput {
+	s.ExclusiveStartStreamArn = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListStreamsInput) SetLimit(v int64) *ListStreamsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *ListStreamsInput) SetTableName(v string) *ListStreamsInput {
+	s.TableName = &v
+	return s
+}
+
 // Represents the output of a ListStreams operation.
 type ListStreamsOutput struct {
 	_ struct{} `type:"structure"`
@@ -656,6 +752,18 @@ func (s ListStreamsOutput) String() string {
 // GoString returns the string representation
 func (s ListStreamsOutput) GoString() string {
 	return s.String()
+}
+
+// SetLastEvaluatedStreamArn sets the LastEvaluatedStreamArn field's value.
+func (s *ListStreamsOutput) SetLastEvaluatedStreamArn(v string) *ListStreamsOutput {
+	s.LastEvaluatedStreamArn = &v
+	return s
+}
+
+// SetStreams sets the Streams field's value.
+func (s *ListStreamsOutput) SetStreams(v []*Stream) *ListStreamsOutput {
+	s.Streams = v
+	return s
 }
 
 // A description of a unique event within a stream.
@@ -705,6 +813,42 @@ func (s Record) GoString() string {
 	return s.String()
 }
 
+// SetAwsRegion sets the AwsRegion field's value.
+func (s *Record) SetAwsRegion(v string) *Record {
+	s.AwsRegion = &v
+	return s
+}
+
+// SetDynamodb sets the Dynamodb field's value.
+func (s *Record) SetDynamodb(v *StreamRecord) *Record {
+	s.Dynamodb = v
+	return s
+}
+
+// SetEventID sets the EventID field's value.
+func (s *Record) SetEventID(v string) *Record {
+	s.EventID = &v
+	return s
+}
+
+// SetEventName sets the EventName field's value.
+func (s *Record) SetEventName(v string) *Record {
+	s.EventName = &v
+	return s
+}
+
+// SetEventSource sets the EventSource field's value.
+func (s *Record) SetEventSource(v string) *Record {
+	s.EventSource = &v
+	return s
+}
+
+// SetEventVersion sets the EventVersion field's value.
+func (s *Record) SetEventVersion(v string) *Record {
+	s.EventVersion = &v
+	return s
+}
+
 // The beginning and ending sequence numbers for the stream records contained
 // within a shard.
 type SequenceNumberRange struct {
@@ -725,6 +869,18 @@ func (s SequenceNumberRange) String() string {
 // GoString returns the string representation
 func (s SequenceNumberRange) GoString() string {
 	return s.String()
+}
+
+// SetEndingSequenceNumber sets the EndingSequenceNumber field's value.
+func (s *SequenceNumberRange) SetEndingSequenceNumber(v string) *SequenceNumberRange {
+	s.EndingSequenceNumber = &v
+	return s
+}
+
+// SetStartingSequenceNumber sets the StartingSequenceNumber field's value.
+func (s *SequenceNumberRange) SetStartingSequenceNumber(v string) *SequenceNumberRange {
+	s.StartingSequenceNumber = &v
+	return s
 }
 
 // A uniquely identified group of stream records within a stream.
@@ -749,6 +905,24 @@ func (s Shard) String() string {
 // GoString returns the string representation
 func (s Shard) GoString() string {
 	return s.String()
+}
+
+// SetParentShardId sets the ParentShardId field's value.
+func (s *Shard) SetParentShardId(v string) *Shard {
+	s.ParentShardId = &v
+	return s
+}
+
+// SetSequenceNumberRange sets the SequenceNumberRange field's value.
+func (s *Shard) SetSequenceNumberRange(v *SequenceNumberRange) *Shard {
+	s.SequenceNumberRange = v
+	return s
+}
+
+// SetShardId sets the ShardId field's value.
+func (s *Shard) SetShardId(v string) *Shard {
+	s.ShardId = &v
+	return s
 }
 
 // Represents all of the data describing a particular stream.
@@ -784,6 +958,24 @@ func (s Stream) String() string {
 // GoString returns the string representation
 func (s Stream) GoString() string {
 	return s.String()
+}
+
+// SetStreamArn sets the StreamArn field's value.
+func (s *Stream) SetStreamArn(v string) *Stream {
+	s.StreamArn = &v
+	return s
+}
+
+// SetStreamLabel sets the StreamLabel field's value.
+func (s *Stream) SetStreamLabel(v string) *Stream {
+	s.StreamLabel = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *Stream) SetTableName(v string) *Stream {
+	s.TableName = &v
+	return s
 }
 
 // Represents all of the data describing a particular stream.
@@ -868,6 +1060,60 @@ func (s StreamDescription) GoString() string {
 	return s.String()
 }
 
+// SetCreationRequestDateTime sets the CreationRequestDateTime field's value.
+func (s *StreamDescription) SetCreationRequestDateTime(v time.Time) *StreamDescription {
+	s.CreationRequestDateTime = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *StreamDescription) SetKeySchema(v []*dynamodb.KeySchemaElement) *StreamDescription {
+	s.KeySchema = v
+	return s
+}
+
+// SetLastEvaluatedShardId sets the LastEvaluatedShardId field's value.
+func (s *StreamDescription) SetLastEvaluatedShardId(v string) *StreamDescription {
+	s.LastEvaluatedShardId = &v
+	return s
+}
+
+// SetShards sets the Shards field's value.
+func (s *StreamDescription) SetShards(v []*Shard) *StreamDescription {
+	s.Shards = v
+	return s
+}
+
+// SetStreamArn sets the StreamArn field's value.
+func (s *StreamDescription) SetStreamArn(v string) *StreamDescription {
+	s.StreamArn = &v
+	return s
+}
+
+// SetStreamLabel sets the StreamLabel field's value.
+func (s *StreamDescription) SetStreamLabel(v string) *StreamDescription {
+	s.StreamLabel = &v
+	return s
+}
+
+// SetStreamStatus sets the StreamStatus field's value.
+func (s *StreamDescription) SetStreamStatus(v string) *StreamDescription {
+	s.StreamStatus = &v
+	return s
+}
+
+// SetStreamViewType sets the StreamViewType field's value.
+func (s *StreamDescription) SetStreamViewType(v string) *StreamDescription {
+	s.StreamViewType = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *StreamDescription) SetTableName(v string) *StreamDescription {
+	s.TableName = &v
+	return s
+}
+
 // A description of a single data modification that was performed on an item
 // in a DynamoDB table.
 type StreamRecord struct {
@@ -913,6 +1159,48 @@ func (s StreamRecord) String() string {
 // GoString returns the string representation
 func (s StreamRecord) GoString() string {
 	return s.String()
+}
+
+// SetApproximateCreationDateTime sets the ApproximateCreationDateTime field's value.
+func (s *StreamRecord) SetApproximateCreationDateTime(v time.Time) *StreamRecord {
+	s.ApproximateCreationDateTime = &v
+	return s
+}
+
+// SetKeys sets the Keys field's value.
+func (s *StreamRecord) SetKeys(v map[string]*dynamodb.AttributeValue) *StreamRecord {
+	s.Keys = v
+	return s
+}
+
+// SetNewImage sets the NewImage field's value.
+func (s *StreamRecord) SetNewImage(v map[string]*dynamodb.AttributeValue) *StreamRecord {
+	s.NewImage = v
+	return s
+}
+
+// SetOldImage sets the OldImage field's value.
+func (s *StreamRecord) SetOldImage(v map[string]*dynamodb.AttributeValue) *StreamRecord {
+	s.OldImage = v
+	return s
+}
+
+// SetSequenceNumber sets the SequenceNumber field's value.
+func (s *StreamRecord) SetSequenceNumber(v string) *StreamRecord {
+	s.SequenceNumber = &v
+	return s
+}
+
+// SetSizeBytes sets the SizeBytes field's value.
+func (s *StreamRecord) SetSizeBytes(v int64) *StreamRecord {
+	s.SizeBytes = &v
+	return s
+}
+
+// SetStreamViewType sets the StreamViewType field's value.
+func (s *StreamRecord) SetStreamViewType(v string) *StreamRecord {
+	s.StreamViewType = &v
+	return s
 }
 
 const (

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -14554,6 +14554,24 @@ func (s *AcceptReservedInstancesExchangeQuoteInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *AcceptReservedInstancesExchangeQuoteInput) SetDryRun(v bool) *AcceptReservedInstancesExchangeQuoteInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetReservedInstanceIds sets the ReservedInstanceIds field's value.
+func (s *AcceptReservedInstancesExchangeQuoteInput) SetReservedInstanceIds(v []*string) *AcceptReservedInstancesExchangeQuoteInput {
+	s.ReservedInstanceIds = v
+	return s
+}
+
+// SetTargetConfigurations sets the TargetConfigurations field's value.
+func (s *AcceptReservedInstancesExchangeQuoteInput) SetTargetConfigurations(v []*TargetConfigurationRequest) *AcceptReservedInstancesExchangeQuoteInput {
+	s.TargetConfigurations = v
+	return s
+}
+
 // The result of the exchange and whether it was successful.
 type AcceptReservedInstancesExchangeQuoteOutput struct {
 	_ struct{} `type:"structure"`
@@ -14570,6 +14588,12 @@ func (s AcceptReservedInstancesExchangeQuoteOutput) String() string {
 // GoString returns the string representation
 func (s AcceptReservedInstancesExchangeQuoteOutput) GoString() string {
 	return s.String()
+}
+
+// SetExchangeId sets the ExchangeId field's value.
+func (s *AcceptReservedInstancesExchangeQuoteOutput) SetExchangeId(v string) *AcceptReservedInstancesExchangeQuoteOutput {
+	s.ExchangeId = &v
+	return s
 }
 
 // Contains the parameters for AcceptVpcPeeringConnection.
@@ -14596,6 +14620,18 @@ func (s AcceptVpcPeeringConnectionInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *AcceptVpcPeeringConnectionInput) SetDryRun(v bool) *AcceptVpcPeeringConnectionInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *AcceptVpcPeeringConnectionInput) SetVpcPeeringConnectionId(v string) *AcceptVpcPeeringConnectionInput {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 // Contains the output of AcceptVpcPeeringConnection.
 type AcceptVpcPeeringConnectionOutput struct {
 	_ struct{} `type:"structure"`
@@ -14612,6 +14648,12 @@ func (s AcceptVpcPeeringConnectionOutput) String() string {
 // GoString returns the string representation
 func (s AcceptVpcPeeringConnectionOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpcPeeringConnection sets the VpcPeeringConnection field's value.
+func (s *AcceptVpcPeeringConnectionOutput) SetVpcPeeringConnection(v *VpcPeeringConnection) *AcceptVpcPeeringConnectionOutput {
+	s.VpcPeeringConnection = v
+	return s
 }
 
 // Describes an account attribute.
@@ -14635,6 +14677,18 @@ func (s AccountAttribute) GoString() string {
 	return s.String()
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *AccountAttribute) SetAttributeName(v string) *AccountAttribute {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValues sets the AttributeValues field's value.
+func (s *AccountAttribute) SetAttributeValues(v []*AccountAttributeValue) *AccountAttribute {
+	s.AttributeValues = v
+	return s
+}
+
 // Describes a value of an account attribute.
 type AccountAttributeValue struct {
 	_ struct{} `type:"structure"`
@@ -14651,6 +14705,12 @@ func (s AccountAttributeValue) String() string {
 // GoString returns the string representation
 func (s AccountAttributeValue) GoString() string {
 	return s.String()
+}
+
+// SetAttributeValue sets the AttributeValue field's value.
+func (s *AccountAttributeValue) SetAttributeValue(v string) *AccountAttributeValue {
+	s.AttributeValue = &v
+	return s
 }
 
 // Describes a running instance in a Spot fleet.
@@ -14675,6 +14735,24 @@ func (s ActiveInstance) String() string {
 // GoString returns the string representation
 func (s ActiveInstance) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ActiveInstance) SetInstanceId(v string) *ActiveInstance {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ActiveInstance) SetInstanceType(v string) *ActiveInstance {
+	s.InstanceType = &v
+	return s
+}
+
+// SetSpotInstanceRequestId sets the SpotInstanceRequestId field's value.
+func (s *ActiveInstance) SetSpotInstanceRequestId(v string) *ActiveInstance {
+	s.SpotInstanceRequestId = &v
+	return s
 }
 
 // Describes an Elastic IP address.
@@ -14718,6 +14796,54 @@ func (s Address) GoString() string {
 	return s.String()
 }
 
+// SetAllocationId sets the AllocationId field's value.
+func (s *Address) SetAllocationId(v string) *Address {
+	s.AllocationId = &v
+	return s
+}
+
+// SetAssociationId sets the AssociationId field's value.
+func (s *Address) SetAssociationId(v string) *Address {
+	s.AssociationId = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *Address) SetDomain(v string) *Address {
+	s.Domain = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Address) SetInstanceId(v string) *Address {
+	s.InstanceId = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *Address) SetNetworkInterfaceId(v string) *Address {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetNetworkInterfaceOwnerId sets the NetworkInterfaceOwnerId field's value.
+func (s *Address) SetNetworkInterfaceOwnerId(v string) *Address {
+	s.NetworkInterfaceOwnerId = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *Address) SetPrivateIpAddress(v string) *Address {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *Address) SetPublicIp(v string) *Address {
+	s.PublicIp = &v
+	return s
+}
+
 // Contains the parameters for AllocateAddress.
 type AllocateAddressInput struct {
 	_ struct{} `type:"structure"`
@@ -14744,6 +14870,18 @@ func (s AllocateAddressInput) GoString() string {
 	return s.String()
 }
 
+// SetDomain sets the Domain field's value.
+func (s *AllocateAddressInput) SetDomain(v string) *AllocateAddressInput {
+	s.Domain = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AllocateAddressInput) SetDryRun(v bool) *AllocateAddressInput {
+	s.DryRun = &v
+	return s
+}
+
 // Contains the output of AllocateAddress.
 type AllocateAddressOutput struct {
 	_ struct{} `type:"structure"`
@@ -14768,6 +14906,24 @@ func (s AllocateAddressOutput) String() string {
 // GoString returns the string representation
 func (s AllocateAddressOutput) GoString() string {
 	return s.String()
+}
+
+// SetAllocationId sets the AllocationId field's value.
+func (s *AllocateAddressOutput) SetAllocationId(v string) *AllocateAddressOutput {
+	s.AllocationId = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *AllocateAddressOutput) SetDomain(v string) *AllocateAddressOutput {
+	s.Domain = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *AllocateAddressOutput) SetPublicIp(v string) *AllocateAddressOutput {
+	s.PublicIp = &v
+	return s
 }
 
 // Contains the parameters for AllocateHosts.
@@ -14834,6 +14990,36 @@ func (s *AllocateHostsInput) Validate() error {
 	return nil
 }
 
+// SetAutoPlacement sets the AutoPlacement field's value.
+func (s *AllocateHostsInput) SetAutoPlacement(v string) *AllocateHostsInput {
+	s.AutoPlacement = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *AllocateHostsInput) SetAvailabilityZone(v string) *AllocateHostsInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *AllocateHostsInput) SetClientToken(v string) *AllocateHostsInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *AllocateHostsInput) SetInstanceType(v string) *AllocateHostsInput {
+	s.InstanceType = &v
+	return s
+}
+
+// SetQuantity sets the Quantity field's value.
+func (s *AllocateHostsInput) SetQuantity(v int64) *AllocateHostsInput {
+	s.Quantity = &v
+	return s
+}
+
 // Contains the output of AllocateHosts.
 type AllocateHostsOutput struct {
 	_ struct{} `type:"structure"`
@@ -14851,6 +15037,12 @@ func (s AllocateHostsOutput) String() string {
 // GoString returns the string representation
 func (s AllocateHostsOutput) GoString() string {
 	return s.String()
+}
+
+// SetHostIds sets the HostIds field's value.
+func (s *AllocateHostsOutput) SetHostIds(v []*string) *AllocateHostsOutput {
+	s.HostIds = v
+	return s
 }
 
 // Contains the parameters for AssignPrivateIpAddresses.
@@ -14900,6 +15092,30 @@ func (s *AssignPrivateIpAddressesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAllowReassignment sets the AllowReassignment field's value.
+func (s *AssignPrivateIpAddressesInput) SetAllowReassignment(v bool) *AssignPrivateIpAddressesInput {
+	s.AllowReassignment = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *AssignPrivateIpAddressesInput) SetNetworkInterfaceId(v string) *AssignPrivateIpAddressesInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetPrivateIpAddresses sets the PrivateIpAddresses field's value.
+func (s *AssignPrivateIpAddressesInput) SetPrivateIpAddresses(v []*string) *AssignPrivateIpAddressesInput {
+	s.PrivateIpAddresses = v
+	return s
+}
+
+// SetSecondaryPrivateIpAddressCount sets the SecondaryPrivateIpAddressCount field's value.
+func (s *AssignPrivateIpAddressesInput) SetSecondaryPrivateIpAddressCount(v int64) *AssignPrivateIpAddressesInput {
+	s.SecondaryPrivateIpAddressCount = &v
+	return s
 }
 
 type AssignPrivateIpAddressesOutput struct {
@@ -14966,6 +15182,48 @@ func (s AssociateAddressInput) GoString() string {
 	return s.String()
 }
 
+// SetAllocationId sets the AllocationId field's value.
+func (s *AssociateAddressInput) SetAllocationId(v string) *AssociateAddressInput {
+	s.AllocationId = &v
+	return s
+}
+
+// SetAllowReassociation sets the AllowReassociation field's value.
+func (s *AssociateAddressInput) SetAllowReassociation(v bool) *AssociateAddressInput {
+	s.AllowReassociation = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AssociateAddressInput) SetDryRun(v bool) *AssociateAddressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *AssociateAddressInput) SetInstanceId(v string) *AssociateAddressInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *AssociateAddressInput) SetNetworkInterfaceId(v string) *AssociateAddressInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *AssociateAddressInput) SetPrivateIpAddress(v string) *AssociateAddressInput {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *AssociateAddressInput) SetPublicIp(v string) *AssociateAddressInput {
+	s.PublicIp = &v
+	return s
+}
+
 // Contains the output of AssociateAddress.
 type AssociateAddressOutput struct {
 	_ struct{} `type:"structure"`
@@ -14983,6 +15241,12 @@ func (s AssociateAddressOutput) String() string {
 // GoString returns the string representation
 func (s AssociateAddressOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssociationId sets the AssociationId field's value.
+func (s *AssociateAddressOutput) SetAssociationId(v string) *AssociateAddressOutput {
+	s.AssociationId = &v
+	return s
 }
 
 // Contains the parameters for AssociateDhcpOptions.
@@ -15031,6 +15295,24 @@ func (s *AssociateDhcpOptionsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDhcpOptionsId sets the DhcpOptionsId field's value.
+func (s *AssociateDhcpOptionsInput) SetDhcpOptionsId(v string) *AssociateDhcpOptionsInput {
+	s.DhcpOptionsId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AssociateDhcpOptionsInput) SetDryRun(v bool) *AssociateDhcpOptionsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *AssociateDhcpOptionsInput) SetVpcId(v string) *AssociateDhcpOptionsInput {
+	s.VpcId = &v
+	return s
 }
 
 type AssociateDhcpOptionsOutput struct {
@@ -15094,6 +15376,24 @@ func (s *AssociateRouteTableInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *AssociateRouteTableInput) SetDryRun(v bool) *AssociateRouteTableInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *AssociateRouteTableInput) SetRouteTableId(v string) *AssociateRouteTableInput {
+	s.RouteTableId = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *AssociateRouteTableInput) SetSubnetId(v string) *AssociateRouteTableInput {
+	s.SubnetId = &v
+	return s
+}
+
 // Contains the output of AssociateRouteTable.
 type AssociateRouteTableOutput struct {
 	_ struct{} `type:"structure"`
@@ -15110,6 +15410,12 @@ func (s AssociateRouteTableOutput) String() string {
 // GoString returns the string representation
 func (s AssociateRouteTableOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssociationId sets the AssociationId field's value.
+func (s *AssociateRouteTableOutput) SetAssociationId(v string) *AssociateRouteTableOutput {
+	s.AssociationId = &v
+	return s
 }
 
 // Contains the parameters for AttachClassicLinkVpc.
@@ -15168,6 +15474,30 @@ func (s *AttachClassicLinkVpcInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *AttachClassicLinkVpcInput) SetDryRun(v bool) *AttachClassicLinkVpcInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *AttachClassicLinkVpcInput) SetGroups(v []*string) *AttachClassicLinkVpcInput {
+	s.Groups = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *AttachClassicLinkVpcInput) SetInstanceId(v string) *AttachClassicLinkVpcInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *AttachClassicLinkVpcInput) SetVpcId(v string) *AttachClassicLinkVpcInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of AttachClassicLinkVpc.
 type AttachClassicLinkVpcOutput struct {
 	_ struct{} `type:"structure"`
@@ -15184,6 +15514,12 @@ func (s AttachClassicLinkVpcOutput) String() string {
 // GoString returns the string representation
 func (s AttachClassicLinkVpcOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *AttachClassicLinkVpcOutput) SetReturn(v bool) *AttachClassicLinkVpcOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for AttachInternetGateway.
@@ -15231,6 +15567,24 @@ func (s *AttachInternetGatewayInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AttachInternetGatewayInput) SetDryRun(v bool) *AttachInternetGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInternetGatewayId sets the InternetGatewayId field's value.
+func (s *AttachInternetGatewayInput) SetInternetGatewayId(v string) *AttachInternetGatewayInput {
+	s.InternetGatewayId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *AttachInternetGatewayInput) SetVpcId(v string) *AttachInternetGatewayInput {
+	s.VpcId = &v
+	return s
 }
 
 type AttachInternetGatewayOutput struct {
@@ -15302,6 +15656,30 @@ func (s *AttachNetworkInterfaceInput) Validate() error {
 	return nil
 }
 
+// SetDeviceIndex sets the DeviceIndex field's value.
+func (s *AttachNetworkInterfaceInput) SetDeviceIndex(v int64) *AttachNetworkInterfaceInput {
+	s.DeviceIndex = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AttachNetworkInterfaceInput) SetDryRun(v bool) *AttachNetworkInterfaceInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *AttachNetworkInterfaceInput) SetInstanceId(v string) *AttachNetworkInterfaceInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *AttachNetworkInterfaceInput) SetNetworkInterfaceId(v string) *AttachNetworkInterfaceInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
 // Contains the output of AttachNetworkInterface.
 type AttachNetworkInterfaceOutput struct {
 	_ struct{} `type:"structure"`
@@ -15318,6 +15696,12 @@ func (s AttachNetworkInterfaceOutput) String() string {
 // GoString returns the string representation
 func (s AttachNetworkInterfaceOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttachmentId sets the AttachmentId field's value.
+func (s *AttachNetworkInterfaceOutput) SetAttachmentId(v string) *AttachNetworkInterfaceOutput {
+	s.AttachmentId = &v
+	return s
 }
 
 // Contains the parameters for AttachVolume.
@@ -15376,6 +15760,30 @@ func (s *AttachVolumeInput) Validate() error {
 	return nil
 }
 
+// SetDevice sets the Device field's value.
+func (s *AttachVolumeInput) SetDevice(v string) *AttachVolumeInput {
+	s.Device = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AttachVolumeInput) SetDryRun(v bool) *AttachVolumeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *AttachVolumeInput) SetInstanceId(v string) *AttachVolumeInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *AttachVolumeInput) SetVolumeId(v string) *AttachVolumeInput {
+	s.VolumeId = &v
+	return s
+}
+
 // Contains the parameters for AttachVpnGateway.
 type AttachVpnGatewayInput struct {
 	_ struct{} `type:"structure"`
@@ -15423,6 +15831,24 @@ func (s *AttachVpnGatewayInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *AttachVpnGatewayInput) SetDryRun(v bool) *AttachVpnGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *AttachVpnGatewayInput) SetVpcId(v string) *AttachVpnGatewayInput {
+	s.VpcId = &v
+	return s
+}
+
+// SetVpnGatewayId sets the VpnGatewayId field's value.
+func (s *AttachVpnGatewayInput) SetVpnGatewayId(v string) *AttachVpnGatewayInput {
+	s.VpnGatewayId = &v
+	return s
+}
+
 // Contains the output of AttachVpnGateway.
 type AttachVpnGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -15439,6 +15865,12 @@ func (s AttachVpnGatewayOutput) String() string {
 // GoString returns the string representation
 func (s AttachVpnGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpcAttachment sets the VpcAttachment field's value.
+func (s *AttachVpnGatewayOutput) SetVpcAttachment(v *VpcAttachment) *AttachVpnGatewayOutput {
+	s.VpcAttachment = v
+	return s
 }
 
 // Describes a value for a resource attribute that is a Boolean value.
@@ -15459,6 +15891,12 @@ func (s AttributeBooleanValue) GoString() string {
 	return s.String()
 }
 
+// SetValue sets the Value field's value.
+func (s *AttributeBooleanValue) SetValue(v bool) *AttributeBooleanValue {
+	s.Value = &v
+	return s
+}
+
 // Describes a value for a resource attribute that is a String.
 type AttributeValue struct {
 	_ struct{} `type:"structure"`
@@ -15475,6 +15913,12 @@ func (s AttributeValue) String() string {
 // GoString returns the string representation
 func (s AttributeValue) GoString() string {
 	return s.String()
+}
+
+// SetValue sets the Value field's value.
+func (s *AttributeValue) SetValue(v string) *AttributeValue {
+	s.Value = &v
+	return s
 }
 
 // Contains the parameters for AuthorizeSecurityGroupEgress.
@@ -15544,6 +15988,60 @@ func (s *AuthorizeSecurityGroupEgressInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCidrIp sets the CidrIp field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetCidrIp(v string) *AuthorizeSecurityGroupEgressInput {
+	s.CidrIp = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetDryRun(v bool) *AuthorizeSecurityGroupEgressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFromPort sets the FromPort field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetFromPort(v int64) *AuthorizeSecurityGroupEgressInput {
+	s.FromPort = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetGroupId(v string) *AuthorizeSecurityGroupEgressInput {
+	s.GroupId = &v
+	return s
+}
+
+// SetIpPermissions sets the IpPermissions field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetIpPermissions(v []*IpPermission) *AuthorizeSecurityGroupEgressInput {
+	s.IpPermissions = v
+	return s
+}
+
+// SetIpProtocol sets the IpProtocol field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetIpProtocol(v string) *AuthorizeSecurityGroupEgressInput {
+	s.IpProtocol = &v
+	return s
+}
+
+// SetSourceSecurityGroupName sets the SourceSecurityGroupName field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetSourceSecurityGroupName(v string) *AuthorizeSecurityGroupEgressInput {
+	s.SourceSecurityGroupName = &v
+	return s
+}
+
+// SetSourceSecurityGroupOwnerId sets the SourceSecurityGroupOwnerId field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetSourceSecurityGroupOwnerId(v string) *AuthorizeSecurityGroupEgressInput {
+	s.SourceSecurityGroupOwnerId = &v
+	return s
+}
+
+// SetToPort sets the ToPort field's value.
+func (s *AuthorizeSecurityGroupEgressInput) SetToPort(v int64) *AuthorizeSecurityGroupEgressInput {
+	s.ToPort = &v
+	return s
 }
 
 type AuthorizeSecurityGroupEgressOutput struct {
@@ -15625,6 +16123,66 @@ func (s AuthorizeSecurityGroupIngressInput) GoString() string {
 	return s.String()
 }
 
+// SetCidrIp sets the CidrIp field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetCidrIp(v string) *AuthorizeSecurityGroupIngressInput {
+	s.CidrIp = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetDryRun(v bool) *AuthorizeSecurityGroupIngressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFromPort sets the FromPort field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetFromPort(v int64) *AuthorizeSecurityGroupIngressInput {
+	s.FromPort = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetGroupId(v string) *AuthorizeSecurityGroupIngressInput {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetGroupName(v string) *AuthorizeSecurityGroupIngressInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetIpPermissions sets the IpPermissions field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetIpPermissions(v []*IpPermission) *AuthorizeSecurityGroupIngressInput {
+	s.IpPermissions = v
+	return s
+}
+
+// SetIpProtocol sets the IpProtocol field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetIpProtocol(v string) *AuthorizeSecurityGroupIngressInput {
+	s.IpProtocol = &v
+	return s
+}
+
+// SetSourceSecurityGroupName sets the SourceSecurityGroupName field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetSourceSecurityGroupName(v string) *AuthorizeSecurityGroupIngressInput {
+	s.SourceSecurityGroupName = &v
+	return s
+}
+
+// SetSourceSecurityGroupOwnerId sets the SourceSecurityGroupOwnerId field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetSourceSecurityGroupOwnerId(v string) *AuthorizeSecurityGroupIngressInput {
+	s.SourceSecurityGroupOwnerId = &v
+	return s
+}
+
+// SetToPort sets the ToPort field's value.
+func (s *AuthorizeSecurityGroupIngressInput) SetToPort(v int64) *AuthorizeSecurityGroupIngressInput {
+	s.ToPort = &v
+	return s
+}
+
 type AuthorizeSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -15666,6 +16224,30 @@ func (s AvailabilityZone) GoString() string {
 	return s.String()
 }
 
+// SetMessages sets the Messages field's value.
+func (s *AvailabilityZone) SetMessages(v []*AvailabilityZoneMessage) *AvailabilityZone {
+	s.Messages = v
+	return s
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *AvailabilityZone) SetRegionName(v string) *AvailabilityZone {
+	s.RegionName = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *AvailabilityZone) SetState(v string) *AvailabilityZone {
+	s.State = &v
+	return s
+}
+
+// SetZoneName sets the ZoneName field's value.
+func (s *AvailabilityZone) SetZoneName(v string) *AvailabilityZone {
+	s.ZoneName = &v
+	return s
+}
+
 // Describes a message about an Availability Zone.
 type AvailabilityZoneMessage struct {
 	_ struct{} `type:"structure"`
@@ -15682,6 +16264,12 @@ func (s AvailabilityZoneMessage) String() string {
 // GoString returns the string representation
 func (s AvailabilityZoneMessage) GoString() string {
 	return s.String()
+}
+
+// SetMessage sets the Message field's value.
+func (s *AvailabilityZoneMessage) SetMessage(v string) *AvailabilityZoneMessage {
+	s.Message = &v
+	return s
 }
 
 // The capacity information for instances launched onto the Dedicated Host.
@@ -15705,6 +16293,18 @@ func (s AvailableCapacity) GoString() string {
 	return s.String()
 }
 
+// SetAvailableInstanceCapacity sets the AvailableInstanceCapacity field's value.
+func (s *AvailableCapacity) SetAvailableInstanceCapacity(v []*InstanceCapacity) *AvailableCapacity {
+	s.AvailableInstanceCapacity = v
+	return s
+}
+
+// SetAvailableVCpus sets the AvailableVCpus field's value.
+func (s *AvailableCapacity) SetAvailableVCpus(v int64) *AvailableCapacity {
+	s.AvailableVCpus = &v
+	return s
+}
+
 type BlobAttributeValue struct {
 	_ struct{} `type:"structure"`
 
@@ -15720,6 +16320,12 @@ func (s BlobAttributeValue) String() string {
 // GoString returns the string representation
 func (s BlobAttributeValue) GoString() string {
 	return s.String()
+}
+
+// SetValue sets the Value field's value.
+func (s *BlobAttributeValue) SetValue(v []byte) *BlobAttributeValue {
+	s.Value = v
+	return s
 }
 
 // Describes a block device mapping.
@@ -15758,6 +16364,30 @@ func (s BlockDeviceMapping) String() string {
 // GoString returns the string representation
 func (s BlockDeviceMapping) GoString() string {
 	return s.String()
+}
+
+// SetDeviceName sets the DeviceName field's value.
+func (s *BlockDeviceMapping) SetDeviceName(v string) *BlockDeviceMapping {
+	s.DeviceName = &v
+	return s
+}
+
+// SetEbs sets the Ebs field's value.
+func (s *BlockDeviceMapping) SetEbs(v *EbsBlockDevice) *BlockDeviceMapping {
+	s.Ebs = v
+	return s
+}
+
+// SetNoDevice sets the NoDevice field's value.
+func (s *BlockDeviceMapping) SetNoDevice(v string) *BlockDeviceMapping {
+	s.NoDevice = &v
+	return s
+}
+
+// SetVirtualName sets the VirtualName field's value.
+func (s *BlockDeviceMapping) SetVirtualName(v string) *BlockDeviceMapping {
+	s.VirtualName = &v
+	return s
 }
 
 // Contains the parameters for BundleInstance.
@@ -15815,6 +16445,24 @@ func (s *BundleInstanceInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *BundleInstanceInput) SetDryRun(v bool) *BundleInstanceInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *BundleInstanceInput) SetInstanceId(v string) *BundleInstanceInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetStorage sets the Storage field's value.
+func (s *BundleInstanceInput) SetStorage(v *Storage) *BundleInstanceInput {
+	s.Storage = v
+	return s
+}
+
 // Contains the output of BundleInstance.
 type BundleInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -15831,6 +16479,12 @@ func (s BundleInstanceOutput) String() string {
 // GoString returns the string representation
 func (s BundleInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetBundleTask sets the BundleTask field's value.
+func (s *BundleInstanceOutput) SetBundleTask(v *BundleTask) *BundleInstanceOutput {
+	s.BundleTask = v
+	return s
 }
 
 // Describes a bundle task.
@@ -15872,6 +16526,54 @@ func (s BundleTask) GoString() string {
 	return s.String()
 }
 
+// SetBundleId sets the BundleId field's value.
+func (s *BundleTask) SetBundleId(v string) *BundleTask {
+	s.BundleId = &v
+	return s
+}
+
+// SetBundleTaskError sets the BundleTaskError field's value.
+func (s *BundleTask) SetBundleTaskError(v *BundleTaskError) *BundleTask {
+	s.BundleTaskError = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *BundleTask) SetInstanceId(v string) *BundleTask {
+	s.InstanceId = &v
+	return s
+}
+
+// SetProgress sets the Progress field's value.
+func (s *BundleTask) SetProgress(v string) *BundleTask {
+	s.Progress = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *BundleTask) SetStartTime(v time.Time) *BundleTask {
+	s.StartTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *BundleTask) SetState(v string) *BundleTask {
+	s.State = &v
+	return s
+}
+
+// SetStorage sets the Storage field's value.
+func (s *BundleTask) SetStorage(v *Storage) *BundleTask {
+	s.Storage = v
+	return s
+}
+
+// SetUpdateTime sets the UpdateTime field's value.
+func (s *BundleTask) SetUpdateTime(v time.Time) *BundleTask {
+	s.UpdateTime = &v
+	return s
+}
+
 // Describes an error for BundleInstance.
 type BundleTaskError struct {
 	_ struct{} `type:"structure"`
@@ -15891,6 +16593,18 @@ func (s BundleTaskError) String() string {
 // GoString returns the string representation
 func (s BundleTaskError) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *BundleTaskError) SetCode(v string) *BundleTaskError {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *BundleTaskError) SetMessage(v string) *BundleTaskError {
+	s.Message = &v
+	return s
 }
 
 // Contains the parameters for CancelBundleTask.
@@ -15932,6 +16646,18 @@ func (s *CancelBundleTaskInput) Validate() error {
 	return nil
 }
 
+// SetBundleId sets the BundleId field's value.
+func (s *CancelBundleTaskInput) SetBundleId(v string) *CancelBundleTaskInput {
+	s.BundleId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CancelBundleTaskInput) SetDryRun(v bool) *CancelBundleTaskInput {
+	s.DryRun = &v
+	return s
+}
+
 // Contains the output of CancelBundleTask.
 type CancelBundleTaskOutput struct {
 	_ struct{} `type:"structure"`
@@ -15948,6 +16674,12 @@ func (s CancelBundleTaskOutput) String() string {
 // GoString returns the string representation
 func (s CancelBundleTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetBundleTask sets the BundleTask field's value.
+func (s *CancelBundleTaskOutput) SetBundleTask(v *BundleTask) *CancelBundleTaskOutput {
+	s.BundleTask = v
+	return s
 }
 
 // Contains the parameters for CancelConversionTask.
@@ -15990,6 +16722,24 @@ func (s *CancelConversionTaskInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetConversionTaskId sets the ConversionTaskId field's value.
+func (s *CancelConversionTaskInput) SetConversionTaskId(v string) *CancelConversionTaskInput {
+	s.ConversionTaskId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CancelConversionTaskInput) SetDryRun(v bool) *CancelConversionTaskInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetReasonMessage sets the ReasonMessage field's value.
+func (s *CancelConversionTaskInput) SetReasonMessage(v string) *CancelConversionTaskInput {
+	s.ReasonMessage = &v
+	return s
 }
 
 type CancelConversionTaskOutput struct {
@@ -16039,6 +16789,12 @@ func (s *CancelExportTaskInput) Validate() error {
 	return nil
 }
 
+// SetExportTaskId sets the ExportTaskId field's value.
+func (s *CancelExportTaskInput) SetExportTaskId(v string) *CancelExportTaskInput {
+	s.ExportTaskId = &v
+	return s
+}
+
 type CancelExportTaskOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -16080,6 +16836,24 @@ func (s CancelImportTaskInput) GoString() string {
 	return s.String()
 }
 
+// SetCancelReason sets the CancelReason field's value.
+func (s *CancelImportTaskInput) SetCancelReason(v string) *CancelImportTaskInput {
+	s.CancelReason = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CancelImportTaskInput) SetDryRun(v bool) *CancelImportTaskInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetImportTaskId sets the ImportTaskId field's value.
+func (s *CancelImportTaskInput) SetImportTaskId(v string) *CancelImportTaskInput {
+	s.ImportTaskId = &v
+	return s
+}
+
 // Contains the output for CancelImportTask.
 type CancelImportTaskOutput struct {
 	_ struct{} `type:"structure"`
@@ -16102,6 +16876,24 @@ func (s CancelImportTaskOutput) String() string {
 // GoString returns the string representation
 func (s CancelImportTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetImportTaskId sets the ImportTaskId field's value.
+func (s *CancelImportTaskOutput) SetImportTaskId(v string) *CancelImportTaskOutput {
+	s.ImportTaskId = &v
+	return s
+}
+
+// SetPreviousState sets the PreviousState field's value.
+func (s *CancelImportTaskOutput) SetPreviousState(v string) *CancelImportTaskOutput {
+	s.PreviousState = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *CancelImportTaskOutput) SetState(v string) *CancelImportTaskOutput {
+	s.State = &v
+	return s
 }
 
 // Contains the parameters for CancelReservedInstancesListing.
@@ -16137,6 +16929,12 @@ func (s *CancelReservedInstancesListingInput) Validate() error {
 	return nil
 }
 
+// SetReservedInstancesListingId sets the ReservedInstancesListingId field's value.
+func (s *CancelReservedInstancesListingInput) SetReservedInstancesListingId(v string) *CancelReservedInstancesListingInput {
+	s.ReservedInstancesListingId = &v
+	return s
+}
+
 // Contains the output of CancelReservedInstancesListing.
 type CancelReservedInstancesListingOutput struct {
 	_ struct{} `type:"structure"`
@@ -16153,6 +16951,12 @@ func (s CancelReservedInstancesListingOutput) String() string {
 // GoString returns the string representation
 func (s CancelReservedInstancesListingOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedInstancesListings sets the ReservedInstancesListings field's value.
+func (s *CancelReservedInstancesListingOutput) SetReservedInstancesListings(v []*ReservedInstancesListing) *CancelReservedInstancesListingOutput {
+	s.ReservedInstancesListings = v
+	return s
 }
 
 // Describes a Spot fleet error.
@@ -16180,6 +16984,18 @@ func (s CancelSpotFleetRequestsError) GoString() string {
 	return s.String()
 }
 
+// SetCode sets the Code field's value.
+func (s *CancelSpotFleetRequestsError) SetCode(v string) *CancelSpotFleetRequestsError {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *CancelSpotFleetRequestsError) SetMessage(v string) *CancelSpotFleetRequestsError {
+	s.Message = &v
+	return s
+}
+
 // Describes a Spot fleet request that was not successfully canceled.
 type CancelSpotFleetRequestsErrorItem struct {
 	_ struct{} `type:"structure"`
@@ -16203,6 +17019,18 @@ func (s CancelSpotFleetRequestsErrorItem) String() string {
 // GoString returns the string representation
 func (s CancelSpotFleetRequestsErrorItem) GoString() string {
 	return s.String()
+}
+
+// SetError sets the Error field's value.
+func (s *CancelSpotFleetRequestsErrorItem) SetError(v *CancelSpotFleetRequestsError) *CancelSpotFleetRequestsErrorItem {
+	s.Error = v
+	return s
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *CancelSpotFleetRequestsErrorItem) SetSpotFleetRequestId(v string) *CancelSpotFleetRequestsErrorItem {
+	s.SpotFleetRequestId = &v
+	return s
 }
 
 // Contains the parameters for CancelSpotFleetRequests.
@@ -16253,6 +17081,24 @@ func (s *CancelSpotFleetRequestsInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *CancelSpotFleetRequestsInput) SetDryRun(v bool) *CancelSpotFleetRequestsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSpotFleetRequestIds sets the SpotFleetRequestIds field's value.
+func (s *CancelSpotFleetRequestsInput) SetSpotFleetRequestIds(v []*string) *CancelSpotFleetRequestsInput {
+	s.SpotFleetRequestIds = v
+	return s
+}
+
+// SetTerminateInstances sets the TerminateInstances field's value.
+func (s *CancelSpotFleetRequestsInput) SetTerminateInstances(v bool) *CancelSpotFleetRequestsInput {
+	s.TerminateInstances = &v
+	return s
+}
+
 // Contains the output of CancelSpotFleetRequests.
 type CancelSpotFleetRequestsOutput struct {
 	_ struct{} `type:"structure"`
@@ -16272,6 +17118,18 @@ func (s CancelSpotFleetRequestsOutput) String() string {
 // GoString returns the string representation
 func (s CancelSpotFleetRequestsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSuccessfulFleetRequests sets the SuccessfulFleetRequests field's value.
+func (s *CancelSpotFleetRequestsOutput) SetSuccessfulFleetRequests(v []*CancelSpotFleetRequestsSuccessItem) *CancelSpotFleetRequestsOutput {
+	s.SuccessfulFleetRequests = v
+	return s
+}
+
+// SetUnsuccessfulFleetRequests sets the UnsuccessfulFleetRequests field's value.
+func (s *CancelSpotFleetRequestsOutput) SetUnsuccessfulFleetRequests(v []*CancelSpotFleetRequestsErrorItem) *CancelSpotFleetRequestsOutput {
+	s.UnsuccessfulFleetRequests = v
+	return s
 }
 
 // Describes a Spot fleet request that was successfully canceled.
@@ -16302,6 +17160,24 @@ func (s CancelSpotFleetRequestsSuccessItem) String() string {
 // GoString returns the string representation
 func (s CancelSpotFleetRequestsSuccessItem) GoString() string {
 	return s.String()
+}
+
+// SetCurrentSpotFleetRequestState sets the CurrentSpotFleetRequestState field's value.
+func (s *CancelSpotFleetRequestsSuccessItem) SetCurrentSpotFleetRequestState(v string) *CancelSpotFleetRequestsSuccessItem {
+	s.CurrentSpotFleetRequestState = &v
+	return s
+}
+
+// SetPreviousSpotFleetRequestState sets the PreviousSpotFleetRequestState field's value.
+func (s *CancelSpotFleetRequestsSuccessItem) SetPreviousSpotFleetRequestState(v string) *CancelSpotFleetRequestsSuccessItem {
+	s.PreviousSpotFleetRequestState = &v
+	return s
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *CancelSpotFleetRequestsSuccessItem) SetSpotFleetRequestId(v string) *CancelSpotFleetRequestsSuccessItem {
+	s.SpotFleetRequestId = &v
+	return s
 }
 
 // Contains the parameters for CancelSpotInstanceRequests.
@@ -16343,6 +17219,18 @@ func (s *CancelSpotInstanceRequestsInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *CancelSpotInstanceRequestsInput) SetDryRun(v bool) *CancelSpotInstanceRequestsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSpotInstanceRequestIds sets the SpotInstanceRequestIds field's value.
+func (s *CancelSpotInstanceRequestsInput) SetSpotInstanceRequestIds(v []*string) *CancelSpotInstanceRequestsInput {
+	s.SpotInstanceRequestIds = v
+	return s
+}
+
 // Contains the output of CancelSpotInstanceRequests.
 type CancelSpotInstanceRequestsOutput struct {
 	_ struct{} `type:"structure"`
@@ -16359,6 +17247,12 @@ func (s CancelSpotInstanceRequestsOutput) String() string {
 // GoString returns the string representation
 func (s CancelSpotInstanceRequestsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCancelledSpotInstanceRequests sets the CancelledSpotInstanceRequests field's value.
+func (s *CancelSpotInstanceRequestsOutput) SetCancelledSpotInstanceRequests(v []*CancelledSpotInstanceRequest) *CancelSpotInstanceRequestsOutput {
+	s.CancelledSpotInstanceRequests = v
+	return s
 }
 
 // Describes a request to cancel a Spot instance.
@@ -16382,6 +17276,18 @@ func (s CancelledSpotInstanceRequest) GoString() string {
 	return s.String()
 }
 
+// SetSpotInstanceRequestId sets the SpotInstanceRequestId field's value.
+func (s *CancelledSpotInstanceRequest) SetSpotInstanceRequestId(v string) *CancelledSpotInstanceRequest {
+	s.SpotInstanceRequestId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *CancelledSpotInstanceRequest) SetState(v string) *CancelledSpotInstanceRequest {
+	s.State = &v
+	return s
+}
+
 // Describes the ClassicLink DNS support status of a VPC.
 type ClassicLinkDnsSupport struct {
 	_ struct{} `type:"structure"`
@@ -16401,6 +17307,18 @@ func (s ClassicLinkDnsSupport) String() string {
 // GoString returns the string representation
 func (s ClassicLinkDnsSupport) GoString() string {
 	return s.String()
+}
+
+// SetClassicLinkDnsSupported sets the ClassicLinkDnsSupported field's value.
+func (s *ClassicLinkDnsSupport) SetClassicLinkDnsSupported(v bool) *ClassicLinkDnsSupport {
+	s.ClassicLinkDnsSupported = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *ClassicLinkDnsSupport) SetVpcId(v string) *ClassicLinkDnsSupport {
+	s.VpcId = &v
+	return s
 }
 
 // Describes a linked EC2-Classic instance.
@@ -16430,6 +17348,30 @@ func (s ClassicLinkInstance) GoString() string {
 	return s.String()
 }
 
+// SetGroups sets the Groups field's value.
+func (s *ClassicLinkInstance) SetGroups(v []*GroupIdentifier) *ClassicLinkInstance {
+	s.Groups = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ClassicLinkInstance) SetInstanceId(v string) *ClassicLinkInstance {
+	s.InstanceId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ClassicLinkInstance) SetTags(v []*Tag) *ClassicLinkInstance {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *ClassicLinkInstance) SetVpcId(v string) *ClassicLinkInstance {
+	s.VpcId = &v
+	return s
+}
+
 // Describes the client-specific data.
 type ClientData struct {
 	_ struct{} `type:"structure"`
@@ -16455,6 +17397,30 @@ func (s ClientData) String() string {
 // GoString returns the string representation
 func (s ClientData) GoString() string {
 	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *ClientData) SetComment(v string) *ClientData {
+	s.Comment = &v
+	return s
+}
+
+// SetUploadEnd sets the UploadEnd field's value.
+func (s *ClientData) SetUploadEnd(v time.Time) *ClientData {
+	s.UploadEnd = &v
+	return s
+}
+
+// SetUploadSize sets the UploadSize field's value.
+func (s *ClientData) SetUploadSize(v float64) *ClientData {
+	s.UploadSize = &v
+	return s
+}
+
+// SetUploadStart sets the UploadStart field's value.
+func (s *ClientData) SetUploadStart(v time.Time) *ClientData {
+	s.UploadStart = &v
+	return s
 }
 
 // Contains the parameters for ConfirmProductInstance.
@@ -16504,6 +17470,24 @@ func (s *ConfirmProductInstanceInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *ConfirmProductInstanceInput) SetDryRun(v bool) *ConfirmProductInstanceInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ConfirmProductInstanceInput) SetInstanceId(v string) *ConfirmProductInstanceInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetProductCode sets the ProductCode field's value.
+func (s *ConfirmProductInstanceInput) SetProductCode(v string) *ConfirmProductInstanceInput {
+	s.ProductCode = &v
+	return s
+}
+
 // Contains the output of ConfirmProductInstance.
 type ConfirmProductInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -16525,6 +17509,18 @@ func (s ConfirmProductInstanceOutput) String() string {
 // GoString returns the string representation
 func (s ConfirmProductInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *ConfirmProductInstanceOutput) SetOwnerId(v string) *ConfirmProductInstanceOutput {
+	s.OwnerId = &v
+	return s
+}
+
+// SetReturn sets the Return field's value.
+func (s *ConfirmProductInstanceOutput) SetReturn(v bool) *ConfirmProductInstanceOutput {
+	s.Return = &v
+	return s
 }
 
 // Describes a conversion task.
@@ -16568,6 +17564,48 @@ func (s ConversionTask) String() string {
 // GoString returns the string representation
 func (s ConversionTask) GoString() string {
 	return s.String()
+}
+
+// SetConversionTaskId sets the ConversionTaskId field's value.
+func (s *ConversionTask) SetConversionTaskId(v string) *ConversionTask {
+	s.ConversionTaskId = &v
+	return s
+}
+
+// SetExpirationTime sets the ExpirationTime field's value.
+func (s *ConversionTask) SetExpirationTime(v string) *ConversionTask {
+	s.ExpirationTime = &v
+	return s
+}
+
+// SetImportInstance sets the ImportInstance field's value.
+func (s *ConversionTask) SetImportInstance(v *ImportInstanceTaskDetails) *ConversionTask {
+	s.ImportInstance = v
+	return s
+}
+
+// SetImportVolume sets the ImportVolume field's value.
+func (s *ConversionTask) SetImportVolume(v *ImportVolumeTaskDetails) *ConversionTask {
+	s.ImportVolume = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ConversionTask) SetState(v string) *ConversionTask {
+	s.State = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ConversionTask) SetStatusMessage(v string) *ConversionTask {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ConversionTask) SetTags(v []*Tag) *ConversionTask {
+	s.Tags = v
+	return s
 }
 
 // Contains the parameters for CopyImage.
@@ -16650,6 +17688,54 @@ func (s *CopyImageInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *CopyImageInput) SetClientToken(v string) *CopyImageInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CopyImageInput) SetDescription(v string) *CopyImageInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CopyImageInput) SetDryRun(v bool) *CopyImageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *CopyImageInput) SetEncrypted(v bool) *CopyImageInput {
+	s.Encrypted = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CopyImageInput) SetKmsKeyId(v string) *CopyImageInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CopyImageInput) SetName(v string) *CopyImageInput {
+	s.Name = &v
+	return s
+}
+
+// SetSourceImageId sets the SourceImageId field's value.
+func (s *CopyImageInput) SetSourceImageId(v string) *CopyImageInput {
+	s.SourceImageId = &v
+	return s
+}
+
+// SetSourceRegion sets the SourceRegion field's value.
+func (s *CopyImageInput) SetSourceRegion(v string) *CopyImageInput {
+	s.SourceRegion = &v
+	return s
+}
+
 // Contains the output of CopyImage.
 type CopyImageOutput struct {
 	_ struct{} `type:"structure"`
@@ -16666,6 +17752,12 @@ func (s CopyImageOutput) String() string {
 // GoString returns the string representation
 func (s CopyImageOutput) GoString() string {
 	return s.String()
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *CopyImageOutput) SetImageId(v string) *CopyImageOutput {
+	s.ImageId = &v
+	return s
 }
 
 // Contains the parameters for CopySnapshot.
@@ -16761,6 +17853,54 @@ func (s *CopySnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CopySnapshotInput) SetDescription(v string) *CopySnapshotInput {
+	s.Description = &v
+	return s
+}
+
+// SetDestinationRegion sets the DestinationRegion field's value.
+func (s *CopySnapshotInput) SetDestinationRegion(v string) *CopySnapshotInput {
+	s.DestinationRegion = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CopySnapshotInput) SetDryRun(v bool) *CopySnapshotInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *CopySnapshotInput) SetEncrypted(v bool) *CopySnapshotInput {
+	s.Encrypted = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CopySnapshotInput) SetKmsKeyId(v string) *CopySnapshotInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetPresignedUrl sets the PresignedUrl field's value.
+func (s *CopySnapshotInput) SetPresignedUrl(v string) *CopySnapshotInput {
+	s.PresignedUrl = &v
+	return s
+}
+
+// SetSourceRegion sets the SourceRegion field's value.
+func (s *CopySnapshotInput) SetSourceRegion(v string) *CopySnapshotInput {
+	s.SourceRegion = &v
+	return s
+}
+
+// SetSourceSnapshotId sets the SourceSnapshotId field's value.
+func (s *CopySnapshotInput) SetSourceSnapshotId(v string) *CopySnapshotInput {
+	s.SourceSnapshotId = &v
+	return s
+}
+
 // Contains the output of CopySnapshot.
 type CopySnapshotOutput struct {
 	_ struct{} `type:"structure"`
@@ -16777,6 +17917,12 @@ func (s CopySnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CopySnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *CopySnapshotOutput) SetSnapshotId(v string) *CopySnapshotOutput {
+	s.SnapshotId = &v
+	return s
 }
 
 // Contains the parameters for CreateCustomerGateway.
@@ -16837,6 +17983,30 @@ func (s *CreateCustomerGatewayInput) Validate() error {
 	return nil
 }
 
+// SetBgpAsn sets the BgpAsn field's value.
+func (s *CreateCustomerGatewayInput) SetBgpAsn(v int64) *CreateCustomerGatewayInput {
+	s.BgpAsn = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateCustomerGatewayInput) SetDryRun(v bool) *CreateCustomerGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *CreateCustomerGatewayInput) SetPublicIp(v string) *CreateCustomerGatewayInput {
+	s.PublicIp = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CreateCustomerGatewayInput) SetType(v string) *CreateCustomerGatewayInput {
+	s.Type = &v
+	return s
+}
+
 // Contains the output of CreateCustomerGateway.
 type CreateCustomerGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -16853,6 +18023,12 @@ func (s CreateCustomerGatewayOutput) String() string {
 // GoString returns the string representation
 func (s CreateCustomerGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetCustomerGateway sets the CustomerGateway field's value.
+func (s *CreateCustomerGatewayOutput) SetCustomerGateway(v *CustomerGateway) *CreateCustomerGatewayOutput {
+	s.CustomerGateway = v
+	return s
 }
 
 // Contains the parameters for CreateDhcpOptions.
@@ -16894,6 +18070,18 @@ func (s *CreateDhcpOptionsInput) Validate() error {
 	return nil
 }
 
+// SetDhcpConfigurations sets the DhcpConfigurations field's value.
+func (s *CreateDhcpOptionsInput) SetDhcpConfigurations(v []*NewDhcpConfiguration) *CreateDhcpOptionsInput {
+	s.DhcpConfigurations = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateDhcpOptionsInput) SetDryRun(v bool) *CreateDhcpOptionsInput {
+	s.DryRun = &v
+	return s
+}
+
 // Contains the output of CreateDhcpOptions.
 type CreateDhcpOptionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -16910,6 +18098,12 @@ func (s CreateDhcpOptionsOutput) String() string {
 // GoString returns the string representation
 func (s CreateDhcpOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDhcpOptions sets the DhcpOptions field's value.
+func (s *CreateDhcpOptionsOutput) SetDhcpOptions(v *DhcpOptions) *CreateDhcpOptionsOutput {
+	s.DhcpOptions = v
+	return s
 }
 
 // Contains the parameters for CreateFlowLogs.
@@ -16984,6 +18178,42 @@ func (s *CreateFlowLogsInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateFlowLogsInput) SetClientToken(v string) *CreateFlowLogsInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDeliverLogsPermissionArn sets the DeliverLogsPermissionArn field's value.
+func (s *CreateFlowLogsInput) SetDeliverLogsPermissionArn(v string) *CreateFlowLogsInput {
+	s.DeliverLogsPermissionArn = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *CreateFlowLogsInput) SetLogGroupName(v string) *CreateFlowLogsInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetResourceIds sets the ResourceIds field's value.
+func (s *CreateFlowLogsInput) SetResourceIds(v []*string) *CreateFlowLogsInput {
+	s.ResourceIds = v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *CreateFlowLogsInput) SetResourceType(v string) *CreateFlowLogsInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTrafficType sets the TrafficType field's value.
+func (s *CreateFlowLogsInput) SetTrafficType(v string) *CreateFlowLogsInput {
+	s.TrafficType = &v
+	return s
+}
+
 // Contains the output of CreateFlowLogs.
 type CreateFlowLogsOutput struct {
 	_ struct{} `type:"structure"`
@@ -17007,6 +18237,24 @@ func (s CreateFlowLogsOutput) String() string {
 // GoString returns the string representation
 func (s CreateFlowLogsOutput) GoString() string {
 	return s.String()
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateFlowLogsOutput) SetClientToken(v string) *CreateFlowLogsOutput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetFlowLogIds sets the FlowLogIds field's value.
+func (s *CreateFlowLogsOutput) SetFlowLogIds(v []*string) *CreateFlowLogsOutput {
+	s.FlowLogIds = v
+	return s
+}
+
+// SetUnsuccessful sets the Unsuccessful field's value.
+func (s *CreateFlowLogsOutput) SetUnsuccessful(v []*UnsuccessfulItem) *CreateFlowLogsOutput {
+	s.Unsuccessful = v
+	return s
 }
 
 // Contains the parameters for CreateImage.
@@ -17072,6 +18320,42 @@ func (s *CreateImageInput) Validate() error {
 	return nil
 }
 
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *CreateImageInput) SetBlockDeviceMappings(v []*BlockDeviceMapping) *CreateImageInput {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateImageInput) SetDescription(v string) *CreateImageInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateImageInput) SetDryRun(v bool) *CreateImageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CreateImageInput) SetInstanceId(v string) *CreateImageInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateImageInput) SetName(v string) *CreateImageInput {
+	s.Name = &v
+	return s
+}
+
+// SetNoReboot sets the NoReboot field's value.
+func (s *CreateImageInput) SetNoReboot(v bool) *CreateImageInput {
+	s.NoReboot = &v
+	return s
+}
+
 // Contains the output of CreateImage.
 type CreateImageOutput struct {
 	_ struct{} `type:"structure"`
@@ -17088,6 +18372,12 @@ func (s CreateImageOutput) String() string {
 // GoString returns the string representation
 func (s CreateImageOutput) GoString() string {
 	return s.String()
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *CreateImageOutput) SetImageId(v string) *CreateImageOutput {
+	s.ImageId = &v
+	return s
 }
 
 // Contains the parameters for CreateInstanceExportTask.
@@ -17133,6 +18423,30 @@ func (s *CreateInstanceExportTaskInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateInstanceExportTaskInput) SetDescription(v string) *CreateInstanceExportTaskInput {
+	s.Description = &v
+	return s
+}
+
+// SetExportToS3Task sets the ExportToS3Task field's value.
+func (s *CreateInstanceExportTaskInput) SetExportToS3Task(v *ExportToS3TaskSpecification) *CreateInstanceExportTaskInput {
+	s.ExportToS3Task = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CreateInstanceExportTaskInput) SetInstanceId(v string) *CreateInstanceExportTaskInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetTargetEnvironment sets the TargetEnvironment field's value.
+func (s *CreateInstanceExportTaskInput) SetTargetEnvironment(v string) *CreateInstanceExportTaskInput {
+	s.TargetEnvironment = &v
+	return s
+}
+
 // Contains the output for CreateInstanceExportTask.
 type CreateInstanceExportTaskOutput struct {
 	_ struct{} `type:"structure"`
@@ -17149,6 +18463,12 @@ func (s CreateInstanceExportTaskOutput) String() string {
 // GoString returns the string representation
 func (s CreateInstanceExportTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetExportTask sets the ExportTask field's value.
+func (s *CreateInstanceExportTaskOutput) SetExportTask(v *ExportTask) *CreateInstanceExportTaskOutput {
+	s.ExportTask = v
+	return s
 }
 
 // Contains the parameters for CreateInternetGateway.
@@ -17172,6 +18492,12 @@ func (s CreateInternetGatewayInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *CreateInternetGatewayInput) SetDryRun(v bool) *CreateInternetGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
 // Contains the output of CreateInternetGateway.
 type CreateInternetGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -17188,6 +18514,12 @@ func (s CreateInternetGatewayOutput) String() string {
 // GoString returns the string representation
 func (s CreateInternetGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetInternetGateway sets the InternetGateway field's value.
+func (s *CreateInternetGatewayOutput) SetInternetGateway(v *InternetGateway) *CreateInternetGatewayOutput {
+	s.InternetGateway = v
+	return s
 }
 
 // Contains the parameters for CreateKeyPair.
@@ -17231,6 +18563,18 @@ func (s *CreateKeyPairInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *CreateKeyPairInput) SetDryRun(v bool) *CreateKeyPairInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *CreateKeyPairInput) SetKeyName(v string) *CreateKeyPairInput {
+	s.KeyName = &v
+	return s
+}
+
 // Describes a key pair.
 type CreateKeyPairOutput struct {
 	_ struct{} `type:"structure"`
@@ -17253,6 +18597,24 @@ func (s CreateKeyPairOutput) String() string {
 // GoString returns the string representation
 func (s CreateKeyPairOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeyFingerprint sets the KeyFingerprint field's value.
+func (s *CreateKeyPairOutput) SetKeyFingerprint(v string) *CreateKeyPairOutput {
+	s.KeyFingerprint = &v
+	return s
+}
+
+// SetKeyMaterial sets the KeyMaterial field's value.
+func (s *CreateKeyPairOutput) SetKeyMaterial(v string) *CreateKeyPairOutput {
+	s.KeyMaterial = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *CreateKeyPairOutput) SetKeyName(v string) *CreateKeyPairOutput {
+	s.KeyName = &v
+	return s
 }
 
 // Contains the parameters for CreateNatGateway.
@@ -17304,6 +18666,24 @@ func (s *CreateNatGatewayInput) Validate() error {
 	return nil
 }
 
+// SetAllocationId sets the AllocationId field's value.
+func (s *CreateNatGatewayInput) SetAllocationId(v string) *CreateNatGatewayInput {
+	s.AllocationId = &v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateNatGatewayInput) SetClientToken(v string) *CreateNatGatewayInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *CreateNatGatewayInput) SetSubnetId(v string) *CreateNatGatewayInput {
+	s.SubnetId = &v
+	return s
+}
+
 // Contains the output of CreateNatGateway.
 type CreateNatGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -17324,6 +18704,18 @@ func (s CreateNatGatewayOutput) String() string {
 // GoString returns the string representation
 func (s CreateNatGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateNatGatewayOutput) SetClientToken(v string) *CreateNatGatewayOutput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetNatGateway sets the NatGateway field's value.
+func (s *CreateNatGatewayOutput) SetNatGateway(v *NatGateway) *CreateNatGatewayOutput {
+	s.NatGateway = v
+	return s
 }
 
 // Contains the parameters for CreateNetworkAclEntry.
@@ -17417,6 +18809,60 @@ func (s *CreateNetworkAclEntryInput) Validate() error {
 	return nil
 }
 
+// SetCidrBlock sets the CidrBlock field's value.
+func (s *CreateNetworkAclEntryInput) SetCidrBlock(v string) *CreateNetworkAclEntryInput {
+	s.CidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateNetworkAclEntryInput) SetDryRun(v bool) *CreateNetworkAclEntryInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEgress sets the Egress field's value.
+func (s *CreateNetworkAclEntryInput) SetEgress(v bool) *CreateNetworkAclEntryInput {
+	s.Egress = &v
+	return s
+}
+
+// SetIcmpTypeCode sets the IcmpTypeCode field's value.
+func (s *CreateNetworkAclEntryInput) SetIcmpTypeCode(v *IcmpTypeCode) *CreateNetworkAclEntryInput {
+	s.IcmpTypeCode = v
+	return s
+}
+
+// SetNetworkAclId sets the NetworkAclId field's value.
+func (s *CreateNetworkAclEntryInput) SetNetworkAclId(v string) *CreateNetworkAclEntryInput {
+	s.NetworkAclId = &v
+	return s
+}
+
+// SetPortRange sets the PortRange field's value.
+func (s *CreateNetworkAclEntryInput) SetPortRange(v *PortRange) *CreateNetworkAclEntryInput {
+	s.PortRange = v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *CreateNetworkAclEntryInput) SetProtocol(v string) *CreateNetworkAclEntryInput {
+	s.Protocol = &v
+	return s
+}
+
+// SetRuleAction sets the RuleAction field's value.
+func (s *CreateNetworkAclEntryInput) SetRuleAction(v string) *CreateNetworkAclEntryInput {
+	s.RuleAction = &v
+	return s
+}
+
+// SetRuleNumber sets the RuleNumber field's value.
+func (s *CreateNetworkAclEntryInput) SetRuleNumber(v int64) *CreateNetworkAclEntryInput {
+	s.RuleNumber = &v
+	return s
+}
+
 type CreateNetworkAclEntryOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -17470,6 +18916,18 @@ func (s *CreateNetworkAclInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *CreateNetworkAclInput) SetDryRun(v bool) *CreateNetworkAclInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateNetworkAclInput) SetVpcId(v string) *CreateNetworkAclInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of CreateNetworkAcl.
 type CreateNetworkAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -17486,6 +18944,12 @@ func (s CreateNetworkAclOutput) String() string {
 // GoString returns the string representation
 func (s CreateNetworkAclOutput) GoString() string {
 	return s.String()
+}
+
+// SetNetworkAcl sets the NetworkAcl field's value.
+func (s *CreateNetworkAclOutput) SetNetworkAcl(v *NetworkAcl) *CreateNetworkAclOutput {
+	s.NetworkAcl = v
+	return s
 }
 
 // Contains the parameters for CreateNetworkInterface.
@@ -17563,6 +19027,48 @@ func (s *CreateNetworkInterfaceInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateNetworkInterfaceInput) SetDescription(v string) *CreateNetworkInterfaceInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateNetworkInterfaceInput) SetDryRun(v bool) *CreateNetworkInterfaceInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *CreateNetworkInterfaceInput) SetGroups(v []*string) *CreateNetworkInterfaceInput {
+	s.Groups = v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *CreateNetworkInterfaceInput) SetPrivateIpAddress(v string) *CreateNetworkInterfaceInput {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetPrivateIpAddresses sets the PrivateIpAddresses field's value.
+func (s *CreateNetworkInterfaceInput) SetPrivateIpAddresses(v []*PrivateIpAddressSpecification) *CreateNetworkInterfaceInput {
+	s.PrivateIpAddresses = v
+	return s
+}
+
+// SetSecondaryPrivateIpAddressCount sets the SecondaryPrivateIpAddressCount field's value.
+func (s *CreateNetworkInterfaceInput) SetSecondaryPrivateIpAddressCount(v int64) *CreateNetworkInterfaceInput {
+	s.SecondaryPrivateIpAddressCount = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *CreateNetworkInterfaceInput) SetSubnetId(v string) *CreateNetworkInterfaceInput {
+	s.SubnetId = &v
+	return s
+}
+
 // Contains the output of CreateNetworkInterface.
 type CreateNetworkInterfaceOutput struct {
 	_ struct{} `type:"structure"`
@@ -17579,6 +19085,12 @@ func (s CreateNetworkInterfaceOutput) String() string {
 // GoString returns the string representation
 func (s CreateNetworkInterfaceOutput) GoString() string {
 	return s.String()
+}
+
+// SetNetworkInterface sets the NetworkInterface field's value.
+func (s *CreateNetworkInterfaceOutput) SetNetworkInterface(v *NetworkInterface) *CreateNetworkInterfaceOutput {
+	s.NetworkInterface = v
+	return s
 }
 
 // Contains the parameters for CreatePlacementGroup.
@@ -17628,6 +19140,24 @@ func (s *CreatePlacementGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreatePlacementGroupInput) SetDryRun(v bool) *CreatePlacementGroupInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *CreatePlacementGroupInput) SetGroupName(v string) *CreatePlacementGroupInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetStrategy sets the Strategy field's value.
+func (s *CreatePlacementGroupInput) SetStrategy(v string) *CreatePlacementGroupInput {
+	s.Strategy = &v
+	return s
 }
 
 type CreatePlacementGroupOutput struct {
@@ -17707,6 +19237,30 @@ func (s *CreateReservedInstancesListingInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateReservedInstancesListingInput) SetClientToken(v string) *CreateReservedInstancesListingInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *CreateReservedInstancesListingInput) SetInstanceCount(v int64) *CreateReservedInstancesListingInput {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetPriceSchedules sets the PriceSchedules field's value.
+func (s *CreateReservedInstancesListingInput) SetPriceSchedules(v []*PriceScheduleSpecification) *CreateReservedInstancesListingInput {
+	s.PriceSchedules = v
+	return s
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *CreateReservedInstancesListingInput) SetReservedInstancesId(v string) *CreateReservedInstancesListingInput {
+	s.ReservedInstancesId = &v
+	return s
+}
+
 // Contains the output of CreateReservedInstancesListing.
 type CreateReservedInstancesListingOutput struct {
 	_ struct{} `type:"structure"`
@@ -17723,6 +19277,12 @@ func (s CreateReservedInstancesListingOutput) String() string {
 // GoString returns the string representation
 func (s CreateReservedInstancesListingOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedInstancesListings sets the ReservedInstancesListings field's value.
+func (s *CreateReservedInstancesListingOutput) SetReservedInstancesListings(v []*ReservedInstancesListing) *CreateReservedInstancesListingOutput {
+	s.ReservedInstancesListings = v
+	return s
 }
 
 // Contains the parameters for CreateRoute.
@@ -17790,6 +19350,54 @@ func (s *CreateRouteInput) Validate() error {
 	return nil
 }
 
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *CreateRouteInput) SetDestinationCidrBlock(v string) *CreateRouteInput {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateRouteInput) SetDryRun(v bool) *CreateRouteInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *CreateRouteInput) SetGatewayId(v string) *CreateRouteInput {
+	s.GatewayId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CreateRouteInput) SetInstanceId(v string) *CreateRouteInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetNatGatewayId sets the NatGatewayId field's value.
+func (s *CreateRouteInput) SetNatGatewayId(v string) *CreateRouteInput {
+	s.NatGatewayId = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *CreateRouteInput) SetNetworkInterfaceId(v string) *CreateRouteInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *CreateRouteInput) SetRouteTableId(v string) *CreateRouteInput {
+	s.RouteTableId = &v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *CreateRouteInput) SetVpcPeeringConnectionId(v string) *CreateRouteInput {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 // Contains the output of CreateRoute.
 type CreateRouteOutput struct {
 	_ struct{} `type:"structure"`
@@ -17806,6 +19414,12 @@ func (s CreateRouteOutput) String() string {
 // GoString returns the string representation
 func (s CreateRouteOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *CreateRouteOutput) SetReturn(v bool) *CreateRouteOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for CreateRouteTable.
@@ -17847,6 +19461,18 @@ func (s *CreateRouteTableInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *CreateRouteTableInput) SetDryRun(v bool) *CreateRouteTableInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateRouteTableInput) SetVpcId(v string) *CreateRouteTableInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of CreateRouteTable.
 type CreateRouteTableOutput struct {
 	_ struct{} `type:"structure"`
@@ -17863,6 +19489,12 @@ func (s CreateRouteTableOutput) String() string {
 // GoString returns the string representation
 func (s CreateRouteTableOutput) GoString() string {
 	return s.String()
+}
+
+// SetRouteTable sets the RouteTable field's value.
+func (s *CreateRouteTableOutput) SetRouteTable(v *RouteTable) *CreateRouteTableOutput {
+	s.RouteTable = v
+	return s
 }
 
 // Contains the parameters for CreateSecurityGroup.
@@ -17927,6 +19559,30 @@ func (s *CreateSecurityGroupInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateSecurityGroupInput) SetDescription(v string) *CreateSecurityGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateSecurityGroupInput) SetDryRun(v bool) *CreateSecurityGroupInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *CreateSecurityGroupInput) SetGroupName(v string) *CreateSecurityGroupInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateSecurityGroupInput) SetVpcId(v string) *CreateSecurityGroupInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of CreateSecurityGroup.
 type CreateSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -17943,6 +19599,12 @@ func (s CreateSecurityGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateSecurityGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *CreateSecurityGroupOutput) SetGroupId(v string) *CreateSecurityGroupOutput {
+	s.GroupId = &v
+	return s
 }
 
 // Contains the parameters for CreateSnapshot.
@@ -17987,6 +19649,24 @@ func (s *CreateSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateSnapshotInput) SetDescription(v string) *CreateSnapshotInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateSnapshotInput) SetDryRun(v bool) *CreateSnapshotInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *CreateSnapshotInput) SetVolumeId(v string) *CreateSnapshotInput {
+	s.VolumeId = &v
+	return s
+}
+
 // Contains the parameters for CreateSpotDatafeedSubscription.
 type CreateSpotDatafeedSubscriptionInput struct {
 	_ struct{} `type:"structure"`
@@ -18029,6 +19709,24 @@ func (s *CreateSpotDatafeedSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *CreateSpotDatafeedSubscriptionInput) SetBucket(v string) *CreateSpotDatafeedSubscriptionInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateSpotDatafeedSubscriptionInput) SetDryRun(v bool) *CreateSpotDatafeedSubscriptionInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *CreateSpotDatafeedSubscriptionInput) SetPrefix(v string) *CreateSpotDatafeedSubscriptionInput {
+	s.Prefix = &v
+	return s
+}
+
 // Contains the output of CreateSpotDatafeedSubscription.
 type CreateSpotDatafeedSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -18045,6 +19743,12 @@ func (s CreateSpotDatafeedSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s CreateSpotDatafeedSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetSpotDatafeedSubscription sets the SpotDatafeedSubscription field's value.
+func (s *CreateSpotDatafeedSubscriptionOutput) SetSpotDatafeedSubscription(v *SpotDatafeedSubscription) *CreateSpotDatafeedSubscriptionOutput {
+	s.SpotDatafeedSubscription = v
+	return s
 }
 
 // Contains the parameters for CreateSubnet.
@@ -18100,6 +19804,30 @@ func (s *CreateSubnetInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *CreateSubnetInput) SetAvailabilityZone(v string) *CreateSubnetInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCidrBlock sets the CidrBlock field's value.
+func (s *CreateSubnetInput) SetCidrBlock(v string) *CreateSubnetInput {
+	s.CidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateSubnetInput) SetDryRun(v bool) *CreateSubnetInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateSubnetInput) SetVpcId(v string) *CreateSubnetInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of CreateSubnet.
 type CreateSubnetOutput struct {
 	_ struct{} `type:"structure"`
@@ -18116,6 +19844,12 @@ func (s CreateSubnetOutput) String() string {
 // GoString returns the string representation
 func (s CreateSubnetOutput) GoString() string {
 	return s.String()
+}
+
+// SetSubnet sets the Subnet field's value.
+func (s *CreateSubnetOutput) SetSubnet(v *Subnet) *CreateSubnetOutput {
+	s.Subnet = v
+	return s
 }
 
 // Contains the parameters for CreateTags.
@@ -18165,6 +19899,24 @@ func (s *CreateTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateTagsInput) SetDryRun(v bool) *CreateTagsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *CreateTagsInput) SetResources(v []*string) *CreateTagsInput {
+	s.Resources = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateTagsInput) SetTags(v []*Tag) *CreateTagsInput {
+	s.Tags = v
+	return s
 }
 
 type CreateTagsOutput struct {
@@ -18266,6 +20018,54 @@ func (s *CreateVolumeInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *CreateVolumeInput) SetAvailabilityZone(v string) *CreateVolumeInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateVolumeInput) SetDryRun(v bool) *CreateVolumeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *CreateVolumeInput) SetEncrypted(v bool) *CreateVolumeInput {
+	s.Encrypted = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *CreateVolumeInput) SetIops(v int64) *CreateVolumeInput {
+	s.Iops = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateVolumeInput) SetKmsKeyId(v string) *CreateVolumeInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *CreateVolumeInput) SetSize(v int64) *CreateVolumeInput {
+	s.Size = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *CreateVolumeInput) SetSnapshotId(v string) *CreateVolumeInput {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *CreateVolumeInput) SetVolumeType(v string) *CreateVolumeInput {
+	s.VolumeType = &v
+	return s
+}
+
 // Describes the user or group to be added or removed from the permissions for
 // a volume.
 type CreateVolumePermission struct {
@@ -18290,6 +20090,18 @@ func (s CreateVolumePermission) GoString() string {
 	return s.String()
 }
 
+// SetGroup sets the Group field's value.
+func (s *CreateVolumePermission) SetGroup(v string) *CreateVolumePermission {
+	s.Group = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *CreateVolumePermission) SetUserId(v string) *CreateVolumePermission {
+	s.UserId = &v
+	return s
+}
+
 // Describes modifications to the permissions for a volume.
 type CreateVolumePermissionModifications struct {
 	_ struct{} `type:"structure"`
@@ -18311,6 +20123,18 @@ func (s CreateVolumePermissionModifications) String() string {
 // GoString returns the string representation
 func (s CreateVolumePermissionModifications) GoString() string {
 	return s.String()
+}
+
+// SetAdd sets the Add field's value.
+func (s *CreateVolumePermissionModifications) SetAdd(v []*CreateVolumePermission) *CreateVolumePermissionModifications {
+	s.Add = v
+	return s
+}
+
+// SetRemove sets the Remove field's value.
+func (s *CreateVolumePermissionModifications) SetRemove(v []*CreateVolumePermission) *CreateVolumePermissionModifications {
+	s.Remove = v
+	return s
 }
 
 // Contains the parameters for CreateVpcEndpoint.
@@ -18373,6 +20197,42 @@ func (s *CreateVpcEndpointInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateVpcEndpointInput) SetClientToken(v string) *CreateVpcEndpointInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateVpcEndpointInput) SetDryRun(v bool) *CreateVpcEndpointInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *CreateVpcEndpointInput) SetPolicyDocument(v string) *CreateVpcEndpointInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetRouteTableIds sets the RouteTableIds field's value.
+func (s *CreateVpcEndpointInput) SetRouteTableIds(v []*string) *CreateVpcEndpointInput {
+	s.RouteTableIds = v
+	return s
+}
+
+// SetServiceName sets the ServiceName field's value.
+func (s *CreateVpcEndpointInput) SetServiceName(v string) *CreateVpcEndpointInput {
+	s.ServiceName = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateVpcEndpointInput) SetVpcId(v string) *CreateVpcEndpointInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of CreateVpcEndpoint.
 type CreateVpcEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -18393,6 +20253,18 @@ func (s CreateVpcEndpointOutput) String() string {
 // GoString returns the string representation
 func (s CreateVpcEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateVpcEndpointOutput) SetClientToken(v string) *CreateVpcEndpointOutput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetVpcEndpoint sets the VpcEndpoint field's value.
+func (s *CreateVpcEndpointOutput) SetVpcEndpoint(v *VpcEndpoint) *CreateVpcEndpointOutput {
+	s.VpcEndpoint = v
+	return s
 }
 
 // Contains the parameters for CreateVpc.
@@ -18446,6 +20318,24 @@ func (s *CreateVpcInput) Validate() error {
 	return nil
 }
 
+// SetCidrBlock sets the CidrBlock field's value.
+func (s *CreateVpcInput) SetCidrBlock(v string) *CreateVpcInput {
+	s.CidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateVpcInput) SetDryRun(v bool) *CreateVpcInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceTenancy sets the InstanceTenancy field's value.
+func (s *CreateVpcInput) SetInstanceTenancy(v string) *CreateVpcInput {
+	s.InstanceTenancy = &v
+	return s
+}
+
 // Contains the output of CreateVpc.
 type CreateVpcOutput struct {
 	_ struct{} `type:"structure"`
@@ -18462,6 +20352,12 @@ func (s CreateVpcOutput) String() string {
 // GoString returns the string representation
 func (s CreateVpcOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpc sets the Vpc field's value.
+func (s *CreateVpcOutput) SetVpc(v *Vpc) *CreateVpcOutput {
+	s.Vpc = v
+	return s
 }
 
 // Contains the parameters for CreateVpcPeeringConnection.
@@ -18496,6 +20392,30 @@ func (s CreateVpcPeeringConnectionInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *CreateVpcPeeringConnectionInput) SetDryRun(v bool) *CreateVpcPeeringConnectionInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPeerOwnerId sets the PeerOwnerId field's value.
+func (s *CreateVpcPeeringConnectionInput) SetPeerOwnerId(v string) *CreateVpcPeeringConnectionInput {
+	s.PeerOwnerId = &v
+	return s
+}
+
+// SetPeerVpcId sets the PeerVpcId field's value.
+func (s *CreateVpcPeeringConnectionInput) SetPeerVpcId(v string) *CreateVpcPeeringConnectionInput {
+	s.PeerVpcId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateVpcPeeringConnectionInput) SetVpcId(v string) *CreateVpcPeeringConnectionInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of CreateVpcPeeringConnection.
 type CreateVpcPeeringConnectionOutput struct {
 	_ struct{} `type:"structure"`
@@ -18512,6 +20432,12 @@ func (s CreateVpcPeeringConnectionOutput) String() string {
 // GoString returns the string representation
 func (s CreateVpcPeeringConnectionOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpcPeeringConnection sets the VpcPeeringConnection field's value.
+func (s *CreateVpcPeeringConnectionOutput) SetVpcPeeringConnection(v *VpcPeeringConnection) *CreateVpcPeeringConnectionOutput {
+	s.VpcPeeringConnection = v
+	return s
 }
 
 // Contains the parameters for CreateVpnConnection.
@@ -18576,6 +20502,36 @@ func (s *CreateVpnConnectionInput) Validate() error {
 	return nil
 }
 
+// SetCustomerGatewayId sets the CustomerGatewayId field's value.
+func (s *CreateVpnConnectionInput) SetCustomerGatewayId(v string) *CreateVpnConnectionInput {
+	s.CustomerGatewayId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateVpnConnectionInput) SetDryRun(v bool) *CreateVpnConnectionInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetOptions sets the Options field's value.
+func (s *CreateVpnConnectionInput) SetOptions(v *VpnConnectionOptionsSpecification) *CreateVpnConnectionInput {
+	s.Options = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CreateVpnConnectionInput) SetType(v string) *CreateVpnConnectionInput {
+	s.Type = &v
+	return s
+}
+
+// SetVpnGatewayId sets the VpnGatewayId field's value.
+func (s *CreateVpnConnectionInput) SetVpnGatewayId(v string) *CreateVpnConnectionInput {
+	s.VpnGatewayId = &v
+	return s
+}
+
 // Contains the output of CreateVpnConnection.
 type CreateVpnConnectionOutput struct {
 	_ struct{} `type:"structure"`
@@ -18592,6 +20548,12 @@ func (s CreateVpnConnectionOutput) String() string {
 // GoString returns the string representation
 func (s CreateVpnConnectionOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpnConnection sets the VpnConnection field's value.
+func (s *CreateVpnConnectionOutput) SetVpnConnection(v *VpnConnection) *CreateVpnConnectionOutput {
+	s.VpnConnection = v
+	return s
 }
 
 // Contains the parameters for CreateVpnConnectionRoute.
@@ -18633,6 +20595,18 @@ func (s *CreateVpnConnectionRouteInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *CreateVpnConnectionRouteInput) SetDestinationCidrBlock(v string) *CreateVpnConnectionRouteInput {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetVpnConnectionId sets the VpnConnectionId field's value.
+func (s *CreateVpnConnectionRouteInput) SetVpnConnectionId(v string) *CreateVpnConnectionRouteInput {
+	s.VpnConnectionId = &v
+	return s
 }
 
 type CreateVpnConnectionRouteOutput struct {
@@ -18691,6 +20665,24 @@ func (s *CreateVpnGatewayInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *CreateVpnGatewayInput) SetAvailabilityZone(v string) *CreateVpnGatewayInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CreateVpnGatewayInput) SetDryRun(v bool) *CreateVpnGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CreateVpnGatewayInput) SetType(v string) *CreateVpnGatewayInput {
+	s.Type = &v
+	return s
+}
+
 // Contains the output of CreateVpnGateway.
 type CreateVpnGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -18707,6 +20699,12 @@ func (s CreateVpnGatewayOutput) String() string {
 // GoString returns the string representation
 func (s CreateVpnGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpnGateway sets the VpnGateway field's value.
+func (s *CreateVpnGatewayOutput) SetVpnGateway(v *VpnGateway) *CreateVpnGatewayOutput {
+	s.VpnGateway = v
+	return s
 }
 
 // Describes a customer gateway.
@@ -18742,6 +20740,42 @@ func (s CustomerGateway) String() string {
 // GoString returns the string representation
 func (s CustomerGateway) GoString() string {
 	return s.String()
+}
+
+// SetBgpAsn sets the BgpAsn field's value.
+func (s *CustomerGateway) SetBgpAsn(v string) *CustomerGateway {
+	s.BgpAsn = &v
+	return s
+}
+
+// SetCustomerGatewayId sets the CustomerGatewayId field's value.
+func (s *CustomerGateway) SetCustomerGatewayId(v string) *CustomerGateway {
+	s.CustomerGatewayId = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *CustomerGateway) SetIpAddress(v string) *CustomerGateway {
+	s.IpAddress = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *CustomerGateway) SetState(v string) *CustomerGateway {
+	s.State = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CustomerGateway) SetTags(v []*Tag) *CustomerGateway {
+	s.Tags = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CustomerGateway) SetType(v string) *CustomerGateway {
+	s.Type = &v
+	return s
 }
 
 // Contains the parameters for DeleteCustomerGateway.
@@ -18781,6 +20815,18 @@ func (s *DeleteCustomerGatewayInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCustomerGatewayId sets the CustomerGatewayId field's value.
+func (s *DeleteCustomerGatewayInput) SetCustomerGatewayId(v string) *DeleteCustomerGatewayInput {
+	s.CustomerGatewayId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteCustomerGatewayInput) SetDryRun(v bool) *DeleteCustomerGatewayInput {
+	s.DryRun = &v
+	return s
 }
 
 type DeleteCustomerGatewayOutput struct {
@@ -18836,6 +20882,18 @@ func (s *DeleteDhcpOptionsInput) Validate() error {
 	return nil
 }
 
+// SetDhcpOptionsId sets the DhcpOptionsId field's value.
+func (s *DeleteDhcpOptionsInput) SetDhcpOptionsId(v string) *DeleteDhcpOptionsInput {
+	s.DhcpOptionsId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteDhcpOptionsInput) SetDryRun(v bool) *DeleteDhcpOptionsInput {
+	s.DryRun = &v
+	return s
+}
+
 type DeleteDhcpOptionsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -18883,6 +20941,12 @@ func (s *DeleteFlowLogsInput) Validate() error {
 	return nil
 }
 
+// SetFlowLogIds sets the FlowLogIds field's value.
+func (s *DeleteFlowLogsInput) SetFlowLogIds(v []*string) *DeleteFlowLogsInput {
+	s.FlowLogIds = v
+	return s
+}
+
 // Contains the output of DeleteFlowLogs.
 type DeleteFlowLogsOutput struct {
 	_ struct{} `type:"structure"`
@@ -18899,6 +20963,12 @@ func (s DeleteFlowLogsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFlowLogsOutput) GoString() string {
 	return s.String()
+}
+
+// SetUnsuccessful sets the Unsuccessful field's value.
+func (s *DeleteFlowLogsOutput) SetUnsuccessful(v []*UnsuccessfulItem) *DeleteFlowLogsOutput {
+	s.Unsuccessful = v
+	return s
 }
 
 // Contains the parameters for DeleteInternetGateway.
@@ -18938,6 +21008,18 @@ func (s *DeleteInternetGatewayInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteInternetGatewayInput) SetDryRun(v bool) *DeleteInternetGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInternetGatewayId sets the InternetGatewayId field's value.
+func (s *DeleteInternetGatewayInput) SetInternetGatewayId(v string) *DeleteInternetGatewayInput {
+	s.InternetGatewayId = &v
+	return s
 }
 
 type DeleteInternetGatewayOutput struct {
@@ -18993,6 +21075,18 @@ func (s *DeleteKeyPairInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteKeyPairInput) SetDryRun(v bool) *DeleteKeyPairInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *DeleteKeyPairInput) SetKeyName(v string) *DeleteKeyPairInput {
+	s.KeyName = &v
+	return s
+}
+
 type DeleteKeyPairOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19040,6 +21134,12 @@ func (s *DeleteNatGatewayInput) Validate() error {
 	return nil
 }
 
+// SetNatGatewayId sets the NatGatewayId field's value.
+func (s *DeleteNatGatewayInput) SetNatGatewayId(v string) *DeleteNatGatewayInput {
+	s.NatGatewayId = &v
+	return s
+}
+
 // Contains the output of DeleteNatGateway.
 type DeleteNatGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -19056,6 +21156,12 @@ func (s DeleteNatGatewayOutput) String() string {
 // GoString returns the string representation
 func (s DeleteNatGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetNatGatewayId sets the NatGatewayId field's value.
+func (s *DeleteNatGatewayOutput) SetNatGatewayId(v string) *DeleteNatGatewayOutput {
+	s.NatGatewayId = &v
+	return s
 }
 
 // Contains the parameters for DeleteNetworkAclEntry.
@@ -19113,6 +21219,30 @@ func (s *DeleteNetworkAclEntryInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteNetworkAclEntryInput) SetDryRun(v bool) *DeleteNetworkAclEntryInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEgress sets the Egress field's value.
+func (s *DeleteNetworkAclEntryInput) SetEgress(v bool) *DeleteNetworkAclEntryInput {
+	s.Egress = &v
+	return s
+}
+
+// SetNetworkAclId sets the NetworkAclId field's value.
+func (s *DeleteNetworkAclEntryInput) SetNetworkAclId(v string) *DeleteNetworkAclEntryInput {
+	s.NetworkAclId = &v
+	return s
+}
+
+// SetRuleNumber sets the RuleNumber field's value.
+func (s *DeleteNetworkAclEntryInput) SetRuleNumber(v int64) *DeleteNetworkAclEntryInput {
+	s.RuleNumber = &v
+	return s
+}
+
 type DeleteNetworkAclEntryOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19164,6 +21294,18 @@ func (s *DeleteNetworkAclInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteNetworkAclInput) SetDryRun(v bool) *DeleteNetworkAclInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetNetworkAclId sets the NetworkAclId field's value.
+func (s *DeleteNetworkAclInput) SetNetworkAclId(v string) *DeleteNetworkAclInput {
+	s.NetworkAclId = &v
+	return s
 }
 
 type DeleteNetworkAclOutput struct {
@@ -19219,6 +21361,18 @@ func (s *DeleteNetworkInterfaceInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteNetworkInterfaceInput) SetDryRun(v bool) *DeleteNetworkInterfaceInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *DeleteNetworkInterfaceInput) SetNetworkInterfaceId(v string) *DeleteNetworkInterfaceInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
 type DeleteNetworkInterfaceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19270,6 +21424,18 @@ func (s *DeletePlacementGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeletePlacementGroupInput) SetDryRun(v bool) *DeletePlacementGroupInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *DeletePlacementGroupInput) SetGroupName(v string) *DeletePlacementGroupInput {
+	s.GroupName = &v
+	return s
 }
 
 type DeletePlacementGroupOutput struct {
@@ -19334,6 +21500,24 @@ func (s *DeleteRouteInput) Validate() error {
 	return nil
 }
 
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *DeleteRouteInput) SetDestinationCidrBlock(v string) *DeleteRouteInput {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteRouteInput) SetDryRun(v bool) *DeleteRouteInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *DeleteRouteInput) SetRouteTableId(v string) *DeleteRouteInput {
+	s.RouteTableId = &v
+	return s
+}
+
 type DeleteRouteOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19387,6 +21571,18 @@ func (s *DeleteRouteTableInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteRouteTableInput) SetDryRun(v bool) *DeleteRouteTableInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *DeleteRouteTableInput) SetRouteTableId(v string) *DeleteRouteTableInput {
+	s.RouteTableId = &v
+	return s
+}
+
 type DeleteRouteTableOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19427,6 +21623,24 @@ func (s DeleteSecurityGroupInput) String() string {
 // GoString returns the string representation
 func (s DeleteSecurityGroupInput) GoString() string {
 	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteSecurityGroupInput) SetDryRun(v bool) *DeleteSecurityGroupInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *DeleteSecurityGroupInput) SetGroupId(v string) *DeleteSecurityGroupInput {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *DeleteSecurityGroupInput) SetGroupName(v string) *DeleteSecurityGroupInput {
+	s.GroupName = &v
+	return s
 }
 
 type DeleteSecurityGroupOutput struct {
@@ -19482,6 +21696,18 @@ func (s *DeleteSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteSnapshotInput) SetDryRun(v bool) *DeleteSnapshotInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *DeleteSnapshotInput) SetSnapshotId(v string) *DeleteSnapshotInput {
+	s.SnapshotId = &v
+	return s
+}
+
 type DeleteSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19515,6 +21741,12 @@ func (s DeleteSpotDatafeedSubscriptionInput) String() string {
 // GoString returns the string representation
 func (s DeleteSpotDatafeedSubscriptionInput) GoString() string {
 	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteSpotDatafeedSubscriptionInput) SetDryRun(v bool) *DeleteSpotDatafeedSubscriptionInput {
+	s.DryRun = &v
+	return s
 }
 
 type DeleteSpotDatafeedSubscriptionOutput struct {
@@ -19568,6 +21800,18 @@ func (s *DeleteSubnetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteSubnetInput) SetDryRun(v bool) *DeleteSubnetInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *DeleteSubnetInput) SetSubnetId(v string) *DeleteSubnetInput {
+	s.SubnetId = &v
+	return s
 }
 
 type DeleteSubnetOutput struct {
@@ -19629,6 +21873,24 @@ func (s *DeleteTagsInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteTagsInput) SetDryRun(v bool) *DeleteTagsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *DeleteTagsInput) SetResources(v []*string) *DeleteTagsInput {
+	s.Resources = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DeleteTagsInput) SetTags(v []*Tag) *DeleteTagsInput {
+	s.Tags = v
+	return s
+}
+
 type DeleteTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19680,6 +21942,18 @@ func (s *DeleteVolumeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteVolumeInput) SetDryRun(v bool) *DeleteVolumeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *DeleteVolumeInput) SetVolumeId(v string) *DeleteVolumeInput {
+	s.VolumeId = &v
+	return s
 }
 
 type DeleteVolumeOutput struct {
@@ -19735,6 +22009,18 @@ func (s *DeleteVpcEndpointsInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteVpcEndpointsInput) SetDryRun(v bool) *DeleteVpcEndpointsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcEndpointIds sets the VpcEndpointIds field's value.
+func (s *DeleteVpcEndpointsInput) SetVpcEndpointIds(v []*string) *DeleteVpcEndpointsInput {
+	s.VpcEndpointIds = v
+	return s
+}
+
 // Contains the output of DeleteVpcEndpoints.
 type DeleteVpcEndpointsOutput struct {
 	_ struct{} `type:"structure"`
@@ -19751,6 +22037,12 @@ func (s DeleteVpcEndpointsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVpcEndpointsOutput) GoString() string {
 	return s.String()
+}
+
+// SetUnsuccessful sets the Unsuccessful field's value.
+func (s *DeleteVpcEndpointsOutput) SetUnsuccessful(v []*UnsuccessfulItem) *DeleteVpcEndpointsOutput {
+	s.Unsuccessful = v
+	return s
 }
 
 // Contains the parameters for DeleteVpc.
@@ -19790,6 +22082,18 @@ func (s *DeleteVpcInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteVpcInput) SetDryRun(v bool) *DeleteVpcInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DeleteVpcInput) SetVpcId(v string) *DeleteVpcInput {
+	s.VpcId = &v
+	return s
 }
 
 type DeleteVpcOutput struct {
@@ -19845,6 +22149,18 @@ func (s *DeleteVpcPeeringConnectionInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteVpcPeeringConnectionInput) SetDryRun(v bool) *DeleteVpcPeeringConnectionInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *DeleteVpcPeeringConnectionInput) SetVpcPeeringConnectionId(v string) *DeleteVpcPeeringConnectionInput {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 // Contains the output of DeleteVpcPeeringConnection.
 type DeleteVpcPeeringConnectionOutput struct {
 	_ struct{} `type:"structure"`
@@ -19861,6 +22177,12 @@ func (s DeleteVpcPeeringConnectionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVpcPeeringConnectionOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *DeleteVpcPeeringConnectionOutput) SetReturn(v bool) *DeleteVpcPeeringConnectionOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for DeleteVpnConnection.
@@ -19900,6 +22222,18 @@ func (s *DeleteVpnConnectionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteVpnConnectionInput) SetDryRun(v bool) *DeleteVpnConnectionInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpnConnectionId sets the VpnConnectionId field's value.
+func (s *DeleteVpnConnectionInput) SetVpnConnectionId(v string) *DeleteVpnConnectionInput {
+	s.VpnConnectionId = &v
+	return s
 }
 
 type DeleteVpnConnectionOutput struct {
@@ -19957,6 +22291,18 @@ func (s *DeleteVpnConnectionRouteInput) Validate() error {
 	return nil
 }
 
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *DeleteVpnConnectionRouteInput) SetDestinationCidrBlock(v string) *DeleteVpnConnectionRouteInput {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetVpnConnectionId sets the VpnConnectionId field's value.
+func (s *DeleteVpnConnectionRouteInput) SetVpnConnectionId(v string) *DeleteVpnConnectionRouteInput {
+	s.VpnConnectionId = &v
+	return s
+}
+
 type DeleteVpnConnectionRouteOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -20008,6 +22354,18 @@ func (s *DeleteVpnGatewayInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteVpnGatewayInput) SetDryRun(v bool) *DeleteVpnGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpnGatewayId sets the VpnGatewayId field's value.
+func (s *DeleteVpnGatewayInput) SetVpnGatewayId(v string) *DeleteVpnGatewayInput {
+	s.VpnGatewayId = &v
+	return s
 }
 
 type DeleteVpnGatewayOutput struct {
@@ -20063,6 +22421,18 @@ func (s *DeregisterImageInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DeregisterImageInput) SetDryRun(v bool) *DeregisterImageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *DeregisterImageInput) SetImageId(v string) *DeregisterImageInput {
+	s.ImageId = &v
+	return s
+}
+
 type DeregisterImageOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -20101,6 +22471,18 @@ func (s DescribeAccountAttributesInput) GoString() string {
 	return s.String()
 }
 
+// SetAttributeNames sets the AttributeNames field's value.
+func (s *DescribeAccountAttributesInput) SetAttributeNames(v []*string) *DescribeAccountAttributesInput {
+	s.AttributeNames = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeAccountAttributesInput) SetDryRun(v bool) *DescribeAccountAttributesInput {
+	s.DryRun = &v
+	return s
+}
+
 // Contains the output of DescribeAccountAttributes.
 type DescribeAccountAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -20117,6 +22499,12 @@ func (s DescribeAccountAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAccountAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccountAttributes sets the AccountAttributes field's value.
+func (s *DescribeAccountAttributesOutput) SetAccountAttributes(v []*AccountAttribute) *DescribeAccountAttributesOutput {
+	s.AccountAttributes = v
+	return s
 }
 
 // Contains the parameters for DescribeAddresses.
@@ -20173,6 +22561,30 @@ func (s DescribeAddressesInput) GoString() string {
 	return s.String()
 }
 
+// SetAllocationIds sets the AllocationIds field's value.
+func (s *DescribeAddressesInput) SetAllocationIds(v []*string) *DescribeAddressesInput {
+	s.AllocationIds = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeAddressesInput) SetDryRun(v bool) *DescribeAddressesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeAddressesInput) SetFilters(v []*Filter) *DescribeAddressesInput {
+	s.Filters = v
+	return s
+}
+
+// SetPublicIps sets the PublicIps field's value.
+func (s *DescribeAddressesInput) SetPublicIps(v []*string) *DescribeAddressesInput {
+	s.PublicIps = v
+	return s
+}
+
 // Contains the output of DescribeAddresses.
 type DescribeAddressesOutput struct {
 	_ struct{} `type:"structure"`
@@ -20189,6 +22601,12 @@ func (s DescribeAddressesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAddressesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAddresses sets the Addresses field's value.
+func (s *DescribeAddressesOutput) SetAddresses(v []*Address) *DescribeAddressesOutput {
+	s.Addresses = v
+	return s
 }
 
 // Contains the parameters for DescribeAvailabilityZones.
@@ -20228,6 +22646,24 @@ func (s DescribeAvailabilityZonesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeAvailabilityZonesInput) SetDryRun(v bool) *DescribeAvailabilityZonesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeAvailabilityZonesInput) SetFilters(v []*Filter) *DescribeAvailabilityZonesInput {
+	s.Filters = v
+	return s
+}
+
+// SetZoneNames sets the ZoneNames field's value.
+func (s *DescribeAvailabilityZonesInput) SetZoneNames(v []*string) *DescribeAvailabilityZonesInput {
+	s.ZoneNames = v
+	return s
+}
+
 // Contains the output of DescribeAvailabiltyZones.
 type DescribeAvailabilityZonesOutput struct {
 	_ struct{} `type:"structure"`
@@ -20244,6 +22680,12 @@ func (s DescribeAvailabilityZonesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAvailabilityZonesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *DescribeAvailabilityZonesOutput) SetAvailabilityZones(v []*AvailabilityZone) *DescribeAvailabilityZonesOutput {
+	s.AvailabilityZones = v
+	return s
 }
 
 // Contains the parameters for DescribeBundleTasks.
@@ -20297,6 +22739,24 @@ func (s DescribeBundleTasksInput) GoString() string {
 	return s.String()
 }
 
+// SetBundleIds sets the BundleIds field's value.
+func (s *DescribeBundleTasksInput) SetBundleIds(v []*string) *DescribeBundleTasksInput {
+	s.BundleIds = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeBundleTasksInput) SetDryRun(v bool) *DescribeBundleTasksInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeBundleTasksInput) SetFilters(v []*Filter) *DescribeBundleTasksInput {
+	s.Filters = v
+	return s
+}
+
 // Contains the output of DescribeBundleTasks.
 type DescribeBundleTasksOutput struct {
 	_ struct{} `type:"structure"`
@@ -20313,6 +22773,12 @@ func (s DescribeBundleTasksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeBundleTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetBundleTasks sets the BundleTasks field's value.
+func (s *DescribeBundleTasksOutput) SetBundleTasks(v []*BundleTask) *DescribeBundleTasksOutput {
+	s.BundleTasks = v
+	return s
 }
 
 // Contains the parameters for DescribeClassicLinkInstances.
@@ -20375,6 +22841,36 @@ func (s DescribeClassicLinkInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeClassicLinkInstancesInput) SetDryRun(v bool) *DescribeClassicLinkInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeClassicLinkInstancesInput) SetFilters(v []*Filter) *DescribeClassicLinkInstancesInput {
+	s.Filters = v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *DescribeClassicLinkInstancesInput) SetInstanceIds(v []*string) *DescribeClassicLinkInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeClassicLinkInstancesInput) SetMaxResults(v int64) *DescribeClassicLinkInstancesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeClassicLinkInstancesInput) SetNextToken(v string) *DescribeClassicLinkInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeClassicLinkInstances.
 type DescribeClassicLinkInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -20395,6 +22891,18 @@ func (s DescribeClassicLinkInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClassicLinkInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstances sets the Instances field's value.
+func (s *DescribeClassicLinkInstancesOutput) SetInstances(v []*ClassicLinkInstance) *DescribeClassicLinkInstancesOutput {
+	s.Instances = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeClassicLinkInstancesOutput) SetNextToken(v string) *DescribeClassicLinkInstancesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeConversionTasks.
@@ -20421,6 +22929,18 @@ func (s DescribeConversionTasksInput) GoString() string {
 	return s.String()
 }
 
+// SetConversionTaskIds sets the ConversionTaskIds field's value.
+func (s *DescribeConversionTasksInput) SetConversionTaskIds(v []*string) *DescribeConversionTasksInput {
+	s.ConversionTaskIds = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeConversionTasksInput) SetDryRun(v bool) *DescribeConversionTasksInput {
+	s.DryRun = &v
+	return s
+}
+
 // Contains the output for DescribeConversionTasks.
 type DescribeConversionTasksOutput struct {
 	_ struct{} `type:"structure"`
@@ -20437,6 +22957,12 @@ func (s DescribeConversionTasksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConversionTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetConversionTasks sets the ConversionTasks field's value.
+func (s *DescribeConversionTasksOutput) SetConversionTasks(v []*ConversionTask) *DescribeConversionTasksOutput {
+	s.ConversionTasks = v
+	return s
 }
 
 // Contains the parameters for DescribeCustomerGateways.
@@ -20495,6 +23021,24 @@ func (s DescribeCustomerGatewaysInput) GoString() string {
 	return s.String()
 }
 
+// SetCustomerGatewayIds sets the CustomerGatewayIds field's value.
+func (s *DescribeCustomerGatewaysInput) SetCustomerGatewayIds(v []*string) *DescribeCustomerGatewaysInput {
+	s.CustomerGatewayIds = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeCustomerGatewaysInput) SetDryRun(v bool) *DescribeCustomerGatewaysInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeCustomerGatewaysInput) SetFilters(v []*Filter) *DescribeCustomerGatewaysInput {
+	s.Filters = v
+	return s
+}
+
 // Contains the output of DescribeCustomerGateways.
 type DescribeCustomerGatewaysOutput struct {
 	_ struct{} `type:"structure"`
@@ -20511,6 +23055,12 @@ func (s DescribeCustomerGatewaysOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCustomerGatewaysOutput) GoString() string {
 	return s.String()
+}
+
+// SetCustomerGateways sets the CustomerGateways field's value.
+func (s *DescribeCustomerGatewaysOutput) SetCustomerGateways(v []*CustomerGateway) *DescribeCustomerGatewaysOutput {
+	s.CustomerGateways = v
+	return s
 }
 
 // Contains the parameters for DescribeDhcpOptions.
@@ -20561,6 +23111,24 @@ func (s DescribeDhcpOptionsInput) GoString() string {
 	return s.String()
 }
 
+// SetDhcpOptionsIds sets the DhcpOptionsIds field's value.
+func (s *DescribeDhcpOptionsInput) SetDhcpOptionsIds(v []*string) *DescribeDhcpOptionsInput {
+	s.DhcpOptionsIds = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeDhcpOptionsInput) SetDryRun(v bool) *DescribeDhcpOptionsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDhcpOptionsInput) SetFilters(v []*Filter) *DescribeDhcpOptionsInput {
+	s.Filters = v
+	return s
+}
+
 // Contains the output of DescribeDhcpOptions.
 type DescribeDhcpOptionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -20577,6 +23145,12 @@ func (s DescribeDhcpOptionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDhcpOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDhcpOptions sets the DhcpOptions field's value.
+func (s *DescribeDhcpOptionsOutput) SetDhcpOptions(v []*DhcpOptions) *DescribeDhcpOptionsOutput {
+	s.DhcpOptions = v
+	return s
 }
 
 // Contains the parameters for DescribeExportTasks.
@@ -20597,6 +23171,12 @@ func (s DescribeExportTasksInput) GoString() string {
 	return s.String()
 }
 
+// SetExportTaskIds sets the ExportTaskIds field's value.
+func (s *DescribeExportTasksInput) SetExportTaskIds(v []*string) *DescribeExportTasksInput {
+	s.ExportTaskIds = v
+	return s
+}
+
 // Contains the output for DescribeExportTasks.
 type DescribeExportTasksOutput struct {
 	_ struct{} `type:"structure"`
@@ -20613,6 +23193,12 @@ func (s DescribeExportTasksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeExportTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetExportTasks sets the ExportTasks field's value.
+func (s *DescribeExportTasksOutput) SetExportTasks(v []*ExportTask) *DescribeExportTasksOutput {
+	s.ExportTasks = v
+	return s
 }
 
 // Contains the parameters for DescribeFlowLogs.
@@ -20656,6 +23242,30 @@ func (s DescribeFlowLogsInput) GoString() string {
 	return s.String()
 }
 
+// SetFilter sets the Filter field's value.
+func (s *DescribeFlowLogsInput) SetFilter(v []*Filter) *DescribeFlowLogsInput {
+	s.Filter = v
+	return s
+}
+
+// SetFlowLogIds sets the FlowLogIds field's value.
+func (s *DescribeFlowLogsInput) SetFlowLogIds(v []*string) *DescribeFlowLogsInput {
+	s.FlowLogIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeFlowLogsInput) SetMaxResults(v int64) *DescribeFlowLogsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFlowLogsInput) SetNextToken(v string) *DescribeFlowLogsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeFlowLogs.
 type DescribeFlowLogsOutput struct {
 	_ struct{} `type:"structure"`
@@ -20676,6 +23286,18 @@ func (s DescribeFlowLogsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeFlowLogsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFlowLogs sets the FlowLogs field's value.
+func (s *DescribeFlowLogsOutput) SetFlowLogs(v []*FlowLog) *DescribeFlowLogsOutput {
+	s.FlowLogs = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFlowLogsOutput) SetNextToken(v string) *DescribeFlowLogsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeHostReservationOfferingsInput struct {
@@ -20726,6 +23348,42 @@ func (s DescribeHostReservationOfferingsInput) GoString() string {
 	return s.String()
 }
 
+// SetFilter sets the Filter field's value.
+func (s *DescribeHostReservationOfferingsInput) SetFilter(v []*Filter) *DescribeHostReservationOfferingsInput {
+	s.Filter = v
+	return s
+}
+
+// SetMaxDuration sets the MaxDuration field's value.
+func (s *DescribeHostReservationOfferingsInput) SetMaxDuration(v int64) *DescribeHostReservationOfferingsInput {
+	s.MaxDuration = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeHostReservationOfferingsInput) SetMaxResults(v int64) *DescribeHostReservationOfferingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetMinDuration sets the MinDuration field's value.
+func (s *DescribeHostReservationOfferingsInput) SetMinDuration(v int64) *DescribeHostReservationOfferingsInput {
+	s.MinDuration = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeHostReservationOfferingsInput) SetNextToken(v string) *DescribeHostReservationOfferingsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *DescribeHostReservationOfferingsInput) SetOfferingId(v string) *DescribeHostReservationOfferingsInput {
+	s.OfferingId = &v
+	return s
+}
+
 type DescribeHostReservationOfferingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -20745,6 +23403,18 @@ func (s DescribeHostReservationOfferingsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeHostReservationOfferingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeHostReservationOfferingsOutput) SetNextToken(v string) *DescribeHostReservationOfferingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOfferingSet sets the OfferingSet field's value.
+func (s *DescribeHostReservationOfferingsOutput) SetOfferingSet(v []*HostOffering) *DescribeHostReservationOfferingsOutput {
+	s.OfferingSet = v
+	return s
 }
 
 type DescribeHostReservationsInput struct {
@@ -20784,6 +23454,30 @@ func (s DescribeHostReservationsInput) GoString() string {
 	return s.String()
 }
 
+// SetFilter sets the Filter field's value.
+func (s *DescribeHostReservationsInput) SetFilter(v []*Filter) *DescribeHostReservationsInput {
+	s.Filter = v
+	return s
+}
+
+// SetHostReservationIdSet sets the HostReservationIdSet field's value.
+func (s *DescribeHostReservationsInput) SetHostReservationIdSet(v []*string) *DescribeHostReservationsInput {
+	s.HostReservationIdSet = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeHostReservationsInput) SetMaxResults(v int64) *DescribeHostReservationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeHostReservationsInput) SetNextToken(v string) *DescribeHostReservationsInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeHostReservationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -20803,6 +23497,18 @@ func (s DescribeHostReservationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeHostReservationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetHostReservationSet sets the HostReservationSet field's value.
+func (s *DescribeHostReservationsOutput) SetHostReservationSet(v []*HostReservation) *DescribeHostReservationsOutput {
+	s.HostReservationSet = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeHostReservationsOutput) SetNextToken(v string) *DescribeHostReservationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeHosts.
@@ -20852,6 +23558,30 @@ func (s DescribeHostsInput) GoString() string {
 	return s.String()
 }
 
+// SetFilter sets the Filter field's value.
+func (s *DescribeHostsInput) SetFilter(v []*Filter) *DescribeHostsInput {
+	s.Filter = v
+	return s
+}
+
+// SetHostIds sets the HostIds field's value.
+func (s *DescribeHostsInput) SetHostIds(v []*string) *DescribeHostsInput {
+	s.HostIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeHostsInput) SetMaxResults(v int64) *DescribeHostsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeHostsInput) SetNextToken(v string) *DescribeHostsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeHosts.
 type DescribeHostsOutput struct {
 	_ struct{} `type:"structure"`
@@ -20874,6 +23604,18 @@ func (s DescribeHostsOutput) GoString() string {
 	return s.String()
 }
 
+// SetHosts sets the Hosts field's value.
+func (s *DescribeHostsOutput) SetHosts(v []*Host) *DescribeHostsOutput {
+	s.Hosts = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeHostsOutput) SetNextToken(v string) *DescribeHostsOutput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the parameters for DescribeIdFormat.
 type DescribeIdFormatInput struct {
 	_ struct{} `type:"structure"`
@@ -20892,6 +23634,12 @@ func (s DescribeIdFormatInput) GoString() string {
 	return s.String()
 }
 
+// SetResource sets the Resource field's value.
+func (s *DescribeIdFormatInput) SetResource(v string) *DescribeIdFormatInput {
+	s.Resource = &v
+	return s
+}
+
 // Contains the output of DescribeIdFormat.
 type DescribeIdFormatOutput struct {
 	_ struct{} `type:"structure"`
@@ -20908,6 +23656,12 @@ func (s DescribeIdFormatOutput) String() string {
 // GoString returns the string representation
 func (s DescribeIdFormatOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatuses sets the Statuses field's value.
+func (s *DescribeIdFormatOutput) SetStatuses(v []*IdFormat) *DescribeIdFormatOutput {
+	s.Statuses = v
+	return s
 }
 
 // Contains the parameters for DescribeIdentityIdFormat.
@@ -20947,6 +23701,18 @@ func (s *DescribeIdentityIdFormatInput) Validate() error {
 	return nil
 }
 
+// SetPrincipalArn sets the PrincipalArn field's value.
+func (s *DescribeIdentityIdFormatInput) SetPrincipalArn(v string) *DescribeIdentityIdFormatInput {
+	s.PrincipalArn = &v
+	return s
+}
+
+// SetResource sets the Resource field's value.
+func (s *DescribeIdentityIdFormatInput) SetResource(v string) *DescribeIdentityIdFormatInput {
+	s.Resource = &v
+	return s
+}
+
 // Contains the output of DescribeIdentityIdFormat.
 type DescribeIdentityIdFormatOutput struct {
 	_ struct{} `type:"structure"`
@@ -20963,6 +23729,12 @@ func (s DescribeIdentityIdFormatOutput) String() string {
 // GoString returns the string representation
 func (s DescribeIdentityIdFormatOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatuses sets the Statuses field's value.
+func (s *DescribeIdentityIdFormatOutput) SetStatuses(v []*IdFormat) *DescribeIdentityIdFormatOutput {
+	s.Statuses = v
+	return s
 }
 
 // Contains the parameters for DescribeImageAttribute.
@@ -21016,6 +23788,24 @@ func (s *DescribeImageAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *DescribeImageAttributeInput) SetAttribute(v string) *DescribeImageAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeImageAttributeInput) SetDryRun(v bool) *DescribeImageAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *DescribeImageAttributeInput) SetImageId(v string) *DescribeImageAttributeInput {
+	s.ImageId = &v
+	return s
+}
+
 // Describes an image attribute.
 type DescribeImageAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -21054,6 +23844,54 @@ func (s DescribeImageAttributeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeImageAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *DescribeImageAttributeOutput) SetBlockDeviceMappings(v []*BlockDeviceMapping) *DescribeImageAttributeOutput {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DescribeImageAttributeOutput) SetDescription(v *AttributeValue) *DescribeImageAttributeOutput {
+	s.Description = v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *DescribeImageAttributeOutput) SetImageId(v string) *DescribeImageAttributeOutput {
+	s.ImageId = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *DescribeImageAttributeOutput) SetKernelId(v *AttributeValue) *DescribeImageAttributeOutput {
+	s.KernelId = v
+	return s
+}
+
+// SetLaunchPermissions sets the LaunchPermissions field's value.
+func (s *DescribeImageAttributeOutput) SetLaunchPermissions(v []*LaunchPermission) *DescribeImageAttributeOutput {
+	s.LaunchPermissions = v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *DescribeImageAttributeOutput) SetProductCodes(v []*ProductCode) *DescribeImageAttributeOutput {
+	s.ProductCodes = v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *DescribeImageAttributeOutput) SetRamdiskId(v *AttributeValue) *DescribeImageAttributeOutput {
+	s.RamdiskId = v
+	return s
+}
+
+// SetSriovNetSupport sets the SriovNetSupport field's value.
+func (s *DescribeImageAttributeOutput) SetSriovNetSupport(v *AttributeValue) *DescribeImageAttributeOutput {
+	s.SriovNetSupport = v
+	return s
 }
 
 // Contains the parameters for DescribeImages.
@@ -21168,6 +24006,36 @@ func (s DescribeImagesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeImagesInput) SetDryRun(v bool) *DescribeImagesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetExecutableUsers sets the ExecutableUsers field's value.
+func (s *DescribeImagesInput) SetExecutableUsers(v []*string) *DescribeImagesInput {
+	s.ExecutableUsers = v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeImagesInput) SetFilters(v []*Filter) *DescribeImagesInput {
+	s.Filters = v
+	return s
+}
+
+// SetImageIds sets the ImageIds field's value.
+func (s *DescribeImagesInput) SetImageIds(v []*string) *DescribeImagesInput {
+	s.ImageIds = v
+	return s
+}
+
+// SetOwners sets the Owners field's value.
+func (s *DescribeImagesInput) SetOwners(v []*string) *DescribeImagesInput {
+	s.Owners = v
+	return s
+}
+
 // Contains the output of DescribeImages.
 type DescribeImagesOutput struct {
 	_ struct{} `type:"structure"`
@@ -21184,6 +24052,12 @@ func (s DescribeImagesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeImagesOutput) GoString() string {
 	return s.String()
+}
+
+// SetImages sets the Images field's value.
+func (s *DescribeImagesOutput) SetImages(v []*Image) *DescribeImagesOutput {
+	s.Images = v
+	return s
 }
 
 // Contains the parameters for DescribeImportImageTasks.
@@ -21221,6 +24095,36 @@ func (s DescribeImportImageTasksInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeImportImageTasksInput) SetDryRun(v bool) *DescribeImportImageTasksInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeImportImageTasksInput) SetFilters(v []*Filter) *DescribeImportImageTasksInput {
+	s.Filters = v
+	return s
+}
+
+// SetImportTaskIds sets the ImportTaskIds field's value.
+func (s *DescribeImportImageTasksInput) SetImportTaskIds(v []*string) *DescribeImportImageTasksInput {
+	s.ImportTaskIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeImportImageTasksInput) SetMaxResults(v int64) *DescribeImportImageTasksInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImportImageTasksInput) SetNextToken(v string) *DescribeImportImageTasksInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output for DescribeImportImageTasks.
 type DescribeImportImageTasksOutput struct {
 	_ struct{} `type:"structure"`
@@ -21242,6 +24146,18 @@ func (s DescribeImportImageTasksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeImportImageTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetImportImageTasks sets the ImportImageTasks field's value.
+func (s *DescribeImportImageTasksOutput) SetImportImageTasks(v []*ImportImageTask) *DescribeImportImageTasksOutput {
+	s.ImportImageTasks = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImportImageTasksOutput) SetNextToken(v string) *DescribeImportImageTasksOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeImportSnapshotTasks.
@@ -21278,6 +24194,36 @@ func (s DescribeImportSnapshotTasksInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeImportSnapshotTasksInput) SetDryRun(v bool) *DescribeImportSnapshotTasksInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeImportSnapshotTasksInput) SetFilters(v []*Filter) *DescribeImportSnapshotTasksInput {
+	s.Filters = v
+	return s
+}
+
+// SetImportTaskIds sets the ImportTaskIds field's value.
+func (s *DescribeImportSnapshotTasksInput) SetImportTaskIds(v []*string) *DescribeImportSnapshotTasksInput {
+	s.ImportTaskIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeImportSnapshotTasksInput) SetMaxResults(v int64) *DescribeImportSnapshotTasksInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImportSnapshotTasksInput) SetNextToken(v string) *DescribeImportSnapshotTasksInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output for DescribeImportSnapshotTasks.
 type DescribeImportSnapshotTasksOutput struct {
 	_ struct{} `type:"structure"`
@@ -21299,6 +24245,18 @@ func (s DescribeImportSnapshotTasksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeImportSnapshotTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetImportSnapshotTasks sets the ImportSnapshotTasks field's value.
+func (s *DescribeImportSnapshotTasksOutput) SetImportSnapshotTasks(v []*ImportSnapshotTask) *DescribeImportSnapshotTasksOutput {
+	s.ImportSnapshotTasks = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImportSnapshotTasksOutput) SetNextToken(v string) *DescribeImportSnapshotTasksOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeInstanceAttribute.
@@ -21348,6 +24306,24 @@ func (s *DescribeInstanceAttributeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *DescribeInstanceAttributeInput) SetAttribute(v string) *DescribeInstanceAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeInstanceAttributeInput) SetDryRun(v bool) *DescribeInstanceAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeInstanceAttributeInput) SetInstanceId(v string) *DescribeInstanceAttributeInput {
+	s.InstanceId = &v
+	return s
 }
 
 // Describes an instance attribute.
@@ -21413,6 +24389,96 @@ func (s DescribeInstanceAttributeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInstanceAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *DescribeInstanceAttributeOutput) SetBlockDeviceMappings(v []*InstanceBlockDeviceMapping) *DescribeInstanceAttributeOutput {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetDisableApiTermination sets the DisableApiTermination field's value.
+func (s *DescribeInstanceAttributeOutput) SetDisableApiTermination(v *AttributeBooleanValue) *DescribeInstanceAttributeOutput {
+	s.DisableApiTermination = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *DescribeInstanceAttributeOutput) SetEbsOptimized(v *AttributeBooleanValue) *DescribeInstanceAttributeOutput {
+	s.EbsOptimized = v
+	return s
+}
+
+// SetEnaSupport sets the EnaSupport field's value.
+func (s *DescribeInstanceAttributeOutput) SetEnaSupport(v *AttributeBooleanValue) *DescribeInstanceAttributeOutput {
+	s.EnaSupport = v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *DescribeInstanceAttributeOutput) SetGroups(v []*GroupIdentifier) *DescribeInstanceAttributeOutput {
+	s.Groups = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeInstanceAttributeOutput) SetInstanceId(v string) *DescribeInstanceAttributeOutput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceInitiatedShutdownBehavior sets the InstanceInitiatedShutdownBehavior field's value.
+func (s *DescribeInstanceAttributeOutput) SetInstanceInitiatedShutdownBehavior(v *AttributeValue) *DescribeInstanceAttributeOutput {
+	s.InstanceInitiatedShutdownBehavior = v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *DescribeInstanceAttributeOutput) SetInstanceType(v *AttributeValue) *DescribeInstanceAttributeOutput {
+	s.InstanceType = v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *DescribeInstanceAttributeOutput) SetKernelId(v *AttributeValue) *DescribeInstanceAttributeOutput {
+	s.KernelId = v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *DescribeInstanceAttributeOutput) SetProductCodes(v []*ProductCode) *DescribeInstanceAttributeOutput {
+	s.ProductCodes = v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *DescribeInstanceAttributeOutput) SetRamdiskId(v *AttributeValue) *DescribeInstanceAttributeOutput {
+	s.RamdiskId = v
+	return s
+}
+
+// SetRootDeviceName sets the RootDeviceName field's value.
+func (s *DescribeInstanceAttributeOutput) SetRootDeviceName(v *AttributeValue) *DescribeInstanceAttributeOutput {
+	s.RootDeviceName = v
+	return s
+}
+
+// SetSourceDestCheck sets the SourceDestCheck field's value.
+func (s *DescribeInstanceAttributeOutput) SetSourceDestCheck(v *AttributeBooleanValue) *DescribeInstanceAttributeOutput {
+	s.SourceDestCheck = v
+	return s
+}
+
+// SetSriovNetSupport sets the SriovNetSupport field's value.
+func (s *DescribeInstanceAttributeOutput) SetSriovNetSupport(v *AttributeValue) *DescribeInstanceAttributeOutput {
+	s.SriovNetSupport = v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *DescribeInstanceAttributeOutput) SetUserData(v *AttributeValue) *DescribeInstanceAttributeOutput {
+	s.UserData = v
+	return s
 }
 
 // Contains the parameters for DescribeInstanceStatus.
@@ -21495,6 +24561,42 @@ func (s DescribeInstanceStatusInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeInstanceStatusInput) SetDryRun(v bool) *DescribeInstanceStatusInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeInstanceStatusInput) SetFilters(v []*Filter) *DescribeInstanceStatusInput {
+	s.Filters = v
+	return s
+}
+
+// SetIncludeAllInstances sets the IncludeAllInstances field's value.
+func (s *DescribeInstanceStatusInput) SetIncludeAllInstances(v bool) *DescribeInstanceStatusInput {
+	s.IncludeAllInstances = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *DescribeInstanceStatusInput) SetInstanceIds(v []*string) *DescribeInstanceStatusInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeInstanceStatusInput) SetMaxResults(v int64) *DescribeInstanceStatusInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceStatusInput) SetNextToken(v string) *DescribeInstanceStatusInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeInstanceStatus.
 type DescribeInstanceStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -21515,6 +24617,18 @@ func (s DescribeInstanceStatusOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInstanceStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceStatuses sets the InstanceStatuses field's value.
+func (s *DescribeInstanceStatusOutput) SetInstanceStatuses(v []*InstanceStatus) *DescribeInstanceStatusOutput {
+	s.InstanceStatuses = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceStatusOutput) SetNextToken(v string) *DescribeInstanceStatusOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeInstances.
@@ -21789,6 +24903,36 @@ func (s DescribeInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeInstancesInput) SetDryRun(v bool) *DescribeInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeInstancesInput) SetFilters(v []*Filter) *DescribeInstancesInput {
+	s.Filters = v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *DescribeInstancesInput) SetInstanceIds(v []*string) *DescribeInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeInstancesInput) SetMaxResults(v int64) *DescribeInstancesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstancesInput) SetNextToken(v string) *DescribeInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeInstances.
 type DescribeInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -21809,6 +24953,18 @@ func (s DescribeInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstancesOutput) SetNextToken(v string) *DescribeInstancesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservations sets the Reservations field's value.
+func (s *DescribeInstancesOutput) SetReservations(v []*Reservation) *DescribeInstancesOutput {
+	s.Reservations = v
+	return s
 }
 
 // Contains the parameters for DescribeInternetGateways.
@@ -21860,6 +25016,24 @@ func (s DescribeInternetGatewaysInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeInternetGatewaysInput) SetDryRun(v bool) *DescribeInternetGatewaysInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeInternetGatewaysInput) SetFilters(v []*Filter) *DescribeInternetGatewaysInput {
+	s.Filters = v
+	return s
+}
+
+// SetInternetGatewayIds sets the InternetGatewayIds field's value.
+func (s *DescribeInternetGatewaysInput) SetInternetGatewayIds(v []*string) *DescribeInternetGatewaysInput {
+	s.InternetGatewayIds = v
+	return s
+}
+
 // Contains the output of DescribeInternetGateways.
 type DescribeInternetGatewaysOutput struct {
 	_ struct{} `type:"structure"`
@@ -21876,6 +25050,12 @@ func (s DescribeInternetGatewaysOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInternetGatewaysOutput) GoString() string {
 	return s.String()
+}
+
+// SetInternetGateways sets the InternetGateways field's value.
+func (s *DescribeInternetGatewaysOutput) SetInternetGateways(v []*InternetGateway) *DescribeInternetGatewaysOutput {
+	s.InternetGateways = v
+	return s
 }
 
 // Contains the parameters for DescribeKeyPairs.
@@ -21911,6 +25091,24 @@ func (s DescribeKeyPairsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeKeyPairsInput) SetDryRun(v bool) *DescribeKeyPairsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeKeyPairsInput) SetFilters(v []*Filter) *DescribeKeyPairsInput {
+	s.Filters = v
+	return s
+}
+
+// SetKeyNames sets the KeyNames field's value.
+func (s *DescribeKeyPairsInput) SetKeyNames(v []*string) *DescribeKeyPairsInput {
+	s.KeyNames = v
+	return s
+}
+
 // Contains the output of DescribeKeyPairs.
 type DescribeKeyPairsOutput struct {
 	_ struct{} `type:"structure"`
@@ -21927,6 +25125,12 @@ func (s DescribeKeyPairsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeKeyPairsOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeyPairs sets the KeyPairs field's value.
+func (s *DescribeKeyPairsOutput) SetKeyPairs(v []*KeyPairInfo) *DescribeKeyPairsOutput {
+	s.KeyPairs = v
+	return s
 }
 
 // Contains the parameters for DescribeMovingAddresses.
@@ -21970,6 +25174,36 @@ func (s DescribeMovingAddressesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeMovingAddressesInput) SetDryRun(v bool) *DescribeMovingAddressesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeMovingAddressesInput) SetFilters(v []*Filter) *DescribeMovingAddressesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeMovingAddressesInput) SetMaxResults(v int64) *DescribeMovingAddressesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeMovingAddressesInput) SetNextToken(v string) *DescribeMovingAddressesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPublicIps sets the PublicIps field's value.
+func (s *DescribeMovingAddressesInput) SetPublicIps(v []*string) *DescribeMovingAddressesInput {
+	s.PublicIps = v
+	return s
+}
+
 // Contains the output of DescribeMovingAddresses.
 type DescribeMovingAddressesOutput struct {
 	_ struct{} `type:"structure"`
@@ -21990,6 +25224,18 @@ func (s DescribeMovingAddressesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeMovingAddressesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMovingAddressStatuses sets the MovingAddressStatuses field's value.
+func (s *DescribeMovingAddressesOutput) SetMovingAddressStatuses(v []*MovingAddressStatus) *DescribeMovingAddressesOutput {
+	s.MovingAddressStatuses = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeMovingAddressesOutput) SetNextToken(v string) *DescribeMovingAddressesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeNatGateways.
@@ -22033,6 +25279,30 @@ func (s DescribeNatGatewaysInput) GoString() string {
 	return s.String()
 }
 
+// SetFilter sets the Filter field's value.
+func (s *DescribeNatGatewaysInput) SetFilter(v []*Filter) *DescribeNatGatewaysInput {
+	s.Filter = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeNatGatewaysInput) SetMaxResults(v int64) *DescribeNatGatewaysInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNatGatewayIds sets the NatGatewayIds field's value.
+func (s *DescribeNatGatewaysInput) SetNatGatewayIds(v []*string) *DescribeNatGatewaysInput {
+	s.NatGatewayIds = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeNatGatewaysInput) SetNextToken(v string) *DescribeNatGatewaysInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeNatGateways.
 type DescribeNatGatewaysOutput struct {
 	_ struct{} `type:"structure"`
@@ -22053,6 +25323,18 @@ func (s DescribeNatGatewaysOutput) String() string {
 // GoString returns the string representation
 func (s DescribeNatGatewaysOutput) GoString() string {
 	return s.String()
+}
+
+// SetNatGateways sets the NatGateways field's value.
+func (s *DescribeNatGatewaysOutput) SetNatGateways(v []*NatGateway) *DescribeNatGatewaysOutput {
+	s.NatGateways = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeNatGatewaysOutput) SetNextToken(v string) *DescribeNatGatewaysOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the parameters for DescribeNetworkAcls.
@@ -22133,6 +25415,24 @@ func (s DescribeNetworkAclsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeNetworkAclsInput) SetDryRun(v bool) *DescribeNetworkAclsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeNetworkAclsInput) SetFilters(v []*Filter) *DescribeNetworkAclsInput {
+	s.Filters = v
+	return s
+}
+
+// SetNetworkAclIds sets the NetworkAclIds field's value.
+func (s *DescribeNetworkAclsInput) SetNetworkAclIds(v []*string) *DescribeNetworkAclsInput {
+	s.NetworkAclIds = v
+	return s
+}
+
 // Contains the output of DescribeNetworkAcls.
 type DescribeNetworkAclsOutput struct {
 	_ struct{} `type:"structure"`
@@ -22149,6 +25449,12 @@ func (s DescribeNetworkAclsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeNetworkAclsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNetworkAcls sets the NetworkAcls field's value.
+func (s *DescribeNetworkAclsOutput) SetNetworkAcls(v []*NetworkAcl) *DescribeNetworkAclsOutput {
+	s.NetworkAcls = v
+	return s
 }
 
 // Contains the parameters for DescribeNetworkInterfaceAttribute.
@@ -22193,6 +25499,24 @@ func (s *DescribeNetworkInterfaceAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *DescribeNetworkInterfaceAttributeInput) SetAttribute(v string) *DescribeNetworkInterfaceAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeNetworkInterfaceAttributeInput) SetDryRun(v bool) *DescribeNetworkInterfaceAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *DescribeNetworkInterfaceAttributeInput) SetNetworkInterfaceId(v string) *DescribeNetworkInterfaceAttributeInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
 // Contains the output of DescribeNetworkInterfaceAttribute.
 type DescribeNetworkInterfaceAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -22221,6 +25545,36 @@ func (s DescribeNetworkInterfaceAttributeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeNetworkInterfaceAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttachment sets the Attachment field's value.
+func (s *DescribeNetworkInterfaceAttributeOutput) SetAttachment(v *NetworkInterfaceAttachment) *DescribeNetworkInterfaceAttributeOutput {
+	s.Attachment = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DescribeNetworkInterfaceAttributeOutput) SetDescription(v *AttributeValue) *DescribeNetworkInterfaceAttributeOutput {
+	s.Description = v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *DescribeNetworkInterfaceAttributeOutput) SetGroups(v []*GroupIdentifier) *DescribeNetworkInterfaceAttributeOutput {
+	s.Groups = v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *DescribeNetworkInterfaceAttributeOutput) SetNetworkInterfaceId(v string) *DescribeNetworkInterfaceAttributeOutput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetSourceDestCheck sets the SourceDestCheck field's value.
+func (s *DescribeNetworkInterfaceAttributeOutput) SetSourceDestCheck(v *AttributeBooleanValue) *DescribeNetworkInterfaceAttributeOutput {
+	s.SourceDestCheck = v
+	return s
 }
 
 // Contains the parameters for DescribeNetworkInterfaces.
@@ -22355,6 +25709,24 @@ func (s DescribeNetworkInterfacesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeNetworkInterfacesInput) SetDryRun(v bool) *DescribeNetworkInterfacesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeNetworkInterfacesInput) SetFilters(v []*Filter) *DescribeNetworkInterfacesInput {
+	s.Filters = v
+	return s
+}
+
+// SetNetworkInterfaceIds sets the NetworkInterfaceIds field's value.
+func (s *DescribeNetworkInterfacesInput) SetNetworkInterfaceIds(v []*string) *DescribeNetworkInterfacesInput {
+	s.NetworkInterfaceIds = v
+	return s
+}
+
 // Contains the output of DescribeNetworkInterfaces.
 type DescribeNetworkInterfacesOutput struct {
 	_ struct{} `type:"structure"`
@@ -22371,6 +25743,12 @@ func (s DescribeNetworkInterfacesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeNetworkInterfacesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNetworkInterfaces sets the NetworkInterfaces field's value.
+func (s *DescribeNetworkInterfacesOutput) SetNetworkInterfaces(v []*NetworkInterface) *DescribeNetworkInterfacesOutput {
+	s.NetworkInterfaces = v
+	return s
 }
 
 // Contains the parameters for DescribePlacementGroups.
@@ -22409,6 +25787,24 @@ func (s DescribePlacementGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribePlacementGroupsInput) SetDryRun(v bool) *DescribePlacementGroupsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribePlacementGroupsInput) SetFilters(v []*Filter) *DescribePlacementGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetGroupNames sets the GroupNames field's value.
+func (s *DescribePlacementGroupsInput) SetGroupNames(v []*string) *DescribePlacementGroupsInput {
+	s.GroupNames = v
+	return s
+}
+
 // Contains the output of DescribePlacementGroups.
 type DescribePlacementGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -22425,6 +25821,12 @@ func (s DescribePlacementGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribePlacementGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetPlacementGroups sets the PlacementGroups field's value.
+func (s *DescribePlacementGroupsOutput) SetPlacementGroups(v []*PlacementGroup) *DescribePlacementGroupsOutput {
+	s.PlacementGroups = v
+	return s
 }
 
 // Contains the parameters for DescribePrefixLists.
@@ -22470,6 +25872,36 @@ func (s DescribePrefixListsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribePrefixListsInput) SetDryRun(v bool) *DescribePrefixListsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribePrefixListsInput) SetFilters(v []*Filter) *DescribePrefixListsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribePrefixListsInput) SetMaxResults(v int64) *DescribePrefixListsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribePrefixListsInput) SetNextToken(v string) *DescribePrefixListsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPrefixListIds sets the PrefixListIds field's value.
+func (s *DescribePrefixListsInput) SetPrefixListIds(v []*string) *DescribePrefixListsInput {
+	s.PrefixListIds = v
+	return s
+}
+
 // Contains the output of DescribePrefixLists.
 type DescribePrefixListsOutput struct {
 	_ struct{} `type:"structure"`
@@ -22490,6 +25922,18 @@ func (s DescribePrefixListsOutput) String() string {
 // GoString returns the string representation
 func (s DescribePrefixListsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribePrefixListsOutput) SetNextToken(v string) *DescribePrefixListsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPrefixLists sets the PrefixLists field's value.
+func (s *DescribePrefixListsOutput) SetPrefixLists(v []*PrefixList) *DescribePrefixListsOutput {
+	s.PrefixLists = v
+	return s
 }
 
 // Contains the parameters for DescribeRegions.
@@ -22523,6 +25967,24 @@ func (s DescribeRegionsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeRegionsInput) SetDryRun(v bool) *DescribeRegionsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeRegionsInput) SetFilters(v []*Filter) *DescribeRegionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetRegionNames sets the RegionNames field's value.
+func (s *DescribeRegionsInput) SetRegionNames(v []*string) *DescribeRegionsInput {
+	s.RegionNames = v
+	return s
+}
+
 // Contains the output of DescribeRegions.
 type DescribeRegionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -22539,6 +26001,12 @@ func (s DescribeRegionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRegionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetRegions sets the Regions field's value.
+func (s *DescribeRegionsOutput) SetRegions(v []*Region) *DescribeRegionsOutput {
+	s.Regions = v
+	return s
 }
 
 // Contains the parameters for DescribeReservedInstances.
@@ -22627,6 +26095,36 @@ func (s DescribeReservedInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeReservedInstancesInput) SetDryRun(v bool) *DescribeReservedInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeReservedInstancesInput) SetFilters(v []*Filter) *DescribeReservedInstancesInput {
+	s.Filters = v
+	return s
+}
+
+// SetOfferingClass sets the OfferingClass field's value.
+func (s *DescribeReservedInstancesInput) SetOfferingClass(v string) *DescribeReservedInstancesInput {
+	s.OfferingClass = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DescribeReservedInstancesInput) SetOfferingType(v string) *DescribeReservedInstancesInput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetReservedInstancesIds sets the ReservedInstancesIds field's value.
+func (s *DescribeReservedInstancesInput) SetReservedInstancesIds(v []*string) *DescribeReservedInstancesInput {
+	s.ReservedInstancesIds = v
+	return s
+}
+
 // Contains the parameters for DescribeReservedInstancesListings.
 type DescribeReservedInstancesListingsInput struct {
 	_ struct{} `type:"structure"`
@@ -22660,6 +26158,24 @@ func (s DescribeReservedInstancesListingsInput) GoString() string {
 	return s.String()
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeReservedInstancesListingsInput) SetFilters(v []*Filter) *DescribeReservedInstancesListingsInput {
+	s.Filters = v
+	return s
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *DescribeReservedInstancesListingsInput) SetReservedInstancesId(v string) *DescribeReservedInstancesListingsInput {
+	s.ReservedInstancesId = &v
+	return s
+}
+
+// SetReservedInstancesListingId sets the ReservedInstancesListingId field's value.
+func (s *DescribeReservedInstancesListingsInput) SetReservedInstancesListingId(v string) *DescribeReservedInstancesListingsInput {
+	s.ReservedInstancesListingId = &v
+	return s
+}
+
 // Contains the output of DescribeReservedInstancesListings.
 type DescribeReservedInstancesListingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -22676,6 +26192,12 @@ func (s DescribeReservedInstancesListingsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReservedInstancesListingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedInstancesListings sets the ReservedInstancesListings field's value.
+func (s *DescribeReservedInstancesListingsOutput) SetReservedInstancesListings(v []*ReservedInstancesListing) *DescribeReservedInstancesListingsOutput {
+	s.ReservedInstancesListings = v
+	return s
 }
 
 // Contains the parameters for DescribeReservedInstancesModifications.
@@ -22735,6 +26257,24 @@ func (s DescribeReservedInstancesModificationsInput) GoString() string {
 	return s.String()
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeReservedInstancesModificationsInput) SetFilters(v []*Filter) *DescribeReservedInstancesModificationsInput {
+	s.Filters = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeReservedInstancesModificationsInput) SetNextToken(v string) *DescribeReservedInstancesModificationsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservedInstancesModificationIds sets the ReservedInstancesModificationIds field's value.
+func (s *DescribeReservedInstancesModificationsInput) SetReservedInstancesModificationIds(v []*string) *DescribeReservedInstancesModificationsInput {
+	s.ReservedInstancesModificationIds = v
+	return s
+}
+
 // Contains the output of DescribeReservedInstancesModifications.
 type DescribeReservedInstancesModificationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -22755,6 +26295,18 @@ func (s DescribeReservedInstancesModificationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReservedInstancesModificationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeReservedInstancesModificationsOutput) SetNextToken(v string) *DescribeReservedInstancesModificationsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservedInstancesModifications sets the ReservedInstancesModifications field's value.
+func (s *DescribeReservedInstancesModificationsOutput) SetReservedInstancesModifications(v []*ReservedInstancesModification) *DescribeReservedInstancesModificationsOutput {
+	s.ReservedInstancesModifications = v
+	return s
 }
 
 // Contains the parameters for DescribeReservedInstancesOfferings.
@@ -22873,6 +26425,96 @@ func (s DescribeReservedInstancesOfferingsInput) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetAvailabilityZone(v string) *DescribeReservedInstancesOfferingsInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetDryRun(v bool) *DescribeReservedInstancesOfferingsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetFilters(v []*Filter) *DescribeReservedInstancesOfferingsInput {
+	s.Filters = v
+	return s
+}
+
+// SetIncludeMarketplace sets the IncludeMarketplace field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetIncludeMarketplace(v bool) *DescribeReservedInstancesOfferingsInput {
+	s.IncludeMarketplace = &v
+	return s
+}
+
+// SetInstanceTenancy sets the InstanceTenancy field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetInstanceTenancy(v string) *DescribeReservedInstancesOfferingsInput {
+	s.InstanceTenancy = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetInstanceType(v string) *DescribeReservedInstancesOfferingsInput {
+	s.InstanceType = &v
+	return s
+}
+
+// SetMaxDuration sets the MaxDuration field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetMaxDuration(v int64) *DescribeReservedInstancesOfferingsInput {
+	s.MaxDuration = &v
+	return s
+}
+
+// SetMaxInstanceCount sets the MaxInstanceCount field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetMaxInstanceCount(v int64) *DescribeReservedInstancesOfferingsInput {
+	s.MaxInstanceCount = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetMaxResults(v int64) *DescribeReservedInstancesOfferingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetMinDuration sets the MinDuration field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetMinDuration(v int64) *DescribeReservedInstancesOfferingsInput {
+	s.MinDuration = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetNextToken(v string) *DescribeReservedInstancesOfferingsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOfferingClass sets the OfferingClass field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetOfferingClass(v string) *DescribeReservedInstancesOfferingsInput {
+	s.OfferingClass = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetOfferingType(v string) *DescribeReservedInstancesOfferingsInput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetProductDescription(v string) *DescribeReservedInstancesOfferingsInput {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetReservedInstancesOfferingIds sets the ReservedInstancesOfferingIds field's value.
+func (s *DescribeReservedInstancesOfferingsInput) SetReservedInstancesOfferingIds(v []*string) *DescribeReservedInstancesOfferingsInput {
+	s.ReservedInstancesOfferingIds = v
+	return s
+}
+
 // Contains the output of DescribeReservedInstancesOfferings.
 type DescribeReservedInstancesOfferingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -22895,6 +26537,18 @@ func (s DescribeReservedInstancesOfferingsOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeReservedInstancesOfferingsOutput) SetNextToken(v string) *DescribeReservedInstancesOfferingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservedInstancesOfferings sets the ReservedInstancesOfferings field's value.
+func (s *DescribeReservedInstancesOfferingsOutput) SetReservedInstancesOfferings(v []*ReservedInstancesOffering) *DescribeReservedInstancesOfferingsOutput {
+	s.ReservedInstancesOfferings = v
+	return s
+}
+
 // Contains the output for DescribeReservedInstances.
 type DescribeReservedInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -22911,6 +26565,12 @@ func (s DescribeReservedInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReservedInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedInstances sets the ReservedInstances field's value.
+func (s *DescribeReservedInstancesOutput) SetReservedInstances(v []*ReservedInstances) *DescribeReservedInstancesOutput {
+	s.ReservedInstances = v
+	return s
 }
 
 // Contains the parameters for DescribeRouteTables.
@@ -22997,6 +26657,24 @@ func (s DescribeRouteTablesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeRouteTablesInput) SetDryRun(v bool) *DescribeRouteTablesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeRouteTablesInput) SetFilters(v []*Filter) *DescribeRouteTablesInput {
+	s.Filters = v
+	return s
+}
+
+// SetRouteTableIds sets the RouteTableIds field's value.
+func (s *DescribeRouteTablesInput) SetRouteTableIds(v []*string) *DescribeRouteTablesInput {
+	s.RouteTableIds = v
+	return s
+}
+
 // Contains the output of DescribeRouteTables.
 type DescribeRouteTablesOutput struct {
 	_ struct{} `type:"structure"`
@@ -23013,6 +26691,12 @@ func (s DescribeRouteTablesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRouteTablesOutput) GoString() string {
 	return s.String()
+}
+
+// SetRouteTables sets the RouteTables field's value.
+func (s *DescribeRouteTablesOutput) SetRouteTables(v []*RouteTable) *DescribeRouteTablesOutput {
+	s.RouteTables = v
+	return s
 }
 
 // Contains the parameters for DescribeScheduledInstanceAvailability.
@@ -23096,6 +26780,54 @@ func (s *DescribeScheduledInstanceAvailabilityInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeScheduledInstanceAvailabilityInput) SetDryRun(v bool) *DescribeScheduledInstanceAvailabilityInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeScheduledInstanceAvailabilityInput) SetFilters(v []*Filter) *DescribeScheduledInstanceAvailabilityInput {
+	s.Filters = v
+	return s
+}
+
+// SetFirstSlotStartTimeRange sets the FirstSlotStartTimeRange field's value.
+func (s *DescribeScheduledInstanceAvailabilityInput) SetFirstSlotStartTimeRange(v *SlotDateTimeRangeRequest) *DescribeScheduledInstanceAvailabilityInput {
+	s.FirstSlotStartTimeRange = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeScheduledInstanceAvailabilityInput) SetMaxResults(v int64) *DescribeScheduledInstanceAvailabilityInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetMaxSlotDurationInHours sets the MaxSlotDurationInHours field's value.
+func (s *DescribeScheduledInstanceAvailabilityInput) SetMaxSlotDurationInHours(v int64) *DescribeScheduledInstanceAvailabilityInput {
+	s.MaxSlotDurationInHours = &v
+	return s
+}
+
+// SetMinSlotDurationInHours sets the MinSlotDurationInHours field's value.
+func (s *DescribeScheduledInstanceAvailabilityInput) SetMinSlotDurationInHours(v int64) *DescribeScheduledInstanceAvailabilityInput {
+	s.MinSlotDurationInHours = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScheduledInstanceAvailabilityInput) SetNextToken(v string) *DescribeScheduledInstanceAvailabilityInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRecurrence sets the Recurrence field's value.
+func (s *DescribeScheduledInstanceAvailabilityInput) SetRecurrence(v *ScheduledInstanceRecurrenceRequest) *DescribeScheduledInstanceAvailabilityInput {
+	s.Recurrence = v
+	return s
+}
+
 // Contains the output of DescribeScheduledInstanceAvailability.
 type DescribeScheduledInstanceAvailabilityOutput struct {
 	_ struct{} `type:"structure"`
@@ -23116,6 +26848,18 @@ func (s DescribeScheduledInstanceAvailabilityOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScheduledInstanceAvailabilityOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScheduledInstanceAvailabilityOutput) SetNextToken(v string) *DescribeScheduledInstanceAvailabilityOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScheduledInstanceAvailabilitySet sets the ScheduledInstanceAvailabilitySet field's value.
+func (s *DescribeScheduledInstanceAvailabilityOutput) SetScheduledInstanceAvailabilitySet(v []*ScheduledInstanceAvailability) *DescribeScheduledInstanceAvailabilityOutput {
+	s.ScheduledInstanceAvailabilitySet = v
+	return s
 }
 
 // Contains the parameters for DescribeScheduledInstances.
@@ -23164,6 +26908,42 @@ func (s DescribeScheduledInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeScheduledInstancesInput) SetDryRun(v bool) *DescribeScheduledInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeScheduledInstancesInput) SetFilters(v []*Filter) *DescribeScheduledInstancesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeScheduledInstancesInput) SetMaxResults(v int64) *DescribeScheduledInstancesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScheduledInstancesInput) SetNextToken(v string) *DescribeScheduledInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScheduledInstanceIds sets the ScheduledInstanceIds field's value.
+func (s *DescribeScheduledInstancesInput) SetScheduledInstanceIds(v []*string) *DescribeScheduledInstancesInput {
+	s.ScheduledInstanceIds = v
+	return s
+}
+
+// SetSlotStartTimeRange sets the SlotStartTimeRange field's value.
+func (s *DescribeScheduledInstancesInput) SetSlotStartTimeRange(v *SlotStartTimeRangeRequest) *DescribeScheduledInstancesInput {
+	s.SlotStartTimeRange = v
+	return s
+}
+
 // Contains the output of DescribeScheduledInstances.
 type DescribeScheduledInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -23184,6 +26964,18 @@ func (s DescribeScheduledInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScheduledInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScheduledInstancesOutput) SetNextToken(v string) *DescribeScheduledInstancesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScheduledInstanceSet sets the ScheduledInstanceSet field's value.
+func (s *DescribeScheduledInstancesOutput) SetScheduledInstanceSet(v []*ScheduledInstance) *DescribeScheduledInstancesOutput {
+	s.ScheduledInstanceSet = v
+	return s
 }
 
 type DescribeSecurityGroupReferencesInput struct {
@@ -23224,6 +27016,18 @@ func (s *DescribeSecurityGroupReferencesInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSecurityGroupReferencesInput) SetDryRun(v bool) *DescribeSecurityGroupReferencesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *DescribeSecurityGroupReferencesInput) SetGroupId(v []*string) *DescribeSecurityGroupReferencesInput {
+	s.GroupId = v
+	return s
+}
+
 type DescribeSecurityGroupReferencesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -23239,6 +27043,12 @@ func (s DescribeSecurityGroupReferencesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSecurityGroupReferencesOutput) GoString() string {
 	return s.String()
+}
+
+// SetSecurityGroupReferenceSet sets the SecurityGroupReferenceSet field's value.
+func (s *DescribeSecurityGroupReferencesOutput) SetSecurityGroupReferenceSet(v []*SecurityGroupReference) *DescribeSecurityGroupReferencesOutput {
+	s.SecurityGroupReferenceSet = v
+	return s
 }
 
 // Contains the parameters for DescribeSecurityGroups.
@@ -23318,6 +27128,30 @@ func (s DescribeSecurityGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSecurityGroupsInput) SetDryRun(v bool) *DescribeSecurityGroupsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeSecurityGroupsInput) SetFilters(v []*Filter) *DescribeSecurityGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetGroupIds sets the GroupIds field's value.
+func (s *DescribeSecurityGroupsInput) SetGroupIds(v []*string) *DescribeSecurityGroupsInput {
+	s.GroupIds = v
+	return s
+}
+
+// SetGroupNames sets the GroupNames field's value.
+func (s *DescribeSecurityGroupsInput) SetGroupNames(v []*string) *DescribeSecurityGroupsInput {
+	s.GroupNames = v
+	return s
+}
+
 // Contains the output of DescribeSecurityGroups.
 type DescribeSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -23334,6 +27168,12 @@ func (s DescribeSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *DescribeSecurityGroupsOutput) SetSecurityGroups(v []*SecurityGroup) *DescribeSecurityGroupsOutput {
+	s.SecurityGroups = v
+	return s
 }
 
 // Contains the parameters for DescribeSnapshotAttribute.
@@ -23383,6 +27223,24 @@ func (s *DescribeSnapshotAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *DescribeSnapshotAttributeInput) SetAttribute(v string) *DescribeSnapshotAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSnapshotAttributeInput) SetDryRun(v bool) *DescribeSnapshotAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *DescribeSnapshotAttributeInput) SetSnapshotId(v string) *DescribeSnapshotAttributeInput {
+	s.SnapshotId = &v
+	return s
+}
+
 // Contains the output of DescribeSnapshotAttribute.
 type DescribeSnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -23405,6 +27263,24 @@ func (s DescribeSnapshotAttributeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSnapshotAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// SetCreateVolumePermissions sets the CreateVolumePermissions field's value.
+func (s *DescribeSnapshotAttributeOutput) SetCreateVolumePermissions(v []*CreateVolumePermission) *DescribeSnapshotAttributeOutput {
+	s.CreateVolumePermissions = v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *DescribeSnapshotAttributeOutput) SetProductCodes(v []*ProductCode) *DescribeSnapshotAttributeOutput {
+	s.ProductCodes = v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *DescribeSnapshotAttributeOutput) SetSnapshotId(v string) *DescribeSnapshotAttributeOutput {
+	s.SnapshotId = &v
+	return s
 }
 
 // Contains the parameters for DescribeSnapshots.
@@ -23495,6 +27371,48 @@ func (s DescribeSnapshotsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSnapshotsInput) SetDryRun(v bool) *DescribeSnapshotsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeSnapshotsInput) SetFilters(v []*Filter) *DescribeSnapshotsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeSnapshotsInput) SetMaxResults(v int64) *DescribeSnapshotsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSnapshotsInput) SetNextToken(v string) *DescribeSnapshotsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOwnerIds sets the OwnerIds field's value.
+func (s *DescribeSnapshotsInput) SetOwnerIds(v []*string) *DescribeSnapshotsInput {
+	s.OwnerIds = v
+	return s
+}
+
+// SetRestorableByUserIds sets the RestorableByUserIds field's value.
+func (s *DescribeSnapshotsInput) SetRestorableByUserIds(v []*string) *DescribeSnapshotsInput {
+	s.RestorableByUserIds = v
+	return s
+}
+
+// SetSnapshotIds sets the SnapshotIds field's value.
+func (s *DescribeSnapshotsInput) SetSnapshotIds(v []*string) *DescribeSnapshotsInput {
+	s.SnapshotIds = v
+	return s
+}
+
 // Contains the output of DescribeSnapshots.
 type DescribeSnapshotsOutput struct {
 	_ struct{} `type:"structure"`
@@ -23519,6 +27437,18 @@ func (s DescribeSnapshotsOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSnapshotsOutput) SetNextToken(v string) *DescribeSnapshotsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSnapshots sets the Snapshots field's value.
+func (s *DescribeSnapshotsOutput) SetSnapshots(v []*Snapshot) *DescribeSnapshotsOutput {
+	s.Snapshots = v
+	return s
+}
+
 // Contains the parameters for DescribeSpotDatafeedSubscription.
 type DescribeSpotDatafeedSubscriptionInput struct {
 	_ struct{} `type:"structure"`
@@ -23540,6 +27470,12 @@ func (s DescribeSpotDatafeedSubscriptionInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSpotDatafeedSubscriptionInput) SetDryRun(v bool) *DescribeSpotDatafeedSubscriptionInput {
+	s.DryRun = &v
+	return s
+}
+
 // Contains the output of DescribeSpotDatafeedSubscription.
 type DescribeSpotDatafeedSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -23556,6 +27492,12 @@ func (s DescribeSpotDatafeedSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSpotDatafeedSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetSpotDatafeedSubscription sets the SpotDatafeedSubscription field's value.
+func (s *DescribeSpotDatafeedSubscriptionOutput) SetSpotDatafeedSubscription(v *SpotDatafeedSubscription) *DescribeSpotDatafeedSubscriptionOutput {
+	s.SpotDatafeedSubscription = v
+	return s
 }
 
 // Contains the parameters for DescribeSpotFleetInstances.
@@ -23605,6 +27547,30 @@ func (s *DescribeSpotFleetInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSpotFleetInstancesInput) SetDryRun(v bool) *DescribeSpotFleetInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeSpotFleetInstancesInput) SetMaxResults(v int64) *DescribeSpotFleetInstancesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSpotFleetInstancesInput) SetNextToken(v string) *DescribeSpotFleetInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *DescribeSpotFleetInstancesInput) SetSpotFleetRequestId(v string) *DescribeSpotFleetInstancesInput {
+	s.SpotFleetRequestId = &v
+	return s
+}
+
 // Contains the output of DescribeSpotFleetInstances.
 type DescribeSpotFleetInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -23633,6 +27599,24 @@ func (s DescribeSpotFleetInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSpotFleetInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetActiveInstances sets the ActiveInstances field's value.
+func (s *DescribeSpotFleetInstancesOutput) SetActiveInstances(v []*ActiveInstance) *DescribeSpotFleetInstancesOutput {
+	s.ActiveInstances = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSpotFleetInstancesOutput) SetNextToken(v string) *DescribeSpotFleetInstancesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *DescribeSpotFleetInstancesOutput) SetSpotFleetRequestId(v string) *DescribeSpotFleetInstancesOutput {
+	s.SpotFleetRequestId = &v
+	return s
 }
 
 // Contains the parameters for DescribeSpotFleetRequestHistory.
@@ -23693,6 +27677,42 @@ func (s *DescribeSpotFleetRequestHistoryInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSpotFleetRequestHistoryInput) SetDryRun(v bool) *DescribeSpotFleetRequestHistoryInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEventType sets the EventType field's value.
+func (s *DescribeSpotFleetRequestHistoryInput) SetEventType(v string) *DescribeSpotFleetRequestHistoryInput {
+	s.EventType = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeSpotFleetRequestHistoryInput) SetMaxResults(v int64) *DescribeSpotFleetRequestHistoryInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSpotFleetRequestHistoryInput) SetNextToken(v string) *DescribeSpotFleetRequestHistoryInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *DescribeSpotFleetRequestHistoryInput) SetSpotFleetRequestId(v string) *DescribeSpotFleetRequestHistoryInput {
+	s.SpotFleetRequestId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeSpotFleetRequestHistoryInput) SetStartTime(v time.Time) *DescribeSpotFleetRequestHistoryInput {
+	s.StartTime = &v
+	return s
+}
+
 // Contains the output of DescribeSpotFleetRequestHistory.
 type DescribeSpotFleetRequestHistoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -23735,6 +27755,36 @@ func (s DescribeSpotFleetRequestHistoryOutput) GoString() string {
 	return s.String()
 }
 
+// SetHistoryRecords sets the HistoryRecords field's value.
+func (s *DescribeSpotFleetRequestHistoryOutput) SetHistoryRecords(v []*HistoryRecord) *DescribeSpotFleetRequestHistoryOutput {
+	s.HistoryRecords = v
+	return s
+}
+
+// SetLastEvaluatedTime sets the LastEvaluatedTime field's value.
+func (s *DescribeSpotFleetRequestHistoryOutput) SetLastEvaluatedTime(v time.Time) *DescribeSpotFleetRequestHistoryOutput {
+	s.LastEvaluatedTime = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSpotFleetRequestHistoryOutput) SetNextToken(v string) *DescribeSpotFleetRequestHistoryOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *DescribeSpotFleetRequestHistoryOutput) SetSpotFleetRequestId(v string) *DescribeSpotFleetRequestHistoryOutput {
+	s.SpotFleetRequestId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeSpotFleetRequestHistoryOutput) SetStartTime(v time.Time) *DescribeSpotFleetRequestHistoryOutput {
+	s.StartTime = &v
+	return s
+}
+
 // Contains the parameters for DescribeSpotFleetRequests.
 type DescribeSpotFleetRequestsInput struct {
 	_ struct{} `type:"structure"`
@@ -23767,6 +27817,30 @@ func (s DescribeSpotFleetRequestsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSpotFleetRequestsInput) SetDryRun(v bool) *DescribeSpotFleetRequestsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeSpotFleetRequestsInput) SetMaxResults(v int64) *DescribeSpotFleetRequestsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSpotFleetRequestsInput) SetNextToken(v string) *DescribeSpotFleetRequestsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSpotFleetRequestIds sets the SpotFleetRequestIds field's value.
+func (s *DescribeSpotFleetRequestsInput) SetSpotFleetRequestIds(v []*string) *DescribeSpotFleetRequestsInput {
+	s.SpotFleetRequestIds = v
+	return s
+}
+
 // Contains the output of DescribeSpotFleetRequests.
 type DescribeSpotFleetRequestsOutput struct {
 	_ struct{} `type:"structure"`
@@ -23789,6 +27863,18 @@ func (s DescribeSpotFleetRequestsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSpotFleetRequestsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSpotFleetRequestsOutput) SetNextToken(v string) *DescribeSpotFleetRequestsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSpotFleetRequestConfigs sets the SpotFleetRequestConfigs field's value.
+func (s *DescribeSpotFleetRequestsOutput) SetSpotFleetRequestConfigs(v []*SpotFleetRequestConfig) *DescribeSpotFleetRequestsOutput {
+	s.SpotFleetRequestConfigs = v
+	return s
 }
 
 // Contains the parameters for DescribeSpotInstanceRequests.
@@ -23927,6 +28013,24 @@ func (s DescribeSpotInstanceRequestsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSpotInstanceRequestsInput) SetDryRun(v bool) *DescribeSpotInstanceRequestsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeSpotInstanceRequestsInput) SetFilters(v []*Filter) *DescribeSpotInstanceRequestsInput {
+	s.Filters = v
+	return s
+}
+
+// SetSpotInstanceRequestIds sets the SpotInstanceRequestIds field's value.
+func (s *DescribeSpotInstanceRequestsInput) SetSpotInstanceRequestIds(v []*string) *DescribeSpotInstanceRequestsInput {
+	s.SpotInstanceRequestIds = v
+	return s
+}
+
 // Contains the output of DescribeSpotInstanceRequests.
 type DescribeSpotInstanceRequestsOutput struct {
 	_ struct{} `type:"structure"`
@@ -23943,6 +28047,12 @@ func (s DescribeSpotInstanceRequestsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSpotInstanceRequestsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSpotInstanceRequests sets the SpotInstanceRequests field's value.
+func (s *DescribeSpotInstanceRequestsOutput) SetSpotInstanceRequests(v []*SpotInstanceRequest) *DescribeSpotInstanceRequestsOutput {
+	s.SpotInstanceRequests = v
+	return s
 }
 
 // Contains the parameters for DescribeSpotPriceHistory.
@@ -24010,6 +28120,60 @@ func (s DescribeSpotPriceHistoryInput) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *DescribeSpotPriceHistoryInput) SetAvailabilityZone(v string) *DescribeSpotPriceHistoryInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSpotPriceHistoryInput) SetDryRun(v bool) *DescribeSpotPriceHistoryInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeSpotPriceHistoryInput) SetEndTime(v time.Time) *DescribeSpotPriceHistoryInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeSpotPriceHistoryInput) SetFilters(v []*Filter) *DescribeSpotPriceHistoryInput {
+	s.Filters = v
+	return s
+}
+
+// SetInstanceTypes sets the InstanceTypes field's value.
+func (s *DescribeSpotPriceHistoryInput) SetInstanceTypes(v []*string) *DescribeSpotPriceHistoryInput {
+	s.InstanceTypes = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeSpotPriceHistoryInput) SetMaxResults(v int64) *DescribeSpotPriceHistoryInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSpotPriceHistoryInput) SetNextToken(v string) *DescribeSpotPriceHistoryInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetProductDescriptions sets the ProductDescriptions field's value.
+func (s *DescribeSpotPriceHistoryInput) SetProductDescriptions(v []*string) *DescribeSpotPriceHistoryInput {
+	s.ProductDescriptions = v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeSpotPriceHistoryInput) SetStartTime(v time.Time) *DescribeSpotPriceHistoryInput {
+	s.StartTime = &v
+	return s
+}
+
 // Contains the output of DescribeSpotPriceHistory.
 type DescribeSpotPriceHistoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -24030,6 +28194,18 @@ func (s DescribeSpotPriceHistoryOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSpotPriceHistoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSpotPriceHistoryOutput) SetNextToken(v string) *DescribeSpotPriceHistoryOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSpotPriceHistory sets the SpotPriceHistory field's value.
+func (s *DescribeSpotPriceHistoryOutput) SetSpotPriceHistory(v []*SpotPrice) *DescribeSpotPriceHistoryOutput {
+	s.SpotPriceHistory = v
+	return s
 }
 
 type DescribeStaleSecurityGroupsInput struct {
@@ -24085,6 +28261,30 @@ func (s *DescribeStaleSecurityGroupsInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeStaleSecurityGroupsInput) SetDryRun(v bool) *DescribeStaleSecurityGroupsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeStaleSecurityGroupsInput) SetMaxResults(v int64) *DescribeStaleSecurityGroupsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeStaleSecurityGroupsInput) SetNextToken(v string) *DescribeStaleSecurityGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DescribeStaleSecurityGroupsInput) SetVpcId(v string) *DescribeStaleSecurityGroupsInput {
+	s.VpcId = &v
+	return s
+}
+
 type DescribeStaleSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -24104,6 +28304,18 @@ func (s DescribeStaleSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStaleSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeStaleSecurityGroupsOutput) SetNextToken(v string) *DescribeStaleSecurityGroupsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStaleSecurityGroupSet sets the StaleSecurityGroupSet field's value.
+func (s *DescribeStaleSecurityGroupsOutput) SetStaleSecurityGroupSet(v []*StaleSecurityGroup) *DescribeStaleSecurityGroupsOutput {
+	s.StaleSecurityGroupSet = v
+	return s
 }
 
 // Contains the parameters for DescribeSubnets.
@@ -24167,6 +28379,24 @@ func (s DescribeSubnetsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeSubnetsInput) SetDryRun(v bool) *DescribeSubnetsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeSubnetsInput) SetFilters(v []*Filter) *DescribeSubnetsInput {
+	s.Filters = v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *DescribeSubnetsInput) SetSubnetIds(v []*string) *DescribeSubnetsInput {
+	s.SubnetIds = v
+	return s
+}
+
 // Contains the output of DescribeSubnets.
 type DescribeSubnetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -24183,6 +28413,12 @@ func (s DescribeSubnetsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSubnetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *DescribeSubnetsOutput) SetSubnets(v []*Subnet) *DescribeSubnetsOutput {
+	s.Subnets = v
+	return s
 }
 
 // Contains the parameters for DescribeTags.
@@ -24228,6 +28464,30 @@ func (s DescribeTagsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeTagsInput) SetDryRun(v bool) *DescribeTagsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeTagsInput) SetFilters(v []*Filter) *DescribeTagsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeTagsInput) SetMaxResults(v int64) *DescribeTagsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTagsInput) SetNextToken(v string) *DescribeTagsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeTags.
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -24248,6 +28508,18 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeTagsOutput) SetNextToken(v string) *DescribeTagsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DescribeTagsOutput) SetTags(v []*TagDescription) *DescribeTagsOutput {
+	s.Tags = v
+	return s
 }
 
 // Contains the parameters for DescribeVolumeAttribute.
@@ -24292,6 +28564,24 @@ func (s *DescribeVolumeAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *DescribeVolumeAttributeInput) SetAttribute(v string) *DescribeVolumeAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVolumeAttributeInput) SetDryRun(v bool) *DescribeVolumeAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *DescribeVolumeAttributeInput) SetVolumeId(v string) *DescribeVolumeAttributeInput {
+	s.VolumeId = &v
+	return s
+}
+
 // Contains the output of DescribeVolumeAttribute.
 type DescribeVolumeAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -24314,6 +28604,24 @@ func (s DescribeVolumeAttributeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVolumeAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAutoEnableIO sets the AutoEnableIO field's value.
+func (s *DescribeVolumeAttributeOutput) SetAutoEnableIO(v *AttributeBooleanValue) *DescribeVolumeAttributeOutput {
+	s.AutoEnableIO = v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *DescribeVolumeAttributeOutput) SetProductCodes(v []*ProductCode) *DescribeVolumeAttributeOutput {
+	s.ProductCodes = v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *DescribeVolumeAttributeOutput) SetVolumeId(v string) *DescribeVolumeAttributeOutput {
+	s.VolumeId = &v
+	return s
 }
 
 // Contains the parameters for DescribeVolumeStatus.
@@ -24391,6 +28699,36 @@ func (s DescribeVolumeStatusInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVolumeStatusInput) SetDryRun(v bool) *DescribeVolumeStatusInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeVolumeStatusInput) SetFilters(v []*Filter) *DescribeVolumeStatusInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeVolumeStatusInput) SetMaxResults(v int64) *DescribeVolumeStatusInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVolumeStatusInput) SetNextToken(v string) *DescribeVolumeStatusInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVolumeIds sets the VolumeIds field's value.
+func (s *DescribeVolumeStatusInput) SetVolumeIds(v []*string) *DescribeVolumeStatusInput {
+	s.VolumeIds = v
+	return s
+}
+
 // Contains the output of DescribeVolumeStatus.
 type DescribeVolumeStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -24411,6 +28749,18 @@ func (s DescribeVolumeStatusOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVolumeStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVolumeStatusOutput) SetNextToken(v string) *DescribeVolumeStatusOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVolumeStatuses sets the VolumeStatuses field's value.
+func (s *DescribeVolumeStatusOutput) SetVolumeStatuses(v []*VolumeStatusItem) *DescribeVolumeStatusOutput {
+	s.VolumeStatuses = v
+	return s
 }
 
 // Contains the parameters for DescribeVolumes.
@@ -24503,6 +28853,36 @@ func (s DescribeVolumesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVolumesInput) SetDryRun(v bool) *DescribeVolumesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeVolumesInput) SetFilters(v []*Filter) *DescribeVolumesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeVolumesInput) SetMaxResults(v int64) *DescribeVolumesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVolumesInput) SetNextToken(v string) *DescribeVolumesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVolumeIds sets the VolumeIds field's value.
+func (s *DescribeVolumesInput) SetVolumeIds(v []*string) *DescribeVolumesInput {
+	s.VolumeIds = v
+	return s
+}
+
 // Contains the output of DescribeVolumes.
 type DescribeVolumesOutput struct {
 	_ struct{} `type:"structure"`
@@ -24525,6 +28905,18 @@ func (s DescribeVolumesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVolumesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVolumesOutput) SetNextToken(v string) *DescribeVolumesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVolumes sets the Volumes field's value.
+func (s *DescribeVolumesOutput) SetVolumes(v []*Volume) *DescribeVolumesOutput {
+	s.Volumes = v
+	return s
 }
 
 // Contains the parameters for DescribeVpcAttribute.
@@ -24574,6 +28966,24 @@ func (s *DescribeVpcAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *DescribeVpcAttributeInput) SetAttribute(v string) *DescribeVpcAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVpcAttributeInput) SetDryRun(v bool) *DescribeVpcAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DescribeVpcAttributeInput) SetVpcId(v string) *DescribeVpcAttributeInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of DescribeVpcAttribute.
 type DescribeVpcAttributeOutput struct {
 	_ struct{} `type:"structure"`
@@ -24600,6 +29010,24 @@ func (s DescribeVpcAttributeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpcAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// SetEnableDnsHostnames sets the EnableDnsHostnames field's value.
+func (s *DescribeVpcAttributeOutput) SetEnableDnsHostnames(v *AttributeBooleanValue) *DescribeVpcAttributeOutput {
+	s.EnableDnsHostnames = v
+	return s
+}
+
+// SetEnableDnsSupport sets the EnableDnsSupport field's value.
+func (s *DescribeVpcAttributeOutput) SetEnableDnsSupport(v *AttributeBooleanValue) *DescribeVpcAttributeOutput {
+	s.EnableDnsSupport = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DescribeVpcAttributeOutput) SetVpcId(v string) *DescribeVpcAttributeOutput {
+	s.VpcId = &v
+	return s
 }
 
 // Contains the parameters for DescribeVpcClassicLinkDnsSupport.
@@ -24645,6 +29073,24 @@ func (s *DescribeVpcClassicLinkDnsSupportInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeVpcClassicLinkDnsSupportInput) SetMaxResults(v int64) *DescribeVpcClassicLinkDnsSupportInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVpcClassicLinkDnsSupportInput) SetNextToken(v string) *DescribeVpcClassicLinkDnsSupportInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVpcIds sets the VpcIds field's value.
+func (s *DescribeVpcClassicLinkDnsSupportInput) SetVpcIds(v []*string) *DescribeVpcClassicLinkDnsSupportInput {
+	s.VpcIds = v
+	return s
+}
+
 // Contains the output of DescribeVpcClassicLinkDnsSupport.
 type DescribeVpcClassicLinkDnsSupportOutput struct {
 	_ struct{} `type:"structure"`
@@ -24664,6 +29110,18 @@ func (s DescribeVpcClassicLinkDnsSupportOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpcClassicLinkDnsSupportOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVpcClassicLinkDnsSupportOutput) SetNextToken(v string) *DescribeVpcClassicLinkDnsSupportOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVpcs sets the Vpcs field's value.
+func (s *DescribeVpcClassicLinkDnsSupportOutput) SetVpcs(v []*ClassicLinkDnsSupport) *DescribeVpcClassicLinkDnsSupportOutput {
+	s.Vpcs = v
+	return s
 }
 
 // Contains the parameters for DescribeVpcClassicLink.
@@ -24709,6 +29167,24 @@ func (s DescribeVpcClassicLinkInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVpcClassicLinkInput) SetDryRun(v bool) *DescribeVpcClassicLinkInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeVpcClassicLinkInput) SetFilters(v []*Filter) *DescribeVpcClassicLinkInput {
+	s.Filters = v
+	return s
+}
+
+// SetVpcIds sets the VpcIds field's value.
+func (s *DescribeVpcClassicLinkInput) SetVpcIds(v []*string) *DescribeVpcClassicLinkInput {
+	s.VpcIds = v
+	return s
+}
+
 // Contains the output of DescribeVpcClassicLink.
 type DescribeVpcClassicLinkOutput struct {
 	_ struct{} `type:"structure"`
@@ -24725,6 +29201,12 @@ func (s DescribeVpcClassicLinkOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpcClassicLinkOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpcs sets the Vpcs field's value.
+func (s *DescribeVpcClassicLinkOutput) SetVpcs(v []*VpcClassicLink) *DescribeVpcClassicLinkOutput {
+	s.Vpcs = v
+	return s
 }
 
 // Contains the parameters for DescribeVpcEndpointServices.
@@ -24759,6 +29241,24 @@ func (s DescribeVpcEndpointServicesInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVpcEndpointServicesInput) SetDryRun(v bool) *DescribeVpcEndpointServicesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeVpcEndpointServicesInput) SetMaxResults(v int64) *DescribeVpcEndpointServicesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVpcEndpointServicesInput) SetNextToken(v string) *DescribeVpcEndpointServicesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeVpcEndpointServices.
 type DescribeVpcEndpointServicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -24779,6 +29279,18 @@ func (s DescribeVpcEndpointServicesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpcEndpointServicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVpcEndpointServicesOutput) SetNextToken(v string) *DescribeVpcEndpointServicesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetServiceNames sets the ServiceNames field's value.
+func (s *DescribeVpcEndpointServicesOutput) SetServiceNames(v []*string) *DescribeVpcEndpointServicesOutput {
+	s.ServiceNames = v
+	return s
 }
 
 // Contains the parameters for DescribeVpcEndpoints.
@@ -24828,6 +29340,36 @@ func (s DescribeVpcEndpointsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVpcEndpointsInput) SetDryRun(v bool) *DescribeVpcEndpointsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeVpcEndpointsInput) SetFilters(v []*Filter) *DescribeVpcEndpointsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeVpcEndpointsInput) SetMaxResults(v int64) *DescribeVpcEndpointsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVpcEndpointsInput) SetNextToken(v string) *DescribeVpcEndpointsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVpcEndpointIds sets the VpcEndpointIds field's value.
+func (s *DescribeVpcEndpointsInput) SetVpcEndpointIds(v []*string) *DescribeVpcEndpointsInput {
+	s.VpcEndpointIds = v
+	return s
+}
+
 // Contains the output of DescribeVpcEndpoints.
 type DescribeVpcEndpointsOutput struct {
 	_ struct{} `type:"structure"`
@@ -24848,6 +29390,18 @@ func (s DescribeVpcEndpointsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpcEndpointsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeVpcEndpointsOutput) SetNextToken(v string) *DescribeVpcEndpointsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVpcEndpoints sets the VpcEndpoints field's value.
+func (s *DescribeVpcEndpointsOutput) SetVpcEndpoints(v []*VpcEndpoint) *DescribeVpcEndpointsOutput {
+	s.VpcEndpoints = v
+	return s
 }
 
 // Contains the parameters for DescribeVpcPeeringConnections.
@@ -24916,6 +29470,24 @@ func (s DescribeVpcPeeringConnectionsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVpcPeeringConnectionsInput) SetDryRun(v bool) *DescribeVpcPeeringConnectionsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeVpcPeeringConnectionsInput) SetFilters(v []*Filter) *DescribeVpcPeeringConnectionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetVpcPeeringConnectionIds sets the VpcPeeringConnectionIds field's value.
+func (s *DescribeVpcPeeringConnectionsInput) SetVpcPeeringConnectionIds(v []*string) *DescribeVpcPeeringConnectionsInput {
+	s.VpcPeeringConnectionIds = v
+	return s
+}
+
 // Contains the output of DescribeVpcPeeringConnections.
 type DescribeVpcPeeringConnectionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -24932,6 +29504,12 @@ func (s DescribeVpcPeeringConnectionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpcPeeringConnectionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpcPeeringConnections sets the VpcPeeringConnections field's value.
+func (s *DescribeVpcPeeringConnectionsOutput) SetVpcPeeringConnections(v []*VpcPeeringConnection) *DescribeVpcPeeringConnectionsOutput {
+	s.VpcPeeringConnections = v
+	return s
 }
 
 // Contains the parameters for DescribeVpcs.
@@ -24988,6 +29566,24 @@ func (s DescribeVpcsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVpcsInput) SetDryRun(v bool) *DescribeVpcsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeVpcsInput) SetFilters(v []*Filter) *DescribeVpcsInput {
+	s.Filters = v
+	return s
+}
+
+// SetVpcIds sets the VpcIds field's value.
+func (s *DescribeVpcsInput) SetVpcIds(v []*string) *DescribeVpcsInput {
+	s.VpcIds = v
+	return s
+}
+
 // Contains the output of DescribeVpcs.
 type DescribeVpcsOutput struct {
 	_ struct{} `type:"structure"`
@@ -25004,6 +29600,12 @@ func (s DescribeVpcsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpcsOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpcs sets the Vpcs field's value.
+func (s *DescribeVpcsOutput) SetVpcs(v []*Vpc) *DescribeVpcsOutput {
+	s.Vpcs = v
+	return s
 }
 
 // Contains the parameters for DescribeVpnConnections.
@@ -25075,6 +29677,24 @@ func (s DescribeVpnConnectionsInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVpnConnectionsInput) SetDryRun(v bool) *DescribeVpnConnectionsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeVpnConnectionsInput) SetFilters(v []*Filter) *DescribeVpnConnectionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetVpnConnectionIds sets the VpnConnectionIds field's value.
+func (s *DescribeVpnConnectionsInput) SetVpnConnectionIds(v []*string) *DescribeVpnConnectionsInput {
+	s.VpnConnectionIds = v
+	return s
+}
+
 // Contains the output of DescribeVpnConnections.
 type DescribeVpnConnectionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -25091,6 +29711,12 @@ func (s DescribeVpnConnectionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpnConnectionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpnConnections sets the VpnConnections field's value.
+func (s *DescribeVpnConnectionsOutput) SetVpnConnections(v []*VpnConnection) *DescribeVpnConnectionsOutput {
+	s.VpnConnections = v
+	return s
 }
 
 // Contains the parameters for DescribeVpnGateways.
@@ -25151,6 +29777,24 @@ func (s DescribeVpnGatewaysInput) GoString() string {
 	return s.String()
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeVpnGatewaysInput) SetDryRun(v bool) *DescribeVpnGatewaysInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeVpnGatewaysInput) SetFilters(v []*Filter) *DescribeVpnGatewaysInput {
+	s.Filters = v
+	return s
+}
+
+// SetVpnGatewayIds sets the VpnGatewayIds field's value.
+func (s *DescribeVpnGatewaysInput) SetVpnGatewayIds(v []*string) *DescribeVpnGatewaysInput {
+	s.VpnGatewayIds = v
+	return s
+}
+
 // Contains the output of DescribeVpnGateways.
 type DescribeVpnGatewaysOutput struct {
 	_ struct{} `type:"structure"`
@@ -25167,6 +29811,12 @@ func (s DescribeVpnGatewaysOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVpnGatewaysOutput) GoString() string {
 	return s.String()
+}
+
+// SetVpnGateways sets the VpnGateways field's value.
+func (s *DescribeVpnGatewaysOutput) SetVpnGateways(v []*VpnGateway) *DescribeVpnGatewaysOutput {
+	s.VpnGateways = v
+	return s
 }
 
 // Contains the parameters for DetachClassicLinkVpc.
@@ -25216,6 +29866,24 @@ func (s *DetachClassicLinkVpcInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DetachClassicLinkVpcInput) SetDryRun(v bool) *DetachClassicLinkVpcInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *DetachClassicLinkVpcInput) SetInstanceId(v string) *DetachClassicLinkVpcInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DetachClassicLinkVpcInput) SetVpcId(v string) *DetachClassicLinkVpcInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of DetachClassicLinkVpc.
 type DetachClassicLinkVpcOutput struct {
 	_ struct{} `type:"structure"`
@@ -25232,6 +29900,12 @@ func (s DetachClassicLinkVpcOutput) String() string {
 // GoString returns the string representation
 func (s DetachClassicLinkVpcOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *DetachClassicLinkVpcOutput) SetReturn(v bool) *DetachClassicLinkVpcOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for DetachInternetGateway.
@@ -25279,6 +29953,24 @@ func (s *DetachInternetGatewayInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DetachInternetGatewayInput) SetDryRun(v bool) *DetachInternetGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInternetGatewayId sets the InternetGatewayId field's value.
+func (s *DetachInternetGatewayInput) SetInternetGatewayId(v string) *DetachInternetGatewayInput {
+	s.InternetGatewayId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DetachInternetGatewayInput) SetVpcId(v string) *DetachInternetGatewayInput {
+	s.VpcId = &v
+	return s
 }
 
 type DetachInternetGatewayOutput struct {
@@ -25335,6 +30027,24 @@ func (s *DetachNetworkInterfaceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttachmentId sets the AttachmentId field's value.
+func (s *DetachNetworkInterfaceInput) SetAttachmentId(v string) *DetachNetworkInterfaceInput {
+	s.AttachmentId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DetachNetworkInterfaceInput) SetDryRun(v bool) *DetachNetworkInterfaceInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetForce sets the Force field's value.
+func (s *DetachNetworkInterfaceInput) SetForce(v bool) *DetachNetworkInterfaceInput {
+	s.Force = &v
+	return s
 }
 
 type DetachNetworkInterfaceOutput struct {
@@ -25405,6 +30115,36 @@ func (s *DetachVolumeInput) Validate() error {
 	return nil
 }
 
+// SetDevice sets the Device field's value.
+func (s *DetachVolumeInput) SetDevice(v string) *DetachVolumeInput {
+	s.Device = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DetachVolumeInput) SetDryRun(v bool) *DetachVolumeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetForce sets the Force field's value.
+func (s *DetachVolumeInput) SetForce(v bool) *DetachVolumeInput {
+	s.Force = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *DetachVolumeInput) SetInstanceId(v string) *DetachVolumeInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *DetachVolumeInput) SetVolumeId(v string) *DetachVolumeInput {
+	s.VolumeId = &v
+	return s
+}
+
 // Contains the parameters for DetachVpnGateway.
 type DetachVpnGatewayInput struct {
 	_ struct{} `type:"structure"`
@@ -25452,6 +30192,24 @@ func (s *DetachVpnGatewayInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DetachVpnGatewayInput) SetDryRun(v bool) *DetachVpnGatewayInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DetachVpnGatewayInput) SetVpcId(v string) *DetachVpnGatewayInput {
+	s.VpcId = &v
+	return s
+}
+
+// SetVpnGatewayId sets the VpnGatewayId field's value.
+func (s *DetachVpnGatewayInput) SetVpnGatewayId(v string) *DetachVpnGatewayInput {
+	s.VpnGatewayId = &v
+	return s
+}
+
 type DetachVpnGatewayOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -25487,6 +30245,18 @@ func (s DhcpConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *DhcpConfiguration) SetKey(v string) *DhcpConfiguration {
+	s.Key = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *DhcpConfiguration) SetValues(v []*AttributeValue) *DhcpConfiguration {
+	s.Values = v
+	return s
+}
+
 // Describes a set of DHCP options.
 type DhcpOptions struct {
 	_ struct{} `type:"structure"`
@@ -25509,6 +30279,24 @@ func (s DhcpOptions) String() string {
 // GoString returns the string representation
 func (s DhcpOptions) GoString() string {
 	return s.String()
+}
+
+// SetDhcpConfigurations sets the DhcpConfigurations field's value.
+func (s *DhcpOptions) SetDhcpConfigurations(v []*DhcpConfiguration) *DhcpOptions {
+	s.DhcpConfigurations = v
+	return s
+}
+
+// SetDhcpOptionsId sets the DhcpOptionsId field's value.
+func (s *DhcpOptions) SetDhcpOptionsId(v string) *DhcpOptions {
+	s.DhcpOptionsId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DhcpOptions) SetTags(v []*Tag) *DhcpOptions {
+	s.Tags = v
+	return s
 }
 
 // Contains the parameters for DisableVgwRoutePropagation.
@@ -25552,6 +30340,18 @@ func (s *DisableVgwRoutePropagationInput) Validate() error {
 	return nil
 }
 
+// SetGatewayId sets the GatewayId field's value.
+func (s *DisableVgwRoutePropagationInput) SetGatewayId(v string) *DisableVgwRoutePropagationInput {
+	s.GatewayId = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *DisableVgwRoutePropagationInput) SetRouteTableId(v string) *DisableVgwRoutePropagationInput {
+	s.RouteTableId = &v
+	return s
+}
+
 type DisableVgwRoutePropagationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -25584,6 +30384,12 @@ func (s DisableVpcClassicLinkDnsSupportInput) GoString() string {
 	return s.String()
 }
 
+// SetVpcId sets the VpcId field's value.
+func (s *DisableVpcClassicLinkDnsSupportInput) SetVpcId(v string) *DisableVpcClassicLinkDnsSupportInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of DisableVpcClassicLinkDnsSupport.
 type DisableVpcClassicLinkDnsSupportOutput struct {
 	_ struct{} `type:"structure"`
@@ -25600,6 +30406,12 @@ func (s DisableVpcClassicLinkDnsSupportOutput) String() string {
 // GoString returns the string representation
 func (s DisableVpcClassicLinkDnsSupportOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *DisableVpcClassicLinkDnsSupportOutput) SetReturn(v bool) *DisableVpcClassicLinkDnsSupportOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for DisableVpcClassicLink.
@@ -25641,6 +30453,18 @@ func (s *DisableVpcClassicLinkInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *DisableVpcClassicLinkInput) SetDryRun(v bool) *DisableVpcClassicLinkInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DisableVpcClassicLinkInput) SetVpcId(v string) *DisableVpcClassicLinkInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of DisableVpcClassicLink.
 type DisableVpcClassicLinkOutput struct {
 	_ struct{} `type:"structure"`
@@ -25657,6 +30481,12 @@ func (s DisableVpcClassicLinkOutput) String() string {
 // GoString returns the string representation
 func (s DisableVpcClassicLinkOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *DisableVpcClassicLinkOutput) SetReturn(v bool) *DisableVpcClassicLinkOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for DisassociateAddress.
@@ -25684,6 +30514,24 @@ func (s DisassociateAddressInput) String() string {
 // GoString returns the string representation
 func (s DisassociateAddressInput) GoString() string {
 	return s.String()
+}
+
+// SetAssociationId sets the AssociationId field's value.
+func (s *DisassociateAddressInput) SetAssociationId(v string) *DisassociateAddressInput {
+	s.AssociationId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DisassociateAddressInput) SetDryRun(v bool) *DisassociateAddressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *DisassociateAddressInput) SetPublicIp(v string) *DisassociateAddressInput {
+	s.PublicIp = &v
+	return s
 }
 
 type DisassociateAddressOutput struct {
@@ -25738,6 +30586,18 @@ func (s *DisassociateRouteTableInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAssociationId sets the AssociationId field's value.
+func (s *DisassociateRouteTableInput) SetAssociationId(v string) *DisassociateRouteTableInput {
+	s.AssociationId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DisassociateRouteTableInput) SetDryRun(v bool) *DisassociateRouteTableInput {
+	s.DryRun = &v
+	return s
 }
 
 type DisassociateRouteTableOutput struct {
@@ -25798,6 +30658,24 @@ func (s *DiskImage) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *DiskImage) SetDescription(v string) *DiskImage {
+	s.Description = &v
+	return s
+}
+
+// SetImage sets the Image field's value.
+func (s *DiskImage) SetImage(v *DiskImageDetail) *DiskImage {
+	s.Image = v
+	return s
+}
+
+// SetVolume sets the Volume field's value.
+func (s *DiskImage) SetVolume(v *VolumeDetail) *DiskImage {
+	s.Volume = v
+	return s
+}
+
 // Describes a disk image.
 type DiskImageDescription struct {
 	_ struct{} `type:"structure"`
@@ -25836,6 +30714,30 @@ func (s DiskImageDescription) String() string {
 // GoString returns the string representation
 func (s DiskImageDescription) GoString() string {
 	return s.String()
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *DiskImageDescription) SetChecksum(v string) *DiskImageDescription {
+	s.Checksum = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *DiskImageDescription) SetFormat(v string) *DiskImageDescription {
+	s.Format = &v
+	return s
+}
+
+// SetImportManifestUrl sets the ImportManifestUrl field's value.
+func (s *DiskImageDescription) SetImportManifestUrl(v string) *DiskImageDescription {
+	s.ImportManifestUrl = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *DiskImageDescription) SetSize(v int64) *DiskImageDescription {
+	s.Size = &v
+	return s
 }
 
 // Describes a disk image.
@@ -25894,6 +30796,24 @@ func (s *DiskImageDetail) Validate() error {
 	return nil
 }
 
+// SetBytes sets the Bytes field's value.
+func (s *DiskImageDetail) SetBytes(v int64) *DiskImageDetail {
+	s.Bytes = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *DiskImageDetail) SetFormat(v string) *DiskImageDetail {
+	s.Format = &v
+	return s
+}
+
+// SetImportManifestUrl sets the ImportManifestUrl field's value.
+func (s *DiskImageDetail) SetImportManifestUrl(v string) *DiskImageDetail {
+	s.ImportManifestUrl = &v
+	return s
+}
+
 // Describes a disk image volume.
 type DiskImageVolumeDescription struct {
 	_ struct{} `type:"structure"`
@@ -25915,6 +30835,18 @@ func (s DiskImageVolumeDescription) String() string {
 // GoString returns the string representation
 func (s DiskImageVolumeDescription) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *DiskImageVolumeDescription) SetId(v string) *DiskImageVolumeDescription {
+	s.Id = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *DiskImageVolumeDescription) SetSize(v int64) *DiskImageVolumeDescription {
+	s.Size = &v
+	return s
 }
 
 // Describes a block device for an EBS volume.
@@ -25974,6 +30906,42 @@ func (s EbsBlockDevice) GoString() string {
 	return s.String()
 }
 
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *EbsBlockDevice) SetDeleteOnTermination(v bool) *EbsBlockDevice {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *EbsBlockDevice) SetEncrypted(v bool) *EbsBlockDevice {
+	s.Encrypted = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *EbsBlockDevice) SetIops(v int64) *EbsBlockDevice {
+	s.Iops = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *EbsBlockDevice) SetSnapshotId(v string) *EbsBlockDevice {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetVolumeSize sets the VolumeSize field's value.
+func (s *EbsBlockDevice) SetVolumeSize(v int64) *EbsBlockDevice {
+	s.VolumeSize = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *EbsBlockDevice) SetVolumeType(v string) *EbsBlockDevice {
+	s.VolumeType = &v
+	return s
+}
+
 // Describes a parameter used to set up an EBS volume in a block device mapping.
 type EbsInstanceBlockDevice struct {
 	_ struct{} `type:"structure"`
@@ -26001,6 +30969,30 @@ func (s EbsInstanceBlockDevice) GoString() string {
 	return s.String()
 }
 
+// SetAttachTime sets the AttachTime field's value.
+func (s *EbsInstanceBlockDevice) SetAttachTime(v time.Time) *EbsInstanceBlockDevice {
+	s.AttachTime = &v
+	return s
+}
+
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *EbsInstanceBlockDevice) SetDeleteOnTermination(v bool) *EbsInstanceBlockDevice {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EbsInstanceBlockDevice) SetStatus(v string) *EbsInstanceBlockDevice {
+	s.Status = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *EbsInstanceBlockDevice) SetVolumeId(v string) *EbsInstanceBlockDevice {
+	s.VolumeId = &v
+	return s
+}
+
 // Describes information used to set up an EBS volume specified in a block device
 // mapping.
 type EbsInstanceBlockDeviceSpecification struct {
@@ -26021,6 +31013,18 @@ func (s EbsInstanceBlockDeviceSpecification) String() string {
 // GoString returns the string representation
 func (s EbsInstanceBlockDeviceSpecification) GoString() string {
 	return s.String()
+}
+
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *EbsInstanceBlockDeviceSpecification) SetDeleteOnTermination(v bool) *EbsInstanceBlockDeviceSpecification {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *EbsInstanceBlockDeviceSpecification) SetVolumeId(v string) *EbsInstanceBlockDeviceSpecification {
+	s.VolumeId = &v
+	return s
 }
 
 // Contains the parameters for EnableVgwRoutePropagation.
@@ -26062,6 +31066,18 @@ func (s *EnableVgwRoutePropagationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *EnableVgwRoutePropagationInput) SetGatewayId(v string) *EnableVgwRoutePropagationInput {
+	s.GatewayId = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *EnableVgwRoutePropagationInput) SetRouteTableId(v string) *EnableVgwRoutePropagationInput {
+	s.RouteTableId = &v
+	return s
 }
 
 type EnableVgwRoutePropagationOutput struct {
@@ -26117,6 +31133,18 @@ func (s *EnableVolumeIOInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *EnableVolumeIOInput) SetDryRun(v bool) *EnableVolumeIOInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *EnableVolumeIOInput) SetVolumeId(v string) *EnableVolumeIOInput {
+	s.VolumeId = &v
+	return s
+}
+
 type EnableVolumeIOOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -26149,6 +31177,12 @@ func (s EnableVpcClassicLinkDnsSupportInput) GoString() string {
 	return s.String()
 }
 
+// SetVpcId sets the VpcId field's value.
+func (s *EnableVpcClassicLinkDnsSupportInput) SetVpcId(v string) *EnableVpcClassicLinkDnsSupportInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of EnableVpcClassicLinkDnsSupport.
 type EnableVpcClassicLinkDnsSupportOutput struct {
 	_ struct{} `type:"structure"`
@@ -26165,6 +31199,12 @@ func (s EnableVpcClassicLinkDnsSupportOutput) String() string {
 // GoString returns the string representation
 func (s EnableVpcClassicLinkDnsSupportOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *EnableVpcClassicLinkDnsSupportOutput) SetReturn(v bool) *EnableVpcClassicLinkDnsSupportOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for EnableVpcClassicLink.
@@ -26206,6 +31246,18 @@ func (s *EnableVpcClassicLinkInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *EnableVpcClassicLinkInput) SetDryRun(v bool) *EnableVpcClassicLinkInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *EnableVpcClassicLinkInput) SetVpcId(v string) *EnableVpcClassicLinkInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of EnableVpcClassicLink.
 type EnableVpcClassicLinkOutput struct {
 	_ struct{} `type:"structure"`
@@ -26222,6 +31274,12 @@ func (s EnableVpcClassicLinkOutput) String() string {
 // GoString returns the string representation
 func (s EnableVpcClassicLinkOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *EnableVpcClassicLinkOutput) SetReturn(v bool) *EnableVpcClassicLinkOutput {
+	s.Return = &v
+	return s
 }
 
 // Describes a Spot fleet event.
@@ -26300,6 +31358,24 @@ func (s EventInformation) GoString() string {
 	return s.String()
 }
 
+// SetEventDescription sets the EventDescription field's value.
+func (s *EventInformation) SetEventDescription(v string) *EventInformation {
+	s.EventDescription = &v
+	return s
+}
+
+// SetEventSubType sets the EventSubType field's value.
+func (s *EventInformation) SetEventSubType(v string) *EventInformation {
+	s.EventSubType = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *EventInformation) SetInstanceId(v string) *EventInformation {
+	s.InstanceId = &v
+	return s
+}
+
 // Describes an instance export task.
 type ExportTask struct {
 	_ struct{} `type:"structure"`
@@ -26333,6 +31409,42 @@ func (s ExportTask) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *ExportTask) SetDescription(v string) *ExportTask {
+	s.Description = &v
+	return s
+}
+
+// SetExportTaskId sets the ExportTaskId field's value.
+func (s *ExportTask) SetExportTaskId(v string) *ExportTask {
+	s.ExportTaskId = &v
+	return s
+}
+
+// SetExportToS3Task sets the ExportToS3Task field's value.
+func (s *ExportTask) SetExportToS3Task(v *ExportToS3Task) *ExportTask {
+	s.ExportToS3Task = v
+	return s
+}
+
+// SetInstanceExportDetails sets the InstanceExportDetails field's value.
+func (s *ExportTask) SetInstanceExportDetails(v *InstanceExportDetails) *ExportTask {
+	s.InstanceExportDetails = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ExportTask) SetState(v string) *ExportTask {
+	s.State = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ExportTask) SetStatusMessage(v string) *ExportTask {
+	s.StatusMessage = &v
+	return s
+}
+
 // Describes the format and location for an instance export task.
 type ExportToS3Task struct {
 	_ struct{} `type:"structure"`
@@ -26360,6 +31472,30 @@ func (s ExportToS3Task) String() string {
 // GoString returns the string representation
 func (s ExportToS3Task) GoString() string {
 	return s.String()
+}
+
+// SetContainerFormat sets the ContainerFormat field's value.
+func (s *ExportToS3Task) SetContainerFormat(v string) *ExportToS3Task {
+	s.ContainerFormat = &v
+	return s
+}
+
+// SetDiskImageFormat sets the DiskImageFormat field's value.
+func (s *ExportToS3Task) SetDiskImageFormat(v string) *ExportToS3Task {
+	s.DiskImageFormat = &v
+	return s
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *ExportToS3Task) SetS3Bucket(v string) *ExportToS3Task {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetS3Key sets the S3Key field's value.
+func (s *ExportToS3Task) SetS3Key(v string) *ExportToS3Task {
+	s.S3Key = &v
+	return s
 }
 
 // Describes an instance export task.
@@ -26392,6 +31528,30 @@ func (s ExportToS3TaskSpecification) GoString() string {
 	return s.String()
 }
 
+// SetContainerFormat sets the ContainerFormat field's value.
+func (s *ExportToS3TaskSpecification) SetContainerFormat(v string) *ExportToS3TaskSpecification {
+	s.ContainerFormat = &v
+	return s
+}
+
+// SetDiskImageFormat sets the DiskImageFormat field's value.
+func (s *ExportToS3TaskSpecification) SetDiskImageFormat(v string) *ExportToS3TaskSpecification {
+	s.DiskImageFormat = &v
+	return s
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *ExportToS3TaskSpecification) SetS3Bucket(v string) *ExportToS3TaskSpecification {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetS3Prefix sets the S3Prefix field's value.
+func (s *ExportToS3TaskSpecification) SetS3Prefix(v string) *ExportToS3TaskSpecification {
+	s.S3Prefix = &v
+	return s
+}
+
 // A filter name and value pair that is used to return a more specific list
 // of results. Filters can be used to match a set of resources by various criteria,
 // such as tags, attributes, or IDs.
@@ -26413,6 +31573,18 @@ func (s Filter) String() string {
 // GoString returns the string representation
 func (s Filter) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *Filter) SetName(v string) *Filter {
+	s.Name = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *Filter) SetValues(v []*string) *Filter {
+	s.Values = v
+	return s
 }
 
 // Describes a flow log.
@@ -26462,6 +31634,60 @@ func (s FlowLog) GoString() string {
 	return s.String()
 }
 
+// SetCreationTime sets the CreationTime field's value.
+func (s *FlowLog) SetCreationTime(v time.Time) *FlowLog {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDeliverLogsErrorMessage sets the DeliverLogsErrorMessage field's value.
+func (s *FlowLog) SetDeliverLogsErrorMessage(v string) *FlowLog {
+	s.DeliverLogsErrorMessage = &v
+	return s
+}
+
+// SetDeliverLogsPermissionArn sets the DeliverLogsPermissionArn field's value.
+func (s *FlowLog) SetDeliverLogsPermissionArn(v string) *FlowLog {
+	s.DeliverLogsPermissionArn = &v
+	return s
+}
+
+// SetDeliverLogsStatus sets the DeliverLogsStatus field's value.
+func (s *FlowLog) SetDeliverLogsStatus(v string) *FlowLog {
+	s.DeliverLogsStatus = &v
+	return s
+}
+
+// SetFlowLogId sets the FlowLogId field's value.
+func (s *FlowLog) SetFlowLogId(v string) *FlowLog {
+	s.FlowLogId = &v
+	return s
+}
+
+// SetFlowLogStatus sets the FlowLogStatus field's value.
+func (s *FlowLog) SetFlowLogStatus(v string) *FlowLog {
+	s.FlowLogStatus = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *FlowLog) SetLogGroupName(v string) *FlowLog {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *FlowLog) SetResourceId(v string) *FlowLog {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTrafficType sets the TrafficType field's value.
+func (s *FlowLog) SetTrafficType(v string) *FlowLog {
+	s.TrafficType = &v
+	return s
+}
+
 // Contains the parameters for GetConsoleOutput.
 type GetConsoleOutputInput struct {
 	_ struct{} `type:"structure"`
@@ -26501,6 +31727,18 @@ func (s *GetConsoleOutputInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *GetConsoleOutputInput) SetDryRun(v bool) *GetConsoleOutputInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *GetConsoleOutputInput) SetInstanceId(v string) *GetConsoleOutputInput {
+	s.InstanceId = &v
+	return s
+}
+
 // Contains the output of GetConsoleOutput.
 type GetConsoleOutputOutput struct {
 	_ struct{} `type:"structure"`
@@ -26524,6 +31762,24 @@ func (s GetConsoleOutputOutput) String() string {
 // GoString returns the string representation
 func (s GetConsoleOutputOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *GetConsoleOutputOutput) SetInstanceId(v string) *GetConsoleOutputOutput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetOutput sets the Output field's value.
+func (s *GetConsoleOutputOutput) SetOutput(v string) *GetConsoleOutputOutput {
+	s.Output = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *GetConsoleOutputOutput) SetTimestamp(v time.Time) *GetConsoleOutputOutput {
+	s.Timestamp = &v
+	return s
 }
 
 // Contains the parameters for the request.
@@ -26569,6 +31825,24 @@ func (s *GetConsoleScreenshotInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *GetConsoleScreenshotInput) SetDryRun(v bool) *GetConsoleScreenshotInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *GetConsoleScreenshotInput) SetInstanceId(v string) *GetConsoleScreenshotInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetWakeUp sets the WakeUp field's value.
+func (s *GetConsoleScreenshotInput) SetWakeUp(v bool) *GetConsoleScreenshotInput {
+	s.WakeUp = &v
+	return s
+}
+
 // Contains the output of the request.
 type GetConsoleScreenshotOutput struct {
 	_ struct{} `type:"structure"`
@@ -26588,6 +31862,18 @@ func (s GetConsoleScreenshotOutput) String() string {
 // GoString returns the string representation
 func (s GetConsoleScreenshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetImageData sets the ImageData field's value.
+func (s *GetConsoleScreenshotOutput) SetImageData(v string) *GetConsoleScreenshotOutput {
+	s.ImageData = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *GetConsoleScreenshotOutput) SetInstanceId(v string) *GetConsoleScreenshotOutput {
+	s.InstanceId = &v
+	return s
 }
 
 type GetHostReservationPurchasePreviewInput struct {
@@ -26631,6 +31917,18 @@ func (s *GetHostReservationPurchasePreviewInput) Validate() error {
 	return nil
 }
 
+// SetHostIdSet sets the HostIdSet field's value.
+func (s *GetHostReservationPurchasePreviewInput) SetHostIdSet(v []*string) *GetHostReservationPurchasePreviewInput {
+	s.HostIdSet = v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *GetHostReservationPurchasePreviewInput) SetOfferingId(v string) *GetHostReservationPurchasePreviewInput {
+	s.OfferingId = &v
+	return s
+}
+
 type GetHostReservationPurchasePreviewOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -26657,6 +31955,30 @@ func (s GetHostReservationPurchasePreviewOutput) String() string {
 // GoString returns the string representation
 func (s GetHostReservationPurchasePreviewOutput) GoString() string {
 	return s.String()
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *GetHostReservationPurchasePreviewOutput) SetCurrencyCode(v string) *GetHostReservationPurchasePreviewOutput {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetPurchase sets the Purchase field's value.
+func (s *GetHostReservationPurchasePreviewOutput) SetPurchase(v []*Purchase) *GetHostReservationPurchasePreviewOutput {
+	s.Purchase = v
+	return s
+}
+
+// SetTotalHourlyPrice sets the TotalHourlyPrice field's value.
+func (s *GetHostReservationPurchasePreviewOutput) SetTotalHourlyPrice(v string) *GetHostReservationPurchasePreviewOutput {
+	s.TotalHourlyPrice = &v
+	return s
+}
+
+// SetTotalUpfrontPrice sets the TotalUpfrontPrice field's value.
+func (s *GetHostReservationPurchasePreviewOutput) SetTotalUpfrontPrice(v string) *GetHostReservationPurchasePreviewOutput {
+	s.TotalUpfrontPrice = &v
+	return s
 }
 
 // Contains the parameters for GetPasswordData.
@@ -26698,6 +32020,18 @@ func (s *GetPasswordDataInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *GetPasswordDataInput) SetDryRun(v bool) *GetPasswordDataInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *GetPasswordDataInput) SetInstanceId(v string) *GetPasswordDataInput {
+	s.InstanceId = &v
+	return s
+}
+
 // Contains the output of GetPasswordData.
 type GetPasswordDataOutput struct {
 	_ struct{} `type:"structure"`
@@ -26720,6 +32054,24 @@ func (s GetPasswordDataOutput) String() string {
 // GoString returns the string representation
 func (s GetPasswordDataOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *GetPasswordDataOutput) SetInstanceId(v string) *GetPasswordDataOutput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetPasswordData sets the PasswordData field's value.
+func (s *GetPasswordDataOutput) SetPasswordData(v string) *GetPasswordDataOutput {
+	s.PasswordData = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *GetPasswordDataOutput) SetTimestamp(v time.Time) *GetPasswordDataOutput {
+	s.Timestamp = &v
+	return s
 }
 
 // Contains the parameters for GetReservedInstanceExchangeQuote.
@@ -26775,6 +32127,24 @@ func (s *GetReservedInstancesExchangeQuoteInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *GetReservedInstancesExchangeQuoteInput) SetDryRun(v bool) *GetReservedInstancesExchangeQuoteInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetReservedInstanceIds sets the ReservedInstanceIds field's value.
+func (s *GetReservedInstancesExchangeQuoteInput) SetReservedInstanceIds(v []*string) *GetReservedInstancesExchangeQuoteInput {
+	s.ReservedInstanceIds = v
+	return s
+}
+
+// SetTargetConfigurations sets the TargetConfigurations field's value.
+func (s *GetReservedInstancesExchangeQuoteInput) SetTargetConfigurations(v []*TargetConfigurationRequest) *GetReservedInstancesExchangeQuoteInput {
+	s.TargetConfigurations = v
+	return s
+}
+
 // Contains the output of GetReservedInstancesExchangeQuote.
 type GetReservedInstancesExchangeQuoteOutput struct {
 	_ struct{} `type:"structure"`
@@ -26817,6 +32187,60 @@ func (s GetReservedInstancesExchangeQuoteOutput) GoString() string {
 	return s.String()
 }
 
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetCurrencyCode(v string) *GetReservedInstancesExchangeQuoteOutput {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetIsValidExchange sets the IsValidExchange field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetIsValidExchange(v bool) *GetReservedInstancesExchangeQuoteOutput {
+	s.IsValidExchange = &v
+	return s
+}
+
+// SetOutputReservedInstancesWillExpireAt sets the OutputReservedInstancesWillExpireAt field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetOutputReservedInstancesWillExpireAt(v time.Time) *GetReservedInstancesExchangeQuoteOutput {
+	s.OutputReservedInstancesWillExpireAt = &v
+	return s
+}
+
+// SetPaymentDue sets the PaymentDue field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetPaymentDue(v string) *GetReservedInstancesExchangeQuoteOutput {
+	s.PaymentDue = &v
+	return s
+}
+
+// SetReservedInstanceValueRollup sets the ReservedInstanceValueRollup field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetReservedInstanceValueRollup(v *ReservationValue) *GetReservedInstancesExchangeQuoteOutput {
+	s.ReservedInstanceValueRollup = v
+	return s
+}
+
+// SetReservedInstanceValueSet sets the ReservedInstanceValueSet field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetReservedInstanceValueSet(v []*ReservedInstanceReservationValue) *GetReservedInstancesExchangeQuoteOutput {
+	s.ReservedInstanceValueSet = v
+	return s
+}
+
+// SetTargetConfigurationValueRollup sets the TargetConfigurationValueRollup field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetTargetConfigurationValueRollup(v *ReservationValue) *GetReservedInstancesExchangeQuoteOutput {
+	s.TargetConfigurationValueRollup = v
+	return s
+}
+
+// SetTargetConfigurationValueSet sets the TargetConfigurationValueSet field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetTargetConfigurationValueSet(v []*TargetReservationValue) *GetReservedInstancesExchangeQuoteOutput {
+	s.TargetConfigurationValueSet = v
+	return s
+}
+
+// SetValidationFailureReason sets the ValidationFailureReason field's value.
+func (s *GetReservedInstancesExchangeQuoteOutput) SetValidationFailureReason(v string) *GetReservedInstancesExchangeQuoteOutput {
+	s.ValidationFailureReason = &v
+	return s
+}
+
 // Describes a security group.
 type GroupIdentifier struct {
 	_ struct{} `type:"structure"`
@@ -26836,6 +32260,18 @@ func (s GroupIdentifier) String() string {
 // GoString returns the string representation
 func (s GroupIdentifier) GoString() string {
 	return s.String()
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *GroupIdentifier) SetGroupId(v string) *GroupIdentifier {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *GroupIdentifier) SetGroupName(v string) *GroupIdentifier {
+	s.GroupName = &v
+	return s
 }
 
 // Describes an event in the history of the Spot fleet request.
@@ -26873,6 +32309,24 @@ func (s HistoryRecord) String() string {
 // GoString returns the string representation
 func (s HistoryRecord) GoString() string {
 	return s.String()
+}
+
+// SetEventInformation sets the EventInformation field's value.
+func (s *HistoryRecord) SetEventInformation(v *EventInformation) *HistoryRecord {
+	s.EventInformation = v
+	return s
+}
+
+// SetEventType sets the EventType field's value.
+func (s *HistoryRecord) SetEventType(v string) *HistoryRecord {
+	s.EventType = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *HistoryRecord) SetTimestamp(v time.Time) *HistoryRecord {
+	s.Timestamp = &v
+	return s
 }
 
 // Describes the properties of the Dedicated Host.
@@ -26920,6 +32374,60 @@ func (s Host) GoString() string {
 	return s.String()
 }
 
+// SetAutoPlacement sets the AutoPlacement field's value.
+func (s *Host) SetAutoPlacement(v string) *Host {
+	s.AutoPlacement = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Host) SetAvailabilityZone(v string) *Host {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetAvailableCapacity sets the AvailableCapacity field's value.
+func (s *Host) SetAvailableCapacity(v *AvailableCapacity) *Host {
+	s.AvailableCapacity = v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *Host) SetClientToken(v string) *Host {
+	s.ClientToken = &v
+	return s
+}
+
+// SetHostId sets the HostId field's value.
+func (s *Host) SetHostId(v string) *Host {
+	s.HostId = &v
+	return s
+}
+
+// SetHostProperties sets the HostProperties field's value.
+func (s *Host) SetHostProperties(v *HostProperties) *Host {
+	s.HostProperties = v
+	return s
+}
+
+// SetHostReservationId sets the HostReservationId field's value.
+func (s *Host) SetHostReservationId(v string) *Host {
+	s.HostReservationId = &v
+	return s
+}
+
+// SetInstances sets the Instances field's value.
+func (s *Host) SetInstances(v []*HostInstance) *Host {
+	s.Instances = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Host) SetState(v string) *Host {
+	s.State = &v
+	return s
+}
+
 // Describes an instance running on a Dedicated Host.
 type HostInstance struct {
 	_ struct{} `type:"structure"`
@@ -26939,6 +32447,18 @@ func (s HostInstance) String() string {
 // GoString returns the string representation
 func (s HostInstance) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *HostInstance) SetInstanceId(v string) *HostInstance {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *HostInstance) SetInstanceType(v string) *HostInstance {
+	s.InstanceType = &v
+	return s
 }
 
 // Details about the Dedicated Host Reservation offering.
@@ -26977,6 +32497,48 @@ func (s HostOffering) GoString() string {
 	return s.String()
 }
 
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *HostOffering) SetCurrencyCode(v string) *HostOffering {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *HostOffering) SetDuration(v int64) *HostOffering {
+	s.Duration = &v
+	return s
+}
+
+// SetHourlyPrice sets the HourlyPrice field's value.
+func (s *HostOffering) SetHourlyPrice(v string) *HostOffering {
+	s.HourlyPrice = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *HostOffering) SetInstanceFamily(v string) *HostOffering {
+	s.InstanceFamily = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *HostOffering) SetOfferingId(v string) *HostOffering {
+	s.OfferingId = &v
+	return s
+}
+
+// SetPaymentOption sets the PaymentOption field's value.
+func (s *HostOffering) SetPaymentOption(v string) *HostOffering {
+	s.PaymentOption = &v
+	return s
+}
+
+// SetUpfrontPrice sets the UpfrontPrice field's value.
+func (s *HostOffering) SetUpfrontPrice(v string) *HostOffering {
+	s.UpfrontPrice = &v
+	return s
+}
+
 // Describes properties of a Dedicated Host.
 type HostProperties struct {
 	_ struct{} `type:"structure"`
@@ -27002,6 +32564,30 @@ func (s HostProperties) String() string {
 // GoString returns the string representation
 func (s HostProperties) GoString() string {
 	return s.String()
+}
+
+// SetCores sets the Cores field's value.
+func (s *HostProperties) SetCores(v int64) *HostProperties {
+	s.Cores = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *HostProperties) SetInstanceType(v string) *HostProperties {
+	s.InstanceType = &v
+	return s
+}
+
+// SetSockets sets the Sockets field's value.
+func (s *HostProperties) SetSockets(v int64) *HostProperties {
+	s.Sockets = &v
+	return s
+}
+
+// SetTotalVCpus sets the TotalVCpus field's value.
+func (s *HostProperties) SetTotalVCpus(v int64) *HostProperties {
+	s.TotalVCpus = &v
+	return s
 }
 
 // Details about the Dedicated Host Reservation and associated Dedicated Hosts.
@@ -27063,6 +32649,84 @@ func (s HostReservation) GoString() string {
 	return s.String()
 }
 
+// SetCount sets the Count field's value.
+func (s *HostReservation) SetCount(v int64) *HostReservation {
+	s.Count = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *HostReservation) SetCurrencyCode(v string) *HostReservation {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *HostReservation) SetDuration(v int64) *HostReservation {
+	s.Duration = &v
+	return s
+}
+
+// SetEnd sets the End field's value.
+func (s *HostReservation) SetEnd(v time.Time) *HostReservation {
+	s.End = &v
+	return s
+}
+
+// SetHostIdSet sets the HostIdSet field's value.
+func (s *HostReservation) SetHostIdSet(v []*string) *HostReservation {
+	s.HostIdSet = v
+	return s
+}
+
+// SetHostReservationId sets the HostReservationId field's value.
+func (s *HostReservation) SetHostReservationId(v string) *HostReservation {
+	s.HostReservationId = &v
+	return s
+}
+
+// SetHourlyPrice sets the HourlyPrice field's value.
+func (s *HostReservation) SetHourlyPrice(v string) *HostReservation {
+	s.HourlyPrice = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *HostReservation) SetInstanceFamily(v string) *HostReservation {
+	s.InstanceFamily = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *HostReservation) SetOfferingId(v string) *HostReservation {
+	s.OfferingId = &v
+	return s
+}
+
+// SetPaymentOption sets the PaymentOption field's value.
+func (s *HostReservation) SetPaymentOption(v string) *HostReservation {
+	s.PaymentOption = &v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *HostReservation) SetStart(v time.Time) *HostReservation {
+	s.Start = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *HostReservation) SetState(v string) *HostReservation {
+	s.State = &v
+	return s
+}
+
+// SetUpfrontPrice sets the UpfrontPrice field's value.
+func (s *HostReservation) SetUpfrontPrice(v string) *HostReservation {
+	s.UpfrontPrice = &v
+	return s
+}
+
 // Describes an IAM instance profile.
 type IamInstanceProfile struct {
 	_ struct{} `type:"structure"`
@@ -27082,6 +32746,18 @@ func (s IamInstanceProfile) String() string {
 // GoString returns the string representation
 func (s IamInstanceProfile) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *IamInstanceProfile) SetArn(v string) *IamInstanceProfile {
+	s.Arn = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *IamInstanceProfile) SetId(v string) *IamInstanceProfile {
+	s.Id = &v
+	return s
 }
 
 // Describes an IAM instance profile.
@@ -27105,6 +32781,18 @@ func (s IamInstanceProfileSpecification) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *IamInstanceProfileSpecification) SetArn(v string) *IamInstanceProfileSpecification {
+	s.Arn = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *IamInstanceProfileSpecification) SetName(v string) *IamInstanceProfileSpecification {
+	s.Name = &v
+	return s
+}
+
 // Describes the ICMP type and code.
 type IcmpTypeCode struct {
 	_ struct{} `type:"structure"`
@@ -27124,6 +32812,18 @@ func (s IcmpTypeCode) String() string {
 // GoString returns the string representation
 func (s IcmpTypeCode) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *IcmpTypeCode) SetCode(v int64) *IcmpTypeCode {
+	s.Code = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *IcmpTypeCode) SetType(v int64) *IcmpTypeCode {
+	s.Type = &v
+	return s
 }
 
 // Describes the ID format for a resource.
@@ -27150,6 +32850,24 @@ func (s IdFormat) String() string {
 // GoString returns the string representation
 func (s IdFormat) GoString() string {
 	return s.String()
+}
+
+// SetDeadline sets the Deadline field's value.
+func (s *IdFormat) SetDeadline(v time.Time) *IdFormat {
+	s.Deadline = &v
+	return s
+}
+
+// SetResource sets the Resource field's value.
+func (s *IdFormat) SetResource(v string) *IdFormat {
+	s.Resource = &v
+	return s
+}
+
+// SetUseLongIds sets the UseLongIds field's value.
+func (s *IdFormat) SetUseLongIds(v bool) *IdFormat {
+	s.UseLongIds = &v
+	return s
 }
 
 // Describes an image.
@@ -27247,6 +32965,150 @@ func (s Image) GoString() string {
 	return s.String()
 }
 
+// SetArchitecture sets the Architecture field's value.
+func (s *Image) SetArchitecture(v string) *Image {
+	s.Architecture = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *Image) SetBlockDeviceMappings(v []*BlockDeviceMapping) *Image {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *Image) SetCreationDate(v string) *Image {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Image) SetDescription(v string) *Image {
+	s.Description = &v
+	return s
+}
+
+// SetEnaSupport sets the EnaSupport field's value.
+func (s *Image) SetEnaSupport(v bool) *Image {
+	s.EnaSupport = &v
+	return s
+}
+
+// SetHypervisor sets the Hypervisor field's value.
+func (s *Image) SetHypervisor(v string) *Image {
+	s.Hypervisor = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *Image) SetImageId(v string) *Image {
+	s.ImageId = &v
+	return s
+}
+
+// SetImageLocation sets the ImageLocation field's value.
+func (s *Image) SetImageLocation(v string) *Image {
+	s.ImageLocation = &v
+	return s
+}
+
+// SetImageOwnerAlias sets the ImageOwnerAlias field's value.
+func (s *Image) SetImageOwnerAlias(v string) *Image {
+	s.ImageOwnerAlias = &v
+	return s
+}
+
+// SetImageType sets the ImageType field's value.
+func (s *Image) SetImageType(v string) *Image {
+	s.ImageType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *Image) SetKernelId(v string) *Image {
+	s.KernelId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Image) SetName(v string) *Image {
+	s.Name = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *Image) SetOwnerId(v string) *Image {
+	s.OwnerId = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *Image) SetPlatform(v string) *Image {
+	s.Platform = &v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *Image) SetProductCodes(v []*ProductCode) *Image {
+	s.ProductCodes = v
+	return s
+}
+
+// SetPublic sets the Public field's value.
+func (s *Image) SetPublic(v bool) *Image {
+	s.Public = &v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *Image) SetRamdiskId(v string) *Image {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetRootDeviceName sets the RootDeviceName field's value.
+func (s *Image) SetRootDeviceName(v string) *Image {
+	s.RootDeviceName = &v
+	return s
+}
+
+// SetRootDeviceType sets the RootDeviceType field's value.
+func (s *Image) SetRootDeviceType(v string) *Image {
+	s.RootDeviceType = &v
+	return s
+}
+
+// SetSriovNetSupport sets the SriovNetSupport field's value.
+func (s *Image) SetSriovNetSupport(v string) *Image {
+	s.SriovNetSupport = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Image) SetState(v string) *Image {
+	s.State = &v
+	return s
+}
+
+// SetStateReason sets the StateReason field's value.
+func (s *Image) SetStateReason(v *StateReason) *Image {
+	s.StateReason = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Image) SetTags(v []*Tag) *Image {
+	s.Tags = v
+	return s
+}
+
+// SetVirtualizationType sets the VirtualizationType field's value.
+func (s *Image) SetVirtualizationType(v string) *Image {
+	s.VirtualizationType = &v
+	return s
+}
+
 // Describes the disk container object for an import image task.
 type ImageDiskContainer struct {
 	_ struct{} `type:"structure"`
@@ -27281,6 +33143,42 @@ func (s ImageDiskContainer) String() string {
 // GoString returns the string representation
 func (s ImageDiskContainer) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImageDiskContainer) SetDescription(v string) *ImageDiskContainer {
+	s.Description = &v
+	return s
+}
+
+// SetDeviceName sets the DeviceName field's value.
+func (s *ImageDiskContainer) SetDeviceName(v string) *ImageDiskContainer {
+	s.DeviceName = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *ImageDiskContainer) SetFormat(v string) *ImageDiskContainer {
+	s.Format = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *ImageDiskContainer) SetSnapshotId(v string) *ImageDiskContainer {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *ImageDiskContainer) SetUrl(v string) *ImageDiskContainer {
+	s.Url = &v
+	return s
+}
+
+// SetUserBucket sets the UserBucket field's value.
+func (s *ImageDiskContainer) SetUserBucket(v *UserBucket) *ImageDiskContainer {
+	s.UserBucket = v
+	return s
 }
 
 // Contains the parameters for ImportImage.
@@ -27344,6 +33242,66 @@ func (s ImportImageInput) GoString() string {
 	return s.String()
 }
 
+// SetArchitecture sets the Architecture field's value.
+func (s *ImportImageInput) SetArchitecture(v string) *ImportImageInput {
+	s.Architecture = &v
+	return s
+}
+
+// SetClientData sets the ClientData field's value.
+func (s *ImportImageInput) SetClientData(v *ClientData) *ImportImageInput {
+	s.ClientData = v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *ImportImageInput) SetClientToken(v string) *ImportImageInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportImageInput) SetDescription(v string) *ImportImageInput {
+	s.Description = &v
+	return s
+}
+
+// SetDiskContainers sets the DiskContainers field's value.
+func (s *ImportImageInput) SetDiskContainers(v []*ImageDiskContainer) *ImportImageInput {
+	s.DiskContainers = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ImportImageInput) SetDryRun(v bool) *ImportImageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetHypervisor sets the Hypervisor field's value.
+func (s *ImportImageInput) SetHypervisor(v string) *ImportImageInput {
+	s.Hypervisor = &v
+	return s
+}
+
+// SetLicenseType sets the LicenseType field's value.
+func (s *ImportImageInput) SetLicenseType(v string) *ImportImageInput {
+	s.LicenseType = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *ImportImageInput) SetPlatform(v string) *ImportImageInput {
+	s.Platform = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *ImportImageInput) SetRoleName(v string) *ImportImageInput {
+	s.RoleName = &v
+	return s
+}
+
 // Contains the output for ImportImage.
 type ImportImageOutput struct {
 	_ struct{} `type:"structure"`
@@ -27390,6 +33348,72 @@ func (s ImportImageOutput) String() string {
 // GoString returns the string representation
 func (s ImportImageOutput) GoString() string {
 	return s.String()
+}
+
+// SetArchitecture sets the Architecture field's value.
+func (s *ImportImageOutput) SetArchitecture(v string) *ImportImageOutput {
+	s.Architecture = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportImageOutput) SetDescription(v string) *ImportImageOutput {
+	s.Description = &v
+	return s
+}
+
+// SetHypervisor sets the Hypervisor field's value.
+func (s *ImportImageOutput) SetHypervisor(v string) *ImportImageOutput {
+	s.Hypervisor = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *ImportImageOutput) SetImageId(v string) *ImportImageOutput {
+	s.ImageId = &v
+	return s
+}
+
+// SetImportTaskId sets the ImportTaskId field's value.
+func (s *ImportImageOutput) SetImportTaskId(v string) *ImportImageOutput {
+	s.ImportTaskId = &v
+	return s
+}
+
+// SetLicenseType sets the LicenseType field's value.
+func (s *ImportImageOutput) SetLicenseType(v string) *ImportImageOutput {
+	s.LicenseType = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *ImportImageOutput) SetPlatform(v string) *ImportImageOutput {
+	s.Platform = &v
+	return s
+}
+
+// SetProgress sets the Progress field's value.
+func (s *ImportImageOutput) SetProgress(v string) *ImportImageOutput {
+	s.Progress = &v
+	return s
+}
+
+// SetSnapshotDetails sets the SnapshotDetails field's value.
+func (s *ImportImageOutput) SetSnapshotDetails(v []*SnapshotDetail) *ImportImageOutput {
+	s.SnapshotDetails = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ImportImageOutput) SetStatus(v string) *ImportImageOutput {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ImportImageOutput) SetStatusMessage(v string) *ImportImageOutput {
+	s.StatusMessage = &v
+	return s
 }
 
 // Describes an import image task.
@@ -27442,6 +33466,72 @@ func (s ImportImageTask) String() string {
 // GoString returns the string representation
 func (s ImportImageTask) GoString() string {
 	return s.String()
+}
+
+// SetArchitecture sets the Architecture field's value.
+func (s *ImportImageTask) SetArchitecture(v string) *ImportImageTask {
+	s.Architecture = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportImageTask) SetDescription(v string) *ImportImageTask {
+	s.Description = &v
+	return s
+}
+
+// SetHypervisor sets the Hypervisor field's value.
+func (s *ImportImageTask) SetHypervisor(v string) *ImportImageTask {
+	s.Hypervisor = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *ImportImageTask) SetImageId(v string) *ImportImageTask {
+	s.ImageId = &v
+	return s
+}
+
+// SetImportTaskId sets the ImportTaskId field's value.
+func (s *ImportImageTask) SetImportTaskId(v string) *ImportImageTask {
+	s.ImportTaskId = &v
+	return s
+}
+
+// SetLicenseType sets the LicenseType field's value.
+func (s *ImportImageTask) SetLicenseType(v string) *ImportImageTask {
+	s.LicenseType = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *ImportImageTask) SetPlatform(v string) *ImportImageTask {
+	s.Platform = &v
+	return s
+}
+
+// SetProgress sets the Progress field's value.
+func (s *ImportImageTask) SetProgress(v string) *ImportImageTask {
+	s.Progress = &v
+	return s
+}
+
+// SetSnapshotDetails sets the SnapshotDetails field's value.
+func (s *ImportImageTask) SetSnapshotDetails(v []*SnapshotDetail) *ImportImageTask {
+	s.SnapshotDetails = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ImportImageTask) SetStatus(v string) *ImportImageTask {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ImportImageTask) SetStatusMessage(v string) *ImportImageTask {
+	s.StatusMessage = &v
+	return s
 }
 
 // Contains the parameters for ImportInstance.
@@ -27502,6 +33592,36 @@ func (s *ImportInstanceInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *ImportInstanceInput) SetDescription(v string) *ImportInstanceInput {
+	s.Description = &v
+	return s
+}
+
+// SetDiskImages sets the DiskImages field's value.
+func (s *ImportInstanceInput) SetDiskImages(v []*DiskImage) *ImportInstanceInput {
+	s.DiskImages = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ImportInstanceInput) SetDryRun(v bool) *ImportInstanceInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetLaunchSpecification sets the LaunchSpecification field's value.
+func (s *ImportInstanceInput) SetLaunchSpecification(v *ImportInstanceLaunchSpecification) *ImportInstanceInput {
+	s.LaunchSpecification = v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *ImportInstanceInput) SetPlatform(v string) *ImportInstanceInput {
+	s.Platform = &v
+	return s
+}
+
 // Describes the launch specification for VM import.
 type ImportInstanceLaunchSpecification struct {
 	_ struct{} `type:"structure"`
@@ -27555,6 +33675,72 @@ func (s ImportInstanceLaunchSpecification) GoString() string {
 	return s.String()
 }
 
+// SetAdditionalInfo sets the AdditionalInfo field's value.
+func (s *ImportInstanceLaunchSpecification) SetAdditionalInfo(v string) *ImportInstanceLaunchSpecification {
+	s.AdditionalInfo = &v
+	return s
+}
+
+// SetArchitecture sets the Architecture field's value.
+func (s *ImportInstanceLaunchSpecification) SetArchitecture(v string) *ImportInstanceLaunchSpecification {
+	s.Architecture = &v
+	return s
+}
+
+// SetGroupIds sets the GroupIds field's value.
+func (s *ImportInstanceLaunchSpecification) SetGroupIds(v []*string) *ImportInstanceLaunchSpecification {
+	s.GroupIds = v
+	return s
+}
+
+// SetGroupNames sets the GroupNames field's value.
+func (s *ImportInstanceLaunchSpecification) SetGroupNames(v []*string) *ImportInstanceLaunchSpecification {
+	s.GroupNames = v
+	return s
+}
+
+// SetInstanceInitiatedShutdownBehavior sets the InstanceInitiatedShutdownBehavior field's value.
+func (s *ImportInstanceLaunchSpecification) SetInstanceInitiatedShutdownBehavior(v string) *ImportInstanceLaunchSpecification {
+	s.InstanceInitiatedShutdownBehavior = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ImportInstanceLaunchSpecification) SetInstanceType(v string) *ImportInstanceLaunchSpecification {
+	s.InstanceType = &v
+	return s
+}
+
+// SetMonitoring sets the Monitoring field's value.
+func (s *ImportInstanceLaunchSpecification) SetMonitoring(v bool) *ImportInstanceLaunchSpecification {
+	s.Monitoring = &v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *ImportInstanceLaunchSpecification) SetPlacement(v *Placement) *ImportInstanceLaunchSpecification {
+	s.Placement = v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *ImportInstanceLaunchSpecification) SetPrivateIpAddress(v string) *ImportInstanceLaunchSpecification {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *ImportInstanceLaunchSpecification) SetSubnetId(v string) *ImportInstanceLaunchSpecification {
+	s.SubnetId = &v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *ImportInstanceLaunchSpecification) SetUserData(v *UserData) *ImportInstanceLaunchSpecification {
+	s.UserData = v
+	return s
+}
+
 // Contains the output for ImportInstance.
 type ImportInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -27571,6 +33757,12 @@ func (s ImportInstanceOutput) String() string {
 // GoString returns the string representation
 func (s ImportInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetConversionTask sets the ConversionTask field's value.
+func (s *ImportInstanceOutput) SetConversionTask(v *ConversionTask) *ImportInstanceOutput {
+	s.ConversionTask = v
+	return s
 }
 
 // Describes an import instance task.
@@ -27600,6 +33792,30 @@ func (s ImportInstanceTaskDetails) String() string {
 // GoString returns the string representation
 func (s ImportInstanceTaskDetails) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportInstanceTaskDetails) SetDescription(v string) *ImportInstanceTaskDetails {
+	s.Description = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ImportInstanceTaskDetails) SetInstanceId(v string) *ImportInstanceTaskDetails {
+	s.InstanceId = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *ImportInstanceTaskDetails) SetPlatform(v string) *ImportInstanceTaskDetails {
+	s.Platform = &v
+	return s
+}
+
+// SetVolumes sets the Volumes field's value.
+func (s *ImportInstanceTaskDetails) SetVolumes(v []*ImportInstanceVolumeDetailItem) *ImportInstanceTaskDetails {
+	s.Volumes = v
+	return s
 }
 
 // Describes an import volume task.
@@ -27646,6 +33862,48 @@ func (s ImportInstanceVolumeDetailItem) String() string {
 // GoString returns the string representation
 func (s ImportInstanceVolumeDetailItem) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ImportInstanceVolumeDetailItem) SetAvailabilityZone(v string) *ImportInstanceVolumeDetailItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetBytesConverted sets the BytesConverted field's value.
+func (s *ImportInstanceVolumeDetailItem) SetBytesConverted(v int64) *ImportInstanceVolumeDetailItem {
+	s.BytesConverted = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportInstanceVolumeDetailItem) SetDescription(v string) *ImportInstanceVolumeDetailItem {
+	s.Description = &v
+	return s
+}
+
+// SetImage sets the Image field's value.
+func (s *ImportInstanceVolumeDetailItem) SetImage(v *DiskImageDescription) *ImportInstanceVolumeDetailItem {
+	s.Image = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ImportInstanceVolumeDetailItem) SetStatus(v string) *ImportInstanceVolumeDetailItem {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ImportInstanceVolumeDetailItem) SetStatusMessage(v string) *ImportInstanceVolumeDetailItem {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetVolume sets the Volume field's value.
+func (s *ImportInstanceVolumeDetailItem) SetVolume(v *DiskImageVolumeDescription) *ImportInstanceVolumeDetailItem {
+	s.Volume = v
+	return s
 }
 
 // Contains the parameters for ImportKeyPair.
@@ -27698,6 +33956,24 @@ func (s *ImportKeyPairInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *ImportKeyPairInput) SetDryRun(v bool) *ImportKeyPairInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *ImportKeyPairInput) SetKeyName(v string) *ImportKeyPairInput {
+	s.KeyName = &v
+	return s
+}
+
+// SetPublicKeyMaterial sets the PublicKeyMaterial field's value.
+func (s *ImportKeyPairInput) SetPublicKeyMaterial(v []byte) *ImportKeyPairInput {
+	s.PublicKeyMaterial = v
+	return s
+}
+
 // Contains the output of ImportKeyPair.
 type ImportKeyPairOutput struct {
 	_ struct{} `type:"structure"`
@@ -27717,6 +33993,18 @@ func (s ImportKeyPairOutput) String() string {
 // GoString returns the string representation
 func (s ImportKeyPairOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeyFingerprint sets the KeyFingerprint field's value.
+func (s *ImportKeyPairOutput) SetKeyFingerprint(v string) *ImportKeyPairOutput {
+	s.KeyFingerprint = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *ImportKeyPairOutput) SetKeyName(v string) *ImportKeyPairOutput {
+	s.KeyName = &v
+	return s
 }
 
 // Contains the parameters for ImportSnapshot.
@@ -27755,6 +34043,42 @@ func (s ImportSnapshotInput) GoString() string {
 	return s.String()
 }
 
+// SetClientData sets the ClientData field's value.
+func (s *ImportSnapshotInput) SetClientData(v *ClientData) *ImportSnapshotInput {
+	s.ClientData = v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *ImportSnapshotInput) SetClientToken(v string) *ImportSnapshotInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportSnapshotInput) SetDescription(v string) *ImportSnapshotInput {
+	s.Description = &v
+	return s
+}
+
+// SetDiskContainer sets the DiskContainer field's value.
+func (s *ImportSnapshotInput) SetDiskContainer(v *SnapshotDiskContainer) *ImportSnapshotInput {
+	s.DiskContainer = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ImportSnapshotInput) SetDryRun(v bool) *ImportSnapshotInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *ImportSnapshotInput) SetRoleName(v string) *ImportSnapshotInput {
+	s.RoleName = &v
+	return s
+}
+
 // Contains the output for ImportSnapshot.
 type ImportSnapshotOutput struct {
 	_ struct{} `type:"structure"`
@@ -27779,6 +34103,24 @@ func (s ImportSnapshotOutput) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *ImportSnapshotOutput) SetDescription(v string) *ImportSnapshotOutput {
+	s.Description = &v
+	return s
+}
+
+// SetImportTaskId sets the ImportTaskId field's value.
+func (s *ImportSnapshotOutput) SetImportTaskId(v string) *ImportSnapshotOutput {
+	s.ImportTaskId = &v
+	return s
+}
+
+// SetSnapshotTaskDetail sets the SnapshotTaskDetail field's value.
+func (s *ImportSnapshotOutput) SetSnapshotTaskDetail(v *SnapshotTaskDetail) *ImportSnapshotOutput {
+	s.SnapshotTaskDetail = v
+	return s
+}
+
 // Describes an import snapshot task.
 type ImportSnapshotTask struct {
 	_ struct{} `type:"structure"`
@@ -27801,6 +34143,24 @@ func (s ImportSnapshotTask) String() string {
 // GoString returns the string representation
 func (s ImportSnapshotTask) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportSnapshotTask) SetDescription(v string) *ImportSnapshotTask {
+	s.Description = &v
+	return s
+}
+
+// SetImportTaskId sets the ImportTaskId field's value.
+func (s *ImportSnapshotTask) SetImportTaskId(v string) *ImportSnapshotTask {
+	s.ImportTaskId = &v
+	return s
+}
+
+// SetSnapshotTaskDetail sets the SnapshotTaskDetail field's value.
+func (s *ImportSnapshotTask) SetSnapshotTaskDetail(v *SnapshotTaskDetail) *ImportSnapshotTask {
+	s.SnapshotTaskDetail = v
+	return s
 }
 
 // Contains the parameters for ImportVolume.
@@ -27871,6 +34231,36 @@ func (s *ImportVolumeInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ImportVolumeInput) SetAvailabilityZone(v string) *ImportVolumeInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportVolumeInput) SetDescription(v string) *ImportVolumeInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ImportVolumeInput) SetDryRun(v bool) *ImportVolumeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetImage sets the Image field's value.
+func (s *ImportVolumeInput) SetImage(v *DiskImageDetail) *ImportVolumeInput {
+	s.Image = v
+	return s
+}
+
+// SetVolume sets the Volume field's value.
+func (s *ImportVolumeInput) SetVolume(v *VolumeDetail) *ImportVolumeInput {
+	s.Volume = v
+	return s
+}
+
 // Contains the output for ImportVolume.
 type ImportVolumeOutput struct {
 	_ struct{} `type:"structure"`
@@ -27887,6 +34277,12 @@ func (s ImportVolumeOutput) String() string {
 // GoString returns the string representation
 func (s ImportVolumeOutput) GoString() string {
 	return s.String()
+}
+
+// SetConversionTask sets the ConversionTask field's value.
+func (s *ImportVolumeOutput) SetConversionTask(v *ConversionTask) *ImportVolumeOutput {
+	s.ConversionTask = v
+	return s
 }
 
 // Describes an import volume task.
@@ -27925,6 +34321,36 @@ func (s ImportVolumeTaskDetails) String() string {
 // GoString returns the string representation
 func (s ImportVolumeTaskDetails) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ImportVolumeTaskDetails) SetAvailabilityZone(v string) *ImportVolumeTaskDetails {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetBytesConverted sets the BytesConverted field's value.
+func (s *ImportVolumeTaskDetails) SetBytesConverted(v int64) *ImportVolumeTaskDetails {
+	s.BytesConverted = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ImportVolumeTaskDetails) SetDescription(v string) *ImportVolumeTaskDetails {
+	s.Description = &v
+	return s
+}
+
+// SetImage sets the Image field's value.
+func (s *ImportVolumeTaskDetails) SetImage(v *DiskImageDescription) *ImportVolumeTaskDetails {
+	s.Image = v
+	return s
+}
+
+// SetVolume sets the Volume field's value.
+func (s *ImportVolumeTaskDetails) SetVolume(v *DiskImageVolumeDescription) *ImportVolumeTaskDetails {
+	s.Volume = v
+	return s
 }
 
 // Describes an instance.
@@ -28074,6 +34500,234 @@ func (s Instance) GoString() string {
 	return s.String()
 }
 
+// SetAmiLaunchIndex sets the AmiLaunchIndex field's value.
+func (s *Instance) SetAmiLaunchIndex(v int64) *Instance {
+	s.AmiLaunchIndex = &v
+	return s
+}
+
+// SetArchitecture sets the Architecture field's value.
+func (s *Instance) SetArchitecture(v string) *Instance {
+	s.Architecture = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *Instance) SetBlockDeviceMappings(v []*InstanceBlockDeviceMapping) *Instance {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *Instance) SetClientToken(v string) *Instance {
+	s.ClientToken = &v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *Instance) SetEbsOptimized(v bool) *Instance {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetEnaSupport sets the EnaSupport field's value.
+func (s *Instance) SetEnaSupport(v bool) *Instance {
+	s.EnaSupport = &v
+	return s
+}
+
+// SetHypervisor sets the Hypervisor field's value.
+func (s *Instance) SetHypervisor(v string) *Instance {
+	s.Hypervisor = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *Instance) SetIamInstanceProfile(v *IamInstanceProfile) *Instance {
+	s.IamInstanceProfile = v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *Instance) SetImageId(v string) *Instance {
+	s.ImageId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Instance) SetInstanceId(v string) *Instance {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceLifecycle sets the InstanceLifecycle field's value.
+func (s *Instance) SetInstanceLifecycle(v string) *Instance {
+	s.InstanceLifecycle = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *Instance) SetInstanceType(v string) *Instance {
+	s.InstanceType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *Instance) SetKernelId(v string) *Instance {
+	s.KernelId = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *Instance) SetKeyName(v string) *Instance {
+	s.KeyName = &v
+	return s
+}
+
+// SetLaunchTime sets the LaunchTime field's value.
+func (s *Instance) SetLaunchTime(v time.Time) *Instance {
+	s.LaunchTime = &v
+	return s
+}
+
+// SetMonitoring sets the Monitoring field's value.
+func (s *Instance) SetMonitoring(v *Monitoring) *Instance {
+	s.Monitoring = v
+	return s
+}
+
+// SetNetworkInterfaces sets the NetworkInterfaces field's value.
+func (s *Instance) SetNetworkInterfaces(v []*InstanceNetworkInterface) *Instance {
+	s.NetworkInterfaces = v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *Instance) SetPlacement(v *Placement) *Instance {
+	s.Placement = v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *Instance) SetPlatform(v string) *Instance {
+	s.Platform = &v
+	return s
+}
+
+// SetPrivateDnsName sets the PrivateDnsName field's value.
+func (s *Instance) SetPrivateDnsName(v string) *Instance {
+	s.PrivateDnsName = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *Instance) SetPrivateIpAddress(v string) *Instance {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *Instance) SetProductCodes(v []*ProductCode) *Instance {
+	s.ProductCodes = v
+	return s
+}
+
+// SetPublicDnsName sets the PublicDnsName field's value.
+func (s *Instance) SetPublicDnsName(v string) *Instance {
+	s.PublicDnsName = &v
+	return s
+}
+
+// SetPublicIpAddress sets the PublicIpAddress field's value.
+func (s *Instance) SetPublicIpAddress(v string) *Instance {
+	s.PublicIpAddress = &v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *Instance) SetRamdiskId(v string) *Instance {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetRootDeviceName sets the RootDeviceName field's value.
+func (s *Instance) SetRootDeviceName(v string) *Instance {
+	s.RootDeviceName = &v
+	return s
+}
+
+// SetRootDeviceType sets the RootDeviceType field's value.
+func (s *Instance) SetRootDeviceType(v string) *Instance {
+	s.RootDeviceType = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *Instance) SetSecurityGroups(v []*GroupIdentifier) *Instance {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSourceDestCheck sets the SourceDestCheck field's value.
+func (s *Instance) SetSourceDestCheck(v bool) *Instance {
+	s.SourceDestCheck = &v
+	return s
+}
+
+// SetSpotInstanceRequestId sets the SpotInstanceRequestId field's value.
+func (s *Instance) SetSpotInstanceRequestId(v string) *Instance {
+	s.SpotInstanceRequestId = &v
+	return s
+}
+
+// SetSriovNetSupport sets the SriovNetSupport field's value.
+func (s *Instance) SetSriovNetSupport(v string) *Instance {
+	s.SriovNetSupport = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Instance) SetState(v *InstanceState) *Instance {
+	s.State = v
+	return s
+}
+
+// SetStateReason sets the StateReason field's value.
+func (s *Instance) SetStateReason(v *StateReason) *Instance {
+	s.StateReason = v
+	return s
+}
+
+// SetStateTransitionReason sets the StateTransitionReason field's value.
+func (s *Instance) SetStateTransitionReason(v string) *Instance {
+	s.StateTransitionReason = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *Instance) SetSubnetId(v string) *Instance {
+	s.SubnetId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Instance) SetTags(v []*Tag) *Instance {
+	s.Tags = v
+	return s
+}
+
+// SetVirtualizationType sets the VirtualizationType field's value.
+func (s *Instance) SetVirtualizationType(v string) *Instance {
+	s.VirtualizationType = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *Instance) SetVpcId(v string) *Instance {
+	s.VpcId = &v
+	return s
+}
+
 // Describes a block device mapping.
 type InstanceBlockDeviceMapping struct {
 	_ struct{} `type:"structure"`
@@ -28094,6 +34748,18 @@ func (s InstanceBlockDeviceMapping) String() string {
 // GoString returns the string representation
 func (s InstanceBlockDeviceMapping) GoString() string {
 	return s.String()
+}
+
+// SetDeviceName sets the DeviceName field's value.
+func (s *InstanceBlockDeviceMapping) SetDeviceName(v string) *InstanceBlockDeviceMapping {
+	s.DeviceName = &v
+	return s
+}
+
+// SetEbs sets the Ebs field's value.
+func (s *InstanceBlockDeviceMapping) SetEbs(v *EbsInstanceBlockDevice) *InstanceBlockDeviceMapping {
+	s.Ebs = v
+	return s
 }
 
 // Describes a block device mapping entry.
@@ -28124,6 +34790,30 @@ func (s InstanceBlockDeviceMappingSpecification) GoString() string {
 	return s.String()
 }
 
+// SetDeviceName sets the DeviceName field's value.
+func (s *InstanceBlockDeviceMappingSpecification) SetDeviceName(v string) *InstanceBlockDeviceMappingSpecification {
+	s.DeviceName = &v
+	return s
+}
+
+// SetEbs sets the Ebs field's value.
+func (s *InstanceBlockDeviceMappingSpecification) SetEbs(v *EbsInstanceBlockDeviceSpecification) *InstanceBlockDeviceMappingSpecification {
+	s.Ebs = v
+	return s
+}
+
+// SetNoDevice sets the NoDevice field's value.
+func (s *InstanceBlockDeviceMappingSpecification) SetNoDevice(v string) *InstanceBlockDeviceMappingSpecification {
+	s.NoDevice = &v
+	return s
+}
+
+// SetVirtualName sets the VirtualName field's value.
+func (s *InstanceBlockDeviceMappingSpecification) SetVirtualName(v string) *InstanceBlockDeviceMappingSpecification {
+	s.VirtualName = &v
+	return s
+}
+
 // Information about the instance type that the Dedicated Host supports.
 type InstanceCapacity struct {
 	_ struct{} `type:"structure"`
@@ -28148,6 +34838,24 @@ func (s InstanceCapacity) GoString() string {
 	return s.String()
 }
 
+// SetAvailableCapacity sets the AvailableCapacity field's value.
+func (s *InstanceCapacity) SetAvailableCapacity(v int64) *InstanceCapacity {
+	s.AvailableCapacity = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *InstanceCapacity) SetInstanceType(v string) *InstanceCapacity {
+	s.InstanceType = &v
+	return s
+}
+
+// SetTotalCapacity sets the TotalCapacity field's value.
+func (s *InstanceCapacity) SetTotalCapacity(v int64) *InstanceCapacity {
+	s.TotalCapacity = &v
+	return s
+}
+
 // Describes a Reserved Instance listing state.
 type InstanceCount struct {
 	_ struct{} `type:"structure"`
@@ -28167,6 +34875,18 @@ func (s InstanceCount) String() string {
 // GoString returns the string representation
 func (s InstanceCount) GoString() string {
 	return s.String()
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *InstanceCount) SetInstanceCount(v int64) *InstanceCount {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *InstanceCount) SetState(v string) *InstanceCount {
+	s.State = &v
+	return s
 }
 
 // Describes an instance to export.
@@ -28190,6 +34910,18 @@ func (s InstanceExportDetails) GoString() string {
 	return s.String()
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceExportDetails) SetInstanceId(v string) *InstanceExportDetails {
+	s.InstanceId = &v
+	return s
+}
+
+// SetTargetEnvironment sets the TargetEnvironment field's value.
+func (s *InstanceExportDetails) SetTargetEnvironment(v string) *InstanceExportDetails {
+	s.TargetEnvironment = &v
+	return s
+}
+
 // Describes the monitoring information of the instance.
 type InstanceMonitoring struct {
 	_ struct{} `type:"structure"`
@@ -28209,6 +34941,18 @@ func (s InstanceMonitoring) String() string {
 // GoString returns the string representation
 func (s InstanceMonitoring) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceMonitoring) SetInstanceId(v string) *InstanceMonitoring {
+	s.InstanceId = &v
+	return s
+}
+
+// SetMonitoring sets the Monitoring field's value.
+func (s *InstanceMonitoring) SetMonitoring(v *Monitoring) *InstanceMonitoring {
+	s.Monitoring = v
+	return s
 }
 
 // Describes a network interface.
@@ -28269,6 +35013,90 @@ func (s InstanceNetworkInterface) GoString() string {
 	return s.String()
 }
 
+// SetAssociation sets the Association field's value.
+func (s *InstanceNetworkInterface) SetAssociation(v *InstanceNetworkInterfaceAssociation) *InstanceNetworkInterface {
+	s.Association = v
+	return s
+}
+
+// SetAttachment sets the Attachment field's value.
+func (s *InstanceNetworkInterface) SetAttachment(v *InstanceNetworkInterfaceAttachment) *InstanceNetworkInterface {
+	s.Attachment = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *InstanceNetworkInterface) SetDescription(v string) *InstanceNetworkInterface {
+	s.Description = &v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *InstanceNetworkInterface) SetGroups(v []*GroupIdentifier) *InstanceNetworkInterface {
+	s.Groups = v
+	return s
+}
+
+// SetMacAddress sets the MacAddress field's value.
+func (s *InstanceNetworkInterface) SetMacAddress(v string) *InstanceNetworkInterface {
+	s.MacAddress = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *InstanceNetworkInterface) SetNetworkInterfaceId(v string) *InstanceNetworkInterface {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *InstanceNetworkInterface) SetOwnerId(v string) *InstanceNetworkInterface {
+	s.OwnerId = &v
+	return s
+}
+
+// SetPrivateDnsName sets the PrivateDnsName field's value.
+func (s *InstanceNetworkInterface) SetPrivateDnsName(v string) *InstanceNetworkInterface {
+	s.PrivateDnsName = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *InstanceNetworkInterface) SetPrivateIpAddress(v string) *InstanceNetworkInterface {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetPrivateIpAddresses sets the PrivateIpAddresses field's value.
+func (s *InstanceNetworkInterface) SetPrivateIpAddresses(v []*InstancePrivateIpAddress) *InstanceNetworkInterface {
+	s.PrivateIpAddresses = v
+	return s
+}
+
+// SetSourceDestCheck sets the SourceDestCheck field's value.
+func (s *InstanceNetworkInterface) SetSourceDestCheck(v bool) *InstanceNetworkInterface {
+	s.SourceDestCheck = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *InstanceNetworkInterface) SetStatus(v string) *InstanceNetworkInterface {
+	s.Status = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *InstanceNetworkInterface) SetSubnetId(v string) *InstanceNetworkInterface {
+	s.SubnetId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *InstanceNetworkInterface) SetVpcId(v string) *InstanceNetworkInterface {
+	s.VpcId = &v
+	return s
+}
+
 // Describes association information for an Elastic IP address.
 type InstanceNetworkInterfaceAssociation struct {
 	_ struct{} `type:"structure"`
@@ -28291,6 +35119,24 @@ func (s InstanceNetworkInterfaceAssociation) String() string {
 // GoString returns the string representation
 func (s InstanceNetworkInterfaceAssociation) GoString() string {
 	return s.String()
+}
+
+// SetIpOwnerId sets the IpOwnerId field's value.
+func (s *InstanceNetworkInterfaceAssociation) SetIpOwnerId(v string) *InstanceNetworkInterfaceAssociation {
+	s.IpOwnerId = &v
+	return s
+}
+
+// SetPublicDnsName sets the PublicDnsName field's value.
+func (s *InstanceNetworkInterfaceAssociation) SetPublicDnsName(v string) *InstanceNetworkInterfaceAssociation {
+	s.PublicDnsName = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *InstanceNetworkInterfaceAssociation) SetPublicIp(v string) *InstanceNetworkInterfaceAssociation {
+	s.PublicIp = &v
+	return s
 }
 
 // Describes a network interface attachment.
@@ -28321,6 +35167,36 @@ func (s InstanceNetworkInterfaceAttachment) String() string {
 // GoString returns the string representation
 func (s InstanceNetworkInterfaceAttachment) GoString() string {
 	return s.String()
+}
+
+// SetAttachTime sets the AttachTime field's value.
+func (s *InstanceNetworkInterfaceAttachment) SetAttachTime(v time.Time) *InstanceNetworkInterfaceAttachment {
+	s.AttachTime = &v
+	return s
+}
+
+// SetAttachmentId sets the AttachmentId field's value.
+func (s *InstanceNetworkInterfaceAttachment) SetAttachmentId(v string) *InstanceNetworkInterfaceAttachment {
+	s.AttachmentId = &v
+	return s
+}
+
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *InstanceNetworkInterfaceAttachment) SetDeleteOnTermination(v bool) *InstanceNetworkInterfaceAttachment {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetDeviceIndex sets the DeviceIndex field's value.
+func (s *InstanceNetworkInterfaceAttachment) SetDeviceIndex(v int64) *InstanceNetworkInterfaceAttachment {
+	s.DeviceIndex = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *InstanceNetworkInterfaceAttachment) SetStatus(v string) *InstanceNetworkInterfaceAttachment {
+	s.Status = &v
+	return s
 }
 
 // Describes a network interface.
@@ -28406,6 +35282,66 @@ func (s *InstanceNetworkInterfaceSpecification) Validate() error {
 	return nil
 }
 
+// SetAssociatePublicIpAddress sets the AssociatePublicIpAddress field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetAssociatePublicIpAddress(v bool) *InstanceNetworkInterfaceSpecification {
+	s.AssociatePublicIpAddress = &v
+	return s
+}
+
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetDeleteOnTermination(v bool) *InstanceNetworkInterfaceSpecification {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetDescription(v string) *InstanceNetworkInterfaceSpecification {
+	s.Description = &v
+	return s
+}
+
+// SetDeviceIndex sets the DeviceIndex field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetDeviceIndex(v int64) *InstanceNetworkInterfaceSpecification {
+	s.DeviceIndex = &v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetGroups(v []*string) *InstanceNetworkInterfaceSpecification {
+	s.Groups = v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetNetworkInterfaceId(v string) *InstanceNetworkInterfaceSpecification {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetPrivateIpAddress(v string) *InstanceNetworkInterfaceSpecification {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetPrivateIpAddresses sets the PrivateIpAddresses field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetPrivateIpAddresses(v []*PrivateIpAddressSpecification) *InstanceNetworkInterfaceSpecification {
+	s.PrivateIpAddresses = v
+	return s
+}
+
+// SetSecondaryPrivateIpAddressCount sets the SecondaryPrivateIpAddressCount field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetSecondaryPrivateIpAddressCount(v int64) *InstanceNetworkInterfaceSpecification {
+	s.SecondaryPrivateIpAddressCount = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *InstanceNetworkInterfaceSpecification) SetSubnetId(v string) *InstanceNetworkInterfaceSpecification {
+	s.SubnetId = &v
+	return s
+}
+
 // Describes a private IP address.
 type InstancePrivateIpAddress struct {
 	_ struct{} `type:"structure"`
@@ -28432,6 +35368,30 @@ func (s InstancePrivateIpAddress) String() string {
 // GoString returns the string representation
 func (s InstancePrivateIpAddress) GoString() string {
 	return s.String()
+}
+
+// SetAssociation sets the Association field's value.
+func (s *InstancePrivateIpAddress) SetAssociation(v *InstanceNetworkInterfaceAssociation) *InstancePrivateIpAddress {
+	s.Association = v
+	return s
+}
+
+// SetPrimary sets the Primary field's value.
+func (s *InstancePrivateIpAddress) SetPrimary(v bool) *InstancePrivateIpAddress {
+	s.Primary = &v
+	return s
+}
+
+// SetPrivateDnsName sets the PrivateDnsName field's value.
+func (s *InstancePrivateIpAddress) SetPrivateDnsName(v string) *InstancePrivateIpAddress {
+	s.PrivateDnsName = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *InstancePrivateIpAddress) SetPrivateIpAddress(v string) *InstancePrivateIpAddress {
+	s.PrivateIpAddress = &v
+	return s
 }
 
 // Describes the current state of the instance.
@@ -28468,6 +35428,18 @@ func (s InstanceState) GoString() string {
 	return s.String()
 }
 
+// SetCode sets the Code field's value.
+func (s *InstanceState) SetCode(v int64) *InstanceState {
+	s.Code = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InstanceState) SetName(v string) *InstanceState {
+	s.Name = &v
+	return s
+}
+
 // Describes an instance state change.
 type InstanceStateChange struct {
 	_ struct{} `type:"structure"`
@@ -28490,6 +35462,24 @@ func (s InstanceStateChange) String() string {
 // GoString returns the string representation
 func (s InstanceStateChange) GoString() string {
 	return s.String()
+}
+
+// SetCurrentState sets the CurrentState field's value.
+func (s *InstanceStateChange) SetCurrentState(v *InstanceState) *InstanceStateChange {
+	s.CurrentState = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceStateChange) SetInstanceId(v string) *InstanceStateChange {
+	s.InstanceId = &v
+	return s
+}
+
+// SetPreviousState sets the PreviousState field's value.
+func (s *InstanceStateChange) SetPreviousState(v *InstanceState) *InstanceStateChange {
+	s.PreviousState = v
+	return s
 }
 
 // Describes the status of an instance.
@@ -28529,6 +35519,42 @@ func (s InstanceStatus) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *InstanceStatus) SetAvailabilityZone(v string) *InstanceStatus {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *InstanceStatus) SetEvents(v []*InstanceStatusEvent) *InstanceStatus {
+	s.Events = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceStatus) SetInstanceId(v string) *InstanceStatus {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceState sets the InstanceState field's value.
+func (s *InstanceStatus) SetInstanceState(v *InstanceState) *InstanceStatus {
+	s.InstanceState = v
+	return s
+}
+
+// SetInstanceStatus sets the InstanceStatus field's value.
+func (s *InstanceStatus) SetInstanceStatus(v *InstanceStatusSummary) *InstanceStatus {
+	s.InstanceStatus = v
+	return s
+}
+
+// SetSystemStatus sets the SystemStatus field's value.
+func (s *InstanceStatus) SetSystemStatus(v *InstanceStatusSummary) *InstanceStatus {
+	s.SystemStatus = v
+	return s
+}
+
 // Describes the instance status.
 type InstanceStatusDetails struct {
 	_ struct{} `type:"structure"`
@@ -28552,6 +35578,24 @@ func (s InstanceStatusDetails) String() string {
 // GoString returns the string representation
 func (s InstanceStatusDetails) GoString() string {
 	return s.String()
+}
+
+// SetImpairedSince sets the ImpairedSince field's value.
+func (s *InstanceStatusDetails) SetImpairedSince(v time.Time) *InstanceStatusDetails {
+	s.ImpairedSince = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InstanceStatusDetails) SetName(v string) *InstanceStatusDetails {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *InstanceStatusDetails) SetStatus(v string) *InstanceStatusDetails {
+	s.Status = &v
+	return s
 }
 
 // Describes a scheduled event for an instance.
@@ -28585,6 +35629,30 @@ func (s InstanceStatusEvent) GoString() string {
 	return s.String()
 }
 
+// SetCode sets the Code field's value.
+func (s *InstanceStatusEvent) SetCode(v string) *InstanceStatusEvent {
+	s.Code = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *InstanceStatusEvent) SetDescription(v string) *InstanceStatusEvent {
+	s.Description = &v
+	return s
+}
+
+// SetNotAfter sets the NotAfter field's value.
+func (s *InstanceStatusEvent) SetNotAfter(v time.Time) *InstanceStatusEvent {
+	s.NotAfter = &v
+	return s
+}
+
+// SetNotBefore sets the NotBefore field's value.
+func (s *InstanceStatusEvent) SetNotBefore(v time.Time) *InstanceStatusEvent {
+	s.NotBefore = &v
+	return s
+}
+
 // Describes the status of an instance.
 type InstanceStatusSummary struct {
 	_ struct{} `type:"structure"`
@@ -28604,6 +35672,18 @@ func (s InstanceStatusSummary) String() string {
 // GoString returns the string representation
 func (s InstanceStatusSummary) GoString() string {
 	return s.String()
+}
+
+// SetDetails sets the Details field's value.
+func (s *InstanceStatusSummary) SetDetails(v []*InstanceStatusDetails) *InstanceStatusSummary {
+	s.Details = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *InstanceStatusSummary) SetStatus(v string) *InstanceStatusSummary {
+	s.Status = &v
+	return s
 }
 
 // Describes an Internet gateway.
@@ -28630,6 +35710,24 @@ func (s InternetGateway) GoString() string {
 	return s.String()
 }
 
+// SetAttachments sets the Attachments field's value.
+func (s *InternetGateway) SetAttachments(v []*InternetGatewayAttachment) *InternetGateway {
+	s.Attachments = v
+	return s
+}
+
+// SetInternetGatewayId sets the InternetGatewayId field's value.
+func (s *InternetGateway) SetInternetGatewayId(v string) *InternetGateway {
+	s.InternetGatewayId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *InternetGateway) SetTags(v []*Tag) *InternetGateway {
+	s.Tags = v
+	return s
+}
+
 // Describes the attachment of a VPC to an Internet gateway.
 type InternetGatewayAttachment struct {
 	_ struct{} `type:"structure"`
@@ -28649,6 +35747,18 @@ func (s InternetGatewayAttachment) String() string {
 // GoString returns the string representation
 func (s InternetGatewayAttachment) GoString() string {
 	return s.String()
+}
+
+// SetState sets the State field's value.
+func (s *InternetGatewayAttachment) SetState(v string) *InternetGatewayAttachment {
+	s.State = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *InternetGatewayAttachment) SetVpcId(v string) *InternetGatewayAttachment {
+	s.VpcId = &v
+	return s
 }
 
 // Describes a security group rule.
@@ -28693,6 +35803,42 @@ func (s IpPermission) GoString() string {
 	return s.String()
 }
 
+// SetFromPort sets the FromPort field's value.
+func (s *IpPermission) SetFromPort(v int64) *IpPermission {
+	s.FromPort = &v
+	return s
+}
+
+// SetIpProtocol sets the IpProtocol field's value.
+func (s *IpPermission) SetIpProtocol(v string) *IpPermission {
+	s.IpProtocol = &v
+	return s
+}
+
+// SetIpRanges sets the IpRanges field's value.
+func (s *IpPermission) SetIpRanges(v []*IpRange) *IpPermission {
+	s.IpRanges = v
+	return s
+}
+
+// SetPrefixListIds sets the PrefixListIds field's value.
+func (s *IpPermission) SetPrefixListIds(v []*PrefixListId) *IpPermission {
+	s.PrefixListIds = v
+	return s
+}
+
+// SetToPort sets the ToPort field's value.
+func (s *IpPermission) SetToPort(v int64) *IpPermission {
+	s.ToPort = &v
+	return s
+}
+
+// SetUserIdGroupPairs sets the UserIdGroupPairs field's value.
+func (s *IpPermission) SetUserIdGroupPairs(v []*UserIdGroupPair) *IpPermission {
+	s.UserIdGroupPairs = v
+	return s
+}
+
 // Describes an IP range.
 type IpRange struct {
 	_ struct{} `type:"structure"`
@@ -28710,6 +35856,12 @@ func (s IpRange) String() string {
 // GoString returns the string representation
 func (s IpRange) GoString() string {
 	return s.String()
+}
+
+// SetCidrIp sets the CidrIp field's value.
+func (s *IpRange) SetCidrIp(v string) *IpRange {
+	s.CidrIp = &v
+	return s
 }
 
 // Describes a key pair.
@@ -28736,6 +35888,18 @@ func (s KeyPairInfo) GoString() string {
 	return s.String()
 }
 
+// SetKeyFingerprint sets the KeyFingerprint field's value.
+func (s *KeyPairInfo) SetKeyFingerprint(v string) *KeyPairInfo {
+	s.KeyFingerprint = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *KeyPairInfo) SetKeyName(v string) *KeyPairInfo {
+	s.KeyName = &v
+	return s
+}
+
 // Describes a launch permission.
 type LaunchPermission struct {
 	_ struct{} `type:"structure"`
@@ -28755,6 +35919,18 @@ func (s LaunchPermission) String() string {
 // GoString returns the string representation
 func (s LaunchPermission) GoString() string {
 	return s.String()
+}
+
+// SetGroup sets the Group field's value.
+func (s *LaunchPermission) SetGroup(v string) *LaunchPermission {
+	s.Group = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *LaunchPermission) SetUserId(v string) *LaunchPermission {
+	s.UserId = &v
+	return s
 }
 
 // Describes a launch permission modification.
@@ -28777,6 +35953,18 @@ func (s LaunchPermissionModifications) String() string {
 // GoString returns the string representation
 func (s LaunchPermissionModifications) GoString() string {
 	return s.String()
+}
+
+// SetAdd sets the Add field's value.
+func (s *LaunchPermissionModifications) SetAdd(v []*LaunchPermission) *LaunchPermissionModifications {
+	s.Add = v
+	return s
+}
+
+// SetRemove sets the Remove field's value.
+func (s *LaunchPermissionModifications) SetRemove(v []*LaunchPermission) *LaunchPermissionModifications {
+	s.Remove = v
+	return s
 }
 
 // Describes the launch specification for an instance.
@@ -28852,6 +36040,96 @@ func (s LaunchSpecification) GoString() string {
 	return s.String()
 }
 
+// SetAddressingType sets the AddressingType field's value.
+func (s *LaunchSpecification) SetAddressingType(v string) *LaunchSpecification {
+	s.AddressingType = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *LaunchSpecification) SetBlockDeviceMappings(v []*BlockDeviceMapping) *LaunchSpecification {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *LaunchSpecification) SetEbsOptimized(v bool) *LaunchSpecification {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *LaunchSpecification) SetIamInstanceProfile(v *IamInstanceProfileSpecification) *LaunchSpecification {
+	s.IamInstanceProfile = v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *LaunchSpecification) SetImageId(v string) *LaunchSpecification {
+	s.ImageId = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *LaunchSpecification) SetInstanceType(v string) *LaunchSpecification {
+	s.InstanceType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *LaunchSpecification) SetKernelId(v string) *LaunchSpecification {
+	s.KernelId = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *LaunchSpecification) SetKeyName(v string) *LaunchSpecification {
+	s.KeyName = &v
+	return s
+}
+
+// SetMonitoring sets the Monitoring field's value.
+func (s *LaunchSpecification) SetMonitoring(v *RunInstancesMonitoringEnabled) *LaunchSpecification {
+	s.Monitoring = v
+	return s
+}
+
+// SetNetworkInterfaces sets the NetworkInterfaces field's value.
+func (s *LaunchSpecification) SetNetworkInterfaces(v []*InstanceNetworkInterfaceSpecification) *LaunchSpecification {
+	s.NetworkInterfaces = v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *LaunchSpecification) SetPlacement(v *SpotPlacement) *LaunchSpecification {
+	s.Placement = v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *LaunchSpecification) SetRamdiskId(v string) *LaunchSpecification {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *LaunchSpecification) SetSecurityGroups(v []*GroupIdentifier) *LaunchSpecification {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *LaunchSpecification) SetSubnetId(v string) *LaunchSpecification {
+	s.SubnetId = &v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *LaunchSpecification) SetUserData(v string) *LaunchSpecification {
+	s.UserData = &v
+	return s
+}
+
 // Contains the parameters for ModifyHosts.
 type ModifyHostsInput struct {
 	_ struct{} `type:"structure"`
@@ -28893,6 +36171,18 @@ func (s *ModifyHostsInput) Validate() error {
 	return nil
 }
 
+// SetAutoPlacement sets the AutoPlacement field's value.
+func (s *ModifyHostsInput) SetAutoPlacement(v string) *ModifyHostsInput {
+	s.AutoPlacement = &v
+	return s
+}
+
+// SetHostIds sets the HostIds field's value.
+func (s *ModifyHostsInput) SetHostIds(v []*string) *ModifyHostsInput {
+	s.HostIds = v
+	return s
+}
+
 // Contains the output of ModifyHosts.
 type ModifyHostsOutput struct {
 	_ struct{} `type:"structure"`
@@ -28913,6 +36203,18 @@ func (s ModifyHostsOutput) String() string {
 // GoString returns the string representation
 func (s ModifyHostsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSuccessful sets the Successful field's value.
+func (s *ModifyHostsOutput) SetSuccessful(v []*string) *ModifyHostsOutput {
+	s.Successful = v
+	return s
+}
+
+// SetUnsuccessful sets the Unsuccessful field's value.
+func (s *ModifyHostsOutput) SetUnsuccessful(v []*UnsuccessfulItem) *ModifyHostsOutput {
+	s.Unsuccessful = v
+	return s
 }
 
 // Contains the parameters of ModifyIdFormat.
@@ -28954,6 +36256,18 @@ func (s *ModifyIdFormatInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResource sets the Resource field's value.
+func (s *ModifyIdFormatInput) SetResource(v string) *ModifyIdFormatInput {
+	s.Resource = &v
+	return s
+}
+
+// SetUseLongIds sets the UseLongIds field's value.
+func (s *ModifyIdFormatInput) SetUseLongIds(v bool) *ModifyIdFormatInput {
+	s.UseLongIds = &v
+	return s
 }
 
 type ModifyIdFormatOutput struct {
@@ -29019,6 +36333,24 @@ func (s *ModifyIdentityIdFormatInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPrincipalArn sets the PrincipalArn field's value.
+func (s *ModifyIdentityIdFormatInput) SetPrincipalArn(v string) *ModifyIdentityIdFormatInput {
+	s.PrincipalArn = &v
+	return s
+}
+
+// SetResource sets the Resource field's value.
+func (s *ModifyIdentityIdFormatInput) SetResource(v string) *ModifyIdentityIdFormatInput {
+	s.Resource = &v
+	return s
+}
+
+// SetUseLongIds sets the UseLongIds field's value.
+func (s *ModifyIdentityIdFormatInput) SetUseLongIds(v bool) *ModifyIdentityIdFormatInput {
+	s.UseLongIds = &v
+	return s
 }
 
 type ModifyIdentityIdFormatOutput struct {
@@ -29100,6 +36432,66 @@ func (s *ModifyImageAttributeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *ModifyImageAttributeInput) SetAttribute(v string) *ModifyImageAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ModifyImageAttributeInput) SetDescription(v *AttributeValue) *ModifyImageAttributeInput {
+	s.Description = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyImageAttributeInput) SetDryRun(v bool) *ModifyImageAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *ModifyImageAttributeInput) SetImageId(v string) *ModifyImageAttributeInput {
+	s.ImageId = &v
+	return s
+}
+
+// SetLaunchPermission sets the LaunchPermission field's value.
+func (s *ModifyImageAttributeInput) SetLaunchPermission(v *LaunchPermissionModifications) *ModifyImageAttributeInput {
+	s.LaunchPermission = v
+	return s
+}
+
+// SetOperationType sets the OperationType field's value.
+func (s *ModifyImageAttributeInput) SetOperationType(v string) *ModifyImageAttributeInput {
+	s.OperationType = &v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *ModifyImageAttributeInput) SetProductCodes(v []*string) *ModifyImageAttributeInput {
+	s.ProductCodes = v
+	return s
+}
+
+// SetUserGroups sets the UserGroups field's value.
+func (s *ModifyImageAttributeInput) SetUserGroups(v []*string) *ModifyImageAttributeInput {
+	s.UserGroups = v
+	return s
+}
+
+// SetUserIds sets the UserIds field's value.
+func (s *ModifyImageAttributeInput) SetUserIds(v []*string) *ModifyImageAttributeInput {
+	s.UserIds = v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ModifyImageAttributeInput) SetValue(v string) *ModifyImageAttributeInput {
+	s.Value = &v
+	return s
 }
 
 type ModifyImageAttributeOutput struct {
@@ -29236,6 +36628,102 @@ func (s *ModifyInstanceAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *ModifyInstanceAttributeInput) SetAttribute(v string) *ModifyInstanceAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *ModifyInstanceAttributeInput) SetBlockDeviceMappings(v []*InstanceBlockDeviceMappingSpecification) *ModifyInstanceAttributeInput {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetDisableApiTermination sets the DisableApiTermination field's value.
+func (s *ModifyInstanceAttributeInput) SetDisableApiTermination(v *AttributeBooleanValue) *ModifyInstanceAttributeInput {
+	s.DisableApiTermination = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyInstanceAttributeInput) SetDryRun(v bool) *ModifyInstanceAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *ModifyInstanceAttributeInput) SetEbsOptimized(v *AttributeBooleanValue) *ModifyInstanceAttributeInput {
+	s.EbsOptimized = v
+	return s
+}
+
+// SetEnaSupport sets the EnaSupport field's value.
+func (s *ModifyInstanceAttributeInput) SetEnaSupport(v *AttributeBooleanValue) *ModifyInstanceAttributeInput {
+	s.EnaSupport = v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *ModifyInstanceAttributeInput) SetGroups(v []*string) *ModifyInstanceAttributeInput {
+	s.Groups = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ModifyInstanceAttributeInput) SetInstanceId(v string) *ModifyInstanceAttributeInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceInitiatedShutdownBehavior sets the InstanceInitiatedShutdownBehavior field's value.
+func (s *ModifyInstanceAttributeInput) SetInstanceInitiatedShutdownBehavior(v *AttributeValue) *ModifyInstanceAttributeInput {
+	s.InstanceInitiatedShutdownBehavior = v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ModifyInstanceAttributeInput) SetInstanceType(v *AttributeValue) *ModifyInstanceAttributeInput {
+	s.InstanceType = v
+	return s
+}
+
+// SetKernel sets the Kernel field's value.
+func (s *ModifyInstanceAttributeInput) SetKernel(v *AttributeValue) *ModifyInstanceAttributeInput {
+	s.Kernel = v
+	return s
+}
+
+// SetRamdisk sets the Ramdisk field's value.
+func (s *ModifyInstanceAttributeInput) SetRamdisk(v *AttributeValue) *ModifyInstanceAttributeInput {
+	s.Ramdisk = v
+	return s
+}
+
+// SetSourceDestCheck sets the SourceDestCheck field's value.
+func (s *ModifyInstanceAttributeInput) SetSourceDestCheck(v *AttributeBooleanValue) *ModifyInstanceAttributeInput {
+	s.SourceDestCheck = v
+	return s
+}
+
+// SetSriovNetSupport sets the SriovNetSupport field's value.
+func (s *ModifyInstanceAttributeInput) SetSriovNetSupport(v *AttributeValue) *ModifyInstanceAttributeInput {
+	s.SriovNetSupport = v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *ModifyInstanceAttributeInput) SetUserData(v *BlobAttributeValue) *ModifyInstanceAttributeInput {
+	s.UserData = v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ModifyInstanceAttributeInput) SetValue(v string) *ModifyInstanceAttributeInput {
+	s.Value = &v
+	return s
+}
+
 type ModifyInstanceAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -29292,6 +36780,30 @@ func (s *ModifyInstancePlacementInput) Validate() error {
 	return nil
 }
 
+// SetAffinity sets the Affinity field's value.
+func (s *ModifyInstancePlacementInput) SetAffinity(v string) *ModifyInstancePlacementInput {
+	s.Affinity = &v
+	return s
+}
+
+// SetHostId sets the HostId field's value.
+func (s *ModifyInstancePlacementInput) SetHostId(v string) *ModifyInstancePlacementInput {
+	s.HostId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ModifyInstancePlacementInput) SetInstanceId(v string) *ModifyInstancePlacementInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetTenancy sets the Tenancy field's value.
+func (s *ModifyInstancePlacementInput) SetTenancy(v string) *ModifyInstancePlacementInput {
+	s.Tenancy = &v
+	return s
+}
+
 // Contains the output of ModifyInstancePlacement.
 type ModifyInstancePlacementOutput struct {
 	_ struct{} `type:"structure"`
@@ -29308,6 +36820,12 @@ func (s ModifyInstancePlacementOutput) String() string {
 // GoString returns the string representation
 func (s ModifyInstancePlacementOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *ModifyInstancePlacementOutput) SetReturn(v bool) *ModifyInstancePlacementOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for ModifyNetworkInterfaceAttribute.
@@ -29369,6 +36887,42 @@ func (s *ModifyNetworkInterfaceAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttachment sets the Attachment field's value.
+func (s *ModifyNetworkInterfaceAttributeInput) SetAttachment(v *NetworkInterfaceAttachmentChanges) *ModifyNetworkInterfaceAttributeInput {
+	s.Attachment = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ModifyNetworkInterfaceAttributeInput) SetDescription(v *AttributeValue) *ModifyNetworkInterfaceAttributeInput {
+	s.Description = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyNetworkInterfaceAttributeInput) SetDryRun(v bool) *ModifyNetworkInterfaceAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *ModifyNetworkInterfaceAttributeInput) SetGroups(v []*string) *ModifyNetworkInterfaceAttributeInput {
+	s.Groups = v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *ModifyNetworkInterfaceAttributeInput) SetNetworkInterfaceId(v string) *ModifyNetworkInterfaceAttributeInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetSourceDestCheck sets the SourceDestCheck field's value.
+func (s *ModifyNetworkInterfaceAttributeInput) SetSourceDestCheck(v *AttributeBooleanValue) *ModifyNetworkInterfaceAttributeInput {
+	s.SourceDestCheck = v
+	return s
+}
+
 type ModifyNetworkInterfaceAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -29428,6 +36982,24 @@ func (s *ModifyReservedInstancesInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *ModifyReservedInstancesInput) SetClientToken(v string) *ModifyReservedInstancesInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetReservedInstancesIds sets the ReservedInstancesIds field's value.
+func (s *ModifyReservedInstancesInput) SetReservedInstancesIds(v []*string) *ModifyReservedInstancesInput {
+	s.ReservedInstancesIds = v
+	return s
+}
+
+// SetTargetConfigurations sets the TargetConfigurations field's value.
+func (s *ModifyReservedInstancesInput) SetTargetConfigurations(v []*ReservedInstancesConfiguration) *ModifyReservedInstancesInput {
+	s.TargetConfigurations = v
+	return s
+}
+
 // Contains the output of ModifyReservedInstances.
 type ModifyReservedInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -29444,6 +37016,12 @@ func (s ModifyReservedInstancesOutput) String() string {
 // GoString returns the string representation
 func (s ModifyReservedInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedInstancesModificationId sets the ReservedInstancesModificationId field's value.
+func (s *ModifyReservedInstancesOutput) SetReservedInstancesModificationId(v string) *ModifyReservedInstancesOutput {
+	s.ReservedInstancesModificationId = &v
+	return s
 }
 
 // Contains the parameters for ModifySnapshotAttribute.
@@ -29502,6 +37080,48 @@ func (s *ModifySnapshotAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *ModifySnapshotAttributeInput) SetAttribute(v string) *ModifySnapshotAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetCreateVolumePermission sets the CreateVolumePermission field's value.
+func (s *ModifySnapshotAttributeInput) SetCreateVolumePermission(v *CreateVolumePermissionModifications) *ModifySnapshotAttributeInput {
+	s.CreateVolumePermission = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifySnapshotAttributeInput) SetDryRun(v bool) *ModifySnapshotAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupNames sets the GroupNames field's value.
+func (s *ModifySnapshotAttributeInput) SetGroupNames(v []*string) *ModifySnapshotAttributeInput {
+	s.GroupNames = v
+	return s
+}
+
+// SetOperationType sets the OperationType field's value.
+func (s *ModifySnapshotAttributeInput) SetOperationType(v string) *ModifySnapshotAttributeInput {
+	s.OperationType = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *ModifySnapshotAttributeInput) SetSnapshotId(v string) *ModifySnapshotAttributeInput {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetUserIds sets the UserIds field's value.
+func (s *ModifySnapshotAttributeInput) SetUserIds(v []*string) *ModifySnapshotAttributeInput {
+	s.UserIds = v
+	return s
+}
+
 type ModifySnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -29557,6 +37177,24 @@ func (s *ModifySpotFleetRequestInput) Validate() error {
 	return nil
 }
 
+// SetExcessCapacityTerminationPolicy sets the ExcessCapacityTerminationPolicy field's value.
+func (s *ModifySpotFleetRequestInput) SetExcessCapacityTerminationPolicy(v string) *ModifySpotFleetRequestInput {
+	s.ExcessCapacityTerminationPolicy = &v
+	return s
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *ModifySpotFleetRequestInput) SetSpotFleetRequestId(v string) *ModifySpotFleetRequestInput {
+	s.SpotFleetRequestId = &v
+	return s
+}
+
+// SetTargetCapacity sets the TargetCapacity field's value.
+func (s *ModifySpotFleetRequestInput) SetTargetCapacity(v int64) *ModifySpotFleetRequestInput {
+	s.TargetCapacity = &v
+	return s
+}
+
 // Contains the output of ModifySpotFleetRequest.
 type ModifySpotFleetRequestOutput struct {
 	_ struct{} `type:"structure"`
@@ -29573,6 +37211,12 @@ func (s ModifySpotFleetRequestOutput) String() string {
 // GoString returns the string representation
 func (s ModifySpotFleetRequestOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *ModifySpotFleetRequestOutput) SetReturn(v bool) *ModifySpotFleetRequestOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for ModifySubnetAttribute.
@@ -29610,6 +37254,18 @@ func (s *ModifySubnetAttributeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMapPublicIpOnLaunch sets the MapPublicIpOnLaunch field's value.
+func (s *ModifySubnetAttributeInput) SetMapPublicIpOnLaunch(v *AttributeBooleanValue) *ModifySubnetAttributeInput {
+	s.MapPublicIpOnLaunch = v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *ModifySubnetAttributeInput) SetSubnetId(v string) *ModifySubnetAttributeInput {
+	s.SubnetId = &v
+	return s
 }
 
 type ModifySubnetAttributeOutput struct {
@@ -29666,6 +37322,24 @@ func (s *ModifyVolumeAttributeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAutoEnableIO sets the AutoEnableIO field's value.
+func (s *ModifyVolumeAttributeInput) SetAutoEnableIO(v *AttributeBooleanValue) *ModifyVolumeAttributeInput {
+	s.AutoEnableIO = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyVolumeAttributeInput) SetDryRun(v bool) *ModifyVolumeAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *ModifyVolumeAttributeInput) SetVolumeId(v string) *ModifyVolumeAttributeInput {
+	s.VolumeId = &v
+	return s
 }
 
 type ModifyVolumeAttributeOutput struct {
@@ -29731,6 +37405,24 @@ func (s *ModifyVpcAttributeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEnableDnsHostnames sets the EnableDnsHostnames field's value.
+func (s *ModifyVpcAttributeInput) SetEnableDnsHostnames(v *AttributeBooleanValue) *ModifyVpcAttributeInput {
+	s.EnableDnsHostnames = v
+	return s
+}
+
+// SetEnableDnsSupport sets the EnableDnsSupport field's value.
+func (s *ModifyVpcAttributeInput) SetEnableDnsSupport(v *AttributeBooleanValue) *ModifyVpcAttributeInput {
+	s.EnableDnsSupport = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *ModifyVpcAttributeInput) SetVpcId(v string) *ModifyVpcAttributeInput {
+	s.VpcId = &v
+	return s
 }
 
 type ModifyVpcAttributeOutput struct {
@@ -29800,6 +37492,42 @@ func (s *ModifyVpcEndpointInput) Validate() error {
 	return nil
 }
 
+// SetAddRouteTableIds sets the AddRouteTableIds field's value.
+func (s *ModifyVpcEndpointInput) SetAddRouteTableIds(v []*string) *ModifyVpcEndpointInput {
+	s.AddRouteTableIds = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyVpcEndpointInput) SetDryRun(v bool) *ModifyVpcEndpointInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *ModifyVpcEndpointInput) SetPolicyDocument(v string) *ModifyVpcEndpointInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetRemoveRouteTableIds sets the RemoveRouteTableIds field's value.
+func (s *ModifyVpcEndpointInput) SetRemoveRouteTableIds(v []*string) *ModifyVpcEndpointInput {
+	s.RemoveRouteTableIds = v
+	return s
+}
+
+// SetResetPolicy sets the ResetPolicy field's value.
+func (s *ModifyVpcEndpointInput) SetResetPolicy(v bool) *ModifyVpcEndpointInput {
+	s.ResetPolicy = &v
+	return s
+}
+
+// SetVpcEndpointId sets the VpcEndpointId field's value.
+func (s *ModifyVpcEndpointInput) SetVpcEndpointId(v string) *ModifyVpcEndpointInput {
+	s.VpcEndpointId = &v
+	return s
+}
+
 // Contains the output of ModifyVpcEndpoint.
 type ModifyVpcEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -29816,6 +37544,12 @@ func (s ModifyVpcEndpointOutput) String() string {
 // GoString returns the string representation
 func (s ModifyVpcEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *ModifyVpcEndpointOutput) SetReturn(v bool) *ModifyVpcEndpointOutput {
+	s.Return = &v
+	return s
 }
 
 type ModifyVpcPeeringConnectionOptionsInput struct {
@@ -29862,6 +37596,30 @@ func (s *ModifyVpcPeeringConnectionOptionsInput) Validate() error {
 	return nil
 }
 
+// SetAccepterPeeringConnectionOptions sets the AccepterPeeringConnectionOptions field's value.
+func (s *ModifyVpcPeeringConnectionOptionsInput) SetAccepterPeeringConnectionOptions(v *PeeringConnectionOptionsRequest) *ModifyVpcPeeringConnectionOptionsInput {
+	s.AccepterPeeringConnectionOptions = v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyVpcPeeringConnectionOptionsInput) SetDryRun(v bool) *ModifyVpcPeeringConnectionOptionsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetRequesterPeeringConnectionOptions sets the RequesterPeeringConnectionOptions field's value.
+func (s *ModifyVpcPeeringConnectionOptionsInput) SetRequesterPeeringConnectionOptions(v *PeeringConnectionOptionsRequest) *ModifyVpcPeeringConnectionOptionsInput {
+	s.RequesterPeeringConnectionOptions = v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *ModifyVpcPeeringConnectionOptionsInput) SetVpcPeeringConnectionId(v string) *ModifyVpcPeeringConnectionOptionsInput {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 type ModifyVpcPeeringConnectionOptionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -29880,6 +37638,18 @@ func (s ModifyVpcPeeringConnectionOptionsOutput) String() string {
 // GoString returns the string representation
 func (s ModifyVpcPeeringConnectionOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccepterPeeringConnectionOptions sets the AccepterPeeringConnectionOptions field's value.
+func (s *ModifyVpcPeeringConnectionOptionsOutput) SetAccepterPeeringConnectionOptions(v *PeeringConnectionOptions) *ModifyVpcPeeringConnectionOptionsOutput {
+	s.AccepterPeeringConnectionOptions = v
+	return s
+}
+
+// SetRequesterPeeringConnectionOptions sets the RequesterPeeringConnectionOptions field's value.
+func (s *ModifyVpcPeeringConnectionOptionsOutput) SetRequesterPeeringConnectionOptions(v *PeeringConnectionOptions) *ModifyVpcPeeringConnectionOptionsOutput {
+	s.RequesterPeeringConnectionOptions = v
+	return s
 }
 
 // Contains the parameters for MonitorInstances.
@@ -29921,6 +37691,18 @@ func (s *MonitorInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *MonitorInstancesInput) SetDryRun(v bool) *MonitorInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *MonitorInstancesInput) SetInstanceIds(v []*string) *MonitorInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
 // Contains the output of MonitorInstances.
 type MonitorInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -29939,6 +37721,12 @@ func (s MonitorInstancesOutput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceMonitorings sets the InstanceMonitorings field's value.
+func (s *MonitorInstancesOutput) SetInstanceMonitorings(v []*InstanceMonitoring) *MonitorInstancesOutput {
+	s.InstanceMonitorings = v
+	return s
+}
+
 // Describes the monitoring for the instance.
 type Monitoring struct {
 	_ struct{} `type:"structure"`
@@ -29955,6 +37743,12 @@ func (s Monitoring) String() string {
 // GoString returns the string representation
 func (s Monitoring) GoString() string {
 	return s.String()
+}
+
+// SetState sets the State field's value.
+func (s *Monitoring) SetState(v string) *Monitoring {
+	s.State = &v
+	return s
 }
 
 // Contains the parameters for MoveAddressToVpc.
@@ -29996,6 +37790,18 @@ func (s *MoveAddressToVpcInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *MoveAddressToVpcInput) SetDryRun(v bool) *MoveAddressToVpcInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *MoveAddressToVpcInput) SetPublicIp(v string) *MoveAddressToVpcInput {
+	s.PublicIp = &v
+	return s
+}
+
 // Contains the output of MoveAddressToVpc.
 type MoveAddressToVpcOutput struct {
 	_ struct{} `type:"structure"`
@@ -30015,6 +37821,18 @@ func (s MoveAddressToVpcOutput) String() string {
 // GoString returns the string representation
 func (s MoveAddressToVpcOutput) GoString() string {
 	return s.String()
+}
+
+// SetAllocationId sets the AllocationId field's value.
+func (s *MoveAddressToVpcOutput) SetAllocationId(v string) *MoveAddressToVpcOutput {
+	s.AllocationId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *MoveAddressToVpcOutput) SetStatus(v string) *MoveAddressToVpcOutput {
+	s.Status = &v
+	return s
 }
 
 // Describes the status of a moving Elastic IP address.
@@ -30037,6 +37855,18 @@ func (s MovingAddressStatus) String() string {
 // GoString returns the string representation
 func (s MovingAddressStatus) GoString() string {
 	return s.String()
+}
+
+// SetMoveStatus sets the MoveStatus field's value.
+func (s *MovingAddressStatus) SetMoveStatus(v string) *MovingAddressStatus {
+	s.MoveStatus = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *MovingAddressStatus) SetPublicIp(v string) *MovingAddressStatus {
+	s.PublicIp = &v
+	return s
 }
 
 // Describes a NAT gateway.
@@ -30124,6 +37954,66 @@ func (s NatGateway) GoString() string {
 	return s.String()
 }
 
+// SetCreateTime sets the CreateTime field's value.
+func (s *NatGateway) SetCreateTime(v time.Time) *NatGateway {
+	s.CreateTime = &v
+	return s
+}
+
+// SetDeleteTime sets the DeleteTime field's value.
+func (s *NatGateway) SetDeleteTime(v time.Time) *NatGateway {
+	s.DeleteTime = &v
+	return s
+}
+
+// SetFailureCode sets the FailureCode field's value.
+func (s *NatGateway) SetFailureCode(v string) *NatGateway {
+	s.FailureCode = &v
+	return s
+}
+
+// SetFailureMessage sets the FailureMessage field's value.
+func (s *NatGateway) SetFailureMessage(v string) *NatGateway {
+	s.FailureMessage = &v
+	return s
+}
+
+// SetNatGatewayAddresses sets the NatGatewayAddresses field's value.
+func (s *NatGateway) SetNatGatewayAddresses(v []*NatGatewayAddress) *NatGateway {
+	s.NatGatewayAddresses = v
+	return s
+}
+
+// SetNatGatewayId sets the NatGatewayId field's value.
+func (s *NatGateway) SetNatGatewayId(v string) *NatGateway {
+	s.NatGatewayId = &v
+	return s
+}
+
+// SetProvisionedBandwidth sets the ProvisionedBandwidth field's value.
+func (s *NatGateway) SetProvisionedBandwidth(v *ProvisionedBandwidth) *NatGateway {
+	s.ProvisionedBandwidth = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *NatGateway) SetState(v string) *NatGateway {
+	s.State = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *NatGateway) SetSubnetId(v string) *NatGateway {
+	s.SubnetId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *NatGateway) SetVpcId(v string) *NatGateway {
+	s.VpcId = &v
+	return s
+}
+
 // Describes the IP addresses and network interface associated with a NAT gateway.
 type NatGatewayAddress struct {
 	_ struct{} `type:"structure"`
@@ -30150,6 +38040,30 @@ func (s NatGatewayAddress) String() string {
 // GoString returns the string representation
 func (s NatGatewayAddress) GoString() string {
 	return s.String()
+}
+
+// SetAllocationId sets the AllocationId field's value.
+func (s *NatGatewayAddress) SetAllocationId(v string) *NatGatewayAddress {
+	s.AllocationId = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *NatGatewayAddress) SetNetworkInterfaceId(v string) *NatGatewayAddress {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetPrivateIp sets the PrivateIp field's value.
+func (s *NatGatewayAddress) SetPrivateIp(v string) *NatGatewayAddress {
+	s.PrivateIp = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *NatGatewayAddress) SetPublicIp(v string) *NatGatewayAddress {
+	s.PublicIp = &v
+	return s
 }
 
 // Describes a network ACL.
@@ -30185,6 +38099,42 @@ func (s NetworkAcl) GoString() string {
 	return s.String()
 }
 
+// SetAssociations sets the Associations field's value.
+func (s *NetworkAcl) SetAssociations(v []*NetworkAclAssociation) *NetworkAcl {
+	s.Associations = v
+	return s
+}
+
+// SetEntries sets the Entries field's value.
+func (s *NetworkAcl) SetEntries(v []*NetworkAclEntry) *NetworkAcl {
+	s.Entries = v
+	return s
+}
+
+// SetIsDefault sets the IsDefault field's value.
+func (s *NetworkAcl) SetIsDefault(v bool) *NetworkAcl {
+	s.IsDefault = &v
+	return s
+}
+
+// SetNetworkAclId sets the NetworkAclId field's value.
+func (s *NetworkAcl) SetNetworkAclId(v string) *NetworkAcl {
+	s.NetworkAclId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *NetworkAcl) SetTags(v []*Tag) *NetworkAcl {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *NetworkAcl) SetVpcId(v string) *NetworkAcl {
+	s.VpcId = &v
+	return s
+}
+
 // Describes an association between a network ACL and a subnet.
 type NetworkAclAssociation struct {
 	_ struct{} `type:"structure"`
@@ -30207,6 +38157,24 @@ func (s NetworkAclAssociation) String() string {
 // GoString returns the string representation
 func (s NetworkAclAssociation) GoString() string {
 	return s.String()
+}
+
+// SetNetworkAclAssociationId sets the NetworkAclAssociationId field's value.
+func (s *NetworkAclAssociation) SetNetworkAclAssociationId(v string) *NetworkAclAssociation {
+	s.NetworkAclAssociationId = &v
+	return s
+}
+
+// SetNetworkAclId sets the NetworkAclId field's value.
+func (s *NetworkAclAssociation) SetNetworkAclId(v string) *NetworkAclAssociation {
+	s.NetworkAclId = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *NetworkAclAssociation) SetSubnetId(v string) *NetworkAclAssociation {
+	s.SubnetId = &v
+	return s
 }
 
 // Describes an entry in a network ACL.
@@ -30245,6 +38213,48 @@ func (s NetworkAclEntry) String() string {
 // GoString returns the string representation
 func (s NetworkAclEntry) GoString() string {
 	return s.String()
+}
+
+// SetCidrBlock sets the CidrBlock field's value.
+func (s *NetworkAclEntry) SetCidrBlock(v string) *NetworkAclEntry {
+	s.CidrBlock = &v
+	return s
+}
+
+// SetEgress sets the Egress field's value.
+func (s *NetworkAclEntry) SetEgress(v bool) *NetworkAclEntry {
+	s.Egress = &v
+	return s
+}
+
+// SetIcmpTypeCode sets the IcmpTypeCode field's value.
+func (s *NetworkAclEntry) SetIcmpTypeCode(v *IcmpTypeCode) *NetworkAclEntry {
+	s.IcmpTypeCode = v
+	return s
+}
+
+// SetPortRange sets the PortRange field's value.
+func (s *NetworkAclEntry) SetPortRange(v *PortRange) *NetworkAclEntry {
+	s.PortRange = v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *NetworkAclEntry) SetProtocol(v string) *NetworkAclEntry {
+	s.Protocol = &v
+	return s
+}
+
+// SetRuleAction sets the RuleAction field's value.
+func (s *NetworkAclEntry) SetRuleAction(v string) *NetworkAclEntry {
+	s.RuleAction = &v
+	return s
+}
+
+// SetRuleNumber sets the RuleNumber field's value.
+func (s *NetworkAclEntry) SetRuleNumber(v int64) *NetworkAclEntry {
+	s.RuleNumber = &v
+	return s
 }
 
 // Describes a network interface.
@@ -30321,6 +38331,120 @@ func (s NetworkInterface) GoString() string {
 	return s.String()
 }
 
+// SetAssociation sets the Association field's value.
+func (s *NetworkInterface) SetAssociation(v *NetworkInterfaceAssociation) *NetworkInterface {
+	s.Association = v
+	return s
+}
+
+// SetAttachment sets the Attachment field's value.
+func (s *NetworkInterface) SetAttachment(v *NetworkInterfaceAttachment) *NetworkInterface {
+	s.Attachment = v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *NetworkInterface) SetAvailabilityZone(v string) *NetworkInterface {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *NetworkInterface) SetDescription(v string) *NetworkInterface {
+	s.Description = &v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *NetworkInterface) SetGroups(v []*GroupIdentifier) *NetworkInterface {
+	s.Groups = v
+	return s
+}
+
+// SetInterfaceType sets the InterfaceType field's value.
+func (s *NetworkInterface) SetInterfaceType(v string) *NetworkInterface {
+	s.InterfaceType = &v
+	return s
+}
+
+// SetMacAddress sets the MacAddress field's value.
+func (s *NetworkInterface) SetMacAddress(v string) *NetworkInterface {
+	s.MacAddress = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *NetworkInterface) SetNetworkInterfaceId(v string) *NetworkInterface {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *NetworkInterface) SetOwnerId(v string) *NetworkInterface {
+	s.OwnerId = &v
+	return s
+}
+
+// SetPrivateDnsName sets the PrivateDnsName field's value.
+func (s *NetworkInterface) SetPrivateDnsName(v string) *NetworkInterface {
+	s.PrivateDnsName = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *NetworkInterface) SetPrivateIpAddress(v string) *NetworkInterface {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetPrivateIpAddresses sets the PrivateIpAddresses field's value.
+func (s *NetworkInterface) SetPrivateIpAddresses(v []*NetworkInterfacePrivateIpAddress) *NetworkInterface {
+	s.PrivateIpAddresses = v
+	return s
+}
+
+// SetRequesterId sets the RequesterId field's value.
+func (s *NetworkInterface) SetRequesterId(v string) *NetworkInterface {
+	s.RequesterId = &v
+	return s
+}
+
+// SetRequesterManaged sets the RequesterManaged field's value.
+func (s *NetworkInterface) SetRequesterManaged(v bool) *NetworkInterface {
+	s.RequesterManaged = &v
+	return s
+}
+
+// SetSourceDestCheck sets the SourceDestCheck field's value.
+func (s *NetworkInterface) SetSourceDestCheck(v bool) *NetworkInterface {
+	s.SourceDestCheck = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *NetworkInterface) SetStatus(v string) *NetworkInterface {
+	s.Status = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *NetworkInterface) SetSubnetId(v string) *NetworkInterface {
+	s.SubnetId = &v
+	return s
+}
+
+// SetTagSet sets the TagSet field's value.
+func (s *NetworkInterface) SetTagSet(v []*Tag) *NetworkInterface {
+	s.TagSet = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *NetworkInterface) SetVpcId(v string) *NetworkInterface {
+	s.VpcId = &v
+	return s
+}
+
 // Describes association information for an Elastic IP address.
 type NetworkInterfaceAssociation struct {
 	_ struct{} `type:"structure"`
@@ -30349,6 +38473,36 @@ func (s NetworkInterfaceAssociation) String() string {
 // GoString returns the string representation
 func (s NetworkInterfaceAssociation) GoString() string {
 	return s.String()
+}
+
+// SetAllocationId sets the AllocationId field's value.
+func (s *NetworkInterfaceAssociation) SetAllocationId(v string) *NetworkInterfaceAssociation {
+	s.AllocationId = &v
+	return s
+}
+
+// SetAssociationId sets the AssociationId field's value.
+func (s *NetworkInterfaceAssociation) SetAssociationId(v string) *NetworkInterfaceAssociation {
+	s.AssociationId = &v
+	return s
+}
+
+// SetIpOwnerId sets the IpOwnerId field's value.
+func (s *NetworkInterfaceAssociation) SetIpOwnerId(v string) *NetworkInterfaceAssociation {
+	s.IpOwnerId = &v
+	return s
+}
+
+// SetPublicDnsName sets the PublicDnsName field's value.
+func (s *NetworkInterfaceAssociation) SetPublicDnsName(v string) *NetworkInterfaceAssociation {
+	s.PublicDnsName = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *NetworkInterfaceAssociation) SetPublicIp(v string) *NetworkInterfaceAssociation {
+	s.PublicIp = &v
+	return s
 }
 
 // Describes a network interface attachment.
@@ -30387,6 +38541,48 @@ func (s NetworkInterfaceAttachment) GoString() string {
 	return s.String()
 }
 
+// SetAttachTime sets the AttachTime field's value.
+func (s *NetworkInterfaceAttachment) SetAttachTime(v time.Time) *NetworkInterfaceAttachment {
+	s.AttachTime = &v
+	return s
+}
+
+// SetAttachmentId sets the AttachmentId field's value.
+func (s *NetworkInterfaceAttachment) SetAttachmentId(v string) *NetworkInterfaceAttachment {
+	s.AttachmentId = &v
+	return s
+}
+
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *NetworkInterfaceAttachment) SetDeleteOnTermination(v bool) *NetworkInterfaceAttachment {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetDeviceIndex sets the DeviceIndex field's value.
+func (s *NetworkInterfaceAttachment) SetDeviceIndex(v int64) *NetworkInterfaceAttachment {
+	s.DeviceIndex = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *NetworkInterfaceAttachment) SetInstanceId(v string) *NetworkInterfaceAttachment {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceOwnerId sets the InstanceOwnerId field's value.
+func (s *NetworkInterfaceAttachment) SetInstanceOwnerId(v string) *NetworkInterfaceAttachment {
+	s.InstanceOwnerId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *NetworkInterfaceAttachment) SetStatus(v string) *NetworkInterfaceAttachment {
+	s.Status = &v
+	return s
+}
+
 // Describes an attachment change.
 type NetworkInterfaceAttachmentChanges struct {
 	_ struct{} `type:"structure"`
@@ -30406,6 +38602,18 @@ func (s NetworkInterfaceAttachmentChanges) String() string {
 // GoString returns the string representation
 func (s NetworkInterfaceAttachmentChanges) GoString() string {
 	return s.String()
+}
+
+// SetAttachmentId sets the AttachmentId field's value.
+func (s *NetworkInterfaceAttachmentChanges) SetAttachmentId(v string) *NetworkInterfaceAttachmentChanges {
+	s.AttachmentId = &v
+	return s
+}
+
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *NetworkInterfaceAttachmentChanges) SetDeleteOnTermination(v bool) *NetworkInterfaceAttachmentChanges {
+	s.DeleteOnTermination = &v
+	return s
 }
 
 // Describes the private IP address of a network interface.
@@ -30437,6 +38645,30 @@ func (s NetworkInterfacePrivateIpAddress) GoString() string {
 	return s.String()
 }
 
+// SetAssociation sets the Association field's value.
+func (s *NetworkInterfacePrivateIpAddress) SetAssociation(v *NetworkInterfaceAssociation) *NetworkInterfacePrivateIpAddress {
+	s.Association = v
+	return s
+}
+
+// SetPrimary sets the Primary field's value.
+func (s *NetworkInterfacePrivateIpAddress) SetPrimary(v bool) *NetworkInterfacePrivateIpAddress {
+	s.Primary = &v
+	return s
+}
+
+// SetPrivateDnsName sets the PrivateDnsName field's value.
+func (s *NetworkInterfacePrivateIpAddress) SetPrivateDnsName(v string) *NetworkInterfacePrivateIpAddress {
+	s.PrivateDnsName = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *NetworkInterfacePrivateIpAddress) SetPrivateIpAddress(v string) *NetworkInterfacePrivateIpAddress {
+	s.PrivateIpAddress = &v
+	return s
+}
+
 type NewDhcpConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -30453,6 +38685,18 @@ func (s NewDhcpConfiguration) String() string {
 // GoString returns the string representation
 func (s NewDhcpConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *NewDhcpConfiguration) SetKey(v string) *NewDhcpConfiguration {
+	s.Key = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *NewDhcpConfiguration) SetValues(v []*string) *NewDhcpConfiguration {
+	s.Values = v
+	return s
 }
 
 // Describes the VPC peering connection options.
@@ -30482,6 +38726,24 @@ func (s PeeringConnectionOptions) GoString() string {
 	return s.String()
 }
 
+// SetAllowDnsResolutionFromRemoteVpc sets the AllowDnsResolutionFromRemoteVpc field's value.
+func (s *PeeringConnectionOptions) SetAllowDnsResolutionFromRemoteVpc(v bool) *PeeringConnectionOptions {
+	s.AllowDnsResolutionFromRemoteVpc = &v
+	return s
+}
+
+// SetAllowEgressFromLocalClassicLinkToRemoteVpc sets the AllowEgressFromLocalClassicLinkToRemoteVpc field's value.
+func (s *PeeringConnectionOptions) SetAllowEgressFromLocalClassicLinkToRemoteVpc(v bool) *PeeringConnectionOptions {
+	s.AllowEgressFromLocalClassicLinkToRemoteVpc = &v
+	return s
+}
+
+// SetAllowEgressFromLocalVpcToRemoteClassicLink sets the AllowEgressFromLocalVpcToRemoteClassicLink field's value.
+func (s *PeeringConnectionOptions) SetAllowEgressFromLocalVpcToRemoteClassicLink(v bool) *PeeringConnectionOptions {
+	s.AllowEgressFromLocalVpcToRemoteClassicLink = &v
+	return s
+}
+
 // The VPC peering connection options.
 type PeeringConnectionOptionsRequest struct {
 	_ struct{} `type:"structure"`
@@ -30507,6 +38769,24 @@ func (s PeeringConnectionOptionsRequest) String() string {
 // GoString returns the string representation
 func (s PeeringConnectionOptionsRequest) GoString() string {
 	return s.String()
+}
+
+// SetAllowDnsResolutionFromRemoteVpc sets the AllowDnsResolutionFromRemoteVpc field's value.
+func (s *PeeringConnectionOptionsRequest) SetAllowDnsResolutionFromRemoteVpc(v bool) *PeeringConnectionOptionsRequest {
+	s.AllowDnsResolutionFromRemoteVpc = &v
+	return s
+}
+
+// SetAllowEgressFromLocalClassicLinkToRemoteVpc sets the AllowEgressFromLocalClassicLinkToRemoteVpc field's value.
+func (s *PeeringConnectionOptionsRequest) SetAllowEgressFromLocalClassicLinkToRemoteVpc(v bool) *PeeringConnectionOptionsRequest {
+	s.AllowEgressFromLocalClassicLinkToRemoteVpc = &v
+	return s
+}
+
+// SetAllowEgressFromLocalVpcToRemoteClassicLink sets the AllowEgressFromLocalVpcToRemoteClassicLink field's value.
+func (s *PeeringConnectionOptionsRequest) SetAllowEgressFromLocalVpcToRemoteClassicLink(v bool) *PeeringConnectionOptionsRequest {
+	s.AllowEgressFromLocalVpcToRemoteClassicLink = &v
+	return s
 }
 
 // Describes the placement for the instance.
@@ -30543,6 +38823,36 @@ func (s Placement) GoString() string {
 	return s.String()
 }
 
+// SetAffinity sets the Affinity field's value.
+func (s *Placement) SetAffinity(v string) *Placement {
+	s.Affinity = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Placement) SetAvailabilityZone(v string) *Placement {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *Placement) SetGroupName(v string) *Placement {
+	s.GroupName = &v
+	return s
+}
+
+// SetHostId sets the HostId field's value.
+func (s *Placement) SetHostId(v string) *Placement {
+	s.HostId = &v
+	return s
+}
+
+// SetTenancy sets the Tenancy field's value.
+func (s *Placement) SetTenancy(v string) *Placement {
+	s.Tenancy = &v
+	return s
+}
+
 // Describes a placement group.
 type PlacementGroup struct {
 	_ struct{} `type:"structure"`
@@ -30567,6 +38877,24 @@ func (s PlacementGroup) GoString() string {
 	return s.String()
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *PlacementGroup) SetGroupName(v string) *PlacementGroup {
+	s.GroupName = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *PlacementGroup) SetState(v string) *PlacementGroup {
+	s.State = &v
+	return s
+}
+
+// SetStrategy sets the Strategy field's value.
+func (s *PlacementGroup) SetStrategy(v string) *PlacementGroup {
+	s.Strategy = &v
+	return s
+}
+
 // Describes a range of ports.
 type PortRange struct {
 	_ struct{} `type:"structure"`
@@ -30586,6 +38914,18 @@ func (s PortRange) String() string {
 // GoString returns the string representation
 func (s PortRange) GoString() string {
 	return s.String()
+}
+
+// SetFrom sets the From field's value.
+func (s *PortRange) SetFrom(v int64) *PortRange {
+	s.From = &v
+	return s
+}
+
+// SetTo sets the To field's value.
+func (s *PortRange) SetTo(v int64) *PortRange {
+	s.To = &v
+	return s
 }
 
 // Describes prefixes for AWS services.
@@ -30612,6 +38952,24 @@ func (s PrefixList) GoString() string {
 	return s.String()
 }
 
+// SetCidrs sets the Cidrs field's value.
+func (s *PrefixList) SetCidrs(v []*string) *PrefixList {
+	s.Cidrs = v
+	return s
+}
+
+// SetPrefixListId sets the PrefixListId field's value.
+func (s *PrefixList) SetPrefixListId(v string) *PrefixList {
+	s.PrefixListId = &v
+	return s
+}
+
+// SetPrefixListName sets the PrefixListName field's value.
+func (s *PrefixList) SetPrefixListName(v string) *PrefixList {
+	s.PrefixListName = &v
+	return s
+}
+
 // The ID of the prefix.
 type PrefixListId struct {
 	_ struct{} `type:"structure"`
@@ -30628,6 +38986,12 @@ func (s PrefixListId) String() string {
 // GoString returns the string representation
 func (s PrefixListId) GoString() string {
 	return s.String()
+}
+
+// SetPrefixListId sets the PrefixListId field's value.
+func (s *PrefixListId) SetPrefixListId(v string) *PrefixListId {
+	s.PrefixListId = &v
+	return s
 }
 
 // Describes the price for a Reserved Instance.
@@ -30668,6 +39032,30 @@ func (s PriceSchedule) GoString() string {
 	return s.String()
 }
 
+// SetActive sets the Active field's value.
+func (s *PriceSchedule) SetActive(v bool) *PriceSchedule {
+	s.Active = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *PriceSchedule) SetCurrencyCode(v string) *PriceSchedule {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetPrice sets the Price field's value.
+func (s *PriceSchedule) SetPrice(v float64) *PriceSchedule {
+	s.Price = &v
+	return s
+}
+
+// SetTerm sets the Term field's value.
+func (s *PriceSchedule) SetTerm(v int64) *PriceSchedule {
+	s.Term = &v
+	return s
+}
+
 // Describes the price for a Reserved Instance.
 type PriceScheduleSpecification struct {
 	_ struct{} `type:"structure"`
@@ -30694,6 +39082,24 @@ func (s PriceScheduleSpecification) GoString() string {
 	return s.String()
 }
 
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *PriceScheduleSpecification) SetCurrencyCode(v string) *PriceScheduleSpecification {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetPrice sets the Price field's value.
+func (s *PriceScheduleSpecification) SetPrice(v float64) *PriceScheduleSpecification {
+	s.Price = &v
+	return s
+}
+
+// SetTerm sets the Term field's value.
+func (s *PriceScheduleSpecification) SetTerm(v int64) *PriceScheduleSpecification {
+	s.Term = &v
+	return s
+}
+
 // Describes a Reserved Instance offering.
 type PricingDetail struct {
 	_ struct{} `type:"structure"`
@@ -30713,6 +39119,18 @@ func (s PricingDetail) String() string {
 // GoString returns the string representation
 func (s PricingDetail) GoString() string {
 	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *PricingDetail) SetCount(v int64) *PricingDetail {
+	s.Count = &v
+	return s
+}
+
+// SetPrice sets the Price field's value.
+func (s *PricingDetail) SetPrice(v float64) *PricingDetail {
+	s.Price = &v
+	return s
 }
 
 // Describes a secondary private IP address for a network interface.
@@ -30752,6 +39170,18 @@ func (s *PrivateIpAddressSpecification) Validate() error {
 	return nil
 }
 
+// SetPrimary sets the Primary field's value.
+func (s *PrivateIpAddressSpecification) SetPrimary(v bool) *PrivateIpAddressSpecification {
+	s.Primary = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *PrivateIpAddressSpecification) SetPrivateIpAddress(v string) *PrivateIpAddressSpecification {
+	s.PrivateIpAddress = &v
+	return s
+}
+
 // Describes a product code.
 type ProductCode struct {
 	_ struct{} `type:"structure"`
@@ -30773,6 +39203,18 @@ func (s ProductCode) GoString() string {
 	return s.String()
 }
 
+// SetProductCodeId sets the ProductCodeId field's value.
+func (s *ProductCode) SetProductCodeId(v string) *ProductCode {
+	s.ProductCodeId = &v
+	return s
+}
+
+// SetProductCodeType sets the ProductCodeType field's value.
+func (s *ProductCode) SetProductCodeType(v string) *ProductCode {
+	s.ProductCodeType = &v
+	return s
+}
+
 // Describes a virtual private gateway propagating route.
 type PropagatingVgw struct {
 	_ struct{} `type:"structure"`
@@ -30789,6 +39231,12 @@ func (s PropagatingVgw) String() string {
 // GoString returns the string representation
 func (s PropagatingVgw) GoString() string {
 	return s.String()
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *PropagatingVgw) SetGatewayId(v string) *PropagatingVgw {
+	s.GatewayId = &v
+	return s
 }
 
 // Reserved. If you need to sustain traffic greater than the documented limits
@@ -30833,6 +39281,36 @@ func (s ProvisionedBandwidth) GoString() string {
 	return s.String()
 }
 
+// SetProvisionTime sets the ProvisionTime field's value.
+func (s *ProvisionedBandwidth) SetProvisionTime(v time.Time) *ProvisionedBandwidth {
+	s.ProvisionTime = &v
+	return s
+}
+
+// SetProvisioned sets the Provisioned field's value.
+func (s *ProvisionedBandwidth) SetProvisioned(v string) *ProvisionedBandwidth {
+	s.Provisioned = &v
+	return s
+}
+
+// SetRequestTime sets the RequestTime field's value.
+func (s *ProvisionedBandwidth) SetRequestTime(v time.Time) *ProvisionedBandwidth {
+	s.RequestTime = &v
+	return s
+}
+
+// SetRequested sets the Requested field's value.
+func (s *ProvisionedBandwidth) SetRequested(v string) *ProvisionedBandwidth {
+	s.Requested = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ProvisionedBandwidth) SetStatus(v string) *ProvisionedBandwidth {
+	s.Status = &v
+	return s
+}
+
 // Describes the result of the purchase.
 type Purchase struct {
 	_ struct{} `type:"structure"`
@@ -30872,6 +39350,54 @@ func (s Purchase) String() string {
 // GoString returns the string representation
 func (s Purchase) GoString() string {
 	return s.String()
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *Purchase) SetCurrencyCode(v string) *Purchase {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *Purchase) SetDuration(v int64) *Purchase {
+	s.Duration = &v
+	return s
+}
+
+// SetHostIdSet sets the HostIdSet field's value.
+func (s *Purchase) SetHostIdSet(v []*string) *Purchase {
+	s.HostIdSet = v
+	return s
+}
+
+// SetHostReservationId sets the HostReservationId field's value.
+func (s *Purchase) SetHostReservationId(v string) *Purchase {
+	s.HostReservationId = &v
+	return s
+}
+
+// SetHourlyPrice sets the HourlyPrice field's value.
+func (s *Purchase) SetHourlyPrice(v string) *Purchase {
+	s.HourlyPrice = &v
+	return s
+}
+
+// SetInstanceFamily sets the InstanceFamily field's value.
+func (s *Purchase) SetInstanceFamily(v string) *Purchase {
+	s.InstanceFamily = &v
+	return s
+}
+
+// SetPaymentOption sets the PaymentOption field's value.
+func (s *Purchase) SetPaymentOption(v string) *Purchase {
+	s.PaymentOption = &v
+	return s
+}
+
+// SetUpfrontPrice sets the UpfrontPrice field's value.
+func (s *Purchase) SetUpfrontPrice(v string) *Purchase {
+	s.UpfrontPrice = &v
+	return s
 }
 
 type PurchaseHostReservationInput struct {
@@ -30933,6 +39459,36 @@ func (s *PurchaseHostReservationInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *PurchaseHostReservationInput) SetClientToken(v string) *PurchaseHostReservationInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *PurchaseHostReservationInput) SetCurrencyCode(v string) *PurchaseHostReservationInput {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetHostIdSet sets the HostIdSet field's value.
+func (s *PurchaseHostReservationInput) SetHostIdSet(v []*string) *PurchaseHostReservationInput {
+	s.HostIdSet = v
+	return s
+}
+
+// SetLimitPrice sets the LimitPrice field's value.
+func (s *PurchaseHostReservationInput) SetLimitPrice(v string) *PurchaseHostReservationInput {
+	s.LimitPrice = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *PurchaseHostReservationInput) SetOfferingId(v string) *PurchaseHostReservationInput {
+	s.OfferingId = &v
+	return s
+}
+
 type PurchaseHostReservationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -30964,6 +39520,36 @@ func (s PurchaseHostReservationOutput) String() string {
 // GoString returns the string representation
 func (s PurchaseHostReservationOutput) GoString() string {
 	return s.String()
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *PurchaseHostReservationOutput) SetClientToken(v string) *PurchaseHostReservationOutput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *PurchaseHostReservationOutput) SetCurrencyCode(v string) *PurchaseHostReservationOutput {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetPurchase sets the Purchase field's value.
+func (s *PurchaseHostReservationOutput) SetPurchase(v []*Purchase) *PurchaseHostReservationOutput {
+	s.Purchase = v
+	return s
+}
+
+// SetTotalHourlyPrice sets the TotalHourlyPrice field's value.
+func (s *PurchaseHostReservationOutput) SetTotalHourlyPrice(v string) *PurchaseHostReservationOutput {
+	s.TotalHourlyPrice = &v
+	return s
+}
+
+// SetTotalUpfrontPrice sets the TotalUpfrontPrice field's value.
+func (s *PurchaseHostReservationOutput) SetTotalUpfrontPrice(v string) *PurchaseHostReservationOutput {
+	s.TotalUpfrontPrice = &v
+	return s
 }
 
 // Describes a request to purchase Scheduled Instances.
@@ -31005,6 +39591,18 @@ func (s *PurchaseRequest) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *PurchaseRequest) SetInstanceCount(v int64) *PurchaseRequest {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetPurchaseToken sets the PurchaseToken field's value.
+func (s *PurchaseRequest) SetPurchaseToken(v string) *PurchaseRequest {
+	s.PurchaseToken = &v
+	return s
 }
 
 // Contains the parameters for PurchaseReservedInstancesOffering.
@@ -31059,6 +39657,30 @@ func (s *PurchaseReservedInstancesOfferingInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *PurchaseReservedInstancesOfferingInput) SetDryRun(v bool) *PurchaseReservedInstancesOfferingInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *PurchaseReservedInstancesOfferingInput) SetInstanceCount(v int64) *PurchaseReservedInstancesOfferingInput {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetLimitPrice sets the LimitPrice field's value.
+func (s *PurchaseReservedInstancesOfferingInput) SetLimitPrice(v *ReservedInstanceLimitPrice) *PurchaseReservedInstancesOfferingInput {
+	s.LimitPrice = v
+	return s
+}
+
+// SetReservedInstancesOfferingId sets the ReservedInstancesOfferingId field's value.
+func (s *PurchaseReservedInstancesOfferingInput) SetReservedInstancesOfferingId(v string) *PurchaseReservedInstancesOfferingInput {
+	s.ReservedInstancesOfferingId = &v
+	return s
+}
+
 // Contains the output of PurchaseReservedInstancesOffering.
 type PurchaseReservedInstancesOfferingOutput struct {
 	_ struct{} `type:"structure"`
@@ -31075,6 +39697,12 @@ func (s PurchaseReservedInstancesOfferingOutput) String() string {
 // GoString returns the string representation
 func (s PurchaseReservedInstancesOfferingOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *PurchaseReservedInstancesOfferingOutput) SetReservedInstancesId(v string) *PurchaseReservedInstancesOfferingOutput {
+	s.ReservedInstancesId = &v
+	return s
 }
 
 // Contains the parameters for PurchaseScheduledInstances.
@@ -31133,6 +39761,24 @@ func (s *PurchaseScheduledInstancesInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *PurchaseScheduledInstancesInput) SetClientToken(v string) *PurchaseScheduledInstancesInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *PurchaseScheduledInstancesInput) SetDryRun(v bool) *PurchaseScheduledInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPurchaseRequests sets the PurchaseRequests field's value.
+func (s *PurchaseScheduledInstancesInput) SetPurchaseRequests(v []*PurchaseRequest) *PurchaseScheduledInstancesInput {
+	s.PurchaseRequests = v
+	return s
+}
+
 // Contains the output of PurchaseScheduledInstances.
 type PurchaseScheduledInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -31149,6 +39795,12 @@ func (s PurchaseScheduledInstancesOutput) String() string {
 // GoString returns the string representation
 func (s PurchaseScheduledInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetScheduledInstanceSet sets the ScheduledInstanceSet field's value.
+func (s *PurchaseScheduledInstancesOutput) SetScheduledInstanceSet(v []*ScheduledInstance) *PurchaseScheduledInstancesOutput {
+	s.ScheduledInstanceSet = v
+	return s
 }
 
 // Contains the parameters for RebootInstances.
@@ -31190,6 +39842,18 @@ func (s *RebootInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *RebootInstancesInput) SetDryRun(v bool) *RebootInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *RebootInstancesInput) SetInstanceIds(v []*string) *RebootInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
 type RebootInstancesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -31225,6 +39889,18 @@ func (s RecurringCharge) GoString() string {
 	return s.String()
 }
 
+// SetAmount sets the Amount field's value.
+func (s *RecurringCharge) SetAmount(v float64) *RecurringCharge {
+	s.Amount = &v
+	return s
+}
+
+// SetFrequency sets the Frequency field's value.
+func (s *RecurringCharge) SetFrequency(v string) *RecurringCharge {
+	s.Frequency = &v
+	return s
+}
+
 // Describes a region.
 type Region struct {
 	_ struct{} `type:"structure"`
@@ -31244,6 +39920,18 @@ func (s Region) String() string {
 // GoString returns the string representation
 func (s Region) GoString() string {
 	return s.String()
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *Region) SetEndpoint(v string) *Region {
+	s.Endpoint = &v
+	return s
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *Region) SetRegionName(v string) *Region {
+	s.RegionName = &v
+	return s
 }
 
 // Contains the parameters for RegisterImage.
@@ -31335,6 +40023,78 @@ func (s *RegisterImageInput) Validate() error {
 	return nil
 }
 
+// SetArchitecture sets the Architecture field's value.
+func (s *RegisterImageInput) SetArchitecture(v string) *RegisterImageInput {
+	s.Architecture = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *RegisterImageInput) SetBlockDeviceMappings(v []*BlockDeviceMapping) *RegisterImageInput {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *RegisterImageInput) SetDescription(v string) *RegisterImageInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RegisterImageInput) SetDryRun(v bool) *RegisterImageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEnaSupport sets the EnaSupport field's value.
+func (s *RegisterImageInput) SetEnaSupport(v bool) *RegisterImageInput {
+	s.EnaSupport = &v
+	return s
+}
+
+// SetImageLocation sets the ImageLocation field's value.
+func (s *RegisterImageInput) SetImageLocation(v string) *RegisterImageInput {
+	s.ImageLocation = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *RegisterImageInput) SetKernelId(v string) *RegisterImageInput {
+	s.KernelId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RegisterImageInput) SetName(v string) *RegisterImageInput {
+	s.Name = &v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *RegisterImageInput) SetRamdiskId(v string) *RegisterImageInput {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetRootDeviceName sets the RootDeviceName field's value.
+func (s *RegisterImageInput) SetRootDeviceName(v string) *RegisterImageInput {
+	s.RootDeviceName = &v
+	return s
+}
+
+// SetSriovNetSupport sets the SriovNetSupport field's value.
+func (s *RegisterImageInput) SetSriovNetSupport(v string) *RegisterImageInput {
+	s.SriovNetSupport = &v
+	return s
+}
+
+// SetVirtualizationType sets the VirtualizationType field's value.
+func (s *RegisterImageInput) SetVirtualizationType(v string) *RegisterImageInput {
+	s.VirtualizationType = &v
+	return s
+}
+
 // Contains the output of RegisterImage.
 type RegisterImageOutput struct {
 	_ struct{} `type:"structure"`
@@ -31351,6 +40111,12 @@ func (s RegisterImageOutput) String() string {
 // GoString returns the string representation
 func (s RegisterImageOutput) GoString() string {
 	return s.String()
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *RegisterImageOutput) SetImageId(v string) *RegisterImageOutput {
+	s.ImageId = &v
+	return s
 }
 
 // Contains the parameters for RejectVpcPeeringConnection.
@@ -31392,6 +40158,18 @@ func (s *RejectVpcPeeringConnectionInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *RejectVpcPeeringConnectionInput) SetDryRun(v bool) *RejectVpcPeeringConnectionInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *RejectVpcPeeringConnectionInput) SetVpcPeeringConnectionId(v string) *RejectVpcPeeringConnectionInput {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 // Contains the output of RejectVpcPeeringConnection.
 type RejectVpcPeeringConnectionOutput struct {
 	_ struct{} `type:"structure"`
@@ -31408,6 +40186,12 @@ func (s RejectVpcPeeringConnectionOutput) String() string {
 // GoString returns the string representation
 func (s RejectVpcPeeringConnectionOutput) GoString() string {
 	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *RejectVpcPeeringConnectionOutput) SetReturn(v bool) *RejectVpcPeeringConnectionOutput {
+	s.Return = &v
+	return s
 }
 
 // Contains the parameters for ReleaseAddress.
@@ -31435,6 +40219,24 @@ func (s ReleaseAddressInput) String() string {
 // GoString returns the string representation
 func (s ReleaseAddressInput) GoString() string {
 	return s.String()
+}
+
+// SetAllocationId sets the AllocationId field's value.
+func (s *ReleaseAddressInput) SetAllocationId(v string) *ReleaseAddressInput {
+	s.AllocationId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ReleaseAddressInput) SetDryRun(v bool) *ReleaseAddressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *ReleaseAddressInput) SetPublicIp(v string) *ReleaseAddressInput {
+	s.PublicIp = &v
+	return s
 }
 
 type ReleaseAddressOutput struct {
@@ -31484,6 +40286,12 @@ func (s *ReleaseHostsInput) Validate() error {
 	return nil
 }
 
+// SetHostIds sets the HostIds field's value.
+func (s *ReleaseHostsInput) SetHostIds(v []*string) *ReleaseHostsInput {
+	s.HostIds = v
+	return s
+}
+
 // Contains the output of ReleaseHosts.
 type ReleaseHostsOutput struct {
 	_ struct{} `type:"structure"`
@@ -31504,6 +40312,18 @@ func (s ReleaseHostsOutput) String() string {
 // GoString returns the string representation
 func (s ReleaseHostsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSuccessful sets the Successful field's value.
+func (s *ReleaseHostsOutput) SetSuccessful(v []*string) *ReleaseHostsOutput {
+	s.Successful = v
+	return s
+}
+
+// SetUnsuccessful sets the Unsuccessful field's value.
+func (s *ReleaseHostsOutput) SetUnsuccessful(v []*UnsuccessfulItem) *ReleaseHostsOutput {
+	s.Unsuccessful = v
+	return s
 }
 
 // Contains the parameters for ReplaceNetworkAclAssociation.
@@ -31554,6 +40374,24 @@ func (s *ReplaceNetworkAclAssociationInput) Validate() error {
 	return nil
 }
 
+// SetAssociationId sets the AssociationId field's value.
+func (s *ReplaceNetworkAclAssociationInput) SetAssociationId(v string) *ReplaceNetworkAclAssociationInput {
+	s.AssociationId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ReplaceNetworkAclAssociationInput) SetDryRun(v bool) *ReplaceNetworkAclAssociationInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetNetworkAclId sets the NetworkAclId field's value.
+func (s *ReplaceNetworkAclAssociationInput) SetNetworkAclId(v string) *ReplaceNetworkAclAssociationInput {
+	s.NetworkAclId = &v
+	return s
+}
+
 // Contains the output of ReplaceNetworkAclAssociation.
 type ReplaceNetworkAclAssociationOutput struct {
 	_ struct{} `type:"structure"`
@@ -31570,6 +40408,12 @@ func (s ReplaceNetworkAclAssociationOutput) String() string {
 // GoString returns the string representation
 func (s ReplaceNetworkAclAssociationOutput) GoString() string {
 	return s.String()
+}
+
+// SetNewAssociationId sets the NewAssociationId field's value.
+func (s *ReplaceNetworkAclAssociationOutput) SetNewAssociationId(v string) *ReplaceNetworkAclAssociationOutput {
+	s.NewAssociationId = &v
+	return s
 }
 
 // Contains the parameters for ReplaceNetworkAclEntry.
@@ -31661,6 +40505,60 @@ func (s *ReplaceNetworkAclEntryInput) Validate() error {
 	return nil
 }
 
+// SetCidrBlock sets the CidrBlock field's value.
+func (s *ReplaceNetworkAclEntryInput) SetCidrBlock(v string) *ReplaceNetworkAclEntryInput {
+	s.CidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ReplaceNetworkAclEntryInput) SetDryRun(v bool) *ReplaceNetworkAclEntryInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEgress sets the Egress field's value.
+func (s *ReplaceNetworkAclEntryInput) SetEgress(v bool) *ReplaceNetworkAclEntryInput {
+	s.Egress = &v
+	return s
+}
+
+// SetIcmpTypeCode sets the IcmpTypeCode field's value.
+func (s *ReplaceNetworkAclEntryInput) SetIcmpTypeCode(v *IcmpTypeCode) *ReplaceNetworkAclEntryInput {
+	s.IcmpTypeCode = v
+	return s
+}
+
+// SetNetworkAclId sets the NetworkAclId field's value.
+func (s *ReplaceNetworkAclEntryInput) SetNetworkAclId(v string) *ReplaceNetworkAclEntryInput {
+	s.NetworkAclId = &v
+	return s
+}
+
+// SetPortRange sets the PortRange field's value.
+func (s *ReplaceNetworkAclEntryInput) SetPortRange(v *PortRange) *ReplaceNetworkAclEntryInput {
+	s.PortRange = v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *ReplaceNetworkAclEntryInput) SetProtocol(v string) *ReplaceNetworkAclEntryInput {
+	s.Protocol = &v
+	return s
+}
+
+// SetRuleAction sets the RuleAction field's value.
+func (s *ReplaceNetworkAclEntryInput) SetRuleAction(v string) *ReplaceNetworkAclEntryInput {
+	s.RuleAction = &v
+	return s
+}
+
+// SetRuleNumber sets the RuleNumber field's value.
+func (s *ReplaceNetworkAclEntryInput) SetRuleNumber(v int64) *ReplaceNetworkAclEntryInput {
+	s.RuleNumber = &v
+	return s
+}
+
 type ReplaceNetworkAclEntryOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -31738,6 +40636,54 @@ func (s *ReplaceRouteInput) Validate() error {
 	return nil
 }
 
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *ReplaceRouteInput) SetDestinationCidrBlock(v string) *ReplaceRouteInput {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ReplaceRouteInput) SetDryRun(v bool) *ReplaceRouteInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *ReplaceRouteInput) SetGatewayId(v string) *ReplaceRouteInput {
+	s.GatewayId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ReplaceRouteInput) SetInstanceId(v string) *ReplaceRouteInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetNatGatewayId sets the NatGatewayId field's value.
+func (s *ReplaceRouteInput) SetNatGatewayId(v string) *ReplaceRouteInput {
+	s.NatGatewayId = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *ReplaceRouteInput) SetNetworkInterfaceId(v string) *ReplaceRouteInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *ReplaceRouteInput) SetRouteTableId(v string) *ReplaceRouteInput {
+	s.RouteTableId = &v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *ReplaceRouteInput) SetVpcPeeringConnectionId(v string) *ReplaceRouteInput {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 type ReplaceRouteOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -31799,6 +40745,24 @@ func (s *ReplaceRouteTableAssociationInput) Validate() error {
 	return nil
 }
 
+// SetAssociationId sets the AssociationId field's value.
+func (s *ReplaceRouteTableAssociationInput) SetAssociationId(v string) *ReplaceRouteTableAssociationInput {
+	s.AssociationId = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ReplaceRouteTableAssociationInput) SetDryRun(v bool) *ReplaceRouteTableAssociationInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *ReplaceRouteTableAssociationInput) SetRouteTableId(v string) *ReplaceRouteTableAssociationInput {
+	s.RouteTableId = &v
+	return s
+}
+
 // Contains the output of ReplaceRouteTableAssociation.
 type ReplaceRouteTableAssociationOutput struct {
 	_ struct{} `type:"structure"`
@@ -31815,6 +40779,12 @@ func (s ReplaceRouteTableAssociationOutput) String() string {
 // GoString returns the string representation
 func (s ReplaceRouteTableAssociationOutput) GoString() string {
 	return s.String()
+}
+
+// SetNewAssociationId sets the NewAssociationId field's value.
+func (s *ReplaceRouteTableAssociationOutput) SetNewAssociationId(v string) *ReplaceRouteTableAssociationOutput {
+	s.NewAssociationId = &v
+	return s
 }
 
 // Contains the parameters for ReportInstanceStatus.
@@ -31902,6 +40872,48 @@ func (s *ReportInstanceStatusInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *ReportInstanceStatusInput) SetDescription(v string) *ReportInstanceStatusInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ReportInstanceStatusInput) SetDryRun(v bool) *ReportInstanceStatusInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *ReportInstanceStatusInput) SetEndTime(v time.Time) *ReportInstanceStatusInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetInstances sets the Instances field's value.
+func (s *ReportInstanceStatusInput) SetInstances(v []*string) *ReportInstanceStatusInput {
+	s.Instances = v
+	return s
+}
+
+// SetReasonCodes sets the ReasonCodes field's value.
+func (s *ReportInstanceStatusInput) SetReasonCodes(v []*string) *ReportInstanceStatusInput {
+	s.ReasonCodes = v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ReportInstanceStatusInput) SetStartTime(v time.Time) *ReportInstanceStatusInput {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ReportInstanceStatusInput) SetStatus(v string) *ReportInstanceStatusInput {
+	s.Status = &v
+	return s
+}
+
 type ReportInstanceStatusOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -31960,6 +40972,18 @@ func (s *RequestSpotFleetInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *RequestSpotFleetInput) SetDryRun(v bool) *RequestSpotFleetInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSpotFleetRequestConfig sets the SpotFleetRequestConfig field's value.
+func (s *RequestSpotFleetInput) SetSpotFleetRequestConfig(v *SpotFleetRequestConfigData) *RequestSpotFleetInput {
+	s.SpotFleetRequestConfig = v
+	return s
+}
+
 // Contains the output of RequestSpotFleet.
 type RequestSpotFleetOutput struct {
 	_ struct{} `type:"structure"`
@@ -31978,6 +41002,12 @@ func (s RequestSpotFleetOutput) String() string {
 // GoString returns the string representation
 func (s RequestSpotFleetOutput) GoString() string {
 	return s.String()
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *RequestSpotFleetOutput) SetSpotFleetRequestId(v string) *RequestSpotFleetOutput {
+	s.SpotFleetRequestId = &v
+	return s
 }
 
 // Contains the parameters for RequestSpotInstances.
@@ -32100,6 +41130,72 @@ func (s *RequestSpotInstancesInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZoneGroup sets the AvailabilityZoneGroup field's value.
+func (s *RequestSpotInstancesInput) SetAvailabilityZoneGroup(v string) *RequestSpotInstancesInput {
+	s.AvailabilityZoneGroup = &v
+	return s
+}
+
+// SetBlockDurationMinutes sets the BlockDurationMinutes field's value.
+func (s *RequestSpotInstancesInput) SetBlockDurationMinutes(v int64) *RequestSpotInstancesInput {
+	s.BlockDurationMinutes = &v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *RequestSpotInstancesInput) SetClientToken(v string) *RequestSpotInstancesInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RequestSpotInstancesInput) SetDryRun(v bool) *RequestSpotInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *RequestSpotInstancesInput) SetInstanceCount(v int64) *RequestSpotInstancesInput {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetLaunchGroup sets the LaunchGroup field's value.
+func (s *RequestSpotInstancesInput) SetLaunchGroup(v string) *RequestSpotInstancesInput {
+	s.LaunchGroup = &v
+	return s
+}
+
+// SetLaunchSpecification sets the LaunchSpecification field's value.
+func (s *RequestSpotInstancesInput) SetLaunchSpecification(v *RequestSpotLaunchSpecification) *RequestSpotInstancesInput {
+	s.LaunchSpecification = v
+	return s
+}
+
+// SetSpotPrice sets the SpotPrice field's value.
+func (s *RequestSpotInstancesInput) SetSpotPrice(v string) *RequestSpotInstancesInput {
+	s.SpotPrice = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *RequestSpotInstancesInput) SetType(v string) *RequestSpotInstancesInput {
+	s.Type = &v
+	return s
+}
+
+// SetValidFrom sets the ValidFrom field's value.
+func (s *RequestSpotInstancesInput) SetValidFrom(v time.Time) *RequestSpotInstancesInput {
+	s.ValidFrom = &v
+	return s
+}
+
+// SetValidUntil sets the ValidUntil field's value.
+func (s *RequestSpotInstancesInput) SetValidUntil(v time.Time) *RequestSpotInstancesInput {
+	s.ValidUntil = &v
+	return s
+}
+
 // Contains the output of RequestSpotInstances.
 type RequestSpotInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -32116,6 +41212,12 @@ func (s RequestSpotInstancesOutput) String() string {
 // GoString returns the string representation
 func (s RequestSpotInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetSpotInstanceRequests sets the SpotInstanceRequests field's value.
+func (s *RequestSpotInstancesOutput) SetSpotInstanceRequests(v []*SpotInstanceRequest) *RequestSpotInstancesOutput {
+	s.SpotInstanceRequests = v
+	return s
 }
 
 // Describes the launch specification for an instance.
@@ -32215,6 +41317,102 @@ func (s *RequestSpotLaunchSpecification) Validate() error {
 	return nil
 }
 
+// SetAddressingType sets the AddressingType field's value.
+func (s *RequestSpotLaunchSpecification) SetAddressingType(v string) *RequestSpotLaunchSpecification {
+	s.AddressingType = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *RequestSpotLaunchSpecification) SetBlockDeviceMappings(v []*BlockDeviceMapping) *RequestSpotLaunchSpecification {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *RequestSpotLaunchSpecification) SetEbsOptimized(v bool) *RequestSpotLaunchSpecification {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *RequestSpotLaunchSpecification) SetIamInstanceProfile(v *IamInstanceProfileSpecification) *RequestSpotLaunchSpecification {
+	s.IamInstanceProfile = v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *RequestSpotLaunchSpecification) SetImageId(v string) *RequestSpotLaunchSpecification {
+	s.ImageId = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *RequestSpotLaunchSpecification) SetInstanceType(v string) *RequestSpotLaunchSpecification {
+	s.InstanceType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *RequestSpotLaunchSpecification) SetKernelId(v string) *RequestSpotLaunchSpecification {
+	s.KernelId = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *RequestSpotLaunchSpecification) SetKeyName(v string) *RequestSpotLaunchSpecification {
+	s.KeyName = &v
+	return s
+}
+
+// SetMonitoring sets the Monitoring field's value.
+func (s *RequestSpotLaunchSpecification) SetMonitoring(v *RunInstancesMonitoringEnabled) *RequestSpotLaunchSpecification {
+	s.Monitoring = v
+	return s
+}
+
+// SetNetworkInterfaces sets the NetworkInterfaces field's value.
+func (s *RequestSpotLaunchSpecification) SetNetworkInterfaces(v []*InstanceNetworkInterfaceSpecification) *RequestSpotLaunchSpecification {
+	s.NetworkInterfaces = v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *RequestSpotLaunchSpecification) SetPlacement(v *SpotPlacement) *RequestSpotLaunchSpecification {
+	s.Placement = v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *RequestSpotLaunchSpecification) SetRamdiskId(v string) *RequestSpotLaunchSpecification {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *RequestSpotLaunchSpecification) SetSecurityGroupIds(v []*string) *RequestSpotLaunchSpecification {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *RequestSpotLaunchSpecification) SetSecurityGroups(v []*string) *RequestSpotLaunchSpecification {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *RequestSpotLaunchSpecification) SetSubnetId(v string) *RequestSpotLaunchSpecification {
+	s.SubnetId = &v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *RequestSpotLaunchSpecification) SetUserData(v string) *RequestSpotLaunchSpecification {
+	s.UserData = &v
+	return s
+}
+
 // Describes a reservation.
 type Reservation struct {
 	_ struct{} `type:"structure"`
@@ -32246,6 +41444,36 @@ func (s Reservation) GoString() string {
 	return s.String()
 }
 
+// SetGroups sets the Groups field's value.
+func (s *Reservation) SetGroups(v []*GroupIdentifier) *Reservation {
+	s.Groups = v
+	return s
+}
+
+// SetInstances sets the Instances field's value.
+func (s *Reservation) SetInstances(v []*Instance) *Reservation {
+	s.Instances = v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *Reservation) SetOwnerId(v string) *Reservation {
+	s.OwnerId = &v
+	return s
+}
+
+// SetRequesterId sets the RequesterId field's value.
+func (s *Reservation) SetRequesterId(v string) *Reservation {
+	s.RequesterId = &v
+	return s
+}
+
+// SetReservationId sets the ReservationId field's value.
+func (s *Reservation) SetReservationId(v string) *Reservation {
+	s.ReservationId = &v
+	return s
+}
+
 // The cost associated with the Reserved Instance.
 type ReservationValue struct {
 	_ struct{} `type:"structure"`
@@ -32271,6 +41499,24 @@ func (s ReservationValue) GoString() string {
 	return s.String()
 }
 
+// SetHourlyPrice sets the HourlyPrice field's value.
+func (s *ReservationValue) SetHourlyPrice(v string) *ReservationValue {
+	s.HourlyPrice = &v
+	return s
+}
+
+// SetRemainingTotalValue sets the RemainingTotalValue field's value.
+func (s *ReservationValue) SetRemainingTotalValue(v string) *ReservationValue {
+	s.RemainingTotalValue = &v
+	return s
+}
+
+// SetRemainingUpfrontValue sets the RemainingUpfrontValue field's value.
+func (s *ReservationValue) SetRemainingUpfrontValue(v string) *ReservationValue {
+	s.RemainingUpfrontValue = &v
+	return s
+}
+
 // Describes the limit price of a Reserved Instance offering.
 type ReservedInstanceLimitPrice struct {
 	_ struct{} `type:"structure"`
@@ -32294,6 +41540,18 @@ func (s ReservedInstanceLimitPrice) GoString() string {
 	return s.String()
 }
 
+// SetAmount sets the Amount field's value.
+func (s *ReservedInstanceLimitPrice) SetAmount(v float64) *ReservedInstanceLimitPrice {
+	s.Amount = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedInstanceLimitPrice) SetCurrencyCode(v string) *ReservedInstanceLimitPrice {
+	s.CurrencyCode = &v
+	return s
+}
+
 // The total value of the Convertible Reserved Instance.
 type ReservedInstanceReservationValue struct {
 	_ struct{} `type:"structure"`
@@ -32313,6 +41571,18 @@ func (s ReservedInstanceReservationValue) String() string {
 // GoString returns the string representation
 func (s ReservedInstanceReservationValue) GoString() string {
 	return s.String()
+}
+
+// SetReservationValue sets the ReservationValue field's value.
+func (s *ReservedInstanceReservationValue) SetReservationValue(v *ReservationValue) *ReservedInstanceReservationValue {
+	s.ReservationValue = v
+	return s
+}
+
+// SetReservedInstanceId sets the ReservedInstanceId field's value.
+func (s *ReservedInstanceReservationValue) SetReservedInstanceId(v string) *ReservedInstanceReservationValue {
+	s.ReservedInstanceId = &v
+	return s
 }
 
 // Describes a Reserved Instance.
@@ -32385,6 +41655,114 @@ func (s ReservedInstances) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ReservedInstances) SetAvailabilityZone(v string) *ReservedInstances {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedInstances) SetCurrencyCode(v string) *ReservedInstances {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedInstances) SetDuration(v int64) *ReservedInstances {
+	s.Duration = &v
+	return s
+}
+
+// SetEnd sets the End field's value.
+func (s *ReservedInstances) SetEnd(v time.Time) *ReservedInstances {
+	s.End = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedInstances) SetFixedPrice(v float64) *ReservedInstances {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *ReservedInstances) SetInstanceCount(v int64) *ReservedInstances {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceTenancy sets the InstanceTenancy field's value.
+func (s *ReservedInstances) SetInstanceTenancy(v string) *ReservedInstances {
+	s.InstanceTenancy = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ReservedInstances) SetInstanceType(v string) *ReservedInstances {
+	s.InstanceType = &v
+	return s
+}
+
+// SetOfferingClass sets the OfferingClass field's value.
+func (s *ReservedInstances) SetOfferingClass(v string) *ReservedInstances {
+	s.OfferingClass = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *ReservedInstances) SetOfferingType(v string) *ReservedInstances {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *ReservedInstances) SetProductDescription(v string) *ReservedInstances {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedInstances) SetRecurringCharges(v []*RecurringCharge) *ReservedInstances {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *ReservedInstances) SetReservedInstancesId(v string) *ReservedInstances {
+	s.ReservedInstancesId = &v
+	return s
+}
+
+// SetScope sets the Scope field's value.
+func (s *ReservedInstances) SetScope(v string) *ReservedInstances {
+	s.Scope = &v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *ReservedInstances) SetStart(v time.Time) *ReservedInstances {
+	s.Start = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ReservedInstances) SetState(v string) *ReservedInstances {
+	s.State = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ReservedInstances) SetTags(v []*Tag) *ReservedInstances {
+	s.Tags = v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedInstances) SetUsagePrice(v float64) *ReservedInstances {
+	s.UsagePrice = &v
+	return s
+}
+
 // Describes the configuration settings for the modified Reserved Instances.
 type ReservedInstancesConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -32416,6 +41794,36 @@ func (s ReservedInstancesConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ReservedInstancesConfiguration) SetAvailabilityZone(v string) *ReservedInstancesConfiguration {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *ReservedInstancesConfiguration) SetInstanceCount(v int64) *ReservedInstancesConfiguration {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ReservedInstancesConfiguration) SetInstanceType(v string) *ReservedInstancesConfiguration {
+	s.InstanceType = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *ReservedInstancesConfiguration) SetPlatform(v string) *ReservedInstancesConfiguration {
+	s.Platform = &v
+	return s
+}
+
+// SetScope sets the Scope field's value.
+func (s *ReservedInstancesConfiguration) SetScope(v string) *ReservedInstancesConfiguration {
+	s.Scope = &v
+	return s
+}
+
 // Describes the ID of a Reserved Instance.
 type ReservedInstancesId struct {
 	_ struct{} `type:"structure"`
@@ -32432,6 +41840,12 @@ func (s ReservedInstancesId) String() string {
 // GoString returns the string representation
 func (s ReservedInstancesId) GoString() string {
 	return s.String()
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *ReservedInstancesId) SetReservedInstancesId(v string) *ReservedInstancesId {
+	s.ReservedInstancesId = &v
+	return s
 }
 
 // Describes a Reserved Instance listing.
@@ -32481,6 +41895,66 @@ func (s ReservedInstancesListing) GoString() string {
 	return s.String()
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *ReservedInstancesListing) SetClientToken(v string) *ReservedInstancesListing {
+	s.ClientToken = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *ReservedInstancesListing) SetCreateDate(v time.Time) *ReservedInstancesListing {
+	s.CreateDate = &v
+	return s
+}
+
+// SetInstanceCounts sets the InstanceCounts field's value.
+func (s *ReservedInstancesListing) SetInstanceCounts(v []*InstanceCount) *ReservedInstancesListing {
+	s.InstanceCounts = v
+	return s
+}
+
+// SetPriceSchedules sets the PriceSchedules field's value.
+func (s *ReservedInstancesListing) SetPriceSchedules(v []*PriceSchedule) *ReservedInstancesListing {
+	s.PriceSchedules = v
+	return s
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *ReservedInstancesListing) SetReservedInstancesId(v string) *ReservedInstancesListing {
+	s.ReservedInstancesId = &v
+	return s
+}
+
+// SetReservedInstancesListingId sets the ReservedInstancesListingId field's value.
+func (s *ReservedInstancesListing) SetReservedInstancesListingId(v string) *ReservedInstancesListing {
+	s.ReservedInstancesListingId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ReservedInstancesListing) SetStatus(v string) *ReservedInstancesListing {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ReservedInstancesListing) SetStatusMessage(v string) *ReservedInstancesListing {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ReservedInstancesListing) SetTags(v []*Tag) *ReservedInstancesListing {
+	s.Tags = v
+	return s
+}
+
+// SetUpdateDate sets the UpdateDate field's value.
+func (s *ReservedInstancesListing) SetUpdateDate(v time.Time) *ReservedInstancesListing {
+	s.UpdateDate = &v
+	return s
+}
+
 // Describes a Reserved Instance modification.
 type ReservedInstancesModification struct {
 	_ struct{} `type:"structure"`
@@ -32525,6 +41999,60 @@ func (s ReservedInstancesModification) GoString() string {
 	return s.String()
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *ReservedInstancesModification) SetClientToken(v string) *ReservedInstancesModification {
+	s.ClientToken = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *ReservedInstancesModification) SetCreateDate(v time.Time) *ReservedInstancesModification {
+	s.CreateDate = &v
+	return s
+}
+
+// SetEffectiveDate sets the EffectiveDate field's value.
+func (s *ReservedInstancesModification) SetEffectiveDate(v time.Time) *ReservedInstancesModification {
+	s.EffectiveDate = &v
+	return s
+}
+
+// SetModificationResults sets the ModificationResults field's value.
+func (s *ReservedInstancesModification) SetModificationResults(v []*ReservedInstancesModificationResult) *ReservedInstancesModification {
+	s.ModificationResults = v
+	return s
+}
+
+// SetReservedInstancesIds sets the ReservedInstancesIds field's value.
+func (s *ReservedInstancesModification) SetReservedInstancesIds(v []*ReservedInstancesId) *ReservedInstancesModification {
+	s.ReservedInstancesIds = v
+	return s
+}
+
+// SetReservedInstancesModificationId sets the ReservedInstancesModificationId field's value.
+func (s *ReservedInstancesModification) SetReservedInstancesModificationId(v string) *ReservedInstancesModification {
+	s.ReservedInstancesModificationId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ReservedInstancesModification) SetStatus(v string) *ReservedInstancesModification {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ReservedInstancesModification) SetStatusMessage(v string) *ReservedInstancesModification {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetUpdateDate sets the UpdateDate field's value.
+func (s *ReservedInstancesModification) SetUpdateDate(v time.Time) *ReservedInstancesModification {
+	s.UpdateDate = &v
+	return s
+}
+
 // Describes the modification request/s.
 type ReservedInstancesModificationResult struct {
 	_ struct{} `type:"structure"`
@@ -32546,6 +42074,18 @@ func (s ReservedInstancesModificationResult) String() string {
 // GoString returns the string representation
 func (s ReservedInstancesModificationResult) GoString() string {
 	return s.String()
+}
+
+// SetReservedInstancesId sets the ReservedInstancesId field's value.
+func (s *ReservedInstancesModificationResult) SetReservedInstancesId(v string) *ReservedInstancesModificationResult {
+	s.ReservedInstancesId = &v
+	return s
+}
+
+// SetTargetConfiguration sets the TargetConfiguration field's value.
+func (s *ReservedInstancesModificationResult) SetTargetConfiguration(v *ReservedInstancesConfiguration) *ReservedInstancesModificationResult {
+	s.TargetConfiguration = v
+	return s
 }
 
 // Describes a Reserved Instance offering.
@@ -32616,6 +42156,96 @@ func (s ReservedInstancesOffering) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ReservedInstancesOffering) SetAvailabilityZone(v string) *ReservedInstancesOffering {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedInstancesOffering) SetCurrencyCode(v string) *ReservedInstancesOffering {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedInstancesOffering) SetDuration(v int64) *ReservedInstancesOffering {
+	s.Duration = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedInstancesOffering) SetFixedPrice(v float64) *ReservedInstancesOffering {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetInstanceTenancy sets the InstanceTenancy field's value.
+func (s *ReservedInstancesOffering) SetInstanceTenancy(v string) *ReservedInstancesOffering {
+	s.InstanceTenancy = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ReservedInstancesOffering) SetInstanceType(v string) *ReservedInstancesOffering {
+	s.InstanceType = &v
+	return s
+}
+
+// SetMarketplace sets the Marketplace field's value.
+func (s *ReservedInstancesOffering) SetMarketplace(v bool) *ReservedInstancesOffering {
+	s.Marketplace = &v
+	return s
+}
+
+// SetOfferingClass sets the OfferingClass field's value.
+func (s *ReservedInstancesOffering) SetOfferingClass(v string) *ReservedInstancesOffering {
+	s.OfferingClass = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *ReservedInstancesOffering) SetOfferingType(v string) *ReservedInstancesOffering {
+	s.OfferingType = &v
+	return s
+}
+
+// SetPricingDetails sets the PricingDetails field's value.
+func (s *ReservedInstancesOffering) SetPricingDetails(v []*PricingDetail) *ReservedInstancesOffering {
+	s.PricingDetails = v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *ReservedInstancesOffering) SetProductDescription(v string) *ReservedInstancesOffering {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedInstancesOffering) SetRecurringCharges(v []*RecurringCharge) *ReservedInstancesOffering {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedInstancesOfferingId sets the ReservedInstancesOfferingId field's value.
+func (s *ReservedInstancesOffering) SetReservedInstancesOfferingId(v string) *ReservedInstancesOffering {
+	s.ReservedInstancesOfferingId = &v
+	return s
+}
+
+// SetScope sets the Scope field's value.
+func (s *ReservedInstancesOffering) SetScope(v string) *ReservedInstancesOffering {
+	s.Scope = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedInstancesOffering) SetUsagePrice(v float64) *ReservedInstancesOffering {
+	s.UsagePrice = &v
+	return s
+}
+
 // Contains the parameters for ResetImageAttribute.
 type ResetImageAttributeInput struct {
 	_ struct{} `type:"structure"`
@@ -32662,6 +42292,24 @@ func (s *ResetImageAttributeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *ResetImageAttributeInput) SetAttribute(v string) *ResetImageAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ResetImageAttributeInput) SetDryRun(v bool) *ResetImageAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *ResetImageAttributeInput) SetImageId(v string) *ResetImageAttributeInput {
+	s.ImageId = &v
+	return s
 }
 
 type ResetImageAttributeOutput struct {
@@ -32728,6 +42376,24 @@ func (s *ResetInstanceAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *ResetInstanceAttributeInput) SetAttribute(v string) *ResetInstanceAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ResetInstanceAttributeInput) SetDryRun(v bool) *ResetInstanceAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ResetInstanceAttributeInput) SetInstanceId(v string) *ResetInstanceAttributeInput {
+	s.InstanceId = &v
+	return s
+}
+
 type ResetInstanceAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -32782,6 +42448,24 @@ func (s *ResetNetworkInterfaceAttributeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ResetNetworkInterfaceAttributeInput) SetDryRun(v bool) *ResetNetworkInterfaceAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *ResetNetworkInterfaceAttributeInput) SetNetworkInterfaceId(v string) *ResetNetworkInterfaceAttributeInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetSourceDestCheck sets the SourceDestCheck field's value.
+func (s *ResetNetworkInterfaceAttributeInput) SetSourceDestCheck(v string) *ResetNetworkInterfaceAttributeInput {
+	s.SourceDestCheck = &v
+	return s
 }
 
 type ResetNetworkInterfaceAttributeOutput struct {
@@ -32846,6 +42530,24 @@ func (s *ResetSnapshotAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttribute sets the Attribute field's value.
+func (s *ResetSnapshotAttributeInput) SetAttribute(v string) *ResetSnapshotAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ResetSnapshotAttributeInput) SetDryRun(v bool) *ResetSnapshotAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *ResetSnapshotAttributeInput) SetSnapshotId(v string) *ResetSnapshotAttributeInput {
+	s.SnapshotId = &v
+	return s
+}
+
 type ResetSnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -32899,6 +42601,18 @@ func (s *RestoreAddressToClassicInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *RestoreAddressToClassicInput) SetDryRun(v bool) *RestoreAddressToClassicInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *RestoreAddressToClassicInput) SetPublicIp(v string) *RestoreAddressToClassicInput {
+	s.PublicIp = &v
+	return s
+}
+
 // Contains the output of RestoreAddressToClassic.
 type RestoreAddressToClassicOutput struct {
 	_ struct{} `type:"structure"`
@@ -32918,6 +42632,18 @@ func (s RestoreAddressToClassicOutput) String() string {
 // GoString returns the string representation
 func (s RestoreAddressToClassicOutput) GoString() string {
 	return s.String()
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *RestoreAddressToClassicOutput) SetPublicIp(v string) *RestoreAddressToClassicOutput {
+	s.PublicIp = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *RestoreAddressToClassicOutput) SetStatus(v string) *RestoreAddressToClassicOutput {
+	s.Status = &v
+	return s
 }
 
 // Contains the parameters for RevokeSecurityGroupEgress.
@@ -32987,6 +42713,60 @@ func (s *RevokeSecurityGroupEgressInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCidrIp sets the CidrIp field's value.
+func (s *RevokeSecurityGroupEgressInput) SetCidrIp(v string) *RevokeSecurityGroupEgressInput {
+	s.CidrIp = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RevokeSecurityGroupEgressInput) SetDryRun(v bool) *RevokeSecurityGroupEgressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFromPort sets the FromPort field's value.
+func (s *RevokeSecurityGroupEgressInput) SetFromPort(v int64) *RevokeSecurityGroupEgressInput {
+	s.FromPort = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *RevokeSecurityGroupEgressInput) SetGroupId(v string) *RevokeSecurityGroupEgressInput {
+	s.GroupId = &v
+	return s
+}
+
+// SetIpPermissions sets the IpPermissions field's value.
+func (s *RevokeSecurityGroupEgressInput) SetIpPermissions(v []*IpPermission) *RevokeSecurityGroupEgressInput {
+	s.IpPermissions = v
+	return s
+}
+
+// SetIpProtocol sets the IpProtocol field's value.
+func (s *RevokeSecurityGroupEgressInput) SetIpProtocol(v string) *RevokeSecurityGroupEgressInput {
+	s.IpProtocol = &v
+	return s
+}
+
+// SetSourceSecurityGroupName sets the SourceSecurityGroupName field's value.
+func (s *RevokeSecurityGroupEgressInput) SetSourceSecurityGroupName(v string) *RevokeSecurityGroupEgressInput {
+	s.SourceSecurityGroupName = &v
+	return s
+}
+
+// SetSourceSecurityGroupOwnerId sets the SourceSecurityGroupOwnerId field's value.
+func (s *RevokeSecurityGroupEgressInput) SetSourceSecurityGroupOwnerId(v string) *RevokeSecurityGroupEgressInput {
+	s.SourceSecurityGroupOwnerId = &v
+	return s
+}
+
+// SetToPort sets the ToPort field's value.
+func (s *RevokeSecurityGroupEgressInput) SetToPort(v int64) *RevokeSecurityGroupEgressInput {
+	s.ToPort = &v
+	return s
 }
 
 type RevokeSecurityGroupEgressOutput struct {
@@ -33067,6 +42847,66 @@ func (s RevokeSecurityGroupIngressInput) GoString() string {
 	return s.String()
 }
 
+// SetCidrIp sets the CidrIp field's value.
+func (s *RevokeSecurityGroupIngressInput) SetCidrIp(v string) *RevokeSecurityGroupIngressInput {
+	s.CidrIp = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RevokeSecurityGroupIngressInput) SetDryRun(v bool) *RevokeSecurityGroupIngressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFromPort sets the FromPort field's value.
+func (s *RevokeSecurityGroupIngressInput) SetFromPort(v int64) *RevokeSecurityGroupIngressInput {
+	s.FromPort = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *RevokeSecurityGroupIngressInput) SetGroupId(v string) *RevokeSecurityGroupIngressInput {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *RevokeSecurityGroupIngressInput) SetGroupName(v string) *RevokeSecurityGroupIngressInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetIpPermissions sets the IpPermissions field's value.
+func (s *RevokeSecurityGroupIngressInput) SetIpPermissions(v []*IpPermission) *RevokeSecurityGroupIngressInput {
+	s.IpPermissions = v
+	return s
+}
+
+// SetIpProtocol sets the IpProtocol field's value.
+func (s *RevokeSecurityGroupIngressInput) SetIpProtocol(v string) *RevokeSecurityGroupIngressInput {
+	s.IpProtocol = &v
+	return s
+}
+
+// SetSourceSecurityGroupName sets the SourceSecurityGroupName field's value.
+func (s *RevokeSecurityGroupIngressInput) SetSourceSecurityGroupName(v string) *RevokeSecurityGroupIngressInput {
+	s.SourceSecurityGroupName = &v
+	return s
+}
+
+// SetSourceSecurityGroupOwnerId sets the SourceSecurityGroupOwnerId field's value.
+func (s *RevokeSecurityGroupIngressInput) SetSourceSecurityGroupOwnerId(v string) *RevokeSecurityGroupIngressInput {
+	s.SourceSecurityGroupOwnerId = &v
+	return s
+}
+
+// SetToPort sets the ToPort field's value.
+func (s *RevokeSecurityGroupIngressInput) SetToPort(v int64) *RevokeSecurityGroupIngressInput {
+	s.ToPort = &v
+	return s
+}
+
 type RevokeSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -33135,6 +42975,66 @@ func (s Route) GoString() string {
 	return s.String()
 }
 
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *Route) SetDestinationCidrBlock(v string) *Route {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetDestinationPrefixListId sets the DestinationPrefixListId field's value.
+func (s *Route) SetDestinationPrefixListId(v string) *Route {
+	s.DestinationPrefixListId = &v
+	return s
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *Route) SetGatewayId(v string) *Route {
+	s.GatewayId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Route) SetInstanceId(v string) *Route {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceOwnerId sets the InstanceOwnerId field's value.
+func (s *Route) SetInstanceOwnerId(v string) *Route {
+	s.InstanceOwnerId = &v
+	return s
+}
+
+// SetNatGatewayId sets the NatGatewayId field's value.
+func (s *Route) SetNatGatewayId(v string) *Route {
+	s.NatGatewayId = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *Route) SetNetworkInterfaceId(v string) *Route {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetOrigin sets the Origin field's value.
+func (s *Route) SetOrigin(v string) *Route {
+	s.Origin = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Route) SetState(v string) *Route {
+	s.State = &v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *Route) SetVpcPeeringConnectionId(v string) *Route {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 // Describes a route table.
 type RouteTable struct {
 	_ struct{} `type:"structure"`
@@ -33168,6 +43068,42 @@ func (s RouteTable) GoString() string {
 	return s.String()
 }
 
+// SetAssociations sets the Associations field's value.
+func (s *RouteTable) SetAssociations(v []*RouteTableAssociation) *RouteTable {
+	s.Associations = v
+	return s
+}
+
+// SetPropagatingVgws sets the PropagatingVgws field's value.
+func (s *RouteTable) SetPropagatingVgws(v []*PropagatingVgw) *RouteTable {
+	s.PropagatingVgws = v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *RouteTable) SetRouteTableId(v string) *RouteTable {
+	s.RouteTableId = &v
+	return s
+}
+
+// SetRoutes sets the Routes field's value.
+func (s *RouteTable) SetRoutes(v []*Route) *RouteTable {
+	s.Routes = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RouteTable) SetTags(v []*Tag) *RouteTable {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *RouteTable) SetVpcId(v string) *RouteTable {
+	s.VpcId = &v
+	return s
+}
+
 // Describes an association between a route table and a subnet.
 type RouteTableAssociation struct {
 	_ struct{} `type:"structure"`
@@ -33193,6 +43129,30 @@ func (s RouteTableAssociation) String() string {
 // GoString returns the string representation
 func (s RouteTableAssociation) GoString() string {
 	return s.String()
+}
+
+// SetMain sets the Main field's value.
+func (s *RouteTableAssociation) SetMain(v bool) *RouteTableAssociation {
+	s.Main = &v
+	return s
+}
+
+// SetRouteTableAssociationId sets the RouteTableAssociationId field's value.
+func (s *RouteTableAssociation) SetRouteTableAssociationId(v string) *RouteTableAssociation {
+	s.RouteTableAssociationId = &v
+	return s
+}
+
+// SetRouteTableId sets the RouteTableId field's value.
+func (s *RouteTableAssociation) SetRouteTableId(v string) *RouteTableAssociation {
+	s.RouteTableId = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *RouteTableAssociation) SetSubnetId(v string) *RouteTableAssociation {
+	s.SubnetId = &v
+	return s
 }
 
 // Contains the parameters for RunInstances.
@@ -33397,6 +43357,144 @@ func (s *RunInstancesInput) Validate() error {
 	return nil
 }
 
+// SetAdditionalInfo sets the AdditionalInfo field's value.
+func (s *RunInstancesInput) SetAdditionalInfo(v string) *RunInstancesInput {
+	s.AdditionalInfo = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *RunInstancesInput) SetBlockDeviceMappings(v []*BlockDeviceMapping) *RunInstancesInput {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *RunInstancesInput) SetClientToken(v string) *RunInstancesInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDisableApiTermination sets the DisableApiTermination field's value.
+func (s *RunInstancesInput) SetDisableApiTermination(v bool) *RunInstancesInput {
+	s.DisableApiTermination = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RunInstancesInput) SetDryRun(v bool) *RunInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *RunInstancesInput) SetEbsOptimized(v bool) *RunInstancesInput {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *RunInstancesInput) SetIamInstanceProfile(v *IamInstanceProfileSpecification) *RunInstancesInput {
+	s.IamInstanceProfile = v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *RunInstancesInput) SetImageId(v string) *RunInstancesInput {
+	s.ImageId = &v
+	return s
+}
+
+// SetInstanceInitiatedShutdownBehavior sets the InstanceInitiatedShutdownBehavior field's value.
+func (s *RunInstancesInput) SetInstanceInitiatedShutdownBehavior(v string) *RunInstancesInput {
+	s.InstanceInitiatedShutdownBehavior = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *RunInstancesInput) SetInstanceType(v string) *RunInstancesInput {
+	s.InstanceType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *RunInstancesInput) SetKernelId(v string) *RunInstancesInput {
+	s.KernelId = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *RunInstancesInput) SetKeyName(v string) *RunInstancesInput {
+	s.KeyName = &v
+	return s
+}
+
+// SetMaxCount sets the MaxCount field's value.
+func (s *RunInstancesInput) SetMaxCount(v int64) *RunInstancesInput {
+	s.MaxCount = &v
+	return s
+}
+
+// SetMinCount sets the MinCount field's value.
+func (s *RunInstancesInput) SetMinCount(v int64) *RunInstancesInput {
+	s.MinCount = &v
+	return s
+}
+
+// SetMonitoring sets the Monitoring field's value.
+func (s *RunInstancesInput) SetMonitoring(v *RunInstancesMonitoringEnabled) *RunInstancesInput {
+	s.Monitoring = v
+	return s
+}
+
+// SetNetworkInterfaces sets the NetworkInterfaces field's value.
+func (s *RunInstancesInput) SetNetworkInterfaces(v []*InstanceNetworkInterfaceSpecification) *RunInstancesInput {
+	s.NetworkInterfaces = v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *RunInstancesInput) SetPlacement(v *Placement) *RunInstancesInput {
+	s.Placement = v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *RunInstancesInput) SetPrivateIpAddress(v string) *RunInstancesInput {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *RunInstancesInput) SetRamdiskId(v string) *RunInstancesInput {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *RunInstancesInput) SetSecurityGroupIds(v []*string) *RunInstancesInput {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *RunInstancesInput) SetSecurityGroups(v []*string) *RunInstancesInput {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *RunInstancesInput) SetSubnetId(v string) *RunInstancesInput {
+	s.SubnetId = &v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *RunInstancesInput) SetUserData(v string) *RunInstancesInput {
+	s.UserData = &v
+	return s
+}
+
 // Describes the monitoring for the instance.
 type RunInstancesMonitoringEnabled struct {
 	_ struct{} `type:"structure"`
@@ -33428,6 +43526,12 @@ func (s *RunInstancesMonitoringEnabled) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *RunInstancesMonitoringEnabled) SetEnabled(v bool) *RunInstancesMonitoringEnabled {
+	s.Enabled = &v
+	return s
 }
 
 // Contains the parameters for RunScheduledInstances.
@@ -33492,6 +43596,36 @@ func (s *RunScheduledInstancesInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *RunScheduledInstancesInput) SetClientToken(v string) *RunScheduledInstancesInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *RunScheduledInstancesInput) SetDryRun(v bool) *RunScheduledInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *RunScheduledInstancesInput) SetInstanceCount(v int64) *RunScheduledInstancesInput {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetLaunchSpecification sets the LaunchSpecification field's value.
+func (s *RunScheduledInstancesInput) SetLaunchSpecification(v *ScheduledInstancesLaunchSpecification) *RunScheduledInstancesInput {
+	s.LaunchSpecification = v
+	return s
+}
+
+// SetScheduledInstanceId sets the ScheduledInstanceId field's value.
+func (s *RunScheduledInstancesInput) SetScheduledInstanceId(v string) *RunScheduledInstancesInput {
+	s.ScheduledInstanceId = &v
+	return s
+}
+
 // Contains the output of RunScheduledInstances.
 type RunScheduledInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -33508,6 +43642,12 @@ func (s RunScheduledInstancesOutput) String() string {
 // GoString returns the string representation
 func (s RunScheduledInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceIdSet sets the InstanceIdSet field's value.
+func (s *RunScheduledInstancesOutput) SetInstanceIdSet(v []*string) *RunScheduledInstancesOutput {
+	s.InstanceIdSet = v
+	return s
 }
 
 // Describes the storage parameters for S3 and S3 buckets for an instance store-backed
@@ -33546,6 +43686,36 @@ func (s S3Storage) String() string {
 // GoString returns the string representation
 func (s S3Storage) GoString() string {
 	return s.String()
+}
+
+// SetAWSAccessKeyId sets the AWSAccessKeyId field's value.
+func (s *S3Storage) SetAWSAccessKeyId(v string) *S3Storage {
+	s.AWSAccessKeyId = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *S3Storage) SetBucket(v string) *S3Storage {
+	s.Bucket = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *S3Storage) SetPrefix(v string) *S3Storage {
+	s.Prefix = &v
+	return s
+}
+
+// SetUploadPolicy sets the UploadPolicy field's value.
+func (s *S3Storage) SetUploadPolicy(v []byte) *S3Storage {
+	s.UploadPolicy = v
+	return s
+}
+
+// SetUploadPolicySignature sets the UploadPolicySignature field's value.
+func (s *S3Storage) SetUploadPolicySignature(v string) *S3Storage {
+	s.UploadPolicySignature = &v
+	return s
 }
 
 // Describes a Scheduled Instance.
@@ -33608,6 +43778,96 @@ func (s ScheduledInstance) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ScheduledInstance) SetAvailabilityZone(v string) *ScheduledInstance {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *ScheduledInstance) SetCreateDate(v time.Time) *ScheduledInstance {
+	s.CreateDate = &v
+	return s
+}
+
+// SetHourlyPrice sets the HourlyPrice field's value.
+func (s *ScheduledInstance) SetHourlyPrice(v string) *ScheduledInstance {
+	s.HourlyPrice = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *ScheduledInstance) SetInstanceCount(v int64) *ScheduledInstance {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ScheduledInstance) SetInstanceType(v string) *ScheduledInstance {
+	s.InstanceType = &v
+	return s
+}
+
+// SetNetworkPlatform sets the NetworkPlatform field's value.
+func (s *ScheduledInstance) SetNetworkPlatform(v string) *ScheduledInstance {
+	s.NetworkPlatform = &v
+	return s
+}
+
+// SetNextSlotStartTime sets the NextSlotStartTime field's value.
+func (s *ScheduledInstance) SetNextSlotStartTime(v time.Time) *ScheduledInstance {
+	s.NextSlotStartTime = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *ScheduledInstance) SetPlatform(v string) *ScheduledInstance {
+	s.Platform = &v
+	return s
+}
+
+// SetPreviousSlotEndTime sets the PreviousSlotEndTime field's value.
+func (s *ScheduledInstance) SetPreviousSlotEndTime(v time.Time) *ScheduledInstance {
+	s.PreviousSlotEndTime = &v
+	return s
+}
+
+// SetRecurrence sets the Recurrence field's value.
+func (s *ScheduledInstance) SetRecurrence(v *ScheduledInstanceRecurrence) *ScheduledInstance {
+	s.Recurrence = v
+	return s
+}
+
+// SetScheduledInstanceId sets the ScheduledInstanceId field's value.
+func (s *ScheduledInstance) SetScheduledInstanceId(v string) *ScheduledInstance {
+	s.ScheduledInstanceId = &v
+	return s
+}
+
+// SetSlotDurationInHours sets the SlotDurationInHours field's value.
+func (s *ScheduledInstance) SetSlotDurationInHours(v int64) *ScheduledInstance {
+	s.SlotDurationInHours = &v
+	return s
+}
+
+// SetTermEndDate sets the TermEndDate field's value.
+func (s *ScheduledInstance) SetTermEndDate(v time.Time) *ScheduledInstance {
+	s.TermEndDate = &v
+	return s
+}
+
+// SetTermStartDate sets the TermStartDate field's value.
+func (s *ScheduledInstance) SetTermStartDate(v time.Time) *ScheduledInstance {
+	s.TermStartDate = &v
+	return s
+}
+
+// SetTotalScheduledInstanceHours sets the TotalScheduledInstanceHours field's value.
+func (s *ScheduledInstance) SetTotalScheduledInstanceHours(v int64) *ScheduledInstance {
+	s.TotalScheduledInstanceHours = &v
+	return s
+}
+
 // Describes a schedule that is available for your Scheduled Instances.
 type ScheduledInstanceAvailability struct {
 	_ struct{} `type:"structure"`
@@ -33663,6 +43923,84 @@ func (s ScheduledInstanceAvailability) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ScheduledInstanceAvailability) SetAvailabilityZone(v string) *ScheduledInstanceAvailability {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetAvailableInstanceCount sets the AvailableInstanceCount field's value.
+func (s *ScheduledInstanceAvailability) SetAvailableInstanceCount(v int64) *ScheduledInstanceAvailability {
+	s.AvailableInstanceCount = &v
+	return s
+}
+
+// SetFirstSlotStartTime sets the FirstSlotStartTime field's value.
+func (s *ScheduledInstanceAvailability) SetFirstSlotStartTime(v time.Time) *ScheduledInstanceAvailability {
+	s.FirstSlotStartTime = &v
+	return s
+}
+
+// SetHourlyPrice sets the HourlyPrice field's value.
+func (s *ScheduledInstanceAvailability) SetHourlyPrice(v string) *ScheduledInstanceAvailability {
+	s.HourlyPrice = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ScheduledInstanceAvailability) SetInstanceType(v string) *ScheduledInstanceAvailability {
+	s.InstanceType = &v
+	return s
+}
+
+// SetMaxTermDurationInDays sets the MaxTermDurationInDays field's value.
+func (s *ScheduledInstanceAvailability) SetMaxTermDurationInDays(v int64) *ScheduledInstanceAvailability {
+	s.MaxTermDurationInDays = &v
+	return s
+}
+
+// SetMinTermDurationInDays sets the MinTermDurationInDays field's value.
+func (s *ScheduledInstanceAvailability) SetMinTermDurationInDays(v int64) *ScheduledInstanceAvailability {
+	s.MinTermDurationInDays = &v
+	return s
+}
+
+// SetNetworkPlatform sets the NetworkPlatform field's value.
+func (s *ScheduledInstanceAvailability) SetNetworkPlatform(v string) *ScheduledInstanceAvailability {
+	s.NetworkPlatform = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *ScheduledInstanceAvailability) SetPlatform(v string) *ScheduledInstanceAvailability {
+	s.Platform = &v
+	return s
+}
+
+// SetPurchaseToken sets the PurchaseToken field's value.
+func (s *ScheduledInstanceAvailability) SetPurchaseToken(v string) *ScheduledInstanceAvailability {
+	s.PurchaseToken = &v
+	return s
+}
+
+// SetRecurrence sets the Recurrence field's value.
+func (s *ScheduledInstanceAvailability) SetRecurrence(v *ScheduledInstanceRecurrence) *ScheduledInstanceAvailability {
+	s.Recurrence = v
+	return s
+}
+
+// SetSlotDurationInHours sets the SlotDurationInHours field's value.
+func (s *ScheduledInstanceAvailability) SetSlotDurationInHours(v int64) *ScheduledInstanceAvailability {
+	s.SlotDurationInHours = &v
+	return s
+}
+
+// SetTotalScheduledInstanceHours sets the TotalScheduledInstanceHours field's value.
+func (s *ScheduledInstanceAvailability) SetTotalScheduledInstanceHours(v int64) *ScheduledInstanceAvailability {
+	s.TotalScheduledInstanceHours = &v
+	return s
+}
+
 // Describes the recurring schedule for a Scheduled Instance.
 type ScheduledInstanceRecurrence struct {
 	_ struct{} `type:"structure"`
@@ -33695,6 +44033,36 @@ func (s ScheduledInstanceRecurrence) String() string {
 // GoString returns the string representation
 func (s ScheduledInstanceRecurrence) GoString() string {
 	return s.String()
+}
+
+// SetFrequency sets the Frequency field's value.
+func (s *ScheduledInstanceRecurrence) SetFrequency(v string) *ScheduledInstanceRecurrence {
+	s.Frequency = &v
+	return s
+}
+
+// SetInterval sets the Interval field's value.
+func (s *ScheduledInstanceRecurrence) SetInterval(v int64) *ScheduledInstanceRecurrence {
+	s.Interval = &v
+	return s
+}
+
+// SetOccurrenceDaySet sets the OccurrenceDaySet field's value.
+func (s *ScheduledInstanceRecurrence) SetOccurrenceDaySet(v []*int64) *ScheduledInstanceRecurrence {
+	s.OccurrenceDaySet = v
+	return s
+}
+
+// SetOccurrenceRelativeToEnd sets the OccurrenceRelativeToEnd field's value.
+func (s *ScheduledInstanceRecurrence) SetOccurrenceRelativeToEnd(v bool) *ScheduledInstanceRecurrence {
+	s.OccurrenceRelativeToEnd = &v
+	return s
+}
+
+// SetOccurrenceUnit sets the OccurrenceUnit field's value.
+func (s *ScheduledInstanceRecurrence) SetOccurrenceUnit(v string) *ScheduledInstanceRecurrence {
+	s.OccurrenceUnit = &v
+	return s
 }
 
 // Describes the recurring schedule for a Scheduled Instance.
@@ -33734,6 +44102,36 @@ func (s ScheduledInstanceRecurrenceRequest) GoString() string {
 	return s.String()
 }
 
+// SetFrequency sets the Frequency field's value.
+func (s *ScheduledInstanceRecurrenceRequest) SetFrequency(v string) *ScheduledInstanceRecurrenceRequest {
+	s.Frequency = &v
+	return s
+}
+
+// SetInterval sets the Interval field's value.
+func (s *ScheduledInstanceRecurrenceRequest) SetInterval(v int64) *ScheduledInstanceRecurrenceRequest {
+	s.Interval = &v
+	return s
+}
+
+// SetOccurrenceDays sets the OccurrenceDays field's value.
+func (s *ScheduledInstanceRecurrenceRequest) SetOccurrenceDays(v []*int64) *ScheduledInstanceRecurrenceRequest {
+	s.OccurrenceDays = v
+	return s
+}
+
+// SetOccurrenceRelativeToEnd sets the OccurrenceRelativeToEnd field's value.
+func (s *ScheduledInstanceRecurrenceRequest) SetOccurrenceRelativeToEnd(v bool) *ScheduledInstanceRecurrenceRequest {
+	s.OccurrenceRelativeToEnd = &v
+	return s
+}
+
+// SetOccurrenceUnit sets the OccurrenceUnit field's value.
+func (s *ScheduledInstanceRecurrenceRequest) SetOccurrenceUnit(v string) *ScheduledInstanceRecurrenceRequest {
+	s.OccurrenceUnit = &v
+	return s
+}
+
 // Describes a block device mapping for a Scheduled Instance.
 type ScheduledInstancesBlockDeviceMapping struct {
 	_ struct{} `type:"structure"`
@@ -33770,6 +44168,30 @@ func (s ScheduledInstancesBlockDeviceMapping) String() string {
 // GoString returns the string representation
 func (s ScheduledInstancesBlockDeviceMapping) GoString() string {
 	return s.String()
+}
+
+// SetDeviceName sets the DeviceName field's value.
+func (s *ScheduledInstancesBlockDeviceMapping) SetDeviceName(v string) *ScheduledInstancesBlockDeviceMapping {
+	s.DeviceName = &v
+	return s
+}
+
+// SetEbs sets the Ebs field's value.
+func (s *ScheduledInstancesBlockDeviceMapping) SetEbs(v *ScheduledInstancesEbs) *ScheduledInstancesBlockDeviceMapping {
+	s.Ebs = v
+	return s
+}
+
+// SetNoDevice sets the NoDevice field's value.
+func (s *ScheduledInstancesBlockDeviceMapping) SetNoDevice(v string) *ScheduledInstancesBlockDeviceMapping {
+	s.NoDevice = &v
+	return s
+}
+
+// SetVirtualName sets the VirtualName field's value.
+func (s *ScheduledInstancesBlockDeviceMapping) SetVirtualName(v string) *ScheduledInstancesBlockDeviceMapping {
+	s.VirtualName = &v
+	return s
 }
 
 // Describes an EBS volume for a Scheduled Instance.
@@ -33824,6 +44246,42 @@ func (s ScheduledInstancesEbs) GoString() string {
 	return s.String()
 }
 
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *ScheduledInstancesEbs) SetDeleteOnTermination(v bool) *ScheduledInstancesEbs {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *ScheduledInstancesEbs) SetEncrypted(v bool) *ScheduledInstancesEbs {
+	s.Encrypted = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *ScheduledInstancesEbs) SetIops(v int64) *ScheduledInstancesEbs {
+	s.Iops = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *ScheduledInstancesEbs) SetSnapshotId(v string) *ScheduledInstancesEbs {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetVolumeSize sets the VolumeSize field's value.
+func (s *ScheduledInstancesEbs) SetVolumeSize(v int64) *ScheduledInstancesEbs {
+	s.VolumeSize = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *ScheduledInstancesEbs) SetVolumeType(v string) *ScheduledInstancesEbs {
+	s.VolumeType = &v
+	return s
+}
+
 // Describes an IAM instance profile for a Scheduled Instance.
 type ScheduledInstancesIamInstanceProfile struct {
 	_ struct{} `type:"structure"`
@@ -33843,6 +44301,18 @@ func (s ScheduledInstancesIamInstanceProfile) String() string {
 // GoString returns the string representation
 func (s ScheduledInstancesIamInstanceProfile) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *ScheduledInstancesIamInstanceProfile) SetArn(v string) *ScheduledInstancesIamInstanceProfile {
+	s.Arn = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ScheduledInstancesIamInstanceProfile) SetName(v string) *ScheduledInstancesIamInstanceProfile {
+	s.Name = &v
+	return s
 }
 
 // Describes the launch specification for a Scheduled Instance.
@@ -33927,6 +44397,90 @@ func (s *ScheduledInstancesLaunchSpecification) Validate() error {
 	return nil
 }
 
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetBlockDeviceMappings(v []*ScheduledInstancesBlockDeviceMapping) *ScheduledInstancesLaunchSpecification {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetEbsOptimized(v bool) *ScheduledInstancesLaunchSpecification {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetIamInstanceProfile(v *ScheduledInstancesIamInstanceProfile) *ScheduledInstancesLaunchSpecification {
+	s.IamInstanceProfile = v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetImageId(v string) *ScheduledInstancesLaunchSpecification {
+	s.ImageId = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetInstanceType(v string) *ScheduledInstancesLaunchSpecification {
+	s.InstanceType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetKernelId(v string) *ScheduledInstancesLaunchSpecification {
+	s.KernelId = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetKeyName(v string) *ScheduledInstancesLaunchSpecification {
+	s.KeyName = &v
+	return s
+}
+
+// SetMonitoring sets the Monitoring field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetMonitoring(v *ScheduledInstancesMonitoring) *ScheduledInstancesLaunchSpecification {
+	s.Monitoring = v
+	return s
+}
+
+// SetNetworkInterfaces sets the NetworkInterfaces field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetNetworkInterfaces(v []*ScheduledInstancesNetworkInterface) *ScheduledInstancesLaunchSpecification {
+	s.NetworkInterfaces = v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetPlacement(v *ScheduledInstancesPlacement) *ScheduledInstancesLaunchSpecification {
+	s.Placement = v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetRamdiskId(v string) *ScheduledInstancesLaunchSpecification {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetSecurityGroupIds(v []*string) *ScheduledInstancesLaunchSpecification {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetSubnetId(v string) *ScheduledInstancesLaunchSpecification {
+	s.SubnetId = &v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *ScheduledInstancesLaunchSpecification) SetUserData(v string) *ScheduledInstancesLaunchSpecification {
+	s.UserData = &v
+	return s
+}
+
 // Describes whether monitoring is enabled for a Scheduled Instance.
 type ScheduledInstancesMonitoring struct {
 	_ struct{} `type:"structure"`
@@ -33943,6 +44497,12 @@ func (s ScheduledInstancesMonitoring) String() string {
 // GoString returns the string representation
 func (s ScheduledInstancesMonitoring) GoString() string {
 	return s.String()
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *ScheduledInstancesMonitoring) SetEnabled(v bool) *ScheduledInstancesMonitoring {
+	s.Enabled = &v
+	return s
 }
 
 // Describes a network interface for a Scheduled Instance.
@@ -33994,6 +44554,66 @@ func (s ScheduledInstancesNetworkInterface) GoString() string {
 	return s.String()
 }
 
+// SetAssociatePublicIpAddress sets the AssociatePublicIpAddress field's value.
+func (s *ScheduledInstancesNetworkInterface) SetAssociatePublicIpAddress(v bool) *ScheduledInstancesNetworkInterface {
+	s.AssociatePublicIpAddress = &v
+	return s
+}
+
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *ScheduledInstancesNetworkInterface) SetDeleteOnTermination(v bool) *ScheduledInstancesNetworkInterface {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ScheduledInstancesNetworkInterface) SetDescription(v string) *ScheduledInstancesNetworkInterface {
+	s.Description = &v
+	return s
+}
+
+// SetDeviceIndex sets the DeviceIndex field's value.
+func (s *ScheduledInstancesNetworkInterface) SetDeviceIndex(v int64) *ScheduledInstancesNetworkInterface {
+	s.DeviceIndex = &v
+	return s
+}
+
+// SetGroups sets the Groups field's value.
+func (s *ScheduledInstancesNetworkInterface) SetGroups(v []*string) *ScheduledInstancesNetworkInterface {
+	s.Groups = v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *ScheduledInstancesNetworkInterface) SetNetworkInterfaceId(v string) *ScheduledInstancesNetworkInterface {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *ScheduledInstancesNetworkInterface) SetPrivateIpAddress(v string) *ScheduledInstancesNetworkInterface {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetPrivateIpAddressConfigs sets the PrivateIpAddressConfigs field's value.
+func (s *ScheduledInstancesNetworkInterface) SetPrivateIpAddressConfigs(v []*ScheduledInstancesPrivateIpAddressConfig) *ScheduledInstancesNetworkInterface {
+	s.PrivateIpAddressConfigs = v
+	return s
+}
+
+// SetSecondaryPrivateIpAddressCount sets the SecondaryPrivateIpAddressCount field's value.
+func (s *ScheduledInstancesNetworkInterface) SetSecondaryPrivateIpAddressCount(v int64) *ScheduledInstancesNetworkInterface {
+	s.SecondaryPrivateIpAddressCount = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *ScheduledInstancesNetworkInterface) SetSubnetId(v string) *ScheduledInstancesNetworkInterface {
+	s.SubnetId = &v
+	return s
+}
+
 // Describes the placement for a Scheduled Instance.
 type ScheduledInstancesPlacement struct {
 	_ struct{} `type:"structure"`
@@ -34013,6 +44633,18 @@ func (s ScheduledInstancesPlacement) String() string {
 // GoString returns the string representation
 func (s ScheduledInstancesPlacement) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *ScheduledInstancesPlacement) SetAvailabilityZone(v string) *ScheduledInstancesPlacement {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *ScheduledInstancesPlacement) SetGroupName(v string) *ScheduledInstancesPlacement {
+	s.GroupName = &v
+	return s
 }
 
 // Describes a private IP address for a Scheduled Instance.
@@ -34035,6 +44667,18 @@ func (s ScheduledInstancesPrivateIpAddressConfig) String() string {
 // GoString returns the string representation
 func (s ScheduledInstancesPrivateIpAddressConfig) GoString() string {
 	return s.String()
+}
+
+// SetPrimary sets the Primary field's value.
+func (s *ScheduledInstancesPrivateIpAddressConfig) SetPrimary(v bool) *ScheduledInstancesPrivateIpAddressConfig {
+	s.Primary = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *ScheduledInstancesPrivateIpAddressConfig) SetPrivateIpAddress(v string) *ScheduledInstancesPrivateIpAddressConfig {
+	s.PrivateIpAddress = &v
+	return s
 }
 
 // Describes a security group
@@ -34076,6 +44720,54 @@ func (s SecurityGroup) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *SecurityGroup) SetDescription(v string) *SecurityGroup {
+	s.Description = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *SecurityGroup) SetGroupId(v string) *SecurityGroup {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *SecurityGroup) SetGroupName(v string) *SecurityGroup {
+	s.GroupName = &v
+	return s
+}
+
+// SetIpPermissions sets the IpPermissions field's value.
+func (s *SecurityGroup) SetIpPermissions(v []*IpPermission) *SecurityGroup {
+	s.IpPermissions = v
+	return s
+}
+
+// SetIpPermissionsEgress sets the IpPermissionsEgress field's value.
+func (s *SecurityGroup) SetIpPermissionsEgress(v []*IpPermission) *SecurityGroup {
+	s.IpPermissionsEgress = v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *SecurityGroup) SetOwnerId(v string) *SecurityGroup {
+	s.OwnerId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *SecurityGroup) SetTags(v []*Tag) *SecurityGroup {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *SecurityGroup) SetVpcId(v string) *SecurityGroup {
+	s.VpcId = &v
+	return s
+}
+
 // Describes a VPC with a security group that references your security group.
 type SecurityGroupReference struct {
 	_ struct{} `type:"structure"`
@@ -34102,6 +44794,24 @@ func (s SecurityGroupReference) String() string {
 // GoString returns the string representation
 func (s SecurityGroupReference) GoString() string {
 	return s.String()
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *SecurityGroupReference) SetGroupId(v string) *SecurityGroupReference {
+	s.GroupId = &v
+	return s
+}
+
+// SetReferencingVpcId sets the ReferencingVpcId field's value.
+func (s *SecurityGroupReference) SetReferencingVpcId(v string) *SecurityGroupReference {
+	s.ReferencingVpcId = &v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *SecurityGroupReference) SetVpcPeeringConnectionId(v string) *SecurityGroupReference {
+	s.VpcPeeringConnectionId = &v
+	return s
 }
 
 // Describes the time period for a Scheduled Instance to start its first schedule.
@@ -34148,6 +44858,18 @@ func (s *SlotDateTimeRangeRequest) Validate() error {
 	return nil
 }
 
+// SetEarliestTime sets the EarliestTime field's value.
+func (s *SlotDateTimeRangeRequest) SetEarliestTime(v time.Time) *SlotDateTimeRangeRequest {
+	s.EarliestTime = &v
+	return s
+}
+
+// SetLatestTime sets the LatestTime field's value.
+func (s *SlotDateTimeRangeRequest) SetLatestTime(v time.Time) *SlotDateTimeRangeRequest {
+	s.LatestTime = &v
+	return s
+}
+
 // Describes the time period for a Scheduled Instance to start its first schedule.
 type SlotStartTimeRangeRequest struct {
 	_ struct{} `type:"structure"`
@@ -34167,6 +44889,18 @@ func (s SlotStartTimeRangeRequest) String() string {
 // GoString returns the string representation
 func (s SlotStartTimeRangeRequest) GoString() string {
 	return s.String()
+}
+
+// SetEarliestTime sets the EarliestTime field's value.
+func (s *SlotStartTimeRangeRequest) SetEarliestTime(v time.Time) *SlotStartTimeRangeRequest {
+	s.EarliestTime = &v
+	return s
+}
+
+// SetLatestTime sets the LatestTime field's value.
+func (s *SlotStartTimeRangeRequest) SetLatestTime(v time.Time) *SlotStartTimeRangeRequest {
+	s.LatestTime = &v
+	return s
 }
 
 // Describes a snapshot.
@@ -34242,6 +44976,90 @@ func (s Snapshot) GoString() string {
 	return s.String()
 }
 
+// SetDataEncryptionKeyId sets the DataEncryptionKeyId field's value.
+func (s *Snapshot) SetDataEncryptionKeyId(v string) *Snapshot {
+	s.DataEncryptionKeyId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Snapshot) SetDescription(v string) *Snapshot {
+	s.Description = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *Snapshot) SetEncrypted(v bool) *Snapshot {
+	s.Encrypted = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *Snapshot) SetKmsKeyId(v string) *Snapshot {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetOwnerAlias sets the OwnerAlias field's value.
+func (s *Snapshot) SetOwnerAlias(v string) *Snapshot {
+	s.OwnerAlias = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *Snapshot) SetOwnerId(v string) *Snapshot {
+	s.OwnerId = &v
+	return s
+}
+
+// SetProgress sets the Progress field's value.
+func (s *Snapshot) SetProgress(v string) *Snapshot {
+	s.Progress = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *Snapshot) SetSnapshotId(v string) *Snapshot {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *Snapshot) SetStartTime(v time.Time) *Snapshot {
+	s.StartTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Snapshot) SetState(v string) *Snapshot {
+	s.State = &v
+	return s
+}
+
+// SetStateMessage sets the StateMessage field's value.
+func (s *Snapshot) SetStateMessage(v string) *Snapshot {
+	s.StateMessage = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Snapshot) SetTags(v []*Tag) *Snapshot {
+	s.Tags = v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *Snapshot) SetVolumeId(v string) *Snapshot {
+	s.VolumeId = &v
+	return s
+}
+
+// SetVolumeSize sets the VolumeSize field's value.
+func (s *Snapshot) SetVolumeSize(v int64) *Snapshot {
+	s.VolumeSize = &v
+	return s
+}
+
 // Describes the snapshot created from the imported disk.
 type SnapshotDetail struct {
 	_ struct{} `type:"structure"`
@@ -34287,6 +45105,66 @@ func (s SnapshotDetail) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *SnapshotDetail) SetDescription(v string) *SnapshotDetail {
+	s.Description = &v
+	return s
+}
+
+// SetDeviceName sets the DeviceName field's value.
+func (s *SnapshotDetail) SetDeviceName(v string) *SnapshotDetail {
+	s.DeviceName = &v
+	return s
+}
+
+// SetDiskImageSize sets the DiskImageSize field's value.
+func (s *SnapshotDetail) SetDiskImageSize(v float64) *SnapshotDetail {
+	s.DiskImageSize = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *SnapshotDetail) SetFormat(v string) *SnapshotDetail {
+	s.Format = &v
+	return s
+}
+
+// SetProgress sets the Progress field's value.
+func (s *SnapshotDetail) SetProgress(v string) *SnapshotDetail {
+	s.Progress = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *SnapshotDetail) SetSnapshotId(v string) *SnapshotDetail {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SnapshotDetail) SetStatus(v string) *SnapshotDetail {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *SnapshotDetail) SetStatusMessage(v string) *SnapshotDetail {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *SnapshotDetail) SetUrl(v string) *SnapshotDetail {
+	s.Url = &v
+	return s
+}
+
+// SetUserBucket sets the UserBucket field's value.
+func (s *SnapshotDetail) SetUserBucket(v *UserBucketDetails) *SnapshotDetail {
+	s.UserBucket = v
+	return s
+}
+
 // The disk container object for the import snapshot request.
 type SnapshotDiskContainer struct {
 	_ struct{} `type:"structure"`
@@ -34315,6 +45193,30 @@ func (s SnapshotDiskContainer) String() string {
 // GoString returns the string representation
 func (s SnapshotDiskContainer) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *SnapshotDiskContainer) SetDescription(v string) *SnapshotDiskContainer {
+	s.Description = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *SnapshotDiskContainer) SetFormat(v string) *SnapshotDiskContainer {
+	s.Format = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *SnapshotDiskContainer) SetUrl(v string) *SnapshotDiskContainer {
+	s.Url = &v
+	return s
+}
+
+// SetUserBucket sets the UserBucket field's value.
+func (s *SnapshotDiskContainer) SetUserBucket(v *UserBucket) *SnapshotDiskContainer {
+	s.UserBucket = v
+	return s
 }
 
 // Details about the import snapshot task.
@@ -34359,6 +45261,60 @@ func (s SnapshotTaskDetail) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *SnapshotTaskDetail) SetDescription(v string) *SnapshotTaskDetail {
+	s.Description = &v
+	return s
+}
+
+// SetDiskImageSize sets the DiskImageSize field's value.
+func (s *SnapshotTaskDetail) SetDiskImageSize(v float64) *SnapshotTaskDetail {
+	s.DiskImageSize = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *SnapshotTaskDetail) SetFormat(v string) *SnapshotTaskDetail {
+	s.Format = &v
+	return s
+}
+
+// SetProgress sets the Progress field's value.
+func (s *SnapshotTaskDetail) SetProgress(v string) *SnapshotTaskDetail {
+	s.Progress = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *SnapshotTaskDetail) SetSnapshotId(v string) *SnapshotTaskDetail {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SnapshotTaskDetail) SetStatus(v string) *SnapshotTaskDetail {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *SnapshotTaskDetail) SetStatusMessage(v string) *SnapshotTaskDetail {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *SnapshotTaskDetail) SetUrl(v string) *SnapshotTaskDetail {
+	s.Url = &v
+	return s
+}
+
+// SetUserBucket sets the UserBucket field's value.
+func (s *SnapshotTaskDetail) SetUserBucket(v *UserBucketDetails) *SnapshotTaskDetail {
+	s.UserBucket = v
+	return s
+}
+
 // Describes the data feed for a Spot instance.
 type SpotDatafeedSubscription struct {
 	_ struct{} `type:"structure"`
@@ -34387,6 +45343,36 @@ func (s SpotDatafeedSubscription) String() string {
 // GoString returns the string representation
 func (s SpotDatafeedSubscription) GoString() string {
 	return s.String()
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *SpotDatafeedSubscription) SetBucket(v string) *SpotDatafeedSubscription {
+	s.Bucket = &v
+	return s
+}
+
+// SetFault sets the Fault field's value.
+func (s *SpotDatafeedSubscription) SetFault(v *SpotInstanceStateFault) *SpotDatafeedSubscription {
+	s.Fault = v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *SpotDatafeedSubscription) SetOwnerId(v string) *SpotDatafeedSubscription {
+	s.OwnerId = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *SpotDatafeedSubscription) SetPrefix(v string) *SpotDatafeedSubscription {
+	s.Prefix = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *SpotDatafeedSubscription) SetState(v string) *SpotDatafeedSubscription {
+	s.State = &v
+	return s
 }
 
 // Describes the launch specification for one or more Spot instances.
@@ -34495,6 +45481,108 @@ func (s *SpotFleetLaunchSpecification) Validate() error {
 	return nil
 }
 
+// SetAddressingType sets the AddressingType field's value.
+func (s *SpotFleetLaunchSpecification) SetAddressingType(v string) *SpotFleetLaunchSpecification {
+	s.AddressingType = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *SpotFleetLaunchSpecification) SetBlockDeviceMappings(v []*BlockDeviceMapping) *SpotFleetLaunchSpecification {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *SpotFleetLaunchSpecification) SetEbsOptimized(v bool) *SpotFleetLaunchSpecification {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *SpotFleetLaunchSpecification) SetIamInstanceProfile(v *IamInstanceProfileSpecification) *SpotFleetLaunchSpecification {
+	s.IamInstanceProfile = v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *SpotFleetLaunchSpecification) SetImageId(v string) *SpotFleetLaunchSpecification {
+	s.ImageId = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *SpotFleetLaunchSpecification) SetInstanceType(v string) *SpotFleetLaunchSpecification {
+	s.InstanceType = &v
+	return s
+}
+
+// SetKernelId sets the KernelId field's value.
+func (s *SpotFleetLaunchSpecification) SetKernelId(v string) *SpotFleetLaunchSpecification {
+	s.KernelId = &v
+	return s
+}
+
+// SetKeyName sets the KeyName field's value.
+func (s *SpotFleetLaunchSpecification) SetKeyName(v string) *SpotFleetLaunchSpecification {
+	s.KeyName = &v
+	return s
+}
+
+// SetMonitoring sets the Monitoring field's value.
+func (s *SpotFleetLaunchSpecification) SetMonitoring(v *SpotFleetMonitoring) *SpotFleetLaunchSpecification {
+	s.Monitoring = v
+	return s
+}
+
+// SetNetworkInterfaces sets the NetworkInterfaces field's value.
+func (s *SpotFleetLaunchSpecification) SetNetworkInterfaces(v []*InstanceNetworkInterfaceSpecification) *SpotFleetLaunchSpecification {
+	s.NetworkInterfaces = v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *SpotFleetLaunchSpecification) SetPlacement(v *SpotPlacement) *SpotFleetLaunchSpecification {
+	s.Placement = v
+	return s
+}
+
+// SetRamdiskId sets the RamdiskId field's value.
+func (s *SpotFleetLaunchSpecification) SetRamdiskId(v string) *SpotFleetLaunchSpecification {
+	s.RamdiskId = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *SpotFleetLaunchSpecification) SetSecurityGroups(v []*GroupIdentifier) *SpotFleetLaunchSpecification {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSpotPrice sets the SpotPrice field's value.
+func (s *SpotFleetLaunchSpecification) SetSpotPrice(v string) *SpotFleetLaunchSpecification {
+	s.SpotPrice = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *SpotFleetLaunchSpecification) SetSubnetId(v string) *SpotFleetLaunchSpecification {
+	s.SubnetId = &v
+	return s
+}
+
+// SetUserData sets the UserData field's value.
+func (s *SpotFleetLaunchSpecification) SetUserData(v string) *SpotFleetLaunchSpecification {
+	s.UserData = &v
+	return s
+}
+
+// SetWeightedCapacity sets the WeightedCapacity field's value.
+func (s *SpotFleetLaunchSpecification) SetWeightedCapacity(v float64) *SpotFleetLaunchSpecification {
+	s.WeightedCapacity = &v
+	return s
+}
+
 // Describes whether monitoring is enabled.
 type SpotFleetMonitoring struct {
 	_ struct{} `type:"structure"`
@@ -34513,6 +45601,12 @@ func (s SpotFleetMonitoring) String() string {
 // GoString returns the string representation
 func (s SpotFleetMonitoring) GoString() string {
 	return s.String()
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *SpotFleetMonitoring) SetEnabled(v bool) *SpotFleetMonitoring {
+	s.Enabled = &v
+	return s
 }
 
 // Describes a Spot fleet request.
@@ -34555,6 +45649,36 @@ func (s SpotFleetRequestConfig) String() string {
 // GoString returns the string representation
 func (s SpotFleetRequestConfig) GoString() string {
 	return s.String()
+}
+
+// SetActivityStatus sets the ActivityStatus field's value.
+func (s *SpotFleetRequestConfig) SetActivityStatus(v string) *SpotFleetRequestConfig {
+	s.ActivityStatus = &v
+	return s
+}
+
+// SetCreateTime sets the CreateTime field's value.
+func (s *SpotFleetRequestConfig) SetCreateTime(v time.Time) *SpotFleetRequestConfig {
+	s.CreateTime = &v
+	return s
+}
+
+// SetSpotFleetRequestConfig sets the SpotFleetRequestConfig field's value.
+func (s *SpotFleetRequestConfig) SetSpotFleetRequestConfig(v *SpotFleetRequestConfigData) *SpotFleetRequestConfig {
+	s.SpotFleetRequestConfig = v
+	return s
+}
+
+// SetSpotFleetRequestId sets the SpotFleetRequestId field's value.
+func (s *SpotFleetRequestConfig) SetSpotFleetRequestId(v string) *SpotFleetRequestConfig {
+	s.SpotFleetRequestId = &v
+	return s
+}
+
+// SetSpotFleetRequestState sets the SpotFleetRequestState field's value.
+func (s *SpotFleetRequestConfig) SetSpotFleetRequestState(v string) *SpotFleetRequestConfig {
+	s.SpotFleetRequestState = &v
+	return s
 }
 
 // Describes the configuration of a Spot fleet request.
@@ -34672,6 +45796,78 @@ func (s *SpotFleetRequestConfigData) Validate() error {
 	return nil
 }
 
+// SetAllocationStrategy sets the AllocationStrategy field's value.
+func (s *SpotFleetRequestConfigData) SetAllocationStrategy(v string) *SpotFleetRequestConfigData {
+	s.AllocationStrategy = &v
+	return s
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *SpotFleetRequestConfigData) SetClientToken(v string) *SpotFleetRequestConfigData {
+	s.ClientToken = &v
+	return s
+}
+
+// SetExcessCapacityTerminationPolicy sets the ExcessCapacityTerminationPolicy field's value.
+func (s *SpotFleetRequestConfigData) SetExcessCapacityTerminationPolicy(v string) *SpotFleetRequestConfigData {
+	s.ExcessCapacityTerminationPolicy = &v
+	return s
+}
+
+// SetFulfilledCapacity sets the FulfilledCapacity field's value.
+func (s *SpotFleetRequestConfigData) SetFulfilledCapacity(v float64) *SpotFleetRequestConfigData {
+	s.FulfilledCapacity = &v
+	return s
+}
+
+// SetIamFleetRole sets the IamFleetRole field's value.
+func (s *SpotFleetRequestConfigData) SetIamFleetRole(v string) *SpotFleetRequestConfigData {
+	s.IamFleetRole = &v
+	return s
+}
+
+// SetLaunchSpecifications sets the LaunchSpecifications field's value.
+func (s *SpotFleetRequestConfigData) SetLaunchSpecifications(v []*SpotFleetLaunchSpecification) *SpotFleetRequestConfigData {
+	s.LaunchSpecifications = v
+	return s
+}
+
+// SetSpotPrice sets the SpotPrice field's value.
+func (s *SpotFleetRequestConfigData) SetSpotPrice(v string) *SpotFleetRequestConfigData {
+	s.SpotPrice = &v
+	return s
+}
+
+// SetTargetCapacity sets the TargetCapacity field's value.
+func (s *SpotFleetRequestConfigData) SetTargetCapacity(v int64) *SpotFleetRequestConfigData {
+	s.TargetCapacity = &v
+	return s
+}
+
+// SetTerminateInstancesWithExpiration sets the TerminateInstancesWithExpiration field's value.
+func (s *SpotFleetRequestConfigData) SetTerminateInstancesWithExpiration(v bool) *SpotFleetRequestConfigData {
+	s.TerminateInstancesWithExpiration = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *SpotFleetRequestConfigData) SetType(v string) *SpotFleetRequestConfigData {
+	s.Type = &v
+	return s
+}
+
+// SetValidFrom sets the ValidFrom field's value.
+func (s *SpotFleetRequestConfigData) SetValidFrom(v time.Time) *SpotFleetRequestConfigData {
+	s.ValidFrom = &v
+	return s
+}
+
+// SetValidUntil sets the ValidUntil field's value.
+func (s *SpotFleetRequestConfigData) SetValidUntil(v time.Time) *SpotFleetRequestConfigData {
+	s.ValidUntil = &v
+	return s
+}
+
 // Describes a Spot instance request.
 type SpotInstanceRequest struct {
 	_ struct{} `type:"structure"`
@@ -34755,6 +45951,114 @@ func (s SpotInstanceRequest) GoString() string {
 	return s.String()
 }
 
+// SetActualBlockHourlyPrice sets the ActualBlockHourlyPrice field's value.
+func (s *SpotInstanceRequest) SetActualBlockHourlyPrice(v string) *SpotInstanceRequest {
+	s.ActualBlockHourlyPrice = &v
+	return s
+}
+
+// SetAvailabilityZoneGroup sets the AvailabilityZoneGroup field's value.
+func (s *SpotInstanceRequest) SetAvailabilityZoneGroup(v string) *SpotInstanceRequest {
+	s.AvailabilityZoneGroup = &v
+	return s
+}
+
+// SetBlockDurationMinutes sets the BlockDurationMinutes field's value.
+func (s *SpotInstanceRequest) SetBlockDurationMinutes(v int64) *SpotInstanceRequest {
+	s.BlockDurationMinutes = &v
+	return s
+}
+
+// SetCreateTime sets the CreateTime field's value.
+func (s *SpotInstanceRequest) SetCreateTime(v time.Time) *SpotInstanceRequest {
+	s.CreateTime = &v
+	return s
+}
+
+// SetFault sets the Fault field's value.
+func (s *SpotInstanceRequest) SetFault(v *SpotInstanceStateFault) *SpotInstanceRequest {
+	s.Fault = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *SpotInstanceRequest) SetInstanceId(v string) *SpotInstanceRequest {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLaunchGroup sets the LaunchGroup field's value.
+func (s *SpotInstanceRequest) SetLaunchGroup(v string) *SpotInstanceRequest {
+	s.LaunchGroup = &v
+	return s
+}
+
+// SetLaunchSpecification sets the LaunchSpecification field's value.
+func (s *SpotInstanceRequest) SetLaunchSpecification(v *LaunchSpecification) *SpotInstanceRequest {
+	s.LaunchSpecification = v
+	return s
+}
+
+// SetLaunchedAvailabilityZone sets the LaunchedAvailabilityZone field's value.
+func (s *SpotInstanceRequest) SetLaunchedAvailabilityZone(v string) *SpotInstanceRequest {
+	s.LaunchedAvailabilityZone = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *SpotInstanceRequest) SetProductDescription(v string) *SpotInstanceRequest {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetSpotInstanceRequestId sets the SpotInstanceRequestId field's value.
+func (s *SpotInstanceRequest) SetSpotInstanceRequestId(v string) *SpotInstanceRequest {
+	s.SpotInstanceRequestId = &v
+	return s
+}
+
+// SetSpotPrice sets the SpotPrice field's value.
+func (s *SpotInstanceRequest) SetSpotPrice(v string) *SpotInstanceRequest {
+	s.SpotPrice = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *SpotInstanceRequest) SetState(v string) *SpotInstanceRequest {
+	s.State = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SpotInstanceRequest) SetStatus(v *SpotInstanceStatus) *SpotInstanceRequest {
+	s.Status = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *SpotInstanceRequest) SetTags(v []*Tag) *SpotInstanceRequest {
+	s.Tags = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *SpotInstanceRequest) SetType(v string) *SpotInstanceRequest {
+	s.Type = &v
+	return s
+}
+
+// SetValidFrom sets the ValidFrom field's value.
+func (s *SpotInstanceRequest) SetValidFrom(v time.Time) *SpotInstanceRequest {
+	s.ValidFrom = &v
+	return s
+}
+
+// SetValidUntil sets the ValidUntil field's value.
+func (s *SpotInstanceRequest) SetValidUntil(v time.Time) *SpotInstanceRequest {
+	s.ValidUntil = &v
+	return s
+}
+
 // Describes a Spot instance state change.
 type SpotInstanceStateFault struct {
 	_ struct{} `type:"structure"`
@@ -34774,6 +46078,18 @@ func (s SpotInstanceStateFault) String() string {
 // GoString returns the string representation
 func (s SpotInstanceStateFault) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *SpotInstanceStateFault) SetCode(v string) *SpotInstanceStateFault {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *SpotInstanceStateFault) SetMessage(v string) *SpotInstanceStateFault {
+	s.Message = &v
+	return s
 }
 
 // Describes the status of a Spot instance request.
@@ -34802,6 +46118,24 @@ func (s SpotInstanceStatus) GoString() string {
 	return s.String()
 }
 
+// SetCode sets the Code field's value.
+func (s *SpotInstanceStatus) SetCode(v string) *SpotInstanceStatus {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *SpotInstanceStatus) SetMessage(v string) *SpotInstanceStatus {
+	s.Message = &v
+	return s
+}
+
+// SetUpdateTime sets the UpdateTime field's value.
+func (s *SpotInstanceStatus) SetUpdateTime(v time.Time) *SpotInstanceStatus {
+	s.UpdateTime = &v
+	return s
+}
+
 // Describes Spot instance placement.
 type SpotPlacement struct {
 	_ struct{} `type:"structure"`
@@ -34824,6 +46158,18 @@ func (s SpotPlacement) String() string {
 // GoString returns the string representation
 func (s SpotPlacement) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *SpotPlacement) SetAvailabilityZone(v string) *SpotPlacement {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *SpotPlacement) SetGroupName(v string) *SpotPlacement {
+	s.GroupName = &v
+	return s
 }
 
 // Describes the maximum hourly price (bid) for any Spot instance launched to
@@ -34855,6 +46201,36 @@ func (s SpotPrice) String() string {
 // GoString returns the string representation
 func (s SpotPrice) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *SpotPrice) SetAvailabilityZone(v string) *SpotPrice {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *SpotPrice) SetInstanceType(v string) *SpotPrice {
+	s.InstanceType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *SpotPrice) SetProductDescription(v string) *SpotPrice {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetSpotPrice sets the SpotPrice field's value.
+func (s *SpotPrice) SetSpotPrice(v string) *SpotPrice {
+	s.SpotPrice = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *SpotPrice) SetTimestamp(v time.Time) *SpotPrice {
+	s.Timestamp = &v
+	return s
 }
 
 // Describes a stale rule in a security group.
@@ -34895,6 +46271,42 @@ func (s StaleIpPermission) GoString() string {
 	return s.String()
 }
 
+// SetFromPort sets the FromPort field's value.
+func (s *StaleIpPermission) SetFromPort(v int64) *StaleIpPermission {
+	s.FromPort = &v
+	return s
+}
+
+// SetIpProtocol sets the IpProtocol field's value.
+func (s *StaleIpPermission) SetIpProtocol(v string) *StaleIpPermission {
+	s.IpProtocol = &v
+	return s
+}
+
+// SetIpRanges sets the IpRanges field's value.
+func (s *StaleIpPermission) SetIpRanges(v []*string) *StaleIpPermission {
+	s.IpRanges = v
+	return s
+}
+
+// SetPrefixListIds sets the PrefixListIds field's value.
+func (s *StaleIpPermission) SetPrefixListIds(v []*string) *StaleIpPermission {
+	s.PrefixListIds = v
+	return s
+}
+
+// SetToPort sets the ToPort field's value.
+func (s *StaleIpPermission) SetToPort(v int64) *StaleIpPermission {
+	s.ToPort = &v
+	return s
+}
+
+// SetUserIdGroupPairs sets the UserIdGroupPairs field's value.
+func (s *StaleIpPermission) SetUserIdGroupPairs(v []*UserIdGroupPair) *StaleIpPermission {
+	s.UserIdGroupPairs = v
+	return s
+}
+
 // Describes a stale security group (a security group that contains stale rules).
 type StaleSecurityGroup struct {
 	_ struct{} `type:"structure"`
@@ -34928,6 +46340,42 @@ func (s StaleSecurityGroup) String() string {
 // GoString returns the string representation
 func (s StaleSecurityGroup) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *StaleSecurityGroup) SetDescription(v string) *StaleSecurityGroup {
+	s.Description = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *StaleSecurityGroup) SetGroupId(v string) *StaleSecurityGroup {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *StaleSecurityGroup) SetGroupName(v string) *StaleSecurityGroup {
+	s.GroupName = &v
+	return s
+}
+
+// SetStaleIpPermissions sets the StaleIpPermissions field's value.
+func (s *StaleSecurityGroup) SetStaleIpPermissions(v []*StaleIpPermission) *StaleSecurityGroup {
+	s.StaleIpPermissions = v
+	return s
+}
+
+// SetStaleIpPermissionsEgress sets the StaleIpPermissionsEgress field's value.
+func (s *StaleSecurityGroup) SetStaleIpPermissionsEgress(v []*StaleIpPermission) *StaleSecurityGroup {
+	s.StaleIpPermissionsEgress = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *StaleSecurityGroup) SetVpcId(v string) *StaleSecurityGroup {
+	s.VpcId = &v
+	return s
 }
 
 // Contains the parameters for StartInstances.
@@ -34972,6 +46420,24 @@ func (s *StartInstancesInput) Validate() error {
 	return nil
 }
 
+// SetAdditionalInfo sets the AdditionalInfo field's value.
+func (s *StartInstancesInput) SetAdditionalInfo(v string) *StartInstancesInput {
+	s.AdditionalInfo = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *StartInstancesInput) SetDryRun(v bool) *StartInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *StartInstancesInput) SetInstanceIds(v []*string) *StartInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
 // Contains the output of StartInstances.
 type StartInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -34988,6 +46454,12 @@ func (s StartInstancesOutput) String() string {
 // GoString returns the string representation
 func (s StartInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetStartingInstances sets the StartingInstances field's value.
+func (s *StartInstancesOutput) SetStartingInstances(v []*InstanceStateChange) *StartInstancesOutput {
+	s.StartingInstances = v
+	return s
 }
 
 // Describes a state change.
@@ -35033,6 +46505,18 @@ func (s StateReason) String() string {
 // GoString returns the string representation
 func (s StateReason) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *StateReason) SetCode(v string) *StateReason {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *StateReason) SetMessage(v string) *StateReason {
+	s.Message = &v
+	return s
 }
 
 // Contains the parameters for StopInstances.
@@ -35082,6 +46566,24 @@ func (s *StopInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *StopInstancesInput) SetDryRun(v bool) *StopInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetForce sets the Force field's value.
+func (s *StopInstancesInput) SetForce(v bool) *StopInstancesInput {
+	s.Force = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *StopInstancesInput) SetInstanceIds(v []*string) *StopInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
 // Contains the output of StopInstances.
 type StopInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -35100,6 +46602,12 @@ func (s StopInstancesOutput) GoString() string {
 	return s.String()
 }
 
+// SetStoppingInstances sets the StoppingInstances field's value.
+func (s *StopInstancesOutput) SetStoppingInstances(v []*InstanceStateChange) *StopInstancesOutput {
+	s.StoppingInstances = v
+	return s
+}
+
 // Describes the storage location for an instance store-backed AMI.
 type Storage struct {
 	_ struct{} `type:"structure"`
@@ -35116,6 +46624,12 @@ func (s Storage) String() string {
 // GoString returns the string representation
 func (s Storage) GoString() string {
 	return s.String()
+}
+
+// SetS3 sets the S3 field's value.
+func (s *Storage) SetS3(v *S3Storage) *Storage {
+	s.S3 = v
+	return s
 }
 
 // Describes a subnet.
@@ -35161,6 +46675,60 @@ func (s Subnet) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Subnet) SetAvailabilityZone(v string) *Subnet {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetAvailableIpAddressCount sets the AvailableIpAddressCount field's value.
+func (s *Subnet) SetAvailableIpAddressCount(v int64) *Subnet {
+	s.AvailableIpAddressCount = &v
+	return s
+}
+
+// SetCidrBlock sets the CidrBlock field's value.
+func (s *Subnet) SetCidrBlock(v string) *Subnet {
+	s.CidrBlock = &v
+	return s
+}
+
+// SetDefaultForAz sets the DefaultForAz field's value.
+func (s *Subnet) SetDefaultForAz(v bool) *Subnet {
+	s.DefaultForAz = &v
+	return s
+}
+
+// SetMapPublicIpOnLaunch sets the MapPublicIpOnLaunch field's value.
+func (s *Subnet) SetMapPublicIpOnLaunch(v bool) *Subnet {
+	s.MapPublicIpOnLaunch = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Subnet) SetState(v string) *Subnet {
+	s.State = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *Subnet) SetSubnetId(v string) *Subnet {
+	s.SubnetId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Subnet) SetTags(v []*Tag) *Subnet {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *Subnet) SetVpcId(v string) *Subnet {
+	s.VpcId = &v
+	return s
+}
+
 // Describes a tag.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -35186,6 +46754,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // Describes a tag.
@@ -35215,6 +46795,30 @@ func (s TagDescription) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *TagDescription) SetKey(v string) *TagDescription {
+	s.Key = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *TagDescription) SetResourceId(v string) *TagDescription {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *TagDescription) SetResourceType(v string) *TagDescription {
+	s.ResourceType = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *TagDescription) SetValue(v string) *TagDescription {
+	s.Value = &v
+	return s
+}
+
 // Information about the Convertible Reserved Instance offering.
 type TargetConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -35235,6 +46839,18 @@ func (s TargetConfiguration) String() string {
 // GoString returns the string representation
 func (s TargetConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *TargetConfiguration) SetInstanceCount(v int64) *TargetConfiguration {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *TargetConfiguration) SetOfferingId(v string) *TargetConfiguration {
+	s.OfferingId = &v
+	return s
 }
 
 // Details about the target configuration.
@@ -35276,6 +46892,18 @@ func (s *TargetConfigurationRequest) Validate() error {
 	return nil
 }
 
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *TargetConfigurationRequest) SetInstanceCount(v int64) *TargetConfigurationRequest {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *TargetConfigurationRequest) SetOfferingId(v string) *TargetConfigurationRequest {
+	s.OfferingId = &v
+	return s
+}
+
 // The total value of the new Convertible Reserved Instances.
 type TargetReservationValue struct {
 	_ struct{} `type:"structure"`
@@ -35298,6 +46926,18 @@ func (s TargetReservationValue) String() string {
 // GoString returns the string representation
 func (s TargetReservationValue) GoString() string {
 	return s.String()
+}
+
+// SetReservationValue sets the ReservationValue field's value.
+func (s *TargetReservationValue) SetReservationValue(v *ReservationValue) *TargetReservationValue {
+	s.ReservationValue = v
+	return s
+}
+
+// SetTargetConfiguration sets the TargetConfiguration field's value.
+func (s *TargetReservationValue) SetTargetConfiguration(v *TargetConfiguration) *TargetReservationValue {
+	s.TargetConfiguration = v
+	return s
 }
 
 // Contains the parameters for TerminateInstances.
@@ -35342,6 +46982,18 @@ func (s *TerminateInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *TerminateInstancesInput) SetDryRun(v bool) *TerminateInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *TerminateInstancesInput) SetInstanceIds(v []*string) *TerminateInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
 // Contains the output of TerminateInstances.
 type TerminateInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -35358,6 +47010,12 @@ func (s TerminateInstancesOutput) String() string {
 // GoString returns the string representation
 func (s TerminateInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetTerminatingInstances sets the TerminatingInstances field's value.
+func (s *TerminateInstancesOutput) SetTerminatingInstances(v []*InstanceStateChange) *TerminateInstancesOutput {
+	s.TerminatingInstances = v
+	return s
 }
 
 // Contains the parameters for UnassignPrivateIpAddresses.
@@ -35400,6 +47058,18 @@ func (s *UnassignPrivateIpAddressesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *UnassignPrivateIpAddressesInput) SetNetworkInterfaceId(v string) *UnassignPrivateIpAddressesInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetPrivateIpAddresses sets the PrivateIpAddresses field's value.
+func (s *UnassignPrivateIpAddressesInput) SetPrivateIpAddresses(v []*string) *UnassignPrivateIpAddressesInput {
+	s.PrivateIpAddresses = v
+	return s
 }
 
 type UnassignPrivateIpAddressesOutput struct {
@@ -35455,6 +47125,18 @@ func (s *UnmonitorInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *UnmonitorInstancesInput) SetDryRun(v bool) *UnmonitorInstancesInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *UnmonitorInstancesInput) SetInstanceIds(v []*string) *UnmonitorInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
 // Contains the output of UnmonitorInstances.
 type UnmonitorInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -35471,6 +47153,12 @@ func (s UnmonitorInstancesOutput) String() string {
 // GoString returns the string representation
 func (s UnmonitorInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceMonitorings sets the InstanceMonitorings field's value.
+func (s *UnmonitorInstancesOutput) SetInstanceMonitorings(v []*InstanceMonitoring) *UnmonitorInstancesOutput {
+	s.InstanceMonitorings = v
+	return s
 }
 
 // Information about items that were not successfully processed in a batch call.
@@ -35494,6 +47182,18 @@ func (s UnsuccessfulItem) String() string {
 // GoString returns the string representation
 func (s UnsuccessfulItem) GoString() string {
 	return s.String()
+}
+
+// SetError sets the Error field's value.
+func (s *UnsuccessfulItem) SetError(v *UnsuccessfulItemError) *UnsuccessfulItem {
+	s.Error = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *UnsuccessfulItem) SetResourceId(v string) *UnsuccessfulItem {
+	s.ResourceId = &v
+	return s
 }
 
 // Information about the error that occurred. For more information about errors,
@@ -35522,6 +47222,18 @@ func (s UnsuccessfulItemError) GoString() string {
 	return s.String()
 }
 
+// SetCode sets the Code field's value.
+func (s *UnsuccessfulItemError) SetCode(v string) *UnsuccessfulItemError {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *UnsuccessfulItemError) SetMessage(v string) *UnsuccessfulItemError {
+	s.Message = &v
+	return s
+}
+
 // Describes the S3 bucket for the disk image.
 type UserBucket struct {
 	_ struct{} `type:"structure"`
@@ -35541,6 +47253,18 @@ func (s UserBucket) String() string {
 // GoString returns the string representation
 func (s UserBucket) GoString() string {
 	return s.String()
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *UserBucket) SetS3Bucket(v string) *UserBucket {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetS3Key sets the S3Key field's value.
+func (s *UserBucket) SetS3Key(v string) *UserBucket {
+	s.S3Key = &v
+	return s
 }
 
 // Describes the S3 bucket for the disk image.
@@ -35564,6 +47288,18 @@ func (s UserBucketDetails) GoString() string {
 	return s.String()
 }
 
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *UserBucketDetails) SetS3Bucket(v string) *UserBucketDetails {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetS3Key sets the S3Key field's value.
+func (s *UserBucketDetails) SetS3Key(v string) *UserBucketDetails {
+	s.S3Key = &v
+	return s
+}
+
 // Describes the user data for an instance.
 type UserData struct {
 	_ struct{} `type:"structure"`
@@ -35582,6 +47318,12 @@ func (s UserData) String() string {
 // GoString returns the string representation
 func (s UserData) GoString() string {
 	return s.String()
+}
+
+// SetData sets the Data field's value.
+func (s *UserData) SetData(v string) *UserData {
+	s.Data = &v
+	return s
 }
 
 // Describes a security group and AWS account ID pair.
@@ -35623,6 +47365,42 @@ func (s UserIdGroupPair) GoString() string {
 	return s.String()
 }
 
+// SetGroupId sets the GroupId field's value.
+func (s *UserIdGroupPair) SetGroupId(v string) *UserIdGroupPair {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *UserIdGroupPair) SetGroupName(v string) *UserIdGroupPair {
+	s.GroupName = &v
+	return s
+}
+
+// SetPeeringStatus sets the PeeringStatus field's value.
+func (s *UserIdGroupPair) SetPeeringStatus(v string) *UserIdGroupPair {
+	s.PeeringStatus = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *UserIdGroupPair) SetUserId(v string) *UserIdGroupPair {
+	s.UserId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *UserIdGroupPair) SetVpcId(v string) *UserIdGroupPair {
+	s.VpcId = &v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *UserIdGroupPair) SetVpcPeeringConnectionId(v string) *UserIdGroupPair {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 // Describes telemetry for a VPN tunnel.
 type VgwTelemetry struct {
 	_ struct{} `type:"structure"`
@@ -35652,6 +47430,36 @@ func (s VgwTelemetry) String() string {
 // GoString returns the string representation
 func (s VgwTelemetry) GoString() string {
 	return s.String()
+}
+
+// SetAcceptedRouteCount sets the AcceptedRouteCount field's value.
+func (s *VgwTelemetry) SetAcceptedRouteCount(v int64) *VgwTelemetry {
+	s.AcceptedRouteCount = &v
+	return s
+}
+
+// SetLastStatusChange sets the LastStatusChange field's value.
+func (s *VgwTelemetry) SetLastStatusChange(v time.Time) *VgwTelemetry {
+	s.LastStatusChange = &v
+	return s
+}
+
+// SetOutsideIpAddress sets the OutsideIpAddress field's value.
+func (s *VgwTelemetry) SetOutsideIpAddress(v string) *VgwTelemetry {
+	s.OutsideIpAddress = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *VgwTelemetry) SetStatus(v string) *VgwTelemetry {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *VgwTelemetry) SetStatusMessage(v string) *VgwTelemetry {
+	s.StatusMessage = &v
+	return s
 }
 
 // Describes a volume.
@@ -35720,6 +47528,78 @@ func (s Volume) GoString() string {
 	return s.String()
 }
 
+// SetAttachments sets the Attachments field's value.
+func (s *Volume) SetAttachments(v []*VolumeAttachment) *Volume {
+	s.Attachments = v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Volume) SetAvailabilityZone(v string) *Volume {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCreateTime sets the CreateTime field's value.
+func (s *Volume) SetCreateTime(v time.Time) *Volume {
+	s.CreateTime = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *Volume) SetEncrypted(v bool) *Volume {
+	s.Encrypted = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *Volume) SetIops(v int64) *Volume {
+	s.Iops = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *Volume) SetKmsKeyId(v string) *Volume {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *Volume) SetSize(v int64) *Volume {
+	s.Size = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *Volume) SetSnapshotId(v string) *Volume {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Volume) SetState(v string) *Volume {
+	s.State = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Volume) SetTags(v []*Tag) *Volume {
+	s.Tags = v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *Volume) SetVolumeId(v string) *Volume {
+	s.VolumeId = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *Volume) SetVolumeType(v string) *Volume {
+	s.VolumeType = &v
+	return s
+}
+
 // Describes volume attachment details.
 type VolumeAttachment struct {
 	_ struct{} `type:"structure"`
@@ -35751,6 +47631,42 @@ func (s VolumeAttachment) String() string {
 // GoString returns the string representation
 func (s VolumeAttachment) GoString() string {
 	return s.String()
+}
+
+// SetAttachTime sets the AttachTime field's value.
+func (s *VolumeAttachment) SetAttachTime(v time.Time) *VolumeAttachment {
+	s.AttachTime = &v
+	return s
+}
+
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *VolumeAttachment) SetDeleteOnTermination(v bool) *VolumeAttachment {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetDevice sets the Device field's value.
+func (s *VolumeAttachment) SetDevice(v string) *VolumeAttachment {
+	s.Device = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *VolumeAttachment) SetInstanceId(v string) *VolumeAttachment {
+	s.InstanceId = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *VolumeAttachment) SetState(v string) *VolumeAttachment {
+	s.State = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *VolumeAttachment) SetVolumeId(v string) *VolumeAttachment {
+	s.VolumeId = &v
+	return s
 }
 
 // Describes an EBS volume.
@@ -35786,6 +47702,12 @@ func (s *VolumeDetail) Validate() error {
 	return nil
 }
 
+// SetSize sets the Size field's value.
+func (s *VolumeDetail) SetSize(v int64) *VolumeDetail {
+	s.Size = &v
+	return s
+}
+
 // Describes a volume status operation code.
 type VolumeStatusAction struct {
 	_ struct{} `type:"structure"`
@@ -35813,6 +47735,30 @@ func (s VolumeStatusAction) GoString() string {
 	return s.String()
 }
 
+// SetCode sets the Code field's value.
+func (s *VolumeStatusAction) SetCode(v string) *VolumeStatusAction {
+	s.Code = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *VolumeStatusAction) SetDescription(v string) *VolumeStatusAction {
+	s.Description = &v
+	return s
+}
+
+// SetEventId sets the EventId field's value.
+func (s *VolumeStatusAction) SetEventId(v string) *VolumeStatusAction {
+	s.EventId = &v
+	return s
+}
+
+// SetEventType sets the EventType field's value.
+func (s *VolumeStatusAction) SetEventType(v string) *VolumeStatusAction {
+	s.EventType = &v
+	return s
+}
+
 // Describes a volume status.
 type VolumeStatusDetails struct {
 	_ struct{} `type:"structure"`
@@ -35832,6 +47778,18 @@ func (s VolumeStatusDetails) String() string {
 // GoString returns the string representation
 func (s VolumeStatusDetails) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *VolumeStatusDetails) SetName(v string) *VolumeStatusDetails {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *VolumeStatusDetails) SetStatus(v string) *VolumeStatusDetails {
+	s.Status = &v
+	return s
 }
 
 // Describes a volume status event.
@@ -35864,6 +47822,36 @@ func (s VolumeStatusEvent) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *VolumeStatusEvent) SetDescription(v string) *VolumeStatusEvent {
+	s.Description = &v
+	return s
+}
+
+// SetEventId sets the EventId field's value.
+func (s *VolumeStatusEvent) SetEventId(v string) *VolumeStatusEvent {
+	s.EventId = &v
+	return s
+}
+
+// SetEventType sets the EventType field's value.
+func (s *VolumeStatusEvent) SetEventType(v string) *VolumeStatusEvent {
+	s.EventType = &v
+	return s
+}
+
+// SetNotAfter sets the NotAfter field's value.
+func (s *VolumeStatusEvent) SetNotAfter(v time.Time) *VolumeStatusEvent {
+	s.NotAfter = &v
+	return s
+}
+
+// SetNotBefore sets the NotBefore field's value.
+func (s *VolumeStatusEvent) SetNotBefore(v time.Time) *VolumeStatusEvent {
+	s.NotBefore = &v
+	return s
+}
+
 // Describes the status of a volume.
 type VolumeStatusInfo struct {
 	_ struct{} `type:"structure"`
@@ -35883,6 +47871,18 @@ func (s VolumeStatusInfo) String() string {
 // GoString returns the string representation
 func (s VolumeStatusInfo) GoString() string {
 	return s.String()
+}
+
+// SetDetails sets the Details field's value.
+func (s *VolumeStatusInfo) SetDetails(v []*VolumeStatusDetails) *VolumeStatusInfo {
+	s.Details = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *VolumeStatusInfo) SetStatus(v string) *VolumeStatusInfo {
+	s.Status = &v
+	return s
 }
 
 // Describes the volume status.
@@ -35913,6 +47913,36 @@ func (s VolumeStatusItem) String() string {
 // GoString returns the string representation
 func (s VolumeStatusItem) GoString() string {
 	return s.String()
+}
+
+// SetActions sets the Actions field's value.
+func (s *VolumeStatusItem) SetActions(v []*VolumeStatusAction) *VolumeStatusItem {
+	s.Actions = v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *VolumeStatusItem) SetAvailabilityZone(v string) *VolumeStatusItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *VolumeStatusItem) SetEvents(v []*VolumeStatusEvent) *VolumeStatusItem {
+	s.Events = v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *VolumeStatusItem) SetVolumeId(v string) *VolumeStatusItem {
+	s.VolumeId = &v
+	return s
+}
+
+// SetVolumeStatus sets the VolumeStatus field's value.
+func (s *VolumeStatusItem) SetVolumeStatus(v *VolumeStatusInfo) *VolumeStatusItem {
+	s.VolumeStatus = v
+	return s
 }
 
 // Describes a VPC.
@@ -35952,6 +47982,48 @@ func (s Vpc) GoString() string {
 	return s.String()
 }
 
+// SetCidrBlock sets the CidrBlock field's value.
+func (s *Vpc) SetCidrBlock(v string) *Vpc {
+	s.CidrBlock = &v
+	return s
+}
+
+// SetDhcpOptionsId sets the DhcpOptionsId field's value.
+func (s *Vpc) SetDhcpOptionsId(v string) *Vpc {
+	s.DhcpOptionsId = &v
+	return s
+}
+
+// SetInstanceTenancy sets the InstanceTenancy field's value.
+func (s *Vpc) SetInstanceTenancy(v string) *Vpc {
+	s.InstanceTenancy = &v
+	return s
+}
+
+// SetIsDefault sets the IsDefault field's value.
+func (s *Vpc) SetIsDefault(v bool) *Vpc {
+	s.IsDefault = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Vpc) SetState(v string) *Vpc {
+	s.State = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Vpc) SetTags(v []*Tag) *Vpc {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *Vpc) SetVpcId(v string) *Vpc {
+	s.VpcId = &v
+	return s
+}
+
 // Describes an attachment between a virtual private gateway and a VPC.
 type VpcAttachment struct {
 	_ struct{} `type:"structure"`
@@ -35971,6 +48043,18 @@ func (s VpcAttachment) String() string {
 // GoString returns the string representation
 func (s VpcAttachment) GoString() string {
 	return s.String()
+}
+
+// SetState sets the State field's value.
+func (s *VpcAttachment) SetState(v string) *VpcAttachment {
+	s.State = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *VpcAttachment) SetVpcId(v string) *VpcAttachment {
+	s.VpcId = &v
+	return s
 }
 
 // Describes whether a VPC is enabled for ClassicLink.
@@ -35995,6 +48079,24 @@ func (s VpcClassicLink) String() string {
 // GoString returns the string representation
 func (s VpcClassicLink) GoString() string {
 	return s.String()
+}
+
+// SetClassicLinkEnabled sets the ClassicLinkEnabled field's value.
+func (s *VpcClassicLink) SetClassicLinkEnabled(v bool) *VpcClassicLink {
+	s.ClassicLinkEnabled = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *VpcClassicLink) SetTags(v []*Tag) *VpcClassicLink {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *VpcClassicLink) SetVpcId(v string) *VpcClassicLink {
+	s.VpcId = &v
+	return s
 }
 
 // Describes a VPC endpoint.
@@ -36033,6 +48135,48 @@ func (s VpcEndpoint) GoString() string {
 	return s.String()
 }
 
+// SetCreationTimestamp sets the CreationTimestamp field's value.
+func (s *VpcEndpoint) SetCreationTimestamp(v time.Time) *VpcEndpoint {
+	s.CreationTimestamp = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *VpcEndpoint) SetPolicyDocument(v string) *VpcEndpoint {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetRouteTableIds sets the RouteTableIds field's value.
+func (s *VpcEndpoint) SetRouteTableIds(v []*string) *VpcEndpoint {
+	s.RouteTableIds = v
+	return s
+}
+
+// SetServiceName sets the ServiceName field's value.
+func (s *VpcEndpoint) SetServiceName(v string) *VpcEndpoint {
+	s.ServiceName = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *VpcEndpoint) SetState(v string) *VpcEndpoint {
+	s.State = &v
+	return s
+}
+
+// SetVpcEndpointId sets the VpcEndpointId field's value.
+func (s *VpcEndpoint) SetVpcEndpointId(v string) *VpcEndpoint {
+	s.VpcEndpointId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *VpcEndpoint) SetVpcId(v string) *VpcEndpoint {
+	s.VpcId = &v
+	return s
+}
+
 // Describes a VPC peering connection.
 type VpcPeeringConnection struct {
 	_ struct{} `type:"structure"`
@@ -36068,6 +48212,42 @@ func (s VpcPeeringConnection) GoString() string {
 	return s.String()
 }
 
+// SetAccepterVpcInfo sets the AccepterVpcInfo field's value.
+func (s *VpcPeeringConnection) SetAccepterVpcInfo(v *VpcPeeringConnectionVpcInfo) *VpcPeeringConnection {
+	s.AccepterVpcInfo = v
+	return s
+}
+
+// SetExpirationTime sets the ExpirationTime field's value.
+func (s *VpcPeeringConnection) SetExpirationTime(v time.Time) *VpcPeeringConnection {
+	s.ExpirationTime = &v
+	return s
+}
+
+// SetRequesterVpcInfo sets the RequesterVpcInfo field's value.
+func (s *VpcPeeringConnection) SetRequesterVpcInfo(v *VpcPeeringConnectionVpcInfo) *VpcPeeringConnection {
+	s.RequesterVpcInfo = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *VpcPeeringConnection) SetStatus(v *VpcPeeringConnectionStateReason) *VpcPeeringConnection {
+	s.Status = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *VpcPeeringConnection) SetTags(v []*Tag) *VpcPeeringConnection {
+	s.Tags = v
+	return s
+}
+
+// SetVpcPeeringConnectionId sets the VpcPeeringConnectionId field's value.
+func (s *VpcPeeringConnection) SetVpcPeeringConnectionId(v string) *VpcPeeringConnection {
+	s.VpcPeeringConnectionId = &v
+	return s
+}
+
 // Describes the VPC peering connection options.
 type VpcPeeringConnectionOptionsDescription struct {
 	_ struct{} `type:"structure"`
@@ -36095,6 +48275,24 @@ func (s VpcPeeringConnectionOptionsDescription) GoString() string {
 	return s.String()
 }
 
+// SetAllowDnsResolutionFromRemoteVpc sets the AllowDnsResolutionFromRemoteVpc field's value.
+func (s *VpcPeeringConnectionOptionsDescription) SetAllowDnsResolutionFromRemoteVpc(v bool) *VpcPeeringConnectionOptionsDescription {
+	s.AllowDnsResolutionFromRemoteVpc = &v
+	return s
+}
+
+// SetAllowEgressFromLocalClassicLinkToRemoteVpc sets the AllowEgressFromLocalClassicLinkToRemoteVpc field's value.
+func (s *VpcPeeringConnectionOptionsDescription) SetAllowEgressFromLocalClassicLinkToRemoteVpc(v bool) *VpcPeeringConnectionOptionsDescription {
+	s.AllowEgressFromLocalClassicLinkToRemoteVpc = &v
+	return s
+}
+
+// SetAllowEgressFromLocalVpcToRemoteClassicLink sets the AllowEgressFromLocalVpcToRemoteClassicLink field's value.
+func (s *VpcPeeringConnectionOptionsDescription) SetAllowEgressFromLocalVpcToRemoteClassicLink(v bool) *VpcPeeringConnectionOptionsDescription {
+	s.AllowEgressFromLocalVpcToRemoteClassicLink = &v
+	return s
+}
+
 // Describes the status of a VPC peering connection.
 type VpcPeeringConnectionStateReason struct {
 	_ struct{} `type:"structure"`
@@ -36114,6 +48312,18 @@ func (s VpcPeeringConnectionStateReason) String() string {
 // GoString returns the string representation
 func (s VpcPeeringConnectionStateReason) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *VpcPeeringConnectionStateReason) SetCode(v string) *VpcPeeringConnectionStateReason {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *VpcPeeringConnectionStateReason) SetMessage(v string) *VpcPeeringConnectionStateReason {
+	s.Message = &v
+	return s
 }
 
 // Describes a VPC in a VPC peering connection.
@@ -36142,6 +48352,30 @@ func (s VpcPeeringConnectionVpcInfo) String() string {
 // GoString returns the string representation
 func (s VpcPeeringConnectionVpcInfo) GoString() string {
 	return s.String()
+}
+
+// SetCidrBlock sets the CidrBlock field's value.
+func (s *VpcPeeringConnectionVpcInfo) SetCidrBlock(v string) *VpcPeeringConnectionVpcInfo {
+	s.CidrBlock = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *VpcPeeringConnectionVpcInfo) SetOwnerId(v string) *VpcPeeringConnectionVpcInfo {
+	s.OwnerId = &v
+	return s
+}
+
+// SetPeeringOptions sets the PeeringOptions field's value.
+func (s *VpcPeeringConnectionVpcInfo) SetPeeringOptions(v *VpcPeeringConnectionOptionsDescription) *VpcPeeringConnectionVpcInfo {
+	s.PeeringOptions = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *VpcPeeringConnectionVpcInfo) SetVpcId(v string) *VpcPeeringConnectionVpcInfo {
+	s.VpcId = &v
+	return s
 }
 
 // Describes a VPN connection.
@@ -36192,6 +48426,66 @@ func (s VpnConnection) GoString() string {
 	return s.String()
 }
 
+// SetCustomerGatewayConfiguration sets the CustomerGatewayConfiguration field's value.
+func (s *VpnConnection) SetCustomerGatewayConfiguration(v string) *VpnConnection {
+	s.CustomerGatewayConfiguration = &v
+	return s
+}
+
+// SetCustomerGatewayId sets the CustomerGatewayId field's value.
+func (s *VpnConnection) SetCustomerGatewayId(v string) *VpnConnection {
+	s.CustomerGatewayId = &v
+	return s
+}
+
+// SetOptions sets the Options field's value.
+func (s *VpnConnection) SetOptions(v *VpnConnectionOptions) *VpnConnection {
+	s.Options = v
+	return s
+}
+
+// SetRoutes sets the Routes field's value.
+func (s *VpnConnection) SetRoutes(v []*VpnStaticRoute) *VpnConnection {
+	s.Routes = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *VpnConnection) SetState(v string) *VpnConnection {
+	s.State = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *VpnConnection) SetTags(v []*Tag) *VpnConnection {
+	s.Tags = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *VpnConnection) SetType(v string) *VpnConnection {
+	s.Type = &v
+	return s
+}
+
+// SetVgwTelemetry sets the VgwTelemetry field's value.
+func (s *VpnConnection) SetVgwTelemetry(v []*VgwTelemetry) *VpnConnection {
+	s.VgwTelemetry = v
+	return s
+}
+
+// SetVpnConnectionId sets the VpnConnectionId field's value.
+func (s *VpnConnection) SetVpnConnectionId(v string) *VpnConnection {
+	s.VpnConnectionId = &v
+	return s
+}
+
+// SetVpnGatewayId sets the VpnGatewayId field's value.
+func (s *VpnConnection) SetVpnGatewayId(v string) *VpnConnection {
+	s.VpnGatewayId = &v
+	return s
+}
+
 // Describes VPN connection options.
 type VpnConnectionOptions struct {
 	_ struct{} `type:"structure"`
@@ -36211,6 +48505,12 @@ func (s VpnConnectionOptions) GoString() string {
 	return s.String()
 }
 
+// SetStaticRoutesOnly sets the StaticRoutesOnly field's value.
+func (s *VpnConnectionOptions) SetStaticRoutesOnly(v bool) *VpnConnectionOptions {
+	s.StaticRoutesOnly = &v
+	return s
+}
+
 // Describes VPN connection options.
 type VpnConnectionOptionsSpecification struct {
 	_ struct{} `type:"structure"`
@@ -36228,6 +48528,12 @@ func (s VpnConnectionOptionsSpecification) String() string {
 // GoString returns the string representation
 func (s VpnConnectionOptionsSpecification) GoString() string {
 	return s.String()
+}
+
+// SetStaticRoutesOnly sets the StaticRoutesOnly field's value.
+func (s *VpnConnectionOptionsSpecification) SetStaticRoutesOnly(v bool) *VpnConnectionOptionsSpecification {
+	s.StaticRoutesOnly = &v
+	return s
 }
 
 // Describes a virtual private gateway.
@@ -36264,6 +48570,42 @@ func (s VpnGateway) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *VpnGateway) SetAvailabilityZone(v string) *VpnGateway {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *VpnGateway) SetState(v string) *VpnGateway {
+	s.State = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *VpnGateway) SetTags(v []*Tag) *VpnGateway {
+	s.Tags = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *VpnGateway) SetType(v string) *VpnGateway {
+	s.Type = &v
+	return s
+}
+
+// SetVpcAttachments sets the VpcAttachments field's value.
+func (s *VpnGateway) SetVpcAttachments(v []*VpcAttachment) *VpnGateway {
+	s.VpcAttachments = v
+	return s
+}
+
+// SetVpnGatewayId sets the VpnGatewayId field's value.
+func (s *VpnGateway) SetVpnGatewayId(v string) *VpnGateway {
+	s.VpnGatewayId = &v
+	return s
+}
+
 // Describes a static route for a VPN connection.
 type VpnStaticRoute struct {
 	_ struct{} `type:"structure"`
@@ -36286,6 +48628,24 @@ func (s VpnStaticRoute) String() string {
 // GoString returns the string representation
 func (s VpnStaticRoute) GoString() string {
 	return s.String()
+}
+
+// SetDestinationCidrBlock sets the DestinationCidrBlock field's value.
+func (s *VpnStaticRoute) SetDestinationCidrBlock(v string) *VpnStaticRoute {
+	s.DestinationCidrBlock = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *VpnStaticRoute) SetSource(v string) *VpnStaticRoute {
+	s.Source = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *VpnStaticRoute) SetState(v string) *VpnStaticRoute {
+	s.State = &v
+	return s
 }
 
 const (

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -1376,6 +1376,24 @@ func (s AuthorizationData) GoString() string {
 	return s.String()
 }
 
+// SetAuthorizationToken sets the AuthorizationToken field's value.
+func (s *AuthorizationData) SetAuthorizationToken(v string) *AuthorizationData {
+	s.AuthorizationToken = &v
+	return s
+}
+
+// SetExpiresAt sets the ExpiresAt field's value.
+func (s *AuthorizationData) SetExpiresAt(v time.Time) *AuthorizationData {
+	s.ExpiresAt = &v
+	return s
+}
+
+// SetProxyEndpoint sets the ProxyEndpoint field's value.
+func (s *AuthorizationData) SetProxyEndpoint(v string) *AuthorizationData {
+	s.ProxyEndpoint = &v
+	return s
+}
+
 type BatchCheckLayerAvailabilityInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1426,6 +1444,24 @@ func (s *BatchCheckLayerAvailabilityInput) Validate() error {
 	return nil
 }
 
+// SetLayerDigests sets the LayerDigests field's value.
+func (s *BatchCheckLayerAvailabilityInput) SetLayerDigests(v []*string) *BatchCheckLayerAvailabilityInput {
+	s.LayerDigests = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *BatchCheckLayerAvailabilityInput) SetRegistryId(v string) *BatchCheckLayerAvailabilityInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *BatchCheckLayerAvailabilityInput) SetRepositoryName(v string) *BatchCheckLayerAvailabilityInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type BatchCheckLayerAvailabilityOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1445,6 +1481,18 @@ func (s BatchCheckLayerAvailabilityOutput) String() string {
 // GoString returns the string representation
 func (s BatchCheckLayerAvailabilityOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailures sets the Failures field's value.
+func (s *BatchCheckLayerAvailabilityOutput) SetFailures(v []*LayerFailure) *BatchCheckLayerAvailabilityOutput {
+	s.Failures = v
+	return s
+}
+
+// SetLayers sets the Layers field's value.
+func (s *BatchCheckLayerAvailabilityOutput) SetLayers(v []*Layer) *BatchCheckLayerAvailabilityOutput {
+	s.Layers = v
+	return s
 }
 
 // Deletes specified images within a specified repository. Images are specified
@@ -1500,6 +1548,24 @@ func (s *BatchDeleteImageInput) Validate() error {
 	return nil
 }
 
+// SetImageIds sets the ImageIds field's value.
+func (s *BatchDeleteImageInput) SetImageIds(v []*ImageIdentifier) *BatchDeleteImageInput {
+	s.ImageIds = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *BatchDeleteImageInput) SetRegistryId(v string) *BatchDeleteImageInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *BatchDeleteImageInput) SetRepositoryName(v string) *BatchDeleteImageInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type BatchDeleteImageOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1518,6 +1584,18 @@ func (s BatchDeleteImageOutput) String() string {
 // GoString returns the string representation
 func (s BatchDeleteImageOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailures sets the Failures field's value.
+func (s *BatchDeleteImageOutput) SetFailures(v []*ImageFailure) *BatchDeleteImageOutput {
+	s.Failures = v
+	return s
+}
+
+// SetImageIds sets the ImageIds field's value.
+func (s *BatchDeleteImageOutput) SetImageIds(v []*ImageIdentifier) *BatchDeleteImageOutput {
+	s.ImageIds = v
+	return s
 }
 
 type BatchGetImageInput struct {
@@ -1571,6 +1649,24 @@ func (s *BatchGetImageInput) Validate() error {
 	return nil
 }
 
+// SetImageIds sets the ImageIds field's value.
+func (s *BatchGetImageInput) SetImageIds(v []*ImageIdentifier) *BatchGetImageInput {
+	s.ImageIds = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *BatchGetImageInput) SetRegistryId(v string) *BatchGetImageInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *BatchGetImageInput) SetRepositoryName(v string) *BatchGetImageInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type BatchGetImageOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1589,6 +1685,18 @@ func (s BatchGetImageOutput) String() string {
 // GoString returns the string representation
 func (s BatchGetImageOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailures sets the Failures field's value.
+func (s *BatchGetImageOutput) SetFailures(v []*ImageFailure) *BatchGetImageOutput {
+	s.Failures = v
+	return s
+}
+
+// SetImages sets the Images field's value.
+func (s *BatchGetImageOutput) SetImages(v []*Image) *BatchGetImageOutput {
+	s.Images = v
+	return s
 }
 
 type CompleteLayerUploadInput struct {
@@ -1650,6 +1758,30 @@ func (s *CompleteLayerUploadInput) Validate() error {
 	return nil
 }
 
+// SetLayerDigests sets the LayerDigests field's value.
+func (s *CompleteLayerUploadInput) SetLayerDigests(v []*string) *CompleteLayerUploadInput {
+	s.LayerDigests = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *CompleteLayerUploadInput) SetRegistryId(v string) *CompleteLayerUploadInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *CompleteLayerUploadInput) SetRepositoryName(v string) *CompleteLayerUploadInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *CompleteLayerUploadInput) SetUploadId(v string) *CompleteLayerUploadInput {
+	s.UploadId = &v
+	return s
+}
+
 type CompleteLayerUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1674,6 +1806,30 @@ func (s CompleteLayerUploadOutput) String() string {
 // GoString returns the string representation
 func (s CompleteLayerUploadOutput) GoString() string {
 	return s.String()
+}
+
+// SetLayerDigest sets the LayerDigest field's value.
+func (s *CompleteLayerUploadOutput) SetLayerDigest(v string) *CompleteLayerUploadOutput {
+	s.LayerDigest = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *CompleteLayerUploadOutput) SetRegistryId(v string) *CompleteLayerUploadOutput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *CompleteLayerUploadOutput) SetRepositoryName(v string) *CompleteLayerUploadOutput {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *CompleteLayerUploadOutput) SetUploadId(v string) *CompleteLayerUploadOutput {
+	s.UploadId = &v
+	return s
 }
 
 type CreateRepositoryInput struct {
@@ -1713,6 +1869,12 @@ func (s *CreateRepositoryInput) Validate() error {
 	return nil
 }
 
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *CreateRepositoryInput) SetRepositoryName(v string) *CreateRepositoryInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type CreateRepositoryOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1728,6 +1890,12 @@ func (s CreateRepositoryOutput) String() string {
 // GoString returns the string representation
 func (s CreateRepositoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetRepository sets the Repository field's value.
+func (s *CreateRepositoryOutput) SetRepository(v *Repository) *CreateRepositoryOutput {
+	s.Repository = v
+	return s
 }
 
 type DeleteRepositoryInput struct {
@@ -1772,6 +1940,24 @@ func (s *DeleteRepositoryInput) Validate() error {
 	return nil
 }
 
+// SetForce sets the Force field's value.
+func (s *DeleteRepositoryInput) SetForce(v bool) *DeleteRepositoryInput {
+	s.Force = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *DeleteRepositoryInput) SetRegistryId(v string) *DeleteRepositoryInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DeleteRepositoryInput) SetRepositoryName(v string) *DeleteRepositoryInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type DeleteRepositoryOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1787,6 +1973,12 @@ func (s DeleteRepositoryOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRepositoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetRepository sets the Repository field's value.
+func (s *DeleteRepositoryOutput) SetRepository(v *Repository) *DeleteRepositoryOutput {
+	s.Repository = v
+	return s
 }
 
 type DeleteRepositoryPolicyInput struct {
@@ -1830,6 +2022,18 @@ func (s *DeleteRepositoryPolicyInput) Validate() error {
 	return nil
 }
 
+// SetRegistryId sets the RegistryId field's value.
+func (s *DeleteRepositoryPolicyInput) SetRegistryId(v string) *DeleteRepositoryPolicyInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DeleteRepositoryPolicyInput) SetRepositoryName(v string) *DeleteRepositoryPolicyInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type DeleteRepositoryPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1853,6 +2057,24 @@ func (s DeleteRepositoryPolicyOutput) GoString() string {
 	return s.String()
 }
 
+// SetPolicyText sets the PolicyText field's value.
+func (s *DeleteRepositoryPolicyOutput) SetPolicyText(v string) *DeleteRepositoryPolicyOutput {
+	s.PolicyText = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *DeleteRepositoryPolicyOutput) SetRegistryId(v string) *DeleteRepositoryPolicyOutput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DeleteRepositoryPolicyOutput) SetRepositoryName(v string) *DeleteRepositoryPolicyOutput {
+	s.RepositoryName = &v
+	return s
+}
+
 // An object representing a filter on a DescribeImages operation.
 type DescribeImagesFilter struct {
 	_ struct{} `type:"structure"`
@@ -1870,6 +2092,12 @@ func (s DescribeImagesFilter) String() string {
 // GoString returns the string representation
 func (s DescribeImagesFilter) GoString() string {
 	return s.String()
+}
+
+// SetTagStatus sets the TagStatus field's value.
+func (s *DescribeImagesFilter) SetTagStatus(v string) *DescribeImagesFilter {
+	s.TagStatus = &v
+	return s
 }
 
 type DescribeImagesInput struct {
@@ -1940,6 +2168,42 @@ func (s *DescribeImagesInput) Validate() error {
 	return nil
 }
 
+// SetFilter sets the Filter field's value.
+func (s *DescribeImagesInput) SetFilter(v *DescribeImagesFilter) *DescribeImagesInput {
+	s.Filter = v
+	return s
+}
+
+// SetImageIds sets the ImageIds field's value.
+func (s *DescribeImagesInput) SetImageIds(v []*ImageIdentifier) *DescribeImagesInput {
+	s.ImageIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeImagesInput) SetMaxResults(v int64) *DescribeImagesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImagesInput) SetNextToken(v string) *DescribeImagesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *DescribeImagesInput) SetRegistryId(v string) *DescribeImagesInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *DescribeImagesInput) SetRepositoryName(v string) *DescribeImagesInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type DescribeImagesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1961,6 +2225,18 @@ func (s DescribeImagesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeImagesOutput) GoString() string {
 	return s.String()
+}
+
+// SetImageDetails sets the ImageDetails field's value.
+func (s *DescribeImagesOutput) SetImageDetails(v []*ImageDetail) *DescribeImagesOutput {
+	s.ImageDetails = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImagesOutput) SetNextToken(v string) *DescribeImagesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeRepositoriesInput struct {
@@ -2021,6 +2297,30 @@ func (s *DescribeRepositoriesInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeRepositoriesInput) SetMaxResults(v int64) *DescribeRepositoriesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeRepositoriesInput) SetNextToken(v string) *DescribeRepositoriesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *DescribeRepositoriesInput) SetRegistryId(v string) *DescribeRepositoriesInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryNames sets the RepositoryNames field's value.
+func (s *DescribeRepositoriesInput) SetRepositoryNames(v []*string) *DescribeRepositoriesInput {
+	s.RepositoryNames = v
+	return s
+}
+
 type DescribeRepositoriesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2042,6 +2342,18 @@ func (s DescribeRepositoriesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRepositoriesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeRepositoriesOutput) SetNextToken(v string) *DescribeRepositoriesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRepositories sets the Repositories field's value.
+func (s *DescribeRepositoriesOutput) SetRepositories(v []*Repository) *DescribeRepositoriesOutput {
+	s.Repositories = v
+	return s
 }
 
 type GetAuthorizationTokenInput struct {
@@ -2076,6 +2388,12 @@ func (s *GetAuthorizationTokenInput) Validate() error {
 	return nil
 }
 
+// SetRegistryIds sets the RegistryIds field's value.
+func (s *GetAuthorizationTokenInput) SetRegistryIds(v []*string) *GetAuthorizationTokenInput {
+	s.RegistryIds = v
+	return s
+}
+
 type GetAuthorizationTokenOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2092,6 +2410,12 @@ func (s GetAuthorizationTokenOutput) String() string {
 // GoString returns the string representation
 func (s GetAuthorizationTokenOutput) GoString() string {
 	return s.String()
+}
+
+// SetAuthorizationData sets the AuthorizationData field's value.
+func (s *GetAuthorizationTokenOutput) SetAuthorizationData(v []*AuthorizationData) *GetAuthorizationTokenOutput {
+	s.AuthorizationData = v
+	return s
 }
 
 type GetDownloadUrlForLayerInput struct {
@@ -2141,6 +2465,24 @@ func (s *GetDownloadUrlForLayerInput) Validate() error {
 	return nil
 }
 
+// SetLayerDigest sets the LayerDigest field's value.
+func (s *GetDownloadUrlForLayerInput) SetLayerDigest(v string) *GetDownloadUrlForLayerInput {
+	s.LayerDigest = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *GetDownloadUrlForLayerInput) SetRegistryId(v string) *GetDownloadUrlForLayerInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetDownloadUrlForLayerInput) SetRepositoryName(v string) *GetDownloadUrlForLayerInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type GetDownloadUrlForLayerOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2159,6 +2501,18 @@ func (s GetDownloadUrlForLayerOutput) String() string {
 // GoString returns the string representation
 func (s GetDownloadUrlForLayerOutput) GoString() string {
 	return s.String()
+}
+
+// SetDownloadUrl sets the DownloadUrl field's value.
+func (s *GetDownloadUrlForLayerOutput) SetDownloadUrl(v string) *GetDownloadUrlForLayerOutput {
+	s.DownloadUrl = &v
+	return s
+}
+
+// SetLayerDigest sets the LayerDigest field's value.
+func (s *GetDownloadUrlForLayerOutput) SetLayerDigest(v string) *GetDownloadUrlForLayerOutput {
+	s.LayerDigest = &v
+	return s
 }
 
 type GetRepositoryPolicyInput struct {
@@ -2200,6 +2554,18 @@ func (s *GetRepositoryPolicyInput) Validate() error {
 	return nil
 }
 
+// SetRegistryId sets the RegistryId field's value.
+func (s *GetRepositoryPolicyInput) SetRegistryId(v string) *GetRepositoryPolicyInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetRepositoryPolicyInput) SetRepositoryName(v string) *GetRepositoryPolicyInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type GetRepositoryPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2221,6 +2587,24 @@ func (s GetRepositoryPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetRepositoryPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyText sets the PolicyText field's value.
+func (s *GetRepositoryPolicyOutput) SetPolicyText(v string) *GetRepositoryPolicyOutput {
+	s.PolicyText = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *GetRepositoryPolicyOutput) SetRegistryId(v string) *GetRepositoryPolicyOutput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetRepositoryPolicyOutput) SetRepositoryName(v string) *GetRepositoryPolicyOutput {
+	s.RepositoryName = &v
+	return s
 }
 
 // An object representing an Amazon ECR image.
@@ -2248,6 +2632,30 @@ func (s Image) String() string {
 // GoString returns the string representation
 func (s Image) GoString() string {
 	return s.String()
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *Image) SetImageId(v *ImageIdentifier) *Image {
+	s.ImageId = v
+	return s
+}
+
+// SetImageManifest sets the ImageManifest field's value.
+func (s *Image) SetImageManifest(v string) *Image {
+	s.ImageManifest = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *Image) SetRegistryId(v string) *Image {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *Image) SetRepositoryName(v string) *Image {
+	s.RepositoryName = &v
+	return s
 }
 
 // An object that describes an image returned by a DescribeImages operation.
@@ -2289,6 +2697,42 @@ func (s ImageDetail) GoString() string {
 	return s.String()
 }
 
+// SetImageDigest sets the ImageDigest field's value.
+func (s *ImageDetail) SetImageDigest(v string) *ImageDetail {
+	s.ImageDigest = &v
+	return s
+}
+
+// SetImagePushedAt sets the ImagePushedAt field's value.
+func (s *ImageDetail) SetImagePushedAt(v time.Time) *ImageDetail {
+	s.ImagePushedAt = &v
+	return s
+}
+
+// SetImageSizeInBytes sets the ImageSizeInBytes field's value.
+func (s *ImageDetail) SetImageSizeInBytes(v int64) *ImageDetail {
+	s.ImageSizeInBytes = &v
+	return s
+}
+
+// SetImageTags sets the ImageTags field's value.
+func (s *ImageDetail) SetImageTags(v []*string) *ImageDetail {
+	s.ImageTags = v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *ImageDetail) SetRegistryId(v string) *ImageDetail {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *ImageDetail) SetRepositoryName(v string) *ImageDetail {
+	s.RepositoryName = &v
+	return s
+}
+
 // An object representing an Amazon ECR image failure.
 type ImageFailure struct {
 	_ struct{} `type:"structure"`
@@ -2313,6 +2757,24 @@ func (s ImageFailure) GoString() string {
 	return s.String()
 }
 
+// SetFailureCode sets the FailureCode field's value.
+func (s *ImageFailure) SetFailureCode(v string) *ImageFailure {
+	s.FailureCode = &v
+	return s
+}
+
+// SetFailureReason sets the FailureReason field's value.
+func (s *ImageFailure) SetFailureReason(v string) *ImageFailure {
+	s.FailureReason = &v
+	return s
+}
+
+// SetImageId sets the ImageId field's value.
+func (s *ImageFailure) SetImageId(v *ImageIdentifier) *ImageFailure {
+	s.ImageId = v
+	return s
+}
+
 // An object with identifying information for an Amazon ECR image.
 type ImageIdentifier struct {
 	_ struct{} `type:"structure"`
@@ -2332,6 +2794,18 @@ func (s ImageIdentifier) String() string {
 // GoString returns the string representation
 func (s ImageIdentifier) GoString() string {
 	return s.String()
+}
+
+// SetImageDigest sets the ImageDigest field's value.
+func (s *ImageIdentifier) SetImageDigest(v string) *ImageIdentifier {
+	s.ImageDigest = &v
+	return s
+}
+
+// SetImageTag sets the ImageTag field's value.
+func (s *ImageIdentifier) SetImageTag(v string) *ImageIdentifier {
+	s.ImageTag = &v
+	return s
 }
 
 type InitiateLayerUploadInput struct {
@@ -2373,6 +2847,18 @@ func (s *InitiateLayerUploadInput) Validate() error {
 	return nil
 }
 
+// SetRegistryId sets the RegistryId field's value.
+func (s *InitiateLayerUploadInput) SetRegistryId(v string) *InitiateLayerUploadInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *InitiateLayerUploadInput) SetRepositoryName(v string) *InitiateLayerUploadInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type InitiateLayerUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2393,6 +2879,18 @@ func (s InitiateLayerUploadOutput) String() string {
 // GoString returns the string representation
 func (s InitiateLayerUploadOutput) GoString() string {
 	return s.String()
+}
+
+// SetPartSize sets the PartSize field's value.
+func (s *InitiateLayerUploadOutput) SetPartSize(v int64) *InitiateLayerUploadOutput {
+	s.PartSize = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *InitiateLayerUploadOutput) SetUploadId(v string) *InitiateLayerUploadOutput {
+	s.UploadId = &v
+	return s
 }
 
 // An object representing an Amazon ECR image layer.
@@ -2420,6 +2918,24 @@ func (s Layer) GoString() string {
 	return s.String()
 }
 
+// SetLayerAvailability sets the LayerAvailability field's value.
+func (s *Layer) SetLayerAvailability(v string) *Layer {
+	s.LayerAvailability = &v
+	return s
+}
+
+// SetLayerDigest sets the LayerDigest field's value.
+func (s *Layer) SetLayerDigest(v string) *Layer {
+	s.LayerDigest = &v
+	return s
+}
+
+// SetLayerSize sets the LayerSize field's value.
+func (s *Layer) SetLayerSize(v int64) *Layer {
+	s.LayerSize = &v
+	return s
+}
+
 // An object representing an Amazon ECR image layer failure.
 type LayerFailure struct {
 	_ struct{} `type:"structure"`
@@ -2444,6 +2960,24 @@ func (s LayerFailure) GoString() string {
 	return s.String()
 }
 
+// SetFailureCode sets the FailureCode field's value.
+func (s *LayerFailure) SetFailureCode(v string) *LayerFailure {
+	s.FailureCode = &v
+	return s
+}
+
+// SetFailureReason sets the FailureReason field's value.
+func (s *LayerFailure) SetFailureReason(v string) *LayerFailure {
+	s.FailureReason = &v
+	return s
+}
+
+// SetLayerDigest sets the LayerDigest field's value.
+func (s *LayerFailure) SetLayerDigest(v string) *LayerFailure {
+	s.LayerDigest = &v
+	return s
+}
+
 // An object representing a filter on a ListImages operation.
 type ListImagesFilter struct {
 	_ struct{} `type:"structure"`
@@ -2461,6 +2995,12 @@ func (s ListImagesFilter) String() string {
 // GoString returns the string representation
 func (s ListImagesFilter) GoString() string {
 	return s.String()
+}
+
+// SetTagStatus sets the TagStatus field's value.
+func (s *ListImagesFilter) SetTagStatus(v string) *ListImagesFilter {
+	s.TagStatus = &v
+	return s
 }
 
 type ListImagesInput struct {
@@ -2527,6 +3067,36 @@ func (s *ListImagesInput) Validate() error {
 	return nil
 }
 
+// SetFilter sets the Filter field's value.
+func (s *ListImagesInput) SetFilter(v *ListImagesFilter) *ListImagesInput {
+	s.Filter = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListImagesInput) SetMaxResults(v int64) *ListImagesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListImagesInput) SetNextToken(v string) *ListImagesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *ListImagesInput) SetRegistryId(v string) *ListImagesInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *ListImagesInput) SetRepositoryName(v string) *ListImagesInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type ListImagesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2548,6 +3118,18 @@ func (s ListImagesOutput) String() string {
 // GoString returns the string representation
 func (s ListImagesOutput) GoString() string {
 	return s.String()
+}
+
+// SetImageIds sets the ImageIds field's value.
+func (s *ListImagesOutput) SetImageIds(v []*ImageIdentifier) *ListImagesOutput {
+	s.ImageIds = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListImagesOutput) SetNextToken(v string) *ListImagesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type PutImageInput struct {
@@ -2598,6 +3180,24 @@ func (s *PutImageInput) Validate() error {
 	return nil
 }
 
+// SetImageManifest sets the ImageManifest field's value.
+func (s *PutImageInput) SetImageManifest(v string) *PutImageInput {
+	s.ImageManifest = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *PutImageInput) SetRegistryId(v string) *PutImageInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PutImageInput) SetRepositoryName(v string) *PutImageInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type PutImageOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2613,6 +3213,12 @@ func (s PutImageOutput) String() string {
 // GoString returns the string representation
 func (s PutImageOutput) GoString() string {
 	return s.String()
+}
+
+// SetImage sets the Image field's value.
+func (s *PutImageOutput) SetImage(v *Image) *PutImageOutput {
+	s.Image = v
+	return s
 }
 
 // An object representing a repository.
@@ -2648,6 +3254,36 @@ func (s Repository) String() string {
 // GoString returns the string representation
 func (s Repository) GoString() string {
 	return s.String()
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Repository) SetCreatedAt(v time.Time) *Repository {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *Repository) SetRegistryId(v string) *Repository {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryArn sets the RepositoryArn field's value.
+func (s *Repository) SetRepositoryArn(v string) *Repository {
+	s.RepositoryArn = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *Repository) SetRepositoryName(v string) *Repository {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetRepositoryUri sets the RepositoryUri field's value.
+func (s *Repository) SetRepositoryUri(v string) *Repository {
+	s.RepositoryUri = &v
+	return s
 }
 
 type SetRepositoryPolicyInput struct {
@@ -2702,6 +3338,30 @@ func (s *SetRepositoryPolicyInput) Validate() error {
 	return nil
 }
 
+// SetForce sets the Force field's value.
+func (s *SetRepositoryPolicyInput) SetForce(v bool) *SetRepositoryPolicyInput {
+	s.Force = &v
+	return s
+}
+
+// SetPolicyText sets the PolicyText field's value.
+func (s *SetRepositoryPolicyInput) SetPolicyText(v string) *SetRepositoryPolicyInput {
+	s.PolicyText = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *SetRepositoryPolicyInput) SetRegistryId(v string) *SetRepositoryPolicyInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *SetRepositoryPolicyInput) SetRepositoryName(v string) *SetRepositoryPolicyInput {
+	s.RepositoryName = &v
+	return s
+}
+
 type SetRepositoryPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2723,6 +3383,24 @@ func (s SetRepositoryPolicyOutput) String() string {
 // GoString returns the string representation
 func (s SetRepositoryPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyText sets the PolicyText field's value.
+func (s *SetRepositoryPolicyOutput) SetPolicyText(v string) *SetRepositoryPolicyOutput {
+	s.PolicyText = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *SetRepositoryPolicyOutput) SetRegistryId(v string) *SetRepositoryPolicyOutput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *SetRepositoryPolicyOutput) SetRepositoryName(v string) *SetRepositoryPolicyOutput {
+	s.RepositoryName = &v
+	return s
 }
 
 type UploadLayerPartInput struct {
@@ -2799,6 +3477,42 @@ func (s *UploadLayerPartInput) Validate() error {
 	return nil
 }
 
+// SetLayerPartBlob sets the LayerPartBlob field's value.
+func (s *UploadLayerPartInput) SetLayerPartBlob(v []byte) *UploadLayerPartInput {
+	s.LayerPartBlob = v
+	return s
+}
+
+// SetPartFirstByte sets the PartFirstByte field's value.
+func (s *UploadLayerPartInput) SetPartFirstByte(v int64) *UploadLayerPartInput {
+	s.PartFirstByte = &v
+	return s
+}
+
+// SetPartLastByte sets the PartLastByte field's value.
+func (s *UploadLayerPartInput) SetPartLastByte(v int64) *UploadLayerPartInput {
+	s.PartLastByte = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *UploadLayerPartInput) SetRegistryId(v string) *UploadLayerPartInput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *UploadLayerPartInput) SetRepositoryName(v string) *UploadLayerPartInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *UploadLayerPartInput) SetUploadId(v string) *UploadLayerPartInput {
+	s.UploadId = &v
+	return s
+}
+
 type UploadLayerPartOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2823,6 +3537,30 @@ func (s UploadLayerPartOutput) String() string {
 // GoString returns the string representation
 func (s UploadLayerPartOutput) GoString() string {
 	return s.String()
+}
+
+// SetLastByteReceived sets the LastByteReceived field's value.
+func (s *UploadLayerPartOutput) SetLastByteReceived(v int64) *UploadLayerPartOutput {
+	s.LastByteReceived = &v
+	return s
+}
+
+// SetRegistryId sets the RegistryId field's value.
+func (s *UploadLayerPartOutput) SetRegistryId(v string) *UploadLayerPartOutput {
+	s.RegistryId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *UploadLayerPartOutput) SetRepositoryName(v string) *UploadLayerPartOutput {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *UploadLayerPartOutput) SetUploadId(v string) *UploadLayerPartOutput {
+	s.UploadId = &v
+	return s
 }
 
 const (

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -2512,6 +2512,18 @@ func (s *Attribute) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *Attribute) SetName(v string) *Attribute {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Attribute) SetValue(v string) *Attribute {
+	s.Value = &v
+	return s
+}
+
 // A regional grouping of one or more container instances on which you can run
 // task requests. Each account receives a default cluster the first time you
 // use the Amazon ECS service, but you may also create other clusters. Clusters
@@ -2557,6 +2569,48 @@ func (s Cluster) GoString() string {
 	return s.String()
 }
 
+// SetActiveServicesCount sets the ActiveServicesCount field's value.
+func (s *Cluster) SetActiveServicesCount(v int64) *Cluster {
+	s.ActiveServicesCount = &v
+	return s
+}
+
+// SetClusterArn sets the ClusterArn field's value.
+func (s *Cluster) SetClusterArn(v string) *Cluster {
+	s.ClusterArn = &v
+	return s
+}
+
+// SetClusterName sets the ClusterName field's value.
+func (s *Cluster) SetClusterName(v string) *Cluster {
+	s.ClusterName = &v
+	return s
+}
+
+// SetPendingTasksCount sets the PendingTasksCount field's value.
+func (s *Cluster) SetPendingTasksCount(v int64) *Cluster {
+	s.PendingTasksCount = &v
+	return s
+}
+
+// SetRegisteredContainerInstancesCount sets the RegisteredContainerInstancesCount field's value.
+func (s *Cluster) SetRegisteredContainerInstancesCount(v int64) *Cluster {
+	s.RegisteredContainerInstancesCount = &v
+	return s
+}
+
+// SetRunningTasksCount sets the RunningTasksCount field's value.
+func (s *Cluster) SetRunningTasksCount(v int64) *Cluster {
+	s.RunningTasksCount = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Cluster) SetStatus(v string) *Cluster {
+	s.Status = &v
+	return s
+}
+
 // A Docker container that is part of a task.
 type Container struct {
 	_ struct{} `type:"structure"`
@@ -2592,6 +2646,48 @@ func (s Container) String() string {
 // GoString returns the string representation
 func (s Container) GoString() string {
 	return s.String()
+}
+
+// SetContainerArn sets the ContainerArn field's value.
+func (s *Container) SetContainerArn(v string) *Container {
+	s.ContainerArn = &v
+	return s
+}
+
+// SetExitCode sets the ExitCode field's value.
+func (s *Container) SetExitCode(v int64) *Container {
+	s.ExitCode = &v
+	return s
+}
+
+// SetLastStatus sets the LastStatus field's value.
+func (s *Container) SetLastStatus(v string) *Container {
+	s.LastStatus = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Container) SetName(v string) *Container {
+	s.Name = &v
+	return s
+}
+
+// SetNetworkBindings sets the NetworkBindings field's value.
+func (s *Container) SetNetworkBindings(v []*NetworkBinding) *Container {
+	s.NetworkBindings = v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *Container) SetReason(v string) *Container {
+	s.Reason = &v
+	return s
+}
+
+// SetTaskArn sets the TaskArn field's value.
+func (s *Container) SetTaskArn(v string) *Container {
+	s.TaskArn = &v
+	return s
 }
 
 // Container definitions are used in task definitions to describe the different
@@ -2964,6 +3060,162 @@ func (s *ContainerDefinition) Validate() error {
 	return nil
 }
 
+// SetCommand sets the Command field's value.
+func (s *ContainerDefinition) SetCommand(v []*string) *ContainerDefinition {
+	s.Command = v
+	return s
+}
+
+// SetCpu sets the Cpu field's value.
+func (s *ContainerDefinition) SetCpu(v int64) *ContainerDefinition {
+	s.Cpu = &v
+	return s
+}
+
+// SetDisableNetworking sets the DisableNetworking field's value.
+func (s *ContainerDefinition) SetDisableNetworking(v bool) *ContainerDefinition {
+	s.DisableNetworking = &v
+	return s
+}
+
+// SetDnsSearchDomains sets the DnsSearchDomains field's value.
+func (s *ContainerDefinition) SetDnsSearchDomains(v []*string) *ContainerDefinition {
+	s.DnsSearchDomains = v
+	return s
+}
+
+// SetDnsServers sets the DnsServers field's value.
+func (s *ContainerDefinition) SetDnsServers(v []*string) *ContainerDefinition {
+	s.DnsServers = v
+	return s
+}
+
+// SetDockerLabels sets the DockerLabels field's value.
+func (s *ContainerDefinition) SetDockerLabels(v map[string]*string) *ContainerDefinition {
+	s.DockerLabels = v
+	return s
+}
+
+// SetDockerSecurityOptions sets the DockerSecurityOptions field's value.
+func (s *ContainerDefinition) SetDockerSecurityOptions(v []*string) *ContainerDefinition {
+	s.DockerSecurityOptions = v
+	return s
+}
+
+// SetEntryPoint sets the EntryPoint field's value.
+func (s *ContainerDefinition) SetEntryPoint(v []*string) *ContainerDefinition {
+	s.EntryPoint = v
+	return s
+}
+
+// SetEnvironment sets the Environment field's value.
+func (s *ContainerDefinition) SetEnvironment(v []*KeyValuePair) *ContainerDefinition {
+	s.Environment = v
+	return s
+}
+
+// SetEssential sets the Essential field's value.
+func (s *ContainerDefinition) SetEssential(v bool) *ContainerDefinition {
+	s.Essential = &v
+	return s
+}
+
+// SetExtraHosts sets the ExtraHosts field's value.
+func (s *ContainerDefinition) SetExtraHosts(v []*HostEntry) *ContainerDefinition {
+	s.ExtraHosts = v
+	return s
+}
+
+// SetHostname sets the Hostname field's value.
+func (s *ContainerDefinition) SetHostname(v string) *ContainerDefinition {
+	s.Hostname = &v
+	return s
+}
+
+// SetImage sets the Image field's value.
+func (s *ContainerDefinition) SetImage(v string) *ContainerDefinition {
+	s.Image = &v
+	return s
+}
+
+// SetLinks sets the Links field's value.
+func (s *ContainerDefinition) SetLinks(v []*string) *ContainerDefinition {
+	s.Links = v
+	return s
+}
+
+// SetLogConfiguration sets the LogConfiguration field's value.
+func (s *ContainerDefinition) SetLogConfiguration(v *LogConfiguration) *ContainerDefinition {
+	s.LogConfiguration = v
+	return s
+}
+
+// SetMemory sets the Memory field's value.
+func (s *ContainerDefinition) SetMemory(v int64) *ContainerDefinition {
+	s.Memory = &v
+	return s
+}
+
+// SetMemoryReservation sets the MemoryReservation field's value.
+func (s *ContainerDefinition) SetMemoryReservation(v int64) *ContainerDefinition {
+	s.MemoryReservation = &v
+	return s
+}
+
+// SetMountPoints sets the MountPoints field's value.
+func (s *ContainerDefinition) SetMountPoints(v []*MountPoint) *ContainerDefinition {
+	s.MountPoints = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ContainerDefinition) SetName(v string) *ContainerDefinition {
+	s.Name = &v
+	return s
+}
+
+// SetPortMappings sets the PortMappings field's value.
+func (s *ContainerDefinition) SetPortMappings(v []*PortMapping) *ContainerDefinition {
+	s.PortMappings = v
+	return s
+}
+
+// SetPrivileged sets the Privileged field's value.
+func (s *ContainerDefinition) SetPrivileged(v bool) *ContainerDefinition {
+	s.Privileged = &v
+	return s
+}
+
+// SetReadonlyRootFilesystem sets the ReadonlyRootFilesystem field's value.
+func (s *ContainerDefinition) SetReadonlyRootFilesystem(v bool) *ContainerDefinition {
+	s.ReadonlyRootFilesystem = &v
+	return s
+}
+
+// SetUlimits sets the Ulimits field's value.
+func (s *ContainerDefinition) SetUlimits(v []*Ulimit) *ContainerDefinition {
+	s.Ulimits = v
+	return s
+}
+
+// SetUser sets the User field's value.
+func (s *ContainerDefinition) SetUser(v string) *ContainerDefinition {
+	s.User = &v
+	return s
+}
+
+// SetVolumesFrom sets the VolumesFrom field's value.
+func (s *ContainerDefinition) SetVolumesFrom(v []*VolumeFrom) *ContainerDefinition {
+	s.VolumesFrom = v
+	return s
+}
+
+// SetWorkingDirectory sets the WorkingDirectory field's value.
+func (s *ContainerDefinition) SetWorkingDirectory(v string) *ContainerDefinition {
+	s.WorkingDirectory = &v
+	return s
+}
+
 // An EC2 instance that is running the Amazon ECS agent and has been registered
 // with a cluster.
 type ContainerInstance struct {
@@ -3031,6 +3283,72 @@ func (s ContainerInstance) GoString() string {
 	return s.String()
 }
 
+// SetAgentConnected sets the AgentConnected field's value.
+func (s *ContainerInstance) SetAgentConnected(v bool) *ContainerInstance {
+	s.AgentConnected = &v
+	return s
+}
+
+// SetAgentUpdateStatus sets the AgentUpdateStatus field's value.
+func (s *ContainerInstance) SetAgentUpdateStatus(v string) *ContainerInstance {
+	s.AgentUpdateStatus = &v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *ContainerInstance) SetAttributes(v []*Attribute) *ContainerInstance {
+	s.Attributes = v
+	return s
+}
+
+// SetContainerInstanceArn sets the ContainerInstanceArn field's value.
+func (s *ContainerInstance) SetContainerInstanceArn(v string) *ContainerInstance {
+	s.ContainerInstanceArn = &v
+	return s
+}
+
+// SetEc2InstanceId sets the Ec2InstanceId field's value.
+func (s *ContainerInstance) SetEc2InstanceId(v string) *ContainerInstance {
+	s.Ec2InstanceId = &v
+	return s
+}
+
+// SetPendingTasksCount sets the PendingTasksCount field's value.
+func (s *ContainerInstance) SetPendingTasksCount(v int64) *ContainerInstance {
+	s.PendingTasksCount = &v
+	return s
+}
+
+// SetRegisteredResources sets the RegisteredResources field's value.
+func (s *ContainerInstance) SetRegisteredResources(v []*Resource) *ContainerInstance {
+	s.RegisteredResources = v
+	return s
+}
+
+// SetRemainingResources sets the RemainingResources field's value.
+func (s *ContainerInstance) SetRemainingResources(v []*Resource) *ContainerInstance {
+	s.RemainingResources = v
+	return s
+}
+
+// SetRunningTasksCount sets the RunningTasksCount field's value.
+func (s *ContainerInstance) SetRunningTasksCount(v int64) *ContainerInstance {
+	s.RunningTasksCount = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ContainerInstance) SetStatus(v string) *ContainerInstance {
+	s.Status = &v
+	return s
+}
+
+// SetVersionInfo sets the VersionInfo field's value.
+func (s *ContainerInstance) SetVersionInfo(v *VersionInfo) *ContainerInstance {
+	s.VersionInfo = v
+	return s
+}
+
 // The overrides that should be sent to a container.
 type ContainerOverride struct {
 	_ struct{} `type:"structure"`
@@ -3058,6 +3376,24 @@ func (s ContainerOverride) GoString() string {
 	return s.String()
 }
 
+// SetCommand sets the Command field's value.
+func (s *ContainerOverride) SetCommand(v []*string) *ContainerOverride {
+	s.Command = v
+	return s
+}
+
+// SetEnvironment sets the Environment field's value.
+func (s *ContainerOverride) SetEnvironment(v []*KeyValuePair) *ContainerOverride {
+	s.Environment = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ContainerOverride) SetName(v string) *ContainerOverride {
+	s.Name = &v
+	return s
+}
+
 type CreateClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3077,6 +3413,12 @@ func (s CreateClusterInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterName sets the ClusterName field's value.
+func (s *CreateClusterInput) SetClusterName(v string) *CreateClusterInput {
+	s.ClusterName = &v
+	return s
+}
+
 type CreateClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3092,6 +3434,12 @@ func (s CreateClusterOutput) String() string {
 // GoString returns the string representation
 func (s CreateClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *CreateClusterOutput) SetCluster(v *Cluster) *CreateClusterOutput {
+	s.Cluster = v
+	return s
 }
 
 type CreateServiceInput struct {
@@ -3194,6 +3542,54 @@ func (s *CreateServiceInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateServiceInput) SetClientToken(v string) *CreateServiceInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *CreateServiceInput) SetCluster(v string) *CreateServiceInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetDeploymentConfiguration sets the DeploymentConfiguration field's value.
+func (s *CreateServiceInput) SetDeploymentConfiguration(v *DeploymentConfiguration) *CreateServiceInput {
+	s.DeploymentConfiguration = v
+	return s
+}
+
+// SetDesiredCount sets the DesiredCount field's value.
+func (s *CreateServiceInput) SetDesiredCount(v int64) *CreateServiceInput {
+	s.DesiredCount = &v
+	return s
+}
+
+// SetLoadBalancers sets the LoadBalancers field's value.
+func (s *CreateServiceInput) SetLoadBalancers(v []*LoadBalancer) *CreateServiceInput {
+	s.LoadBalancers = v
+	return s
+}
+
+// SetRole sets the Role field's value.
+func (s *CreateServiceInput) SetRole(v string) *CreateServiceInput {
+	s.Role = &v
+	return s
+}
+
+// SetServiceName sets the ServiceName field's value.
+func (s *CreateServiceInput) SetServiceName(v string) *CreateServiceInput {
+	s.ServiceName = &v
+	return s
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *CreateServiceInput) SetTaskDefinition(v string) *CreateServiceInput {
+	s.TaskDefinition = &v
+	return s
+}
+
 type CreateServiceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3209,6 +3605,12 @@ func (s CreateServiceOutput) String() string {
 // GoString returns the string representation
 func (s CreateServiceOutput) GoString() string {
 	return s.String()
+}
+
+// SetService sets the Service field's value.
+func (s *CreateServiceOutput) SetService(v *Service) *CreateServiceOutput {
+	s.Service = v
+	return s
 }
 
 type DeleteClusterInput struct {
@@ -3243,6 +3645,12 @@ func (s *DeleteClusterInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *DeleteClusterInput) SetCluster(v string) *DeleteClusterInput {
+	s.Cluster = &v
+	return s
+}
+
 type DeleteClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3258,6 +3666,12 @@ func (s DeleteClusterOutput) String() string {
 // GoString returns the string representation
 func (s DeleteClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *DeleteClusterOutput) SetCluster(v *Cluster) *DeleteClusterOutput {
+	s.Cluster = v
+	return s
 }
 
 type DeleteServiceInput struct {
@@ -3296,6 +3710,18 @@ func (s *DeleteServiceInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *DeleteServiceInput) SetCluster(v string) *DeleteServiceInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetService sets the Service field's value.
+func (s *DeleteServiceInput) SetService(v string) *DeleteServiceInput {
+	s.Service = &v
+	return s
+}
+
 type DeleteServiceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3311,6 +3737,12 @@ func (s DeleteServiceOutput) String() string {
 // GoString returns the string representation
 func (s DeleteServiceOutput) GoString() string {
 	return s.String()
+}
+
+// SetService sets the Service field's value.
+func (s *DeleteServiceOutput) SetService(v *Service) *DeleteServiceOutput {
+	s.Service = v
+	return s
 }
 
 // The details of an Amazon ECS service deployment.
@@ -3356,6 +3788,54 @@ func (s Deployment) GoString() string {
 	return s.String()
 }
 
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Deployment) SetCreatedAt(v time.Time) *Deployment {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDesiredCount sets the DesiredCount field's value.
+func (s *Deployment) SetDesiredCount(v int64) *Deployment {
+	s.DesiredCount = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Deployment) SetId(v string) *Deployment {
+	s.Id = &v
+	return s
+}
+
+// SetPendingCount sets the PendingCount field's value.
+func (s *Deployment) SetPendingCount(v int64) *Deployment {
+	s.PendingCount = &v
+	return s
+}
+
+// SetRunningCount sets the RunningCount field's value.
+func (s *Deployment) SetRunningCount(v int64) *Deployment {
+	s.RunningCount = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Deployment) SetStatus(v string) *Deployment {
+	s.Status = &v
+	return s
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *Deployment) SetTaskDefinition(v string) *Deployment {
+	s.TaskDefinition = &v
+	return s
+}
+
+// SetUpdatedAt sets the UpdatedAt field's value.
+func (s *Deployment) SetUpdatedAt(v time.Time) *Deployment {
+	s.UpdatedAt = &v
+	return s
+}
+
 // Optional deployment parameters that control how many tasks run during the
 // deployment and the ordering of stopping and starting tasks.
 type DeploymentConfiguration struct {
@@ -3384,6 +3864,18 @@ func (s DeploymentConfiguration) String() string {
 // GoString returns the string representation
 func (s DeploymentConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetMaximumPercent sets the MaximumPercent field's value.
+func (s *DeploymentConfiguration) SetMaximumPercent(v int64) *DeploymentConfiguration {
+	s.MaximumPercent = &v
+	return s
+}
+
+// SetMinimumHealthyPercent sets the MinimumHealthyPercent field's value.
+func (s *DeploymentConfiguration) SetMinimumHealthyPercent(v int64) *DeploymentConfiguration {
+	s.MinimumHealthyPercent = &v
+	return s
 }
 
 type DeregisterContainerInstanceInput struct {
@@ -3441,6 +3933,24 @@ func (s *DeregisterContainerInstanceInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *DeregisterContainerInstanceInput) SetCluster(v string) *DeregisterContainerInstanceInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetContainerInstance sets the ContainerInstance field's value.
+func (s *DeregisterContainerInstanceInput) SetContainerInstance(v string) *DeregisterContainerInstanceInput {
+	s.ContainerInstance = &v
+	return s
+}
+
+// SetForce sets the Force field's value.
+func (s *DeregisterContainerInstanceInput) SetForce(v bool) *DeregisterContainerInstanceInput {
+	s.Force = &v
+	return s
+}
+
 type DeregisterContainerInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3457,6 +3967,12 @@ func (s DeregisterContainerInstanceOutput) String() string {
 // GoString returns the string representation
 func (s DeregisterContainerInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetContainerInstance sets the ContainerInstance field's value.
+func (s *DeregisterContainerInstanceOutput) SetContainerInstance(v *ContainerInstance) *DeregisterContainerInstanceOutput {
+	s.ContainerInstance = v
+	return s
 }
 
 type DeregisterTaskDefinitionInput struct {
@@ -3492,6 +4008,12 @@ func (s *DeregisterTaskDefinitionInput) Validate() error {
 	return nil
 }
 
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *DeregisterTaskDefinitionInput) SetTaskDefinition(v string) *DeregisterTaskDefinitionInput {
+	s.TaskDefinition = &v
+	return s
+}
+
 type DeregisterTaskDefinitionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3507,6 +4029,12 @@ func (s DeregisterTaskDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeregisterTaskDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *DeregisterTaskDefinitionOutput) SetTaskDefinition(v *TaskDefinition) *DeregisterTaskDefinitionOutput {
+	s.TaskDefinition = v
+	return s
 }
 
 type DescribeClustersInput struct {
@@ -3528,6 +4056,12 @@ func (s DescribeClustersInput) GoString() string {
 	return s.String()
 }
 
+// SetClusters sets the Clusters field's value.
+func (s *DescribeClustersInput) SetClusters(v []*string) *DescribeClustersInput {
+	s.Clusters = v
+	return s
+}
+
 type DescribeClustersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3546,6 +4080,18 @@ func (s DescribeClustersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClustersOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusters sets the Clusters field's value.
+func (s *DescribeClustersOutput) SetClusters(v []*Cluster) *DescribeClustersOutput {
+	s.Clusters = v
+	return s
+}
+
+// SetFailures sets the Failures field's value.
+func (s *DescribeClustersOutput) SetFailures(v []*Failure) *DescribeClustersOutput {
+	s.Failures = v
+	return s
 }
 
 type DescribeContainerInstancesInput struct {
@@ -3586,6 +4132,18 @@ func (s *DescribeContainerInstancesInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *DescribeContainerInstancesInput) SetCluster(v string) *DescribeContainerInstancesInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetContainerInstances sets the ContainerInstances field's value.
+func (s *DescribeContainerInstancesInput) SetContainerInstances(v []*string) *DescribeContainerInstancesInput {
+	s.ContainerInstances = v
+	return s
+}
+
 type DescribeContainerInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3604,6 +4162,18 @@ func (s DescribeContainerInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeContainerInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetContainerInstances sets the ContainerInstances field's value.
+func (s *DescribeContainerInstancesOutput) SetContainerInstances(v []*ContainerInstance) *DescribeContainerInstancesOutput {
+	s.ContainerInstances = v
+	return s
+}
+
+// SetFailures sets the Failures field's value.
+func (s *DescribeContainerInstancesOutput) SetFailures(v []*Failure) *DescribeContainerInstancesOutput {
+	s.Failures = v
+	return s
 }
 
 type DescribeServicesInput struct {
@@ -3643,6 +4213,18 @@ func (s *DescribeServicesInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *DescribeServicesInput) SetCluster(v string) *DescribeServicesInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetServices sets the Services field's value.
+func (s *DescribeServicesInput) SetServices(v []*string) *DescribeServicesInput {
+	s.Services = v
+	return s
+}
+
 type DescribeServicesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3661,6 +4243,18 @@ func (s DescribeServicesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeServicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailures sets the Failures field's value.
+func (s *DescribeServicesOutput) SetFailures(v []*Failure) *DescribeServicesOutput {
+	s.Failures = v
+	return s
+}
+
+// SetServices sets the Services field's value.
+func (s *DescribeServicesOutput) SetServices(v []*Service) *DescribeServicesOutput {
+	s.Services = v
+	return s
 }
 
 type DescribeTaskDefinitionInput struct {
@@ -3697,6 +4291,12 @@ func (s *DescribeTaskDefinitionInput) Validate() error {
 	return nil
 }
 
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *DescribeTaskDefinitionInput) SetTaskDefinition(v string) *DescribeTaskDefinitionInput {
+	s.TaskDefinition = &v
+	return s
+}
+
 type DescribeTaskDefinitionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3712,6 +4312,12 @@ func (s DescribeTaskDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTaskDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *DescribeTaskDefinitionOutput) SetTaskDefinition(v *TaskDefinition) *DescribeTaskDefinitionOutput {
+	s.TaskDefinition = v
+	return s
 }
 
 type DescribeTasksInput struct {
@@ -3751,6 +4357,18 @@ func (s *DescribeTasksInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *DescribeTasksInput) SetCluster(v string) *DescribeTasksInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetTasks sets the Tasks field's value.
+func (s *DescribeTasksInput) SetTasks(v []*string) *DescribeTasksInput {
+	s.Tasks = v
+	return s
+}
+
 type DescribeTasksOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3769,6 +4387,18 @@ func (s DescribeTasksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailures sets the Failures field's value.
+func (s *DescribeTasksOutput) SetFailures(v []*Failure) *DescribeTasksOutput {
+	s.Failures = v
+	return s
+}
+
+// SetTasks sets the Tasks field's value.
+func (s *DescribeTasksOutput) SetTasks(v []*Task) *DescribeTasksOutput {
+	s.Tasks = v
+	return s
 }
 
 type DiscoverPollEndpointInput struct {
@@ -3795,6 +4425,18 @@ func (s DiscoverPollEndpointInput) GoString() string {
 	return s.String()
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *DiscoverPollEndpointInput) SetCluster(v string) *DiscoverPollEndpointInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetContainerInstance sets the ContainerInstance field's value.
+func (s *DiscoverPollEndpointInput) SetContainerInstance(v string) *DiscoverPollEndpointInput {
+	s.ContainerInstance = &v
+	return s
+}
+
 type DiscoverPollEndpointOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3813,6 +4455,18 @@ func (s DiscoverPollEndpointOutput) String() string {
 // GoString returns the string representation
 func (s DiscoverPollEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *DiscoverPollEndpointOutput) SetEndpoint(v string) *DiscoverPollEndpointOutput {
+	s.Endpoint = &v
+	return s
+}
+
+// SetTelemetryEndpoint sets the TelemetryEndpoint field's value.
+func (s *DiscoverPollEndpointOutput) SetTelemetryEndpoint(v string) *DiscoverPollEndpointOutput {
+	s.TelemetryEndpoint = &v
+	return s
 }
 
 // A failed resource.
@@ -3834,6 +4488,18 @@ func (s Failure) String() string {
 // GoString returns the string representation
 func (s Failure) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Failure) SetArn(v string) *Failure {
+	s.Arn = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *Failure) SetReason(v string) *Failure {
+	s.Reason = &v
+	return s
 }
 
 // Hostnames and IP address entries that are added to the /etc/hosts file of
@@ -3878,6 +4544,18 @@ func (s *HostEntry) Validate() error {
 	return nil
 }
 
+// SetHostname sets the Hostname field's value.
+func (s *HostEntry) SetHostname(v string) *HostEntry {
+	s.Hostname = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *HostEntry) SetIpAddress(v string) *HostEntry {
+	s.IpAddress = &v
+	return s
+}
+
 // Details on a container instance host volume.
 type HostVolumeProperties struct {
 	_ struct{} `type:"structure"`
@@ -3902,6 +4580,12 @@ func (s HostVolumeProperties) GoString() string {
 	return s.String()
 }
 
+// SetSourcePath sets the SourcePath field's value.
+func (s *HostVolumeProperties) SetSourcePath(v string) *HostVolumeProperties {
+	s.SourcePath = &v
+	return s
+}
+
 // A key and value pair object.
 type KeyValuePair struct {
 	_ struct{} `type:"structure"`
@@ -3923,6 +4607,18 @@ func (s KeyValuePair) String() string {
 // GoString returns the string representation
 func (s KeyValuePair) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *KeyValuePair) SetName(v string) *KeyValuePair {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *KeyValuePair) SetValue(v string) *KeyValuePair {
+	s.Value = &v
+	return s
 }
 
 type ListClustersInput struct {
@@ -3957,6 +4653,18 @@ func (s ListClustersInput) GoString() string {
 	return s.String()
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListClustersInput) SetMaxResults(v int64) *ListClustersInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListClustersInput) SetNextToken(v string) *ListClustersInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListClustersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3979,6 +4687,18 @@ func (s ListClustersOutput) String() string {
 // GoString returns the string representation
 func (s ListClustersOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterArns sets the ClusterArns field's value.
+func (s *ListClustersOutput) SetClusterArns(v []*string) *ListClustersOutput {
+	s.ClusterArns = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListClustersOutput) SetNextToken(v string) *ListClustersOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListContainerInstancesInput struct {
@@ -4020,6 +4740,24 @@ func (s ListContainerInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *ListContainerInstancesInput) SetCluster(v string) *ListContainerInstancesInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListContainerInstancesInput) SetMaxResults(v int64) *ListContainerInstancesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListContainerInstancesInput) SetNextToken(v string) *ListContainerInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListContainerInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4042,6 +4780,18 @@ func (s ListContainerInstancesOutput) String() string {
 // GoString returns the string representation
 func (s ListContainerInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetContainerInstanceArns sets the ContainerInstanceArns field's value.
+func (s *ListContainerInstancesOutput) SetContainerInstanceArns(v []*string) *ListContainerInstancesOutput {
+	s.ContainerInstanceArns = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListContainerInstancesOutput) SetNextToken(v string) *ListContainerInstancesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListServicesInput struct {
@@ -4081,6 +4831,24 @@ func (s ListServicesInput) GoString() string {
 	return s.String()
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *ListServicesInput) SetCluster(v string) *ListServicesInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListServicesInput) SetMaxResults(v int64) *ListServicesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListServicesInput) SetNextToken(v string) *ListServicesInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListServicesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4103,6 +4871,18 @@ func (s ListServicesOutput) String() string {
 // GoString returns the string representation
 func (s ListServicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListServicesOutput) SetNextToken(v string) *ListServicesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetServiceArns sets the ServiceArns field's value.
+func (s *ListServicesOutput) SetServiceArns(v []*string) *ListServicesOutput {
+	s.ServiceArns = v
+	return s
 }
 
 type ListTaskDefinitionFamiliesInput struct {
@@ -4153,6 +4933,30 @@ func (s ListTaskDefinitionFamiliesInput) GoString() string {
 	return s.String()
 }
 
+// SetFamilyPrefix sets the FamilyPrefix field's value.
+func (s *ListTaskDefinitionFamiliesInput) SetFamilyPrefix(v string) *ListTaskDefinitionFamiliesInput {
+	s.FamilyPrefix = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListTaskDefinitionFamiliesInput) SetMaxResults(v int64) *ListTaskDefinitionFamiliesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTaskDefinitionFamiliesInput) SetNextToken(v string) *ListTaskDefinitionFamiliesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListTaskDefinitionFamiliesInput) SetStatus(v string) *ListTaskDefinitionFamiliesInput {
+	s.Status = &v
+	return s
+}
+
 type ListTaskDefinitionFamiliesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4175,6 +4979,18 @@ func (s ListTaskDefinitionFamiliesOutput) String() string {
 // GoString returns the string representation
 func (s ListTaskDefinitionFamiliesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFamilies sets the Families field's value.
+func (s *ListTaskDefinitionFamiliesOutput) SetFamilies(v []*string) *ListTaskDefinitionFamiliesOutput {
+	s.Families = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTaskDefinitionFamiliesOutput) SetNextToken(v string) *ListTaskDefinitionFamiliesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListTaskDefinitionsInput struct {
@@ -4230,6 +5046,36 @@ func (s ListTaskDefinitionsInput) GoString() string {
 	return s.String()
 }
 
+// SetFamilyPrefix sets the FamilyPrefix field's value.
+func (s *ListTaskDefinitionsInput) SetFamilyPrefix(v string) *ListTaskDefinitionsInput {
+	s.FamilyPrefix = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListTaskDefinitionsInput) SetMaxResults(v int64) *ListTaskDefinitionsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTaskDefinitionsInput) SetNextToken(v string) *ListTaskDefinitionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSort sets the Sort field's value.
+func (s *ListTaskDefinitionsInput) SetSort(v string) *ListTaskDefinitionsInput {
+	s.Sort = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListTaskDefinitionsInput) SetStatus(v string) *ListTaskDefinitionsInput {
+	s.Status = &v
+	return s
+}
+
 type ListTaskDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4252,6 +5098,18 @@ func (s ListTaskDefinitionsOutput) String() string {
 // GoString returns the string representation
 func (s ListTaskDefinitionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTaskDefinitionsOutput) SetNextToken(v string) *ListTaskDefinitionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTaskDefinitionArns sets the TaskDefinitionArns field's value.
+func (s *ListTaskDefinitionsOutput) SetTaskDefinitionArns(v []*string) *ListTaskDefinitionsOutput {
+	s.TaskDefinitionArns = v
+	return s
 }
 
 type ListTasksInput struct {
@@ -4319,6 +5177,54 @@ func (s ListTasksInput) GoString() string {
 	return s.String()
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *ListTasksInput) SetCluster(v string) *ListTasksInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetContainerInstance sets the ContainerInstance field's value.
+func (s *ListTasksInput) SetContainerInstance(v string) *ListTasksInput {
+	s.ContainerInstance = &v
+	return s
+}
+
+// SetDesiredStatus sets the DesiredStatus field's value.
+func (s *ListTasksInput) SetDesiredStatus(v string) *ListTasksInput {
+	s.DesiredStatus = &v
+	return s
+}
+
+// SetFamily sets the Family field's value.
+func (s *ListTasksInput) SetFamily(v string) *ListTasksInput {
+	s.Family = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListTasksInput) SetMaxResults(v int64) *ListTasksInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTasksInput) SetNextToken(v string) *ListTasksInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetServiceName sets the ServiceName field's value.
+func (s *ListTasksInput) SetServiceName(v string) *ListTasksInput {
+	s.ServiceName = &v
+	return s
+}
+
+// SetStartedBy sets the StartedBy field's value.
+func (s *ListTasksInput) SetStartedBy(v string) *ListTasksInput {
+	s.StartedBy = &v
+	return s
+}
+
 type ListTasksOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4340,6 +5246,18 @@ func (s ListTasksOutput) String() string {
 // GoString returns the string representation
 func (s ListTasksOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTasksOutput) SetNextToken(v string) *ListTasksOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTaskArns sets the TaskArns field's value.
+func (s *ListTasksOutput) SetTaskArns(v []*string) *ListTasksOutput {
+	s.TaskArns = v
+	return s
 }
 
 // Details on a load balancer that is used with a service.
@@ -4372,6 +5290,30 @@ func (s LoadBalancer) String() string {
 // GoString returns the string representation
 func (s LoadBalancer) GoString() string {
 	return s.String()
+}
+
+// SetContainerName sets the ContainerName field's value.
+func (s *LoadBalancer) SetContainerName(v string) *LoadBalancer {
+	s.ContainerName = &v
+	return s
+}
+
+// SetContainerPort sets the ContainerPort field's value.
+func (s *LoadBalancer) SetContainerPort(v int64) *LoadBalancer {
+	s.ContainerPort = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *LoadBalancer) SetLoadBalancerName(v string) *LoadBalancer {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *LoadBalancer) SetTargetGroupArn(v string) *LoadBalancer {
+	s.TargetGroupArn = &v
+	return s
 }
 
 // Log configuration options to send to a custom log driver for the container.
@@ -4429,6 +5371,18 @@ func (s *LogConfiguration) Validate() error {
 	return nil
 }
 
+// SetLogDriver sets the LogDriver field's value.
+func (s *LogConfiguration) SetLogDriver(v string) *LogConfiguration {
+	s.LogDriver = &v
+	return s
+}
+
+// SetOptions sets the Options field's value.
+func (s *LogConfiguration) SetOptions(v map[string]*string) *LogConfiguration {
+	s.Options = v
+	return s
+}
+
 // Details on a volume mount point that is used in a container definition.
 type MountPoint struct {
 	_ struct{} `type:"structure"`
@@ -4453,6 +5407,24 @@ func (s MountPoint) String() string {
 // GoString returns the string representation
 func (s MountPoint) GoString() string {
 	return s.String()
+}
+
+// SetContainerPath sets the ContainerPath field's value.
+func (s *MountPoint) SetContainerPath(v string) *MountPoint {
+	s.ContainerPath = &v
+	return s
+}
+
+// SetReadOnly sets the ReadOnly field's value.
+func (s *MountPoint) SetReadOnly(v bool) *MountPoint {
+	s.ReadOnly = &v
+	return s
+}
+
+// SetSourceVolume sets the SourceVolume field's value.
+func (s *MountPoint) SetSourceVolume(v string) *MountPoint {
+	s.SourceVolume = &v
+	return s
 }
 
 // Details on the network bindings between a container and its host container
@@ -4483,6 +5455,30 @@ func (s NetworkBinding) String() string {
 // GoString returns the string representation
 func (s NetworkBinding) GoString() string {
 	return s.String()
+}
+
+// SetBindIP sets the BindIP field's value.
+func (s *NetworkBinding) SetBindIP(v string) *NetworkBinding {
+	s.BindIP = &v
+	return s
+}
+
+// SetContainerPort sets the ContainerPort field's value.
+func (s *NetworkBinding) SetContainerPort(v int64) *NetworkBinding {
+	s.ContainerPort = &v
+	return s
+}
+
+// SetHostPort sets the HostPort field's value.
+func (s *NetworkBinding) SetHostPort(v int64) *NetworkBinding {
+	s.HostPort = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *NetworkBinding) SetProtocol(v string) *NetworkBinding {
+	s.Protocol = &v
+	return s
 }
 
 // Port mappings allow containers to access ports on the host container instance
@@ -4538,6 +5534,24 @@ func (s PortMapping) String() string {
 // GoString returns the string representation
 func (s PortMapping) GoString() string {
 	return s.String()
+}
+
+// SetContainerPort sets the ContainerPort field's value.
+func (s *PortMapping) SetContainerPort(v int64) *PortMapping {
+	s.ContainerPort = &v
+	return s
+}
+
+// SetHostPort sets the HostPort field's value.
+func (s *PortMapping) SetHostPort(v int64) *PortMapping {
+	s.HostPort = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *PortMapping) SetProtocol(v string) *PortMapping {
+	s.Protocol = &v
+	return s
 }
 
 type RegisterContainerInstanceInput struct {
@@ -4602,6 +5616,48 @@ func (s *RegisterContainerInstanceInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *RegisterContainerInstanceInput) SetAttributes(v []*Attribute) *RegisterContainerInstanceInput {
+	s.Attributes = v
+	return s
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *RegisterContainerInstanceInput) SetCluster(v string) *RegisterContainerInstanceInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetContainerInstanceArn sets the ContainerInstanceArn field's value.
+func (s *RegisterContainerInstanceInput) SetContainerInstanceArn(v string) *RegisterContainerInstanceInput {
+	s.ContainerInstanceArn = &v
+	return s
+}
+
+// SetInstanceIdentityDocument sets the InstanceIdentityDocument field's value.
+func (s *RegisterContainerInstanceInput) SetInstanceIdentityDocument(v string) *RegisterContainerInstanceInput {
+	s.InstanceIdentityDocument = &v
+	return s
+}
+
+// SetInstanceIdentityDocumentSignature sets the InstanceIdentityDocumentSignature field's value.
+func (s *RegisterContainerInstanceInput) SetInstanceIdentityDocumentSignature(v string) *RegisterContainerInstanceInput {
+	s.InstanceIdentityDocumentSignature = &v
+	return s
+}
+
+// SetTotalResources sets the TotalResources field's value.
+func (s *RegisterContainerInstanceInput) SetTotalResources(v []*Resource) *RegisterContainerInstanceInput {
+	s.TotalResources = v
+	return s
+}
+
+// SetVersionInfo sets the VersionInfo field's value.
+func (s *RegisterContainerInstanceInput) SetVersionInfo(v *VersionInfo) *RegisterContainerInstanceInput {
+	s.VersionInfo = v
+	return s
+}
+
 type RegisterContainerInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4618,6 +5674,12 @@ func (s RegisterContainerInstanceOutput) String() string {
 // GoString returns the string representation
 func (s RegisterContainerInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetContainerInstance sets the ContainerInstance field's value.
+func (s *RegisterContainerInstanceOutput) SetContainerInstance(v *ContainerInstance) *RegisterContainerInstanceOutput {
+	s.ContainerInstance = v
+	return s
 }
 
 type RegisterTaskDefinitionInput struct {
@@ -4702,6 +5764,36 @@ func (s *RegisterTaskDefinitionInput) Validate() error {
 	return nil
 }
 
+// SetContainerDefinitions sets the ContainerDefinitions field's value.
+func (s *RegisterTaskDefinitionInput) SetContainerDefinitions(v []*ContainerDefinition) *RegisterTaskDefinitionInput {
+	s.ContainerDefinitions = v
+	return s
+}
+
+// SetFamily sets the Family field's value.
+func (s *RegisterTaskDefinitionInput) SetFamily(v string) *RegisterTaskDefinitionInput {
+	s.Family = &v
+	return s
+}
+
+// SetNetworkMode sets the NetworkMode field's value.
+func (s *RegisterTaskDefinitionInput) SetNetworkMode(v string) *RegisterTaskDefinitionInput {
+	s.NetworkMode = &v
+	return s
+}
+
+// SetTaskRoleArn sets the TaskRoleArn field's value.
+func (s *RegisterTaskDefinitionInput) SetTaskRoleArn(v string) *RegisterTaskDefinitionInput {
+	s.TaskRoleArn = &v
+	return s
+}
+
+// SetVolumes sets the Volumes field's value.
+func (s *RegisterTaskDefinitionInput) SetVolumes(v []*Volume) *RegisterTaskDefinitionInput {
+	s.Volumes = v
+	return s
+}
+
 type RegisterTaskDefinitionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4717,6 +5809,12 @@ func (s RegisterTaskDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s RegisterTaskDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *RegisterTaskDefinitionOutput) SetTaskDefinition(v *TaskDefinition) *RegisterTaskDefinitionOutput {
+	s.TaskDefinition = v
+	return s
 }
 
 // Describes the resources available for a container instance.
@@ -4753,6 +5851,42 @@ func (s Resource) String() string {
 // GoString returns the string representation
 func (s Resource) GoString() string {
 	return s.String()
+}
+
+// SetDoubleValue sets the DoubleValue field's value.
+func (s *Resource) SetDoubleValue(v float64) *Resource {
+	s.DoubleValue = &v
+	return s
+}
+
+// SetIntegerValue sets the IntegerValue field's value.
+func (s *Resource) SetIntegerValue(v int64) *Resource {
+	s.IntegerValue = &v
+	return s
+}
+
+// SetLongValue sets the LongValue field's value.
+func (s *Resource) SetLongValue(v int64) *Resource {
+	s.LongValue = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Resource) SetName(v string) *Resource {
+	s.Name = &v
+	return s
+}
+
+// SetStringSetValue sets the StringSetValue field's value.
+func (s *Resource) SetStringSetValue(v []*string) *Resource {
+	s.StringSetValue = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Resource) SetType(v string) *Resource {
+	s.Type = &v
+	return s
 }
 
 type RunTaskInput struct {
@@ -4822,6 +5956,36 @@ func (s *RunTaskInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *RunTaskInput) SetCluster(v string) *RunTaskInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetCount sets the Count field's value.
+func (s *RunTaskInput) SetCount(v int64) *RunTaskInput {
+	s.Count = &v
+	return s
+}
+
+// SetOverrides sets the Overrides field's value.
+func (s *RunTaskInput) SetOverrides(v *TaskOverride) *RunTaskInput {
+	s.Overrides = v
+	return s
+}
+
+// SetStartedBy sets the StartedBy field's value.
+func (s *RunTaskInput) SetStartedBy(v string) *RunTaskInput {
+	s.StartedBy = &v
+	return s
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *RunTaskInput) SetTaskDefinition(v string) *RunTaskInput {
+	s.TaskDefinition = &v
+	return s
+}
+
 type RunTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4841,6 +6005,18 @@ func (s RunTaskOutput) String() string {
 // GoString returns the string representation
 func (s RunTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailures sets the Failures field's value.
+func (s *RunTaskOutput) SetFailures(v []*Failure) *RunTaskOutput {
+	s.Failures = v
+	return s
+}
+
+// SetTasks sets the Tasks field's value.
+func (s *RunTaskOutput) SetTasks(v []*Task) *RunTaskOutput {
+	s.Tasks = v
+	return s
 }
 
 // Details on a service within a cluster
@@ -4916,6 +6092,90 @@ func (s Service) GoString() string {
 	return s.String()
 }
 
+// SetClusterArn sets the ClusterArn field's value.
+func (s *Service) SetClusterArn(v string) *Service {
+	s.ClusterArn = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Service) SetCreatedAt(v time.Time) *Service {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDeploymentConfiguration sets the DeploymentConfiguration field's value.
+func (s *Service) SetDeploymentConfiguration(v *DeploymentConfiguration) *Service {
+	s.DeploymentConfiguration = v
+	return s
+}
+
+// SetDeployments sets the Deployments field's value.
+func (s *Service) SetDeployments(v []*Deployment) *Service {
+	s.Deployments = v
+	return s
+}
+
+// SetDesiredCount sets the DesiredCount field's value.
+func (s *Service) SetDesiredCount(v int64) *Service {
+	s.DesiredCount = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *Service) SetEvents(v []*ServiceEvent) *Service {
+	s.Events = v
+	return s
+}
+
+// SetLoadBalancers sets the LoadBalancers field's value.
+func (s *Service) SetLoadBalancers(v []*LoadBalancer) *Service {
+	s.LoadBalancers = v
+	return s
+}
+
+// SetPendingCount sets the PendingCount field's value.
+func (s *Service) SetPendingCount(v int64) *Service {
+	s.PendingCount = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *Service) SetRoleArn(v string) *Service {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRunningCount sets the RunningCount field's value.
+func (s *Service) SetRunningCount(v int64) *Service {
+	s.RunningCount = &v
+	return s
+}
+
+// SetServiceArn sets the ServiceArn field's value.
+func (s *Service) SetServiceArn(v string) *Service {
+	s.ServiceArn = &v
+	return s
+}
+
+// SetServiceName sets the ServiceName field's value.
+func (s *Service) SetServiceName(v string) *Service {
+	s.ServiceName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Service) SetStatus(v string) *Service {
+	s.Status = &v
+	return s
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *Service) SetTaskDefinition(v string) *Service {
+	s.TaskDefinition = &v
+	return s
+}
+
 // Details on an event associated with a service.
 type ServiceEvent struct {
 	_ struct{} `type:"structure"`
@@ -4938,6 +6198,24 @@ func (s ServiceEvent) String() string {
 // GoString returns the string representation
 func (s ServiceEvent) GoString() string {
 	return s.String()
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *ServiceEvent) SetCreatedAt(v time.Time) *ServiceEvent {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ServiceEvent) SetId(v string) *ServiceEvent {
+	s.Id = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *ServiceEvent) SetMessage(v string) *ServiceEvent {
+	s.Message = &v
+	return s
 }
 
 type StartTaskInput struct {
@@ -5013,6 +6291,36 @@ func (s *StartTaskInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *StartTaskInput) SetCluster(v string) *StartTaskInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetContainerInstances sets the ContainerInstances field's value.
+func (s *StartTaskInput) SetContainerInstances(v []*string) *StartTaskInput {
+	s.ContainerInstances = v
+	return s
+}
+
+// SetOverrides sets the Overrides field's value.
+func (s *StartTaskInput) SetOverrides(v *TaskOverride) *StartTaskInput {
+	s.Overrides = v
+	return s
+}
+
+// SetStartedBy sets the StartedBy field's value.
+func (s *StartTaskInput) SetStartedBy(v string) *StartTaskInput {
+	s.StartedBy = &v
+	return s
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *StartTaskInput) SetTaskDefinition(v string) *StartTaskInput {
+	s.TaskDefinition = &v
+	return s
+}
+
 type StartTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5032,6 +6340,18 @@ func (s StartTaskOutput) String() string {
 // GoString returns the string representation
 func (s StartTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailures sets the Failures field's value.
+func (s *StartTaskOutput) SetFailures(v []*Failure) *StartTaskOutput {
+	s.Failures = v
+	return s
+}
+
+// SetTasks sets the Tasks field's value.
+func (s *StartTaskOutput) SetTasks(v []*Task) *StartTaskOutput {
+	s.Tasks = v
+	return s
 }
 
 type StopTaskInput struct {
@@ -5077,6 +6397,24 @@ func (s *StopTaskInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *StopTaskInput) SetCluster(v string) *StopTaskInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *StopTaskInput) SetReason(v string) *StopTaskInput {
+	s.Reason = &v
+	return s
+}
+
+// SetTask sets the Task field's value.
+func (s *StopTaskInput) SetTask(v string) *StopTaskInput {
+	s.Task = &v
+	return s
+}
+
 type StopTaskOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5092,6 +6430,12 @@ func (s StopTaskOutput) String() string {
 // GoString returns the string representation
 func (s StopTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetTask sets the Task field's value.
+func (s *StopTaskOutput) SetTask(v *Task) *StopTaskOutput {
+	s.Task = v
+	return s
 }
 
 type SubmitContainerStateChangeInput struct {
@@ -5131,6 +6475,48 @@ func (s SubmitContainerStateChangeInput) GoString() string {
 	return s.String()
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *SubmitContainerStateChangeInput) SetCluster(v string) *SubmitContainerStateChangeInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetContainerName sets the ContainerName field's value.
+func (s *SubmitContainerStateChangeInput) SetContainerName(v string) *SubmitContainerStateChangeInput {
+	s.ContainerName = &v
+	return s
+}
+
+// SetExitCode sets the ExitCode field's value.
+func (s *SubmitContainerStateChangeInput) SetExitCode(v int64) *SubmitContainerStateChangeInput {
+	s.ExitCode = &v
+	return s
+}
+
+// SetNetworkBindings sets the NetworkBindings field's value.
+func (s *SubmitContainerStateChangeInput) SetNetworkBindings(v []*NetworkBinding) *SubmitContainerStateChangeInput {
+	s.NetworkBindings = v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *SubmitContainerStateChangeInput) SetReason(v string) *SubmitContainerStateChangeInput {
+	s.Reason = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SubmitContainerStateChangeInput) SetStatus(v string) *SubmitContainerStateChangeInput {
+	s.Status = &v
+	return s
+}
+
+// SetTask sets the Task field's value.
+func (s *SubmitContainerStateChangeInput) SetTask(v string) *SubmitContainerStateChangeInput {
+	s.Task = &v
+	return s
+}
+
 type SubmitContainerStateChangeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5146,6 +6532,12 @@ func (s SubmitContainerStateChangeOutput) String() string {
 // GoString returns the string representation
 func (s SubmitContainerStateChangeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAcknowledgment sets the Acknowledgment field's value.
+func (s *SubmitContainerStateChangeOutput) SetAcknowledgment(v string) *SubmitContainerStateChangeOutput {
+	s.Acknowledgment = &v
+	return s
 }
 
 type SubmitTaskStateChangeInput struct {
@@ -5176,6 +6568,30 @@ func (s SubmitTaskStateChangeInput) GoString() string {
 	return s.String()
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *SubmitTaskStateChangeInput) SetCluster(v string) *SubmitTaskStateChangeInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *SubmitTaskStateChangeInput) SetReason(v string) *SubmitTaskStateChangeInput {
+	s.Reason = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SubmitTaskStateChangeInput) SetStatus(v string) *SubmitTaskStateChangeInput {
+	s.Status = &v
+	return s
+}
+
+// SetTask sets the Task field's value.
+func (s *SubmitTaskStateChangeInput) SetTask(v string) *SubmitTaskStateChangeInput {
+	s.Task = &v
+	return s
+}
+
 type SubmitTaskStateChangeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5191,6 +6607,12 @@ func (s SubmitTaskStateChangeOutput) String() string {
 // GoString returns the string representation
 func (s SubmitTaskStateChangeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAcknowledgment sets the Acknowledgment field's value.
+func (s *SubmitTaskStateChangeOutput) SetAcknowledgment(v string) *SubmitTaskStateChangeOutput {
+	s.Acknowledgment = &v
+	return s
 }
 
 // Details on a task in a cluster.
@@ -5250,6 +6672,84 @@ func (s Task) String() string {
 // GoString returns the string representation
 func (s Task) GoString() string {
 	return s.String()
+}
+
+// SetClusterArn sets the ClusterArn field's value.
+func (s *Task) SetClusterArn(v string) *Task {
+	s.ClusterArn = &v
+	return s
+}
+
+// SetContainerInstanceArn sets the ContainerInstanceArn field's value.
+func (s *Task) SetContainerInstanceArn(v string) *Task {
+	s.ContainerInstanceArn = &v
+	return s
+}
+
+// SetContainers sets the Containers field's value.
+func (s *Task) SetContainers(v []*Container) *Task {
+	s.Containers = v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Task) SetCreatedAt(v time.Time) *Task {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDesiredStatus sets the DesiredStatus field's value.
+func (s *Task) SetDesiredStatus(v string) *Task {
+	s.DesiredStatus = &v
+	return s
+}
+
+// SetLastStatus sets the LastStatus field's value.
+func (s *Task) SetLastStatus(v string) *Task {
+	s.LastStatus = &v
+	return s
+}
+
+// SetOverrides sets the Overrides field's value.
+func (s *Task) SetOverrides(v *TaskOverride) *Task {
+	s.Overrides = v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *Task) SetStartedAt(v time.Time) *Task {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStartedBy sets the StartedBy field's value.
+func (s *Task) SetStartedBy(v string) *Task {
+	s.StartedBy = &v
+	return s
+}
+
+// SetStoppedAt sets the StoppedAt field's value.
+func (s *Task) SetStoppedAt(v time.Time) *Task {
+	s.StoppedAt = &v
+	return s
+}
+
+// SetStoppedReason sets the StoppedReason field's value.
+func (s *Task) SetStoppedReason(v string) *Task {
+	s.StoppedReason = &v
+	return s
+}
+
+// SetTaskArn sets the TaskArn field's value.
+func (s *Task) SetTaskArn(v string) *Task {
+	s.TaskArn = &v
+	return s
+}
+
+// SetTaskDefinitionArn sets the TaskDefinitionArn field's value.
+func (s *Task) SetTaskDefinitionArn(v string) *Task {
+	s.TaskDefinitionArn = &v
+	return s
 }
 
 // Details of a task definition.
@@ -5314,6 +6814,60 @@ func (s TaskDefinition) GoString() string {
 	return s.String()
 }
 
+// SetContainerDefinitions sets the ContainerDefinitions field's value.
+func (s *TaskDefinition) SetContainerDefinitions(v []*ContainerDefinition) *TaskDefinition {
+	s.ContainerDefinitions = v
+	return s
+}
+
+// SetFamily sets the Family field's value.
+func (s *TaskDefinition) SetFamily(v string) *TaskDefinition {
+	s.Family = &v
+	return s
+}
+
+// SetNetworkMode sets the NetworkMode field's value.
+func (s *TaskDefinition) SetNetworkMode(v string) *TaskDefinition {
+	s.NetworkMode = &v
+	return s
+}
+
+// SetRequiresAttributes sets the RequiresAttributes field's value.
+func (s *TaskDefinition) SetRequiresAttributes(v []*Attribute) *TaskDefinition {
+	s.RequiresAttributes = v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *TaskDefinition) SetRevision(v int64) *TaskDefinition {
+	s.Revision = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *TaskDefinition) SetStatus(v string) *TaskDefinition {
+	s.Status = &v
+	return s
+}
+
+// SetTaskDefinitionArn sets the TaskDefinitionArn field's value.
+func (s *TaskDefinition) SetTaskDefinitionArn(v string) *TaskDefinition {
+	s.TaskDefinitionArn = &v
+	return s
+}
+
+// SetTaskRoleArn sets the TaskRoleArn field's value.
+func (s *TaskDefinition) SetTaskRoleArn(v string) *TaskDefinition {
+	s.TaskRoleArn = &v
+	return s
+}
+
+// SetVolumes sets the Volumes field's value.
+func (s *TaskDefinition) SetVolumes(v []*Volume) *TaskDefinition {
+	s.Volumes = v
+	return s
+}
+
 // The overrides associated with a task.
 type TaskOverride struct {
 	_ struct{} `type:"structure"`
@@ -5335,6 +6889,18 @@ func (s TaskOverride) String() string {
 // GoString returns the string representation
 func (s TaskOverride) GoString() string {
 	return s.String()
+}
+
+// SetContainerOverrides sets the ContainerOverrides field's value.
+func (s *TaskOverride) SetContainerOverrides(v []*ContainerOverride) *TaskOverride {
+	s.ContainerOverrides = v
+	return s
+}
+
+// SetTaskRoleArn sets the TaskRoleArn field's value.
+func (s *TaskOverride) SetTaskRoleArn(v string) *TaskOverride {
+	s.TaskRoleArn = &v
+	return s
 }
 
 // The ulimit settings to pass to the container.
@@ -5386,6 +6952,24 @@ func (s *Ulimit) Validate() error {
 	return nil
 }
 
+// SetHardLimit sets the HardLimit field's value.
+func (s *Ulimit) SetHardLimit(v int64) *Ulimit {
+	s.HardLimit = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Ulimit) SetName(v string) *Ulimit {
+	s.Name = &v
+	return s
+}
+
+// SetSoftLimit sets the SoftLimit field's value.
+func (s *Ulimit) SetSoftLimit(v int64) *Ulimit {
+	s.SoftLimit = &v
+	return s
+}
+
 type UpdateContainerAgentInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5425,6 +7009,18 @@ func (s *UpdateContainerAgentInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *UpdateContainerAgentInput) SetCluster(v string) *UpdateContainerAgentInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetContainerInstance sets the ContainerInstance field's value.
+func (s *UpdateContainerAgentInput) SetContainerInstance(v string) *UpdateContainerAgentInput {
+	s.ContainerInstance = &v
+	return s
+}
+
 type UpdateContainerAgentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5441,6 +7037,12 @@ func (s UpdateContainerAgentOutput) String() string {
 // GoString returns the string representation
 func (s UpdateContainerAgentOutput) GoString() string {
 	return s.String()
+}
+
+// SetContainerInstance sets the ContainerInstance field's value.
+func (s *UpdateContainerAgentOutput) SetContainerInstance(v *ContainerInstance) *UpdateContainerAgentOutput {
+	s.ContainerInstance = v
+	return s
 }
 
 type UpdateServiceInput struct {
@@ -5495,6 +7097,36 @@ func (s *UpdateServiceInput) Validate() error {
 	return nil
 }
 
+// SetCluster sets the Cluster field's value.
+func (s *UpdateServiceInput) SetCluster(v string) *UpdateServiceInput {
+	s.Cluster = &v
+	return s
+}
+
+// SetDeploymentConfiguration sets the DeploymentConfiguration field's value.
+func (s *UpdateServiceInput) SetDeploymentConfiguration(v *DeploymentConfiguration) *UpdateServiceInput {
+	s.DeploymentConfiguration = v
+	return s
+}
+
+// SetDesiredCount sets the DesiredCount field's value.
+func (s *UpdateServiceInput) SetDesiredCount(v int64) *UpdateServiceInput {
+	s.DesiredCount = &v
+	return s
+}
+
+// SetService sets the Service field's value.
+func (s *UpdateServiceInput) SetService(v string) *UpdateServiceInput {
+	s.Service = &v
+	return s
+}
+
+// SetTaskDefinition sets the TaskDefinition field's value.
+func (s *UpdateServiceInput) SetTaskDefinition(v string) *UpdateServiceInput {
+	s.TaskDefinition = &v
+	return s
+}
+
 type UpdateServiceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5510,6 +7142,12 @@ func (s UpdateServiceOutput) String() string {
 // GoString returns the string representation
 func (s UpdateServiceOutput) GoString() string {
 	return s.String()
+}
+
+// SetService sets the Service field's value.
+func (s *UpdateServiceOutput) SetService(v *Service) *UpdateServiceOutput {
+	s.Service = v
+	return s
 }
 
 // The Docker and Amazon ECS container agent version information about a container
@@ -5536,6 +7174,24 @@ func (s VersionInfo) String() string {
 // GoString returns the string representation
 func (s VersionInfo) GoString() string {
 	return s.String()
+}
+
+// SetAgentHash sets the AgentHash field's value.
+func (s *VersionInfo) SetAgentHash(v string) *VersionInfo {
+	s.AgentHash = &v
+	return s
+}
+
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *VersionInfo) SetAgentVersion(v string) *VersionInfo {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetDockerVersion sets the DockerVersion field's value.
+func (s *VersionInfo) SetDockerVersion(v string) *VersionInfo {
+	s.DockerVersion = &v
+	return s
 }
 
 // A data volume used in a task definition.
@@ -5565,6 +7221,18 @@ func (s Volume) GoString() string {
 	return s.String()
 }
 
+// SetHost sets the Host field's value.
+func (s *Volume) SetHost(v *HostVolumeProperties) *Volume {
+	s.Host = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Volume) SetName(v string) *Volume {
+	s.Name = &v
+	return s
+}
+
 // Details on a data volume from another container.
 type VolumeFrom struct {
 	_ struct{} `type:"structure"`
@@ -5586,6 +7254,18 @@ func (s VolumeFrom) String() string {
 // GoString returns the string representation
 func (s VolumeFrom) GoString() string {
 	return s.String()
+}
+
+// SetReadOnly sets the ReadOnly field's value.
+func (s *VolumeFrom) SetReadOnly(v bool) *VolumeFrom {
+	s.ReadOnly = &v
+	return s
+}
+
+// SetSourceContainer sets the SourceContainer field's value.
+func (s *VolumeFrom) SetSourceContainer(v string) *VolumeFrom {
+	s.SourceContainer = &v
+	return s
 }
 
 const (

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -1175,6 +1175,18 @@ func (s *CreateFileSystemInput) Validate() error {
 	return nil
 }
 
+// SetCreationToken sets the CreationToken field's value.
+func (s *CreateFileSystemInput) SetCreationToken(v string) *CreateFileSystemInput {
+	s.CreationToken = &v
+	return s
+}
+
+// SetPerformanceMode sets the PerformanceMode field's value.
+func (s *CreateFileSystemInput) SetPerformanceMode(v string) *CreateFileSystemInput {
+	s.PerformanceMode = &v
+	return s
+}
+
 type CreateMountTargetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1220,6 +1232,30 @@ func (s *CreateMountTargetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *CreateMountTargetInput) SetFileSystemId(v string) *CreateMountTargetInput {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *CreateMountTargetInput) SetIpAddress(v string) *CreateMountTargetInput {
+	s.IpAddress = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *CreateMountTargetInput) SetSecurityGroups(v []*string) *CreateMountTargetInput {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *CreateMountTargetInput) SetSubnetId(v string) *CreateMountTargetInput {
+	s.SubnetId = &v
+	return s
 }
 
 type CreateTagsInput struct {
@@ -1273,6 +1309,18 @@ func (s *CreateTagsInput) Validate() error {
 	return nil
 }
 
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *CreateTagsInput) SetFileSystemId(v string) *CreateTagsInput {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateTagsInput) SetTags(v []*Tag) *CreateTagsInput {
+	s.Tags = v
+	return s
+}
+
 type CreateTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1319,6 +1367,12 @@ func (s *DeleteFileSystemInput) Validate() error {
 	return nil
 }
 
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *DeleteFileSystemInput) SetFileSystemId(v string) *DeleteFileSystemInput {
+	s.FileSystemId = &v
+	return s
+}
+
 type DeleteFileSystemOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1363,6 +1417,12 @@ func (s *DeleteMountTargetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMountTargetId sets the MountTargetId field's value.
+func (s *DeleteMountTargetInput) SetMountTargetId(v string) *DeleteMountTargetInput {
+	s.MountTargetId = &v
+	return s
 }
 
 type DeleteMountTargetOutput struct {
@@ -1417,6 +1477,18 @@ func (s *DeleteTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *DeleteTagsInput) SetFileSystemId(v string) *DeleteTagsInput {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DeleteTagsInput) SetTagKeys(v []*string) *DeleteTagsInput {
+	s.TagKeys = v
+	return s
 }
 
 type DeleteTagsOutput struct {
@@ -1483,6 +1555,30 @@ func (s *DescribeFileSystemsInput) Validate() error {
 	return nil
 }
 
+// SetCreationToken sets the CreationToken field's value.
+func (s *DescribeFileSystemsInput) SetCreationToken(v string) *DescribeFileSystemsInput {
+	s.CreationToken = &v
+	return s
+}
+
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *DescribeFileSystemsInput) SetFileSystemId(v string) *DescribeFileSystemsInput {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeFileSystemsInput) SetMarker(v string) *DescribeFileSystemsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *DescribeFileSystemsInput) SetMaxItems(v int64) *DescribeFileSystemsInput {
+	s.MaxItems = &v
+	return s
+}
+
 type DescribeFileSystemsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1505,6 +1601,24 @@ func (s DescribeFileSystemsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeFileSystemsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFileSystems sets the FileSystems field's value.
+func (s *DescribeFileSystemsOutput) SetFileSystems(v []*FileSystemDescription) *DescribeFileSystemsOutput {
+	s.FileSystems = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeFileSystemsOutput) SetMarker(v string) *DescribeFileSystemsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeFileSystemsOutput) SetNextMarker(v string) *DescribeFileSystemsOutput {
+	s.NextMarker = &v
+	return s
 }
 
 type DescribeMountTargetSecurityGroupsInput struct {
@@ -1539,6 +1653,12 @@ func (s *DescribeMountTargetSecurityGroupsInput) Validate() error {
 	return nil
 }
 
+// SetMountTargetId sets the MountTargetId field's value.
+func (s *DescribeMountTargetSecurityGroupsInput) SetMountTargetId(v string) *DescribeMountTargetSecurityGroupsInput {
+	s.MountTargetId = &v
+	return s
+}
+
 type DescribeMountTargetSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1556,6 +1676,12 @@ func (s DescribeMountTargetSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeMountTargetSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *DescribeMountTargetSecurityGroupsOutput) SetSecurityGroups(v []*string) *DescribeMountTargetSecurityGroupsOutput {
+	s.SecurityGroups = v
+	return s
 }
 
 type DescribeMountTargetsInput struct {
@@ -1602,6 +1728,30 @@ func (s *DescribeMountTargetsInput) Validate() error {
 	return nil
 }
 
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *DescribeMountTargetsInput) SetFileSystemId(v string) *DescribeMountTargetsInput {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeMountTargetsInput) SetMarker(v string) *DescribeMountTargetsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *DescribeMountTargetsInput) SetMaxItems(v int64) *DescribeMountTargetsInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetMountTargetId sets the MountTargetId field's value.
+func (s *DescribeMountTargetsInput) SetMountTargetId(v string) *DescribeMountTargetsInput {
+	s.MountTargetId = &v
+	return s
+}
+
 type DescribeMountTargetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1627,6 +1777,24 @@ func (s DescribeMountTargetsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeMountTargetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeMountTargetsOutput) SetMarker(v string) *DescribeMountTargetsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetMountTargets sets the MountTargets field's value.
+func (s *DescribeMountTargetsOutput) SetMountTargets(v []*MountTargetDescription) *DescribeMountTargetsOutput {
+	s.MountTargets = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeMountTargetsOutput) SetNextMarker(v string) *DescribeMountTargetsOutput {
+	s.NextMarker = &v
+	return s
 }
 
 type DescribeTagsInput struct {
@@ -1673,6 +1841,24 @@ func (s *DescribeTagsInput) Validate() error {
 	return nil
 }
 
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *DescribeTagsInput) SetFileSystemId(v string) *DescribeTagsInput {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTagsInput) SetMarker(v string) *DescribeTagsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *DescribeTagsInput) SetMaxItems(v int64) *DescribeTagsInput {
+	s.MaxItems = &v
+	return s
+}
+
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1699,6 +1885,24 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTagsOutput) SetMarker(v string) *DescribeTagsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeTagsOutput) SetNextMarker(v string) *DescribeTagsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DescribeTagsOutput) SetTags(v []*Tag) *DescribeTagsOutput {
+	s.Tags = v
+	return s
 }
 
 // Description of the file system.
@@ -1771,6 +1975,60 @@ func (s FileSystemDescription) GoString() string {
 	return s.String()
 }
 
+// SetCreationTime sets the CreationTime field's value.
+func (s *FileSystemDescription) SetCreationTime(v time.Time) *FileSystemDescription {
+	s.CreationTime = &v
+	return s
+}
+
+// SetCreationToken sets the CreationToken field's value.
+func (s *FileSystemDescription) SetCreationToken(v string) *FileSystemDescription {
+	s.CreationToken = &v
+	return s
+}
+
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *FileSystemDescription) SetFileSystemId(v string) *FileSystemDescription {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetLifeCycleState sets the LifeCycleState field's value.
+func (s *FileSystemDescription) SetLifeCycleState(v string) *FileSystemDescription {
+	s.LifeCycleState = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *FileSystemDescription) SetName(v string) *FileSystemDescription {
+	s.Name = &v
+	return s
+}
+
+// SetNumberOfMountTargets sets the NumberOfMountTargets field's value.
+func (s *FileSystemDescription) SetNumberOfMountTargets(v int64) *FileSystemDescription {
+	s.NumberOfMountTargets = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *FileSystemDescription) SetOwnerId(v string) *FileSystemDescription {
+	s.OwnerId = &v
+	return s
+}
+
+// SetPerformanceMode sets the PerformanceMode field's value.
+func (s *FileSystemDescription) SetPerformanceMode(v string) *FileSystemDescription {
+	s.PerformanceMode = &v
+	return s
+}
+
+// SetSizeInBytes sets the SizeInBytes field's value.
+func (s *FileSystemDescription) SetSizeInBytes(v *FileSystemSize) *FileSystemDescription {
+	s.SizeInBytes = v
+	return s
+}
+
 // Latest known metered size (in bytes) of data stored in the file system, in
 // its Value field, and the time at which that size was determined in its Timestamp
 // field. Note that the value does not represent the size of a consistent snapshot
@@ -1800,6 +2058,18 @@ func (s FileSystemSize) String() string {
 // GoString returns the string representation
 func (s FileSystemSize) GoString() string {
 	return s.String()
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *FileSystemSize) SetTimestamp(v time.Time) *FileSystemSize {
+	s.Timestamp = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *FileSystemSize) SetValue(v int64) *FileSystemSize {
+	s.Value = &v
+	return s
 }
 
 type ModifyMountTargetSecurityGroupsInput struct {
@@ -1835,6 +2105,18 @@ func (s *ModifyMountTargetSecurityGroupsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMountTargetId sets the MountTargetId field's value.
+func (s *ModifyMountTargetSecurityGroupsInput) SetMountTargetId(v string) *ModifyMountTargetSecurityGroupsInput {
+	s.MountTargetId = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *ModifyMountTargetSecurityGroupsInput) SetSecurityGroups(v []*string) *ModifyMountTargetSecurityGroupsInput {
+	s.SecurityGroups = v
+	return s
 }
 
 type ModifyMountTargetSecurityGroupsOutput struct {
@@ -1896,6 +2178,48 @@ func (s MountTargetDescription) GoString() string {
 	return s.String()
 }
 
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *MountTargetDescription) SetFileSystemId(v string) *MountTargetDescription {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *MountTargetDescription) SetIpAddress(v string) *MountTargetDescription {
+	s.IpAddress = &v
+	return s
+}
+
+// SetLifeCycleState sets the LifeCycleState field's value.
+func (s *MountTargetDescription) SetLifeCycleState(v string) *MountTargetDescription {
+	s.LifeCycleState = &v
+	return s
+}
+
+// SetMountTargetId sets the MountTargetId field's value.
+func (s *MountTargetDescription) SetMountTargetId(v string) *MountTargetDescription {
+	s.MountTargetId = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *MountTargetDescription) SetNetworkInterfaceId(v string) *MountTargetDescription {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *MountTargetDescription) SetOwnerId(v string) *MountTargetDescription {
+	s.OwnerId = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *MountTargetDescription) SetSubnetId(v string) *MountTargetDescription {
+	s.SubnetId = &v
+	return s
+}
+
 // A tag is a key-value pair. Allowed characters: letters, whitespace, and numbers,
 // representable in UTF-8, and the following characters: + - = . _ : /
 type Tag struct {
@@ -1939,6 +2263,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 const (

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -3615,6 +3615,18 @@ func (s *AddTagsToResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceName sets the ResourceName field's value.
+func (s *AddTagsToResourceInput) SetResourceName(v string) *AddTagsToResourceInput {
+	s.ResourceName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToResourceInput) SetTags(v []*Tag) *AddTagsToResourceInput {
+	s.Tags = v
+	return s
+}
+
 // Represents the input of an AuthorizeCacheSecurityGroupIngress operation.
 type AuthorizeCacheSecurityGroupIngressInput struct {
 	_ struct{} `type:"structure"`
@@ -3667,6 +3679,24 @@ func (s *AuthorizeCacheSecurityGroupIngressInput) Validate() error {
 	return nil
 }
 
+// SetCacheSecurityGroupName sets the CacheSecurityGroupName field's value.
+func (s *AuthorizeCacheSecurityGroupIngressInput) SetCacheSecurityGroupName(v string) *AuthorizeCacheSecurityGroupIngressInput {
+	s.CacheSecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *AuthorizeCacheSecurityGroupIngressInput) SetEC2SecurityGroupName(v string) *AuthorizeCacheSecurityGroupIngressInput {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *AuthorizeCacheSecurityGroupIngressInput) SetEC2SecurityGroupOwnerId(v string) *AuthorizeCacheSecurityGroupIngressInput {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
 type AuthorizeCacheSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3690,6 +3720,12 @@ func (s AuthorizeCacheSecurityGroupIngressOutput) GoString() string {
 	return s.String()
 }
 
+// SetCacheSecurityGroup sets the CacheSecurityGroup field's value.
+func (s *AuthorizeCacheSecurityGroupIngressOutput) SetCacheSecurityGroup(v *CacheSecurityGroup) *AuthorizeCacheSecurityGroupIngressOutput {
+	s.CacheSecurityGroup = v
+	return s
+}
+
 // Describes an Availability Zone in which the cache cluster is launched.
 type AvailabilityZone struct {
 	_ struct{} `type:"structure"`
@@ -3706,6 +3742,12 @@ func (s AvailabilityZone) String() string {
 // GoString returns the string representation
 func (s AvailabilityZone) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *AvailabilityZone) SetName(v string) *AvailabilityZone {
+	s.Name = &v
+	return s
 }
 
 // Contains all of the attributes of a specific cache cluster.
@@ -3869,6 +3911,138 @@ func (s CacheCluster) GoString() string {
 	return s.String()
 }
 
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *CacheCluster) SetAutoMinorVersionUpgrade(v bool) *CacheCluster {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetCacheClusterCreateTime sets the CacheClusterCreateTime field's value.
+func (s *CacheCluster) SetCacheClusterCreateTime(v time.Time) *CacheCluster {
+	s.CacheClusterCreateTime = &v
+	return s
+}
+
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *CacheCluster) SetCacheClusterId(v string) *CacheCluster {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetCacheClusterStatus sets the CacheClusterStatus field's value.
+func (s *CacheCluster) SetCacheClusterStatus(v string) *CacheCluster {
+	s.CacheClusterStatus = &v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *CacheCluster) SetCacheNodeType(v string) *CacheCluster {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetCacheNodes sets the CacheNodes field's value.
+func (s *CacheCluster) SetCacheNodes(v []*CacheNode) *CacheCluster {
+	s.CacheNodes = v
+	return s
+}
+
+// SetCacheParameterGroup sets the CacheParameterGroup field's value.
+func (s *CacheCluster) SetCacheParameterGroup(v *CacheParameterGroupStatus) *CacheCluster {
+	s.CacheParameterGroup = v
+	return s
+}
+
+// SetCacheSecurityGroups sets the CacheSecurityGroups field's value.
+func (s *CacheCluster) SetCacheSecurityGroups(v []*CacheSecurityGroupMembership) *CacheCluster {
+	s.CacheSecurityGroups = v
+	return s
+}
+
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *CacheCluster) SetCacheSubnetGroupName(v string) *CacheCluster {
+	s.CacheSubnetGroupName = &v
+	return s
+}
+
+// SetClientDownloadLandingPage sets the ClientDownloadLandingPage field's value.
+func (s *CacheCluster) SetClientDownloadLandingPage(v string) *CacheCluster {
+	s.ClientDownloadLandingPage = &v
+	return s
+}
+
+// SetConfigurationEndpoint sets the ConfigurationEndpoint field's value.
+func (s *CacheCluster) SetConfigurationEndpoint(v *Endpoint) *CacheCluster {
+	s.ConfigurationEndpoint = v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *CacheCluster) SetEngine(v string) *CacheCluster {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *CacheCluster) SetEngineVersion(v string) *CacheCluster {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetNotificationConfiguration sets the NotificationConfiguration field's value.
+func (s *CacheCluster) SetNotificationConfiguration(v *NotificationConfiguration) *CacheCluster {
+	s.NotificationConfiguration = v
+	return s
+}
+
+// SetNumCacheNodes sets the NumCacheNodes field's value.
+func (s *CacheCluster) SetNumCacheNodes(v int64) *CacheCluster {
+	s.NumCacheNodes = &v
+	return s
+}
+
+// SetPendingModifiedValues sets the PendingModifiedValues field's value.
+func (s *CacheCluster) SetPendingModifiedValues(v *PendingModifiedValues) *CacheCluster {
+	s.PendingModifiedValues = v
+	return s
+}
+
+// SetPreferredAvailabilityZone sets the PreferredAvailabilityZone field's value.
+func (s *CacheCluster) SetPreferredAvailabilityZone(v string) *CacheCluster {
+	s.PreferredAvailabilityZone = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *CacheCluster) SetPreferredMaintenanceWindow(v string) *CacheCluster {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *CacheCluster) SetReplicationGroupId(v string) *CacheCluster {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *CacheCluster) SetSecurityGroups(v []*SecurityGroupMembership) *CacheCluster {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSnapshotRetentionLimit sets the SnapshotRetentionLimit field's value.
+func (s *CacheCluster) SetSnapshotRetentionLimit(v int64) *CacheCluster {
+	s.SnapshotRetentionLimit = &v
+	return s
+}
+
+// SetSnapshotWindow sets the SnapshotWindow field's value.
+func (s *CacheCluster) SetSnapshotWindow(v string) *CacheCluster {
+	s.SnapshotWindow = &v
+	return s
+}
+
 // Provides all of the details about a particular cache engine version.
 type CacheEngineVersion struct {
 	_ struct{} `type:"structure"`
@@ -3899,6 +4073,36 @@ func (s CacheEngineVersion) String() string {
 // GoString returns the string representation
 func (s CacheEngineVersion) GoString() string {
 	return s.String()
+}
+
+// SetCacheEngineDescription sets the CacheEngineDescription field's value.
+func (s *CacheEngineVersion) SetCacheEngineDescription(v string) *CacheEngineVersion {
+	s.CacheEngineDescription = &v
+	return s
+}
+
+// SetCacheEngineVersionDescription sets the CacheEngineVersionDescription field's value.
+func (s *CacheEngineVersion) SetCacheEngineVersionDescription(v string) *CacheEngineVersion {
+	s.CacheEngineVersionDescription = &v
+	return s
+}
+
+// SetCacheParameterGroupFamily sets the CacheParameterGroupFamily field's value.
+func (s *CacheEngineVersion) SetCacheParameterGroupFamily(v string) *CacheEngineVersion {
+	s.CacheParameterGroupFamily = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *CacheEngineVersion) SetEngine(v string) *CacheEngineVersion {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *CacheEngineVersion) SetEngineVersion(v string) *CacheEngineVersion {
+	s.EngineVersion = &v
+	return s
 }
 
 // Represents an individual cache node within a cache cluster. Each cache node
@@ -3980,6 +4184,48 @@ func (s CacheNode) GoString() string {
 	return s.String()
 }
 
+// SetCacheNodeCreateTime sets the CacheNodeCreateTime field's value.
+func (s *CacheNode) SetCacheNodeCreateTime(v time.Time) *CacheNode {
+	s.CacheNodeCreateTime = &v
+	return s
+}
+
+// SetCacheNodeId sets the CacheNodeId field's value.
+func (s *CacheNode) SetCacheNodeId(v string) *CacheNode {
+	s.CacheNodeId = &v
+	return s
+}
+
+// SetCacheNodeStatus sets the CacheNodeStatus field's value.
+func (s *CacheNode) SetCacheNodeStatus(v string) *CacheNode {
+	s.CacheNodeStatus = &v
+	return s
+}
+
+// SetCustomerAvailabilityZone sets the CustomerAvailabilityZone field's value.
+func (s *CacheNode) SetCustomerAvailabilityZone(v string) *CacheNode {
+	s.CustomerAvailabilityZone = &v
+	return s
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *CacheNode) SetEndpoint(v *Endpoint) *CacheNode {
+	s.Endpoint = v
+	return s
+}
+
+// SetParameterGroupStatus sets the ParameterGroupStatus field's value.
+func (s *CacheNode) SetParameterGroupStatus(v string) *CacheNode {
+	s.ParameterGroupStatus = &v
+	return s
+}
+
+// SetSourceCacheNodeId sets the SourceCacheNodeId field's value.
+func (s *CacheNode) SetSourceCacheNodeId(v string) *CacheNode {
+	s.SourceCacheNodeId = &v
+	return s
+}
+
 // A parameter that has a different value for each cache node type it is applied
 // to. For example, in a Redis cache cluster, a cache.m1.large cache node type
 // would have a larger maxmemory value than a cache.m1.small type.
@@ -4029,6 +4275,60 @@ func (s CacheNodeTypeSpecificParameter) GoString() string {
 	return s.String()
 }
 
+// SetAllowedValues sets the AllowedValues field's value.
+func (s *CacheNodeTypeSpecificParameter) SetAllowedValues(v string) *CacheNodeTypeSpecificParameter {
+	s.AllowedValues = &v
+	return s
+}
+
+// SetCacheNodeTypeSpecificValues sets the CacheNodeTypeSpecificValues field's value.
+func (s *CacheNodeTypeSpecificParameter) SetCacheNodeTypeSpecificValues(v []*CacheNodeTypeSpecificValue) *CacheNodeTypeSpecificParameter {
+	s.CacheNodeTypeSpecificValues = v
+	return s
+}
+
+// SetChangeType sets the ChangeType field's value.
+func (s *CacheNodeTypeSpecificParameter) SetChangeType(v string) *CacheNodeTypeSpecificParameter {
+	s.ChangeType = &v
+	return s
+}
+
+// SetDataType sets the DataType field's value.
+func (s *CacheNodeTypeSpecificParameter) SetDataType(v string) *CacheNodeTypeSpecificParameter {
+	s.DataType = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CacheNodeTypeSpecificParameter) SetDescription(v string) *CacheNodeTypeSpecificParameter {
+	s.Description = &v
+	return s
+}
+
+// SetIsModifiable sets the IsModifiable field's value.
+func (s *CacheNodeTypeSpecificParameter) SetIsModifiable(v bool) *CacheNodeTypeSpecificParameter {
+	s.IsModifiable = &v
+	return s
+}
+
+// SetMinimumEngineVersion sets the MinimumEngineVersion field's value.
+func (s *CacheNodeTypeSpecificParameter) SetMinimumEngineVersion(v string) *CacheNodeTypeSpecificParameter {
+	s.MinimumEngineVersion = &v
+	return s
+}
+
+// SetParameterName sets the ParameterName field's value.
+func (s *CacheNodeTypeSpecificParameter) SetParameterName(v string) *CacheNodeTypeSpecificParameter {
+	s.ParameterName = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *CacheNodeTypeSpecificParameter) SetSource(v string) *CacheNodeTypeSpecificParameter {
+	s.Source = &v
+	return s
+}
+
 // A value that applies only to a certain cache node type.
 type CacheNodeTypeSpecificValue struct {
 	_ struct{} `type:"structure"`
@@ -4048,6 +4348,18 @@ func (s CacheNodeTypeSpecificValue) String() string {
 // GoString returns the string representation
 func (s CacheNodeTypeSpecificValue) GoString() string {
 	return s.String()
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *CacheNodeTypeSpecificValue) SetCacheNodeType(v string) *CacheNodeTypeSpecificValue {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *CacheNodeTypeSpecificValue) SetValue(v string) *CacheNodeTypeSpecificValue {
+	s.Value = &v
+	return s
 }
 
 // Represents the output of a CreateCacheParameterGroup operation.
@@ -4077,6 +4389,24 @@ func (s CacheParameterGroup) GoString() string {
 	return s.String()
 }
 
+// SetCacheParameterGroupFamily sets the CacheParameterGroupFamily field's value.
+func (s *CacheParameterGroup) SetCacheParameterGroupFamily(v string) *CacheParameterGroup {
+	s.CacheParameterGroupFamily = &v
+	return s
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *CacheParameterGroup) SetCacheParameterGroupName(v string) *CacheParameterGroup {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CacheParameterGroup) SetDescription(v string) *CacheParameterGroup {
+	s.Description = &v
+	return s
+}
+
 // Represents the output of one of the following operations:
 //
 //    * ModifyCacheParameterGroup
@@ -4097,6 +4427,12 @@ func (s CacheParameterGroupNameMessage) String() string {
 // GoString returns the string representation
 func (s CacheParameterGroupNameMessage) GoString() string {
 	return s.String()
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *CacheParameterGroupNameMessage) SetCacheParameterGroupName(v string) *CacheParameterGroupNameMessage {
+	s.CacheParameterGroupName = &v
+	return s
 }
 
 // Status of the cache parameter group.
@@ -4122,6 +4458,24 @@ func (s CacheParameterGroupStatus) String() string {
 // GoString returns the string representation
 func (s CacheParameterGroupStatus) GoString() string {
 	return s.String()
+}
+
+// SetCacheNodeIdsToReboot sets the CacheNodeIdsToReboot field's value.
+func (s *CacheParameterGroupStatus) SetCacheNodeIdsToReboot(v []*string) *CacheParameterGroupStatus {
+	s.CacheNodeIdsToReboot = v
+	return s
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *CacheParameterGroupStatus) SetCacheParameterGroupName(v string) *CacheParameterGroupStatus {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetParameterApplyStatus sets the ParameterApplyStatus field's value.
+func (s *CacheParameterGroupStatus) SetParameterApplyStatus(v string) *CacheParameterGroupStatus {
+	s.ParameterApplyStatus = &v
+	return s
 }
 
 // Represents the output of one of the following operations:
@@ -4158,6 +4512,30 @@ func (s CacheSecurityGroup) GoString() string {
 	return s.String()
 }
 
+// SetCacheSecurityGroupName sets the CacheSecurityGroupName field's value.
+func (s *CacheSecurityGroup) SetCacheSecurityGroupName(v string) *CacheSecurityGroup {
+	s.CacheSecurityGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CacheSecurityGroup) SetDescription(v string) *CacheSecurityGroup {
+	s.Description = &v
+	return s
+}
+
+// SetEC2SecurityGroups sets the EC2SecurityGroups field's value.
+func (s *CacheSecurityGroup) SetEC2SecurityGroups(v []*EC2SecurityGroup) *CacheSecurityGroup {
+	s.EC2SecurityGroups = v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *CacheSecurityGroup) SetOwnerId(v string) *CacheSecurityGroup {
+	s.OwnerId = &v
+	return s
+}
+
 // Represents a cache cluster's status within a particular cache security group.
 type CacheSecurityGroupMembership struct {
 	_ struct{} `type:"structure"`
@@ -4179,6 +4557,18 @@ func (s CacheSecurityGroupMembership) String() string {
 // GoString returns the string representation
 func (s CacheSecurityGroupMembership) GoString() string {
 	return s.String()
+}
+
+// SetCacheSecurityGroupName sets the CacheSecurityGroupName field's value.
+func (s *CacheSecurityGroupMembership) SetCacheSecurityGroupName(v string) *CacheSecurityGroupMembership {
+	s.CacheSecurityGroupName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CacheSecurityGroupMembership) SetStatus(v string) *CacheSecurityGroupMembership {
+	s.Status = &v
+	return s
 }
 
 // Represents the output of one of the following operations:
@@ -4211,6 +4601,30 @@ func (s CacheSubnetGroup) String() string {
 // GoString returns the string representation
 func (s CacheSubnetGroup) GoString() string {
 	return s.String()
+}
+
+// SetCacheSubnetGroupDescription sets the CacheSubnetGroupDescription field's value.
+func (s *CacheSubnetGroup) SetCacheSubnetGroupDescription(v string) *CacheSubnetGroup {
+	s.CacheSubnetGroupDescription = &v
+	return s
+}
+
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *CacheSubnetGroup) SetCacheSubnetGroupName(v string) *CacheSubnetGroup {
+	s.CacheSubnetGroupName = &v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *CacheSubnetGroup) SetSubnets(v []*Subnet) *CacheSubnetGroup {
+	s.Subnets = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CacheSubnetGroup) SetVpcId(v string) *CacheSubnetGroup {
+	s.VpcId = &v
+	return s
 }
 
 // Represents the input of a CopySnapshotMessage operation.
@@ -4268,6 +4682,24 @@ func (s *CopySnapshotInput) Validate() error {
 	return nil
 }
 
+// SetSourceSnapshotName sets the SourceSnapshotName field's value.
+func (s *CopySnapshotInput) SetSourceSnapshotName(v string) *CopySnapshotInput {
+	s.SourceSnapshotName = &v
+	return s
+}
+
+// SetTargetBucket sets the TargetBucket field's value.
+func (s *CopySnapshotInput) SetTargetBucket(v string) *CopySnapshotInput {
+	s.TargetBucket = &v
+	return s
+}
+
+// SetTargetSnapshotName sets the TargetSnapshotName field's value.
+func (s *CopySnapshotInput) SetTargetSnapshotName(v string) *CopySnapshotInput {
+	s.TargetSnapshotName = &v
+	return s
+}
+
 type CopySnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4284,6 +4716,12 @@ func (s CopySnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CopySnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshot sets the Snapshot field's value.
+func (s *CopySnapshotOutput) SetSnapshot(v *Snapshot) *CopySnapshotOutput {
+	s.Snapshot = v
+	return s
 }
 
 // Represents the input of a CreateCacheCluster operation.
@@ -4555,6 +4993,138 @@ func (s *CreateCacheClusterInput) Validate() error {
 	return nil
 }
 
+// SetAZMode sets the AZMode field's value.
+func (s *CreateCacheClusterInput) SetAZMode(v string) *CreateCacheClusterInput {
+	s.AZMode = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *CreateCacheClusterInput) SetAutoMinorVersionUpgrade(v bool) *CreateCacheClusterInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *CreateCacheClusterInput) SetCacheClusterId(v string) *CreateCacheClusterInput {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *CreateCacheClusterInput) SetCacheNodeType(v string) *CreateCacheClusterInput {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *CreateCacheClusterInput) SetCacheParameterGroupName(v string) *CreateCacheClusterInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetCacheSecurityGroupNames sets the CacheSecurityGroupNames field's value.
+func (s *CreateCacheClusterInput) SetCacheSecurityGroupNames(v []*string) *CreateCacheClusterInput {
+	s.CacheSecurityGroupNames = v
+	return s
+}
+
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *CreateCacheClusterInput) SetCacheSubnetGroupName(v string) *CreateCacheClusterInput {
+	s.CacheSubnetGroupName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *CreateCacheClusterInput) SetEngine(v string) *CreateCacheClusterInput {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *CreateCacheClusterInput) SetEngineVersion(v string) *CreateCacheClusterInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetNotificationTopicArn sets the NotificationTopicArn field's value.
+func (s *CreateCacheClusterInput) SetNotificationTopicArn(v string) *CreateCacheClusterInput {
+	s.NotificationTopicArn = &v
+	return s
+}
+
+// SetNumCacheNodes sets the NumCacheNodes field's value.
+func (s *CreateCacheClusterInput) SetNumCacheNodes(v int64) *CreateCacheClusterInput {
+	s.NumCacheNodes = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateCacheClusterInput) SetPort(v int64) *CreateCacheClusterInput {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredAvailabilityZone sets the PreferredAvailabilityZone field's value.
+func (s *CreateCacheClusterInput) SetPreferredAvailabilityZone(v string) *CreateCacheClusterInput {
+	s.PreferredAvailabilityZone = &v
+	return s
+}
+
+// SetPreferredAvailabilityZones sets the PreferredAvailabilityZones field's value.
+func (s *CreateCacheClusterInput) SetPreferredAvailabilityZones(v []*string) *CreateCacheClusterInput {
+	s.PreferredAvailabilityZones = v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *CreateCacheClusterInput) SetPreferredMaintenanceWindow(v string) *CreateCacheClusterInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *CreateCacheClusterInput) SetReplicationGroupId(v string) *CreateCacheClusterInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *CreateCacheClusterInput) SetSecurityGroupIds(v []*string) *CreateCacheClusterInput {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSnapshotArns sets the SnapshotArns field's value.
+func (s *CreateCacheClusterInput) SetSnapshotArns(v []*string) *CreateCacheClusterInput {
+	s.SnapshotArns = v
+	return s
+}
+
+// SetSnapshotName sets the SnapshotName field's value.
+func (s *CreateCacheClusterInput) SetSnapshotName(v string) *CreateCacheClusterInput {
+	s.SnapshotName = &v
+	return s
+}
+
+// SetSnapshotRetentionLimit sets the SnapshotRetentionLimit field's value.
+func (s *CreateCacheClusterInput) SetSnapshotRetentionLimit(v int64) *CreateCacheClusterInput {
+	s.SnapshotRetentionLimit = &v
+	return s
+}
+
+// SetSnapshotWindow sets the SnapshotWindow field's value.
+func (s *CreateCacheClusterInput) SetSnapshotWindow(v string) *CreateCacheClusterInput {
+	s.SnapshotWindow = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateCacheClusterInput) SetTags(v []*Tag) *CreateCacheClusterInput {
+	s.Tags = v
+	return s
+}
+
 type CreateCacheClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4570,6 +5140,12 @@ func (s CreateCacheClusterOutput) String() string {
 // GoString returns the string representation
 func (s CreateCacheClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheCluster sets the CacheCluster field's value.
+func (s *CreateCacheClusterOutput) SetCacheCluster(v *CacheCluster) *CreateCacheClusterOutput {
+	s.CacheCluster = v
+	return s
 }
 
 // Represents the input of a CreateCacheParameterGroup operation.
@@ -4624,6 +5200,24 @@ func (s *CreateCacheParameterGroupInput) Validate() error {
 	return nil
 }
 
+// SetCacheParameterGroupFamily sets the CacheParameterGroupFamily field's value.
+func (s *CreateCacheParameterGroupInput) SetCacheParameterGroupFamily(v string) *CreateCacheParameterGroupInput {
+	s.CacheParameterGroupFamily = &v
+	return s
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *CreateCacheParameterGroupInput) SetCacheParameterGroupName(v string) *CreateCacheParameterGroupInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateCacheParameterGroupInput) SetDescription(v string) *CreateCacheParameterGroupInput {
+	s.Description = &v
+	return s
+}
+
 type CreateCacheParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4639,6 +5233,12 @@ func (s CreateCacheParameterGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateCacheParameterGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheParameterGroup sets the CacheParameterGroup field's value.
+func (s *CreateCacheParameterGroupOutput) SetCacheParameterGroup(v *CacheParameterGroup) *CreateCacheParameterGroupOutput {
+	s.CacheParameterGroup = v
+	return s
 }
 
 // Represents the input of a CreateCacheSecurityGroup operation.
@@ -4688,6 +5288,18 @@ func (s *CreateCacheSecurityGroupInput) Validate() error {
 	return nil
 }
 
+// SetCacheSecurityGroupName sets the CacheSecurityGroupName field's value.
+func (s *CreateCacheSecurityGroupInput) SetCacheSecurityGroupName(v string) *CreateCacheSecurityGroupInput {
+	s.CacheSecurityGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateCacheSecurityGroupInput) SetDescription(v string) *CreateCacheSecurityGroupInput {
+	s.Description = &v
+	return s
+}
+
 type CreateCacheSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4709,6 +5321,12 @@ func (s CreateCacheSecurityGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateCacheSecurityGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheSecurityGroup sets the CacheSecurityGroup field's value.
+func (s *CreateCacheSecurityGroupOutput) SetCacheSecurityGroup(v *CacheSecurityGroup) *CreateCacheSecurityGroupOutput {
+	s.CacheSecurityGroup = v
+	return s
 }
 
 // Represents the input of a CreateCacheSubnetGroup operation.
@@ -4764,6 +5382,24 @@ func (s *CreateCacheSubnetGroupInput) Validate() error {
 	return nil
 }
 
+// SetCacheSubnetGroupDescription sets the CacheSubnetGroupDescription field's value.
+func (s *CreateCacheSubnetGroupInput) SetCacheSubnetGroupDescription(v string) *CreateCacheSubnetGroupInput {
+	s.CacheSubnetGroupDescription = &v
+	return s
+}
+
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *CreateCacheSubnetGroupInput) SetCacheSubnetGroupName(v string) *CreateCacheSubnetGroupInput {
+	s.CacheSubnetGroupName = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *CreateCacheSubnetGroupInput) SetSubnetIds(v []*string) *CreateCacheSubnetGroupInput {
+	s.SubnetIds = v
+	return s
+}
+
 type CreateCacheSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4783,6 +5419,12 @@ func (s CreateCacheSubnetGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateCacheSubnetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheSubnetGroup sets the CacheSubnetGroup field's value.
+func (s *CreateCacheSubnetGroupOutput) SetCacheSubnetGroup(v *CacheSubnetGroup) *CreateCacheSubnetGroupOutput {
+	s.CacheSubnetGroup = v
+	return s
 }
 
 // Represents the input of a CreateReplicationGroup operation.
@@ -5079,6 +5721,156 @@ func (s *CreateReplicationGroupInput) Validate() error {
 	return nil
 }
 
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *CreateReplicationGroupInput) SetAutoMinorVersionUpgrade(v bool) *CreateReplicationGroupInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAutomaticFailoverEnabled sets the AutomaticFailoverEnabled field's value.
+func (s *CreateReplicationGroupInput) SetAutomaticFailoverEnabled(v bool) *CreateReplicationGroupInput {
+	s.AutomaticFailoverEnabled = &v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *CreateReplicationGroupInput) SetCacheNodeType(v string) *CreateReplicationGroupInput {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *CreateReplicationGroupInput) SetCacheParameterGroupName(v string) *CreateReplicationGroupInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetCacheSecurityGroupNames sets the CacheSecurityGroupNames field's value.
+func (s *CreateReplicationGroupInput) SetCacheSecurityGroupNames(v []*string) *CreateReplicationGroupInput {
+	s.CacheSecurityGroupNames = v
+	return s
+}
+
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *CreateReplicationGroupInput) SetCacheSubnetGroupName(v string) *CreateReplicationGroupInput {
+	s.CacheSubnetGroupName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *CreateReplicationGroupInput) SetEngine(v string) *CreateReplicationGroupInput {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *CreateReplicationGroupInput) SetEngineVersion(v string) *CreateReplicationGroupInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetNodeGroupConfiguration sets the NodeGroupConfiguration field's value.
+func (s *CreateReplicationGroupInput) SetNodeGroupConfiguration(v []*NodeGroupConfiguration) *CreateReplicationGroupInput {
+	s.NodeGroupConfiguration = v
+	return s
+}
+
+// SetNotificationTopicArn sets the NotificationTopicArn field's value.
+func (s *CreateReplicationGroupInput) SetNotificationTopicArn(v string) *CreateReplicationGroupInput {
+	s.NotificationTopicArn = &v
+	return s
+}
+
+// SetNumCacheClusters sets the NumCacheClusters field's value.
+func (s *CreateReplicationGroupInput) SetNumCacheClusters(v int64) *CreateReplicationGroupInput {
+	s.NumCacheClusters = &v
+	return s
+}
+
+// SetNumNodeGroups sets the NumNodeGroups field's value.
+func (s *CreateReplicationGroupInput) SetNumNodeGroups(v int64) *CreateReplicationGroupInput {
+	s.NumNodeGroups = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateReplicationGroupInput) SetPort(v int64) *CreateReplicationGroupInput {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredCacheClusterAZs sets the PreferredCacheClusterAZs field's value.
+func (s *CreateReplicationGroupInput) SetPreferredCacheClusterAZs(v []*string) *CreateReplicationGroupInput {
+	s.PreferredCacheClusterAZs = v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *CreateReplicationGroupInput) SetPreferredMaintenanceWindow(v string) *CreateReplicationGroupInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPrimaryClusterId sets the PrimaryClusterId field's value.
+func (s *CreateReplicationGroupInput) SetPrimaryClusterId(v string) *CreateReplicationGroupInput {
+	s.PrimaryClusterId = &v
+	return s
+}
+
+// SetReplicasPerNodeGroup sets the ReplicasPerNodeGroup field's value.
+func (s *CreateReplicationGroupInput) SetReplicasPerNodeGroup(v int64) *CreateReplicationGroupInput {
+	s.ReplicasPerNodeGroup = &v
+	return s
+}
+
+// SetReplicationGroupDescription sets the ReplicationGroupDescription field's value.
+func (s *CreateReplicationGroupInput) SetReplicationGroupDescription(v string) *CreateReplicationGroupInput {
+	s.ReplicationGroupDescription = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *CreateReplicationGroupInput) SetReplicationGroupId(v string) *CreateReplicationGroupInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *CreateReplicationGroupInput) SetSecurityGroupIds(v []*string) *CreateReplicationGroupInput {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSnapshotArns sets the SnapshotArns field's value.
+func (s *CreateReplicationGroupInput) SetSnapshotArns(v []*string) *CreateReplicationGroupInput {
+	s.SnapshotArns = v
+	return s
+}
+
+// SetSnapshotName sets the SnapshotName field's value.
+func (s *CreateReplicationGroupInput) SetSnapshotName(v string) *CreateReplicationGroupInput {
+	s.SnapshotName = &v
+	return s
+}
+
+// SetSnapshotRetentionLimit sets the SnapshotRetentionLimit field's value.
+func (s *CreateReplicationGroupInput) SetSnapshotRetentionLimit(v int64) *CreateReplicationGroupInput {
+	s.SnapshotRetentionLimit = &v
+	return s
+}
+
+// SetSnapshotWindow sets the SnapshotWindow field's value.
+func (s *CreateReplicationGroupInput) SetSnapshotWindow(v string) *CreateReplicationGroupInput {
+	s.SnapshotWindow = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateReplicationGroupInput) SetTags(v []*Tag) *CreateReplicationGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateReplicationGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5094,6 +5886,12 @@ func (s CreateReplicationGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateReplicationGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationGroup sets the ReplicationGroup field's value.
+func (s *CreateReplicationGroupOutput) SetReplicationGroup(v *ReplicationGroup) *CreateReplicationGroupOutput {
+	s.ReplicationGroup = v
+	return s
 }
 
 // Represents the input of a CreateSnapshot operation.
@@ -5137,6 +5935,24 @@ func (s *CreateSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *CreateSnapshotInput) SetCacheClusterId(v string) *CreateSnapshotInput {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *CreateSnapshotInput) SetReplicationGroupId(v string) *CreateSnapshotInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetSnapshotName sets the SnapshotName field's value.
+func (s *CreateSnapshotInput) SetSnapshotName(v string) *CreateSnapshotInput {
+	s.SnapshotName = &v
+	return s
+}
+
 type CreateSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5153,6 +5969,12 @@ func (s CreateSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshot sets the Snapshot field's value.
+func (s *CreateSnapshotOutput) SetSnapshot(v *Snapshot) *CreateSnapshotOutput {
+	s.Snapshot = v
+	return s
 }
 
 // Represents the input of a DeleteCacheCluster operation.
@@ -5194,6 +6016,18 @@ func (s *DeleteCacheClusterInput) Validate() error {
 	return nil
 }
 
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *DeleteCacheClusterInput) SetCacheClusterId(v string) *DeleteCacheClusterInput {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetFinalSnapshotIdentifier sets the FinalSnapshotIdentifier field's value.
+func (s *DeleteCacheClusterInput) SetFinalSnapshotIdentifier(v string) *DeleteCacheClusterInput {
+	s.FinalSnapshotIdentifier = &v
+	return s
+}
+
 type DeleteCacheClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5209,6 +6043,12 @@ func (s DeleteCacheClusterOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCacheClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheCluster sets the CacheCluster field's value.
+func (s *DeleteCacheClusterOutput) SetCacheCluster(v *CacheCluster) *DeleteCacheClusterOutput {
+	s.CacheCluster = v
+	return s
 }
 
 // Represents the input of a DeleteCacheParameterGroup operation.
@@ -5245,6 +6085,12 @@ func (s *DeleteCacheParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *DeleteCacheParameterGroupInput) SetCacheParameterGroupName(v string) *DeleteCacheParameterGroupInput {
+	s.CacheParameterGroupName = &v
+	return s
 }
 
 type DeleteCacheParameterGroupOutput struct {
@@ -5296,6 +6142,12 @@ func (s *DeleteCacheSecurityGroupInput) Validate() error {
 	return nil
 }
 
+// SetCacheSecurityGroupName sets the CacheSecurityGroupName field's value.
+func (s *DeleteCacheSecurityGroupInput) SetCacheSecurityGroupName(v string) *DeleteCacheSecurityGroupInput {
+	s.CacheSecurityGroupName = &v
+	return s
+}
+
 type DeleteCacheSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5343,6 +6195,12 @@ func (s *DeleteCacheSubnetGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *DeleteCacheSubnetGroupInput) SetCacheSubnetGroupName(v string) *DeleteCacheSubnetGroupInput {
+	s.CacheSubnetGroupName = &v
+	return s
 }
 
 type DeleteCacheSubnetGroupOutput struct {
@@ -5403,6 +6261,24 @@ func (s *DeleteReplicationGroupInput) Validate() error {
 	return nil
 }
 
+// SetFinalSnapshotIdentifier sets the FinalSnapshotIdentifier field's value.
+func (s *DeleteReplicationGroupInput) SetFinalSnapshotIdentifier(v string) *DeleteReplicationGroupInput {
+	s.FinalSnapshotIdentifier = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *DeleteReplicationGroupInput) SetReplicationGroupId(v string) *DeleteReplicationGroupInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetRetainPrimaryCluster sets the RetainPrimaryCluster field's value.
+func (s *DeleteReplicationGroupInput) SetRetainPrimaryCluster(v bool) *DeleteReplicationGroupInput {
+	s.RetainPrimaryCluster = &v
+	return s
+}
+
 type DeleteReplicationGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5418,6 +6294,12 @@ func (s DeleteReplicationGroupOutput) String() string {
 // GoString returns the string representation
 func (s DeleteReplicationGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationGroup sets the ReplicationGroup field's value.
+func (s *DeleteReplicationGroupOutput) SetReplicationGroup(v *ReplicationGroup) *DeleteReplicationGroupOutput {
+	s.ReplicationGroup = v
+	return s
 }
 
 // Represents the input of a DeleteSnapshot operation.
@@ -5453,6 +6335,12 @@ func (s *DeleteSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetSnapshotName sets the SnapshotName field's value.
+func (s *DeleteSnapshotInput) SetSnapshotName(v string) *DeleteSnapshotInput {
+	s.SnapshotName = &v
+	return s
+}
+
 type DeleteSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5469,6 +6357,12 @@ func (s DeleteSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshot sets the Snapshot field's value.
+func (s *DeleteSnapshotOutput) SetSnapshot(v *Snapshot) *DeleteSnapshotOutput {
+	s.Snapshot = v
+	return s
 }
 
 // Represents the input of a DescribeCacheClusters operation.
@@ -5509,6 +6403,30 @@ func (s DescribeCacheClustersInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *DescribeCacheClustersInput) SetCacheClusterId(v string) *DescribeCacheClustersInput {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheClustersInput) SetMarker(v string) *DescribeCacheClustersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeCacheClustersInput) SetMaxRecords(v int64) *DescribeCacheClustersInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetShowCacheNodeInfo sets the ShowCacheNodeInfo field's value.
+func (s *DescribeCacheClustersInput) SetShowCacheNodeInfo(v bool) *DescribeCacheClustersInput {
+	s.ShowCacheNodeInfo = &v
+	return s
+}
+
 // Represents the output of a DescribeCacheClusters operation.
 type DescribeCacheClustersOutput struct {
 	_ struct{} `type:"structure"`
@@ -5529,6 +6447,18 @@ func (s DescribeCacheClustersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCacheClustersOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheClusters sets the CacheClusters field's value.
+func (s *DescribeCacheClustersOutput) SetCacheClusters(v []*CacheCluster) *DescribeCacheClustersOutput {
+	s.CacheClusters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheClustersOutput) SetMarker(v string) *DescribeCacheClustersOutput {
+	s.Marker = &v
+	return s
 }
 
 // Represents the input of a DescribeCacheEngineVersions operation.
@@ -5585,6 +6515,42 @@ func (s DescribeCacheEngineVersionsInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheParameterGroupFamily sets the CacheParameterGroupFamily field's value.
+func (s *DescribeCacheEngineVersionsInput) SetCacheParameterGroupFamily(v string) *DescribeCacheEngineVersionsInput {
+	s.CacheParameterGroupFamily = &v
+	return s
+}
+
+// SetDefaultOnly sets the DefaultOnly field's value.
+func (s *DescribeCacheEngineVersionsInput) SetDefaultOnly(v bool) *DescribeCacheEngineVersionsInput {
+	s.DefaultOnly = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *DescribeCacheEngineVersionsInput) SetEngine(v string) *DescribeCacheEngineVersionsInput {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *DescribeCacheEngineVersionsInput) SetEngineVersion(v string) *DescribeCacheEngineVersionsInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheEngineVersionsInput) SetMarker(v string) *DescribeCacheEngineVersionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeCacheEngineVersionsInput) SetMaxRecords(v int64) *DescribeCacheEngineVersionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Represents the output of a DescribeCacheEngineVersions operation.
 type DescribeCacheEngineVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5605,6 +6571,18 @@ func (s DescribeCacheEngineVersionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCacheEngineVersionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheEngineVersions sets the CacheEngineVersions field's value.
+func (s *DescribeCacheEngineVersionsOutput) SetCacheEngineVersions(v []*CacheEngineVersion) *DescribeCacheEngineVersionsOutput {
+	s.CacheEngineVersions = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheEngineVersionsOutput) SetMarker(v string) *DescribeCacheEngineVersionsOutput {
+	s.Marker = &v
+	return s
 }
 
 // Represents the input of a DescribeCacheParameterGroups operation.
@@ -5639,6 +6617,24 @@ func (s DescribeCacheParameterGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *DescribeCacheParameterGroupsInput) SetCacheParameterGroupName(v string) *DescribeCacheParameterGroupsInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheParameterGroupsInput) SetMarker(v string) *DescribeCacheParameterGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeCacheParameterGroupsInput) SetMaxRecords(v int64) *DescribeCacheParameterGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Represents the output of a DescribeCacheParameterGroups operation.
 type DescribeCacheParameterGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5659,6 +6655,18 @@ func (s DescribeCacheParameterGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCacheParameterGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheParameterGroups sets the CacheParameterGroups field's value.
+func (s *DescribeCacheParameterGroupsOutput) SetCacheParameterGroups(v []*CacheParameterGroup) *DescribeCacheParameterGroupsOutput {
+	s.CacheParameterGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheParameterGroupsOutput) SetMarker(v string) *DescribeCacheParameterGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 // Represents the input of a DescribeCacheParameters operation.
@@ -5713,6 +6721,30 @@ func (s *DescribeCacheParametersInput) Validate() error {
 	return nil
 }
 
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *DescribeCacheParametersInput) SetCacheParameterGroupName(v string) *DescribeCacheParametersInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheParametersInput) SetMarker(v string) *DescribeCacheParametersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeCacheParametersInput) SetMaxRecords(v int64) *DescribeCacheParametersInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *DescribeCacheParametersInput) SetSource(v string) *DescribeCacheParametersInput {
+	s.Source = &v
+	return s
+}
+
 // Represents the output of a DescribeCacheParameters operation.
 type DescribeCacheParametersOutput struct {
 	_ struct{} `type:"structure"`
@@ -5736,6 +6768,24 @@ func (s DescribeCacheParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCacheParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheNodeTypeSpecificParameters sets the CacheNodeTypeSpecificParameters field's value.
+func (s *DescribeCacheParametersOutput) SetCacheNodeTypeSpecificParameters(v []*CacheNodeTypeSpecificParameter) *DescribeCacheParametersOutput {
+	s.CacheNodeTypeSpecificParameters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheParametersOutput) SetMarker(v string) *DescribeCacheParametersOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *DescribeCacheParametersOutput) SetParameters(v []*Parameter) *DescribeCacheParametersOutput {
+	s.Parameters = v
+	return s
 }
 
 // Represents the input of a DescribeCacheSecurityGroups operation.
@@ -5770,6 +6820,24 @@ func (s DescribeCacheSecurityGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheSecurityGroupName sets the CacheSecurityGroupName field's value.
+func (s *DescribeCacheSecurityGroupsInput) SetCacheSecurityGroupName(v string) *DescribeCacheSecurityGroupsInput {
+	s.CacheSecurityGroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheSecurityGroupsInput) SetMarker(v string) *DescribeCacheSecurityGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeCacheSecurityGroupsInput) SetMaxRecords(v int64) *DescribeCacheSecurityGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Represents the output of a DescribeCacheSecurityGroups operation.
 type DescribeCacheSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5790,6 +6858,18 @@ func (s DescribeCacheSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCacheSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheSecurityGroups sets the CacheSecurityGroups field's value.
+func (s *DescribeCacheSecurityGroupsOutput) SetCacheSecurityGroups(v []*CacheSecurityGroup) *DescribeCacheSecurityGroupsOutput {
+	s.CacheSecurityGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheSecurityGroupsOutput) SetMarker(v string) *DescribeCacheSecurityGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 // Represents the input of a DescribeCacheSubnetGroups operation.
@@ -5824,6 +6904,24 @@ func (s DescribeCacheSubnetGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *DescribeCacheSubnetGroupsInput) SetCacheSubnetGroupName(v string) *DescribeCacheSubnetGroupsInput {
+	s.CacheSubnetGroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheSubnetGroupsInput) SetMarker(v string) *DescribeCacheSubnetGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeCacheSubnetGroupsInput) SetMaxRecords(v int64) *DescribeCacheSubnetGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Represents the output of a DescribeCacheSubnetGroups operation.
 type DescribeCacheSubnetGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5844,6 +6942,18 @@ func (s DescribeCacheSubnetGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCacheSubnetGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheSubnetGroups sets the CacheSubnetGroups field's value.
+func (s *DescribeCacheSubnetGroupsOutput) SetCacheSubnetGroups(v []*CacheSubnetGroup) *DescribeCacheSubnetGroupsOutput {
+	s.CacheSubnetGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCacheSubnetGroupsOutput) SetMarker(v string) *DescribeCacheSubnetGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 // Represents the input of a DescribeEngineDefaultParameters operation.
@@ -5895,6 +7005,24 @@ func (s *DescribeEngineDefaultParametersInput) Validate() error {
 	return nil
 }
 
+// SetCacheParameterGroupFamily sets the CacheParameterGroupFamily field's value.
+func (s *DescribeEngineDefaultParametersInput) SetCacheParameterGroupFamily(v string) *DescribeEngineDefaultParametersInput {
+	s.CacheParameterGroupFamily = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEngineDefaultParametersInput) SetMarker(v string) *DescribeEngineDefaultParametersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEngineDefaultParametersInput) SetMaxRecords(v int64) *DescribeEngineDefaultParametersInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeEngineDefaultParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5910,6 +7038,12 @@ func (s DescribeEngineDefaultParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEngineDefaultParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetEngineDefaults sets the EngineDefaults field's value.
+func (s *DescribeEngineDefaultParametersOutput) SetEngineDefaults(v *EngineDefaults) *DescribeEngineDefaultParametersOutput {
+	s.EngineDefaults = v
+	return s
 }
 
 // Represents the input of a DescribeEvents operation.
@@ -5960,6 +7094,48 @@ func (s DescribeEventsInput) GoString() string {
 	return s.String()
 }
 
+// SetDuration sets the Duration field's value.
+func (s *DescribeEventsInput) SetDuration(v int64) *DescribeEventsInput {
+	s.Duration = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeEventsInput) SetEndTime(v time.Time) *DescribeEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventsInput) SetMarker(v string) *DescribeEventsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEventsInput) SetMaxRecords(v int64) *DescribeEventsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *DescribeEventsInput) SetSourceIdentifier(v string) *DescribeEventsInput {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *DescribeEventsInput) SetSourceType(v string) *DescribeEventsInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeEventsInput) SetStartTime(v time.Time) *DescribeEventsInput {
+	s.StartTime = &v
+	return s
+}
+
 // Represents the output of a DescribeEvents operation.
 type DescribeEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5980,6 +7156,18 @@ func (s DescribeEventsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *DescribeEventsOutput) SetEvents(v []*Event) *DescribeEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventsOutput) SetMarker(v string) *DescribeEventsOutput {
+	s.Marker = &v
+	return s
 }
 
 // Represents the input of a DescribeReplicationGroups operation.
@@ -6018,6 +7206,24 @@ func (s DescribeReplicationGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationGroupsInput) SetMarker(v string) *DescribeReplicationGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReplicationGroupsInput) SetMaxRecords(v int64) *DescribeReplicationGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *DescribeReplicationGroupsInput) SetReplicationGroupId(v string) *DescribeReplicationGroupsInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
 // Represents the output of a DescribeReplicationGroups operation.
 type DescribeReplicationGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6038,6 +7244,18 @@ func (s DescribeReplicationGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReplicationGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationGroupsOutput) SetMarker(v string) *DescribeReplicationGroupsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReplicationGroups sets the ReplicationGroups field's value.
+func (s *DescribeReplicationGroupsOutput) SetReplicationGroups(v []*ReplicationGroup) *DescribeReplicationGroupsOutput {
+	s.ReplicationGroups = v
+	return s
 }
 
 // Represents the input of a DescribeReservedCacheNodes operation.
@@ -6134,6 +7352,54 @@ func (s DescribeReservedCacheNodesInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *DescribeReservedCacheNodesInput) SetCacheNodeType(v string) *DescribeReservedCacheNodesInput {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *DescribeReservedCacheNodesInput) SetDuration(v string) *DescribeReservedCacheNodesInput {
+	s.Duration = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedCacheNodesInput) SetMarker(v string) *DescribeReservedCacheNodesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReservedCacheNodesInput) SetMaxRecords(v int64) *DescribeReservedCacheNodesInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DescribeReservedCacheNodesInput) SetOfferingType(v string) *DescribeReservedCacheNodesInput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *DescribeReservedCacheNodesInput) SetProductDescription(v string) *DescribeReservedCacheNodesInput {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetReservedCacheNodeId sets the ReservedCacheNodeId field's value.
+func (s *DescribeReservedCacheNodesInput) SetReservedCacheNodeId(v string) *DescribeReservedCacheNodesInput {
+	s.ReservedCacheNodeId = &v
+	return s
+}
+
+// SetReservedCacheNodesOfferingId sets the ReservedCacheNodesOfferingId field's value.
+func (s *DescribeReservedCacheNodesInput) SetReservedCacheNodesOfferingId(v string) *DescribeReservedCacheNodesInput {
+	s.ReservedCacheNodesOfferingId = &v
+	return s
+}
+
 // Represents the input of a DescribeReservedCacheNodesOfferings operation.
 type DescribeReservedCacheNodesOfferingsInput struct {
 	_ struct{} `type:"structure"`
@@ -6226,6 +7492,48 @@ func (s DescribeReservedCacheNodesOfferingsInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *DescribeReservedCacheNodesOfferingsInput) SetCacheNodeType(v string) *DescribeReservedCacheNodesOfferingsInput {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *DescribeReservedCacheNodesOfferingsInput) SetDuration(v string) *DescribeReservedCacheNodesOfferingsInput {
+	s.Duration = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedCacheNodesOfferingsInput) SetMarker(v string) *DescribeReservedCacheNodesOfferingsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReservedCacheNodesOfferingsInput) SetMaxRecords(v int64) *DescribeReservedCacheNodesOfferingsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DescribeReservedCacheNodesOfferingsInput) SetOfferingType(v string) *DescribeReservedCacheNodesOfferingsInput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *DescribeReservedCacheNodesOfferingsInput) SetProductDescription(v string) *DescribeReservedCacheNodesOfferingsInput {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetReservedCacheNodesOfferingId sets the ReservedCacheNodesOfferingId field's value.
+func (s *DescribeReservedCacheNodesOfferingsInput) SetReservedCacheNodesOfferingId(v string) *DescribeReservedCacheNodesOfferingsInput {
+	s.ReservedCacheNodesOfferingId = &v
+	return s
+}
+
 // Represents the output of a DescribeReservedCacheNodesOfferings operation.
 type DescribeReservedCacheNodesOfferingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6248,6 +7556,18 @@ func (s DescribeReservedCacheNodesOfferingsOutput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedCacheNodesOfferingsOutput) SetMarker(v string) *DescribeReservedCacheNodesOfferingsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReservedCacheNodesOfferings sets the ReservedCacheNodesOfferings field's value.
+func (s *DescribeReservedCacheNodesOfferingsOutput) SetReservedCacheNodesOfferings(v []*ReservedCacheNodesOffering) *DescribeReservedCacheNodesOfferingsOutput {
+	s.ReservedCacheNodesOfferings = v
+	return s
+}
+
 // Represents the output of a DescribeReservedCacheNodes operation.
 type DescribeReservedCacheNodesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6268,6 +7588,18 @@ func (s DescribeReservedCacheNodesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReservedCacheNodesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedCacheNodesOutput) SetMarker(v string) *DescribeReservedCacheNodesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReservedCacheNodes sets the ReservedCacheNodes field's value.
+func (s *DescribeReservedCacheNodesOutput) SetReservedCacheNodes(v []*ReservedCacheNode) *DescribeReservedCacheNodesOutput {
+	s.ReservedCacheNodes = v
+	return s
 }
 
 // Represents the input of a DescribeSnapshotsMessage operation.
@@ -6321,6 +7653,48 @@ func (s DescribeSnapshotsInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *DescribeSnapshotsInput) SetCacheClusterId(v string) *DescribeSnapshotsInput {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeSnapshotsInput) SetMarker(v string) *DescribeSnapshotsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeSnapshotsInput) SetMaxRecords(v int64) *DescribeSnapshotsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *DescribeSnapshotsInput) SetReplicationGroupId(v string) *DescribeSnapshotsInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetShowNodeGroupConfig sets the ShowNodeGroupConfig field's value.
+func (s *DescribeSnapshotsInput) SetShowNodeGroupConfig(v bool) *DescribeSnapshotsInput {
+	s.ShowNodeGroupConfig = &v
+	return s
+}
+
+// SetSnapshotName sets the SnapshotName field's value.
+func (s *DescribeSnapshotsInput) SetSnapshotName(v string) *DescribeSnapshotsInput {
+	s.SnapshotName = &v
+	return s
+}
+
+// SetSnapshotSource sets the SnapshotSource field's value.
+func (s *DescribeSnapshotsInput) SetSnapshotSource(v string) *DescribeSnapshotsInput {
+	s.SnapshotSource = &v
+	return s
+}
+
 // Represents the output of a DescribeSnapshots operation.
 type DescribeSnapshotsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6343,6 +7717,18 @@ func (s DescribeSnapshotsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSnapshotsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeSnapshotsOutput) SetMarker(v string) *DescribeSnapshotsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSnapshots sets the Snapshots field's value.
+func (s *DescribeSnapshotsOutput) SetSnapshots(v []*Snapshot) *DescribeSnapshotsOutput {
+	s.Snapshots = v
+	return s
 }
 
 // Provides ownership and status information for an Amazon EC2 security group.
@@ -6369,6 +7755,24 @@ func (s EC2SecurityGroup) GoString() string {
 	return s.String()
 }
 
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *EC2SecurityGroup) SetEC2SecurityGroupName(v string) *EC2SecurityGroup {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *EC2SecurityGroup) SetEC2SecurityGroupOwnerId(v string) *EC2SecurityGroup {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EC2SecurityGroup) SetStatus(v string) *EC2SecurityGroup {
+	s.Status = &v
+	return s
+}
+
 // Represents the information required for client programs to connect to a cache
 // node.
 type Endpoint struct {
@@ -6389,6 +7793,18 @@ func (s Endpoint) String() string {
 // GoString returns the string representation
 func (s Endpoint) GoString() string {
 	return s.String()
+}
+
+// SetAddress sets the Address field's value.
+func (s *Endpoint) SetAddress(v string) *Endpoint {
+	s.Address = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *Endpoint) SetPort(v int64) *Endpoint {
+	s.Port = &v
+	return s
 }
 
 // Represents the output of a DescribeEngineDefaultParameters operation.
@@ -6420,6 +7836,30 @@ func (s EngineDefaults) String() string {
 // GoString returns the string representation
 func (s EngineDefaults) GoString() string {
 	return s.String()
+}
+
+// SetCacheNodeTypeSpecificParameters sets the CacheNodeTypeSpecificParameters field's value.
+func (s *EngineDefaults) SetCacheNodeTypeSpecificParameters(v []*CacheNodeTypeSpecificParameter) *EngineDefaults {
+	s.CacheNodeTypeSpecificParameters = v
+	return s
+}
+
+// SetCacheParameterGroupFamily sets the CacheParameterGroupFamily field's value.
+func (s *EngineDefaults) SetCacheParameterGroupFamily(v string) *EngineDefaults {
+	s.CacheParameterGroupFamily = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *EngineDefaults) SetMarker(v string) *EngineDefaults {
+	s.Marker = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *EngineDefaults) SetParameters(v []*Parameter) *EngineDefaults {
+	s.Parameters = v
+	return s
 }
 
 // Represents a single occurrence of something interesting within the system.
@@ -6454,6 +7894,30 @@ func (s Event) GoString() string {
 	return s.String()
 }
 
+// SetDate sets the Date field's value.
+func (s *Event) SetDate(v time.Time) *Event {
+	s.Date = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Event) SetMessage(v string) *Event {
+	s.Message = &v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *Event) SetSourceIdentifier(v string) *Event {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *Event) SetSourceType(v string) *Event {
+	s.SourceType = &v
+	return s
+}
+
 // The input parameters for the ListAllowedNodeTypeModifications operation.
 type ListAllowedNodeTypeModificationsInput struct {
 	_ struct{} `type:"structure"`
@@ -6485,6 +7949,18 @@ func (s ListAllowedNodeTypeModificationsInput) GoString() string {
 	return s.String()
 }
 
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *ListAllowedNodeTypeModificationsInput) SetCacheClusterId(v string) *ListAllowedNodeTypeModificationsInput {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *ListAllowedNodeTypeModificationsInput) SetReplicationGroupId(v string) *ListAllowedNodeTypeModificationsInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
 type ListAllowedNodeTypeModificationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6499,6 +7975,12 @@ func (s ListAllowedNodeTypeModificationsOutput) String() string {
 // GoString returns the string representation
 func (s ListAllowedNodeTypeModificationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetScaleUpModifications sets the ScaleUpModifications field's value.
+func (s *ListAllowedNodeTypeModificationsOutput) SetScaleUpModifications(v []*string) *ListAllowedNodeTypeModificationsOutput {
+	s.ScaleUpModifications = v
+	return s
 }
 
 // The input parameters for the ListTagsForResource operation.
@@ -6537,6 +8019,12 @@ func (s *ListTagsForResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *ListTagsForResourceInput) SetResourceName(v string) *ListTagsForResourceInput {
+	s.ResourceName = &v
+	return s
 }
 
 // Represents the input of a ModifyCacheCluster operation.
@@ -6805,6 +8293,108 @@ func (s *ModifyCacheClusterInput) Validate() error {
 	return nil
 }
 
+// SetAZMode sets the AZMode field's value.
+func (s *ModifyCacheClusterInput) SetAZMode(v string) *ModifyCacheClusterInput {
+	s.AZMode = &v
+	return s
+}
+
+// SetApplyImmediately sets the ApplyImmediately field's value.
+func (s *ModifyCacheClusterInput) SetApplyImmediately(v bool) *ModifyCacheClusterInput {
+	s.ApplyImmediately = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *ModifyCacheClusterInput) SetAutoMinorVersionUpgrade(v bool) *ModifyCacheClusterInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *ModifyCacheClusterInput) SetCacheClusterId(v string) *ModifyCacheClusterInput {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetCacheNodeIdsToRemove sets the CacheNodeIdsToRemove field's value.
+func (s *ModifyCacheClusterInput) SetCacheNodeIdsToRemove(v []*string) *ModifyCacheClusterInput {
+	s.CacheNodeIdsToRemove = v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *ModifyCacheClusterInput) SetCacheNodeType(v string) *ModifyCacheClusterInput {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *ModifyCacheClusterInput) SetCacheParameterGroupName(v string) *ModifyCacheClusterInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetCacheSecurityGroupNames sets the CacheSecurityGroupNames field's value.
+func (s *ModifyCacheClusterInput) SetCacheSecurityGroupNames(v []*string) *ModifyCacheClusterInput {
+	s.CacheSecurityGroupNames = v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *ModifyCacheClusterInput) SetEngineVersion(v string) *ModifyCacheClusterInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetNewAvailabilityZones sets the NewAvailabilityZones field's value.
+func (s *ModifyCacheClusterInput) SetNewAvailabilityZones(v []*string) *ModifyCacheClusterInput {
+	s.NewAvailabilityZones = v
+	return s
+}
+
+// SetNotificationTopicArn sets the NotificationTopicArn field's value.
+func (s *ModifyCacheClusterInput) SetNotificationTopicArn(v string) *ModifyCacheClusterInput {
+	s.NotificationTopicArn = &v
+	return s
+}
+
+// SetNotificationTopicStatus sets the NotificationTopicStatus field's value.
+func (s *ModifyCacheClusterInput) SetNotificationTopicStatus(v string) *ModifyCacheClusterInput {
+	s.NotificationTopicStatus = &v
+	return s
+}
+
+// SetNumCacheNodes sets the NumCacheNodes field's value.
+func (s *ModifyCacheClusterInput) SetNumCacheNodes(v int64) *ModifyCacheClusterInput {
+	s.NumCacheNodes = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *ModifyCacheClusterInput) SetPreferredMaintenanceWindow(v string) *ModifyCacheClusterInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *ModifyCacheClusterInput) SetSecurityGroupIds(v []*string) *ModifyCacheClusterInput {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSnapshotRetentionLimit sets the SnapshotRetentionLimit field's value.
+func (s *ModifyCacheClusterInput) SetSnapshotRetentionLimit(v int64) *ModifyCacheClusterInput {
+	s.SnapshotRetentionLimit = &v
+	return s
+}
+
+// SetSnapshotWindow sets the SnapshotWindow field's value.
+func (s *ModifyCacheClusterInput) SetSnapshotWindow(v string) *ModifyCacheClusterInput {
+	s.SnapshotWindow = &v
+	return s
+}
+
 type ModifyCacheClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6820,6 +8410,12 @@ func (s ModifyCacheClusterOutput) String() string {
 // GoString returns the string representation
 func (s ModifyCacheClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheCluster sets the CacheCluster field's value.
+func (s *ModifyCacheClusterOutput) SetCacheCluster(v *CacheCluster) *ModifyCacheClusterOutput {
+	s.CacheCluster = v
+	return s
 }
 
 // Represents the input of a ModifyCacheParameterGroup operation.
@@ -6863,6 +8459,18 @@ func (s *ModifyCacheParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *ModifyCacheParameterGroupInput) SetCacheParameterGroupName(v string) *ModifyCacheParameterGroupInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetParameterNameValues sets the ParameterNameValues field's value.
+func (s *ModifyCacheParameterGroupInput) SetParameterNameValues(v []*ParameterNameValue) *ModifyCacheParameterGroupInput {
+	s.ParameterNameValues = v
+	return s
 }
 
 // Represents the input of a ModifyCacheSubnetGroup operation.
@@ -6909,6 +8517,24 @@ func (s *ModifyCacheSubnetGroupInput) Validate() error {
 	return nil
 }
 
+// SetCacheSubnetGroupDescription sets the CacheSubnetGroupDescription field's value.
+func (s *ModifyCacheSubnetGroupInput) SetCacheSubnetGroupDescription(v string) *ModifyCacheSubnetGroupInput {
+	s.CacheSubnetGroupDescription = &v
+	return s
+}
+
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *ModifyCacheSubnetGroupInput) SetCacheSubnetGroupName(v string) *ModifyCacheSubnetGroupInput {
+	s.CacheSubnetGroupName = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *ModifyCacheSubnetGroupInput) SetSubnetIds(v []*string) *ModifyCacheSubnetGroupInput {
+	s.SubnetIds = v
+	return s
+}
+
 type ModifyCacheSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6928,6 +8554,12 @@ func (s ModifyCacheSubnetGroupOutput) String() string {
 // GoString returns the string representation
 func (s ModifyCacheSubnetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheSubnetGroup sets the CacheSubnetGroup field's value.
+func (s *ModifyCacheSubnetGroupOutput) SetCacheSubnetGroup(v *CacheSubnetGroup) *ModifyCacheSubnetGroupOutput {
+	s.CacheSubnetGroup = v
+	return s
 }
 
 // Represents the input of a ModifyReplicationGroups operation.
@@ -7096,6 +8728,108 @@ func (s *ModifyReplicationGroupInput) Validate() error {
 	return nil
 }
 
+// SetApplyImmediately sets the ApplyImmediately field's value.
+func (s *ModifyReplicationGroupInput) SetApplyImmediately(v bool) *ModifyReplicationGroupInput {
+	s.ApplyImmediately = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *ModifyReplicationGroupInput) SetAutoMinorVersionUpgrade(v bool) *ModifyReplicationGroupInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAutomaticFailoverEnabled sets the AutomaticFailoverEnabled field's value.
+func (s *ModifyReplicationGroupInput) SetAutomaticFailoverEnabled(v bool) *ModifyReplicationGroupInput {
+	s.AutomaticFailoverEnabled = &v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *ModifyReplicationGroupInput) SetCacheNodeType(v string) *ModifyReplicationGroupInput {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *ModifyReplicationGroupInput) SetCacheParameterGroupName(v string) *ModifyReplicationGroupInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetCacheSecurityGroupNames sets the CacheSecurityGroupNames field's value.
+func (s *ModifyReplicationGroupInput) SetCacheSecurityGroupNames(v []*string) *ModifyReplicationGroupInput {
+	s.CacheSecurityGroupNames = v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *ModifyReplicationGroupInput) SetEngineVersion(v string) *ModifyReplicationGroupInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetNotificationTopicArn sets the NotificationTopicArn field's value.
+func (s *ModifyReplicationGroupInput) SetNotificationTopicArn(v string) *ModifyReplicationGroupInput {
+	s.NotificationTopicArn = &v
+	return s
+}
+
+// SetNotificationTopicStatus sets the NotificationTopicStatus field's value.
+func (s *ModifyReplicationGroupInput) SetNotificationTopicStatus(v string) *ModifyReplicationGroupInput {
+	s.NotificationTopicStatus = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *ModifyReplicationGroupInput) SetPreferredMaintenanceWindow(v string) *ModifyReplicationGroupInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPrimaryClusterId sets the PrimaryClusterId field's value.
+func (s *ModifyReplicationGroupInput) SetPrimaryClusterId(v string) *ModifyReplicationGroupInput {
+	s.PrimaryClusterId = &v
+	return s
+}
+
+// SetReplicationGroupDescription sets the ReplicationGroupDescription field's value.
+func (s *ModifyReplicationGroupInput) SetReplicationGroupDescription(v string) *ModifyReplicationGroupInput {
+	s.ReplicationGroupDescription = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *ModifyReplicationGroupInput) SetReplicationGroupId(v string) *ModifyReplicationGroupInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *ModifyReplicationGroupInput) SetSecurityGroupIds(v []*string) *ModifyReplicationGroupInput {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSnapshotRetentionLimit sets the SnapshotRetentionLimit field's value.
+func (s *ModifyReplicationGroupInput) SetSnapshotRetentionLimit(v int64) *ModifyReplicationGroupInput {
+	s.SnapshotRetentionLimit = &v
+	return s
+}
+
+// SetSnapshotWindow sets the SnapshotWindow field's value.
+func (s *ModifyReplicationGroupInput) SetSnapshotWindow(v string) *ModifyReplicationGroupInput {
+	s.SnapshotWindow = &v
+	return s
+}
+
+// SetSnapshottingClusterId sets the SnapshottingClusterId field's value.
+func (s *ModifyReplicationGroupInput) SetSnapshottingClusterId(v string) *ModifyReplicationGroupInput {
+	s.SnapshottingClusterId = &v
+	return s
+}
+
 type ModifyReplicationGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7111,6 +8845,12 @@ func (s ModifyReplicationGroupOutput) String() string {
 // GoString returns the string representation
 func (s ModifyReplicationGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationGroup sets the ReplicationGroup field's value.
+func (s *ModifyReplicationGroupOutput) SetReplicationGroup(v *ReplicationGroup) *ModifyReplicationGroupOutput {
+	s.ReplicationGroup = v
+	return s
 }
 
 // Represents a collection of cache nodes in a replication group. One node in
@@ -7149,6 +8889,36 @@ func (s NodeGroup) GoString() string {
 	return s.String()
 }
 
+// SetNodeGroupId sets the NodeGroupId field's value.
+func (s *NodeGroup) SetNodeGroupId(v string) *NodeGroup {
+	s.NodeGroupId = &v
+	return s
+}
+
+// SetNodeGroupMembers sets the NodeGroupMembers field's value.
+func (s *NodeGroup) SetNodeGroupMembers(v []*NodeGroupMember) *NodeGroup {
+	s.NodeGroupMembers = v
+	return s
+}
+
+// SetPrimaryEndpoint sets the PrimaryEndpoint field's value.
+func (s *NodeGroup) SetPrimaryEndpoint(v *Endpoint) *NodeGroup {
+	s.PrimaryEndpoint = v
+	return s
+}
+
+// SetSlots sets the Slots field's value.
+func (s *NodeGroup) SetSlots(v string) *NodeGroup {
+	s.Slots = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *NodeGroup) SetStatus(v string) *NodeGroup {
+	s.Status = &v
+	return s
+}
+
 // node group (shard) configuration options. Each node group (shard) configuration
 // has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones,
 // ReplicaCount.
@@ -7184,6 +8954,30 @@ func (s NodeGroupConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetPrimaryAvailabilityZone sets the PrimaryAvailabilityZone field's value.
+func (s *NodeGroupConfiguration) SetPrimaryAvailabilityZone(v string) *NodeGroupConfiguration {
+	s.PrimaryAvailabilityZone = &v
+	return s
+}
+
+// SetReplicaAvailabilityZones sets the ReplicaAvailabilityZones field's value.
+func (s *NodeGroupConfiguration) SetReplicaAvailabilityZones(v []*string) *NodeGroupConfiguration {
+	s.ReplicaAvailabilityZones = v
+	return s
+}
+
+// SetReplicaCount sets the ReplicaCount field's value.
+func (s *NodeGroupConfiguration) SetReplicaCount(v int64) *NodeGroupConfiguration {
+	s.ReplicaCount = &v
+	return s
+}
+
+// SetSlots sets the Slots field's value.
+func (s *NodeGroupConfiguration) SetSlots(v string) *NodeGroupConfiguration {
+	s.Slots = &v
+	return s
+}
+
 // Represents a single node within a node group (shard).
 type NodeGroupMember struct {
 	_ struct{} `type:"structure"`
@@ -7214,6 +9008,36 @@ func (s NodeGroupMember) String() string {
 // GoString returns the string representation
 func (s NodeGroupMember) GoString() string {
 	return s.String()
+}
+
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *NodeGroupMember) SetCacheClusterId(v string) *NodeGroupMember {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetCacheNodeId sets the CacheNodeId field's value.
+func (s *NodeGroupMember) SetCacheNodeId(v string) *NodeGroupMember {
+	s.CacheNodeId = &v
+	return s
+}
+
+// SetCurrentRole sets the CurrentRole field's value.
+func (s *NodeGroupMember) SetCurrentRole(v string) *NodeGroupMember {
+	s.CurrentRole = &v
+	return s
+}
+
+// SetPreferredAvailabilityZone sets the PreferredAvailabilityZone field's value.
+func (s *NodeGroupMember) SetPreferredAvailabilityZone(v string) *NodeGroupMember {
+	s.PreferredAvailabilityZone = &v
+	return s
+}
+
+// SetReadEndpoint sets the ReadEndpoint field's value.
+func (s *NodeGroupMember) SetReadEndpoint(v *Endpoint) *NodeGroupMember {
+	s.ReadEndpoint = v
+	return s
 }
 
 // Represents an individual cache node in a snapshot of a cache cluster.
@@ -7253,6 +9077,48 @@ func (s NodeSnapshot) GoString() string {
 	return s.String()
 }
 
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *NodeSnapshot) SetCacheClusterId(v string) *NodeSnapshot {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetCacheNodeCreateTime sets the CacheNodeCreateTime field's value.
+func (s *NodeSnapshot) SetCacheNodeCreateTime(v time.Time) *NodeSnapshot {
+	s.CacheNodeCreateTime = &v
+	return s
+}
+
+// SetCacheNodeId sets the CacheNodeId field's value.
+func (s *NodeSnapshot) SetCacheNodeId(v string) *NodeSnapshot {
+	s.CacheNodeId = &v
+	return s
+}
+
+// SetCacheSize sets the CacheSize field's value.
+func (s *NodeSnapshot) SetCacheSize(v string) *NodeSnapshot {
+	s.CacheSize = &v
+	return s
+}
+
+// SetNodeGroupConfiguration sets the NodeGroupConfiguration field's value.
+func (s *NodeSnapshot) SetNodeGroupConfiguration(v *NodeGroupConfiguration) *NodeSnapshot {
+	s.NodeGroupConfiguration = v
+	return s
+}
+
+// SetNodeGroupId sets the NodeGroupId field's value.
+func (s *NodeSnapshot) SetNodeGroupId(v string) *NodeSnapshot {
+	s.NodeGroupId = &v
+	return s
+}
+
+// SetSnapshotCreateTime sets the SnapshotCreateTime field's value.
+func (s *NodeSnapshot) SetSnapshotCreateTime(v time.Time) *NodeSnapshot {
+	s.SnapshotCreateTime = &v
+	return s
+}
+
 // Describes a notification topic and its status. Notification topics are used
 // for publishing ElastiCache events to subscribers using Amazon Simple Notification
 // Service (SNS).
@@ -7274,6 +9140,18 @@ func (s NotificationConfiguration) String() string {
 // GoString returns the string representation
 func (s NotificationConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *NotificationConfiguration) SetTopicArn(v string) *NotificationConfiguration {
+	s.TopicArn = &v
+	return s
+}
+
+// SetTopicStatus sets the TopicStatus field's value.
+func (s *NotificationConfiguration) SetTopicStatus(v string) *NotificationConfiguration {
+	s.TopicStatus = &v
+	return s
 }
 
 // Describes an individual setting that controls some aspect of ElastiCache
@@ -7324,6 +9202,60 @@ func (s Parameter) GoString() string {
 	return s.String()
 }
 
+// SetAllowedValues sets the AllowedValues field's value.
+func (s *Parameter) SetAllowedValues(v string) *Parameter {
+	s.AllowedValues = &v
+	return s
+}
+
+// SetChangeType sets the ChangeType field's value.
+func (s *Parameter) SetChangeType(v string) *Parameter {
+	s.ChangeType = &v
+	return s
+}
+
+// SetDataType sets the DataType field's value.
+func (s *Parameter) SetDataType(v string) *Parameter {
+	s.DataType = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Parameter) SetDescription(v string) *Parameter {
+	s.Description = &v
+	return s
+}
+
+// SetIsModifiable sets the IsModifiable field's value.
+func (s *Parameter) SetIsModifiable(v bool) *Parameter {
+	s.IsModifiable = &v
+	return s
+}
+
+// SetMinimumEngineVersion sets the MinimumEngineVersion field's value.
+func (s *Parameter) SetMinimumEngineVersion(v string) *Parameter {
+	s.MinimumEngineVersion = &v
+	return s
+}
+
+// SetParameterName sets the ParameterName field's value.
+func (s *Parameter) SetParameterName(v string) *Parameter {
+	s.ParameterName = &v
+	return s
+}
+
+// SetParameterValue sets the ParameterValue field's value.
+func (s *Parameter) SetParameterValue(v string) *Parameter {
+	s.ParameterValue = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *Parameter) SetSource(v string) *Parameter {
+	s.Source = &v
+	return s
+}
+
 // Describes a name-value pair that is used to update the value of a parameter.
 type ParameterNameValue struct {
 	_ struct{} `type:"structure"`
@@ -7343,6 +9275,18 @@ func (s ParameterNameValue) String() string {
 // GoString returns the string representation
 func (s ParameterNameValue) GoString() string {
 	return s.String()
+}
+
+// SetParameterName sets the ParameterName field's value.
+func (s *ParameterNameValue) SetParameterName(v string) *ParameterNameValue {
+	s.ParameterName = &v
+	return s
+}
+
+// SetParameterValue sets the ParameterValue field's value.
+func (s *ParameterNameValue) SetParameterValue(v string) *ParameterNameValue {
+	s.ParameterValue = &v
+	return s
 }
 
 // A group of settings that are applied to the cache cluster in the future,
@@ -7376,6 +9320,30 @@ func (s PendingModifiedValues) String() string {
 // GoString returns the string representation
 func (s PendingModifiedValues) GoString() string {
 	return s.String()
+}
+
+// SetCacheNodeIdsToRemove sets the CacheNodeIdsToRemove field's value.
+func (s *PendingModifiedValues) SetCacheNodeIdsToRemove(v []*string) *PendingModifiedValues {
+	s.CacheNodeIdsToRemove = v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *PendingModifiedValues) SetCacheNodeType(v string) *PendingModifiedValues {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *PendingModifiedValues) SetEngineVersion(v string) *PendingModifiedValues {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetNumCacheNodes sets the NumCacheNodes field's value.
+func (s *PendingModifiedValues) SetNumCacheNodes(v int64) *PendingModifiedValues {
+	s.NumCacheNodes = &v
+	return s
 }
 
 // Represents the input of a PurchaseReservedCacheNodesOffering operation.
@@ -7427,6 +9395,24 @@ func (s *PurchaseReservedCacheNodesOfferingInput) Validate() error {
 	return nil
 }
 
+// SetCacheNodeCount sets the CacheNodeCount field's value.
+func (s *PurchaseReservedCacheNodesOfferingInput) SetCacheNodeCount(v int64) *PurchaseReservedCacheNodesOfferingInput {
+	s.CacheNodeCount = &v
+	return s
+}
+
+// SetReservedCacheNodeId sets the ReservedCacheNodeId field's value.
+func (s *PurchaseReservedCacheNodesOfferingInput) SetReservedCacheNodeId(v string) *PurchaseReservedCacheNodesOfferingInput {
+	s.ReservedCacheNodeId = &v
+	return s
+}
+
+// SetReservedCacheNodesOfferingId sets the ReservedCacheNodesOfferingId field's value.
+func (s *PurchaseReservedCacheNodesOfferingInput) SetReservedCacheNodesOfferingId(v string) *PurchaseReservedCacheNodesOfferingInput {
+	s.ReservedCacheNodesOfferingId = &v
+	return s
+}
+
 type PurchaseReservedCacheNodesOfferingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7442,6 +9428,12 @@ func (s PurchaseReservedCacheNodesOfferingOutput) String() string {
 // GoString returns the string representation
 func (s PurchaseReservedCacheNodesOfferingOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedCacheNode sets the ReservedCacheNode field's value.
+func (s *PurchaseReservedCacheNodesOfferingOutput) SetReservedCacheNode(v *ReservedCacheNode) *PurchaseReservedCacheNodesOfferingOutput {
+	s.ReservedCacheNode = v
+	return s
 }
 
 // Represents the input of a RebootCacheCluster operation.
@@ -7487,6 +9479,18 @@ func (s *RebootCacheClusterInput) Validate() error {
 	return nil
 }
 
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *RebootCacheClusterInput) SetCacheClusterId(v string) *RebootCacheClusterInput {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetCacheNodeIdsToReboot sets the CacheNodeIdsToReboot field's value.
+func (s *RebootCacheClusterInput) SetCacheNodeIdsToReboot(v []*string) *RebootCacheClusterInput {
+	s.CacheNodeIdsToReboot = v
+	return s
+}
+
 type RebootCacheClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7502,6 +9506,12 @@ func (s RebootCacheClusterOutput) String() string {
 // GoString returns the string representation
 func (s RebootCacheClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheCluster sets the CacheCluster field's value.
+func (s *RebootCacheClusterOutput) SetCacheCluster(v *CacheCluster) *RebootCacheClusterOutput {
+	s.CacheCluster = v
+	return s
 }
 
 // Contains the specific price and frequency of a recurring charges for a reserved
@@ -7524,6 +9534,18 @@ func (s RecurringCharge) String() string {
 // GoString returns the string representation
 func (s RecurringCharge) GoString() string {
 	return s.String()
+}
+
+// SetRecurringChargeAmount sets the RecurringChargeAmount field's value.
+func (s *RecurringCharge) SetRecurringChargeAmount(v float64) *RecurringCharge {
+	s.RecurringChargeAmount = &v
+	return s
+}
+
+// SetRecurringChargeFrequency sets the RecurringChargeFrequency field's value.
+func (s *RecurringCharge) SetRecurringChargeFrequency(v string) *RecurringCharge {
+	s.RecurringChargeFrequency = &v
+	return s
 }
 
 // Represents the input of a RemoveTagsFromResource operation.
@@ -7570,6 +9592,18 @@ func (s *RemoveTagsFromResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *RemoveTagsFromResourceInput) SetResourceName(v string) *RemoveTagsFromResourceInput {
+	s.ResourceName = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsFromResourceInput) SetTagKeys(v []*string) *RemoveTagsFromResourceInput {
+	s.TagKeys = v
+	return s
 }
 
 // Contains all of the attributes of a specific Redis replication group.
@@ -7646,6 +9680,72 @@ func (s ReplicationGroup) GoString() string {
 	return s.String()
 }
 
+// SetAutomaticFailover sets the AutomaticFailover field's value.
+func (s *ReplicationGroup) SetAutomaticFailover(v string) *ReplicationGroup {
+	s.AutomaticFailover = &v
+	return s
+}
+
+// SetConfigurationEndpoint sets the ConfigurationEndpoint field's value.
+func (s *ReplicationGroup) SetConfigurationEndpoint(v *Endpoint) *ReplicationGroup {
+	s.ConfigurationEndpoint = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ReplicationGroup) SetDescription(v string) *ReplicationGroup {
+	s.Description = &v
+	return s
+}
+
+// SetMemberClusters sets the MemberClusters field's value.
+func (s *ReplicationGroup) SetMemberClusters(v []*string) *ReplicationGroup {
+	s.MemberClusters = v
+	return s
+}
+
+// SetNodeGroups sets the NodeGroups field's value.
+func (s *ReplicationGroup) SetNodeGroups(v []*NodeGroup) *ReplicationGroup {
+	s.NodeGroups = v
+	return s
+}
+
+// SetPendingModifiedValues sets the PendingModifiedValues field's value.
+func (s *ReplicationGroup) SetPendingModifiedValues(v *ReplicationGroupPendingModifiedValues) *ReplicationGroup {
+	s.PendingModifiedValues = v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *ReplicationGroup) SetReplicationGroupId(v string) *ReplicationGroup {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetSnapshotRetentionLimit sets the SnapshotRetentionLimit field's value.
+func (s *ReplicationGroup) SetSnapshotRetentionLimit(v int64) *ReplicationGroup {
+	s.SnapshotRetentionLimit = &v
+	return s
+}
+
+// SetSnapshotWindow sets the SnapshotWindow field's value.
+func (s *ReplicationGroup) SetSnapshotWindow(v string) *ReplicationGroup {
+	s.SnapshotWindow = &v
+	return s
+}
+
+// SetSnapshottingClusterId sets the SnapshottingClusterId field's value.
+func (s *ReplicationGroup) SetSnapshottingClusterId(v string) *ReplicationGroup {
+	s.SnapshottingClusterId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ReplicationGroup) SetStatus(v string) *ReplicationGroup {
+	s.Status = &v
+	return s
+}
+
 // The settings to be applied to the Redis replication group, either immediately
 // or during the next maintenance window.
 type ReplicationGroupPendingModifiedValues struct {
@@ -7675,6 +9775,18 @@ func (s ReplicationGroupPendingModifiedValues) String() string {
 // GoString returns the string representation
 func (s ReplicationGroupPendingModifiedValues) GoString() string {
 	return s.String()
+}
+
+// SetAutomaticFailoverStatus sets the AutomaticFailoverStatus field's value.
+func (s *ReplicationGroupPendingModifiedValues) SetAutomaticFailoverStatus(v string) *ReplicationGroupPendingModifiedValues {
+	s.AutomaticFailoverStatus = &v
+	return s
+}
+
+// SetPrimaryClusterId sets the PrimaryClusterId field's value.
+func (s *ReplicationGroupPendingModifiedValues) SetPrimaryClusterId(v string) *ReplicationGroupPendingModifiedValues {
+	s.PrimaryClusterId = &v
+	return s
 }
 
 // Represents the output of a PurchaseReservedCacheNodesOffering operation.
@@ -7765,6 +9877,78 @@ func (s ReservedCacheNode) GoString() string {
 	return s.String()
 }
 
+// SetCacheNodeCount sets the CacheNodeCount field's value.
+func (s *ReservedCacheNode) SetCacheNodeCount(v int64) *ReservedCacheNode {
+	s.CacheNodeCount = &v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *ReservedCacheNode) SetCacheNodeType(v string) *ReservedCacheNode {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedCacheNode) SetDuration(v int64) *ReservedCacheNode {
+	s.Duration = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedCacheNode) SetFixedPrice(v float64) *ReservedCacheNode {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *ReservedCacheNode) SetOfferingType(v string) *ReservedCacheNode {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *ReservedCacheNode) SetProductDescription(v string) *ReservedCacheNode {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedCacheNode) SetRecurringCharges(v []*RecurringCharge) *ReservedCacheNode {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedCacheNodeId sets the ReservedCacheNodeId field's value.
+func (s *ReservedCacheNode) SetReservedCacheNodeId(v string) *ReservedCacheNode {
+	s.ReservedCacheNodeId = &v
+	return s
+}
+
+// SetReservedCacheNodesOfferingId sets the ReservedCacheNodesOfferingId field's value.
+func (s *ReservedCacheNode) SetReservedCacheNodesOfferingId(v string) *ReservedCacheNode {
+	s.ReservedCacheNodesOfferingId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ReservedCacheNode) SetStartTime(v time.Time) *ReservedCacheNode {
+	s.StartTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ReservedCacheNode) SetState(v string) *ReservedCacheNode {
+	s.State = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedCacheNode) SetUsagePrice(v float64) *ReservedCacheNode {
+	s.UsagePrice = &v
+	return s
+}
+
 // Describes all of the attributes of a reserved cache node offering.
 type ReservedCacheNodesOffering struct {
 	_ struct{} `type:"structure"`
@@ -7841,6 +10025,54 @@ func (s ReservedCacheNodesOffering) GoString() string {
 	return s.String()
 }
 
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *ReservedCacheNodesOffering) SetCacheNodeType(v string) *ReservedCacheNodesOffering {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedCacheNodesOffering) SetDuration(v int64) *ReservedCacheNodesOffering {
+	s.Duration = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedCacheNodesOffering) SetFixedPrice(v float64) *ReservedCacheNodesOffering {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *ReservedCacheNodesOffering) SetOfferingType(v string) *ReservedCacheNodesOffering {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *ReservedCacheNodesOffering) SetProductDescription(v string) *ReservedCacheNodesOffering {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedCacheNodesOffering) SetRecurringCharges(v []*RecurringCharge) *ReservedCacheNodesOffering {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedCacheNodesOfferingId sets the ReservedCacheNodesOfferingId field's value.
+func (s *ReservedCacheNodesOffering) SetReservedCacheNodesOfferingId(v string) *ReservedCacheNodesOffering {
+	s.ReservedCacheNodesOfferingId = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedCacheNodesOffering) SetUsagePrice(v float64) *ReservedCacheNodesOffering {
+	s.UsagePrice = &v
+	return s
+}
+
 // Represents the input of a ResetCacheParameterGroup operation.
 type ResetCacheParameterGroupInput struct {
 	_ struct{} `type:"structure"`
@@ -7884,6 +10116,24 @@ func (s *ResetCacheParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *ResetCacheParameterGroupInput) SetCacheParameterGroupName(v string) *ResetCacheParameterGroupInput {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetParameterNameValues sets the ParameterNameValues field's value.
+func (s *ResetCacheParameterGroupInput) SetParameterNameValues(v []*ParameterNameValue) *ResetCacheParameterGroupInput {
+	s.ParameterNameValues = v
+	return s
+}
+
+// SetResetAllParameters sets the ResetAllParameters field's value.
+func (s *ResetCacheParameterGroupInput) SetResetAllParameters(v bool) *ResetCacheParameterGroupInput {
+	s.ResetAllParameters = &v
+	return s
 }
 
 // Represents the input of a RevokeCacheSecurityGroupIngress operation.
@@ -7937,6 +10187,24 @@ func (s *RevokeCacheSecurityGroupIngressInput) Validate() error {
 	return nil
 }
 
+// SetCacheSecurityGroupName sets the CacheSecurityGroupName field's value.
+func (s *RevokeCacheSecurityGroupIngressInput) SetCacheSecurityGroupName(v string) *RevokeCacheSecurityGroupIngressInput {
+	s.CacheSecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *RevokeCacheSecurityGroupIngressInput) SetEC2SecurityGroupName(v string) *RevokeCacheSecurityGroupIngressInput {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *RevokeCacheSecurityGroupIngressInput) SetEC2SecurityGroupOwnerId(v string) *RevokeCacheSecurityGroupIngressInput {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
 type RevokeCacheSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7960,6 +10228,12 @@ func (s RevokeCacheSecurityGroupIngressOutput) GoString() string {
 	return s.String()
 }
 
+// SetCacheSecurityGroup sets the CacheSecurityGroup field's value.
+func (s *RevokeCacheSecurityGroupIngressOutput) SetCacheSecurityGroup(v *CacheSecurityGroup) *RevokeCacheSecurityGroupIngressOutput {
+	s.CacheSecurityGroup = v
+	return s
+}
+
 // Represents a single cache security group and its status.
 type SecurityGroupMembership struct {
 	_ struct{} `type:"structure"`
@@ -7981,6 +10255,18 @@ func (s SecurityGroupMembership) String() string {
 // GoString returns the string representation
 func (s SecurityGroupMembership) GoString() string {
 	return s.String()
+}
+
+// SetSecurityGroupId sets the SecurityGroupId field's value.
+func (s *SecurityGroupMembership) SetSecurityGroupId(v string) *SecurityGroupMembership {
+	s.SecurityGroupId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SecurityGroupMembership) SetStatus(v string) *SecurityGroupMembership {
+	s.Status = &v
+	return s
 }
 
 // Represents a copy of an entire Redis cache cluster as of the time when the
@@ -8159,6 +10445,150 @@ func (s Snapshot) GoString() string {
 	return s.String()
 }
 
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *Snapshot) SetAutoMinorVersionUpgrade(v bool) *Snapshot {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAutomaticFailover sets the AutomaticFailover field's value.
+func (s *Snapshot) SetAutomaticFailover(v string) *Snapshot {
+	s.AutomaticFailover = &v
+	return s
+}
+
+// SetCacheClusterCreateTime sets the CacheClusterCreateTime field's value.
+func (s *Snapshot) SetCacheClusterCreateTime(v time.Time) *Snapshot {
+	s.CacheClusterCreateTime = &v
+	return s
+}
+
+// SetCacheClusterId sets the CacheClusterId field's value.
+func (s *Snapshot) SetCacheClusterId(v string) *Snapshot {
+	s.CacheClusterId = &v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *Snapshot) SetCacheNodeType(v string) *Snapshot {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetCacheParameterGroupName sets the CacheParameterGroupName field's value.
+func (s *Snapshot) SetCacheParameterGroupName(v string) *Snapshot {
+	s.CacheParameterGroupName = &v
+	return s
+}
+
+// SetCacheSubnetGroupName sets the CacheSubnetGroupName field's value.
+func (s *Snapshot) SetCacheSubnetGroupName(v string) *Snapshot {
+	s.CacheSubnetGroupName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *Snapshot) SetEngine(v string) *Snapshot {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *Snapshot) SetEngineVersion(v string) *Snapshot {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetNodeSnapshots sets the NodeSnapshots field's value.
+func (s *Snapshot) SetNodeSnapshots(v []*NodeSnapshot) *Snapshot {
+	s.NodeSnapshots = v
+	return s
+}
+
+// SetNumCacheNodes sets the NumCacheNodes field's value.
+func (s *Snapshot) SetNumCacheNodes(v int64) *Snapshot {
+	s.NumCacheNodes = &v
+	return s
+}
+
+// SetNumNodeGroups sets the NumNodeGroups field's value.
+func (s *Snapshot) SetNumNodeGroups(v int64) *Snapshot {
+	s.NumNodeGroups = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *Snapshot) SetPort(v int64) *Snapshot {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredAvailabilityZone sets the PreferredAvailabilityZone field's value.
+func (s *Snapshot) SetPreferredAvailabilityZone(v string) *Snapshot {
+	s.PreferredAvailabilityZone = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *Snapshot) SetPreferredMaintenanceWindow(v string) *Snapshot {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetReplicationGroupDescription sets the ReplicationGroupDescription field's value.
+func (s *Snapshot) SetReplicationGroupDescription(v string) *Snapshot {
+	s.ReplicationGroupDescription = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *Snapshot) SetReplicationGroupId(v string) *Snapshot {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// SetSnapshotName sets the SnapshotName field's value.
+func (s *Snapshot) SetSnapshotName(v string) *Snapshot {
+	s.SnapshotName = &v
+	return s
+}
+
+// SetSnapshotRetentionLimit sets the SnapshotRetentionLimit field's value.
+func (s *Snapshot) SetSnapshotRetentionLimit(v int64) *Snapshot {
+	s.SnapshotRetentionLimit = &v
+	return s
+}
+
+// SetSnapshotSource sets the SnapshotSource field's value.
+func (s *Snapshot) SetSnapshotSource(v string) *Snapshot {
+	s.SnapshotSource = &v
+	return s
+}
+
+// SetSnapshotStatus sets the SnapshotStatus field's value.
+func (s *Snapshot) SetSnapshotStatus(v string) *Snapshot {
+	s.SnapshotStatus = &v
+	return s
+}
+
+// SetSnapshotWindow sets the SnapshotWindow field's value.
+func (s *Snapshot) SetSnapshotWindow(v string) *Snapshot {
+	s.SnapshotWindow = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *Snapshot) SetTopicArn(v string) *Snapshot {
+	s.TopicArn = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *Snapshot) SetVpcId(v string) *Snapshot {
+	s.VpcId = &v
+	return s
+}
+
 // Represents the subnet associated with a cache cluster. This parameter refers
 // to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used
 // with ElastiCache.
@@ -8180,6 +10610,18 @@ func (s Subnet) String() string {
 // GoString returns the string representation
 func (s Subnet) GoString() string {
 	return s.String()
+}
+
+// SetSubnetAvailabilityZone sets the SubnetAvailabilityZone field's value.
+func (s *Subnet) SetSubnetAvailabilityZone(v *AvailabilityZone) *Subnet {
+	s.SubnetAvailabilityZone = v
+	return s
+}
+
+// SetSubnetIdentifier sets the SubnetIdentifier field's value.
+func (s *Subnet) SetSubnetIdentifier(v string) *Subnet {
+	s.SubnetIdentifier = &v
+	return s
 }
 
 // A cost allocation Tag that can be added to an ElastiCache cluster or replication
@@ -8205,6 +10647,18 @@ func (s Tag) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // Represents the output from the AddTagsToResource, ListTagsOnResource, and
 // RemoveTagsFromResource operations.
 type TagListMessage struct {
@@ -8222,6 +10676,12 @@ func (s TagListMessage) String() string {
 // GoString returns the string representation
 func (s TagListMessage) GoString() string {
 	return s.String()
+}
+
+// SetTagList sets the TagList field's value.
+func (s *TagListMessage) SetTagList(v []*Tag) *TagListMessage {
+	s.TagList = v
+	return s
 }
 
 const (

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -2528,6 +2528,18 @@ func (s *AbortEnvironmentUpdateInput) Validate() error {
 	return nil
 }
 
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *AbortEnvironmentUpdateInput) SetEnvironmentId(v string) *AbortEnvironmentUpdateInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *AbortEnvironmentUpdateInput) SetEnvironmentName(v string) *AbortEnvironmentUpdateInput {
+	s.EnvironmentName = &v
+	return s
+}
+
 type AbortEnvironmentUpdateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2575,6 +2587,42 @@ func (s ApplicationDescription) GoString() string {
 	return s.String()
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ApplicationDescription) SetApplicationName(v string) *ApplicationDescription {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetConfigurationTemplates sets the ConfigurationTemplates field's value.
+func (s *ApplicationDescription) SetConfigurationTemplates(v []*string) *ApplicationDescription {
+	s.ConfigurationTemplates = v
+	return s
+}
+
+// SetDateCreated sets the DateCreated field's value.
+func (s *ApplicationDescription) SetDateCreated(v time.Time) *ApplicationDescription {
+	s.DateCreated = &v
+	return s
+}
+
+// SetDateUpdated sets the DateUpdated field's value.
+func (s *ApplicationDescription) SetDateUpdated(v time.Time) *ApplicationDescription {
+	s.DateUpdated = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ApplicationDescription) SetDescription(v string) *ApplicationDescription {
+	s.Description = &v
+	return s
+}
+
+// SetVersions sets the Versions field's value.
+func (s *ApplicationDescription) SetVersions(v []*string) *ApplicationDescription {
+	s.Versions = v
+	return s
+}
+
 // Result message containing a single description of an application.
 type ApplicationDescriptionMessage struct {
 	_ struct{} `type:"structure"`
@@ -2591,6 +2639,12 @@ func (s ApplicationDescriptionMessage) String() string {
 // GoString returns the string representation
 func (s ApplicationDescriptionMessage) GoString() string {
 	return s.String()
+}
+
+// SetApplication sets the Application field's value.
+func (s *ApplicationDescriptionMessage) SetApplication(v *ApplicationDescription) *ApplicationDescriptionMessage {
+	s.Application = v
+	return s
 }
 
 // Represents the application metrics for a specified environment.
@@ -2623,6 +2677,30 @@ func (s ApplicationMetrics) String() string {
 // GoString returns the string representation
 func (s ApplicationMetrics) GoString() string {
 	return s.String()
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ApplicationMetrics) SetDuration(v int64) *ApplicationMetrics {
+	s.Duration = &v
+	return s
+}
+
+// SetLatency sets the Latency field's value.
+func (s *ApplicationMetrics) SetLatency(v *Latency) *ApplicationMetrics {
+	s.Latency = v
+	return s
+}
+
+// SetRequestCount sets the RequestCount field's value.
+func (s *ApplicationMetrics) SetRequestCount(v int64) *ApplicationMetrics {
+	s.RequestCount = &v
+	return s
+}
+
+// SetStatusCodes sets the StatusCodes field's value.
+func (s *ApplicationMetrics) SetStatusCodes(v *StatusCodes) *ApplicationMetrics {
+	s.StatusCodes = v
+	return s
 }
 
 // Describes the properties of an application version.
@@ -2663,6 +2741,54 @@ func (s ApplicationVersionDescription) GoString() string {
 	return s.String()
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ApplicationVersionDescription) SetApplicationName(v string) *ApplicationVersionDescription {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDateCreated sets the DateCreated field's value.
+func (s *ApplicationVersionDescription) SetDateCreated(v time.Time) *ApplicationVersionDescription {
+	s.DateCreated = &v
+	return s
+}
+
+// SetDateUpdated sets the DateUpdated field's value.
+func (s *ApplicationVersionDescription) SetDateUpdated(v time.Time) *ApplicationVersionDescription {
+	s.DateUpdated = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ApplicationVersionDescription) SetDescription(v string) *ApplicationVersionDescription {
+	s.Description = &v
+	return s
+}
+
+// SetSourceBuildInformation sets the SourceBuildInformation field's value.
+func (s *ApplicationVersionDescription) SetSourceBuildInformation(v *SourceBuildInformation) *ApplicationVersionDescription {
+	s.SourceBuildInformation = v
+	return s
+}
+
+// SetSourceBundle sets the SourceBundle field's value.
+func (s *ApplicationVersionDescription) SetSourceBundle(v *S3Location) *ApplicationVersionDescription {
+	s.SourceBundle = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ApplicationVersionDescription) SetStatus(v string) *ApplicationVersionDescription {
+	s.Status = &v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *ApplicationVersionDescription) SetVersionLabel(v string) *ApplicationVersionDescription {
+	s.VersionLabel = &v
+	return s
+}
+
 // Result message wrapping a single description of an application version.
 type ApplicationVersionDescriptionMessage struct {
 	_ struct{} `type:"structure"`
@@ -2679,6 +2805,12 @@ func (s ApplicationVersionDescriptionMessage) String() string {
 // GoString returns the string representation
 func (s ApplicationVersionDescriptionMessage) GoString() string {
 	return s.String()
+}
+
+// SetApplicationVersion sets the ApplicationVersion field's value.
+func (s *ApplicationVersionDescriptionMessage) SetApplicationVersion(v *ApplicationVersionDescription) *ApplicationVersionDescriptionMessage {
+	s.ApplicationVersion = v
+	return s
 }
 
 // Request to execute a scheduled managed action immediately.
@@ -2720,6 +2852,24 @@ func (s *ApplyEnvironmentManagedActionInput) Validate() error {
 	return nil
 }
 
+// SetActionId sets the ActionId field's value.
+func (s *ApplyEnvironmentManagedActionInput) SetActionId(v string) *ApplyEnvironmentManagedActionInput {
+	s.ActionId = &v
+	return s
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *ApplyEnvironmentManagedActionInput) SetEnvironmentId(v string) *ApplyEnvironmentManagedActionInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *ApplyEnvironmentManagedActionInput) SetEnvironmentName(v string) *ApplyEnvironmentManagedActionInput {
+	s.EnvironmentName = &v
+	return s
+}
+
 // The result message containing information about the managed action.
 type ApplyEnvironmentManagedActionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2747,6 +2897,30 @@ func (s ApplyEnvironmentManagedActionOutput) GoString() string {
 	return s.String()
 }
 
+// SetActionDescription sets the ActionDescription field's value.
+func (s *ApplyEnvironmentManagedActionOutput) SetActionDescription(v string) *ApplyEnvironmentManagedActionOutput {
+	s.ActionDescription = &v
+	return s
+}
+
+// SetActionId sets the ActionId field's value.
+func (s *ApplyEnvironmentManagedActionOutput) SetActionId(v string) *ApplyEnvironmentManagedActionOutput {
+	s.ActionId = &v
+	return s
+}
+
+// SetActionType sets the ActionType field's value.
+func (s *ApplyEnvironmentManagedActionOutput) SetActionType(v string) *ApplyEnvironmentManagedActionOutput {
+	s.ActionType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ApplyEnvironmentManagedActionOutput) SetStatus(v string) *ApplyEnvironmentManagedActionOutput {
+	s.Status = &v
+	return s
+}
+
 // Describes an Auto Scaling launch configuration.
 type AutoScalingGroup struct {
 	_ struct{} `type:"structure"`
@@ -2763,6 +2937,12 @@ func (s AutoScalingGroup) String() string {
 // GoString returns the string representation
 func (s AutoScalingGroup) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *AutoScalingGroup) SetName(v string) *AutoScalingGroup {
+	s.Name = &v
+	return s
 }
 
 // Represents CPU utilization information from the specified instance that belongs
@@ -2810,6 +2990,48 @@ func (s CPUUtilization) GoString() string {
 	return s.String()
 }
 
+// SetIOWait sets the IOWait field's value.
+func (s *CPUUtilization) SetIOWait(v float64) *CPUUtilization {
+	s.IOWait = &v
+	return s
+}
+
+// SetIRQ sets the IRQ field's value.
+func (s *CPUUtilization) SetIRQ(v float64) *CPUUtilization {
+	s.IRQ = &v
+	return s
+}
+
+// SetIdle sets the Idle field's value.
+func (s *CPUUtilization) SetIdle(v float64) *CPUUtilization {
+	s.Idle = &v
+	return s
+}
+
+// SetNice sets the Nice field's value.
+func (s *CPUUtilization) SetNice(v float64) *CPUUtilization {
+	s.Nice = &v
+	return s
+}
+
+// SetSoftIRQ sets the SoftIRQ field's value.
+func (s *CPUUtilization) SetSoftIRQ(v float64) *CPUUtilization {
+	s.SoftIRQ = &v
+	return s
+}
+
+// SetSystem sets the System field's value.
+func (s *CPUUtilization) SetSystem(v float64) *CPUUtilization {
+	s.System = &v
+	return s
+}
+
+// SetUser sets the User field's value.
+func (s *CPUUtilization) SetUser(v float64) *CPUUtilization {
+	s.User = &v
+	return s
+}
+
 // Results message indicating whether a CNAME is available.
 type CheckDNSAvailabilityInput struct {
 	_ struct{} `type:"structure"`
@@ -2846,6 +3068,12 @@ func (s *CheckDNSAvailabilityInput) Validate() error {
 	return nil
 }
 
+// SetCNAMEPrefix sets the CNAMEPrefix field's value.
+func (s *CheckDNSAvailabilityInput) SetCNAMEPrefix(v string) *CheckDNSAvailabilityInput {
+	s.CNAMEPrefix = &v
+	return s
+}
+
 // Indicates if the specified CNAME is available.
 type CheckDNSAvailabilityOutput struct {
 	_ struct{} `type:"structure"`
@@ -2870,6 +3098,18 @@ func (s CheckDNSAvailabilityOutput) String() string {
 // GoString returns the string representation
 func (s CheckDNSAvailabilityOutput) GoString() string {
 	return s.String()
+}
+
+// SetAvailable sets the Available field's value.
+func (s *CheckDNSAvailabilityOutput) SetAvailable(v bool) *CheckDNSAvailabilityOutput {
+	s.Available = &v
+	return s
+}
+
+// SetFullyQualifiedCNAME sets the FullyQualifiedCNAME field's value.
+func (s *CheckDNSAvailabilityOutput) SetFullyQualifiedCNAME(v string) *CheckDNSAvailabilityOutput {
+	s.FullyQualifiedCNAME = &v
+	return s
 }
 
 // Request to create or update a group of environments.
@@ -2918,6 +3158,24 @@ func (s *ComposeEnvironmentsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ComposeEnvironmentsInput) SetApplicationName(v string) *ComposeEnvironmentsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *ComposeEnvironmentsInput) SetGroupName(v string) *ComposeEnvironmentsInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetVersionLabels sets the VersionLabels field's value.
+func (s *ComposeEnvironmentsInput) SetVersionLabels(v []*string) *ComposeEnvironmentsInput {
+	s.VersionLabels = v
+	return s
 }
 
 // Describes the possible values for a configuration option.
@@ -3007,6 +3265,72 @@ func (s ConfigurationOptionDescription) GoString() string {
 	return s.String()
 }
 
+// SetChangeSeverity sets the ChangeSeverity field's value.
+func (s *ConfigurationOptionDescription) SetChangeSeverity(v string) *ConfigurationOptionDescription {
+	s.ChangeSeverity = &v
+	return s
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *ConfigurationOptionDescription) SetDefaultValue(v string) *ConfigurationOptionDescription {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetMaxLength sets the MaxLength field's value.
+func (s *ConfigurationOptionDescription) SetMaxLength(v int64) *ConfigurationOptionDescription {
+	s.MaxLength = &v
+	return s
+}
+
+// SetMaxValue sets the MaxValue field's value.
+func (s *ConfigurationOptionDescription) SetMaxValue(v int64) *ConfigurationOptionDescription {
+	s.MaxValue = &v
+	return s
+}
+
+// SetMinValue sets the MinValue field's value.
+func (s *ConfigurationOptionDescription) SetMinValue(v int64) *ConfigurationOptionDescription {
+	s.MinValue = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ConfigurationOptionDescription) SetName(v string) *ConfigurationOptionDescription {
+	s.Name = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *ConfigurationOptionDescription) SetNamespace(v string) *ConfigurationOptionDescription {
+	s.Namespace = &v
+	return s
+}
+
+// SetRegex sets the Regex field's value.
+func (s *ConfigurationOptionDescription) SetRegex(v *OptionRestrictionRegex) *ConfigurationOptionDescription {
+	s.Regex = v
+	return s
+}
+
+// SetUserDefined sets the UserDefined field's value.
+func (s *ConfigurationOptionDescription) SetUserDefined(v bool) *ConfigurationOptionDescription {
+	s.UserDefined = &v
+	return s
+}
+
+// SetValueOptions sets the ValueOptions field's value.
+func (s *ConfigurationOptionDescription) SetValueOptions(v []*string) *ConfigurationOptionDescription {
+	s.ValueOptions = v
+	return s
+}
+
+// SetValueType sets the ValueType field's value.
+func (s *ConfigurationOptionDescription) SetValueType(v string) *ConfigurationOptionDescription {
+	s.ValueType = &v
+	return s
+}
+
 // A specification identifying an individual configuration option along with
 // its current value. For a list of possible option values, go to Option Values
 // (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html)
@@ -3048,6 +3372,30 @@ func (s *ConfigurationOptionSetting) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *ConfigurationOptionSetting) SetNamespace(v string) *ConfigurationOptionSetting {
+	s.Namespace = &v
+	return s
+}
+
+// SetOptionName sets the OptionName field's value.
+func (s *ConfigurationOptionSetting) SetOptionName(v string) *ConfigurationOptionSetting {
+	s.OptionName = &v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *ConfigurationOptionSetting) SetResourceName(v string) *ConfigurationOptionSetting {
+	s.ResourceName = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ConfigurationOptionSetting) SetValue(v string) *ConfigurationOptionSetting {
+	s.Value = &v
+	return s
 }
 
 // Describes the settings for a configuration set.
@@ -3105,6 +3453,60 @@ func (s ConfigurationSettingsDescription) GoString() string {
 	return s.String()
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ConfigurationSettingsDescription) SetApplicationName(v string) *ConfigurationSettingsDescription {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDateCreated sets the DateCreated field's value.
+func (s *ConfigurationSettingsDescription) SetDateCreated(v time.Time) *ConfigurationSettingsDescription {
+	s.DateCreated = &v
+	return s
+}
+
+// SetDateUpdated sets the DateUpdated field's value.
+func (s *ConfigurationSettingsDescription) SetDateUpdated(v time.Time) *ConfigurationSettingsDescription {
+	s.DateUpdated = &v
+	return s
+}
+
+// SetDeploymentStatus sets the DeploymentStatus field's value.
+func (s *ConfigurationSettingsDescription) SetDeploymentStatus(v string) *ConfigurationSettingsDescription {
+	s.DeploymentStatus = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ConfigurationSettingsDescription) SetDescription(v string) *ConfigurationSettingsDescription {
+	s.Description = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *ConfigurationSettingsDescription) SetEnvironmentName(v string) *ConfigurationSettingsDescription {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetOptionSettings sets the OptionSettings field's value.
+func (s *ConfigurationSettingsDescription) SetOptionSettings(v []*ConfigurationOptionSetting) *ConfigurationSettingsDescription {
+	s.OptionSettings = v
+	return s
+}
+
+// SetSolutionStackName sets the SolutionStackName field's value.
+func (s *ConfigurationSettingsDescription) SetSolutionStackName(v string) *ConfigurationSettingsDescription {
+	s.SolutionStackName = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *ConfigurationSettingsDescription) SetTemplateName(v string) *ConfigurationSettingsDescription {
+	s.TemplateName = &v
+	return s
+}
+
 // Request to create an application.
 type CreateApplicationInput struct {
 	_ struct{} `type:"structure"`
@@ -3145,6 +3547,18 @@ func (s *CreateApplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *CreateApplicationInput) SetApplicationName(v string) *CreateApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateApplicationInput) SetDescription(v string) *CreateApplicationInput {
+	s.Description = &v
+	return s
 }
 
 type CreateApplicationVersionInput struct {
@@ -3238,6 +3652,48 @@ func (s *CreateApplicationVersionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *CreateApplicationVersionInput) SetApplicationName(v string) *CreateApplicationVersionInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetAutoCreateApplication sets the AutoCreateApplication field's value.
+func (s *CreateApplicationVersionInput) SetAutoCreateApplication(v bool) *CreateApplicationVersionInput {
+	s.AutoCreateApplication = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateApplicationVersionInput) SetDescription(v string) *CreateApplicationVersionInput {
+	s.Description = &v
+	return s
+}
+
+// SetProcess sets the Process field's value.
+func (s *CreateApplicationVersionInput) SetProcess(v bool) *CreateApplicationVersionInput {
+	s.Process = &v
+	return s
+}
+
+// SetSourceBuildInformation sets the SourceBuildInformation field's value.
+func (s *CreateApplicationVersionInput) SetSourceBuildInformation(v *SourceBuildInformation) *CreateApplicationVersionInput {
+	s.SourceBuildInformation = v
+	return s
+}
+
+// SetSourceBundle sets the SourceBundle field's value.
+func (s *CreateApplicationVersionInput) SetSourceBundle(v *S3Location) *CreateApplicationVersionInput {
+	s.SourceBundle = v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *CreateApplicationVersionInput) SetVersionLabel(v string) *CreateApplicationVersionInput {
+	s.VersionLabel = &v
+	return s
 }
 
 // Request to create a configuration template.
@@ -3347,6 +3803,48 @@ func (s *CreateConfigurationTemplateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *CreateConfigurationTemplateInput) SetApplicationName(v string) *CreateConfigurationTemplateInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateConfigurationTemplateInput) SetDescription(v string) *CreateConfigurationTemplateInput {
+	s.Description = &v
+	return s
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *CreateConfigurationTemplateInput) SetEnvironmentId(v string) *CreateConfigurationTemplateInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetOptionSettings sets the OptionSettings field's value.
+func (s *CreateConfigurationTemplateInput) SetOptionSettings(v []*ConfigurationOptionSetting) *CreateConfigurationTemplateInput {
+	s.OptionSettings = v
+	return s
+}
+
+// SetSolutionStackName sets the SolutionStackName field's value.
+func (s *CreateConfigurationTemplateInput) SetSolutionStackName(v string) *CreateConfigurationTemplateInput {
+	s.SolutionStackName = &v
+	return s
+}
+
+// SetSourceConfiguration sets the SourceConfiguration field's value.
+func (s *CreateConfigurationTemplateInput) SetSourceConfiguration(v *SourceConfiguration) *CreateConfigurationTemplateInput {
+	s.SourceConfiguration = v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *CreateConfigurationTemplateInput) SetTemplateName(v string) *CreateConfigurationTemplateInput {
+	s.TemplateName = &v
+	return s
 }
 
 type CreateEnvironmentInput struct {
@@ -3503,6 +4001,78 @@ func (s *CreateEnvironmentInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *CreateEnvironmentInput) SetApplicationName(v string) *CreateEnvironmentInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCNAMEPrefix sets the CNAMEPrefix field's value.
+func (s *CreateEnvironmentInput) SetCNAMEPrefix(v string) *CreateEnvironmentInput {
+	s.CNAMEPrefix = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateEnvironmentInput) SetDescription(v string) *CreateEnvironmentInput {
+	s.Description = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *CreateEnvironmentInput) SetEnvironmentName(v string) *CreateEnvironmentInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *CreateEnvironmentInput) SetGroupName(v string) *CreateEnvironmentInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetOptionSettings sets the OptionSettings field's value.
+func (s *CreateEnvironmentInput) SetOptionSettings(v []*ConfigurationOptionSetting) *CreateEnvironmentInput {
+	s.OptionSettings = v
+	return s
+}
+
+// SetOptionsToRemove sets the OptionsToRemove field's value.
+func (s *CreateEnvironmentInput) SetOptionsToRemove(v []*OptionSpecification) *CreateEnvironmentInput {
+	s.OptionsToRemove = v
+	return s
+}
+
+// SetSolutionStackName sets the SolutionStackName field's value.
+func (s *CreateEnvironmentInput) SetSolutionStackName(v string) *CreateEnvironmentInput {
+	s.SolutionStackName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateEnvironmentInput) SetTags(v []*Tag) *CreateEnvironmentInput {
+	s.Tags = v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *CreateEnvironmentInput) SetTemplateName(v string) *CreateEnvironmentInput {
+	s.TemplateName = &v
+	return s
+}
+
+// SetTier sets the Tier field's value.
+func (s *CreateEnvironmentInput) SetTier(v *EnvironmentTier) *CreateEnvironmentInput {
+	s.Tier = v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *CreateEnvironmentInput) SetVersionLabel(v string) *CreateEnvironmentInput {
+	s.VersionLabel = &v
+	return s
+}
+
 type CreateStorageLocationInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3533,6 +4103,12 @@ func (s CreateStorageLocationOutput) String() string {
 // GoString returns the string representation
 func (s CreateStorageLocationOutput) GoString() string {
 	return s.String()
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *CreateStorageLocationOutput) SetS3Bucket(v string) *CreateStorageLocationOutput {
+	s.S3Bucket = &v
+	return s
 }
 
 // Request to delete an application.
@@ -3573,6 +4149,18 @@ func (s *DeleteApplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteApplicationInput) SetApplicationName(v string) *DeleteApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetTerminateEnvByForce sets the TerminateEnvByForce field's value.
+func (s *DeleteApplicationInput) SetTerminateEnvByForce(v bool) *DeleteApplicationInput {
+	s.TerminateEnvByForce = &v
+	return s
 }
 
 type DeleteApplicationOutput struct {
@@ -3647,6 +4235,24 @@ func (s *DeleteApplicationVersionInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteApplicationVersionInput) SetApplicationName(v string) *DeleteApplicationVersionInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDeleteSourceBundle sets the DeleteSourceBundle field's value.
+func (s *DeleteApplicationVersionInput) SetDeleteSourceBundle(v bool) *DeleteApplicationVersionInput {
+	s.DeleteSourceBundle = &v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *DeleteApplicationVersionInput) SetVersionLabel(v string) *DeleteApplicationVersionInput {
+	s.VersionLabel = &v
+	return s
+}
+
 type DeleteApplicationVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3706,6 +4312,18 @@ func (s *DeleteConfigurationTemplateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteConfigurationTemplateInput) SetApplicationName(v string) *DeleteConfigurationTemplateInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *DeleteConfigurationTemplateInput) SetTemplateName(v string) *DeleteConfigurationTemplateInput {
+	s.TemplateName = &v
+	return s
 }
 
 type DeleteConfigurationTemplateOutput struct {
@@ -3769,6 +4387,18 @@ func (s *DeleteEnvironmentConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteEnvironmentConfigurationInput) SetApplicationName(v string) *DeleteEnvironmentConfigurationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DeleteEnvironmentConfigurationInput) SetEnvironmentName(v string) *DeleteEnvironmentConfigurationInput {
+	s.EnvironmentName = &v
+	return s
+}
+
 type DeleteEnvironmentConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3819,6 +4449,30 @@ func (s Deployment) GoString() string {
 	return s.String()
 }
 
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *Deployment) SetDeploymentId(v int64) *Deployment {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetDeploymentTime sets the DeploymentTime field's value.
+func (s *Deployment) SetDeploymentTime(v time.Time) *Deployment {
+	s.DeploymentTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Deployment) SetStatus(v string) *Deployment {
+	s.Status = &v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *Deployment) SetVersionLabel(v string) *Deployment {
+	s.VersionLabel = &v
+	return s
+}
+
 // Result message containing a list of configuration descriptions.
 type DescribeApplicationVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -3864,6 +4518,30 @@ func (s *DescribeApplicationVersionsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DescribeApplicationVersionsInput) SetApplicationName(v string) *DescribeApplicationVersionsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeApplicationVersionsInput) SetMaxRecords(v int64) *DescribeApplicationVersionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeApplicationVersionsInput) SetNextToken(v string) *DescribeApplicationVersionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetVersionLabels sets the VersionLabels field's value.
+func (s *DescribeApplicationVersionsInput) SetVersionLabels(v []*string) *DescribeApplicationVersionsInput {
+	s.VersionLabels = v
+	return s
+}
+
 // Result message wrapping a list of application version descriptions.
 type DescribeApplicationVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3886,6 +4564,18 @@ func (s DescribeApplicationVersionsOutput) GoString() string {
 	return s.String()
 }
 
+// SetApplicationVersions sets the ApplicationVersions field's value.
+func (s *DescribeApplicationVersionsOutput) SetApplicationVersions(v []*ApplicationVersionDescription) *DescribeApplicationVersionsOutput {
+	s.ApplicationVersions = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeApplicationVersionsOutput) SetNextToken(v string) *DescribeApplicationVersionsOutput {
+	s.NextToken = &v
+	return s
+}
+
 // Request to describe one or more applications.
 type DescribeApplicationsInput struct {
 	_ struct{} `type:"structure"`
@@ -3905,6 +4595,12 @@ func (s DescribeApplicationsInput) GoString() string {
 	return s.String()
 }
 
+// SetApplicationNames sets the ApplicationNames field's value.
+func (s *DescribeApplicationsInput) SetApplicationNames(v []*string) *DescribeApplicationsInput {
+	s.ApplicationNames = v
+	return s
+}
+
 // Result message containing a list of application descriptions.
 type DescribeApplicationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3921,6 +4617,12 @@ func (s DescribeApplicationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeApplicationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetApplications sets the Applications field's value.
+func (s *DescribeApplicationsOutput) SetApplications(v []*ApplicationDescription) *DescribeApplicationsOutput {
+	s.Applications = v
+	return s
 }
 
 // Result message containig a list of application version descriptions.
@@ -3985,6 +4687,36 @@ func (s *DescribeConfigurationOptionsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DescribeConfigurationOptionsInput) SetApplicationName(v string) *DescribeConfigurationOptionsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeConfigurationOptionsInput) SetEnvironmentName(v string) *DescribeConfigurationOptionsInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetOptions sets the Options field's value.
+func (s *DescribeConfigurationOptionsInput) SetOptions(v []*OptionSpecification) *DescribeConfigurationOptionsInput {
+	s.Options = v
+	return s
+}
+
+// SetSolutionStackName sets the SolutionStackName field's value.
+func (s *DescribeConfigurationOptionsInput) SetSolutionStackName(v string) *DescribeConfigurationOptionsInput {
+	s.SolutionStackName = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *DescribeConfigurationOptionsInput) SetTemplateName(v string) *DescribeConfigurationOptionsInput {
+	s.TemplateName = &v
+	return s
+}
+
 // Describes the settings for a specified configuration set.
 type DescribeConfigurationOptionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4004,6 +4736,18 @@ func (s DescribeConfigurationOptionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConfigurationOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *DescribeConfigurationOptionsOutput) SetOptions(v []*ConfigurationOptionDescription) *DescribeConfigurationOptionsOutput {
+	s.Options = v
+	return s
+}
+
+// SetSolutionStackName sets the SolutionStackName field's value.
+func (s *DescribeConfigurationOptionsOutput) SetSolutionStackName(v string) *DescribeConfigurationOptionsOutput {
+	s.SolutionStackName = &v
+	return s
 }
 
 // Result message containing all of the configuration settings for a specified
@@ -4065,6 +4809,24 @@ func (s *DescribeConfigurationSettingsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DescribeConfigurationSettingsInput) SetApplicationName(v string) *DescribeConfigurationSettingsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeConfigurationSettingsInput) SetEnvironmentName(v string) *DescribeConfigurationSettingsInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *DescribeConfigurationSettingsInput) SetTemplateName(v string) *DescribeConfigurationSettingsInput {
+	s.TemplateName = &v
+	return s
+}
+
 // The results from a request to change the configuration settings of an environment.
 type DescribeConfigurationSettingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4081,6 +4843,12 @@ func (s DescribeConfigurationSettingsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeConfigurationSettingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfigurationSettings sets the ConfigurationSettings field's value.
+func (s *DescribeConfigurationSettingsOutput) SetConfigurationSettings(v []*ConfigurationSettingsDescription) *DescribeConfigurationSettingsOutput {
+	s.ConfigurationSettings = v
+	return s
 }
 
 // See the example below to learn how to create a request body.
@@ -4129,6 +4897,24 @@ func (s *DescribeEnvironmentHealthInput) Validate() error {
 	return nil
 }
 
+// SetAttributeNames sets the AttributeNames field's value.
+func (s *DescribeEnvironmentHealthInput) SetAttributeNames(v []*string) *DescribeEnvironmentHealthInput {
+	s.AttributeNames = v
+	return s
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *DescribeEnvironmentHealthInput) SetEnvironmentId(v string) *DescribeEnvironmentHealthInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeEnvironmentHealthInput) SetEnvironmentName(v string) *DescribeEnvironmentHealthInput {
+	s.EnvironmentName = &v
+	return s
+}
+
 // See the example below for a sample response.
 type DescribeEnvironmentHealthOutput struct {
 	_ struct{} `type:"structure"`
@@ -4171,6 +4957,54 @@ func (s DescribeEnvironmentHealthOutput) GoString() string {
 	return s.String()
 }
 
+// SetApplicationMetrics sets the ApplicationMetrics field's value.
+func (s *DescribeEnvironmentHealthOutput) SetApplicationMetrics(v *ApplicationMetrics) *DescribeEnvironmentHealthOutput {
+	s.ApplicationMetrics = v
+	return s
+}
+
+// SetCauses sets the Causes field's value.
+func (s *DescribeEnvironmentHealthOutput) SetCauses(v []*string) *DescribeEnvironmentHealthOutput {
+	s.Causes = v
+	return s
+}
+
+// SetColor sets the Color field's value.
+func (s *DescribeEnvironmentHealthOutput) SetColor(v string) *DescribeEnvironmentHealthOutput {
+	s.Color = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeEnvironmentHealthOutput) SetEnvironmentName(v string) *DescribeEnvironmentHealthOutput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetHealthStatus sets the HealthStatus field's value.
+func (s *DescribeEnvironmentHealthOutput) SetHealthStatus(v string) *DescribeEnvironmentHealthOutput {
+	s.HealthStatus = &v
+	return s
+}
+
+// SetInstancesHealth sets the InstancesHealth field's value.
+func (s *DescribeEnvironmentHealthOutput) SetInstancesHealth(v *InstanceHealthSummary) *DescribeEnvironmentHealthOutput {
+	s.InstancesHealth = v
+	return s
+}
+
+// SetRefreshedAt sets the RefreshedAt field's value.
+func (s *DescribeEnvironmentHealthOutput) SetRefreshedAt(v time.Time) *DescribeEnvironmentHealthOutput {
+	s.RefreshedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DescribeEnvironmentHealthOutput) SetStatus(v string) *DescribeEnvironmentHealthOutput {
+	s.Status = &v
+	return s
+}
+
 // Request to list completed and failed managed actions.
 type DescribeEnvironmentManagedActionHistoryInput struct {
 	_ struct{} `type:"structure"`
@@ -4211,6 +5045,30 @@ func (s *DescribeEnvironmentManagedActionHistoryInput) Validate() error {
 	return nil
 }
 
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *DescribeEnvironmentManagedActionHistoryInput) SetEnvironmentId(v string) *DescribeEnvironmentManagedActionHistoryInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeEnvironmentManagedActionHistoryInput) SetEnvironmentName(v string) *DescribeEnvironmentManagedActionHistoryInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *DescribeEnvironmentManagedActionHistoryInput) SetMaxItems(v int64) *DescribeEnvironmentManagedActionHistoryInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeEnvironmentManagedActionHistoryInput) SetNextToken(v string) *DescribeEnvironmentManagedActionHistoryInput {
+	s.NextToken = &v
+	return s
+}
+
 // A result message containing a list of completed and failed managed actions.
 type DescribeEnvironmentManagedActionHistoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -4231,6 +5089,18 @@ func (s DescribeEnvironmentManagedActionHistoryOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEnvironmentManagedActionHistoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetManagedActionHistoryItems sets the ManagedActionHistoryItems field's value.
+func (s *DescribeEnvironmentManagedActionHistoryOutput) SetManagedActionHistoryItems(v []*ManagedActionHistoryItem) *DescribeEnvironmentManagedActionHistoryOutput {
+	s.ManagedActionHistoryItems = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeEnvironmentManagedActionHistoryOutput) SetNextToken(v string) *DescribeEnvironmentManagedActionHistoryOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Request to list an environment's upcoming and in-progress managed actions.
@@ -4257,6 +5127,24 @@ func (s DescribeEnvironmentManagedActionsInput) GoString() string {
 	return s.String()
 }
 
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *DescribeEnvironmentManagedActionsInput) SetEnvironmentId(v string) *DescribeEnvironmentManagedActionsInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeEnvironmentManagedActionsInput) SetEnvironmentName(v string) *DescribeEnvironmentManagedActionsInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DescribeEnvironmentManagedActionsInput) SetStatus(v string) *DescribeEnvironmentManagedActionsInput {
+	s.Status = &v
+	return s
+}
+
 // The result message containing a list of managed actions.
 type DescribeEnvironmentManagedActionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4273,6 +5161,12 @@ func (s DescribeEnvironmentManagedActionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEnvironmentManagedActionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetManagedActions sets the ManagedActions field's value.
+func (s *DescribeEnvironmentManagedActionsOutput) SetManagedActions(v []*ManagedAction) *DescribeEnvironmentManagedActionsOutput {
+	s.ManagedActions = v
+	return s
 }
 
 // Request to describe the resources in an environment.
@@ -4317,6 +5211,18 @@ func (s *DescribeEnvironmentResourcesInput) Validate() error {
 	return nil
 }
 
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *DescribeEnvironmentResourcesInput) SetEnvironmentId(v string) *DescribeEnvironmentResourcesInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeEnvironmentResourcesInput) SetEnvironmentName(v string) *DescribeEnvironmentResourcesInput {
+	s.EnvironmentName = &v
+	return s
+}
+
 // Result message containing a list of environment resource descriptions.
 type DescribeEnvironmentResourcesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4333,6 +5239,12 @@ func (s DescribeEnvironmentResourcesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEnvironmentResourcesOutput) GoString() string {
 	return s.String()
+}
+
+// SetEnvironmentResources sets the EnvironmentResources field's value.
+func (s *DescribeEnvironmentResourcesOutput) SetEnvironmentResources(v *EnvironmentResourceDescription) *DescribeEnvironmentResourcesOutput {
+	s.EnvironmentResources = v
+	return s
 }
 
 // Request to describe one or more environments.
@@ -4392,6 +5304,42 @@ func (s *DescribeEnvironmentsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DescribeEnvironmentsInput) SetApplicationName(v string) *DescribeEnvironmentsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetEnvironmentIds sets the EnvironmentIds field's value.
+func (s *DescribeEnvironmentsInput) SetEnvironmentIds(v []*string) *DescribeEnvironmentsInput {
+	s.EnvironmentIds = v
+	return s
+}
+
+// SetEnvironmentNames sets the EnvironmentNames field's value.
+func (s *DescribeEnvironmentsInput) SetEnvironmentNames(v []*string) *DescribeEnvironmentsInput {
+	s.EnvironmentNames = v
+	return s
+}
+
+// SetIncludeDeleted sets the IncludeDeleted field's value.
+func (s *DescribeEnvironmentsInput) SetIncludeDeleted(v bool) *DescribeEnvironmentsInput {
+	s.IncludeDeleted = &v
+	return s
+}
+
+// SetIncludedDeletedBackTo sets the IncludedDeletedBackTo field's value.
+func (s *DescribeEnvironmentsInput) SetIncludedDeletedBackTo(v time.Time) *DescribeEnvironmentsInput {
+	s.IncludedDeletedBackTo = &v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *DescribeEnvironmentsInput) SetVersionLabel(v string) *DescribeEnvironmentsInput {
+	s.VersionLabel = &v
+	return s
 }
 
 // Request to retrieve a list of events for an environment.
@@ -4477,6 +5425,72 @@ func (s *DescribeEventsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DescribeEventsInput) SetApplicationName(v string) *DescribeEventsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeEventsInput) SetEndTime(v time.Time) *DescribeEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *DescribeEventsInput) SetEnvironmentId(v string) *DescribeEventsInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeEventsInput) SetEnvironmentName(v string) *DescribeEventsInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEventsInput) SetMaxRecords(v int64) *DescribeEventsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeEventsInput) SetNextToken(v string) *DescribeEventsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRequestId sets the RequestId field's value.
+func (s *DescribeEventsInput) SetRequestId(v string) *DescribeEventsInput {
+	s.RequestId = &v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *DescribeEventsInput) SetSeverity(v string) *DescribeEventsInput {
+	s.Severity = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeEventsInput) SetStartTime(v time.Time) *DescribeEventsInput {
+	s.StartTime = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *DescribeEventsInput) SetTemplateName(v string) *DescribeEventsInput {
+	s.TemplateName = &v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *DescribeEventsInput) SetVersionLabel(v string) *DescribeEventsInput {
+	s.VersionLabel = &v
+	return s
+}
+
 // Result message wrapping a list of event descriptions.
 type DescribeEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4497,6 +5511,18 @@ func (s DescribeEventsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *DescribeEventsOutput) SetEvents(v []*EventDescription) *DescribeEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeEventsOutput) SetNextToken(v string) *DescribeEventsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // See the example below to learn how to create a request body.
@@ -4543,6 +5569,30 @@ func (s *DescribeInstancesHealthInput) Validate() error {
 	return nil
 }
 
+// SetAttributeNames sets the AttributeNames field's value.
+func (s *DescribeInstancesHealthInput) SetAttributeNames(v []*string) *DescribeInstancesHealthInput {
+	s.AttributeNames = v
+	return s
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *DescribeInstancesHealthInput) SetEnvironmentId(v string) *DescribeInstancesHealthInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *DescribeInstancesHealthInput) SetEnvironmentName(v string) *DescribeInstancesHealthInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstancesHealthInput) SetNextToken(v string) *DescribeInstancesHealthInput {
+	s.NextToken = &v
+	return s
+}
+
 // See the example below for a sample response.
 type DescribeInstancesHealthOutput struct {
 	_ struct{} `type:"structure"`
@@ -4565,6 +5615,24 @@ func (s DescribeInstancesHealthOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInstancesHealthOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceHealthList sets the InstanceHealthList field's value.
+func (s *DescribeInstancesHealthOutput) SetInstanceHealthList(v []*SingleInstanceHealth) *DescribeInstancesHealthOutput {
+	s.InstanceHealthList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstancesHealthOutput) SetNextToken(v string) *DescribeInstancesHealthOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRefreshedAt sets the RefreshedAt field's value.
+func (s *DescribeInstancesHealthOutput) SetRefreshedAt(v time.Time) *DescribeInstancesHealthOutput {
+	s.RefreshedAt = &v
+	return s
 }
 
 // Describes the properties of an environment.
@@ -4670,6 +5738,114 @@ func (s EnvironmentDescription) GoString() string {
 	return s.String()
 }
 
+// SetAbortableOperationInProgress sets the AbortableOperationInProgress field's value.
+func (s *EnvironmentDescription) SetAbortableOperationInProgress(v bool) *EnvironmentDescription {
+	s.AbortableOperationInProgress = &v
+	return s
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *EnvironmentDescription) SetApplicationName(v string) *EnvironmentDescription {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCNAME sets the CNAME field's value.
+func (s *EnvironmentDescription) SetCNAME(v string) *EnvironmentDescription {
+	s.CNAME = &v
+	return s
+}
+
+// SetDateCreated sets the DateCreated field's value.
+func (s *EnvironmentDescription) SetDateCreated(v time.Time) *EnvironmentDescription {
+	s.DateCreated = &v
+	return s
+}
+
+// SetDateUpdated sets the DateUpdated field's value.
+func (s *EnvironmentDescription) SetDateUpdated(v time.Time) *EnvironmentDescription {
+	s.DateUpdated = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *EnvironmentDescription) SetDescription(v string) *EnvironmentDescription {
+	s.Description = &v
+	return s
+}
+
+// SetEndpointURL sets the EndpointURL field's value.
+func (s *EnvironmentDescription) SetEndpointURL(v string) *EnvironmentDescription {
+	s.EndpointURL = &v
+	return s
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *EnvironmentDescription) SetEnvironmentId(v string) *EnvironmentDescription {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentLinks sets the EnvironmentLinks field's value.
+func (s *EnvironmentDescription) SetEnvironmentLinks(v []*EnvironmentLink) *EnvironmentDescription {
+	s.EnvironmentLinks = v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *EnvironmentDescription) SetEnvironmentName(v string) *EnvironmentDescription {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetHealth sets the Health field's value.
+func (s *EnvironmentDescription) SetHealth(v string) *EnvironmentDescription {
+	s.Health = &v
+	return s
+}
+
+// SetHealthStatus sets the HealthStatus field's value.
+func (s *EnvironmentDescription) SetHealthStatus(v string) *EnvironmentDescription {
+	s.HealthStatus = &v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *EnvironmentDescription) SetResources(v *EnvironmentResourcesDescription) *EnvironmentDescription {
+	s.Resources = v
+	return s
+}
+
+// SetSolutionStackName sets the SolutionStackName field's value.
+func (s *EnvironmentDescription) SetSolutionStackName(v string) *EnvironmentDescription {
+	s.SolutionStackName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EnvironmentDescription) SetStatus(v string) *EnvironmentDescription {
+	s.Status = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *EnvironmentDescription) SetTemplateName(v string) *EnvironmentDescription {
+	s.TemplateName = &v
+	return s
+}
+
+// SetTier sets the Tier field's value.
+func (s *EnvironmentDescription) SetTier(v *EnvironmentTier) *EnvironmentDescription {
+	s.Tier = v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *EnvironmentDescription) SetVersionLabel(v string) *EnvironmentDescription {
+	s.VersionLabel = &v
+	return s
+}
+
 // Result message containing a list of environment descriptions.
 type EnvironmentDescriptionsMessage struct {
 	_ struct{} `type:"structure"`
@@ -4686,6 +5862,12 @@ func (s EnvironmentDescriptionsMessage) String() string {
 // GoString returns the string representation
 func (s EnvironmentDescriptionsMessage) GoString() string {
 	return s.String()
+}
+
+// SetEnvironments sets the Environments field's value.
+func (s *EnvironmentDescriptionsMessage) SetEnvironments(v []*EnvironmentDescription) *EnvironmentDescriptionsMessage {
+	s.Environments = v
+	return s
 }
 
 // The information retrieved from the Amazon EC2 instances.
@@ -4715,6 +5897,30 @@ func (s EnvironmentInfoDescription) GoString() string {
 	return s.String()
 }
 
+// SetEc2InstanceId sets the Ec2InstanceId field's value.
+func (s *EnvironmentInfoDescription) SetEc2InstanceId(v string) *EnvironmentInfoDescription {
+	s.Ec2InstanceId = &v
+	return s
+}
+
+// SetInfoType sets the InfoType field's value.
+func (s *EnvironmentInfoDescription) SetInfoType(v string) *EnvironmentInfoDescription {
+	s.InfoType = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *EnvironmentInfoDescription) SetMessage(v string) *EnvironmentInfoDescription {
+	s.Message = &v
+	return s
+}
+
+// SetSampleTimestamp sets the SampleTimestamp field's value.
+func (s *EnvironmentInfoDescription) SetSampleTimestamp(v time.Time) *EnvironmentInfoDescription {
+	s.SampleTimestamp = &v
+	return s
+}
+
 // A link to another environment, defined in the environment's manifest. Links
 // provide connection information in system properties that can be used to connect
 // to another environment in the same group. See Environment Manifest (env.yaml)
@@ -4738,6 +5944,18 @@ func (s EnvironmentLink) String() string {
 // GoString returns the string representation
 func (s EnvironmentLink) GoString() string {
 	return s.String()
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *EnvironmentLink) SetEnvironmentName(v string) *EnvironmentLink {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetLinkName sets the LinkName field's value.
+func (s *EnvironmentLink) SetLinkName(v string) *EnvironmentLink {
+	s.LinkName = &v
+	return s
 }
 
 // Describes the AWS resources in use by this environment. This data is live.
@@ -4776,6 +5994,48 @@ func (s EnvironmentResourceDescription) GoString() string {
 	return s.String()
 }
 
+// SetAutoScalingGroups sets the AutoScalingGroups field's value.
+func (s *EnvironmentResourceDescription) SetAutoScalingGroups(v []*AutoScalingGroup) *EnvironmentResourceDescription {
+	s.AutoScalingGroups = v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *EnvironmentResourceDescription) SetEnvironmentName(v string) *EnvironmentResourceDescription {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetInstances sets the Instances field's value.
+func (s *EnvironmentResourceDescription) SetInstances(v []*Instance) *EnvironmentResourceDescription {
+	s.Instances = v
+	return s
+}
+
+// SetLaunchConfigurations sets the LaunchConfigurations field's value.
+func (s *EnvironmentResourceDescription) SetLaunchConfigurations(v []*LaunchConfiguration) *EnvironmentResourceDescription {
+	s.LaunchConfigurations = v
+	return s
+}
+
+// SetLoadBalancers sets the LoadBalancers field's value.
+func (s *EnvironmentResourceDescription) SetLoadBalancers(v []*LoadBalancer) *EnvironmentResourceDescription {
+	s.LoadBalancers = v
+	return s
+}
+
+// SetQueues sets the Queues field's value.
+func (s *EnvironmentResourceDescription) SetQueues(v []*Queue) *EnvironmentResourceDescription {
+	s.Queues = v
+	return s
+}
+
+// SetTriggers sets the Triggers field's value.
+func (s *EnvironmentResourceDescription) SetTriggers(v []*Trigger) *EnvironmentResourceDescription {
+	s.Triggers = v
+	return s
+}
+
 // Describes the AWS resources in use by this environment. This data is not
 // live data.
 type EnvironmentResourcesDescription struct {
@@ -4793,6 +6053,12 @@ func (s EnvironmentResourcesDescription) String() string {
 // GoString returns the string representation
 func (s EnvironmentResourcesDescription) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancer sets the LoadBalancer field's value.
+func (s *EnvironmentResourcesDescription) SetLoadBalancer(v *LoadBalancerDescription) *EnvironmentResourcesDescription {
+	s.LoadBalancer = v
+	return s
 }
 
 // Describes the properties of an environment tier
@@ -4817,6 +6083,24 @@ func (s EnvironmentTier) String() string {
 // GoString returns the string representation
 func (s EnvironmentTier) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *EnvironmentTier) SetName(v string) *EnvironmentTier {
+	s.Name = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *EnvironmentTier) SetType(v string) *EnvironmentTier {
+	s.Type = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *EnvironmentTier) SetVersion(v string) *EnvironmentTier {
+	s.Version = &v
+	return s
 }
 
 // Describes an event.
@@ -4858,6 +6142,54 @@ func (s EventDescription) GoString() string {
 	return s.String()
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *EventDescription) SetApplicationName(v string) *EventDescription {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *EventDescription) SetEnvironmentName(v string) *EventDescription {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetEventDate sets the EventDate field's value.
+func (s *EventDescription) SetEventDate(v time.Time) *EventDescription {
+	s.EventDate = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *EventDescription) SetMessage(v string) *EventDescription {
+	s.Message = &v
+	return s
+}
+
+// SetRequestId sets the RequestId field's value.
+func (s *EventDescription) SetRequestId(v string) *EventDescription {
+	s.RequestId = &v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *EventDescription) SetSeverity(v string) *EventDescription {
+	s.Severity = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *EventDescription) SetTemplateName(v string) *EventDescription {
+	s.TemplateName = &v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *EventDescription) SetVersionLabel(v string) *EventDescription {
+	s.VersionLabel = &v
+	return s
+}
+
 // The description of an Amazon EC2 instance.
 type Instance struct {
 	_ struct{} `type:"structure"`
@@ -4874,6 +6206,12 @@ func (s Instance) String() string {
 // GoString returns the string representation
 func (s Instance) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *Instance) SetId(v string) *Instance {
+	s.Id = &v
+	return s
 }
 
 // Represents summary information about the health of an instance. For more
@@ -4920,6 +6258,54 @@ func (s InstanceHealthSummary) String() string {
 // GoString returns the string representation
 func (s InstanceHealthSummary) GoString() string {
 	return s.String()
+}
+
+// SetDegraded sets the Degraded field's value.
+func (s *InstanceHealthSummary) SetDegraded(v int64) *InstanceHealthSummary {
+	s.Degraded = &v
+	return s
+}
+
+// SetInfo sets the Info field's value.
+func (s *InstanceHealthSummary) SetInfo(v int64) *InstanceHealthSummary {
+	s.Info = &v
+	return s
+}
+
+// SetNoData sets the NoData field's value.
+func (s *InstanceHealthSummary) SetNoData(v int64) *InstanceHealthSummary {
+	s.NoData = &v
+	return s
+}
+
+// SetOk sets the Ok field's value.
+func (s *InstanceHealthSummary) SetOk(v int64) *InstanceHealthSummary {
+	s.Ok = &v
+	return s
+}
+
+// SetPending sets the Pending field's value.
+func (s *InstanceHealthSummary) SetPending(v int64) *InstanceHealthSummary {
+	s.Pending = &v
+	return s
+}
+
+// SetSevere sets the Severe field's value.
+func (s *InstanceHealthSummary) SetSevere(v int64) *InstanceHealthSummary {
+	s.Severe = &v
+	return s
+}
+
+// SetUnknown sets the Unknown field's value.
+func (s *InstanceHealthSummary) SetUnknown(v int64) *InstanceHealthSummary {
+	s.Unknown = &v
+	return s
+}
+
+// SetWarning sets the Warning field's value.
+func (s *InstanceHealthSummary) SetWarning(v int64) *InstanceHealthSummary {
+	s.Warning = &v
+	return s
 }
 
 // Represents the average latency for the slowest X percent of requests over
@@ -4970,6 +6356,54 @@ func (s Latency) GoString() string {
 	return s.String()
 }
 
+// SetP10 sets the P10 field's value.
+func (s *Latency) SetP10(v float64) *Latency {
+	s.P10 = &v
+	return s
+}
+
+// SetP50 sets the P50 field's value.
+func (s *Latency) SetP50(v float64) *Latency {
+	s.P50 = &v
+	return s
+}
+
+// SetP75 sets the P75 field's value.
+func (s *Latency) SetP75(v float64) *Latency {
+	s.P75 = &v
+	return s
+}
+
+// SetP85 sets the P85 field's value.
+func (s *Latency) SetP85(v float64) *Latency {
+	s.P85 = &v
+	return s
+}
+
+// SetP90 sets the P90 field's value.
+func (s *Latency) SetP90(v float64) *Latency {
+	s.P90 = &v
+	return s
+}
+
+// SetP95 sets the P95 field's value.
+func (s *Latency) SetP95(v float64) *Latency {
+	s.P95 = &v
+	return s
+}
+
+// SetP99 sets the P99 field's value.
+func (s *Latency) SetP99(v float64) *Latency {
+	s.P99 = &v
+	return s
+}
+
+// SetP999 sets the P999 field's value.
+func (s *Latency) SetP999(v float64) *Latency {
+	s.P999 = &v
+	return s
+}
+
 // Describes an Auto Scaling launch configuration.
 type LaunchConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -4986,6 +6420,12 @@ func (s LaunchConfiguration) String() string {
 // GoString returns the string representation
 func (s LaunchConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *LaunchConfiguration) SetName(v string) *LaunchConfiguration {
+	s.Name = &v
+	return s
 }
 
 type ListAvailableSolutionStacksInput struct {
@@ -5023,6 +6463,18 @@ func (s ListAvailableSolutionStacksOutput) GoString() string {
 	return s.String()
 }
 
+// SetSolutionStackDetails sets the SolutionStackDetails field's value.
+func (s *ListAvailableSolutionStacksOutput) SetSolutionStackDetails(v []*SolutionStackDescription) *ListAvailableSolutionStacksOutput {
+	s.SolutionStackDetails = v
+	return s
+}
+
+// SetSolutionStacks sets the SolutionStacks field's value.
+func (s *ListAvailableSolutionStacksOutput) SetSolutionStacks(v []*string) *ListAvailableSolutionStacksOutput {
+	s.SolutionStacks = v
+	return s
+}
+
 // Describes the properties of a Listener for the LoadBalancer.
 type Listener struct {
 	_ struct{} `type:"structure"`
@@ -5044,6 +6496,18 @@ func (s Listener) GoString() string {
 	return s.String()
 }
 
+// SetPort sets the Port field's value.
+func (s *Listener) SetPort(v int64) *Listener {
+	s.Port = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *Listener) SetProtocol(v string) *Listener {
+	s.Protocol = &v
+	return s
+}
+
 // Describes a LoadBalancer.
 type LoadBalancer struct {
 	_ struct{} `type:"structure"`
@@ -5060,6 +6524,12 @@ func (s LoadBalancer) String() string {
 // GoString returns the string representation
 func (s LoadBalancer) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *LoadBalancer) SetName(v string) *LoadBalancer {
+	s.Name = &v
+	return s
 }
 
 // Describes the details of a LoadBalancer.
@@ -5084,6 +6554,24 @@ func (s LoadBalancerDescription) String() string {
 // GoString returns the string representation
 func (s LoadBalancerDescription) GoString() string {
 	return s.String()
+}
+
+// SetDomain sets the Domain field's value.
+func (s *LoadBalancerDescription) SetDomain(v string) *LoadBalancerDescription {
+	s.Domain = &v
+	return s
+}
+
+// SetListeners sets the Listeners field's value.
+func (s *LoadBalancerDescription) SetListeners(v []*Listener) *LoadBalancerDescription {
+	s.Listeners = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *LoadBalancerDescription) SetLoadBalancerName(v string) *LoadBalancerDescription {
+	s.LoadBalancerName = &v
+	return s
 }
 
 // The record of an upcoming or in-progress managed action.
@@ -5116,6 +6604,36 @@ func (s ManagedAction) String() string {
 // GoString returns the string representation
 func (s ManagedAction) GoString() string {
 	return s.String()
+}
+
+// SetActionDescription sets the ActionDescription field's value.
+func (s *ManagedAction) SetActionDescription(v string) *ManagedAction {
+	s.ActionDescription = &v
+	return s
+}
+
+// SetActionId sets the ActionId field's value.
+func (s *ManagedAction) SetActionId(v string) *ManagedAction {
+	s.ActionId = &v
+	return s
+}
+
+// SetActionType sets the ActionType field's value.
+func (s *ManagedAction) SetActionType(v string) *ManagedAction {
+	s.ActionType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ManagedAction) SetStatus(v string) *ManagedAction {
+	s.Status = &v
+	return s
+}
+
+// SetWindowStartTime sets the WindowStartTime field's value.
+func (s *ManagedAction) SetWindowStartTime(v time.Time) *ManagedAction {
+	s.WindowStartTime = &v
+	return s
 }
 
 // The record of a completed or failed managed action.
@@ -5157,6 +6675,54 @@ func (s ManagedActionHistoryItem) GoString() string {
 	return s.String()
 }
 
+// SetActionDescription sets the ActionDescription field's value.
+func (s *ManagedActionHistoryItem) SetActionDescription(v string) *ManagedActionHistoryItem {
+	s.ActionDescription = &v
+	return s
+}
+
+// SetActionId sets the ActionId field's value.
+func (s *ManagedActionHistoryItem) SetActionId(v string) *ManagedActionHistoryItem {
+	s.ActionId = &v
+	return s
+}
+
+// SetActionType sets the ActionType field's value.
+func (s *ManagedActionHistoryItem) SetActionType(v string) *ManagedActionHistoryItem {
+	s.ActionType = &v
+	return s
+}
+
+// SetExecutedTime sets the ExecutedTime field's value.
+func (s *ManagedActionHistoryItem) SetExecutedTime(v time.Time) *ManagedActionHistoryItem {
+	s.ExecutedTime = &v
+	return s
+}
+
+// SetFailureDescription sets the FailureDescription field's value.
+func (s *ManagedActionHistoryItem) SetFailureDescription(v string) *ManagedActionHistoryItem {
+	s.FailureDescription = &v
+	return s
+}
+
+// SetFailureType sets the FailureType field's value.
+func (s *ManagedActionHistoryItem) SetFailureType(v string) *ManagedActionHistoryItem {
+	s.FailureType = &v
+	return s
+}
+
+// SetFinishedTime sets the FinishedTime field's value.
+func (s *ManagedActionHistoryItem) SetFinishedTime(v time.Time) *ManagedActionHistoryItem {
+	s.FinishedTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ManagedActionHistoryItem) SetStatus(v string) *ManagedActionHistoryItem {
+	s.Status = &v
+	return s
+}
+
 // A regular expression representing a restriction on a string configuration
 // option value.
 type OptionRestrictionRegex struct {
@@ -5178,6 +6744,18 @@ func (s OptionRestrictionRegex) String() string {
 // GoString returns the string representation
 func (s OptionRestrictionRegex) GoString() string {
 	return s.String()
+}
+
+// SetLabel sets the Label field's value.
+func (s *OptionRestrictionRegex) SetLabel(v string) *OptionRestrictionRegex {
+	s.Label = &v
+	return s
+}
+
+// SetPattern sets the Pattern field's value.
+func (s *OptionRestrictionRegex) SetPattern(v string) *OptionRestrictionRegex {
+	s.Pattern = &v
+	return s
 }
 
 // A specification identifying an individual configuration option.
@@ -5217,6 +6795,24 @@ func (s *OptionSpecification) Validate() error {
 	return nil
 }
 
+// SetNamespace sets the Namespace field's value.
+func (s *OptionSpecification) SetNamespace(v string) *OptionSpecification {
+	s.Namespace = &v
+	return s
+}
+
+// SetOptionName sets the OptionName field's value.
+func (s *OptionSpecification) SetOptionName(v string) *OptionSpecification {
+	s.OptionName = &v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *OptionSpecification) SetResourceName(v string) *OptionSpecification {
+	s.ResourceName = &v
+	return s
+}
+
 // Describes a queue.
 type Queue struct {
 	_ struct{} `type:"structure"`
@@ -5236,6 +6832,18 @@ func (s Queue) String() string {
 // GoString returns the string representation
 func (s Queue) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *Queue) SetName(v string) *Queue {
+	s.Name = &v
+	return s
+}
+
+// SetURL sets the URL field's value.
+func (s *Queue) SetURL(v string) *Queue {
+	s.URL = &v
+	return s
 }
 
 type RebuildEnvironmentInput struct {
@@ -5277,6 +6885,18 @@ func (s *RebuildEnvironmentInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *RebuildEnvironmentInput) SetEnvironmentId(v string) *RebuildEnvironmentInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *RebuildEnvironmentInput) SetEnvironmentName(v string) *RebuildEnvironmentInput {
+	s.EnvironmentName = &v
+	return s
 }
 
 type RebuildEnvironmentOutput struct {
@@ -5350,6 +6970,24 @@ func (s *RequestEnvironmentInfoInput) Validate() error {
 	return nil
 }
 
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *RequestEnvironmentInfoInput) SetEnvironmentId(v string) *RequestEnvironmentInfoInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *RequestEnvironmentInfoInput) SetEnvironmentName(v string) *RequestEnvironmentInfoInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetInfoType sets the InfoType field's value.
+func (s *RequestEnvironmentInfoInput) SetInfoType(v string) *RequestEnvironmentInfoInput {
+	s.InfoType = &v
+	return s
+}
+
 type RequestEnvironmentInfoOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5403,6 +7041,18 @@ func (s *RestartAppServerInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *RestartAppServerInput) SetEnvironmentId(v string) *RestartAppServerInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *RestartAppServerInput) SetEnvironmentName(v string) *RestartAppServerInput {
+	s.EnvironmentName = &v
+	return s
 }
 
 type RestartAppServerOutput struct {
@@ -5473,6 +7123,24 @@ func (s *RetrieveEnvironmentInfoInput) Validate() error {
 	return nil
 }
 
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *RetrieveEnvironmentInfoInput) SetEnvironmentId(v string) *RetrieveEnvironmentInfoInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *RetrieveEnvironmentInfoInput) SetEnvironmentName(v string) *RetrieveEnvironmentInfoInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetInfoType sets the InfoType field's value.
+func (s *RetrieveEnvironmentInfoInput) SetInfoType(v string) *RetrieveEnvironmentInfoInput {
+	s.InfoType = &v
+	return s
+}
+
 // Result message containing a description of the requested environment info.
 type RetrieveEnvironmentInfoOutput struct {
 	_ struct{} `type:"structure"`
@@ -5489,6 +7157,12 @@ func (s RetrieveEnvironmentInfoOutput) String() string {
 // GoString returns the string representation
 func (s RetrieveEnvironmentInfoOutput) GoString() string {
 	return s.String()
+}
+
+// SetEnvironmentInfo sets the EnvironmentInfo field's value.
+func (s *RetrieveEnvironmentInfoOutput) SetEnvironmentInfo(v []*EnvironmentInfoDescription) *RetrieveEnvironmentInfoOutput {
+	s.EnvironmentInfo = v
+	return s
 }
 
 // A specification of a location in Amazon S3.
@@ -5510,6 +7184,18 @@ func (s S3Location) String() string {
 // GoString returns the string representation
 func (s S3Location) GoString() string {
 	return s.String()
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *S3Location) SetS3Bucket(v string) *S3Location {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetS3Key sets the S3Key field's value.
+func (s *S3Location) SetS3Key(v string) *S3Location {
+	s.S3Key = &v
+	return s
 }
 
 // Represents health information from the specified instance that belongs to
@@ -5564,6 +7250,66 @@ func (s SingleInstanceHealth) GoString() string {
 	return s.String()
 }
 
+// SetApplicationMetrics sets the ApplicationMetrics field's value.
+func (s *SingleInstanceHealth) SetApplicationMetrics(v *ApplicationMetrics) *SingleInstanceHealth {
+	s.ApplicationMetrics = v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *SingleInstanceHealth) SetAvailabilityZone(v string) *SingleInstanceHealth {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCauses sets the Causes field's value.
+func (s *SingleInstanceHealth) SetCauses(v []*string) *SingleInstanceHealth {
+	s.Causes = v
+	return s
+}
+
+// SetColor sets the Color field's value.
+func (s *SingleInstanceHealth) SetColor(v string) *SingleInstanceHealth {
+	s.Color = &v
+	return s
+}
+
+// SetDeployment sets the Deployment field's value.
+func (s *SingleInstanceHealth) SetDeployment(v *Deployment) *SingleInstanceHealth {
+	s.Deployment = v
+	return s
+}
+
+// SetHealthStatus sets the HealthStatus field's value.
+func (s *SingleInstanceHealth) SetHealthStatus(v string) *SingleInstanceHealth {
+	s.HealthStatus = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *SingleInstanceHealth) SetInstanceId(v string) *SingleInstanceHealth {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *SingleInstanceHealth) SetInstanceType(v string) *SingleInstanceHealth {
+	s.InstanceType = &v
+	return s
+}
+
+// SetLaunchedAt sets the LaunchedAt field's value.
+func (s *SingleInstanceHealth) SetLaunchedAt(v time.Time) *SingleInstanceHealth {
+	s.LaunchedAt = &v
+	return s
+}
+
+// SetSystem sets the System field's value.
+func (s *SingleInstanceHealth) SetSystem(v *SystemStatus) *SingleInstanceHealth {
+	s.System = v
+	return s
+}
+
 // Describes the solution stack.
 type SolutionStackDescription struct {
 	_ struct{} `type:"structure"`
@@ -5583,6 +7329,18 @@ func (s SolutionStackDescription) String() string {
 // GoString returns the string representation
 func (s SolutionStackDescription) GoString() string {
 	return s.String()
+}
+
+// SetPermittedFileTypes sets the PermittedFileTypes field's value.
+func (s *SolutionStackDescription) SetPermittedFileTypes(v []*string) *SolutionStackDescription {
+	s.PermittedFileTypes = v
+	return s
+}
+
+// SetSolutionStackName sets the SolutionStackName field's value.
+func (s *SolutionStackDescription) SetSolutionStackName(v string) *SolutionStackDescription {
+	s.SolutionStackName = &v
+	return s
 }
 
 type SourceBuildInformation struct {
@@ -5630,6 +7388,24 @@ func (s *SourceBuildInformation) Validate() error {
 	return nil
 }
 
+// SetSourceLocation sets the SourceLocation field's value.
+func (s *SourceBuildInformation) SetSourceLocation(v string) *SourceBuildInformation {
+	s.SourceLocation = &v
+	return s
+}
+
+// SetSourceRepository sets the SourceRepository field's value.
+func (s *SourceBuildInformation) SetSourceRepository(v string) *SourceBuildInformation {
+	s.SourceRepository = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *SourceBuildInformation) SetSourceType(v string) *SourceBuildInformation {
+	s.SourceType = &v
+	return s
+}
+
 // A specification for an environment configuration
 type SourceConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -5667,6 +7443,18 @@ func (s *SourceConfiguration) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *SourceConfiguration) SetApplicationName(v string) *SourceConfiguration {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *SourceConfiguration) SetTemplateName(v string) *SourceConfiguration {
+	s.TemplateName = &v
+	return s
+}
+
 // Represents the percentage of requests over the last 10 seconds that resulted
 // in each type of status code response. For more information, see Status Code
 // Definitions (http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).
@@ -5698,6 +7486,30 @@ func (s StatusCodes) String() string {
 // GoString returns the string representation
 func (s StatusCodes) GoString() string {
 	return s.String()
+}
+
+// SetStatus2xx sets the Status2xx field's value.
+func (s *StatusCodes) SetStatus2xx(v int64) *StatusCodes {
+	s.Status2xx = &v
+	return s
+}
+
+// SetStatus3xx sets the Status3xx field's value.
+func (s *StatusCodes) SetStatus3xx(v int64) *StatusCodes {
+	s.Status3xx = &v
+	return s
+}
+
+// SetStatus4xx sets the Status4xx field's value.
+func (s *StatusCodes) SetStatus4xx(v int64) *StatusCodes {
+	s.Status4xx = &v
+	return s
+}
+
+// SetStatus5xx sets the Status5xx field's value.
+func (s *StatusCodes) SetStatus5xx(v int64) *StatusCodes {
+	s.Status5xx = &v
+	return s
 }
 
 // Swaps the CNAMEs of two environments.
@@ -5759,6 +7571,30 @@ func (s *SwapEnvironmentCNAMEsInput) Validate() error {
 	return nil
 }
 
+// SetDestinationEnvironmentId sets the DestinationEnvironmentId field's value.
+func (s *SwapEnvironmentCNAMEsInput) SetDestinationEnvironmentId(v string) *SwapEnvironmentCNAMEsInput {
+	s.DestinationEnvironmentId = &v
+	return s
+}
+
+// SetDestinationEnvironmentName sets the DestinationEnvironmentName field's value.
+func (s *SwapEnvironmentCNAMEsInput) SetDestinationEnvironmentName(v string) *SwapEnvironmentCNAMEsInput {
+	s.DestinationEnvironmentName = &v
+	return s
+}
+
+// SetSourceEnvironmentId sets the SourceEnvironmentId field's value.
+func (s *SwapEnvironmentCNAMEsInput) SetSourceEnvironmentId(v string) *SwapEnvironmentCNAMEsInput {
+	s.SourceEnvironmentId = &v
+	return s
+}
+
+// SetSourceEnvironmentName sets the SourceEnvironmentName field's value.
+func (s *SwapEnvironmentCNAMEsInput) SetSourceEnvironmentName(v string) *SwapEnvironmentCNAMEsInput {
+	s.SourceEnvironmentName = &v
+	return s
+}
+
 type SwapEnvironmentCNAMEsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5798,6 +7634,18 @@ func (s SystemStatus) GoString() string {
 	return s.String()
 }
 
+// SetCPUUtilization sets the CPUUtilization field's value.
+func (s *SystemStatus) SetCPUUtilization(v *CPUUtilization) *SystemStatus {
+	s.CPUUtilization = v
+	return s
+}
+
+// SetLoadAverage sets the LoadAverage field's value.
+func (s *SystemStatus) SetLoadAverage(v []*float64) *SystemStatus {
+	s.LoadAverage = v
+	return s
+}
+
 // Describes a tag applied to a resource in an environment.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -5833,6 +7681,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // Request to terminate an environment.
@@ -5897,6 +7757,30 @@ func (s *TerminateEnvironmentInput) Validate() error {
 	return nil
 }
 
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *TerminateEnvironmentInput) SetEnvironmentId(v string) *TerminateEnvironmentInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *TerminateEnvironmentInput) SetEnvironmentName(v string) *TerminateEnvironmentInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetForceTerminate sets the ForceTerminate field's value.
+func (s *TerminateEnvironmentInput) SetForceTerminate(v bool) *TerminateEnvironmentInput {
+	s.ForceTerminate = &v
+	return s
+}
+
+// SetTerminateResources sets the TerminateResources field's value.
+func (s *TerminateEnvironmentInput) SetTerminateResources(v bool) *TerminateEnvironmentInput {
+	s.TerminateResources = &v
+	return s
+}
+
 // Describes a trigger.
 type Trigger struct {
 	_ struct{} `type:"structure"`
@@ -5913,6 +7797,12 @@ func (s Trigger) String() string {
 // GoString returns the string representation
 func (s Trigger) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *Trigger) SetName(v string) *Trigger {
+	s.Name = &v
+	return s
 }
 
 // Request to update an application.
@@ -5955,6 +7845,18 @@ func (s *UpdateApplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *UpdateApplicationInput) SetApplicationName(v string) *UpdateApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateApplicationInput) SetDescription(v string) *UpdateApplicationInput {
+	s.Description = &v
+	return s
 }
 
 type UpdateApplicationVersionInput struct {
@@ -6010,6 +7912,24 @@ func (s *UpdateApplicationVersionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *UpdateApplicationVersionInput) SetApplicationName(v string) *UpdateApplicationVersionInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateApplicationVersionInput) SetDescription(v string) *UpdateApplicationVersionInput {
+	s.Description = &v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *UpdateApplicationVersionInput) SetVersionLabel(v string) *UpdateApplicationVersionInput {
+	s.VersionLabel = &v
+	return s
 }
 
 // The result message containing the options for the specified solution stack.
@@ -6096,6 +8016,36 @@ func (s *UpdateConfigurationTemplateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *UpdateConfigurationTemplateInput) SetApplicationName(v string) *UpdateConfigurationTemplateInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateConfigurationTemplateInput) SetDescription(v string) *UpdateConfigurationTemplateInput {
+	s.Description = &v
+	return s
+}
+
+// SetOptionSettings sets the OptionSettings field's value.
+func (s *UpdateConfigurationTemplateInput) SetOptionSettings(v []*ConfigurationOptionSetting) *UpdateConfigurationTemplateInput {
+	s.OptionSettings = v
+	return s
+}
+
+// SetOptionsToRemove sets the OptionsToRemove field's value.
+func (s *UpdateConfigurationTemplateInput) SetOptionsToRemove(v []*OptionSpecification) *UpdateConfigurationTemplateInput {
+	s.OptionsToRemove = v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *UpdateConfigurationTemplateInput) SetTemplateName(v string) *UpdateConfigurationTemplateInput {
+	s.TemplateName = &v
+	return s
 }
 
 // Request to update an environment.
@@ -6219,6 +8169,72 @@ func (s *UpdateEnvironmentInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *UpdateEnvironmentInput) SetApplicationName(v string) *UpdateEnvironmentInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateEnvironmentInput) SetDescription(v string) *UpdateEnvironmentInput {
+	s.Description = &v
+	return s
+}
+
+// SetEnvironmentId sets the EnvironmentId field's value.
+func (s *UpdateEnvironmentInput) SetEnvironmentId(v string) *UpdateEnvironmentInput {
+	s.EnvironmentId = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *UpdateEnvironmentInput) SetEnvironmentName(v string) *UpdateEnvironmentInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *UpdateEnvironmentInput) SetGroupName(v string) *UpdateEnvironmentInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetOptionSettings sets the OptionSettings field's value.
+func (s *UpdateEnvironmentInput) SetOptionSettings(v []*ConfigurationOptionSetting) *UpdateEnvironmentInput {
+	s.OptionSettings = v
+	return s
+}
+
+// SetOptionsToRemove sets the OptionsToRemove field's value.
+func (s *UpdateEnvironmentInput) SetOptionsToRemove(v []*OptionSpecification) *UpdateEnvironmentInput {
+	s.OptionsToRemove = v
+	return s
+}
+
+// SetSolutionStackName sets the SolutionStackName field's value.
+func (s *UpdateEnvironmentInput) SetSolutionStackName(v string) *UpdateEnvironmentInput {
+	s.SolutionStackName = &v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *UpdateEnvironmentInput) SetTemplateName(v string) *UpdateEnvironmentInput {
+	s.TemplateName = &v
+	return s
+}
+
+// SetTier sets the Tier field's value.
+func (s *UpdateEnvironmentInput) SetTier(v *EnvironmentTier) *UpdateEnvironmentInput {
+	s.Tier = v
+	return s
+}
+
+// SetVersionLabel sets the VersionLabel field's value.
+func (s *UpdateEnvironmentInput) SetVersionLabel(v string) *UpdateEnvironmentInput {
+	s.VersionLabel = &v
+	return s
+}
+
 // A list of validation messages for a specified configuration template.
 type ValidateConfigurationSettingsInput struct {
 	_ struct{} `type:"structure"`
@@ -6290,6 +8306,30 @@ func (s *ValidateConfigurationSettingsInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ValidateConfigurationSettingsInput) SetApplicationName(v string) *ValidateConfigurationSettingsInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetEnvironmentName sets the EnvironmentName field's value.
+func (s *ValidateConfigurationSettingsInput) SetEnvironmentName(v string) *ValidateConfigurationSettingsInput {
+	s.EnvironmentName = &v
+	return s
+}
+
+// SetOptionSettings sets the OptionSettings field's value.
+func (s *ValidateConfigurationSettingsInput) SetOptionSettings(v []*ConfigurationOptionSetting) *ValidateConfigurationSettingsInput {
+	s.OptionSettings = v
+	return s
+}
+
+// SetTemplateName sets the TemplateName field's value.
+func (s *ValidateConfigurationSettingsInput) SetTemplateName(v string) *ValidateConfigurationSettingsInput {
+	s.TemplateName = &v
+	return s
+}
+
 // Provides a list of validation messages.
 type ValidateConfigurationSettingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6306,6 +8346,12 @@ func (s ValidateConfigurationSettingsOutput) String() string {
 // GoString returns the string representation
 func (s ValidateConfigurationSettingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMessages sets the Messages field's value.
+func (s *ValidateConfigurationSettingsOutput) SetMessages(v []*ValidationMessage) *ValidateConfigurationSettingsOutput {
+	s.Messages = v
+	return s
 }
 
 // An error or warning for a desired configuration option value.
@@ -6337,6 +8383,30 @@ func (s ValidationMessage) String() string {
 // GoString returns the string representation
 func (s ValidationMessage) GoString() string {
 	return s.String()
+}
+
+// SetMessage sets the Message field's value.
+func (s *ValidationMessage) SetMessage(v string) *ValidationMessage {
+	s.Message = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *ValidationMessage) SetNamespace(v string) *ValidationMessage {
+	s.Namespace = &v
+	return s
+}
+
+// SetOptionName sets the OptionName field's value.
+func (s *ValidationMessage) SetOptionName(v string) *ValidationMessage {
+	s.OptionName = &v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *ValidationMessage) SetSeverity(v string) *ValidationMessage {
+	s.Severity = &v
+	return s
 }
 
 const (

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -831,6 +831,18 @@ func (s AccessPoliciesStatus) GoString() string {
 	return s.String()
 }
 
+// SetOptions sets the Options field's value.
+func (s *AccessPoliciesStatus) SetOptions(v string) *AccessPoliciesStatus {
+	s.Options = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AccessPoliciesStatus) SetStatus(v *OptionStatus) *AccessPoliciesStatus {
+	s.Status = v
+	return s
+}
+
 // Container for the parameters to the AddTags operation. Specify the tags that
 // you want to attach to the Elasticsearch domain.
 type AddTagsInput struct {
@@ -883,6 +895,18 @@ func (s *AddTagsInput) Validate() error {
 	return nil
 }
 
+// SetARN sets the ARN field's value.
+func (s *AddTagsInput) SetARN(v string) *AddTagsInput {
+	s.ARN = &v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *AddTagsInput) SetTagList(v []*Tag) *AddTagsInput {
+	s.TagList = v
+	return s
+}
+
 type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -931,6 +955,18 @@ func (s AdvancedOptionsStatus) String() string {
 // GoString returns the string representation
 func (s AdvancedOptionsStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *AdvancedOptionsStatus) SetOptions(v map[string]*string) *AdvancedOptionsStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AdvancedOptionsStatus) SetStatus(v *OptionStatus) *AdvancedOptionsStatus {
+	s.Status = v
+	return s
 }
 
 type CreateElasticsearchDomainInput struct {
@@ -997,6 +1033,48 @@ func (s *CreateElasticsearchDomainInput) Validate() error {
 	return nil
 }
 
+// SetAccessPolicies sets the AccessPolicies field's value.
+func (s *CreateElasticsearchDomainInput) SetAccessPolicies(v string) *CreateElasticsearchDomainInput {
+	s.AccessPolicies = &v
+	return s
+}
+
+// SetAdvancedOptions sets the AdvancedOptions field's value.
+func (s *CreateElasticsearchDomainInput) SetAdvancedOptions(v map[string]*string) *CreateElasticsearchDomainInput {
+	s.AdvancedOptions = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *CreateElasticsearchDomainInput) SetDomainName(v string) *CreateElasticsearchDomainInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetEBSOptions sets the EBSOptions field's value.
+func (s *CreateElasticsearchDomainInput) SetEBSOptions(v *EBSOptions) *CreateElasticsearchDomainInput {
+	s.EBSOptions = v
+	return s
+}
+
+// SetElasticsearchClusterConfig sets the ElasticsearchClusterConfig field's value.
+func (s *CreateElasticsearchDomainInput) SetElasticsearchClusterConfig(v *ElasticsearchClusterConfig) *CreateElasticsearchDomainInput {
+	s.ElasticsearchClusterConfig = v
+	return s
+}
+
+// SetElasticsearchVersion sets the ElasticsearchVersion field's value.
+func (s *CreateElasticsearchDomainInput) SetElasticsearchVersion(v string) *CreateElasticsearchDomainInput {
+	s.ElasticsearchVersion = &v
+	return s
+}
+
+// SetSnapshotOptions sets the SnapshotOptions field's value.
+func (s *CreateElasticsearchDomainInput) SetSnapshotOptions(v *SnapshotOptions) *CreateElasticsearchDomainInput {
+	s.SnapshotOptions = v
+	return s
+}
+
 // The result of a CreateElasticsearchDomain operation. Contains the status
 // of the newly created Elasticsearch domain.
 type CreateElasticsearchDomainOutput struct {
@@ -1014,6 +1092,12 @@ func (s CreateElasticsearchDomainOutput) String() string {
 // GoString returns the string representation
 func (s CreateElasticsearchDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainStatus sets the DomainStatus field's value.
+func (s *CreateElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomainStatus) *CreateElasticsearchDomainOutput {
+	s.DomainStatus = v
+	return s
 }
 
 // Container for the parameters to the DeleteElasticsearchDomain operation.
@@ -1053,6 +1137,12 @@ func (s *DeleteElasticsearchDomainInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteElasticsearchDomainInput) SetDomainName(v string) *DeleteElasticsearchDomainInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DeleteElasticsearchDomain request. Contains the status of
 // the pending deletion, or no status if the domain and all of its resources
 // have been deleted.
@@ -1071,6 +1161,12 @@ func (s DeleteElasticsearchDomainOutput) String() string {
 // GoString returns the string representation
 func (s DeleteElasticsearchDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainStatus sets the DomainStatus field's value.
+func (s *DeleteElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomainStatus) *DeleteElasticsearchDomainOutput {
+	s.DomainStatus = v
+	return s
 }
 
 // Container for the parameters to the DescribeElasticsearchDomainConfig operation.
@@ -1110,6 +1206,12 @@ func (s *DescribeElasticsearchDomainConfigInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeElasticsearchDomainConfigInput) SetDomainName(v string) *DescribeElasticsearchDomainConfigInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DescribeElasticsearchDomainConfig request. Contains the configuration
 // information of the requested domain.
 type DescribeElasticsearchDomainConfigOutput struct {
@@ -1130,6 +1232,12 @@ func (s DescribeElasticsearchDomainConfigOutput) String() string {
 // GoString returns the string representation
 func (s DescribeElasticsearchDomainConfigOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainConfig sets the DomainConfig field's value.
+func (s *DescribeElasticsearchDomainConfigOutput) SetDomainConfig(v *ElasticsearchDomainConfig) *DescribeElasticsearchDomainConfigOutput {
+	s.DomainConfig = v
+	return s
 }
 
 // Container for the parameters to the DescribeElasticsearchDomain operation.
@@ -1168,6 +1276,12 @@ func (s *DescribeElasticsearchDomainInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeElasticsearchDomainInput) SetDomainName(v string) *DescribeElasticsearchDomainInput {
+	s.DomainName = &v
+	return s
+}
+
 // The result of a DescribeElasticsearchDomain request. Contains the status
 // of the domain specified in the request.
 type DescribeElasticsearchDomainOutput struct {
@@ -1187,6 +1301,12 @@ func (s DescribeElasticsearchDomainOutput) String() string {
 // GoString returns the string representation
 func (s DescribeElasticsearchDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainStatus sets the DomainStatus field's value.
+func (s *DescribeElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomainStatus) *DescribeElasticsearchDomainOutput {
+	s.DomainStatus = v
+	return s
 }
 
 // Container for the parameters to the DescribeElasticsearchDomains operation.
@@ -1223,6 +1343,12 @@ func (s *DescribeElasticsearchDomainsInput) Validate() error {
 	return nil
 }
 
+// SetDomainNames sets the DomainNames field's value.
+func (s *DescribeElasticsearchDomainsInput) SetDomainNames(v []*string) *DescribeElasticsearchDomainsInput {
+	s.DomainNames = v
+	return s
+}
+
 // The result of a DescribeElasticsearchDomains request. Contains the status
 // of the specified domains or all domains owned by the account.
 type DescribeElasticsearchDomainsOutput struct {
@@ -1244,6 +1370,12 @@ func (s DescribeElasticsearchDomainsOutput) GoString() string {
 	return s.String()
 }
 
+// SetDomainStatusList sets the DomainStatusList field's value.
+func (s *DescribeElasticsearchDomainsOutput) SetDomainStatusList(v []*ElasticsearchDomainStatus) *DescribeElasticsearchDomainsOutput {
+	s.DomainStatusList = v
+	return s
+}
+
 type DomainInfo struct {
 	_ struct{} `type:"structure"`
 
@@ -1259,6 +1391,12 @@ func (s DomainInfo) String() string {
 // GoString returns the string representation
 func (s DomainInfo) GoString() string {
 	return s.String()
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DomainInfo) SetDomainName(v string) *DomainInfo {
+	s.DomainName = &v
+	return s
 }
 
 // Options to enable, disable, and specify the properties of EBS storage volumes.
@@ -1289,6 +1427,30 @@ func (s EBSOptions) GoString() string {
 	return s.String()
 }
 
+// SetEBSEnabled sets the EBSEnabled field's value.
+func (s *EBSOptions) SetEBSEnabled(v bool) *EBSOptions {
+	s.EBSEnabled = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *EBSOptions) SetIops(v int64) *EBSOptions {
+	s.Iops = &v
+	return s
+}
+
+// SetVolumeSize sets the VolumeSize field's value.
+func (s *EBSOptions) SetVolumeSize(v int64) *EBSOptions {
+	s.VolumeSize = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *EBSOptions) SetVolumeType(v string) *EBSOptions {
+	s.VolumeType = &v
+	return s
+}
+
 // Status of the EBS options for the specified Elasticsearch domain.
 type EBSOptionsStatus struct {
 	_ struct{} `type:"structure"`
@@ -1312,6 +1474,18 @@ func (s EBSOptionsStatus) String() string {
 // GoString returns the string representation
 func (s EBSOptionsStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *EBSOptionsStatus) SetOptions(v *EBSOptions) *EBSOptionsStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EBSOptionsStatus) SetStatus(v *OptionStatus) *EBSOptionsStatus {
+	s.Status = v
+	return s
 }
 
 // Specifies the configuration for the domain cluster, such as the type and
@@ -1352,6 +1526,42 @@ func (s ElasticsearchClusterConfig) GoString() string {
 	return s.String()
 }
 
+// SetDedicatedMasterCount sets the DedicatedMasterCount field's value.
+func (s *ElasticsearchClusterConfig) SetDedicatedMasterCount(v int64) *ElasticsearchClusterConfig {
+	s.DedicatedMasterCount = &v
+	return s
+}
+
+// SetDedicatedMasterEnabled sets the DedicatedMasterEnabled field's value.
+func (s *ElasticsearchClusterConfig) SetDedicatedMasterEnabled(v bool) *ElasticsearchClusterConfig {
+	s.DedicatedMasterEnabled = &v
+	return s
+}
+
+// SetDedicatedMasterType sets the DedicatedMasterType field's value.
+func (s *ElasticsearchClusterConfig) SetDedicatedMasterType(v string) *ElasticsearchClusterConfig {
+	s.DedicatedMasterType = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *ElasticsearchClusterConfig) SetInstanceCount(v int64) *ElasticsearchClusterConfig {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *ElasticsearchClusterConfig) SetInstanceType(v string) *ElasticsearchClusterConfig {
+	s.InstanceType = &v
+	return s
+}
+
+// SetZoneAwarenessEnabled sets the ZoneAwarenessEnabled field's value.
+func (s *ElasticsearchClusterConfig) SetZoneAwarenessEnabled(v bool) *ElasticsearchClusterConfig {
+	s.ZoneAwarenessEnabled = &v
+	return s
+}
+
 // Specifies the configuration status for the specified Elasticsearch domain.
 type ElasticsearchClusterConfigStatus struct {
 	_ struct{} `type:"structure"`
@@ -1376,6 +1586,18 @@ func (s ElasticsearchClusterConfigStatus) String() string {
 // GoString returns the string representation
 func (s ElasticsearchClusterConfigStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *ElasticsearchClusterConfigStatus) SetOptions(v *ElasticsearchClusterConfig) *ElasticsearchClusterConfigStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ElasticsearchClusterConfigStatus) SetStatus(v *OptionStatus) *ElasticsearchClusterConfigStatus {
+	s.Status = v
+	return s
 }
 
 // The configuration of an Elasticsearch domain.
@@ -1411,6 +1633,42 @@ func (s ElasticsearchDomainConfig) String() string {
 // GoString returns the string representation
 func (s ElasticsearchDomainConfig) GoString() string {
 	return s.String()
+}
+
+// SetAccessPolicies sets the AccessPolicies field's value.
+func (s *ElasticsearchDomainConfig) SetAccessPolicies(v *AccessPoliciesStatus) *ElasticsearchDomainConfig {
+	s.AccessPolicies = v
+	return s
+}
+
+// SetAdvancedOptions sets the AdvancedOptions field's value.
+func (s *ElasticsearchDomainConfig) SetAdvancedOptions(v *AdvancedOptionsStatus) *ElasticsearchDomainConfig {
+	s.AdvancedOptions = v
+	return s
+}
+
+// SetEBSOptions sets the EBSOptions field's value.
+func (s *ElasticsearchDomainConfig) SetEBSOptions(v *EBSOptionsStatus) *ElasticsearchDomainConfig {
+	s.EBSOptions = v
+	return s
+}
+
+// SetElasticsearchClusterConfig sets the ElasticsearchClusterConfig field's value.
+func (s *ElasticsearchDomainConfig) SetElasticsearchClusterConfig(v *ElasticsearchClusterConfigStatus) *ElasticsearchDomainConfig {
+	s.ElasticsearchClusterConfig = v
+	return s
+}
+
+// SetElasticsearchVersion sets the ElasticsearchVersion field's value.
+func (s *ElasticsearchDomainConfig) SetElasticsearchVersion(v *ElasticsearchVersionStatus) *ElasticsearchDomainConfig {
+	s.ElasticsearchVersion = v
+	return s
+}
+
+// SetSnapshotOptions sets the SnapshotOptions field's value.
+func (s *ElasticsearchDomainConfig) SetSnapshotOptions(v *SnapshotOptionsStatus) *ElasticsearchDomainConfig {
+	s.SnapshotOptions = v
+	return s
 }
 
 // The current status of an Elasticsearch domain.
@@ -1488,6 +1746,84 @@ func (s ElasticsearchDomainStatus) GoString() string {
 	return s.String()
 }
 
+// SetARN sets the ARN field's value.
+func (s *ElasticsearchDomainStatus) SetARN(v string) *ElasticsearchDomainStatus {
+	s.ARN = &v
+	return s
+}
+
+// SetAccessPolicies sets the AccessPolicies field's value.
+func (s *ElasticsearchDomainStatus) SetAccessPolicies(v string) *ElasticsearchDomainStatus {
+	s.AccessPolicies = &v
+	return s
+}
+
+// SetAdvancedOptions sets the AdvancedOptions field's value.
+func (s *ElasticsearchDomainStatus) SetAdvancedOptions(v map[string]*string) *ElasticsearchDomainStatus {
+	s.AdvancedOptions = v
+	return s
+}
+
+// SetCreated sets the Created field's value.
+func (s *ElasticsearchDomainStatus) SetCreated(v bool) *ElasticsearchDomainStatus {
+	s.Created = &v
+	return s
+}
+
+// SetDeleted sets the Deleted field's value.
+func (s *ElasticsearchDomainStatus) SetDeleted(v bool) *ElasticsearchDomainStatus {
+	s.Deleted = &v
+	return s
+}
+
+// SetDomainId sets the DomainId field's value.
+func (s *ElasticsearchDomainStatus) SetDomainId(v string) *ElasticsearchDomainStatus {
+	s.DomainId = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *ElasticsearchDomainStatus) SetDomainName(v string) *ElasticsearchDomainStatus {
+	s.DomainName = &v
+	return s
+}
+
+// SetEBSOptions sets the EBSOptions field's value.
+func (s *ElasticsearchDomainStatus) SetEBSOptions(v *EBSOptions) *ElasticsearchDomainStatus {
+	s.EBSOptions = v
+	return s
+}
+
+// SetElasticsearchClusterConfig sets the ElasticsearchClusterConfig field's value.
+func (s *ElasticsearchDomainStatus) SetElasticsearchClusterConfig(v *ElasticsearchClusterConfig) *ElasticsearchDomainStatus {
+	s.ElasticsearchClusterConfig = v
+	return s
+}
+
+// SetElasticsearchVersion sets the ElasticsearchVersion field's value.
+func (s *ElasticsearchDomainStatus) SetElasticsearchVersion(v string) *ElasticsearchDomainStatus {
+	s.ElasticsearchVersion = &v
+	return s
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *ElasticsearchDomainStatus) SetEndpoint(v string) *ElasticsearchDomainStatus {
+	s.Endpoint = &v
+	return s
+}
+
+// SetProcessing sets the Processing field's value.
+func (s *ElasticsearchDomainStatus) SetProcessing(v bool) *ElasticsearchDomainStatus {
+	s.Processing = &v
+	return s
+}
+
+// SetSnapshotOptions sets the SnapshotOptions field's value.
+func (s *ElasticsearchDomainStatus) SetSnapshotOptions(v *SnapshotOptions) *ElasticsearchDomainStatus {
+	s.SnapshotOptions = v
+	return s
+}
+
 // Status of the Elasticsearch version options for the specified Elasticsearch
 // domain.
 type ElasticsearchVersionStatus struct {
@@ -1513,6 +1849,18 @@ func (s ElasticsearchVersionStatus) String() string {
 // GoString returns the string representation
 func (s ElasticsearchVersionStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *ElasticsearchVersionStatus) SetOptions(v string) *ElasticsearchVersionStatus {
+	s.Options = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ElasticsearchVersionStatus) SetStatus(v *OptionStatus) *ElasticsearchVersionStatus {
+	s.Status = v
+	return s
 }
 
 type ListDomainNamesInput struct {
@@ -1546,6 +1894,12 @@ func (s ListDomainNamesOutput) String() string {
 // GoString returns the string representation
 func (s ListDomainNamesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainNames sets the DomainNames field's value.
+func (s *ListDomainNamesOutput) SetDomainNames(v []*DomainInfo) *ListDomainNamesOutput {
+	s.DomainNames = v
+	return s
 }
 
 // Container for the parameters to the ListTags operation. Specify the ARN for
@@ -1584,6 +1938,12 @@ func (s *ListTagsInput) Validate() error {
 	return nil
 }
 
+// SetARN sets the ARN field's value.
+func (s *ListTagsInput) SetARN(v string) *ListTagsInput {
+	s.ARN = &v
+	return s
+}
+
 // The result of a ListTags operation. Contains tags for all requested Elasticsearch
 // domains.
 type ListTagsOutput struct {
@@ -1601,6 +1961,12 @@ func (s ListTagsOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagList sets the TagList field's value.
+func (s *ListTagsOutput) SetTagList(v []*Tag) *ListTagsOutput {
+	s.TagList = v
+	return s
 }
 
 // Provides the current status of the entity.
@@ -1637,6 +2003,36 @@ func (s OptionStatus) String() string {
 // GoString returns the string representation
 func (s OptionStatus) GoString() string {
 	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *OptionStatus) SetCreationDate(v time.Time) *OptionStatus {
+	s.CreationDate = &v
+	return s
+}
+
+// SetPendingDeletion sets the PendingDeletion field's value.
+func (s *OptionStatus) SetPendingDeletion(v bool) *OptionStatus {
+	s.PendingDeletion = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *OptionStatus) SetState(v string) *OptionStatus {
+	s.State = &v
+	return s
+}
+
+// SetUpdateDate sets the UpdateDate field's value.
+func (s *OptionStatus) SetUpdateDate(v time.Time) *OptionStatus {
+	s.UpdateDate = &v
+	return s
+}
+
+// SetUpdateVersion sets the UpdateVersion field's value.
+func (s *OptionStatus) SetUpdateVersion(v int64) *OptionStatus {
+	s.UpdateVersion = &v
+	return s
 }
 
 // Container for the parameters to the RemoveTags operation. Specify the ARN
@@ -1684,6 +2080,18 @@ func (s *RemoveTagsInput) Validate() error {
 	return nil
 }
 
+// SetARN sets the ARN field's value.
+func (s *RemoveTagsInput) SetARN(v string) *RemoveTagsInput {
+	s.ARN = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsInput) SetTagKeys(v []*string) *RemoveTagsInput {
+	s.TagKeys = v
+	return s
+}
+
 type RemoveTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1718,6 +2126,12 @@ func (s SnapshotOptions) GoString() string {
 	return s.String()
 }
 
+// SetAutomatedSnapshotStartHour sets the AutomatedSnapshotStartHour field's value.
+func (s *SnapshotOptions) SetAutomatedSnapshotStartHour(v int64) *SnapshotOptions {
+	s.AutomatedSnapshotStartHour = &v
+	return s
+}
+
 // Status of a daily automated snapshot.
 type SnapshotOptionsStatus struct {
 	_ struct{} `type:"structure"`
@@ -1741,6 +2155,18 @@ func (s SnapshotOptionsStatus) String() string {
 // GoString returns the string representation
 func (s SnapshotOptionsStatus) GoString() string {
 	return s.String()
+}
+
+// SetOptions sets the Options field's value.
+func (s *SnapshotOptionsStatus) SetOptions(v *SnapshotOptions) *SnapshotOptionsStatus {
+	s.Options = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SnapshotOptionsStatus) SetStatus(v *OptionStatus) *SnapshotOptionsStatus {
+	s.Status = v
+	return s
 }
 
 // Specifies a key value pair for a resource tag.
@@ -1789,6 +2215,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // Container for the parameters to the UpdateElasticsearchDomain operation.
@@ -1847,6 +2285,42 @@ func (s *UpdateElasticsearchDomainConfigInput) Validate() error {
 	return nil
 }
 
+// SetAccessPolicies sets the AccessPolicies field's value.
+func (s *UpdateElasticsearchDomainConfigInput) SetAccessPolicies(v string) *UpdateElasticsearchDomainConfigInput {
+	s.AccessPolicies = &v
+	return s
+}
+
+// SetAdvancedOptions sets the AdvancedOptions field's value.
+func (s *UpdateElasticsearchDomainConfigInput) SetAdvancedOptions(v map[string]*string) *UpdateElasticsearchDomainConfigInput {
+	s.AdvancedOptions = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateElasticsearchDomainConfigInput) SetDomainName(v string) *UpdateElasticsearchDomainConfigInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetEBSOptions sets the EBSOptions field's value.
+func (s *UpdateElasticsearchDomainConfigInput) SetEBSOptions(v *EBSOptions) *UpdateElasticsearchDomainConfigInput {
+	s.EBSOptions = v
+	return s
+}
+
+// SetElasticsearchClusterConfig sets the ElasticsearchClusterConfig field's value.
+func (s *UpdateElasticsearchDomainConfigInput) SetElasticsearchClusterConfig(v *ElasticsearchClusterConfig) *UpdateElasticsearchDomainConfigInput {
+	s.ElasticsearchClusterConfig = v
+	return s
+}
+
+// SetSnapshotOptions sets the SnapshotOptions field's value.
+func (s *UpdateElasticsearchDomainConfigInput) SetSnapshotOptions(v *SnapshotOptions) *UpdateElasticsearchDomainConfigInput {
+	s.SnapshotOptions = v
+	return s
+}
+
 // The result of an UpdateElasticsearchDomain request. Contains the status of
 // the Elasticsearch domain being updated.
 type UpdateElasticsearchDomainConfigOutput struct {
@@ -1866,6 +2340,12 @@ func (s UpdateElasticsearchDomainConfigOutput) String() string {
 // GoString returns the string representation
 func (s UpdateElasticsearchDomainConfigOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainConfig sets the DomainConfig field's value.
+func (s *UpdateElasticsearchDomainConfigOutput) SetDomainConfig(v *ElasticsearchDomainConfig) *UpdateElasticsearchDomainConfigOutput {
+	s.DomainConfig = v
+	return s
 }
 
 const (

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -1646,6 +1646,48 @@ func (s *Artwork) Validate() error {
 	return nil
 }
 
+// SetAlbumArtFormat sets the AlbumArtFormat field's value.
+func (s *Artwork) SetAlbumArtFormat(v string) *Artwork {
+	s.AlbumArtFormat = &v
+	return s
+}
+
+// SetEncryption sets the Encryption field's value.
+func (s *Artwork) SetEncryption(v *Encryption) *Artwork {
+	s.Encryption = v
+	return s
+}
+
+// SetInputKey sets the InputKey field's value.
+func (s *Artwork) SetInputKey(v string) *Artwork {
+	s.InputKey = &v
+	return s
+}
+
+// SetMaxHeight sets the MaxHeight field's value.
+func (s *Artwork) SetMaxHeight(v string) *Artwork {
+	s.MaxHeight = &v
+	return s
+}
+
+// SetMaxWidth sets the MaxWidth field's value.
+func (s *Artwork) SetMaxWidth(v string) *Artwork {
+	s.MaxWidth = &v
+	return s
+}
+
+// SetPaddingPolicy sets the PaddingPolicy field's value.
+func (s *Artwork) SetPaddingPolicy(v string) *Artwork {
+	s.PaddingPolicy = &v
+	return s
+}
+
+// SetSizingPolicy sets the SizingPolicy field's value.
+func (s *Artwork) SetSizingPolicy(v string) *Artwork {
+	s.SizingPolicy = &v
+	return s
+}
+
 // Options associated with your audio codec.
 type AudioCodecOptions struct {
 	_ struct{} `type:"structure"`
@@ -1709,6 +1751,30 @@ func (s AudioCodecOptions) String() string {
 // GoString returns the string representation
 func (s AudioCodecOptions) GoString() string {
 	return s.String()
+}
+
+// SetBitDepth sets the BitDepth field's value.
+func (s *AudioCodecOptions) SetBitDepth(v string) *AudioCodecOptions {
+	s.BitDepth = &v
+	return s
+}
+
+// SetBitOrder sets the BitOrder field's value.
+func (s *AudioCodecOptions) SetBitOrder(v string) *AudioCodecOptions {
+	s.BitOrder = &v
+	return s
+}
+
+// SetProfile sets the Profile field's value.
+func (s *AudioCodecOptions) SetProfile(v string) *AudioCodecOptions {
+	s.Profile = &v
+	return s
+}
+
+// SetSigned sets the Signed field's value.
+func (s *AudioCodecOptions) SetSigned(v string) *AudioCodecOptions {
+	s.Signed = &v
+	return s
 }
 
 // Parameters required for transcoding audio.
@@ -1862,6 +1928,42 @@ func (s AudioParameters) GoString() string {
 	return s.String()
 }
 
+// SetAudioPackingMode sets the AudioPackingMode field's value.
+func (s *AudioParameters) SetAudioPackingMode(v string) *AudioParameters {
+	s.AudioPackingMode = &v
+	return s
+}
+
+// SetBitRate sets the BitRate field's value.
+func (s *AudioParameters) SetBitRate(v string) *AudioParameters {
+	s.BitRate = &v
+	return s
+}
+
+// SetChannels sets the Channels field's value.
+func (s *AudioParameters) SetChannels(v string) *AudioParameters {
+	s.Channels = &v
+	return s
+}
+
+// SetCodec sets the Codec field's value.
+func (s *AudioParameters) SetCodec(v string) *AudioParameters {
+	s.Codec = &v
+	return s
+}
+
+// SetCodecOptions sets the CodecOptions field's value.
+func (s *AudioParameters) SetCodecOptions(v *AudioCodecOptions) *AudioParameters {
+	s.CodecOptions = v
+	return s
+}
+
+// SetSampleRate sets the SampleRate field's value.
+func (s *AudioParameters) SetSampleRate(v string) *AudioParameters {
+	s.SampleRate = &v
+	return s
+}
+
 // The CancelJobRequest structure.
 type CancelJobInput struct {
 	_ struct{} `type:"structure"`
@@ -1896,6 +1998,12 @@ func (s *CancelJobInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *CancelJobInput) SetId(v string) *CancelJobInput {
+	s.Id = &v
+	return s
 }
 
 // The response body contains a JSON object. If the job is successfully canceled,
@@ -1978,6 +2086,24 @@ func (s CaptionFormat) GoString() string {
 	return s.String()
 }
 
+// SetEncryption sets the Encryption field's value.
+func (s *CaptionFormat) SetEncryption(v *Encryption) *CaptionFormat {
+	s.Encryption = v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *CaptionFormat) SetFormat(v string) *CaptionFormat {
+	s.Format = &v
+	return s
+}
+
+// SetPattern sets the Pattern field's value.
+func (s *CaptionFormat) SetPattern(v string) *CaptionFormat {
+	s.Pattern = &v
+	return s
+}
+
 // A source file for the input sidecar captions used during the transcoding
 // process.
 type CaptionSource struct {
@@ -2044,6 +2170,36 @@ func (s *CaptionSource) Validate() error {
 	return nil
 }
 
+// SetEncryption sets the Encryption field's value.
+func (s *CaptionSource) SetEncryption(v *Encryption) *CaptionSource {
+	s.Encryption = v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *CaptionSource) SetKey(v string) *CaptionSource {
+	s.Key = &v
+	return s
+}
+
+// SetLabel sets the Label field's value.
+func (s *CaptionSource) SetLabel(v string) *CaptionSource {
+	s.Label = &v
+	return s
+}
+
+// SetLanguage sets the Language field's value.
+func (s *CaptionSource) SetLanguage(v string) *CaptionSource {
+	s.Language = &v
+	return s
+}
+
+// SetTimeOffset sets the TimeOffset field's value.
+func (s *CaptionSource) SetTimeOffset(v string) *CaptionSource {
+	s.TimeOffset = &v
+	return s
+}
+
 // The captions to be created, if any.
 type Captions struct {
 	_ struct{} `type:"structure"`
@@ -2108,6 +2264,24 @@ func (s *Captions) Validate() error {
 	return nil
 }
 
+// SetCaptionFormats sets the CaptionFormats field's value.
+func (s *Captions) SetCaptionFormats(v []*CaptionFormat) *Captions {
+	s.CaptionFormats = v
+	return s
+}
+
+// SetCaptionSources sets the CaptionSources field's value.
+func (s *Captions) SetCaptionSources(v []*CaptionSource) *Captions {
+	s.CaptionSources = v
+	return s
+}
+
+// SetMergePolicy sets the MergePolicy field's value.
+func (s *Captions) SetMergePolicy(v string) *Captions {
+	s.MergePolicy = &v
+	return s
+}
+
 // Settings for one clip in a composition. All jobs in a playlist must have
 // the same clip settings.
 type Clip struct {
@@ -2125,6 +2299,12 @@ func (s Clip) String() string {
 // GoString returns the string representation
 func (s Clip) GoString() string {
 	return s.String()
+}
+
+// SetTimeSpan sets the TimeSpan field's value.
+func (s *Clip) SetTimeSpan(v *TimeSpan) *Clip {
+	s.TimeSpan = v
+	return s
 }
 
 // The CreateJobRequest structure.
@@ -2229,6 +2409,48 @@ func (s *CreateJobInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInput sets the Input field's value.
+func (s *CreateJobInput) SetInput(v *JobInput) *CreateJobInput {
+	s.Input = v
+	return s
+}
+
+// SetOutput sets the Output field's value.
+func (s *CreateJobInput) SetOutput(v *CreateJobOutput) *CreateJobInput {
+	s.Output = v
+	return s
+}
+
+// SetOutputKeyPrefix sets the OutputKeyPrefix field's value.
+func (s *CreateJobInput) SetOutputKeyPrefix(v string) *CreateJobInput {
+	s.OutputKeyPrefix = &v
+	return s
+}
+
+// SetOutputs sets the Outputs field's value.
+func (s *CreateJobInput) SetOutputs(v []*CreateJobOutput) *CreateJobInput {
+	s.Outputs = v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *CreateJobInput) SetPipelineId(v string) *CreateJobInput {
+	s.PipelineId = &v
+	return s
+}
+
+// SetPlaylists sets the Playlists field's value.
+func (s *CreateJobInput) SetPlaylists(v []*CreateJobPlaylist) *CreateJobInput {
+	s.Playlists = v
+	return s
+}
+
+// SetUserMetadata sets the UserMetadata field's value.
+func (s *CreateJobInput) SetUserMetadata(v map[string]*string) *CreateJobInput {
+	s.UserMetadata = v
+	return s
 }
 
 // The CreateJobOutput structure.
@@ -2418,6 +2640,72 @@ func (s *CreateJobOutput) Validate() error {
 	return nil
 }
 
+// SetAlbumArt sets the AlbumArt field's value.
+func (s *CreateJobOutput) SetAlbumArt(v *JobAlbumArt) *CreateJobOutput {
+	s.AlbumArt = v
+	return s
+}
+
+// SetCaptions sets the Captions field's value.
+func (s *CreateJobOutput) SetCaptions(v *Captions) *CreateJobOutput {
+	s.Captions = v
+	return s
+}
+
+// SetComposition sets the Composition field's value.
+func (s *CreateJobOutput) SetComposition(v []*Clip) *CreateJobOutput {
+	s.Composition = v
+	return s
+}
+
+// SetEncryption sets the Encryption field's value.
+func (s *CreateJobOutput) SetEncryption(v *Encryption) *CreateJobOutput {
+	s.Encryption = v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *CreateJobOutput) SetKey(v string) *CreateJobOutput {
+	s.Key = &v
+	return s
+}
+
+// SetPresetId sets the PresetId field's value.
+func (s *CreateJobOutput) SetPresetId(v string) *CreateJobOutput {
+	s.PresetId = &v
+	return s
+}
+
+// SetRotate sets the Rotate field's value.
+func (s *CreateJobOutput) SetRotate(v string) *CreateJobOutput {
+	s.Rotate = &v
+	return s
+}
+
+// SetSegmentDuration sets the SegmentDuration field's value.
+func (s *CreateJobOutput) SetSegmentDuration(v string) *CreateJobOutput {
+	s.SegmentDuration = &v
+	return s
+}
+
+// SetThumbnailEncryption sets the ThumbnailEncryption field's value.
+func (s *CreateJobOutput) SetThumbnailEncryption(v *Encryption) *CreateJobOutput {
+	s.ThumbnailEncryption = v
+	return s
+}
+
+// SetThumbnailPattern sets the ThumbnailPattern field's value.
+func (s *CreateJobOutput) SetThumbnailPattern(v string) *CreateJobOutput {
+	s.ThumbnailPattern = &v
+	return s
+}
+
+// SetWatermarks sets the Watermarks field's value.
+func (s *CreateJobOutput) SetWatermarks(v []*JobWatermark) *CreateJobOutput {
+	s.Watermarks = v
+	return s
+}
+
 // Information about the master playlist.
 type CreateJobPlaylist struct {
 	_ struct{} `type:"structure"`
@@ -2513,6 +2801,36 @@ func (s *CreateJobPlaylist) Validate() error {
 	return nil
 }
 
+// SetFormat sets the Format field's value.
+func (s *CreateJobPlaylist) SetFormat(v string) *CreateJobPlaylist {
+	s.Format = &v
+	return s
+}
+
+// SetHlsContentProtection sets the HlsContentProtection field's value.
+func (s *CreateJobPlaylist) SetHlsContentProtection(v *HlsContentProtection) *CreateJobPlaylist {
+	s.HlsContentProtection = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateJobPlaylist) SetName(v string) *CreateJobPlaylist {
+	s.Name = &v
+	return s
+}
+
+// SetOutputKeys sets the OutputKeys field's value.
+func (s *CreateJobPlaylist) SetOutputKeys(v []*string) *CreateJobPlaylist {
+	s.OutputKeys = v
+	return s
+}
+
+// SetPlayReadyDrm sets the PlayReadyDrm field's value.
+func (s *CreateJobPlaylist) SetPlayReadyDrm(v *PlayReadyDrm) *CreateJobPlaylist {
+	s.PlayReadyDrm = v
+	return s
+}
+
 // The CreateJobResponse structure.
 type CreateJobResponse struct {
 	_ struct{} `type:"structure"`
@@ -2530,6 +2848,12 @@ func (s CreateJobResponse) String() string {
 // GoString returns the string representation
 func (s CreateJobResponse) GoString() string {
 	return s.String()
+}
+
+// SetJob sets the Job field's value.
+func (s *CreateJobResponse) SetJob(v *Job) *CreateJobResponse {
+	s.Job = v
+	return s
 }
 
 // The CreatePipelineRequest structure.
@@ -2756,6 +3080,54 @@ func (s *CreatePipelineInput) Validate() error {
 	return nil
 }
 
+// SetAwsKmsKeyArn sets the AwsKmsKeyArn field's value.
+func (s *CreatePipelineInput) SetAwsKmsKeyArn(v string) *CreatePipelineInput {
+	s.AwsKmsKeyArn = &v
+	return s
+}
+
+// SetContentConfig sets the ContentConfig field's value.
+func (s *CreatePipelineInput) SetContentConfig(v *PipelineOutputConfig) *CreatePipelineInput {
+	s.ContentConfig = v
+	return s
+}
+
+// SetInputBucket sets the InputBucket field's value.
+func (s *CreatePipelineInput) SetInputBucket(v string) *CreatePipelineInput {
+	s.InputBucket = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreatePipelineInput) SetName(v string) *CreatePipelineInput {
+	s.Name = &v
+	return s
+}
+
+// SetNotifications sets the Notifications field's value.
+func (s *CreatePipelineInput) SetNotifications(v *Notifications) *CreatePipelineInput {
+	s.Notifications = v
+	return s
+}
+
+// SetOutputBucket sets the OutputBucket field's value.
+func (s *CreatePipelineInput) SetOutputBucket(v string) *CreatePipelineInput {
+	s.OutputBucket = &v
+	return s
+}
+
+// SetRole sets the Role field's value.
+func (s *CreatePipelineInput) SetRole(v string) *CreatePipelineInput {
+	s.Role = &v
+	return s
+}
+
+// SetThumbnailConfig sets the ThumbnailConfig field's value.
+func (s *CreatePipelineInput) SetThumbnailConfig(v *PipelineOutputConfig) *CreatePipelineInput {
+	s.ThumbnailConfig = v
+	return s
+}
+
 // When you create a pipeline, Elastic Transcoder returns the values that you
 // specified in the request.
 type CreatePipelineOutput struct {
@@ -2782,6 +3154,18 @@ func (s CreatePipelineOutput) String() string {
 // GoString returns the string representation
 func (s CreatePipelineOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipeline sets the Pipeline field's value.
+func (s *CreatePipelineOutput) SetPipeline(v *Pipeline) *CreatePipelineOutput {
+	s.Pipeline = v
+	return s
+}
+
+// SetWarnings sets the Warnings field's value.
+func (s *CreatePipelineOutput) SetWarnings(v []*Warning) *CreatePipelineOutput {
+	s.Warnings = v
+	return s
 }
 
 // The CreatePresetRequest structure.
@@ -2848,6 +3232,42 @@ func (s *CreatePresetInput) Validate() error {
 	return nil
 }
 
+// SetAudio sets the Audio field's value.
+func (s *CreatePresetInput) SetAudio(v *AudioParameters) *CreatePresetInput {
+	s.Audio = v
+	return s
+}
+
+// SetContainer sets the Container field's value.
+func (s *CreatePresetInput) SetContainer(v string) *CreatePresetInput {
+	s.Container = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreatePresetInput) SetDescription(v string) *CreatePresetInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreatePresetInput) SetName(v string) *CreatePresetInput {
+	s.Name = &v
+	return s
+}
+
+// SetThumbnails sets the Thumbnails field's value.
+func (s *CreatePresetInput) SetThumbnails(v *Thumbnails) *CreatePresetInput {
+	s.Thumbnails = v
+	return s
+}
+
+// SetVideo sets the Video field's value.
+func (s *CreatePresetInput) SetVideo(v *VideoParameters) *CreatePresetInput {
+	s.Video = v
+	return s
+}
+
 // The CreatePresetResponse structure.
 type CreatePresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -2871,6 +3291,18 @@ func (s CreatePresetOutput) String() string {
 // GoString returns the string representation
 func (s CreatePresetOutput) GoString() string {
 	return s.String()
+}
+
+// SetPreset sets the Preset field's value.
+func (s *CreatePresetOutput) SetPreset(v *Preset) *CreatePresetOutput {
+	s.Preset = v
+	return s
+}
+
+// SetWarning sets the Warning field's value.
+func (s *CreatePresetOutput) SetWarning(v string) *CreatePresetOutput {
+	s.Warning = &v
+	return s
 }
 
 // The DeletePipelineRequest structure.
@@ -2904,6 +3336,12 @@ func (s *DeletePipelineInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *DeletePipelineInput) SetId(v string) *DeletePipelineInput {
+	s.Id = &v
+	return s
 }
 
 // The DeletePipelineResponse structure.
@@ -2954,6 +3392,12 @@ func (s *DeletePresetInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *DeletePresetInput) SetId(v string) *DeletePresetInput {
+	s.Id = &v
+	return s
+}
+
 // The DeletePresetResponse structure.
 type DeletePresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -2998,6 +3442,36 @@ func (s DetectedProperties) String() string {
 // GoString returns the string representation
 func (s DetectedProperties) GoString() string {
 	return s.String()
+}
+
+// SetDurationMillis sets the DurationMillis field's value.
+func (s *DetectedProperties) SetDurationMillis(v int64) *DetectedProperties {
+	s.DurationMillis = &v
+	return s
+}
+
+// SetFileSize sets the FileSize field's value.
+func (s *DetectedProperties) SetFileSize(v int64) *DetectedProperties {
+	s.FileSize = &v
+	return s
+}
+
+// SetFrameRate sets the FrameRate field's value.
+func (s *DetectedProperties) SetFrameRate(v string) *DetectedProperties {
+	s.FrameRate = &v
+	return s
+}
+
+// SetHeight sets the Height field's value.
+func (s *DetectedProperties) SetHeight(v int64) *DetectedProperties {
+	s.Height = &v
+	return s
+}
+
+// SetWidth sets the Width field's value.
+func (s *DetectedProperties) SetWidth(v int64) *DetectedProperties {
+	s.Width = &v
+	return s
 }
 
 // The encryption settings, if any, that are used for decrypting your input
@@ -3079,6 +3553,30 @@ func (s Encryption) GoString() string {
 	return s.String()
 }
 
+// SetInitializationVector sets the InitializationVector field's value.
+func (s *Encryption) SetInitializationVector(v string) *Encryption {
+	s.InitializationVector = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *Encryption) SetKey(v string) *Encryption {
+	s.Key = &v
+	return s
+}
+
+// SetKeyMd5 sets the KeyMd5 field's value.
+func (s *Encryption) SetKeyMd5(v string) *Encryption {
+	s.KeyMd5 = &v
+	return s
+}
+
+// SetMode sets the Mode field's value.
+func (s *Encryption) SetMode(v string) *Encryption {
+	s.Mode = &v
+	return s
+}
+
 // The HLS content protection settings, if any, that you want Elastic Transcoder
 // to apply to your output files.
 type HlsContentProtection struct {
@@ -3138,6 +3636,42 @@ func (s HlsContentProtection) String() string {
 // GoString returns the string representation
 func (s HlsContentProtection) GoString() string {
 	return s.String()
+}
+
+// SetInitializationVector sets the InitializationVector field's value.
+func (s *HlsContentProtection) SetInitializationVector(v string) *HlsContentProtection {
+	s.InitializationVector = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *HlsContentProtection) SetKey(v string) *HlsContentProtection {
+	s.Key = &v
+	return s
+}
+
+// SetKeyMd5 sets the KeyMd5 field's value.
+func (s *HlsContentProtection) SetKeyMd5(v string) *HlsContentProtection {
+	s.KeyMd5 = &v
+	return s
+}
+
+// SetKeyStoragePolicy sets the KeyStoragePolicy field's value.
+func (s *HlsContentProtection) SetKeyStoragePolicy(v string) *HlsContentProtection {
+	s.KeyStoragePolicy = &v
+	return s
+}
+
+// SetLicenseAcquisitionUrl sets the LicenseAcquisitionUrl field's value.
+func (s *HlsContentProtection) SetLicenseAcquisitionUrl(v string) *HlsContentProtection {
+	s.LicenseAcquisitionUrl = &v
+	return s
+}
+
+// SetMethod sets the Method field's value.
+func (s *HlsContentProtection) SetMethod(v string) *HlsContentProtection {
+	s.Method = &v
+	return s
 }
 
 // A section of the response body that provides information about the job that
@@ -3227,6 +3761,72 @@ func (s Job) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Job) SetArn(v string) *Job {
+	s.Arn = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Job) SetId(v string) *Job {
+	s.Id = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *Job) SetInput(v *JobInput) *Job {
+	s.Input = v
+	return s
+}
+
+// SetOutput sets the Output field's value.
+func (s *Job) SetOutput(v *JobOutput) *Job {
+	s.Output = v
+	return s
+}
+
+// SetOutputKeyPrefix sets the OutputKeyPrefix field's value.
+func (s *Job) SetOutputKeyPrefix(v string) *Job {
+	s.OutputKeyPrefix = &v
+	return s
+}
+
+// SetOutputs sets the Outputs field's value.
+func (s *Job) SetOutputs(v []*JobOutput) *Job {
+	s.Outputs = v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *Job) SetPipelineId(v string) *Job {
+	s.PipelineId = &v
+	return s
+}
+
+// SetPlaylists sets the Playlists field's value.
+func (s *Job) SetPlaylists(v []*Playlist) *Job {
+	s.Playlists = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Job) SetStatus(v string) *Job {
+	s.Status = &v
+	return s
+}
+
+// SetTiming sets the Timing field's value.
+func (s *Job) SetTiming(v *Timing) *Job {
+	s.Timing = v
+	return s
+}
+
+// SetUserMetadata sets the UserMetadata field's value.
+func (s *Job) SetUserMetadata(v map[string]*string) *Job {
+	s.UserMetadata = v
+	return s
+}
+
 // The .jpg or .png file associated with an audio file.
 type JobAlbumArt struct {
 	_ struct{} `type:"structure"`
@@ -3277,6 +3877,18 @@ func (s *JobAlbumArt) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetArtwork sets the Artwork field's value.
+func (s *JobAlbumArt) SetArtwork(v []*Artwork) *JobAlbumArt {
+	s.Artwork = v
+	return s
+}
+
+// SetMergePolicy sets the MergePolicy field's value.
+func (s *JobAlbumArt) SetMergePolicy(v string) *JobAlbumArt {
+	s.MergePolicy = &v
+	return s
 }
 
 // Information about the file that you're transcoding.
@@ -3367,6 +3979,54 @@ func (s *JobInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAspectRatio sets the AspectRatio field's value.
+func (s *JobInput) SetAspectRatio(v string) *JobInput {
+	s.AspectRatio = &v
+	return s
+}
+
+// SetContainer sets the Container field's value.
+func (s *JobInput) SetContainer(v string) *JobInput {
+	s.Container = &v
+	return s
+}
+
+// SetDetectedProperties sets the DetectedProperties field's value.
+func (s *JobInput) SetDetectedProperties(v *DetectedProperties) *JobInput {
+	s.DetectedProperties = v
+	return s
+}
+
+// SetEncryption sets the Encryption field's value.
+func (s *JobInput) SetEncryption(v *Encryption) *JobInput {
+	s.Encryption = v
+	return s
+}
+
+// SetFrameRate sets the FrameRate field's value.
+func (s *JobInput) SetFrameRate(v string) *JobInput {
+	s.FrameRate = &v
+	return s
+}
+
+// SetInterlaced sets the Interlaced field's value.
+func (s *JobInput) SetInterlaced(v string) *JobInput {
+	s.Interlaced = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *JobInput) SetKey(v string) *JobInput {
+	s.Key = &v
+	return s
+}
+
+// SetResolution sets the Resolution field's value.
+func (s *JobInput) SetResolution(v string) *JobInput {
+	s.Resolution = &v
+	return s
 }
 
 // Outputs recommended instead.If you specified one output for a job, information
@@ -3587,6 +4247,132 @@ func (s JobOutput) GoString() string {
 	return s.String()
 }
 
+// SetAlbumArt sets the AlbumArt field's value.
+func (s *JobOutput) SetAlbumArt(v *JobAlbumArt) *JobOutput {
+	s.AlbumArt = v
+	return s
+}
+
+// SetAppliedColorSpaceConversion sets the AppliedColorSpaceConversion field's value.
+func (s *JobOutput) SetAppliedColorSpaceConversion(v string) *JobOutput {
+	s.AppliedColorSpaceConversion = &v
+	return s
+}
+
+// SetCaptions sets the Captions field's value.
+func (s *JobOutput) SetCaptions(v *Captions) *JobOutput {
+	s.Captions = v
+	return s
+}
+
+// SetComposition sets the Composition field's value.
+func (s *JobOutput) SetComposition(v []*Clip) *JobOutput {
+	s.Composition = v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *JobOutput) SetDuration(v int64) *JobOutput {
+	s.Duration = &v
+	return s
+}
+
+// SetDurationMillis sets the DurationMillis field's value.
+func (s *JobOutput) SetDurationMillis(v int64) *JobOutput {
+	s.DurationMillis = &v
+	return s
+}
+
+// SetEncryption sets the Encryption field's value.
+func (s *JobOutput) SetEncryption(v *Encryption) *JobOutput {
+	s.Encryption = v
+	return s
+}
+
+// SetFileSize sets the FileSize field's value.
+func (s *JobOutput) SetFileSize(v int64) *JobOutput {
+	s.FileSize = &v
+	return s
+}
+
+// SetFrameRate sets the FrameRate field's value.
+func (s *JobOutput) SetFrameRate(v string) *JobOutput {
+	s.FrameRate = &v
+	return s
+}
+
+// SetHeight sets the Height field's value.
+func (s *JobOutput) SetHeight(v int64) *JobOutput {
+	s.Height = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *JobOutput) SetId(v string) *JobOutput {
+	s.Id = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *JobOutput) SetKey(v string) *JobOutput {
+	s.Key = &v
+	return s
+}
+
+// SetPresetId sets the PresetId field's value.
+func (s *JobOutput) SetPresetId(v string) *JobOutput {
+	s.PresetId = &v
+	return s
+}
+
+// SetRotate sets the Rotate field's value.
+func (s *JobOutput) SetRotate(v string) *JobOutput {
+	s.Rotate = &v
+	return s
+}
+
+// SetSegmentDuration sets the SegmentDuration field's value.
+func (s *JobOutput) SetSegmentDuration(v string) *JobOutput {
+	s.SegmentDuration = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *JobOutput) SetStatus(v string) *JobOutput {
+	s.Status = &v
+	return s
+}
+
+// SetStatusDetail sets the StatusDetail field's value.
+func (s *JobOutput) SetStatusDetail(v string) *JobOutput {
+	s.StatusDetail = &v
+	return s
+}
+
+// SetThumbnailEncryption sets the ThumbnailEncryption field's value.
+func (s *JobOutput) SetThumbnailEncryption(v *Encryption) *JobOutput {
+	s.ThumbnailEncryption = v
+	return s
+}
+
+// SetThumbnailPattern sets the ThumbnailPattern field's value.
+func (s *JobOutput) SetThumbnailPattern(v string) *JobOutput {
+	s.ThumbnailPattern = &v
+	return s
+}
+
+// SetWatermarks sets the Watermarks field's value.
+func (s *JobOutput) SetWatermarks(v []*JobWatermark) *JobOutput {
+	s.Watermarks = v
+	return s
+}
+
+// SetWidth sets the Width field's value.
+func (s *JobOutput) SetWidth(v int64) *JobOutput {
+	s.Width = &v
+	return s
+}
+
 // Watermarks can be in .png or .jpg format. If you want to display a watermark
 // that is not rectangular, use the .png format, which supports transparency.
 type JobWatermark struct {
@@ -3639,6 +4425,24 @@ func (s *JobWatermark) Validate() error {
 	return nil
 }
 
+// SetEncryption sets the Encryption field's value.
+func (s *JobWatermark) SetEncryption(v *Encryption) *JobWatermark {
+	s.Encryption = v
+	return s
+}
+
+// SetInputKey sets the InputKey field's value.
+func (s *JobWatermark) SetInputKey(v string) *JobWatermark {
+	s.InputKey = &v
+	return s
+}
+
+// SetPresetWatermarkId sets the PresetWatermarkId field's value.
+func (s *JobWatermark) SetPresetWatermarkId(v string) *JobWatermark {
+	s.PresetWatermarkId = &v
+	return s
+}
+
 // The ListJobsByPipelineRequest structure.
 type ListJobsByPipelineInput struct {
 	_ struct{} `type:"structure"`
@@ -3680,6 +4484,24 @@ func (s *ListJobsByPipelineInput) Validate() error {
 	return nil
 }
 
+// SetAscending sets the Ascending field's value.
+func (s *ListJobsByPipelineInput) SetAscending(v string) *ListJobsByPipelineInput {
+	s.Ascending = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListJobsByPipelineInput) SetPageToken(v string) *ListJobsByPipelineInput {
+	s.PageToken = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *ListJobsByPipelineInput) SetPipelineId(v string) *ListJobsByPipelineInput {
+	s.PipelineId = &v
+	return s
+}
+
 // The ListJobsByPipelineResponse structure.
 type ListJobsByPipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -3701,6 +4523,18 @@ func (s ListJobsByPipelineOutput) String() string {
 // GoString returns the string representation
 func (s ListJobsByPipelineOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobs sets the Jobs field's value.
+func (s *ListJobsByPipelineOutput) SetJobs(v []*Job) *ListJobsByPipelineOutput {
+	s.Jobs = v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListJobsByPipelineOutput) SetNextPageToken(v string) *ListJobsByPipelineOutput {
+	s.NextPageToken = &v
+	return s
 }
 
 // The ListJobsByStatusRequest structure.
@@ -3746,6 +4580,24 @@ func (s *ListJobsByStatusInput) Validate() error {
 	return nil
 }
 
+// SetAscending sets the Ascending field's value.
+func (s *ListJobsByStatusInput) SetAscending(v string) *ListJobsByStatusInput {
+	s.Ascending = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListJobsByStatusInput) SetPageToken(v string) *ListJobsByStatusInput {
+	s.PageToken = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListJobsByStatusInput) SetStatus(v string) *ListJobsByStatusInput {
+	s.Status = &v
+	return s
+}
+
 // The ListJobsByStatusResponse structure.
 type ListJobsByStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -3767,6 +4619,18 @@ func (s ListJobsByStatusOutput) String() string {
 // GoString returns the string representation
 func (s ListJobsByStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobs sets the Jobs field's value.
+func (s *ListJobsByStatusOutput) SetJobs(v []*Job) *ListJobsByStatusOutput {
+	s.Jobs = v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListJobsByStatusOutput) SetNextPageToken(v string) *ListJobsByStatusOutput {
+	s.NextPageToken = &v
+	return s
 }
 
 // The ListPipelineRequest structure.
@@ -3793,6 +4657,18 @@ func (s ListPipelinesInput) GoString() string {
 	return s.String()
 }
 
+// SetAscending sets the Ascending field's value.
+func (s *ListPipelinesInput) SetAscending(v string) *ListPipelinesInput {
+	s.Ascending = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListPipelinesInput) SetPageToken(v string) *ListPipelinesInput {
+	s.PageToken = &v
+	return s
+}
+
 // A list of the pipelines associated with the current AWS account.
 type ListPipelinesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3814,6 +4690,18 @@ func (s ListPipelinesOutput) String() string {
 // GoString returns the string representation
 func (s ListPipelinesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListPipelinesOutput) SetNextPageToken(v string) *ListPipelinesOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetPipelines sets the Pipelines field's value.
+func (s *ListPipelinesOutput) SetPipelines(v []*Pipeline) *ListPipelinesOutput {
+	s.Pipelines = v
+	return s
 }
 
 // The ListPresetsRequest structure.
@@ -3840,6 +4728,18 @@ func (s ListPresetsInput) GoString() string {
 	return s.String()
 }
 
+// SetAscending sets the Ascending field's value.
+func (s *ListPresetsInput) SetAscending(v string) *ListPresetsInput {
+	s.Ascending = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListPresetsInput) SetPageToken(v string) *ListPresetsInput {
+	s.PageToken = &v
+	return s
+}
+
 // The ListPresetsResponse structure.
 type ListPresetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3861,6 +4761,18 @@ func (s ListPresetsOutput) String() string {
 // GoString returns the string representation
 func (s ListPresetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListPresetsOutput) SetNextPageToken(v string) *ListPresetsOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetPresets sets the Presets field's value.
+func (s *ListPresetsOutput) SetPresets(v []*Preset) *ListPresetsOutput {
+	s.Presets = v
+	return s
 }
 
 // The Amazon Simple Notification Service (Amazon SNS) topic or topics to notify
@@ -3896,6 +4808,30 @@ func (s Notifications) String() string {
 // GoString returns the string representation
 func (s Notifications) GoString() string {
 	return s.String()
+}
+
+// SetCompleted sets the Completed field's value.
+func (s *Notifications) SetCompleted(v string) *Notifications {
+	s.Completed = &v
+	return s
+}
+
+// SetError sets the Error field's value.
+func (s *Notifications) SetError(v string) *Notifications {
+	s.Error = &v
+	return s
+}
+
+// SetProgressing sets the Progressing field's value.
+func (s *Notifications) SetProgressing(v string) *Notifications {
+	s.Progressing = &v
+	return s
+}
+
+// SetWarning sets the Warning field's value.
+func (s *Notifications) SetWarning(v string) *Notifications {
+	s.Warning = &v
+	return s
 }
 
 // The Permission structure.
@@ -3951,6 +4887,24 @@ func (s *Permission) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccess sets the Access field's value.
+func (s *Permission) SetAccess(v []*string) *Permission {
+	s.Access = v
+	return s
+}
+
+// SetGrantee sets the Grantee field's value.
+func (s *Permission) SetGrantee(v string) *Permission {
+	s.Grantee = &v
+	return s
+}
+
+// SetGranteeType sets the GranteeType field's value.
+func (s *Permission) SetGranteeType(v string) *Permission {
+	s.GranteeType = &v
+	return s
 }
 
 // The pipeline (queue) that is used to manage jobs.
@@ -4094,6 +5048,72 @@ func (s Pipeline) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Pipeline) SetArn(v string) *Pipeline {
+	s.Arn = &v
+	return s
+}
+
+// SetAwsKmsKeyArn sets the AwsKmsKeyArn field's value.
+func (s *Pipeline) SetAwsKmsKeyArn(v string) *Pipeline {
+	s.AwsKmsKeyArn = &v
+	return s
+}
+
+// SetContentConfig sets the ContentConfig field's value.
+func (s *Pipeline) SetContentConfig(v *PipelineOutputConfig) *Pipeline {
+	s.ContentConfig = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Pipeline) SetId(v string) *Pipeline {
+	s.Id = &v
+	return s
+}
+
+// SetInputBucket sets the InputBucket field's value.
+func (s *Pipeline) SetInputBucket(v string) *Pipeline {
+	s.InputBucket = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Pipeline) SetName(v string) *Pipeline {
+	s.Name = &v
+	return s
+}
+
+// SetNotifications sets the Notifications field's value.
+func (s *Pipeline) SetNotifications(v *Notifications) *Pipeline {
+	s.Notifications = v
+	return s
+}
+
+// SetOutputBucket sets the OutputBucket field's value.
+func (s *Pipeline) SetOutputBucket(v string) *Pipeline {
+	s.OutputBucket = &v
+	return s
+}
+
+// SetRole sets the Role field's value.
+func (s *Pipeline) SetRole(v string) *Pipeline {
+	s.Role = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Pipeline) SetStatus(v string) *Pipeline {
+	s.Status = &v
+	return s
+}
+
+// SetThumbnailConfig sets the ThumbnailConfig field's value.
+func (s *Pipeline) SetThumbnailConfig(v *PipelineOutputConfig) *Pipeline {
+	s.ThumbnailConfig = v
+	return s
+}
+
 // The PipelineOutputConfig structure.
 type PipelineOutputConfig struct {
 	_ struct{} `type:"structure"`
@@ -4163,6 +5183,24 @@ func (s *PipelineOutputConfig) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PipelineOutputConfig) SetBucket(v string) *PipelineOutputConfig {
+	s.Bucket = &v
+	return s
+}
+
+// SetPermissions sets the Permissions field's value.
+func (s *PipelineOutputConfig) SetPermissions(v []*Permission) *PipelineOutputConfig {
+	s.Permissions = v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *PipelineOutputConfig) SetStorageClass(v string) *PipelineOutputConfig {
+	s.StorageClass = &v
+	return s
 }
 
 // The PlayReady DRM settings, if any, that you want Elastic Transcoder to apply
@@ -4238,6 +5276,42 @@ func (s *PlayReadyDrm) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFormat sets the Format field's value.
+func (s *PlayReadyDrm) SetFormat(v string) *PlayReadyDrm {
+	s.Format = &v
+	return s
+}
+
+// SetInitializationVector sets the InitializationVector field's value.
+func (s *PlayReadyDrm) SetInitializationVector(v string) *PlayReadyDrm {
+	s.InitializationVector = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *PlayReadyDrm) SetKey(v string) *PlayReadyDrm {
+	s.Key = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *PlayReadyDrm) SetKeyId(v string) *PlayReadyDrm {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeyMd5 sets the KeyMd5 field's value.
+func (s *PlayReadyDrm) SetKeyMd5(v string) *PlayReadyDrm {
+	s.KeyMd5 = &v
+	return s
+}
+
+// SetLicenseAcquisitionUrl sets the LicenseAcquisitionUrl field's value.
+func (s *PlayReadyDrm) SetLicenseAcquisitionUrl(v string) *PlayReadyDrm {
+	s.LicenseAcquisitionUrl = &v
+	return s
 }
 
 // Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for
@@ -4327,6 +5401,48 @@ func (s Playlist) GoString() string {
 	return s.String()
 }
 
+// SetFormat sets the Format field's value.
+func (s *Playlist) SetFormat(v string) *Playlist {
+	s.Format = &v
+	return s
+}
+
+// SetHlsContentProtection sets the HlsContentProtection field's value.
+func (s *Playlist) SetHlsContentProtection(v *HlsContentProtection) *Playlist {
+	s.HlsContentProtection = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Playlist) SetName(v string) *Playlist {
+	s.Name = &v
+	return s
+}
+
+// SetOutputKeys sets the OutputKeys field's value.
+func (s *Playlist) SetOutputKeys(v []*string) *Playlist {
+	s.OutputKeys = v
+	return s
+}
+
+// SetPlayReadyDrm sets the PlayReadyDrm field's value.
+func (s *Playlist) SetPlayReadyDrm(v *PlayReadyDrm) *Playlist {
+	s.PlayReadyDrm = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Playlist) SetStatus(v string) *Playlist {
+	s.Status = &v
+	return s
+}
+
+// SetStatusDetail sets the StatusDetail field's value.
+func (s *Playlist) SetStatusDetail(v string) *Playlist {
+	s.StatusDetail = &v
+	return s
+}
+
 // Presets are templates that contain most of the settings for transcoding media
 // files from one format to another. Elastic Transcoder includes some default
 // presets for common formats, for example, several iPod and iPhone versions.
@@ -4378,6 +5494,60 @@ func (s Preset) String() string {
 // GoString returns the string representation
 func (s Preset) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Preset) SetArn(v string) *Preset {
+	s.Arn = &v
+	return s
+}
+
+// SetAudio sets the Audio field's value.
+func (s *Preset) SetAudio(v *AudioParameters) *Preset {
+	s.Audio = v
+	return s
+}
+
+// SetContainer sets the Container field's value.
+func (s *Preset) SetContainer(v string) *Preset {
+	s.Container = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Preset) SetDescription(v string) *Preset {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Preset) SetId(v string) *Preset {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Preset) SetName(v string) *Preset {
+	s.Name = &v
+	return s
+}
+
+// SetThumbnails sets the Thumbnails field's value.
+func (s *Preset) SetThumbnails(v *Thumbnails) *Preset {
+	s.Thumbnails = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Preset) SetType(v string) *Preset {
+	s.Type = &v
+	return s
+}
+
+// SetVideo sets the Video field's value.
+func (s *Preset) SetVideo(v *VideoParameters) *Preset {
+	s.Video = v
+	return s
 }
 
 // Settings for the size, location, and opacity of graphics that you want Elastic
@@ -4540,6 +5710,66 @@ func (s *PresetWatermark) Validate() error {
 	return nil
 }
 
+// SetHorizontalAlign sets the HorizontalAlign field's value.
+func (s *PresetWatermark) SetHorizontalAlign(v string) *PresetWatermark {
+	s.HorizontalAlign = &v
+	return s
+}
+
+// SetHorizontalOffset sets the HorizontalOffset field's value.
+func (s *PresetWatermark) SetHorizontalOffset(v string) *PresetWatermark {
+	s.HorizontalOffset = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *PresetWatermark) SetId(v string) *PresetWatermark {
+	s.Id = &v
+	return s
+}
+
+// SetMaxHeight sets the MaxHeight field's value.
+func (s *PresetWatermark) SetMaxHeight(v string) *PresetWatermark {
+	s.MaxHeight = &v
+	return s
+}
+
+// SetMaxWidth sets the MaxWidth field's value.
+func (s *PresetWatermark) SetMaxWidth(v string) *PresetWatermark {
+	s.MaxWidth = &v
+	return s
+}
+
+// SetOpacity sets the Opacity field's value.
+func (s *PresetWatermark) SetOpacity(v string) *PresetWatermark {
+	s.Opacity = &v
+	return s
+}
+
+// SetSizingPolicy sets the SizingPolicy field's value.
+func (s *PresetWatermark) SetSizingPolicy(v string) *PresetWatermark {
+	s.SizingPolicy = &v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *PresetWatermark) SetTarget(v string) *PresetWatermark {
+	s.Target = &v
+	return s
+}
+
+// SetVerticalAlign sets the VerticalAlign field's value.
+func (s *PresetWatermark) SetVerticalAlign(v string) *PresetWatermark {
+	s.VerticalAlign = &v
+	return s
+}
+
+// SetVerticalOffset sets the VerticalOffset field's value.
+func (s *PresetWatermark) SetVerticalOffset(v string) *PresetWatermark {
+	s.VerticalOffset = &v
+	return s
+}
+
 // The ReadJobRequest structure.
 type ReadJobInput struct {
 	_ struct{} `type:"structure"`
@@ -4573,6 +5803,12 @@ func (s *ReadJobInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *ReadJobInput) SetId(v string) *ReadJobInput {
+	s.Id = &v
+	return s
+}
+
 // The ReadJobResponse structure.
 type ReadJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -4589,6 +5825,12 @@ func (s ReadJobOutput) String() string {
 // GoString returns the string representation
 func (s ReadJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetJob sets the Job field's value.
+func (s *ReadJobOutput) SetJob(v *Job) *ReadJobOutput {
+	s.Job = v
+	return s
 }
 
 // The ReadPipelineRequest structure.
@@ -4624,6 +5866,12 @@ func (s *ReadPipelineInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *ReadPipelineInput) SetId(v string) *ReadPipelineInput {
+	s.Id = &v
+	return s
+}
+
 // The ReadPipelineResponse structure.
 type ReadPipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -4648,6 +5896,18 @@ func (s ReadPipelineOutput) String() string {
 // GoString returns the string representation
 func (s ReadPipelineOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipeline sets the Pipeline field's value.
+func (s *ReadPipelineOutput) SetPipeline(v *Pipeline) *ReadPipelineOutput {
+	s.Pipeline = v
+	return s
+}
+
+// SetWarnings sets the Warnings field's value.
+func (s *ReadPipelineOutput) SetWarnings(v []*Warning) *ReadPipelineOutput {
+	s.Warnings = v
+	return s
 }
 
 // The ReadPresetRequest structure.
@@ -4683,6 +5943,12 @@ func (s *ReadPresetInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *ReadPresetInput) SetId(v string) *ReadPresetInput {
+	s.Id = &v
+	return s
+}
+
 // The ReadPresetResponse structure.
 type ReadPresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -4699,6 +5965,12 @@ func (s ReadPresetOutput) String() string {
 // GoString returns the string representation
 func (s ReadPresetOutput) GoString() string {
 	return s.String()
+}
+
+// SetPreset sets the Preset field's value.
+func (s *ReadPresetOutput) SetPreset(v *Preset) *ReadPresetOutput {
+	s.Preset = v
+	return s
 }
 
 // The TestRoleRequest structure.
@@ -4762,6 +6034,30 @@ func (s *TestRoleInput) Validate() error {
 	return nil
 }
 
+// SetInputBucket sets the InputBucket field's value.
+func (s *TestRoleInput) SetInputBucket(v string) *TestRoleInput {
+	s.InputBucket = &v
+	return s
+}
+
+// SetOutputBucket sets the OutputBucket field's value.
+func (s *TestRoleInput) SetOutputBucket(v string) *TestRoleInput {
+	s.OutputBucket = &v
+	return s
+}
+
+// SetRole sets the Role field's value.
+func (s *TestRoleInput) SetRole(v string) *TestRoleInput {
+	s.Role = &v
+	return s
+}
+
+// SetTopics sets the Topics field's value.
+func (s *TestRoleInput) SetTopics(v []*string) *TestRoleInput {
+	s.Topics = v
+	return s
+}
+
 // The TestRoleResponse structure.
 type TestRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -4783,6 +6079,18 @@ func (s TestRoleOutput) String() string {
 // GoString returns the string representation
 func (s TestRoleOutput) GoString() string {
 	return s.String()
+}
+
+// SetMessages sets the Messages field's value.
+func (s *TestRoleOutput) SetMessages(v []*string) *TestRoleOutput {
+	s.Messages = v
+	return s
+}
+
+// SetSuccess sets the Success field's value.
+func (s *TestRoleOutput) SetSuccess(v string) *TestRoleOutput {
+	s.Success = &v
+	return s
 }
 
 // Thumbnails for videos.
@@ -4875,6 +6183,54 @@ func (s Thumbnails) GoString() string {
 	return s.String()
 }
 
+// SetAspectRatio sets the AspectRatio field's value.
+func (s *Thumbnails) SetAspectRatio(v string) *Thumbnails {
+	s.AspectRatio = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *Thumbnails) SetFormat(v string) *Thumbnails {
+	s.Format = &v
+	return s
+}
+
+// SetInterval sets the Interval field's value.
+func (s *Thumbnails) SetInterval(v string) *Thumbnails {
+	s.Interval = &v
+	return s
+}
+
+// SetMaxHeight sets the MaxHeight field's value.
+func (s *Thumbnails) SetMaxHeight(v string) *Thumbnails {
+	s.MaxHeight = &v
+	return s
+}
+
+// SetMaxWidth sets the MaxWidth field's value.
+func (s *Thumbnails) SetMaxWidth(v string) *Thumbnails {
+	s.MaxWidth = &v
+	return s
+}
+
+// SetPaddingPolicy sets the PaddingPolicy field's value.
+func (s *Thumbnails) SetPaddingPolicy(v string) *Thumbnails {
+	s.PaddingPolicy = &v
+	return s
+}
+
+// SetResolution sets the Resolution field's value.
+func (s *Thumbnails) SetResolution(v string) *Thumbnails {
+	s.Resolution = &v
+	return s
+}
+
+// SetSizingPolicy sets the SizingPolicy field's value.
+func (s *Thumbnails) SetSizingPolicy(v string) *Thumbnails {
+	s.SizingPolicy = &v
+	return s
+}
+
 // Settings that determine when a clip begins and how long it lasts.
 type TimeSpan struct {
 	_ struct{} `type:"structure"`
@@ -4905,6 +6261,18 @@ func (s TimeSpan) GoString() string {
 	return s.String()
 }
 
+// SetDuration sets the Duration field's value.
+func (s *TimeSpan) SetDuration(v string) *TimeSpan {
+	s.Duration = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *TimeSpan) SetStartTime(v string) *TimeSpan {
+	s.StartTime = &v
+	return s
+}
+
 // Details about the timing of a job.
 type Timing struct {
 	_ struct{} `type:"structure"`
@@ -4927,6 +6295,24 @@ func (s Timing) String() string {
 // GoString returns the string representation
 func (s Timing) GoString() string {
 	return s.String()
+}
+
+// SetFinishTimeMillis sets the FinishTimeMillis field's value.
+func (s *Timing) SetFinishTimeMillis(v int64) *Timing {
+	s.FinishTimeMillis = &v
+	return s
+}
+
+// SetStartTimeMillis sets the StartTimeMillis field's value.
+func (s *Timing) SetStartTimeMillis(v int64) *Timing {
+	s.StartTimeMillis = &v
+	return s
+}
+
+// SetSubmitTimeMillis sets the SubmitTimeMillis field's value.
+func (s *Timing) SetSubmitTimeMillis(v int64) *Timing {
+	s.SubmitTimeMillis = &v
+	return s
 }
 
 // The UpdatePipelineRequest structure.
@@ -5110,6 +6496,54 @@ func (s *UpdatePipelineInput) Validate() error {
 	return nil
 }
 
+// SetAwsKmsKeyArn sets the AwsKmsKeyArn field's value.
+func (s *UpdatePipelineInput) SetAwsKmsKeyArn(v string) *UpdatePipelineInput {
+	s.AwsKmsKeyArn = &v
+	return s
+}
+
+// SetContentConfig sets the ContentConfig field's value.
+func (s *UpdatePipelineInput) SetContentConfig(v *PipelineOutputConfig) *UpdatePipelineInput {
+	s.ContentConfig = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UpdatePipelineInput) SetId(v string) *UpdatePipelineInput {
+	s.Id = &v
+	return s
+}
+
+// SetInputBucket sets the InputBucket field's value.
+func (s *UpdatePipelineInput) SetInputBucket(v string) *UpdatePipelineInput {
+	s.InputBucket = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdatePipelineInput) SetName(v string) *UpdatePipelineInput {
+	s.Name = &v
+	return s
+}
+
+// SetNotifications sets the Notifications field's value.
+func (s *UpdatePipelineInput) SetNotifications(v *Notifications) *UpdatePipelineInput {
+	s.Notifications = v
+	return s
+}
+
+// SetRole sets the Role field's value.
+func (s *UpdatePipelineInput) SetRole(v string) *UpdatePipelineInput {
+	s.Role = &v
+	return s
+}
+
+// SetThumbnailConfig sets the ThumbnailConfig field's value.
+func (s *UpdatePipelineInput) SetThumbnailConfig(v *PipelineOutputConfig) *UpdatePipelineInput {
+	s.ThumbnailConfig = v
+	return s
+}
+
 // The UpdatePipelineNotificationsRequest structure.
 type UpdatePipelineNotificationsInput struct {
 	_ struct{} `type:"structure"`
@@ -5168,6 +6602,18 @@ func (s *UpdatePipelineNotificationsInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *UpdatePipelineNotificationsInput) SetId(v string) *UpdatePipelineNotificationsInput {
+	s.Id = &v
+	return s
+}
+
+// SetNotifications sets the Notifications field's value.
+func (s *UpdatePipelineNotificationsInput) SetNotifications(v *Notifications) *UpdatePipelineNotificationsInput {
+	s.Notifications = v
+	return s
+}
+
 // The UpdatePipelineNotificationsResponse structure.
 type UpdatePipelineNotificationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5184,6 +6630,12 @@ func (s UpdatePipelineNotificationsOutput) String() string {
 // GoString returns the string representation
 func (s UpdatePipelineNotificationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipeline sets the Pipeline field's value.
+func (s *UpdatePipelineNotificationsOutput) SetPipeline(v *Pipeline) *UpdatePipelineNotificationsOutput {
+	s.Pipeline = v
+	return s
 }
 
 // When you update a pipeline, Elastic Transcoder returns the values that you
@@ -5211,6 +6663,18 @@ func (s UpdatePipelineOutput) String() string {
 // GoString returns the string representation
 func (s UpdatePipelineOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipeline sets the Pipeline field's value.
+func (s *UpdatePipelineOutput) SetPipeline(v *Pipeline) *UpdatePipelineOutput {
+	s.Pipeline = v
+	return s
+}
+
+// SetWarnings sets the Warnings field's value.
+func (s *UpdatePipelineOutput) SetWarnings(v []*Warning) *UpdatePipelineOutput {
+	s.Warnings = v
+	return s
 }
 
 // The UpdatePipelineStatusRequest structure.
@@ -5257,6 +6721,18 @@ func (s *UpdatePipelineStatusInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *UpdatePipelineStatusInput) SetId(v string) *UpdatePipelineStatusInput {
+	s.Id = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UpdatePipelineStatusInput) SetStatus(v string) *UpdatePipelineStatusInput {
+	s.Status = &v
+	return s
+}
+
 // When you update status for a pipeline, Elastic Transcoder returns the values
 // that you specified in the request.
 type UpdatePipelineStatusOutput struct {
@@ -5274,6 +6750,12 @@ func (s UpdatePipelineStatusOutput) String() string {
 // GoString returns the string representation
 func (s UpdatePipelineStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetPipeline sets the Pipeline field's value.
+func (s *UpdatePipelineStatusOutput) SetPipeline(v *Pipeline) *UpdatePipelineStatusOutput {
+	s.Pipeline = v
+	return s
 }
 
 // The VideoParameters structure.
@@ -5658,6 +7140,96 @@ func (s *VideoParameters) Validate() error {
 	return nil
 }
 
+// SetAspectRatio sets the AspectRatio field's value.
+func (s *VideoParameters) SetAspectRatio(v string) *VideoParameters {
+	s.AspectRatio = &v
+	return s
+}
+
+// SetBitRate sets the BitRate field's value.
+func (s *VideoParameters) SetBitRate(v string) *VideoParameters {
+	s.BitRate = &v
+	return s
+}
+
+// SetCodec sets the Codec field's value.
+func (s *VideoParameters) SetCodec(v string) *VideoParameters {
+	s.Codec = &v
+	return s
+}
+
+// SetCodecOptions sets the CodecOptions field's value.
+func (s *VideoParameters) SetCodecOptions(v map[string]*string) *VideoParameters {
+	s.CodecOptions = v
+	return s
+}
+
+// SetDisplayAspectRatio sets the DisplayAspectRatio field's value.
+func (s *VideoParameters) SetDisplayAspectRatio(v string) *VideoParameters {
+	s.DisplayAspectRatio = &v
+	return s
+}
+
+// SetFixedGOP sets the FixedGOP field's value.
+func (s *VideoParameters) SetFixedGOP(v string) *VideoParameters {
+	s.FixedGOP = &v
+	return s
+}
+
+// SetFrameRate sets the FrameRate field's value.
+func (s *VideoParameters) SetFrameRate(v string) *VideoParameters {
+	s.FrameRate = &v
+	return s
+}
+
+// SetKeyframesMaxDist sets the KeyframesMaxDist field's value.
+func (s *VideoParameters) SetKeyframesMaxDist(v string) *VideoParameters {
+	s.KeyframesMaxDist = &v
+	return s
+}
+
+// SetMaxFrameRate sets the MaxFrameRate field's value.
+func (s *VideoParameters) SetMaxFrameRate(v string) *VideoParameters {
+	s.MaxFrameRate = &v
+	return s
+}
+
+// SetMaxHeight sets the MaxHeight field's value.
+func (s *VideoParameters) SetMaxHeight(v string) *VideoParameters {
+	s.MaxHeight = &v
+	return s
+}
+
+// SetMaxWidth sets the MaxWidth field's value.
+func (s *VideoParameters) SetMaxWidth(v string) *VideoParameters {
+	s.MaxWidth = &v
+	return s
+}
+
+// SetPaddingPolicy sets the PaddingPolicy field's value.
+func (s *VideoParameters) SetPaddingPolicy(v string) *VideoParameters {
+	s.PaddingPolicy = &v
+	return s
+}
+
+// SetResolution sets the Resolution field's value.
+func (s *VideoParameters) SetResolution(v string) *VideoParameters {
+	s.Resolution = &v
+	return s
+}
+
+// SetSizingPolicy sets the SizingPolicy field's value.
+func (s *VideoParameters) SetSizingPolicy(v string) *VideoParameters {
+	s.SizingPolicy = &v
+	return s
+}
+
+// SetWatermarks sets the Watermarks field's value.
+func (s *VideoParameters) SetWatermarks(v []*PresetWatermark) *VideoParameters {
+	s.Watermarks = v
+	return s
+}
+
 // Elastic Transcoder returns a warning if the resources used by your pipeline
 // are not in the same region as the pipeline.
 //
@@ -5685,4 +7257,16 @@ func (s Warning) String() string {
 // GoString returns the string representation
 func (s Warning) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *Warning) SetCode(v string) *Warning {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Warning) SetMessage(v string) *Warning {
+	s.Message = &v
+	return s
 }

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -2248,6 +2248,30 @@ func (s *AccessLog) Validate() error {
 	return nil
 }
 
+// SetEmitInterval sets the EmitInterval field's value.
+func (s *AccessLog) SetEmitInterval(v int64) *AccessLog {
+	s.EmitInterval = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *AccessLog) SetEnabled(v bool) *AccessLog {
+	s.Enabled = &v
+	return s
+}
+
+// SetS3BucketName sets the S3BucketName field's value.
+func (s *AccessLog) SetS3BucketName(v string) *AccessLog {
+	s.S3BucketName = &v
+	return s
+}
+
+// SetS3BucketPrefix sets the S3BucketPrefix field's value.
+func (s *AccessLog) SetS3BucketPrefix(v string) *AccessLog {
+	s.S3BucketPrefix = &v
+	return s
+}
+
 // Contains the parameters for AddTags.
 type AddTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -2302,6 +2326,18 @@ func (s *AddTagsInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerNames sets the LoadBalancerNames field's value.
+func (s *AddTagsInput) SetLoadBalancerNames(v []*string) *AddTagsInput {
+	s.LoadBalancerNames = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsInput) SetTags(v []*Tag) *AddTagsInput {
+	s.Tags = v
+	return s
+}
+
 // Contains the output of AddTags.
 type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2338,6 +2374,18 @@ func (s AdditionalAttribute) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *AdditionalAttribute) SetKey(v string) *AdditionalAttribute {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *AdditionalAttribute) SetValue(v string) *AdditionalAttribute {
+	s.Value = &v
+	return s
+}
+
 // Information about a policy for application-controlled session stickiness.
 type AppCookieStickinessPolicy struct {
 	_ struct{} `type:"structure"`
@@ -2358,6 +2406,18 @@ func (s AppCookieStickinessPolicy) String() string {
 // GoString returns the string representation
 func (s AppCookieStickinessPolicy) GoString() string {
 	return s.String()
+}
+
+// SetCookieName sets the CookieName field's value.
+func (s *AppCookieStickinessPolicy) SetCookieName(v string) *AppCookieStickinessPolicy {
+	s.CookieName = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *AppCookieStickinessPolicy) SetPolicyName(v string) *AppCookieStickinessPolicy {
+	s.PolicyName = &v
+	return s
 }
 
 // Contains the parameters for ApplySecurityGroupsToLoadBalancer.
@@ -2402,6 +2462,18 @@ func (s *ApplySecurityGroupsToLoadBalancerInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *ApplySecurityGroupsToLoadBalancerInput) SetLoadBalancerName(v string) *ApplySecurityGroupsToLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *ApplySecurityGroupsToLoadBalancerInput) SetSecurityGroups(v []*string) *ApplySecurityGroupsToLoadBalancerInput {
+	s.SecurityGroups = v
+	return s
+}
+
 // Contains the output of ApplySecurityGroupsToLoadBalancer.
 type ApplySecurityGroupsToLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
@@ -2418,6 +2490,12 @@ func (s ApplySecurityGroupsToLoadBalancerOutput) String() string {
 // GoString returns the string representation
 func (s ApplySecurityGroupsToLoadBalancerOutput) GoString() string {
 	return s.String()
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *ApplySecurityGroupsToLoadBalancerOutput) SetSecurityGroups(v []*string) *ApplySecurityGroupsToLoadBalancerOutput {
+	s.SecurityGroups = v
+	return s
 }
 
 // Contains the parameters for AttachLoaBalancerToSubnets.
@@ -2462,6 +2540,18 @@ func (s *AttachLoadBalancerToSubnetsInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *AttachLoadBalancerToSubnetsInput) SetLoadBalancerName(v string) *AttachLoadBalancerToSubnetsInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *AttachLoadBalancerToSubnetsInput) SetSubnets(v []*string) *AttachLoadBalancerToSubnetsInput {
+	s.Subnets = v
+	return s
+}
+
 // Contains the output of AttachLoadBalancerToSubnets.
 type AttachLoadBalancerToSubnetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2478,6 +2568,12 @@ func (s AttachLoadBalancerToSubnetsOutput) String() string {
 // GoString returns the string representation
 func (s AttachLoadBalancerToSubnetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *AttachLoadBalancerToSubnetsOutput) SetSubnets(v []*string) *AttachLoadBalancerToSubnetsOutput {
+	s.Subnets = v
+	return s
 }
 
 // Information about the configuration of an EC2 instance.
@@ -2499,6 +2595,18 @@ func (s BackendServerDescription) String() string {
 // GoString returns the string representation
 func (s BackendServerDescription) GoString() string {
 	return s.String()
+}
+
+// SetInstancePort sets the InstancePort field's value.
+func (s *BackendServerDescription) SetInstancePort(v int64) *BackendServerDescription {
+	s.InstancePort = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *BackendServerDescription) SetPolicyNames(v []*string) *BackendServerDescription {
+	s.PolicyNames = v
+	return s
 }
 
 // Contains the parameters for ConfigureHealthCheck.
@@ -2547,6 +2655,18 @@ func (s *ConfigureHealthCheckInput) Validate() error {
 	return nil
 }
 
+// SetHealthCheck sets the HealthCheck field's value.
+func (s *ConfigureHealthCheckInput) SetHealthCheck(v *HealthCheck) *ConfigureHealthCheckInput {
+	s.HealthCheck = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *ConfigureHealthCheckInput) SetLoadBalancerName(v string) *ConfigureHealthCheckInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the output of ConfigureHealthCheck.
 type ConfigureHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
@@ -2563,6 +2683,12 @@ func (s ConfigureHealthCheckOutput) String() string {
 // GoString returns the string representation
 func (s ConfigureHealthCheckOutput) GoString() string {
 	return s.String()
+}
+
+// SetHealthCheck sets the HealthCheck field's value.
+func (s *ConfigureHealthCheckOutput) SetHealthCheck(v *HealthCheck) *ConfigureHealthCheckOutput {
+	s.HealthCheck = v
+	return s
 }
 
 // Information about the ConnectionDraining attribute.
@@ -2602,6 +2728,18 @@ func (s *ConnectionDraining) Validate() error {
 	return nil
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *ConnectionDraining) SetEnabled(v bool) *ConnectionDraining {
+	s.Enabled = &v
+	return s
+}
+
+// SetTimeout sets the Timeout field's value.
+func (s *ConnectionDraining) SetTimeout(v int64) *ConnectionDraining {
+	s.Timeout = &v
+	return s
+}
+
 // Information about the ConnectionSettings attribute.
 type ConnectionSettings struct {
 	_ struct{} `type:"structure"`
@@ -2637,6 +2775,12 @@ func (s *ConnectionSettings) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIdleTimeout sets the IdleTimeout field's value.
+func (s *ConnectionSettings) SetIdleTimeout(v int64) *ConnectionSettings {
+	s.IdleTimeout = &v
+	return s
 }
 
 // Contains the parameters for CreateAppCookieStickinessPolicy.
@@ -2688,6 +2832,24 @@ func (s *CreateAppCookieStickinessPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCookieName sets the CookieName field's value.
+func (s *CreateAppCookieStickinessPolicyInput) SetCookieName(v string) *CreateAppCookieStickinessPolicyInput {
+	s.CookieName = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *CreateAppCookieStickinessPolicyInput) SetLoadBalancerName(v string) *CreateAppCookieStickinessPolicyInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *CreateAppCookieStickinessPolicyInput) SetPolicyName(v string) *CreateAppCookieStickinessPolicyInput {
+	s.PolicyName = &v
+	return s
 }
 
 // Contains the output for CreateAppCookieStickinessPolicy.
@@ -2752,6 +2914,24 @@ func (s *CreateLBCookieStickinessPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCookieExpirationPeriod sets the CookieExpirationPeriod field's value.
+func (s *CreateLBCookieStickinessPolicyInput) SetCookieExpirationPeriod(v int64) *CreateLBCookieStickinessPolicyInput {
+	s.CookieExpirationPeriod = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *CreateLBCookieStickinessPolicyInput) SetLoadBalancerName(v string) *CreateLBCookieStickinessPolicyInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *CreateLBCookieStickinessPolicyInput) SetPolicyName(v string) *CreateLBCookieStickinessPolicyInput {
+	s.PolicyName = &v
+	return s
 }
 
 // Contains the output for CreateLBCookieStickinessPolicy.
@@ -2874,6 +3054,48 @@ func (s *CreateLoadBalancerInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *CreateLoadBalancerInput) SetAvailabilityZones(v []*string) *CreateLoadBalancerInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetListeners sets the Listeners field's value.
+func (s *CreateLoadBalancerInput) SetListeners(v []*Listener) *CreateLoadBalancerInput {
+	s.Listeners = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *CreateLoadBalancerInput) SetLoadBalancerName(v string) *CreateLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetScheme sets the Scheme field's value.
+func (s *CreateLoadBalancerInput) SetScheme(v string) *CreateLoadBalancerInput {
+	s.Scheme = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *CreateLoadBalancerInput) SetSecurityGroups(v []*string) *CreateLoadBalancerInput {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *CreateLoadBalancerInput) SetSubnets(v []*string) *CreateLoadBalancerInput {
+	s.Subnets = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateLoadBalancerInput) SetTags(v []*Tag) *CreateLoadBalancerInput {
+	s.Tags = v
+	return s
+}
+
 // Contains the parameters for CreateLoadBalancerListeners.
 type CreateLoadBalancerListenersInput struct {
 	_ struct{} `type:"structure"`
@@ -2925,6 +3147,18 @@ func (s *CreateLoadBalancerListenersInput) Validate() error {
 	return nil
 }
 
+// SetListeners sets the Listeners field's value.
+func (s *CreateLoadBalancerListenersInput) SetListeners(v []*Listener) *CreateLoadBalancerListenersInput {
+	s.Listeners = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *CreateLoadBalancerListenersInput) SetLoadBalancerName(v string) *CreateLoadBalancerListenersInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the parameters for CreateLoadBalancerListener.
 type CreateLoadBalancerListenersOutput struct {
 	_ struct{} `type:"structure"`
@@ -2956,6 +3190,12 @@ func (s CreateLoadBalancerOutput) String() string {
 // GoString returns the string representation
 func (s CreateLoadBalancerOutput) GoString() string {
 	return s.String()
+}
+
+// SetDNSName sets the DNSName field's value.
+func (s *CreateLoadBalancerOutput) SetDNSName(v string) *CreateLoadBalancerOutput {
+	s.DNSName = &v
+	return s
 }
 
 // Contains the parameters for CreateLoadBalancerPolicy.
@@ -3011,6 +3251,30 @@ func (s *CreateLoadBalancerPolicyInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *CreateLoadBalancerPolicyInput) SetLoadBalancerName(v string) *CreateLoadBalancerPolicyInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetPolicyAttributes sets the PolicyAttributes field's value.
+func (s *CreateLoadBalancerPolicyInput) SetPolicyAttributes(v []*PolicyAttribute) *CreateLoadBalancerPolicyInput {
+	s.PolicyAttributes = v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *CreateLoadBalancerPolicyInput) SetPolicyName(v string) *CreateLoadBalancerPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyTypeName sets the PolicyTypeName field's value.
+func (s *CreateLoadBalancerPolicyInput) SetPolicyTypeName(v string) *CreateLoadBalancerPolicyInput {
+	s.PolicyTypeName = &v
+	return s
+}
+
 // Contains the output of CreateLoadBalancerPolicy.
 type CreateLoadBalancerPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -3059,6 +3323,12 @@ func (s *CrossZoneLoadBalancing) Validate() error {
 	return nil
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *CrossZoneLoadBalancing) SetEnabled(v bool) *CrossZoneLoadBalancing {
+	s.Enabled = &v
+	return s
+}
+
 // Contains the parameters for DeleteLoadBalancer.
 type DeleteLoadBalancerInput struct {
 	_ struct{} `type:"structure"`
@@ -3090,6 +3360,12 @@ func (s *DeleteLoadBalancerInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DeleteLoadBalancerInput) SetLoadBalancerName(v string) *DeleteLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
 }
 
 // Contains the parameters for DeleteLoadBalancerListeners.
@@ -3131,6 +3407,18 @@ func (s *DeleteLoadBalancerListenersInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DeleteLoadBalancerListenersInput) SetLoadBalancerName(v string) *DeleteLoadBalancerListenersInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetLoadBalancerPorts sets the LoadBalancerPorts field's value.
+func (s *DeleteLoadBalancerListenersInput) SetLoadBalancerPorts(v []*int64) *DeleteLoadBalancerListenersInput {
+	s.LoadBalancerPorts = v
+	return s
 }
 
 // Contains the output of DeleteLoadBalancerListeners.
@@ -3204,6 +3492,18 @@ func (s *DeleteLoadBalancerPolicyInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DeleteLoadBalancerPolicyInput) SetLoadBalancerName(v string) *DeleteLoadBalancerPolicyInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeleteLoadBalancerPolicyInput) SetPolicyName(v string) *DeleteLoadBalancerPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 // Contains the output of DeleteLoadBalancerPolicy.
 type DeleteLoadBalancerPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -3260,6 +3560,18 @@ func (s *DeregisterInstancesFromLoadBalancerInput) Validate() error {
 	return nil
 }
 
+// SetInstances sets the Instances field's value.
+func (s *DeregisterInstancesFromLoadBalancerInput) SetInstances(v []*Instance) *DeregisterInstancesFromLoadBalancerInput {
+	s.Instances = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DeregisterInstancesFromLoadBalancerInput) SetLoadBalancerName(v string) *DeregisterInstancesFromLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the output of DeregisterInstancesFromLoadBalancer.
 type DeregisterInstancesFromLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
@@ -3276,6 +3588,12 @@ func (s DeregisterInstancesFromLoadBalancerOutput) String() string {
 // GoString returns the string representation
 func (s DeregisterInstancesFromLoadBalancerOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstances sets the Instances field's value.
+func (s *DeregisterInstancesFromLoadBalancerOutput) SetInstances(v []*Instance) *DeregisterInstancesFromLoadBalancerOutput {
+	s.Instances = v
+	return s
 }
 
 // Contains the parameters for DescribeInstanceHealth.
@@ -3314,6 +3632,18 @@ func (s *DescribeInstanceHealthInput) Validate() error {
 	return nil
 }
 
+// SetInstances sets the Instances field's value.
+func (s *DescribeInstanceHealthInput) SetInstances(v []*Instance) *DescribeInstanceHealthInput {
+	s.Instances = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DescribeInstanceHealthInput) SetLoadBalancerName(v string) *DescribeInstanceHealthInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the output for DescribeInstanceHealth.
 type DescribeInstanceHealthOutput struct {
 	_ struct{} `type:"structure"`
@@ -3330,6 +3660,12 @@ func (s DescribeInstanceHealthOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInstanceHealthOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceStates sets the InstanceStates field's value.
+func (s *DescribeInstanceHealthOutput) SetInstanceStates(v []*InstanceState) *DescribeInstanceHealthOutput {
+	s.InstanceStates = v
+	return s
 }
 
 // Contains the parameters for DescribeLoadBalancerAttributes.
@@ -3365,6 +3701,12 @@ func (s *DescribeLoadBalancerAttributesInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DescribeLoadBalancerAttributesInput) SetLoadBalancerName(v string) *DescribeLoadBalancerAttributesInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the output of DescribeLoadBalancerAttributes.
 type DescribeLoadBalancerAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3381,6 +3723,12 @@ func (s DescribeLoadBalancerAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancerAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancerAttributes sets the LoadBalancerAttributes field's value.
+func (s *DescribeLoadBalancerAttributesOutput) SetLoadBalancerAttributes(v *LoadBalancerAttributes) *DescribeLoadBalancerAttributesOutput {
+	s.LoadBalancerAttributes = v
+	return s
 }
 
 // Contains the parameters for DescribeLoadBalancerPolicies.
@@ -3404,6 +3752,18 @@ func (s DescribeLoadBalancerPoliciesInput) GoString() string {
 	return s.String()
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DescribeLoadBalancerPoliciesInput) SetLoadBalancerName(v string) *DescribeLoadBalancerPoliciesInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *DescribeLoadBalancerPoliciesInput) SetPolicyNames(v []*string) *DescribeLoadBalancerPoliciesInput {
+	s.PolicyNames = v
+	return s
+}
+
 // Contains the output of DescribeLoadBalancerPolicies.
 type DescribeLoadBalancerPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3420,6 +3780,12 @@ func (s DescribeLoadBalancerPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancerPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyDescriptions sets the PolicyDescriptions field's value.
+func (s *DescribeLoadBalancerPoliciesOutput) SetPolicyDescriptions(v []*PolicyDescription) *DescribeLoadBalancerPoliciesOutput {
+	s.PolicyDescriptions = v
+	return s
 }
 
 // Contains the parameters for DescribeLoadBalancerPolicyTypes.
@@ -3441,6 +3807,12 @@ func (s DescribeLoadBalancerPolicyTypesInput) GoString() string {
 	return s.String()
 }
 
+// SetPolicyTypeNames sets the PolicyTypeNames field's value.
+func (s *DescribeLoadBalancerPolicyTypesInput) SetPolicyTypeNames(v []*string) *DescribeLoadBalancerPolicyTypesInput {
+	s.PolicyTypeNames = v
+	return s
+}
+
 // Contains the output of DescribeLoadBalancerPolicyTypes.
 type DescribeLoadBalancerPolicyTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3457,6 +3829,12 @@ func (s DescribeLoadBalancerPolicyTypesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancerPolicyTypesOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyTypeDescriptions sets the PolicyTypeDescriptions field's value.
+func (s *DescribeLoadBalancerPolicyTypesOutput) SetPolicyTypeDescriptions(v []*PolicyTypeDescription) *DescribeLoadBalancerPolicyTypesOutput {
+	s.PolicyTypeDescriptions = v
+	return s
 }
 
 // Contains the parameters for DescribeLoadBalancers.
@@ -3498,6 +3876,24 @@ func (s *DescribeLoadBalancersInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerNames sets the LoadBalancerNames field's value.
+func (s *DescribeLoadBalancersInput) SetLoadBalancerNames(v []*string) *DescribeLoadBalancersInput {
+	s.LoadBalancerNames = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeLoadBalancersInput) SetMarker(v string) *DescribeLoadBalancersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeLoadBalancersInput) SetPageSize(v int64) *DescribeLoadBalancersInput {
+	s.PageSize = &v
+	return s
+}
+
 // Contains the parameters for DescribeLoadBalancers.
 type DescribeLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
@@ -3518,6 +3914,18 @@ func (s DescribeLoadBalancersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancersOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancerDescriptions sets the LoadBalancerDescriptions field's value.
+func (s *DescribeLoadBalancersOutput) SetLoadBalancerDescriptions(v []*LoadBalancerDescription) *DescribeLoadBalancersOutput {
+	s.LoadBalancerDescriptions = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeLoadBalancersOutput) SetNextMarker(v string) *DescribeLoadBalancersOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // Contains the parameters for DescribeTags.
@@ -3556,6 +3964,12 @@ func (s *DescribeTagsInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerNames sets the LoadBalancerNames field's value.
+func (s *DescribeTagsInput) SetLoadBalancerNames(v []*string) *DescribeTagsInput {
+	s.LoadBalancerNames = v
+	return s
+}
+
 // Contains the output for DescribeTags.
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3572,6 +3986,12 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagDescriptions sets the TagDescriptions field's value.
+func (s *DescribeTagsOutput) SetTagDescriptions(v []*TagDescription) *DescribeTagsOutput {
+	s.TagDescriptions = v
+	return s
 }
 
 // Contains the parameters for DetachLoadBalancerFromSubnets.
@@ -3615,6 +4035,18 @@ func (s *DetachLoadBalancerFromSubnetsInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DetachLoadBalancerFromSubnetsInput) SetLoadBalancerName(v string) *DetachLoadBalancerFromSubnetsInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *DetachLoadBalancerFromSubnetsInput) SetSubnets(v []*string) *DetachLoadBalancerFromSubnetsInput {
+	s.Subnets = v
+	return s
+}
+
 // Contains the output of DetachLoadBalancerFromSubnets.
 type DetachLoadBalancerFromSubnetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3631,6 +4063,12 @@ func (s DetachLoadBalancerFromSubnetsOutput) String() string {
 // GoString returns the string representation
 func (s DetachLoadBalancerFromSubnetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *DetachLoadBalancerFromSubnetsOutput) SetSubnets(v []*string) *DetachLoadBalancerFromSubnetsOutput {
+	s.Subnets = v
+	return s
 }
 
 // Contains the parameters for DisableAvailabilityZonesForLoadBalancer.
@@ -3674,6 +4112,18 @@ func (s *DisableAvailabilityZonesForLoadBalancerInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *DisableAvailabilityZonesForLoadBalancerInput) SetAvailabilityZones(v []*string) *DisableAvailabilityZonesForLoadBalancerInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DisableAvailabilityZonesForLoadBalancerInput) SetLoadBalancerName(v string) *DisableAvailabilityZonesForLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the output for DisableAvailabilityZonesForLoadBalancer.
 type DisableAvailabilityZonesForLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
@@ -3690,6 +4140,12 @@ func (s DisableAvailabilityZonesForLoadBalancerOutput) String() string {
 // GoString returns the string representation
 func (s DisableAvailabilityZonesForLoadBalancerOutput) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *DisableAvailabilityZonesForLoadBalancerOutput) SetAvailabilityZones(v []*string) *DisableAvailabilityZonesForLoadBalancerOutput {
+	s.AvailabilityZones = v
+	return s
 }
 
 // Contains the parameters for EnableAvailabilityZonesForLoadBalancer.
@@ -3733,6 +4189,18 @@ func (s *EnableAvailabilityZonesForLoadBalancerInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *EnableAvailabilityZonesForLoadBalancerInput) SetAvailabilityZones(v []*string) *EnableAvailabilityZonesForLoadBalancerInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *EnableAvailabilityZonesForLoadBalancerInput) SetLoadBalancerName(v string) *EnableAvailabilityZonesForLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the output of EnableAvailabilityZonesForLoadBalancer.
 type EnableAvailabilityZonesForLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
@@ -3749,6 +4217,12 @@ func (s EnableAvailabilityZonesForLoadBalancerOutput) String() string {
 // GoString returns the string representation
 func (s EnableAvailabilityZonesForLoadBalancerOutput) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *EnableAvailabilityZonesForLoadBalancerOutput) SetAvailabilityZones(v []*string) *EnableAvailabilityZonesForLoadBalancerOutput {
+	s.AvailabilityZones = v
+	return s
 }
 
 // Information about a health check.
@@ -3851,6 +4325,36 @@ func (s *HealthCheck) Validate() error {
 	return nil
 }
 
+// SetHealthyThreshold sets the HealthyThreshold field's value.
+func (s *HealthCheck) SetHealthyThreshold(v int64) *HealthCheck {
+	s.HealthyThreshold = &v
+	return s
+}
+
+// SetInterval sets the Interval field's value.
+func (s *HealthCheck) SetInterval(v int64) *HealthCheck {
+	s.Interval = &v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *HealthCheck) SetTarget(v string) *HealthCheck {
+	s.Target = &v
+	return s
+}
+
+// SetTimeout sets the Timeout field's value.
+func (s *HealthCheck) SetTimeout(v int64) *HealthCheck {
+	s.Timeout = &v
+	return s
+}
+
+// SetUnhealthyThreshold sets the UnhealthyThreshold field's value.
+func (s *HealthCheck) SetUnhealthyThreshold(v int64) *HealthCheck {
+	s.UnhealthyThreshold = &v
+	return s
+}
+
 // The ID of an EC2 instance.
 type Instance struct {
 	_ struct{} `type:"structure"`
@@ -3867,6 +4371,12 @@ func (s Instance) String() string {
 // GoString returns the string representation
 func (s Instance) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Instance) SetInstanceId(v string) *Instance {
+	s.InstanceId = &v
+	return s
 }
 
 // Information about the state of an EC2 instance.
@@ -3929,6 +4439,30 @@ func (s InstanceState) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *InstanceState) SetDescription(v string) *InstanceState {
+	s.Description = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceState) SetInstanceId(v string) *InstanceState {
+	s.InstanceId = &v
+	return s
+}
+
+// SetReasonCode sets the ReasonCode field's value.
+func (s *InstanceState) SetReasonCode(v string) *InstanceState {
+	s.ReasonCode = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *InstanceState) SetState(v string) *InstanceState {
+	s.State = &v
+	return s
+}
+
 // Information about a policy for duration-based session stickiness.
 type LBCookieStickinessPolicy struct {
 	_ struct{} `type:"structure"`
@@ -3951,6 +4485,18 @@ func (s LBCookieStickinessPolicy) String() string {
 // GoString returns the string representation
 func (s LBCookieStickinessPolicy) GoString() string {
 	return s.String()
+}
+
+// SetCookieExpirationPeriod sets the CookieExpirationPeriod field's value.
+func (s *LBCookieStickinessPolicy) SetCookieExpirationPeriod(v int64) *LBCookieStickinessPolicy {
+	s.CookieExpirationPeriod = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *LBCookieStickinessPolicy) SetPolicyName(v string) *LBCookieStickinessPolicy {
+	s.PolicyName = &v
+	return s
 }
 
 // Information about a listener.
@@ -4028,6 +4574,36 @@ func (s *Listener) Validate() error {
 	return nil
 }
 
+// SetInstancePort sets the InstancePort field's value.
+func (s *Listener) SetInstancePort(v int64) *Listener {
+	s.InstancePort = &v
+	return s
+}
+
+// SetInstanceProtocol sets the InstanceProtocol field's value.
+func (s *Listener) SetInstanceProtocol(v string) *Listener {
+	s.InstanceProtocol = &v
+	return s
+}
+
+// SetLoadBalancerPort sets the LoadBalancerPort field's value.
+func (s *Listener) SetLoadBalancerPort(v int64) *Listener {
+	s.LoadBalancerPort = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *Listener) SetProtocol(v string) *Listener {
+	s.Protocol = &v
+	return s
+}
+
+// SetSSLCertificateId sets the SSLCertificateId field's value.
+func (s *Listener) SetSSLCertificateId(v string) *Listener {
+	s.SSLCertificateId = &v
+	return s
+}
+
 // The policies enabled for a listener.
 type ListenerDescription struct {
 	_ struct{} `type:"structure"`
@@ -4051,6 +4627,18 @@ func (s ListenerDescription) String() string {
 // GoString returns the string representation
 func (s ListenerDescription) GoString() string {
 	return s.String()
+}
+
+// SetListener sets the Listener field's value.
+func (s *ListenerDescription) SetListener(v *Listener) *ListenerDescription {
+	s.Listener = v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *ListenerDescription) SetPolicyNames(v []*string) *ListenerDescription {
+	s.PolicyNames = v
+	return s
 }
 
 // The attributes for a load balancer.
@@ -4131,6 +4719,36 @@ func (s *LoadBalancerAttributes) Validate() error {
 	return nil
 }
 
+// SetAccessLog sets the AccessLog field's value.
+func (s *LoadBalancerAttributes) SetAccessLog(v *AccessLog) *LoadBalancerAttributes {
+	s.AccessLog = v
+	return s
+}
+
+// SetAdditionalAttributes sets the AdditionalAttributes field's value.
+func (s *LoadBalancerAttributes) SetAdditionalAttributes(v []*AdditionalAttribute) *LoadBalancerAttributes {
+	s.AdditionalAttributes = v
+	return s
+}
+
+// SetConnectionDraining sets the ConnectionDraining field's value.
+func (s *LoadBalancerAttributes) SetConnectionDraining(v *ConnectionDraining) *LoadBalancerAttributes {
+	s.ConnectionDraining = v
+	return s
+}
+
+// SetConnectionSettings sets the ConnectionSettings field's value.
+func (s *LoadBalancerAttributes) SetConnectionSettings(v *ConnectionSettings) *LoadBalancerAttributes {
+	s.ConnectionSettings = v
+	return s
+}
+
+// SetCrossZoneLoadBalancing sets the CrossZoneLoadBalancing field's value.
+func (s *LoadBalancerAttributes) SetCrossZoneLoadBalancing(v *CrossZoneLoadBalancing) *LoadBalancerAttributes {
+	s.CrossZoneLoadBalancing = v
+	return s
+}
+
 // Information about a load balancer.
 type LoadBalancerDescription struct {
 	_ struct{} `type:"structure"`
@@ -4207,6 +4825,102 @@ func (s LoadBalancerDescription) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *LoadBalancerDescription) SetAvailabilityZones(v []*string) *LoadBalancerDescription {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetBackendServerDescriptions sets the BackendServerDescriptions field's value.
+func (s *LoadBalancerDescription) SetBackendServerDescriptions(v []*BackendServerDescription) *LoadBalancerDescription {
+	s.BackendServerDescriptions = v
+	return s
+}
+
+// SetCanonicalHostedZoneName sets the CanonicalHostedZoneName field's value.
+func (s *LoadBalancerDescription) SetCanonicalHostedZoneName(v string) *LoadBalancerDescription {
+	s.CanonicalHostedZoneName = &v
+	return s
+}
+
+// SetCanonicalHostedZoneNameID sets the CanonicalHostedZoneNameID field's value.
+func (s *LoadBalancerDescription) SetCanonicalHostedZoneNameID(v string) *LoadBalancerDescription {
+	s.CanonicalHostedZoneNameID = &v
+	return s
+}
+
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *LoadBalancerDescription) SetCreatedTime(v time.Time) *LoadBalancerDescription {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetDNSName sets the DNSName field's value.
+func (s *LoadBalancerDescription) SetDNSName(v string) *LoadBalancerDescription {
+	s.DNSName = &v
+	return s
+}
+
+// SetHealthCheck sets the HealthCheck field's value.
+func (s *LoadBalancerDescription) SetHealthCheck(v *HealthCheck) *LoadBalancerDescription {
+	s.HealthCheck = v
+	return s
+}
+
+// SetInstances sets the Instances field's value.
+func (s *LoadBalancerDescription) SetInstances(v []*Instance) *LoadBalancerDescription {
+	s.Instances = v
+	return s
+}
+
+// SetListenerDescriptions sets the ListenerDescriptions field's value.
+func (s *LoadBalancerDescription) SetListenerDescriptions(v []*ListenerDescription) *LoadBalancerDescription {
+	s.ListenerDescriptions = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *LoadBalancerDescription) SetLoadBalancerName(v string) *LoadBalancerDescription {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *LoadBalancerDescription) SetPolicies(v *Policies) *LoadBalancerDescription {
+	s.Policies = v
+	return s
+}
+
+// SetScheme sets the Scheme field's value.
+func (s *LoadBalancerDescription) SetScheme(v string) *LoadBalancerDescription {
+	s.Scheme = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *LoadBalancerDescription) SetSecurityGroups(v []*string) *LoadBalancerDescription {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSourceSecurityGroup sets the SourceSecurityGroup field's value.
+func (s *LoadBalancerDescription) SetSourceSecurityGroup(v *SourceSecurityGroup) *LoadBalancerDescription {
+	s.SourceSecurityGroup = v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *LoadBalancerDescription) SetSubnets(v []*string) *LoadBalancerDescription {
+	s.Subnets = v
+	return s
+}
+
+// SetVPCId sets the VPCId field's value.
+func (s *LoadBalancerDescription) SetVPCId(v string) *LoadBalancerDescription {
+	s.VPCId = &v
+	return s
+}
+
 // Contains the parameters for ModifyLoadBalancerAttributes.
 type ModifyLoadBalancerAttributesInput struct {
 	_ struct{} `type:"structure"`
@@ -4253,6 +4967,18 @@ func (s *ModifyLoadBalancerAttributesInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerAttributes sets the LoadBalancerAttributes field's value.
+func (s *ModifyLoadBalancerAttributesInput) SetLoadBalancerAttributes(v *LoadBalancerAttributes) *ModifyLoadBalancerAttributesInput {
+	s.LoadBalancerAttributes = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *ModifyLoadBalancerAttributesInput) SetLoadBalancerName(v string) *ModifyLoadBalancerAttributesInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the output of ModifyLoadBalancerAttributes.
 type ModifyLoadBalancerAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4272,6 +4998,18 @@ func (s ModifyLoadBalancerAttributesOutput) String() string {
 // GoString returns the string representation
 func (s ModifyLoadBalancerAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancerAttributes sets the LoadBalancerAttributes field's value.
+func (s *ModifyLoadBalancerAttributesOutput) SetLoadBalancerAttributes(v *LoadBalancerAttributes) *ModifyLoadBalancerAttributesOutput {
+	s.LoadBalancerAttributes = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *ModifyLoadBalancerAttributesOutput) SetLoadBalancerName(v string) *ModifyLoadBalancerAttributesOutput {
+	s.LoadBalancerName = &v
+	return s
 }
 
 // The policies for a load balancer.
@@ -4298,6 +5036,24 @@ func (s Policies) GoString() string {
 	return s.String()
 }
 
+// SetAppCookieStickinessPolicies sets the AppCookieStickinessPolicies field's value.
+func (s *Policies) SetAppCookieStickinessPolicies(v []*AppCookieStickinessPolicy) *Policies {
+	s.AppCookieStickinessPolicies = v
+	return s
+}
+
+// SetLBCookieStickinessPolicies sets the LBCookieStickinessPolicies field's value.
+func (s *Policies) SetLBCookieStickinessPolicies(v []*LBCookieStickinessPolicy) *Policies {
+	s.LBCookieStickinessPolicies = v
+	return s
+}
+
+// SetOtherPolicies sets the OtherPolicies field's value.
+func (s *Policies) SetOtherPolicies(v []*string) *Policies {
+	s.OtherPolicies = v
+	return s
+}
+
 // Information about a policy attribute.
 type PolicyAttribute struct {
 	_ struct{} `type:"structure"`
@@ -4319,6 +5075,18 @@ func (s PolicyAttribute) GoString() string {
 	return s.String()
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *PolicyAttribute) SetAttributeName(v string) *PolicyAttribute {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValue sets the AttributeValue field's value.
+func (s *PolicyAttribute) SetAttributeValue(v string) *PolicyAttribute {
+	s.AttributeValue = &v
+	return s
+}
+
 // Information about a policy attribute.
 type PolicyAttributeDescription struct {
 	_ struct{} `type:"structure"`
@@ -4338,6 +5106,18 @@ func (s PolicyAttributeDescription) String() string {
 // GoString returns the string representation
 func (s PolicyAttributeDescription) GoString() string {
 	return s.String()
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *PolicyAttributeDescription) SetAttributeName(v string) *PolicyAttributeDescription {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValue sets the AttributeValue field's value.
+func (s *PolicyAttributeDescription) SetAttributeValue(v string) *PolicyAttributeDescription {
+	s.AttributeValue = &v
+	return s
 }
 
 // Information about a policy attribute type.
@@ -4380,6 +5160,36 @@ func (s PolicyAttributeTypeDescription) GoString() string {
 	return s.String()
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *PolicyAttributeTypeDescription) SetAttributeName(v string) *PolicyAttributeTypeDescription {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeType sets the AttributeType field's value.
+func (s *PolicyAttributeTypeDescription) SetAttributeType(v string) *PolicyAttributeTypeDescription {
+	s.AttributeType = &v
+	return s
+}
+
+// SetCardinality sets the Cardinality field's value.
+func (s *PolicyAttributeTypeDescription) SetCardinality(v string) *PolicyAttributeTypeDescription {
+	s.Cardinality = &v
+	return s
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *PolicyAttributeTypeDescription) SetDefaultValue(v string) *PolicyAttributeTypeDescription {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *PolicyAttributeTypeDescription) SetDescription(v string) *PolicyAttributeTypeDescription {
+	s.Description = &v
+	return s
+}
+
 // Information about a policy.
 type PolicyDescription struct {
 	_ struct{} `type:"structure"`
@@ -4402,6 +5212,24 @@ func (s PolicyDescription) String() string {
 // GoString returns the string representation
 func (s PolicyDescription) GoString() string {
 	return s.String()
+}
+
+// SetPolicyAttributeDescriptions sets the PolicyAttributeDescriptions field's value.
+func (s *PolicyDescription) SetPolicyAttributeDescriptions(v []*PolicyAttributeDescription) *PolicyDescription {
+	s.PolicyAttributeDescriptions = v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *PolicyDescription) SetPolicyName(v string) *PolicyDescription {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyTypeName sets the PolicyTypeName field's value.
+func (s *PolicyDescription) SetPolicyTypeName(v string) *PolicyDescription {
+	s.PolicyTypeName = &v
+	return s
 }
 
 // Information about a policy type.
@@ -4427,6 +5255,24 @@ func (s PolicyTypeDescription) String() string {
 // GoString returns the string representation
 func (s PolicyTypeDescription) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *PolicyTypeDescription) SetDescription(v string) *PolicyTypeDescription {
+	s.Description = &v
+	return s
+}
+
+// SetPolicyAttributeTypeDescriptions sets the PolicyAttributeTypeDescriptions field's value.
+func (s *PolicyTypeDescription) SetPolicyAttributeTypeDescriptions(v []*PolicyAttributeTypeDescription) *PolicyTypeDescription {
+	s.PolicyAttributeTypeDescriptions = v
+	return s
+}
+
+// SetPolicyTypeName sets the PolicyTypeName field's value.
+func (s *PolicyTypeDescription) SetPolicyTypeName(v string) *PolicyTypeDescription {
+	s.PolicyTypeName = &v
+	return s
 }
 
 // Contains the parameters for RegisterInstancesWithLoadBalancer.
@@ -4470,6 +5316,18 @@ func (s *RegisterInstancesWithLoadBalancerInput) Validate() error {
 	return nil
 }
 
+// SetInstances sets the Instances field's value.
+func (s *RegisterInstancesWithLoadBalancerInput) SetInstances(v []*Instance) *RegisterInstancesWithLoadBalancerInput {
+	s.Instances = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *RegisterInstancesWithLoadBalancerInput) SetLoadBalancerName(v string) *RegisterInstancesWithLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
 // Contains the output of RegisterInstancesWithLoadBalancer.
 type RegisterInstancesWithLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
@@ -4486,6 +5344,12 @@ func (s RegisterInstancesWithLoadBalancerOutput) String() string {
 // GoString returns the string representation
 func (s RegisterInstancesWithLoadBalancerOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstances sets the Instances field's value.
+func (s *RegisterInstancesWithLoadBalancerOutput) SetInstances(v []*Instance) *RegisterInstancesWithLoadBalancerOutput {
+	s.Instances = v
+	return s
 }
 
 // Contains the parameters for RemoveTags.
@@ -4541,6 +5405,18 @@ func (s *RemoveTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLoadBalancerNames sets the LoadBalancerNames field's value.
+func (s *RemoveTagsInput) SetLoadBalancerNames(v []*string) *RemoveTagsInput {
+	s.LoadBalancerNames = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RemoveTagsInput) SetTags(v []*TagKeyOnly) *RemoveTagsInput {
+	s.Tags = v
+	return s
 }
 
 // Contains the output of RemoveTags.
@@ -4607,6 +5483,24 @@ func (s *SetLoadBalancerListenerSSLCertificateInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *SetLoadBalancerListenerSSLCertificateInput) SetLoadBalancerName(v string) *SetLoadBalancerListenerSSLCertificateInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetLoadBalancerPort sets the LoadBalancerPort field's value.
+func (s *SetLoadBalancerListenerSSLCertificateInput) SetLoadBalancerPort(v int64) *SetLoadBalancerListenerSSLCertificateInput {
+	s.LoadBalancerPort = &v
+	return s
+}
+
+// SetSSLCertificateId sets the SSLCertificateId field's value.
+func (s *SetLoadBalancerListenerSSLCertificateInput) SetSSLCertificateId(v string) *SetLoadBalancerListenerSSLCertificateInput {
+	s.SSLCertificateId = &v
+	return s
+}
+
 // Contains the output of SetLoadBalancerListenerSSLCertificate.
 type SetLoadBalancerListenerSSLCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -4670,6 +5564,24 @@ func (s *SetLoadBalancerPoliciesForBackendServerInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstancePort sets the InstancePort field's value.
+func (s *SetLoadBalancerPoliciesForBackendServerInput) SetInstancePort(v int64) *SetLoadBalancerPoliciesForBackendServerInput {
+	s.InstancePort = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *SetLoadBalancerPoliciesForBackendServerInput) SetLoadBalancerName(v string) *SetLoadBalancerPoliciesForBackendServerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *SetLoadBalancerPoliciesForBackendServerInput) SetPolicyNames(v []*string) *SetLoadBalancerPoliciesForBackendServerInput {
+	s.PolicyNames = v
+	return s
 }
 
 // Contains the output of SetLoadBalancerPoliciesForBackendServer.
@@ -4738,6 +5650,24 @@ func (s *SetLoadBalancerPoliciesOfListenerInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *SetLoadBalancerPoliciesOfListenerInput) SetLoadBalancerName(v string) *SetLoadBalancerPoliciesOfListenerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetLoadBalancerPort sets the LoadBalancerPort field's value.
+func (s *SetLoadBalancerPoliciesOfListenerInput) SetLoadBalancerPort(v int64) *SetLoadBalancerPoliciesOfListenerInput {
+	s.LoadBalancerPort = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *SetLoadBalancerPoliciesOfListenerInput) SetPolicyNames(v []*string) *SetLoadBalancerPoliciesOfListenerInput {
+	s.PolicyNames = v
+	return s
+}
+
 // Contains the output of SetLoadBalancePoliciesOfListener.
 type SetLoadBalancerPoliciesOfListenerOutput struct {
 	_ struct{} `type:"structure"`
@@ -4772,6 +5702,18 @@ func (s SourceSecurityGroup) String() string {
 // GoString returns the string representation
 func (s SourceSecurityGroup) GoString() string {
 	return s.String()
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *SourceSecurityGroup) SetGroupName(v string) *SourceSecurityGroup {
+	s.GroupName = &v
+	return s
+}
+
+// SetOwnerAlias sets the OwnerAlias field's value.
+func (s *SourceSecurityGroup) SetOwnerAlias(v string) *SourceSecurityGroup {
+	s.OwnerAlias = &v
+	return s
 }
 
 // Information about a tag.
@@ -4813,6 +5755,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // The tags associated with a load balancer.
 type TagDescription struct {
 	_ struct{} `type:"structure"`
@@ -4832,6 +5786,18 @@ func (s TagDescription) String() string {
 // GoString returns the string representation
 func (s TagDescription) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *TagDescription) SetLoadBalancerName(v string) *TagDescription {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagDescription) SetTags(v []*Tag) *TagDescription {
+	s.Tags = v
+	return s
 }
 
 // The key of a tag.
@@ -4863,4 +5829,10 @@ func (s *TagKeyOnly) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *TagKeyOnly) SetKey(v string) *TagKeyOnly {
+	s.Key = &v
+	return s
 }

--- a/service/elbv2/api.go
+++ b/service/elbv2/api.go
@@ -2340,6 +2340,18 @@ func (s *Action) Validate() error {
 	return nil
 }
 
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *Action) SetTargetGroupArn(v string) *Action {
+	s.TargetGroupArn = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Action) SetType(v string) *Action {
+	s.Type = &v
+	return s
+}
+
 // Contains the parameters for AddTags.
 type AddTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -2394,6 +2406,18 @@ func (s *AddTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceArns sets the ResourceArns field's value.
+func (s *AddTagsInput) SetResourceArns(v []*string) *AddTagsInput {
+	s.ResourceArns = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsInput) SetTags(v []*Tag) *AddTagsInput {
+	s.Tags = v
+	return s
+}
+
 // Contains the output of AddTags.
 type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2430,6 +2454,18 @@ func (s AvailabilityZone) GoString() string {
 	return s.String()
 }
 
+// SetSubnetId sets the SubnetId field's value.
+func (s *AvailabilityZone) SetSubnetId(v string) *AvailabilityZone {
+	s.SubnetId = &v
+	return s
+}
+
+// SetZoneName sets the ZoneName field's value.
+func (s *AvailabilityZone) SetZoneName(v string) *AvailabilityZone {
+	s.ZoneName = &v
+	return s
+}
+
 // Information about an SSL server certificate deployed on a load balancer.
 type Certificate struct {
 	_ struct{} `type:"structure"`
@@ -2446,6 +2482,12 @@ func (s Certificate) String() string {
 // GoString returns the string representation
 func (s Certificate) GoString() string {
 	return s.String()
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *Certificate) SetCertificateArn(v string) *Certificate {
+	s.CertificateArn = &v
+	return s
 }
 
 // Information about a cipher used in a policy.
@@ -2467,6 +2509,18 @@ func (s Cipher) String() string {
 // GoString returns the string representation
 func (s Cipher) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *Cipher) SetName(v string) *Cipher {
+	s.Name = &v
+	return s
+}
+
+// SetPriority sets the Priority field's value.
+func (s *Cipher) SetPriority(v int64) *Cipher {
+	s.Priority = &v
+	return s
 }
 
 // Contains the parameters for CreateListener.
@@ -2547,6 +2601,42 @@ func (s *CreateListenerInput) Validate() error {
 	return nil
 }
 
+// SetCertificates sets the Certificates field's value.
+func (s *CreateListenerInput) SetCertificates(v []*Certificate) *CreateListenerInput {
+	s.Certificates = v
+	return s
+}
+
+// SetDefaultActions sets the DefaultActions field's value.
+func (s *CreateListenerInput) SetDefaultActions(v []*Action) *CreateListenerInput {
+	s.DefaultActions = v
+	return s
+}
+
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *CreateListenerInput) SetLoadBalancerArn(v string) *CreateListenerInput {
+	s.LoadBalancerArn = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateListenerInput) SetPort(v int64) *CreateListenerInput {
+	s.Port = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *CreateListenerInput) SetProtocol(v string) *CreateListenerInput {
+	s.Protocol = &v
+	return s
+}
+
+// SetSslPolicy sets the SslPolicy field's value.
+func (s *CreateListenerInput) SetSslPolicy(v string) *CreateListenerInput {
+	s.SslPolicy = &v
+	return s
+}
+
 // Contains the output of CreateListener.
 type CreateListenerOutput struct {
 	_ struct{} `type:"structure"`
@@ -2563,6 +2653,12 @@ func (s CreateListenerOutput) String() string {
 // GoString returns the string representation
 func (s CreateListenerOutput) GoString() string {
 	return s.String()
+}
+
+// SetListeners sets the Listeners field's value.
+func (s *CreateListenerOutput) SetListeners(v []*Listener) *CreateListenerOutput {
+	s.Listeners = v
+	return s
 }
 
 // Contains the parameters for CreateLoadBalancer.
@@ -2644,6 +2740,36 @@ func (s *CreateLoadBalancerInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *CreateLoadBalancerInput) SetName(v string) *CreateLoadBalancerInput {
+	s.Name = &v
+	return s
+}
+
+// SetScheme sets the Scheme field's value.
+func (s *CreateLoadBalancerInput) SetScheme(v string) *CreateLoadBalancerInput {
+	s.Scheme = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *CreateLoadBalancerInput) SetSecurityGroups(v []*string) *CreateLoadBalancerInput {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *CreateLoadBalancerInput) SetSubnets(v []*string) *CreateLoadBalancerInput {
+	s.Subnets = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateLoadBalancerInput) SetTags(v []*Tag) *CreateLoadBalancerInput {
+	s.Tags = v
+	return s
+}
+
 // Contains the output of CreateLoadBalancer.
 type CreateLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
@@ -2660,6 +2786,12 @@ func (s CreateLoadBalancerOutput) String() string {
 // GoString returns the string representation
 func (s CreateLoadBalancerOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancers sets the LoadBalancers field's value.
+func (s *CreateLoadBalancerOutput) SetLoadBalancers(v []*LoadBalancer) *CreateLoadBalancerOutput {
+	s.LoadBalancers = v
+	return s
 }
 
 // Contains the parameters for CreateRule.
@@ -2745,6 +2877,30 @@ func (s *CreateRuleInput) Validate() error {
 	return nil
 }
 
+// SetActions sets the Actions field's value.
+func (s *CreateRuleInput) SetActions(v []*Action) *CreateRuleInput {
+	s.Actions = v
+	return s
+}
+
+// SetConditions sets the Conditions field's value.
+func (s *CreateRuleInput) SetConditions(v []*RuleCondition) *CreateRuleInput {
+	s.Conditions = v
+	return s
+}
+
+// SetListenerArn sets the ListenerArn field's value.
+func (s *CreateRuleInput) SetListenerArn(v string) *CreateRuleInput {
+	s.ListenerArn = &v
+	return s
+}
+
+// SetPriority sets the Priority field's value.
+func (s *CreateRuleInput) SetPriority(v int64) *CreateRuleInput {
+	s.Priority = &v
+	return s
+}
+
 // Contains the output of CreateRule.
 type CreateRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -2761,6 +2917,12 @@ func (s CreateRuleOutput) String() string {
 // GoString returns the string representation
 func (s CreateRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetRules sets the Rules field's value.
+func (s *CreateRuleOutput) SetRules(v []*Rule) *CreateRuleOutput {
+	s.Rules = v
+	return s
 }
 
 // Contains the parameters for CreateTargetGroup.
@@ -2877,6 +3039,78 @@ func (s *CreateTargetGroupInput) Validate() error {
 	return nil
 }
 
+// SetHealthCheckIntervalSeconds sets the HealthCheckIntervalSeconds field's value.
+func (s *CreateTargetGroupInput) SetHealthCheckIntervalSeconds(v int64) *CreateTargetGroupInput {
+	s.HealthCheckIntervalSeconds = &v
+	return s
+}
+
+// SetHealthCheckPath sets the HealthCheckPath field's value.
+func (s *CreateTargetGroupInput) SetHealthCheckPath(v string) *CreateTargetGroupInput {
+	s.HealthCheckPath = &v
+	return s
+}
+
+// SetHealthCheckPort sets the HealthCheckPort field's value.
+func (s *CreateTargetGroupInput) SetHealthCheckPort(v string) *CreateTargetGroupInput {
+	s.HealthCheckPort = &v
+	return s
+}
+
+// SetHealthCheckProtocol sets the HealthCheckProtocol field's value.
+func (s *CreateTargetGroupInput) SetHealthCheckProtocol(v string) *CreateTargetGroupInput {
+	s.HealthCheckProtocol = &v
+	return s
+}
+
+// SetHealthCheckTimeoutSeconds sets the HealthCheckTimeoutSeconds field's value.
+func (s *CreateTargetGroupInput) SetHealthCheckTimeoutSeconds(v int64) *CreateTargetGroupInput {
+	s.HealthCheckTimeoutSeconds = &v
+	return s
+}
+
+// SetHealthyThresholdCount sets the HealthyThresholdCount field's value.
+func (s *CreateTargetGroupInput) SetHealthyThresholdCount(v int64) *CreateTargetGroupInput {
+	s.HealthyThresholdCount = &v
+	return s
+}
+
+// SetMatcher sets the Matcher field's value.
+func (s *CreateTargetGroupInput) SetMatcher(v *Matcher) *CreateTargetGroupInput {
+	s.Matcher = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateTargetGroupInput) SetName(v string) *CreateTargetGroupInput {
+	s.Name = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateTargetGroupInput) SetPort(v int64) *CreateTargetGroupInput {
+	s.Port = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *CreateTargetGroupInput) SetProtocol(v string) *CreateTargetGroupInput {
+	s.Protocol = &v
+	return s
+}
+
+// SetUnhealthyThresholdCount sets the UnhealthyThresholdCount field's value.
+func (s *CreateTargetGroupInput) SetUnhealthyThresholdCount(v int64) *CreateTargetGroupInput {
+	s.UnhealthyThresholdCount = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateTargetGroupInput) SetVpcId(v string) *CreateTargetGroupInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the output of CreateTargetGroup.
 type CreateTargetGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -2893,6 +3127,12 @@ func (s CreateTargetGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateTargetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetTargetGroups sets the TargetGroups field's value.
+func (s *CreateTargetGroupOutput) SetTargetGroups(v []*TargetGroup) *CreateTargetGroupOutput {
+	s.TargetGroups = v
+	return s
 }
 
 // Contains the parameters for DeleteListener.
@@ -2926,6 +3166,12 @@ func (s *DeleteListenerInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetListenerArn sets the ListenerArn field's value.
+func (s *DeleteListenerInput) SetListenerArn(v string) *DeleteListenerInput {
+	s.ListenerArn = &v
+	return s
 }
 
 // Contains the output of DeleteListener.
@@ -2976,6 +3222,12 @@ func (s *DeleteLoadBalancerInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *DeleteLoadBalancerInput) SetLoadBalancerArn(v string) *DeleteLoadBalancerInput {
+	s.LoadBalancerArn = &v
+	return s
+}
+
 // Contains the output of DeleteLoadBalancer.
 type DeleteLoadBalancerOutput struct {
 	_ struct{} `type:"structure"`
@@ -3024,6 +3276,12 @@ func (s *DeleteRuleInput) Validate() error {
 	return nil
 }
 
+// SetRuleArn sets the RuleArn field's value.
+func (s *DeleteRuleInput) SetRuleArn(v string) *DeleteRuleInput {
+	s.RuleArn = &v
+	return s
+}
+
 // Contains the output of DeleteRule.
 type DeleteRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -3070,6 +3328,12 @@ func (s *DeleteTargetGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *DeleteTargetGroupInput) SetTargetGroupArn(v string) *DeleteTargetGroupInput {
+	s.TargetGroupArn = &v
+	return s
 }
 
 // Contains the output of DeleteTargetGroup.
@@ -3139,6 +3403,18 @@ func (s *DeregisterTargetsInput) Validate() error {
 	return nil
 }
 
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *DeregisterTargetsInput) SetTargetGroupArn(v string) *DeregisterTargetsInput {
+	s.TargetGroupArn = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *DeregisterTargetsInput) SetTargets(v []*TargetDescription) *DeregisterTargetsInput {
+	s.Targets = v
+	return s
+}
+
 // Contains the output of DeregisterTargets.
 type DeregisterTargetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3195,6 +3471,30 @@ func (s *DescribeListenersInput) Validate() error {
 	return nil
 }
 
+// SetListenerArns sets the ListenerArns field's value.
+func (s *DescribeListenersInput) SetListenerArns(v []*string) *DescribeListenersInput {
+	s.ListenerArns = v
+	return s
+}
+
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *DescribeListenersInput) SetLoadBalancerArn(v string) *DescribeListenersInput {
+	s.LoadBalancerArn = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeListenersInput) SetMarker(v string) *DescribeListenersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeListenersInput) SetPageSize(v int64) *DescribeListenersInput {
+	s.PageSize = &v
+	return s
+}
+
 // Contains the output of DescribeListeners.
 type DescribeListenersOutput struct {
 	_ struct{} `type:"structure"`
@@ -3215,6 +3515,18 @@ func (s DescribeListenersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeListenersOutput) GoString() string {
 	return s.String()
+}
+
+// SetListeners sets the Listeners field's value.
+func (s *DescribeListenersOutput) SetListeners(v []*Listener) *DescribeListenersOutput {
+	s.Listeners = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeListenersOutput) SetNextMarker(v string) *DescribeListenersOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // Contains the parameters for DescribeLoadBalancerAttributes.
@@ -3250,6 +3562,12 @@ func (s *DescribeLoadBalancerAttributesInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *DescribeLoadBalancerAttributesInput) SetLoadBalancerArn(v string) *DescribeLoadBalancerAttributesInput {
+	s.LoadBalancerArn = &v
+	return s
+}
+
 // Contains the output of DescribeLoadBalancerAttributes.
 type DescribeLoadBalancerAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3266,6 +3584,12 @@ func (s DescribeLoadBalancerAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancerAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *DescribeLoadBalancerAttributesOutput) SetAttributes(v []*LoadBalancerAttribute) *DescribeLoadBalancerAttributesOutput {
+	s.Attributes = v
+	return s
 }
 
 // Contains the parameters for DescribeLoadBalancers.
@@ -3309,6 +3633,30 @@ func (s *DescribeLoadBalancersInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerArns sets the LoadBalancerArns field's value.
+func (s *DescribeLoadBalancersInput) SetLoadBalancerArns(v []*string) *DescribeLoadBalancersInput {
+	s.LoadBalancerArns = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeLoadBalancersInput) SetMarker(v string) *DescribeLoadBalancersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetNames sets the Names field's value.
+func (s *DescribeLoadBalancersInput) SetNames(v []*string) *DescribeLoadBalancersInput {
+	s.Names = v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeLoadBalancersInput) SetPageSize(v int64) *DescribeLoadBalancersInput {
+	s.PageSize = &v
+	return s
+}
+
 // Contains the output of DescribeLoadBalancers.
 type DescribeLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
@@ -3329,6 +3677,18 @@ func (s DescribeLoadBalancersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBalancersOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoadBalancers sets the LoadBalancers field's value.
+func (s *DescribeLoadBalancersOutput) SetLoadBalancers(v []*LoadBalancer) *DescribeLoadBalancersOutput {
+	s.LoadBalancers = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeLoadBalancersOutput) SetNextMarker(v string) *DescribeLoadBalancersOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // Contains the parameters for DescribeRules.
@@ -3352,6 +3712,18 @@ func (s DescribeRulesInput) GoString() string {
 	return s.String()
 }
 
+// SetListenerArn sets the ListenerArn field's value.
+func (s *DescribeRulesInput) SetListenerArn(v string) *DescribeRulesInput {
+	s.ListenerArn = &v
+	return s
+}
+
+// SetRuleArns sets the RuleArns field's value.
+func (s *DescribeRulesInput) SetRuleArns(v []*string) *DescribeRulesInput {
+	s.RuleArns = v
+	return s
+}
+
 // Contains the output of DescribeRules.
 type DescribeRulesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3368,6 +3740,12 @@ func (s DescribeRulesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRulesOutput) GoString() string {
 	return s.String()
+}
+
+// SetRules sets the Rules field's value.
+func (s *DescribeRulesOutput) SetRules(v []*Rule) *DescribeRulesOutput {
+	s.Rules = v
+	return s
 }
 
 // Contains the parameters for DescribeSSLPolicies.
@@ -3408,6 +3786,24 @@ func (s *DescribeSSLPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeSSLPoliciesInput) SetMarker(v string) *DescribeSSLPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetNames sets the Names field's value.
+func (s *DescribeSSLPoliciesInput) SetNames(v []*string) *DescribeSSLPoliciesInput {
+	s.Names = v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeSSLPoliciesInput) SetPageSize(v int64) *DescribeSSLPoliciesInput {
+	s.PageSize = &v
+	return s
+}
+
 // Contains the output of DescribeSSLPolicies.
 type DescribeSSLPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3428,6 +3824,18 @@ func (s DescribeSSLPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSSLPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeSSLPoliciesOutput) SetNextMarker(v string) *DescribeSSLPoliciesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetSslPolicies sets the SslPolicies field's value.
+func (s *DescribeSSLPoliciesOutput) SetSslPolicies(v []*SslPolicy) *DescribeSSLPoliciesOutput {
+	s.SslPolicies = v
+	return s
 }
 
 // Contains the parameters for DescribeTags.
@@ -3463,6 +3871,12 @@ func (s *DescribeTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceArns sets the ResourceArns field's value.
+func (s *DescribeTagsInput) SetResourceArns(v []*string) *DescribeTagsInput {
+	s.ResourceArns = v
+	return s
+}
+
 // Contains the output of DescribeTags.
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3479,6 +3893,12 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagDescriptions sets the TagDescriptions field's value.
+func (s *DescribeTagsOutput) SetTagDescriptions(v []*TagDescription) *DescribeTagsOutput {
+	s.TagDescriptions = v
+	return s
 }
 
 // Contains the parameters for DescribeTargetGroupAttributes.
@@ -3514,6 +3934,12 @@ func (s *DescribeTargetGroupAttributesInput) Validate() error {
 	return nil
 }
 
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *DescribeTargetGroupAttributesInput) SetTargetGroupArn(v string) *DescribeTargetGroupAttributesInput {
+	s.TargetGroupArn = &v
+	return s
+}
+
 // Contains the output of DescribeTargetGroupAttributes.
 type DescribeTargetGroupAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3530,6 +3956,12 @@ func (s DescribeTargetGroupAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTargetGroupAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *DescribeTargetGroupAttributesOutput) SetAttributes(v []*TargetGroupAttribute) *DescribeTargetGroupAttributesOutput {
+	s.Attributes = v
+	return s
 }
 
 // Contains the parameters for DescribeTargetGroups.
@@ -3576,6 +4008,36 @@ func (s *DescribeTargetGroupsInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *DescribeTargetGroupsInput) SetLoadBalancerArn(v string) *DescribeTargetGroupsInput {
+	s.LoadBalancerArn = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTargetGroupsInput) SetMarker(v string) *DescribeTargetGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetNames sets the Names field's value.
+func (s *DescribeTargetGroupsInput) SetNames(v []*string) *DescribeTargetGroupsInput {
+	s.Names = v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeTargetGroupsInput) SetPageSize(v int64) *DescribeTargetGroupsInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetTargetGroupArns sets the TargetGroupArns field's value.
+func (s *DescribeTargetGroupsInput) SetTargetGroupArns(v []*string) *DescribeTargetGroupsInput {
+	s.TargetGroupArns = v
+	return s
+}
+
 // Contains the output of DescribeTargetGroups.
 type DescribeTargetGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3596,6 +4058,18 @@ func (s DescribeTargetGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTargetGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeTargetGroupsOutput) SetNextMarker(v string) *DescribeTargetGroupsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetTargetGroups sets the TargetGroups field's value.
+func (s *DescribeTargetGroupsOutput) SetTargetGroups(v []*TargetGroup) *DescribeTargetGroupsOutput {
+	s.TargetGroups = v
+	return s
 }
 
 // Contains the parameters for DescribeTargetHealth.
@@ -3644,6 +4118,18 @@ func (s *DescribeTargetHealthInput) Validate() error {
 	return nil
 }
 
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *DescribeTargetHealthInput) SetTargetGroupArn(v string) *DescribeTargetHealthInput {
+	s.TargetGroupArn = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *DescribeTargetHealthInput) SetTargets(v []*TargetDescription) *DescribeTargetHealthInput {
+	s.Targets = v
+	return s
+}
+
 // Contains the output of DescribeTargetHealth.
 type DescribeTargetHealthOutput struct {
 	_ struct{} `type:"structure"`
@@ -3660,6 +4146,12 @@ func (s DescribeTargetHealthOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTargetHealthOutput) GoString() string {
 	return s.String()
+}
+
+// SetTargetHealthDescriptions sets the TargetHealthDescriptions field's value.
+func (s *DescribeTargetHealthOutput) SetTargetHealthDescriptions(v []*TargetHealthDescription) *DescribeTargetHealthOutput {
+	s.TargetHealthDescriptions = v
+	return s
 }
 
 // Information about a listener.
@@ -3698,6 +4190,48 @@ func (s Listener) String() string {
 // GoString returns the string representation
 func (s Listener) GoString() string {
 	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *Listener) SetCertificates(v []*Certificate) *Listener {
+	s.Certificates = v
+	return s
+}
+
+// SetDefaultActions sets the DefaultActions field's value.
+func (s *Listener) SetDefaultActions(v []*Action) *Listener {
+	s.DefaultActions = v
+	return s
+}
+
+// SetListenerArn sets the ListenerArn field's value.
+func (s *Listener) SetListenerArn(v string) *Listener {
+	s.ListenerArn = &v
+	return s
+}
+
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *Listener) SetLoadBalancerArn(v string) *Listener {
+	s.LoadBalancerArn = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *Listener) SetPort(v int64) *Listener {
+	s.Port = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *Listener) SetProtocol(v string) *Listener {
+	s.Protocol = &v
+	return s
+}
+
+// SetSslPolicy sets the SslPolicy field's value.
+func (s *Listener) SetSslPolicy(v string) *Listener {
+	s.SslPolicy = &v
+	return s
 }
 
 // Information about a load balancer.
@@ -3756,6 +4290,72 @@ func (s LoadBalancer) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *LoadBalancer) SetAvailabilityZones(v []*AvailabilityZone) *LoadBalancer {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetCanonicalHostedZoneId sets the CanonicalHostedZoneId field's value.
+func (s *LoadBalancer) SetCanonicalHostedZoneId(v string) *LoadBalancer {
+	s.CanonicalHostedZoneId = &v
+	return s
+}
+
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *LoadBalancer) SetCreatedTime(v time.Time) *LoadBalancer {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetDNSName sets the DNSName field's value.
+func (s *LoadBalancer) SetDNSName(v string) *LoadBalancer {
+	s.DNSName = &v
+	return s
+}
+
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *LoadBalancer) SetLoadBalancerArn(v string) *LoadBalancer {
+	s.LoadBalancerArn = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *LoadBalancer) SetLoadBalancerName(v string) *LoadBalancer {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetScheme sets the Scheme field's value.
+func (s *LoadBalancer) SetScheme(v string) *LoadBalancer {
+	s.Scheme = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *LoadBalancer) SetSecurityGroups(v []*string) *LoadBalancer {
+	s.SecurityGroups = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LoadBalancer) SetState(v *LoadBalancerState) *LoadBalancer {
+	s.State = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *LoadBalancer) SetType(v string) *LoadBalancer {
+	s.Type = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *LoadBalancer) SetVpcId(v string) *LoadBalancer {
+	s.VpcId = &v
+	return s
+}
+
 // Information about a load balancer attribute.
 type LoadBalancerAttribute struct {
 	_ struct{} `type:"structure"`
@@ -3795,6 +4395,18 @@ func (s LoadBalancerAttribute) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *LoadBalancerAttribute) SetKey(v string) *LoadBalancerAttribute {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *LoadBalancerAttribute) SetValue(v string) *LoadBalancerAttribute {
+	s.Value = &v
+	return s
+}
+
 // Information about the state of the load balancer.
 type LoadBalancerState struct {
 	_ struct{} `type:"structure"`
@@ -3816,6 +4428,18 @@ func (s LoadBalancerState) String() string {
 // GoString returns the string representation
 func (s LoadBalancerState) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *LoadBalancerState) SetCode(v string) *LoadBalancerState {
+	s.Code = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *LoadBalancerState) SetReason(v string) *LoadBalancerState {
+	s.Reason = &v
+	return s
 }
 
 // Information to use when checking for a successful response from a target.
@@ -3850,6 +4474,12 @@ func (s *Matcher) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHttpCode sets the HttpCode field's value.
+func (s *Matcher) SetHttpCode(v string) *Matcher {
+	s.HttpCode = &v
+	return s
 }
 
 // Contains the parameters for ModifyListener.
@@ -3913,6 +4543,42 @@ func (s *ModifyListenerInput) Validate() error {
 	return nil
 }
 
+// SetCertificates sets the Certificates field's value.
+func (s *ModifyListenerInput) SetCertificates(v []*Certificate) *ModifyListenerInput {
+	s.Certificates = v
+	return s
+}
+
+// SetDefaultActions sets the DefaultActions field's value.
+func (s *ModifyListenerInput) SetDefaultActions(v []*Action) *ModifyListenerInput {
+	s.DefaultActions = v
+	return s
+}
+
+// SetListenerArn sets the ListenerArn field's value.
+func (s *ModifyListenerInput) SetListenerArn(v string) *ModifyListenerInput {
+	s.ListenerArn = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *ModifyListenerInput) SetPort(v int64) *ModifyListenerInput {
+	s.Port = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *ModifyListenerInput) SetProtocol(v string) *ModifyListenerInput {
+	s.Protocol = &v
+	return s
+}
+
+// SetSslPolicy sets the SslPolicy field's value.
+func (s *ModifyListenerInput) SetSslPolicy(v string) *ModifyListenerInput {
+	s.SslPolicy = &v
+	return s
+}
+
 // Contains the output of ModifyListener.
 type ModifyListenerOutput struct {
 	_ struct{} `type:"structure"`
@@ -3929,6 +4595,12 @@ func (s ModifyListenerOutput) String() string {
 // GoString returns the string representation
 func (s ModifyListenerOutput) GoString() string {
 	return s.String()
+}
+
+// SetListeners sets the Listeners field's value.
+func (s *ModifyListenerOutput) SetListeners(v []*Listener) *ModifyListenerOutput {
+	s.Listeners = v
+	return s
 }
 
 // Contains the parameters for ModifyLoadBalancerAttributes.
@@ -3972,6 +4644,18 @@ func (s *ModifyLoadBalancerAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *ModifyLoadBalancerAttributesInput) SetAttributes(v []*LoadBalancerAttribute) *ModifyLoadBalancerAttributesInput {
+	s.Attributes = v
+	return s
+}
+
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *ModifyLoadBalancerAttributesInput) SetLoadBalancerArn(v string) *ModifyLoadBalancerAttributesInput {
+	s.LoadBalancerArn = &v
+	return s
+}
+
 // Contains the output of ModifyLoadBalancerAttributes.
 type ModifyLoadBalancerAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3988,6 +4672,12 @@ func (s ModifyLoadBalancerAttributesOutput) String() string {
 // GoString returns the string representation
 func (s ModifyLoadBalancerAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *ModifyLoadBalancerAttributesOutput) SetAttributes(v []*LoadBalancerAttribute) *ModifyLoadBalancerAttributesOutput {
+	s.Attributes = v
+	return s
 }
 
 // Contains the parameters for ModifyRules.
@@ -4039,6 +4729,24 @@ func (s *ModifyRuleInput) Validate() error {
 	return nil
 }
 
+// SetActions sets the Actions field's value.
+func (s *ModifyRuleInput) SetActions(v []*Action) *ModifyRuleInput {
+	s.Actions = v
+	return s
+}
+
+// SetConditions sets the Conditions field's value.
+func (s *ModifyRuleInput) SetConditions(v []*RuleCondition) *ModifyRuleInput {
+	s.Conditions = v
+	return s
+}
+
+// SetRuleArn sets the RuleArn field's value.
+func (s *ModifyRuleInput) SetRuleArn(v string) *ModifyRuleInput {
+	s.RuleArn = &v
+	return s
+}
+
 // Contains the output of ModifyRules.
 type ModifyRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -4055,6 +4763,12 @@ func (s ModifyRuleOutput) String() string {
 // GoString returns the string representation
 func (s ModifyRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetRules sets the Rules field's value.
+func (s *ModifyRuleOutput) SetRules(v []*Rule) *ModifyRuleOutput {
+	s.Rules = v
+	return s
 }
 
 // Contains the parameters for ModifyTargetGroupAttributes.
@@ -4098,6 +4812,18 @@ func (s *ModifyTargetGroupAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *ModifyTargetGroupAttributesInput) SetAttributes(v []*TargetGroupAttribute) *ModifyTargetGroupAttributesInput {
+	s.Attributes = v
+	return s
+}
+
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *ModifyTargetGroupAttributesInput) SetTargetGroupArn(v string) *ModifyTargetGroupAttributesInput {
+	s.TargetGroupArn = &v
+	return s
+}
+
 // Contains the output of ModifyTargetGroupAttributes.
 type ModifyTargetGroupAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4114,6 +4840,12 @@ func (s ModifyTargetGroupAttributesOutput) String() string {
 // GoString returns the string representation
 func (s ModifyTargetGroupAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *ModifyTargetGroupAttributesOutput) SetAttributes(v []*TargetGroupAttribute) *ModifyTargetGroupAttributesOutput {
+	s.Attributes = v
+	return s
 }
 
 // Contains the parameters for ModifyTargetGroup.
@@ -4197,6 +4929,60 @@ func (s *ModifyTargetGroupInput) Validate() error {
 	return nil
 }
 
+// SetHealthCheckIntervalSeconds sets the HealthCheckIntervalSeconds field's value.
+func (s *ModifyTargetGroupInput) SetHealthCheckIntervalSeconds(v int64) *ModifyTargetGroupInput {
+	s.HealthCheckIntervalSeconds = &v
+	return s
+}
+
+// SetHealthCheckPath sets the HealthCheckPath field's value.
+func (s *ModifyTargetGroupInput) SetHealthCheckPath(v string) *ModifyTargetGroupInput {
+	s.HealthCheckPath = &v
+	return s
+}
+
+// SetHealthCheckPort sets the HealthCheckPort field's value.
+func (s *ModifyTargetGroupInput) SetHealthCheckPort(v string) *ModifyTargetGroupInput {
+	s.HealthCheckPort = &v
+	return s
+}
+
+// SetHealthCheckProtocol sets the HealthCheckProtocol field's value.
+func (s *ModifyTargetGroupInput) SetHealthCheckProtocol(v string) *ModifyTargetGroupInput {
+	s.HealthCheckProtocol = &v
+	return s
+}
+
+// SetHealthCheckTimeoutSeconds sets the HealthCheckTimeoutSeconds field's value.
+func (s *ModifyTargetGroupInput) SetHealthCheckTimeoutSeconds(v int64) *ModifyTargetGroupInput {
+	s.HealthCheckTimeoutSeconds = &v
+	return s
+}
+
+// SetHealthyThresholdCount sets the HealthyThresholdCount field's value.
+func (s *ModifyTargetGroupInput) SetHealthyThresholdCount(v int64) *ModifyTargetGroupInput {
+	s.HealthyThresholdCount = &v
+	return s
+}
+
+// SetMatcher sets the Matcher field's value.
+func (s *ModifyTargetGroupInput) SetMatcher(v *Matcher) *ModifyTargetGroupInput {
+	s.Matcher = v
+	return s
+}
+
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *ModifyTargetGroupInput) SetTargetGroupArn(v string) *ModifyTargetGroupInput {
+	s.TargetGroupArn = &v
+	return s
+}
+
+// SetUnhealthyThresholdCount sets the UnhealthyThresholdCount field's value.
+func (s *ModifyTargetGroupInput) SetUnhealthyThresholdCount(v int64) *ModifyTargetGroupInput {
+	s.UnhealthyThresholdCount = &v
+	return s
+}
+
 // Contains the output of ModifyTargetGroup.
 type ModifyTargetGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -4213,6 +4999,12 @@ func (s ModifyTargetGroupOutput) String() string {
 // GoString returns the string representation
 func (s ModifyTargetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetTargetGroups sets the TargetGroups field's value.
+func (s *ModifyTargetGroupOutput) SetTargetGroups(v []*TargetGroup) *ModifyTargetGroupOutput {
+	s.TargetGroups = v
+	return s
 }
 
 // Contains the parameters for RegisterTargets.
@@ -4266,6 +5058,18 @@ func (s *RegisterTargetsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *RegisterTargetsInput) SetTargetGroupArn(v string) *RegisterTargetsInput {
+	s.TargetGroupArn = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *RegisterTargetsInput) SetTargets(v []*TargetDescription) *RegisterTargetsInput {
+	s.Targets = v
+	return s
 }
 
 // Contains the output of RegisterTargets.
@@ -4324,6 +5128,18 @@ func (s *RemoveTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceArns sets the ResourceArns field's value.
+func (s *RemoveTagsInput) SetResourceArns(v []*string) *RemoveTagsInput {
+	s.ResourceArns = v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsInput) SetTagKeys(v []*string) *RemoveTagsInput {
+	s.TagKeys = v
+	return s
+}
+
 // Contains the output of RemoveTags.
 type RemoveTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4369,6 +5185,36 @@ func (s Rule) GoString() string {
 	return s.String()
 }
 
+// SetActions sets the Actions field's value.
+func (s *Rule) SetActions(v []*Action) *Rule {
+	s.Actions = v
+	return s
+}
+
+// SetConditions sets the Conditions field's value.
+func (s *Rule) SetConditions(v []*RuleCondition) *Rule {
+	s.Conditions = v
+	return s
+}
+
+// SetIsDefault sets the IsDefault field's value.
+func (s *Rule) SetIsDefault(v bool) *Rule {
+	s.IsDefault = &v
+	return s
+}
+
+// SetPriority sets the Priority field's value.
+func (s *Rule) SetPriority(v string) *Rule {
+	s.Priority = &v
+	return s
+}
+
+// SetRuleArn sets the RuleArn field's value.
+func (s *Rule) SetRuleArn(v string) *Rule {
+	s.RuleArn = &v
+	return s
+}
+
 // Information about a condition for a rule.
 type RuleCondition struct {
 	_ struct{} `type:"structure"`
@@ -4403,6 +5249,18 @@ func (s RuleCondition) GoString() string {
 	return s.String()
 }
 
+// SetField sets the Field field's value.
+func (s *RuleCondition) SetField(v string) *RuleCondition {
+	s.Field = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *RuleCondition) SetValues(v []*string) *RuleCondition {
+	s.Values = v
+	return s
+}
+
 // Information about the priorities for the rules for a listener.
 type RulePriorityPair struct {
 	_ struct{} `type:"structure"`
@@ -4435,6 +5293,18 @@ func (s *RulePriorityPair) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPriority sets the Priority field's value.
+func (s *RulePriorityPair) SetPriority(v int64) *RulePriorityPair {
+	s.Priority = &v
+	return s
+}
+
+// SetRuleArn sets the RuleArn field's value.
+func (s *RulePriorityPair) SetRuleArn(v string) *RulePriorityPair {
+	s.RuleArn = &v
+	return s
 }
 
 // Contains the parameters for SetRulePriorities.
@@ -4480,6 +5350,12 @@ func (s *SetRulePrioritiesInput) Validate() error {
 	return nil
 }
 
+// SetRulePriorities sets the RulePriorities field's value.
+func (s *SetRulePrioritiesInput) SetRulePriorities(v []*RulePriorityPair) *SetRulePrioritiesInput {
+	s.RulePriorities = v
+	return s
+}
+
 // Contains the output of SetRulePriorities.
 type SetRulePrioritiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4496,6 +5372,12 @@ func (s SetRulePrioritiesOutput) String() string {
 // GoString returns the string representation
 func (s SetRulePrioritiesOutput) GoString() string {
 	return s.String()
+}
+
+// SetRules sets the Rules field's value.
+func (s *SetRulePrioritiesOutput) SetRules(v []*Rule) *SetRulePrioritiesOutput {
+	s.Rules = v
+	return s
 }
 
 // Contains the parameters for SetSecurityGroups.
@@ -4539,6 +5421,18 @@ func (s *SetSecurityGroupsInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *SetSecurityGroupsInput) SetLoadBalancerArn(v string) *SetSecurityGroupsInput {
+	s.LoadBalancerArn = &v
+	return s
+}
+
+// SetSecurityGroups sets the SecurityGroups field's value.
+func (s *SetSecurityGroupsInput) SetSecurityGroups(v []*string) *SetSecurityGroupsInput {
+	s.SecurityGroups = v
+	return s
+}
+
 // Contains the output of SetSecurityGroups.
 type SetSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4555,6 +5449,12 @@ func (s SetSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s SetSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *SetSecurityGroupsOutput) SetSecurityGroupIds(v []*string) *SetSecurityGroupsOutput {
+	s.SecurityGroupIds = v
+	return s
 }
 
 // Contains the parameters for SetSubnets.
@@ -4599,6 +5499,18 @@ func (s *SetSubnetsInput) Validate() error {
 	return nil
 }
 
+// SetLoadBalancerArn sets the LoadBalancerArn field's value.
+func (s *SetSubnetsInput) SetLoadBalancerArn(v string) *SetSubnetsInput {
+	s.LoadBalancerArn = &v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *SetSubnetsInput) SetSubnets(v []*string) *SetSubnetsInput {
+	s.Subnets = v
+	return s
+}
+
 // Contains the output of SetSubnets.
 type SetSubnetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4615,6 +5527,12 @@ func (s SetSubnetsOutput) String() string {
 // GoString returns the string representation
 func (s SetSubnetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *SetSubnetsOutput) SetAvailabilityZones(v []*AvailabilityZone) *SetSubnetsOutput {
+	s.AvailabilityZones = v
+	return s
 }
 
 // Information about a policy used for SSL negotiation.
@@ -4639,6 +5557,24 @@ func (s SslPolicy) String() string {
 // GoString returns the string representation
 func (s SslPolicy) GoString() string {
 	return s.String()
+}
+
+// SetCiphers sets the Ciphers field's value.
+func (s *SslPolicy) SetCiphers(v []*Cipher) *SslPolicy {
+	s.Ciphers = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *SslPolicy) SetName(v string) *SslPolicy {
+	s.Name = &v
+	return s
+}
+
+// SetSslProtocols sets the SslProtocols field's value.
+func (s *SslPolicy) SetSslProtocols(v []*string) *SslPolicy {
+	s.SslProtocols = v
+	return s
 }
 
 // Information about a tag.
@@ -4680,6 +5616,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // The tags associated with a resource.
 type TagDescription struct {
 	_ struct{} `type:"structure"`
@@ -4699,6 +5647,18 @@ func (s TagDescription) String() string {
 // GoString returns the string representation
 func (s TagDescription) GoString() string {
 	return s.String()
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *TagDescription) SetResourceArn(v string) *TagDescription {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagDescription) SetTags(v []*Tag) *TagDescription {
+	s.Tags = v
+	return s
 }
 
 // Information about a target.
@@ -4738,6 +5698,18 @@ func (s *TargetDescription) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *TargetDescription) SetId(v string) *TargetDescription {
+	s.Id = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *TargetDescription) SetPort(v int64) *TargetDescription {
+	s.Port = &v
+	return s
 }
 
 // Information about a target group.
@@ -4802,6 +5774,90 @@ func (s TargetGroup) GoString() string {
 	return s.String()
 }
 
+// SetHealthCheckIntervalSeconds sets the HealthCheckIntervalSeconds field's value.
+func (s *TargetGroup) SetHealthCheckIntervalSeconds(v int64) *TargetGroup {
+	s.HealthCheckIntervalSeconds = &v
+	return s
+}
+
+// SetHealthCheckPath sets the HealthCheckPath field's value.
+func (s *TargetGroup) SetHealthCheckPath(v string) *TargetGroup {
+	s.HealthCheckPath = &v
+	return s
+}
+
+// SetHealthCheckPort sets the HealthCheckPort field's value.
+func (s *TargetGroup) SetHealthCheckPort(v string) *TargetGroup {
+	s.HealthCheckPort = &v
+	return s
+}
+
+// SetHealthCheckProtocol sets the HealthCheckProtocol field's value.
+func (s *TargetGroup) SetHealthCheckProtocol(v string) *TargetGroup {
+	s.HealthCheckProtocol = &v
+	return s
+}
+
+// SetHealthCheckTimeoutSeconds sets the HealthCheckTimeoutSeconds field's value.
+func (s *TargetGroup) SetHealthCheckTimeoutSeconds(v int64) *TargetGroup {
+	s.HealthCheckTimeoutSeconds = &v
+	return s
+}
+
+// SetHealthyThresholdCount sets the HealthyThresholdCount field's value.
+func (s *TargetGroup) SetHealthyThresholdCount(v int64) *TargetGroup {
+	s.HealthyThresholdCount = &v
+	return s
+}
+
+// SetLoadBalancerArns sets the LoadBalancerArns field's value.
+func (s *TargetGroup) SetLoadBalancerArns(v []*string) *TargetGroup {
+	s.LoadBalancerArns = v
+	return s
+}
+
+// SetMatcher sets the Matcher field's value.
+func (s *TargetGroup) SetMatcher(v *Matcher) *TargetGroup {
+	s.Matcher = v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *TargetGroup) SetPort(v int64) *TargetGroup {
+	s.Port = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *TargetGroup) SetProtocol(v string) *TargetGroup {
+	s.Protocol = &v
+	return s
+}
+
+// SetTargetGroupArn sets the TargetGroupArn field's value.
+func (s *TargetGroup) SetTargetGroupArn(v string) *TargetGroup {
+	s.TargetGroupArn = &v
+	return s
+}
+
+// SetTargetGroupName sets the TargetGroupName field's value.
+func (s *TargetGroup) SetTargetGroupName(v string) *TargetGroup {
+	s.TargetGroupName = &v
+	return s
+}
+
+// SetUnhealthyThresholdCount sets the UnhealthyThresholdCount field's value.
+func (s *TargetGroup) SetUnhealthyThresholdCount(v int64) *TargetGroup {
+	s.UnhealthyThresholdCount = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *TargetGroup) SetVpcId(v string) *TargetGroup {
+	s.VpcId = &v
+	return s
+}
+
 // Information about a target group attribute.
 type TargetGroupAttribute struct {
 	_ struct{} `type:"structure"`
@@ -4838,6 +5894,18 @@ func (s TargetGroupAttribute) String() string {
 // GoString returns the string representation
 func (s TargetGroupAttribute) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *TargetGroupAttribute) SetKey(v string) *TargetGroupAttribute {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *TargetGroupAttribute) SetValue(v string) *TargetGroupAttribute {
+	s.Value = &v
+	return s
 }
 
 // Information about the current health of a target.
@@ -4905,6 +5973,24 @@ func (s TargetHealth) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *TargetHealth) SetDescription(v string) *TargetHealth {
+	s.Description = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *TargetHealth) SetReason(v string) *TargetHealth {
+	s.Reason = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *TargetHealth) SetState(v string) *TargetHealth {
+	s.State = &v
+	return s
+}
+
 // Information about the health of a target.
 type TargetHealthDescription struct {
 	_ struct{} `type:"structure"`
@@ -4927,6 +6013,24 @@ func (s TargetHealthDescription) String() string {
 // GoString returns the string representation
 func (s TargetHealthDescription) GoString() string {
 	return s.String()
+}
+
+// SetHealthCheckPort sets the HealthCheckPort field's value.
+func (s *TargetHealthDescription) SetHealthCheckPort(v string) *TargetHealthDescription {
+	s.HealthCheckPort = &v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *TargetHealthDescription) SetTarget(v *TargetDescription) *TargetHealthDescription {
+	s.Target = v
+	return s
+}
+
+// SetTargetHealth sets the TargetHealth field's value.
+func (s *TargetHealthDescription) SetTargetHealth(v *TargetHealth) *TargetHealthDescription {
+	s.TargetHealth = v
+	return s
 }
 
 const (

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -1740,6 +1740,18 @@ func (s *AddInstanceGroupsInput) Validate() error {
 	return nil
 }
 
+// SetInstanceGroups sets the InstanceGroups field's value.
+func (s *AddInstanceGroupsInput) SetInstanceGroups(v []*InstanceGroupConfig) *AddInstanceGroupsInput {
+	s.InstanceGroups = v
+	return s
+}
+
+// SetJobFlowId sets the JobFlowId field's value.
+func (s *AddInstanceGroupsInput) SetJobFlowId(v string) *AddInstanceGroupsInput {
+	s.JobFlowId = &v
+	return s
+}
+
 // Output from an AddInstanceGroups call.
 type AddInstanceGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1759,6 +1771,18 @@ func (s AddInstanceGroupsOutput) String() string {
 // GoString returns the string representation
 func (s AddInstanceGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceGroupIds sets the InstanceGroupIds field's value.
+func (s *AddInstanceGroupsOutput) SetInstanceGroupIds(v []*string) *AddInstanceGroupsOutput {
+	s.InstanceGroupIds = v
+	return s
+}
+
+// SetJobFlowId sets the JobFlowId field's value.
+func (s *AddInstanceGroupsOutput) SetJobFlowId(v string) *AddInstanceGroupsOutput {
+	s.JobFlowId = &v
+	return s
 }
 
 // The input argument to the AddJobFlowSteps operation.
@@ -1813,6 +1837,18 @@ func (s *AddJobFlowStepsInput) Validate() error {
 	return nil
 }
 
+// SetJobFlowId sets the JobFlowId field's value.
+func (s *AddJobFlowStepsInput) SetJobFlowId(v string) *AddJobFlowStepsInput {
+	s.JobFlowId = &v
+	return s
+}
+
+// SetSteps sets the Steps field's value.
+func (s *AddJobFlowStepsInput) SetSteps(v []*StepConfig) *AddJobFlowStepsInput {
+	s.Steps = v
+	return s
+}
+
 // The output for the AddJobFlowSteps operation.
 type AddJobFlowStepsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1829,6 +1865,12 @@ func (s AddJobFlowStepsOutput) String() string {
 // GoString returns the string representation
 func (s AddJobFlowStepsOutput) GoString() string {
 	return s.String()
+}
+
+// SetStepIds sets the StepIds field's value.
+func (s *AddJobFlowStepsOutput) SetStepIds(v []*string) *AddJobFlowStepsOutput {
+	s.StepIds = v
+	return s
 }
 
 // This input identifies a cluster and a list of tags to attach.
@@ -1874,6 +1916,18 @@ func (s *AddTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *AddTagsInput) SetResourceId(v string) *AddTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsInput) SetTags(v []*Tag) *AddTagsInput {
+	s.Tags = v
+	return s
 }
 
 // This output indicates the result of adding tags to a resource.
@@ -1936,6 +1990,30 @@ func (s Application) GoString() string {
 	return s.String()
 }
 
+// SetAdditionalInfo sets the AdditionalInfo field's value.
+func (s *Application) SetAdditionalInfo(v map[string]*string) *Application {
+	s.AdditionalInfo = v
+	return s
+}
+
+// SetArgs sets the Args field's value.
+func (s *Application) SetArgs(v []*string) *Application {
+	s.Args = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Application) SetName(v string) *Application {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *Application) SetVersion(v string) *Application {
+	s.Version = &v
+	return s
+}
+
 type BootstrapActionConfig struct {
 	_ struct{} `type:"structure"`
 
@@ -1977,6 +2055,18 @@ func (s *BootstrapActionConfig) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *BootstrapActionConfig) SetName(v string) *BootstrapActionConfig {
+	s.Name = &v
+	return s
+}
+
+// SetScriptBootstrapAction sets the ScriptBootstrapAction field's value.
+func (s *BootstrapActionConfig) SetScriptBootstrapAction(v *ScriptBootstrapActionConfig) *BootstrapActionConfig {
+	s.ScriptBootstrapAction = v
+	return s
+}
+
 // Reports the configuration of a bootstrap action in a job flow.
 type BootstrapActionDetail struct {
 	_ struct{} `type:"structure"`
@@ -1993,6 +2083,12 @@ func (s BootstrapActionDetail) String() string {
 // GoString returns the string representation
 func (s BootstrapActionDetail) GoString() string {
 	return s.String()
+}
+
+// SetBootstrapActionConfig sets the BootstrapActionConfig field's value.
+func (s *BootstrapActionDetail) SetBootstrapActionConfig(v *BootstrapActionConfig) *BootstrapActionDetail {
+	s.BootstrapActionConfig = v
+	return s
 }
 
 // The detailed description of the cluster.
@@ -2081,6 +2177,114 @@ func (s Cluster) GoString() string {
 	return s.String()
 }
 
+// SetApplications sets the Applications field's value.
+func (s *Cluster) SetApplications(v []*Application) *Cluster {
+	s.Applications = v
+	return s
+}
+
+// SetAutoTerminate sets the AutoTerminate field's value.
+func (s *Cluster) SetAutoTerminate(v bool) *Cluster {
+	s.AutoTerminate = &v
+	return s
+}
+
+// SetConfigurations sets the Configurations field's value.
+func (s *Cluster) SetConfigurations(v []*Configuration) *Cluster {
+	s.Configurations = v
+	return s
+}
+
+// SetEc2InstanceAttributes sets the Ec2InstanceAttributes field's value.
+func (s *Cluster) SetEc2InstanceAttributes(v *Ec2InstanceAttributes) *Cluster {
+	s.Ec2InstanceAttributes = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Cluster) SetId(v string) *Cluster {
+	s.Id = &v
+	return s
+}
+
+// SetLogUri sets the LogUri field's value.
+func (s *Cluster) SetLogUri(v string) *Cluster {
+	s.LogUri = &v
+	return s
+}
+
+// SetMasterPublicDnsName sets the MasterPublicDnsName field's value.
+func (s *Cluster) SetMasterPublicDnsName(v string) *Cluster {
+	s.MasterPublicDnsName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Cluster) SetName(v string) *Cluster {
+	s.Name = &v
+	return s
+}
+
+// SetNormalizedInstanceHours sets the NormalizedInstanceHours field's value.
+func (s *Cluster) SetNormalizedInstanceHours(v int64) *Cluster {
+	s.NormalizedInstanceHours = &v
+	return s
+}
+
+// SetReleaseLabel sets the ReleaseLabel field's value.
+func (s *Cluster) SetReleaseLabel(v string) *Cluster {
+	s.ReleaseLabel = &v
+	return s
+}
+
+// SetRequestedAmiVersion sets the RequestedAmiVersion field's value.
+func (s *Cluster) SetRequestedAmiVersion(v string) *Cluster {
+	s.RequestedAmiVersion = &v
+	return s
+}
+
+// SetRunningAmiVersion sets the RunningAmiVersion field's value.
+func (s *Cluster) SetRunningAmiVersion(v string) *Cluster {
+	s.RunningAmiVersion = &v
+	return s
+}
+
+// SetSecurityConfiguration sets the SecurityConfiguration field's value.
+func (s *Cluster) SetSecurityConfiguration(v string) *Cluster {
+	s.SecurityConfiguration = &v
+	return s
+}
+
+// SetServiceRole sets the ServiceRole field's value.
+func (s *Cluster) SetServiceRole(v string) *Cluster {
+	s.ServiceRole = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Cluster) SetStatus(v *ClusterStatus) *Cluster {
+	s.Status = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Cluster) SetTags(v []*Tag) *Cluster {
+	s.Tags = v
+	return s
+}
+
+// SetTerminationProtected sets the TerminationProtected field's value.
+func (s *Cluster) SetTerminationProtected(v bool) *Cluster {
+	s.TerminationProtected = &v
+	return s
+}
+
+// SetVisibleToAllUsers sets the VisibleToAllUsers field's value.
+func (s *Cluster) SetVisibleToAllUsers(v bool) *Cluster {
+	s.VisibleToAllUsers = &v
+	return s
+}
+
 // The reason that the cluster changed to its current state.
 type ClusterStateChangeReason struct {
 	_ struct{} `type:"structure"`
@@ -2100,6 +2304,18 @@ func (s ClusterStateChangeReason) String() string {
 // GoString returns the string representation
 func (s ClusterStateChangeReason) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *ClusterStateChangeReason) SetCode(v string) *ClusterStateChangeReason {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *ClusterStateChangeReason) SetMessage(v string) *ClusterStateChangeReason {
+	s.Message = &v
+	return s
 }
 
 // The detailed status of the cluster.
@@ -2125,6 +2341,24 @@ func (s ClusterStatus) String() string {
 // GoString returns the string representation
 func (s ClusterStatus) GoString() string {
 	return s.String()
+}
+
+// SetState sets the State field's value.
+func (s *ClusterStatus) SetState(v string) *ClusterStatus {
+	s.State = &v
+	return s
+}
+
+// SetStateChangeReason sets the StateChangeReason field's value.
+func (s *ClusterStatus) SetStateChangeReason(v *ClusterStateChangeReason) *ClusterStatus {
+	s.StateChangeReason = v
+	return s
+}
+
+// SetTimeline sets the Timeline field's value.
+func (s *ClusterStatus) SetTimeline(v *ClusterTimeline) *ClusterStatus {
+	s.Timeline = v
+	return s
 }
 
 // The summary description of the cluster.
@@ -2159,6 +2393,30 @@ func (s ClusterSummary) GoString() string {
 	return s.String()
 }
 
+// SetId sets the Id field's value.
+func (s *ClusterSummary) SetId(v string) *ClusterSummary {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ClusterSummary) SetName(v string) *ClusterSummary {
+	s.Name = &v
+	return s
+}
+
+// SetNormalizedInstanceHours sets the NormalizedInstanceHours field's value.
+func (s *ClusterSummary) SetNormalizedInstanceHours(v int64) *ClusterSummary {
+	s.NormalizedInstanceHours = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ClusterSummary) SetStatus(v *ClusterStatus) *ClusterSummary {
+	s.Status = v
+	return s
+}
+
 // Represents the timeline of the cluster's lifecycle.
 type ClusterTimeline struct {
 	_ struct{} `type:"structure"`
@@ -2183,6 +2441,24 @@ func (s ClusterTimeline) GoString() string {
 	return s.String()
 }
 
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *ClusterTimeline) SetCreationDateTime(v time.Time) *ClusterTimeline {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetEndDateTime sets the EndDateTime field's value.
+func (s *ClusterTimeline) SetEndDateTime(v time.Time) *ClusterTimeline {
+	s.EndDateTime = &v
+	return s
+}
+
+// SetReadyDateTime sets the ReadyDateTime field's value.
+func (s *ClusterTimeline) SetReadyDateTime(v time.Time) *ClusterTimeline {
+	s.ReadyDateTime = &v
+	return s
+}
+
 // An entity describing an executable that runs on a cluster.
 type Command struct {
 	_ struct{} `type:"structure"`
@@ -2205,6 +2481,24 @@ func (s Command) String() string {
 // GoString returns the string representation
 func (s Command) GoString() string {
 	return s.String()
+}
+
+// SetArgs sets the Args field's value.
+func (s *Command) SetArgs(v []*string) *Command {
+	s.Args = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Command) SetName(v string) *Command {
+	s.Name = &v
+	return s
+}
+
+// SetScriptPath sets the ScriptPath field's value.
+func (s *Command) SetScriptPath(v string) *Command {
+	s.ScriptPath = &v
+	return s
 }
 
 // Amazon EMR releases 4.x or later.
@@ -2236,6 +2530,24 @@ func (s Configuration) String() string {
 // GoString returns the string representation
 func (s Configuration) GoString() string {
 	return s.String()
+}
+
+// SetClassification sets the Classification field's value.
+func (s *Configuration) SetClassification(v string) *Configuration {
+	s.Classification = &v
+	return s
+}
+
+// SetConfigurations sets the Configurations field's value.
+func (s *Configuration) SetConfigurations(v []*Configuration) *Configuration {
+	s.Configurations = v
+	return s
+}
+
+// SetProperties sets the Properties field's value.
+func (s *Configuration) SetProperties(v map[string]*string) *Configuration {
+	s.Properties = v
+	return s
 }
 
 type CreateSecurityConfigurationInput struct {
@@ -2278,6 +2590,18 @@ func (s *CreateSecurityConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *CreateSecurityConfigurationInput) SetName(v string) *CreateSecurityConfigurationInput {
+	s.Name = &v
+	return s
+}
+
+// SetSecurityConfiguration sets the SecurityConfiguration field's value.
+func (s *CreateSecurityConfigurationInput) SetSecurityConfiguration(v string) *CreateSecurityConfigurationInput {
+	s.SecurityConfiguration = &v
+	return s
+}
+
 type CreateSecurityConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2300,6 +2624,18 @@ func (s CreateSecurityConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s CreateSecurityConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *CreateSecurityConfigurationOutput) SetCreationDateTime(v time.Time) *CreateSecurityConfigurationOutput {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateSecurityConfigurationOutput) SetName(v string) *CreateSecurityConfigurationOutput {
+	s.Name = &v
+	return s
 }
 
 type DeleteSecurityConfigurationInput struct {
@@ -2332,6 +2668,12 @@ func (s *DeleteSecurityConfigurationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteSecurityConfigurationInput) SetName(v string) *DeleteSecurityConfigurationInput {
+	s.Name = &v
+	return s
 }
 
 type DeleteSecurityConfigurationOutput struct {
@@ -2381,6 +2723,12 @@ func (s *DescribeClusterInput) Validate() error {
 	return nil
 }
 
+// SetClusterId sets the ClusterId field's value.
+func (s *DescribeClusterInput) SetClusterId(v string) *DescribeClusterInput {
+	s.ClusterId = &v
+	return s
+}
+
 // This output contains the description of the cluster.
 type DescribeClusterOutput struct {
 	_ struct{} `type:"structure"`
@@ -2397,6 +2745,12 @@ func (s DescribeClusterOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *DescribeClusterOutput) SetCluster(v *Cluster) *DescribeClusterOutput {
+	s.Cluster = v
+	return s
 }
 
 // The input for the DescribeJobFlows operation.
@@ -2426,6 +2780,30 @@ func (s DescribeJobFlowsInput) GoString() string {
 	return s.String()
 }
 
+// SetCreatedAfter sets the CreatedAfter field's value.
+func (s *DescribeJobFlowsInput) SetCreatedAfter(v time.Time) *DescribeJobFlowsInput {
+	s.CreatedAfter = &v
+	return s
+}
+
+// SetCreatedBefore sets the CreatedBefore field's value.
+func (s *DescribeJobFlowsInput) SetCreatedBefore(v time.Time) *DescribeJobFlowsInput {
+	s.CreatedBefore = &v
+	return s
+}
+
+// SetJobFlowIds sets the JobFlowIds field's value.
+func (s *DescribeJobFlowsInput) SetJobFlowIds(v []*string) *DescribeJobFlowsInput {
+	s.JobFlowIds = v
+	return s
+}
+
+// SetJobFlowStates sets the JobFlowStates field's value.
+func (s *DescribeJobFlowsInput) SetJobFlowStates(v []*string) *DescribeJobFlowsInput {
+	s.JobFlowStates = v
+	return s
+}
+
 // The output for the DescribeJobFlows operation.
 type DescribeJobFlowsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2442,6 +2820,12 @@ func (s DescribeJobFlowsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeJobFlowsOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobFlows sets the JobFlows field's value.
+func (s *DescribeJobFlowsOutput) SetJobFlows(v []*JobFlowDetail) *DescribeJobFlowsOutput {
+	s.JobFlows = v
+	return s
 }
 
 type DescribeSecurityConfigurationInput struct {
@@ -2476,6 +2860,12 @@ func (s *DescribeSecurityConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *DescribeSecurityConfigurationInput) SetName(v string) *DescribeSecurityConfigurationInput {
+	s.Name = &v
+	return s
+}
+
 type DescribeSecurityConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2497,6 +2887,24 @@ func (s DescribeSecurityConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSecurityConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *DescribeSecurityConfigurationOutput) SetCreationDateTime(v time.Time) *DescribeSecurityConfigurationOutput {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DescribeSecurityConfigurationOutput) SetName(v string) *DescribeSecurityConfigurationOutput {
+	s.Name = &v
+	return s
+}
+
+// SetSecurityConfiguration sets the SecurityConfiguration field's value.
+func (s *DescribeSecurityConfigurationOutput) SetSecurityConfiguration(v string) *DescribeSecurityConfigurationOutput {
+	s.SecurityConfiguration = &v
+	return s
 }
 
 // This input determines which step to describe.
@@ -2540,6 +2948,18 @@ func (s *DescribeStepInput) Validate() error {
 	return nil
 }
 
+// SetClusterId sets the ClusterId field's value.
+func (s *DescribeStepInput) SetClusterId(v string) *DescribeStepInput {
+	s.ClusterId = &v
+	return s
+}
+
+// SetStepId sets the StepId field's value.
+func (s *DescribeStepInput) SetStepId(v string) *DescribeStepInput {
+	s.StepId = &v
+	return s
+}
+
 // This output contains the description of the cluster step.
 type DescribeStepOutput struct {
 	_ struct{} `type:"structure"`
@@ -2556,6 +2976,12 @@ func (s DescribeStepOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStepOutput) GoString() string {
 	return s.String()
+}
+
+// SetStep sets the Step field's value.
+func (s *DescribeStepOutput) SetStep(v *Step) *DescribeStepOutput {
+	s.Step = v
+	return s
 }
 
 // Configuration of requested EBS block device associated with the instance
@@ -2579,6 +3005,18 @@ func (s EbsBlockDevice) String() string {
 // GoString returns the string representation
 func (s EbsBlockDevice) GoString() string {
 	return s.String()
+}
+
+// SetDevice sets the Device field's value.
+func (s *EbsBlockDevice) SetDevice(v string) *EbsBlockDevice {
+	s.Device = &v
+	return s
+}
+
+// SetVolumeSpecification sets the VolumeSpecification field's value.
+func (s *EbsBlockDevice) SetVolumeSpecification(v *VolumeSpecification) *EbsBlockDevice {
+	s.VolumeSpecification = v
+	return s
 }
 
 // Configuration of requested EBS block device associated with the instance
@@ -2625,6 +3063,18 @@ func (s *EbsBlockDeviceConfig) Validate() error {
 	return nil
 }
 
+// SetVolumeSpecification sets the VolumeSpecification field's value.
+func (s *EbsBlockDeviceConfig) SetVolumeSpecification(v *VolumeSpecification) *EbsBlockDeviceConfig {
+	s.VolumeSpecification = v
+	return s
+}
+
+// SetVolumesPerInstance sets the VolumesPerInstance field's value.
+func (s *EbsBlockDeviceConfig) SetVolumesPerInstance(v int64) *EbsBlockDeviceConfig {
+	s.VolumesPerInstance = &v
+	return s
+}
+
 type EbsConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -2663,6 +3113,18 @@ func (s *EbsConfiguration) Validate() error {
 	return nil
 }
 
+// SetEbsBlockDeviceConfigs sets the EbsBlockDeviceConfigs field's value.
+func (s *EbsConfiguration) SetEbsBlockDeviceConfigs(v []*EbsBlockDeviceConfig) *EbsConfiguration {
+	s.EbsBlockDeviceConfigs = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *EbsConfiguration) SetEbsOptimized(v bool) *EbsConfiguration {
+	s.EbsOptimized = &v
+	return s
+}
+
 // EBS block device that's attached to an EC2 instance.
 type EbsVolume struct {
 	_ struct{} `type:"structure"`
@@ -2682,6 +3144,18 @@ func (s EbsVolume) String() string {
 // GoString returns the string representation
 func (s EbsVolume) GoString() string {
 	return s.String()
+}
+
+// SetDevice sets the Device field's value.
+func (s *EbsVolume) SetDevice(v string) *EbsVolume {
+	s.Device = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *EbsVolume) SetVolumeId(v string) *EbsVolume {
+	s.VolumeId = &v
+	return s
 }
 
 // Provides information about the EC2 instances in a cluster grouped by category.
@@ -2737,6 +3211,60 @@ func (s Ec2InstanceAttributes) GoString() string {
 	return s.String()
 }
 
+// SetAdditionalMasterSecurityGroups sets the AdditionalMasterSecurityGroups field's value.
+func (s *Ec2InstanceAttributes) SetAdditionalMasterSecurityGroups(v []*string) *Ec2InstanceAttributes {
+	s.AdditionalMasterSecurityGroups = v
+	return s
+}
+
+// SetAdditionalSlaveSecurityGroups sets the AdditionalSlaveSecurityGroups field's value.
+func (s *Ec2InstanceAttributes) SetAdditionalSlaveSecurityGroups(v []*string) *Ec2InstanceAttributes {
+	s.AdditionalSlaveSecurityGroups = v
+	return s
+}
+
+// SetEc2AvailabilityZone sets the Ec2AvailabilityZone field's value.
+func (s *Ec2InstanceAttributes) SetEc2AvailabilityZone(v string) *Ec2InstanceAttributes {
+	s.Ec2AvailabilityZone = &v
+	return s
+}
+
+// SetEc2KeyName sets the Ec2KeyName field's value.
+func (s *Ec2InstanceAttributes) SetEc2KeyName(v string) *Ec2InstanceAttributes {
+	s.Ec2KeyName = &v
+	return s
+}
+
+// SetEc2SubnetId sets the Ec2SubnetId field's value.
+func (s *Ec2InstanceAttributes) SetEc2SubnetId(v string) *Ec2InstanceAttributes {
+	s.Ec2SubnetId = &v
+	return s
+}
+
+// SetEmrManagedMasterSecurityGroup sets the EmrManagedMasterSecurityGroup field's value.
+func (s *Ec2InstanceAttributes) SetEmrManagedMasterSecurityGroup(v string) *Ec2InstanceAttributes {
+	s.EmrManagedMasterSecurityGroup = &v
+	return s
+}
+
+// SetEmrManagedSlaveSecurityGroup sets the EmrManagedSlaveSecurityGroup field's value.
+func (s *Ec2InstanceAttributes) SetEmrManagedSlaveSecurityGroup(v string) *Ec2InstanceAttributes {
+	s.EmrManagedSlaveSecurityGroup = &v
+	return s
+}
+
+// SetIamInstanceProfile sets the IamInstanceProfile field's value.
+func (s *Ec2InstanceAttributes) SetIamInstanceProfile(v string) *Ec2InstanceAttributes {
+	s.IamInstanceProfile = &v
+	return s
+}
+
+// SetServiceAccessSecurityGroup sets the ServiceAccessSecurityGroup field's value.
+func (s *Ec2InstanceAttributes) SetServiceAccessSecurityGroup(v string) *Ec2InstanceAttributes {
+	s.ServiceAccessSecurityGroup = &v
+	return s
+}
+
 // The details of the step failure. The service attempts to detect the root
 // cause for many common failures.
 type FailureDetails struct {
@@ -2765,6 +3293,24 @@ func (s FailureDetails) String() string {
 // GoString returns the string representation
 func (s FailureDetails) GoString() string {
 	return s.String()
+}
+
+// SetLogFile sets the LogFile field's value.
+func (s *FailureDetails) SetLogFile(v string) *FailureDetails {
+	s.LogFile = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *FailureDetails) SetMessage(v string) *FailureDetails {
+	s.Message = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *FailureDetails) SetReason(v string) *FailureDetails {
+	s.Reason = &v
+	return s
 }
 
 // A job flow step consisting of a JAR file whose main function will be executed.
@@ -2814,6 +3360,30 @@ func (s *HadoopJarStepConfig) Validate() error {
 	return nil
 }
 
+// SetArgs sets the Args field's value.
+func (s *HadoopJarStepConfig) SetArgs(v []*string) *HadoopJarStepConfig {
+	s.Args = v
+	return s
+}
+
+// SetJar sets the Jar field's value.
+func (s *HadoopJarStepConfig) SetJar(v string) *HadoopJarStepConfig {
+	s.Jar = &v
+	return s
+}
+
+// SetMainClass sets the MainClass field's value.
+func (s *HadoopJarStepConfig) SetMainClass(v string) *HadoopJarStepConfig {
+	s.MainClass = &v
+	return s
+}
+
+// SetProperties sets the Properties field's value.
+func (s *HadoopJarStepConfig) SetProperties(v []*KeyValue) *HadoopJarStepConfig {
+	s.Properties = v
+	return s
+}
+
 // A cluster step consisting of a JAR file whose main function will be executed.
 // The main function submits a job for Hadoop to execute and waits for the job
 // to finish or fail.
@@ -2844,6 +3414,30 @@ func (s HadoopStepConfig) String() string {
 // GoString returns the string representation
 func (s HadoopStepConfig) GoString() string {
 	return s.String()
+}
+
+// SetArgs sets the Args field's value.
+func (s *HadoopStepConfig) SetArgs(v []*string) *HadoopStepConfig {
+	s.Args = v
+	return s
+}
+
+// SetJar sets the Jar field's value.
+func (s *HadoopStepConfig) SetJar(v string) *HadoopStepConfig {
+	s.Jar = &v
+	return s
+}
+
+// SetMainClass sets the MainClass field's value.
+func (s *HadoopStepConfig) SetMainClass(v string) *HadoopStepConfig {
+	s.MainClass = &v
+	return s
+}
+
+// SetProperties sets the Properties field's value.
+func (s *HadoopStepConfig) SetProperties(v map[string]*string) *HadoopStepConfig {
+	s.Properties = v
+	return s
 }
 
 // Represents an EC2 instance provisioned as part of cluster.
@@ -2886,6 +3480,60 @@ func (s Instance) String() string {
 // GoString returns the string representation
 func (s Instance) GoString() string {
 	return s.String()
+}
+
+// SetEbsVolumes sets the EbsVolumes field's value.
+func (s *Instance) SetEbsVolumes(v []*EbsVolume) *Instance {
+	s.EbsVolumes = v
+	return s
+}
+
+// SetEc2InstanceId sets the Ec2InstanceId field's value.
+func (s *Instance) SetEc2InstanceId(v string) *Instance {
+	s.Ec2InstanceId = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Instance) SetId(v string) *Instance {
+	s.Id = &v
+	return s
+}
+
+// SetInstanceGroupId sets the InstanceGroupId field's value.
+func (s *Instance) SetInstanceGroupId(v string) *Instance {
+	s.InstanceGroupId = &v
+	return s
+}
+
+// SetPrivateDnsName sets the PrivateDnsName field's value.
+func (s *Instance) SetPrivateDnsName(v string) *Instance {
+	s.PrivateDnsName = &v
+	return s
+}
+
+// SetPrivateIpAddress sets the PrivateIpAddress field's value.
+func (s *Instance) SetPrivateIpAddress(v string) *Instance {
+	s.PrivateIpAddress = &v
+	return s
+}
+
+// SetPublicDnsName sets the PublicDnsName field's value.
+func (s *Instance) SetPublicDnsName(v string) *Instance {
+	s.PublicDnsName = &v
+	return s
+}
+
+// SetPublicIpAddress sets the PublicIpAddress field's value.
+func (s *Instance) SetPublicIpAddress(v string) *Instance {
+	s.PublicIpAddress = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Instance) SetStatus(v *InstanceStatus) *Instance {
+	s.Status = v
+	return s
 }
 
 // This entity represents an instance group, which is a group of instances that
@@ -2949,6 +3597,84 @@ func (s InstanceGroup) String() string {
 // GoString returns the string representation
 func (s InstanceGroup) GoString() string {
 	return s.String()
+}
+
+// SetBidPrice sets the BidPrice field's value.
+func (s *InstanceGroup) SetBidPrice(v string) *InstanceGroup {
+	s.BidPrice = &v
+	return s
+}
+
+// SetConfigurations sets the Configurations field's value.
+func (s *InstanceGroup) SetConfigurations(v []*Configuration) *InstanceGroup {
+	s.Configurations = v
+	return s
+}
+
+// SetEbsBlockDevices sets the EbsBlockDevices field's value.
+func (s *InstanceGroup) SetEbsBlockDevices(v []*EbsBlockDevice) *InstanceGroup {
+	s.EbsBlockDevices = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *InstanceGroup) SetEbsOptimized(v bool) *InstanceGroup {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *InstanceGroup) SetId(v string) *InstanceGroup {
+	s.Id = &v
+	return s
+}
+
+// SetInstanceGroupType sets the InstanceGroupType field's value.
+func (s *InstanceGroup) SetInstanceGroupType(v string) *InstanceGroup {
+	s.InstanceGroupType = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *InstanceGroup) SetInstanceType(v string) *InstanceGroup {
+	s.InstanceType = &v
+	return s
+}
+
+// SetMarket sets the Market field's value.
+func (s *InstanceGroup) SetMarket(v string) *InstanceGroup {
+	s.Market = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InstanceGroup) SetName(v string) *InstanceGroup {
+	s.Name = &v
+	return s
+}
+
+// SetRequestedInstanceCount sets the RequestedInstanceCount field's value.
+func (s *InstanceGroup) SetRequestedInstanceCount(v int64) *InstanceGroup {
+	s.RequestedInstanceCount = &v
+	return s
+}
+
+// SetRunningInstanceCount sets the RunningInstanceCount field's value.
+func (s *InstanceGroup) SetRunningInstanceCount(v int64) *InstanceGroup {
+	s.RunningInstanceCount = &v
+	return s
+}
+
+// SetShrinkPolicy sets the ShrinkPolicy field's value.
+func (s *InstanceGroup) SetShrinkPolicy(v *ShrinkPolicy) *InstanceGroup {
+	s.ShrinkPolicy = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *InstanceGroup) SetStatus(v *InstanceGroupStatus) *InstanceGroup {
+	s.Status = v
+	return s
 }
 
 // Configuration defining a new instance group.
@@ -3029,6 +3755,54 @@ func (s *InstanceGroupConfig) Validate() error {
 	return nil
 }
 
+// SetBidPrice sets the BidPrice field's value.
+func (s *InstanceGroupConfig) SetBidPrice(v string) *InstanceGroupConfig {
+	s.BidPrice = &v
+	return s
+}
+
+// SetConfigurations sets the Configurations field's value.
+func (s *InstanceGroupConfig) SetConfigurations(v []*Configuration) *InstanceGroupConfig {
+	s.Configurations = v
+	return s
+}
+
+// SetEbsConfiguration sets the EbsConfiguration field's value.
+func (s *InstanceGroupConfig) SetEbsConfiguration(v *EbsConfiguration) *InstanceGroupConfig {
+	s.EbsConfiguration = v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *InstanceGroupConfig) SetInstanceCount(v int64) *InstanceGroupConfig {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceRole sets the InstanceRole field's value.
+func (s *InstanceGroupConfig) SetInstanceRole(v string) *InstanceGroupConfig {
+	s.InstanceRole = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *InstanceGroupConfig) SetInstanceType(v string) *InstanceGroupConfig {
+	s.InstanceType = &v
+	return s
+}
+
+// SetMarket sets the Market field's value.
+func (s *InstanceGroupConfig) SetMarket(v string) *InstanceGroupConfig {
+	s.Market = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InstanceGroupConfig) SetName(v string) *InstanceGroupConfig {
+	s.Name = &v
+	return s
+}
+
 // Detailed information about an instance group.
 type InstanceGroupDetail struct {
 	_ struct{} `type:"structure"`
@@ -3102,6 +3876,90 @@ func (s InstanceGroupDetail) GoString() string {
 	return s.String()
 }
 
+// SetBidPrice sets the BidPrice field's value.
+func (s *InstanceGroupDetail) SetBidPrice(v string) *InstanceGroupDetail {
+	s.BidPrice = &v
+	return s
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *InstanceGroupDetail) SetCreationDateTime(v time.Time) *InstanceGroupDetail {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetEndDateTime sets the EndDateTime field's value.
+func (s *InstanceGroupDetail) SetEndDateTime(v time.Time) *InstanceGroupDetail {
+	s.EndDateTime = &v
+	return s
+}
+
+// SetInstanceGroupId sets the InstanceGroupId field's value.
+func (s *InstanceGroupDetail) SetInstanceGroupId(v string) *InstanceGroupDetail {
+	s.InstanceGroupId = &v
+	return s
+}
+
+// SetInstanceRequestCount sets the InstanceRequestCount field's value.
+func (s *InstanceGroupDetail) SetInstanceRequestCount(v int64) *InstanceGroupDetail {
+	s.InstanceRequestCount = &v
+	return s
+}
+
+// SetInstanceRole sets the InstanceRole field's value.
+func (s *InstanceGroupDetail) SetInstanceRole(v string) *InstanceGroupDetail {
+	s.InstanceRole = &v
+	return s
+}
+
+// SetInstanceRunningCount sets the InstanceRunningCount field's value.
+func (s *InstanceGroupDetail) SetInstanceRunningCount(v int64) *InstanceGroupDetail {
+	s.InstanceRunningCount = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *InstanceGroupDetail) SetInstanceType(v string) *InstanceGroupDetail {
+	s.InstanceType = &v
+	return s
+}
+
+// SetLastStateChangeReason sets the LastStateChangeReason field's value.
+func (s *InstanceGroupDetail) SetLastStateChangeReason(v string) *InstanceGroupDetail {
+	s.LastStateChangeReason = &v
+	return s
+}
+
+// SetMarket sets the Market field's value.
+func (s *InstanceGroupDetail) SetMarket(v string) *InstanceGroupDetail {
+	s.Market = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InstanceGroupDetail) SetName(v string) *InstanceGroupDetail {
+	s.Name = &v
+	return s
+}
+
+// SetReadyDateTime sets the ReadyDateTime field's value.
+func (s *InstanceGroupDetail) SetReadyDateTime(v time.Time) *InstanceGroupDetail {
+	s.ReadyDateTime = &v
+	return s
+}
+
+// SetStartDateTime sets the StartDateTime field's value.
+func (s *InstanceGroupDetail) SetStartDateTime(v time.Time) *InstanceGroupDetail {
+	s.StartDateTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *InstanceGroupDetail) SetState(v string) *InstanceGroupDetail {
+	s.State = &v
+	return s
+}
+
 // Modify an instance group size.
 type InstanceGroupModifyConfig struct {
 	_ struct{} `type:"structure"`
@@ -3145,6 +4003,30 @@ func (s *InstanceGroupModifyConfig) Validate() error {
 	return nil
 }
 
+// SetEC2InstanceIdsToTerminate sets the EC2InstanceIdsToTerminate field's value.
+func (s *InstanceGroupModifyConfig) SetEC2InstanceIdsToTerminate(v []*string) *InstanceGroupModifyConfig {
+	s.EC2InstanceIdsToTerminate = v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *InstanceGroupModifyConfig) SetInstanceCount(v int64) *InstanceGroupModifyConfig {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceGroupId sets the InstanceGroupId field's value.
+func (s *InstanceGroupModifyConfig) SetInstanceGroupId(v string) *InstanceGroupModifyConfig {
+	s.InstanceGroupId = &v
+	return s
+}
+
+// SetShrinkPolicy sets the ShrinkPolicy field's value.
+func (s *InstanceGroupModifyConfig) SetShrinkPolicy(v *ShrinkPolicy) *InstanceGroupModifyConfig {
+	s.ShrinkPolicy = v
+	return s
+}
+
 // The status change reason details for the instance group.
 type InstanceGroupStateChangeReason struct {
 	_ struct{} `type:"structure"`
@@ -3164,6 +4046,18 @@ func (s InstanceGroupStateChangeReason) String() string {
 // GoString returns the string representation
 func (s InstanceGroupStateChangeReason) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *InstanceGroupStateChangeReason) SetCode(v string) *InstanceGroupStateChangeReason {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *InstanceGroupStateChangeReason) SetMessage(v string) *InstanceGroupStateChangeReason {
+	s.Message = &v
+	return s
 }
 
 // The details of the instance group status.
@@ -3190,6 +4084,24 @@ func (s InstanceGroupStatus) GoString() string {
 	return s.String()
 }
 
+// SetState sets the State field's value.
+func (s *InstanceGroupStatus) SetState(v string) *InstanceGroupStatus {
+	s.State = &v
+	return s
+}
+
+// SetStateChangeReason sets the StateChangeReason field's value.
+func (s *InstanceGroupStatus) SetStateChangeReason(v *InstanceGroupStateChangeReason) *InstanceGroupStatus {
+	s.StateChangeReason = v
+	return s
+}
+
+// SetTimeline sets the Timeline field's value.
+func (s *InstanceGroupStatus) SetTimeline(v *InstanceGroupTimeline) *InstanceGroupStatus {
+	s.Timeline = v
+	return s
+}
+
 // The timeline of the instance group lifecycle.
 type InstanceGroupTimeline struct {
 	_ struct{} `type:"structure"`
@@ -3212,6 +4124,24 @@ func (s InstanceGroupTimeline) String() string {
 // GoString returns the string representation
 func (s InstanceGroupTimeline) GoString() string {
 	return s.String()
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *InstanceGroupTimeline) SetCreationDateTime(v time.Time) *InstanceGroupTimeline {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetEndDateTime sets the EndDateTime field's value.
+func (s *InstanceGroupTimeline) SetEndDateTime(v time.Time) *InstanceGroupTimeline {
+	s.EndDateTime = &v
+	return s
+}
+
+// SetReadyDateTime sets the ReadyDateTime field's value.
+func (s *InstanceGroupTimeline) SetReadyDateTime(v time.Time) *InstanceGroupTimeline {
+	s.ReadyDateTime = &v
+	return s
 }
 
 // Custom policy for requesting termination protection or termination of specific
@@ -3240,6 +4170,24 @@ func (s InstanceResizePolicy) GoString() string {
 	return s.String()
 }
 
+// SetInstanceTerminationTimeout sets the InstanceTerminationTimeout field's value.
+func (s *InstanceResizePolicy) SetInstanceTerminationTimeout(v int64) *InstanceResizePolicy {
+	s.InstanceTerminationTimeout = &v
+	return s
+}
+
+// SetInstancesToProtect sets the InstancesToProtect field's value.
+func (s *InstanceResizePolicy) SetInstancesToProtect(v []*string) *InstanceResizePolicy {
+	s.InstancesToProtect = v
+	return s
+}
+
+// SetInstancesToTerminate sets the InstancesToTerminate field's value.
+func (s *InstanceResizePolicy) SetInstancesToTerminate(v []*string) *InstanceResizePolicy {
+	s.InstancesToTerminate = v
+	return s
+}
+
 // The details of the status change reason for the instance.
 type InstanceStateChangeReason struct {
 	_ struct{} `type:"structure"`
@@ -3259,6 +4207,18 @@ func (s InstanceStateChangeReason) String() string {
 // GoString returns the string representation
 func (s InstanceStateChangeReason) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *InstanceStateChangeReason) SetCode(v string) *InstanceStateChangeReason {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *InstanceStateChangeReason) SetMessage(v string) *InstanceStateChangeReason {
+	s.Message = &v
+	return s
 }
 
 // The instance status details.
@@ -3285,6 +4245,24 @@ func (s InstanceStatus) GoString() string {
 	return s.String()
 }
 
+// SetState sets the State field's value.
+func (s *InstanceStatus) SetState(v string) *InstanceStatus {
+	s.State = &v
+	return s
+}
+
+// SetStateChangeReason sets the StateChangeReason field's value.
+func (s *InstanceStatus) SetStateChangeReason(v *InstanceStateChangeReason) *InstanceStatus {
+	s.StateChangeReason = v
+	return s
+}
+
+// SetTimeline sets the Timeline field's value.
+func (s *InstanceStatus) SetTimeline(v *InstanceTimeline) *InstanceStatus {
+	s.Timeline = v
+	return s
+}
+
 // The timeline of the instance lifecycle.
 type InstanceTimeline struct {
 	_ struct{} `type:"structure"`
@@ -3307,6 +4285,24 @@ func (s InstanceTimeline) String() string {
 // GoString returns the string representation
 func (s InstanceTimeline) GoString() string {
 	return s.String()
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *InstanceTimeline) SetCreationDateTime(v time.Time) *InstanceTimeline {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetEndDateTime sets the EndDateTime field's value.
+func (s *InstanceTimeline) SetEndDateTime(v time.Time) *InstanceTimeline {
+	s.EndDateTime = &v
+	return s
+}
+
+// SetReadyDateTime sets the ReadyDateTime field's value.
+func (s *InstanceTimeline) SetReadyDateTime(v time.Time) *InstanceTimeline {
+	s.ReadyDateTime = &v
+	return s
 }
 
 // A description of a job flow.
@@ -3380,6 +4376,78 @@ func (s JobFlowDetail) GoString() string {
 	return s.String()
 }
 
+// SetAmiVersion sets the AmiVersion field's value.
+func (s *JobFlowDetail) SetAmiVersion(v string) *JobFlowDetail {
+	s.AmiVersion = &v
+	return s
+}
+
+// SetBootstrapActions sets the BootstrapActions field's value.
+func (s *JobFlowDetail) SetBootstrapActions(v []*BootstrapActionDetail) *JobFlowDetail {
+	s.BootstrapActions = v
+	return s
+}
+
+// SetExecutionStatusDetail sets the ExecutionStatusDetail field's value.
+func (s *JobFlowDetail) SetExecutionStatusDetail(v *JobFlowExecutionStatusDetail) *JobFlowDetail {
+	s.ExecutionStatusDetail = v
+	return s
+}
+
+// SetInstances sets the Instances field's value.
+func (s *JobFlowDetail) SetInstances(v *JobFlowInstancesDetail) *JobFlowDetail {
+	s.Instances = v
+	return s
+}
+
+// SetJobFlowId sets the JobFlowId field's value.
+func (s *JobFlowDetail) SetJobFlowId(v string) *JobFlowDetail {
+	s.JobFlowId = &v
+	return s
+}
+
+// SetJobFlowRole sets the JobFlowRole field's value.
+func (s *JobFlowDetail) SetJobFlowRole(v string) *JobFlowDetail {
+	s.JobFlowRole = &v
+	return s
+}
+
+// SetLogUri sets the LogUri field's value.
+func (s *JobFlowDetail) SetLogUri(v string) *JobFlowDetail {
+	s.LogUri = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *JobFlowDetail) SetName(v string) *JobFlowDetail {
+	s.Name = &v
+	return s
+}
+
+// SetServiceRole sets the ServiceRole field's value.
+func (s *JobFlowDetail) SetServiceRole(v string) *JobFlowDetail {
+	s.ServiceRole = &v
+	return s
+}
+
+// SetSteps sets the Steps field's value.
+func (s *JobFlowDetail) SetSteps(v []*StepDetail) *JobFlowDetail {
+	s.Steps = v
+	return s
+}
+
+// SetSupportedProducts sets the SupportedProducts field's value.
+func (s *JobFlowDetail) SetSupportedProducts(v []*string) *JobFlowDetail {
+	s.SupportedProducts = v
+	return s
+}
+
+// SetVisibleToAllUsers sets the VisibleToAllUsers field's value.
+func (s *JobFlowDetail) SetVisibleToAllUsers(v bool) *JobFlowDetail {
+	s.VisibleToAllUsers = &v
+	return s
+}
+
 // Describes the status of the job flow.
 type JobFlowExecutionStatusDetail struct {
 	_ struct{} `type:"structure"`
@@ -3416,6 +4484,42 @@ func (s JobFlowExecutionStatusDetail) String() string {
 // GoString returns the string representation
 func (s JobFlowExecutionStatusDetail) GoString() string {
 	return s.String()
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *JobFlowExecutionStatusDetail) SetCreationDateTime(v time.Time) *JobFlowExecutionStatusDetail {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetEndDateTime sets the EndDateTime field's value.
+func (s *JobFlowExecutionStatusDetail) SetEndDateTime(v time.Time) *JobFlowExecutionStatusDetail {
+	s.EndDateTime = &v
+	return s
+}
+
+// SetLastStateChangeReason sets the LastStateChangeReason field's value.
+func (s *JobFlowExecutionStatusDetail) SetLastStateChangeReason(v string) *JobFlowExecutionStatusDetail {
+	s.LastStateChangeReason = &v
+	return s
+}
+
+// SetReadyDateTime sets the ReadyDateTime field's value.
+func (s *JobFlowExecutionStatusDetail) SetReadyDateTime(v time.Time) *JobFlowExecutionStatusDetail {
+	s.ReadyDateTime = &v
+	return s
+}
+
+// SetStartDateTime sets the StartDateTime field's value.
+func (s *JobFlowExecutionStatusDetail) SetStartDateTime(v time.Time) *JobFlowExecutionStatusDetail {
+	s.StartDateTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *JobFlowExecutionStatusDetail) SetState(v string) *JobFlowExecutionStatusDetail {
+	s.State = &v
+	return s
 }
 
 // A description of the Amazon EC2 instance running the job flow. A valid JobFlowInstancesConfig
@@ -3528,6 +4632,96 @@ func (s *JobFlowInstancesConfig) Validate() error {
 	return nil
 }
 
+// SetAdditionalMasterSecurityGroups sets the AdditionalMasterSecurityGroups field's value.
+func (s *JobFlowInstancesConfig) SetAdditionalMasterSecurityGroups(v []*string) *JobFlowInstancesConfig {
+	s.AdditionalMasterSecurityGroups = v
+	return s
+}
+
+// SetAdditionalSlaveSecurityGroups sets the AdditionalSlaveSecurityGroups field's value.
+func (s *JobFlowInstancesConfig) SetAdditionalSlaveSecurityGroups(v []*string) *JobFlowInstancesConfig {
+	s.AdditionalSlaveSecurityGroups = v
+	return s
+}
+
+// SetEc2KeyName sets the Ec2KeyName field's value.
+func (s *JobFlowInstancesConfig) SetEc2KeyName(v string) *JobFlowInstancesConfig {
+	s.Ec2KeyName = &v
+	return s
+}
+
+// SetEc2SubnetId sets the Ec2SubnetId field's value.
+func (s *JobFlowInstancesConfig) SetEc2SubnetId(v string) *JobFlowInstancesConfig {
+	s.Ec2SubnetId = &v
+	return s
+}
+
+// SetEmrManagedMasterSecurityGroup sets the EmrManagedMasterSecurityGroup field's value.
+func (s *JobFlowInstancesConfig) SetEmrManagedMasterSecurityGroup(v string) *JobFlowInstancesConfig {
+	s.EmrManagedMasterSecurityGroup = &v
+	return s
+}
+
+// SetEmrManagedSlaveSecurityGroup sets the EmrManagedSlaveSecurityGroup field's value.
+func (s *JobFlowInstancesConfig) SetEmrManagedSlaveSecurityGroup(v string) *JobFlowInstancesConfig {
+	s.EmrManagedSlaveSecurityGroup = &v
+	return s
+}
+
+// SetHadoopVersion sets the HadoopVersion field's value.
+func (s *JobFlowInstancesConfig) SetHadoopVersion(v string) *JobFlowInstancesConfig {
+	s.HadoopVersion = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *JobFlowInstancesConfig) SetInstanceCount(v int64) *JobFlowInstancesConfig {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceGroups sets the InstanceGroups field's value.
+func (s *JobFlowInstancesConfig) SetInstanceGroups(v []*InstanceGroupConfig) *JobFlowInstancesConfig {
+	s.InstanceGroups = v
+	return s
+}
+
+// SetKeepJobFlowAliveWhenNoSteps sets the KeepJobFlowAliveWhenNoSteps field's value.
+func (s *JobFlowInstancesConfig) SetKeepJobFlowAliveWhenNoSteps(v bool) *JobFlowInstancesConfig {
+	s.KeepJobFlowAliveWhenNoSteps = &v
+	return s
+}
+
+// SetMasterInstanceType sets the MasterInstanceType field's value.
+func (s *JobFlowInstancesConfig) SetMasterInstanceType(v string) *JobFlowInstancesConfig {
+	s.MasterInstanceType = &v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *JobFlowInstancesConfig) SetPlacement(v *PlacementType) *JobFlowInstancesConfig {
+	s.Placement = v
+	return s
+}
+
+// SetServiceAccessSecurityGroup sets the ServiceAccessSecurityGroup field's value.
+func (s *JobFlowInstancesConfig) SetServiceAccessSecurityGroup(v string) *JobFlowInstancesConfig {
+	s.ServiceAccessSecurityGroup = &v
+	return s
+}
+
+// SetSlaveInstanceType sets the SlaveInstanceType field's value.
+func (s *JobFlowInstancesConfig) SetSlaveInstanceType(v string) *JobFlowInstancesConfig {
+	s.SlaveInstanceType = &v
+	return s
+}
+
+// SetTerminationProtected sets the TerminationProtected field's value.
+func (s *JobFlowInstancesConfig) SetTerminationProtected(v bool) *JobFlowInstancesConfig {
+	s.TerminationProtected = &v
+	return s
+}
+
 // Specify the type of Amazon EC2 instances to run the job flow on.
 type JobFlowInstancesDetail struct {
 	_ struct{} `type:"structure"`
@@ -3599,6 +4793,84 @@ func (s JobFlowInstancesDetail) GoString() string {
 	return s.String()
 }
 
+// SetEc2KeyName sets the Ec2KeyName field's value.
+func (s *JobFlowInstancesDetail) SetEc2KeyName(v string) *JobFlowInstancesDetail {
+	s.Ec2KeyName = &v
+	return s
+}
+
+// SetEc2SubnetId sets the Ec2SubnetId field's value.
+func (s *JobFlowInstancesDetail) SetEc2SubnetId(v string) *JobFlowInstancesDetail {
+	s.Ec2SubnetId = &v
+	return s
+}
+
+// SetHadoopVersion sets the HadoopVersion field's value.
+func (s *JobFlowInstancesDetail) SetHadoopVersion(v string) *JobFlowInstancesDetail {
+	s.HadoopVersion = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *JobFlowInstancesDetail) SetInstanceCount(v int64) *JobFlowInstancesDetail {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceGroups sets the InstanceGroups field's value.
+func (s *JobFlowInstancesDetail) SetInstanceGroups(v []*InstanceGroupDetail) *JobFlowInstancesDetail {
+	s.InstanceGroups = v
+	return s
+}
+
+// SetKeepJobFlowAliveWhenNoSteps sets the KeepJobFlowAliveWhenNoSteps field's value.
+func (s *JobFlowInstancesDetail) SetKeepJobFlowAliveWhenNoSteps(v bool) *JobFlowInstancesDetail {
+	s.KeepJobFlowAliveWhenNoSteps = &v
+	return s
+}
+
+// SetMasterInstanceId sets the MasterInstanceId field's value.
+func (s *JobFlowInstancesDetail) SetMasterInstanceId(v string) *JobFlowInstancesDetail {
+	s.MasterInstanceId = &v
+	return s
+}
+
+// SetMasterInstanceType sets the MasterInstanceType field's value.
+func (s *JobFlowInstancesDetail) SetMasterInstanceType(v string) *JobFlowInstancesDetail {
+	s.MasterInstanceType = &v
+	return s
+}
+
+// SetMasterPublicDnsName sets the MasterPublicDnsName field's value.
+func (s *JobFlowInstancesDetail) SetMasterPublicDnsName(v string) *JobFlowInstancesDetail {
+	s.MasterPublicDnsName = &v
+	return s
+}
+
+// SetNormalizedInstanceHours sets the NormalizedInstanceHours field's value.
+func (s *JobFlowInstancesDetail) SetNormalizedInstanceHours(v int64) *JobFlowInstancesDetail {
+	s.NormalizedInstanceHours = &v
+	return s
+}
+
+// SetPlacement sets the Placement field's value.
+func (s *JobFlowInstancesDetail) SetPlacement(v *PlacementType) *JobFlowInstancesDetail {
+	s.Placement = v
+	return s
+}
+
+// SetSlaveInstanceType sets the SlaveInstanceType field's value.
+func (s *JobFlowInstancesDetail) SetSlaveInstanceType(v string) *JobFlowInstancesDetail {
+	s.SlaveInstanceType = &v
+	return s
+}
+
+// SetTerminationProtected sets the TerminationProtected field's value.
+func (s *JobFlowInstancesDetail) SetTerminationProtected(v bool) *JobFlowInstancesDetail {
+	s.TerminationProtected = &v
+	return s
+}
+
 // A key value pair.
 type KeyValue struct {
 	_ struct{} `type:"structure"`
@@ -3618,6 +4890,18 @@ func (s KeyValue) String() string {
 // GoString returns the string representation
 func (s KeyValue) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *KeyValue) SetKey(v string) *KeyValue {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *KeyValue) SetValue(v string) *KeyValue {
+	s.Value = &v
+	return s
 }
 
 // This input determines which bootstrap actions to retrieve.
@@ -3656,6 +4940,18 @@ func (s *ListBootstrapActionsInput) Validate() error {
 	return nil
 }
 
+// SetClusterId sets the ClusterId field's value.
+func (s *ListBootstrapActionsInput) SetClusterId(v string) *ListBootstrapActionsInput {
+	s.ClusterId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListBootstrapActionsInput) SetMarker(v string) *ListBootstrapActionsInput {
+	s.Marker = &v
+	return s
+}
+
 // This output contains the boostrap actions detail .
 type ListBootstrapActionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3675,6 +4971,18 @@ func (s ListBootstrapActionsOutput) String() string {
 // GoString returns the string representation
 func (s ListBootstrapActionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetBootstrapActions sets the BootstrapActions field's value.
+func (s *ListBootstrapActionsOutput) SetBootstrapActions(v []*Command) *ListBootstrapActionsOutput {
+	s.BootstrapActions = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListBootstrapActionsOutput) SetMarker(v string) *ListBootstrapActionsOutput {
+	s.Marker = &v
+	return s
 }
 
 // This input determines how the ListClusters action filters the list of clusters
@@ -3705,6 +5013,30 @@ func (s ListClustersInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterStates sets the ClusterStates field's value.
+func (s *ListClustersInput) SetClusterStates(v []*string) *ListClustersInput {
+	s.ClusterStates = v
+	return s
+}
+
+// SetCreatedAfter sets the CreatedAfter field's value.
+func (s *ListClustersInput) SetCreatedAfter(v time.Time) *ListClustersInput {
+	s.CreatedAfter = &v
+	return s
+}
+
+// SetCreatedBefore sets the CreatedBefore field's value.
+func (s *ListClustersInput) SetCreatedBefore(v time.Time) *ListClustersInput {
+	s.CreatedBefore = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListClustersInput) SetMarker(v string) *ListClustersInput {
+	s.Marker = &v
+	return s
+}
+
 // This contains a ClusterSummaryList with the cluster details; for example,
 // the cluster IDs, names, and status.
 type ListClustersOutput struct {
@@ -3725,6 +5057,18 @@ func (s ListClustersOutput) String() string {
 // GoString returns the string representation
 func (s ListClustersOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusters sets the Clusters field's value.
+func (s *ListClustersOutput) SetClusters(v []*ClusterSummary) *ListClustersOutput {
+	s.Clusters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListClustersOutput) SetMarker(v string) *ListClustersOutput {
+	s.Marker = &v
+	return s
 }
 
 // This input determines which instance groups to retrieve.
@@ -3763,6 +5107,18 @@ func (s *ListInstanceGroupsInput) Validate() error {
 	return nil
 }
 
+// SetClusterId sets the ClusterId field's value.
+func (s *ListInstanceGroupsInput) SetClusterId(v string) *ListInstanceGroupsInput {
+	s.ClusterId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListInstanceGroupsInput) SetMarker(v string) *ListInstanceGroupsInput {
+	s.Marker = &v
+	return s
+}
+
 // This input determines which instance groups to retrieve.
 type ListInstanceGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3782,6 +5138,18 @@ func (s ListInstanceGroupsOutput) String() string {
 // GoString returns the string representation
 func (s ListInstanceGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceGroups sets the InstanceGroups field's value.
+func (s *ListInstanceGroupsOutput) SetInstanceGroups(v []*InstanceGroup) *ListInstanceGroupsOutput {
+	s.InstanceGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListInstanceGroupsOutput) SetMarker(v string) *ListInstanceGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 // This input determines which instances to list.
@@ -3830,6 +5198,36 @@ func (s *ListInstancesInput) Validate() error {
 	return nil
 }
 
+// SetClusterId sets the ClusterId field's value.
+func (s *ListInstancesInput) SetClusterId(v string) *ListInstancesInput {
+	s.ClusterId = &v
+	return s
+}
+
+// SetInstanceGroupId sets the InstanceGroupId field's value.
+func (s *ListInstancesInput) SetInstanceGroupId(v string) *ListInstancesInput {
+	s.InstanceGroupId = &v
+	return s
+}
+
+// SetInstanceGroupTypes sets the InstanceGroupTypes field's value.
+func (s *ListInstancesInput) SetInstanceGroupTypes(v []*string) *ListInstancesInput {
+	s.InstanceGroupTypes = v
+	return s
+}
+
+// SetInstanceStates sets the InstanceStates field's value.
+func (s *ListInstancesInput) SetInstanceStates(v []*string) *ListInstancesInput {
+	s.InstanceStates = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListInstancesInput) SetMarker(v string) *ListInstancesInput {
+	s.Marker = &v
+	return s
+}
+
 // This output contains the list of instances.
 type ListInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3851,6 +5249,18 @@ func (s ListInstancesOutput) GoString() string {
 	return s.String()
 }
 
+// SetInstances sets the Instances field's value.
+func (s *ListInstancesOutput) SetInstances(v []*Instance) *ListInstancesOutput {
+	s.Instances = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListInstancesOutput) SetMarker(v string) *ListInstancesOutput {
+	s.Marker = &v
+	return s
+}
+
 type ListSecurityConfigurationsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3866,6 +5276,12 @@ func (s ListSecurityConfigurationsInput) String() string {
 // GoString returns the string representation
 func (s ListSecurityConfigurationsInput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListSecurityConfigurationsInput) SetMarker(v string) *ListSecurityConfigurationsInput {
+	s.Marker = &v
+	return s
 }
 
 type ListSecurityConfigurationsOutput struct {
@@ -3888,6 +5304,18 @@ func (s ListSecurityConfigurationsOutput) String() string {
 // GoString returns the string representation
 func (s ListSecurityConfigurationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListSecurityConfigurationsOutput) SetMarker(v string) *ListSecurityConfigurationsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSecurityConfigurations sets the SecurityConfigurations field's value.
+func (s *ListSecurityConfigurationsOutput) SetSecurityConfigurations(v []*SecurityConfigurationSummary) *ListSecurityConfigurationsOutput {
+	s.SecurityConfigurations = v
+	return s
 }
 
 // This input determines which steps to list.
@@ -3932,6 +5360,30 @@ func (s *ListStepsInput) Validate() error {
 	return nil
 }
 
+// SetClusterId sets the ClusterId field's value.
+func (s *ListStepsInput) SetClusterId(v string) *ListStepsInput {
+	s.ClusterId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListStepsInput) SetMarker(v string) *ListStepsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetStepIds sets the StepIds field's value.
+func (s *ListStepsInput) SetStepIds(v []*string) *ListStepsInput {
+	s.StepIds = v
+	return s
+}
+
+// SetStepStates sets the StepStates field's value.
+func (s *ListStepsInput) SetStepStates(v []*string) *ListStepsInput {
+	s.StepStates = v
+	return s
+}
+
 // This output contains the list of steps returned in reverse order. This means
 // that the last step is the first element in the list.
 type ListStepsOutput struct {
@@ -3952,6 +5404,18 @@ func (s ListStepsOutput) String() string {
 // GoString returns the string representation
 func (s ListStepsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListStepsOutput) SetMarker(v string) *ListStepsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSteps sets the Steps field's value.
+func (s *ListStepsOutput) SetSteps(v []*StepSummary) *ListStepsOutput {
+	s.Steps = v
+	return s
 }
 
 // Change the size of some instance groups.
@@ -3990,6 +5454,12 @@ func (s *ModifyInstanceGroupsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceGroups sets the InstanceGroups field's value.
+func (s *ModifyInstanceGroupsInput) SetInstanceGroups(v []*InstanceGroupModifyConfig) *ModifyInstanceGroupsInput {
+	s.InstanceGroups = v
+	return s
 }
 
 type ModifyInstanceGroupsOutput struct {
@@ -4039,6 +5509,12 @@ func (s *PlacementType) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *PlacementType) SetAvailabilityZone(v string) *PlacementType {
+	s.AvailabilityZone = &v
+	return s
+}
+
 // This input identifies a cluster and a list of tags to remove.
 type RemoveTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -4079,6 +5555,18 @@ func (s *RemoveTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *RemoveTagsInput) SetResourceId(v string) *RemoveTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsInput) SetTagKeys(v []*string) *RemoveTagsInput {
+	s.TagKeys = v
+	return s
 }
 
 // This output indicates the result of removing tags from a resource.
@@ -4275,6 +5763,108 @@ func (s *RunJobFlowInput) Validate() error {
 	return nil
 }
 
+// SetAdditionalInfo sets the AdditionalInfo field's value.
+func (s *RunJobFlowInput) SetAdditionalInfo(v string) *RunJobFlowInput {
+	s.AdditionalInfo = &v
+	return s
+}
+
+// SetAmiVersion sets the AmiVersion field's value.
+func (s *RunJobFlowInput) SetAmiVersion(v string) *RunJobFlowInput {
+	s.AmiVersion = &v
+	return s
+}
+
+// SetApplications sets the Applications field's value.
+func (s *RunJobFlowInput) SetApplications(v []*Application) *RunJobFlowInput {
+	s.Applications = v
+	return s
+}
+
+// SetBootstrapActions sets the BootstrapActions field's value.
+func (s *RunJobFlowInput) SetBootstrapActions(v []*BootstrapActionConfig) *RunJobFlowInput {
+	s.BootstrapActions = v
+	return s
+}
+
+// SetConfigurations sets the Configurations field's value.
+func (s *RunJobFlowInput) SetConfigurations(v []*Configuration) *RunJobFlowInput {
+	s.Configurations = v
+	return s
+}
+
+// SetInstances sets the Instances field's value.
+func (s *RunJobFlowInput) SetInstances(v *JobFlowInstancesConfig) *RunJobFlowInput {
+	s.Instances = v
+	return s
+}
+
+// SetJobFlowRole sets the JobFlowRole field's value.
+func (s *RunJobFlowInput) SetJobFlowRole(v string) *RunJobFlowInput {
+	s.JobFlowRole = &v
+	return s
+}
+
+// SetLogUri sets the LogUri field's value.
+func (s *RunJobFlowInput) SetLogUri(v string) *RunJobFlowInput {
+	s.LogUri = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RunJobFlowInput) SetName(v string) *RunJobFlowInput {
+	s.Name = &v
+	return s
+}
+
+// SetNewSupportedProducts sets the NewSupportedProducts field's value.
+func (s *RunJobFlowInput) SetNewSupportedProducts(v []*SupportedProductConfig) *RunJobFlowInput {
+	s.NewSupportedProducts = v
+	return s
+}
+
+// SetReleaseLabel sets the ReleaseLabel field's value.
+func (s *RunJobFlowInput) SetReleaseLabel(v string) *RunJobFlowInput {
+	s.ReleaseLabel = &v
+	return s
+}
+
+// SetSecurityConfiguration sets the SecurityConfiguration field's value.
+func (s *RunJobFlowInput) SetSecurityConfiguration(v string) *RunJobFlowInput {
+	s.SecurityConfiguration = &v
+	return s
+}
+
+// SetServiceRole sets the ServiceRole field's value.
+func (s *RunJobFlowInput) SetServiceRole(v string) *RunJobFlowInput {
+	s.ServiceRole = &v
+	return s
+}
+
+// SetSteps sets the Steps field's value.
+func (s *RunJobFlowInput) SetSteps(v []*StepConfig) *RunJobFlowInput {
+	s.Steps = v
+	return s
+}
+
+// SetSupportedProducts sets the SupportedProducts field's value.
+func (s *RunJobFlowInput) SetSupportedProducts(v []*string) *RunJobFlowInput {
+	s.SupportedProducts = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RunJobFlowInput) SetTags(v []*Tag) *RunJobFlowInput {
+	s.Tags = v
+	return s
+}
+
+// SetVisibleToAllUsers sets the VisibleToAllUsers field's value.
+func (s *RunJobFlowInput) SetVisibleToAllUsers(v bool) *RunJobFlowInput {
+	s.VisibleToAllUsers = &v
+	return s
+}
+
 // The result of the RunJobFlow operation.
 type RunJobFlowOutput struct {
 	_ struct{} `type:"structure"`
@@ -4291,6 +5881,12 @@ func (s RunJobFlowOutput) String() string {
 // GoString returns the string representation
 func (s RunJobFlowOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobFlowId sets the JobFlowId field's value.
+func (s *RunJobFlowOutput) SetJobFlowId(v string) *RunJobFlowOutput {
+	s.JobFlowId = &v
+	return s
 }
 
 type ScriptBootstrapActionConfig struct {
@@ -4325,6 +5921,18 @@ func (s *ScriptBootstrapActionConfig) Validate() error {
 	return nil
 }
 
+// SetArgs sets the Args field's value.
+func (s *ScriptBootstrapActionConfig) SetArgs(v []*string) *ScriptBootstrapActionConfig {
+	s.Args = v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *ScriptBootstrapActionConfig) SetPath(v string) *ScriptBootstrapActionConfig {
+	s.Path = &v
+	return s
+}
+
 // The creation date and time, and name, of a security configuration.
 type SecurityConfigurationSummary struct {
 	_ struct{} `type:"structure"`
@@ -4344,6 +5952,18 @@ func (s SecurityConfigurationSummary) String() string {
 // GoString returns the string representation
 func (s SecurityConfigurationSummary) GoString() string {
 	return s.String()
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *SecurityConfigurationSummary) SetCreationDateTime(v time.Time) *SecurityConfigurationSummary {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *SecurityConfigurationSummary) SetName(v string) *SecurityConfigurationSummary {
+	s.Name = &v
+	return s
 }
 
 // The input argument to the TerminationProtection operation.
@@ -4389,6 +6009,18 @@ func (s *SetTerminationProtectionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetJobFlowIds sets the JobFlowIds field's value.
+func (s *SetTerminationProtectionInput) SetJobFlowIds(v []*string) *SetTerminationProtectionInput {
+	s.JobFlowIds = v
+	return s
+}
+
+// SetTerminationProtected sets the TerminationProtected field's value.
+func (s *SetTerminationProtectionInput) SetTerminationProtected(v bool) *SetTerminationProtectionInput {
+	s.TerminationProtected = &v
+	return s
 }
 
 type SetTerminationProtectionOutput struct {
@@ -4450,6 +6082,18 @@ func (s *SetVisibleToAllUsersInput) Validate() error {
 	return nil
 }
 
+// SetJobFlowIds sets the JobFlowIds field's value.
+func (s *SetVisibleToAllUsersInput) SetJobFlowIds(v []*string) *SetVisibleToAllUsersInput {
+	s.JobFlowIds = v
+	return s
+}
+
+// SetVisibleToAllUsers sets the VisibleToAllUsers field's value.
+func (s *SetVisibleToAllUsersInput) SetVisibleToAllUsers(v bool) *SetVisibleToAllUsersInput {
+	s.VisibleToAllUsers = &v
+	return s
+}
+
 type SetVisibleToAllUsersOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4488,6 +6132,18 @@ func (s ShrinkPolicy) GoString() string {
 	return s.String()
 }
 
+// SetDecommissionTimeout sets the DecommissionTimeout field's value.
+func (s *ShrinkPolicy) SetDecommissionTimeout(v int64) *ShrinkPolicy {
+	s.DecommissionTimeout = &v
+	return s
+}
+
+// SetInstanceResizePolicy sets the InstanceResizePolicy field's value.
+func (s *ShrinkPolicy) SetInstanceResizePolicy(v *InstanceResizePolicy) *ShrinkPolicy {
+	s.InstanceResizePolicy = v
+	return s
+}
+
 // This represents a step in a cluster.
 type Step struct {
 	_ struct{} `type:"structure"`
@@ -4517,6 +6173,36 @@ func (s Step) String() string {
 // GoString returns the string representation
 func (s Step) GoString() string {
 	return s.String()
+}
+
+// SetActionOnFailure sets the ActionOnFailure field's value.
+func (s *Step) SetActionOnFailure(v string) *Step {
+	s.ActionOnFailure = &v
+	return s
+}
+
+// SetConfig sets the Config field's value.
+func (s *Step) SetConfig(v *HadoopStepConfig) *Step {
+	s.Config = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Step) SetId(v string) *Step {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Step) SetName(v string) *Step {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Step) SetStatus(v *StepStatus) *Step {
+	s.Status = v
+	return s
 }
 
 // Specification of a job flow step.
@@ -4568,6 +6254,24 @@ func (s *StepConfig) Validate() error {
 	return nil
 }
 
+// SetActionOnFailure sets the ActionOnFailure field's value.
+func (s *StepConfig) SetActionOnFailure(v string) *StepConfig {
+	s.ActionOnFailure = &v
+	return s
+}
+
+// SetHadoopJarStep sets the HadoopJarStep field's value.
+func (s *StepConfig) SetHadoopJarStep(v *HadoopJarStepConfig) *StepConfig {
+	s.HadoopJarStep = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *StepConfig) SetName(v string) *StepConfig {
+	s.Name = &v
+	return s
+}
+
 // Combines the execution state and configuration of a step.
 type StepDetail struct {
 	_ struct{} `type:"structure"`
@@ -4591,6 +6295,18 @@ func (s StepDetail) String() string {
 // GoString returns the string representation
 func (s StepDetail) GoString() string {
 	return s.String()
+}
+
+// SetExecutionStatusDetail sets the ExecutionStatusDetail field's value.
+func (s *StepDetail) SetExecutionStatusDetail(v *StepExecutionStatusDetail) *StepDetail {
+	s.ExecutionStatusDetail = v
+	return s
+}
+
+// SetStepConfig sets the StepConfig field's value.
+func (s *StepDetail) SetStepConfig(v *StepConfig) *StepDetail {
+	s.StepConfig = v
+	return s
 }
 
 // The execution state of a step.
@@ -4627,6 +6343,36 @@ func (s StepExecutionStatusDetail) GoString() string {
 	return s.String()
 }
 
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *StepExecutionStatusDetail) SetCreationDateTime(v time.Time) *StepExecutionStatusDetail {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetEndDateTime sets the EndDateTime field's value.
+func (s *StepExecutionStatusDetail) SetEndDateTime(v time.Time) *StepExecutionStatusDetail {
+	s.EndDateTime = &v
+	return s
+}
+
+// SetLastStateChangeReason sets the LastStateChangeReason field's value.
+func (s *StepExecutionStatusDetail) SetLastStateChangeReason(v string) *StepExecutionStatusDetail {
+	s.LastStateChangeReason = &v
+	return s
+}
+
+// SetStartDateTime sets the StartDateTime field's value.
+func (s *StepExecutionStatusDetail) SetStartDateTime(v time.Time) *StepExecutionStatusDetail {
+	s.StartDateTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *StepExecutionStatusDetail) SetState(v string) *StepExecutionStatusDetail {
+	s.State = &v
+	return s
+}
+
 // The details of the step state change reason.
 type StepStateChangeReason struct {
 	_ struct{} `type:"structure"`
@@ -4647,6 +6393,18 @@ func (s StepStateChangeReason) String() string {
 // GoString returns the string representation
 func (s StepStateChangeReason) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *StepStateChangeReason) SetCode(v string) *StepStateChangeReason {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *StepStateChangeReason) SetMessage(v string) *StepStateChangeReason {
+	s.Message = &v
+	return s
 }
 
 // The execution status details of the cluster step.
@@ -4675,6 +6433,30 @@ func (s StepStatus) String() string {
 // GoString returns the string representation
 func (s StepStatus) GoString() string {
 	return s.String()
+}
+
+// SetFailureDetails sets the FailureDetails field's value.
+func (s *StepStatus) SetFailureDetails(v *FailureDetails) *StepStatus {
+	s.FailureDetails = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *StepStatus) SetState(v string) *StepStatus {
+	s.State = &v
+	return s
+}
+
+// SetStateChangeReason sets the StateChangeReason field's value.
+func (s *StepStatus) SetStateChangeReason(v *StepStateChangeReason) *StepStatus {
+	s.StateChangeReason = v
+	return s
+}
+
+// SetTimeline sets the Timeline field's value.
+func (s *StepStatus) SetTimeline(v *StepTimeline) *StepStatus {
+	s.Timeline = v
+	return s
 }
 
 // The summary of the cluster step.
@@ -4708,6 +6490,36 @@ func (s StepSummary) GoString() string {
 	return s.String()
 }
 
+// SetActionOnFailure sets the ActionOnFailure field's value.
+func (s *StepSummary) SetActionOnFailure(v string) *StepSummary {
+	s.ActionOnFailure = &v
+	return s
+}
+
+// SetConfig sets the Config field's value.
+func (s *StepSummary) SetConfig(v *HadoopStepConfig) *StepSummary {
+	s.Config = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *StepSummary) SetId(v string) *StepSummary {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *StepSummary) SetName(v string) *StepSummary {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *StepSummary) SetStatus(v *StepStatus) *StepSummary {
+	s.Status = v
+	return s
+}
+
 // The timeline of the cluster step lifecycle.
 type StepTimeline struct {
 	_ struct{} `type:"structure"`
@@ -4732,6 +6544,24 @@ func (s StepTimeline) GoString() string {
 	return s.String()
 }
 
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *StepTimeline) SetCreationDateTime(v time.Time) *StepTimeline {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetEndDateTime sets the EndDateTime field's value.
+func (s *StepTimeline) SetEndDateTime(v time.Time) *StepTimeline {
+	s.EndDateTime = &v
+	return s
+}
+
+// SetStartDateTime sets the StartDateTime field's value.
+func (s *StepTimeline) SetStartDateTime(v time.Time) *StepTimeline {
+	s.StartDateTime = &v
+	return s
+}
+
 // The list of supported product configurations which allow user-supplied arguments.
 // EMR accepts these arguments and forwards them to the corresponding installation
 // script as bootstrap action arguments.
@@ -4753,6 +6583,18 @@ func (s SupportedProductConfig) String() string {
 // GoString returns the string representation
 func (s SupportedProductConfig) GoString() string {
 	return s.String()
+}
+
+// SetArgs sets the Args field's value.
+func (s *SupportedProductConfig) SetArgs(v []*string) *SupportedProductConfig {
+	s.Args = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *SupportedProductConfig) SetName(v string) *SupportedProductConfig {
+	s.Name = &v
+	return s
 }
 
 // A key/value pair containing user-defined metadata that you can associate
@@ -4780,6 +6622,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // Input to the TerminateJobFlows operation.
@@ -4813,6 +6667,12 @@ func (s *TerminateJobFlowsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetJobFlowIds sets the JobFlowIds field's value.
+func (s *TerminateJobFlowsInput) SetJobFlowIds(v []*string) *TerminateJobFlowsInput {
+	s.JobFlowIds = v
+	return s
 }
 
 type TerminateJobFlowsOutput struct {
@@ -4873,6 +6733,24 @@ func (s *VolumeSpecification) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIops sets the Iops field's value.
+func (s *VolumeSpecification) SetIops(v int64) *VolumeSpecification {
+	s.Iops = &v
+	return s
+}
+
+// SetSizeInGB sets the SizeInGB field's value.
+func (s *VolumeSpecification) SetSizeInGB(v int64) *VolumeSpecification {
+	s.SizeInGB = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *VolumeSpecification) SetVolumeType(v string) *VolumeSpecification {
+	s.VolumeType = &v
+	return s
 }
 
 const (

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -725,6 +725,18 @@ func (s *BufferingHints) Validate() error {
 	return nil
 }
 
+// SetIntervalInSeconds sets the IntervalInSeconds field's value.
+func (s *BufferingHints) SetIntervalInSeconds(v int64) *BufferingHints {
+	s.IntervalInSeconds = &v
+	return s
+}
+
+// SetSizeInMBs sets the SizeInMBs field's value.
+func (s *BufferingHints) SetSizeInMBs(v int64) *BufferingHints {
+	s.SizeInMBs = &v
+	return s
+}
+
 // Describes CloudWatch logging options for your delivery stream.
 type CloudWatchLoggingOptions struct {
 	_ struct{} `type:"structure"`
@@ -749,6 +761,24 @@ func (s CloudWatchLoggingOptions) String() string {
 // GoString returns the string representation
 func (s CloudWatchLoggingOptions) GoString() string {
 	return s.String()
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *CloudWatchLoggingOptions) SetEnabled(v bool) *CloudWatchLoggingOptions {
+	s.Enabled = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *CloudWatchLoggingOptions) SetLogGroupName(v string) *CloudWatchLoggingOptions {
+	s.LogGroupName = &v
+	return s
+}
+
+// SetLogStreamName sets the LogStreamName field's value.
+func (s *CloudWatchLoggingOptions) SetLogStreamName(v string) *CloudWatchLoggingOptions {
+	s.LogStreamName = &v
+	return s
 }
 
 // Describes a COPY command for Amazon Redshift.
@@ -810,6 +840,24 @@ func (s *CopyCommand) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCopyOptions sets the CopyOptions field's value.
+func (s *CopyCommand) SetCopyOptions(v string) *CopyCommand {
+	s.CopyOptions = &v
+	return s
+}
+
+// SetDataTableColumns sets the DataTableColumns field's value.
+func (s *CopyCommand) SetDataTableColumns(v string) *CopyCommand {
+	s.DataTableColumns = &v
+	return s
+}
+
+// SetDataTableName sets the DataTableName field's value.
+func (s *CopyCommand) SetDataTableName(v string) *CopyCommand {
+	s.DataTableName = &v
+	return s
 }
 
 // Contains the parameters for CreateDeliveryStream.
@@ -877,6 +925,30 @@ func (s *CreateDeliveryStreamInput) Validate() error {
 	return nil
 }
 
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *CreateDeliveryStreamInput) SetDeliveryStreamName(v string) *CreateDeliveryStreamInput {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetElasticsearchDestinationConfiguration sets the ElasticsearchDestinationConfiguration field's value.
+func (s *CreateDeliveryStreamInput) SetElasticsearchDestinationConfiguration(v *ElasticsearchDestinationConfiguration) *CreateDeliveryStreamInput {
+	s.ElasticsearchDestinationConfiguration = v
+	return s
+}
+
+// SetRedshiftDestinationConfiguration sets the RedshiftDestinationConfiguration field's value.
+func (s *CreateDeliveryStreamInput) SetRedshiftDestinationConfiguration(v *RedshiftDestinationConfiguration) *CreateDeliveryStreamInput {
+	s.RedshiftDestinationConfiguration = v
+	return s
+}
+
+// SetS3DestinationConfiguration sets the S3DestinationConfiguration field's value.
+func (s *CreateDeliveryStreamInput) SetS3DestinationConfiguration(v *S3DestinationConfiguration) *CreateDeliveryStreamInput {
+	s.S3DestinationConfiguration = v
+	return s
+}
+
 // Contains the output of CreateDeliveryStream.
 type CreateDeliveryStreamOutput struct {
 	_ struct{} `type:"structure"`
@@ -893,6 +965,12 @@ func (s CreateDeliveryStreamOutput) String() string {
 // GoString returns the string representation
 func (s CreateDeliveryStreamOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeliveryStreamARN sets the DeliveryStreamARN field's value.
+func (s *CreateDeliveryStreamOutput) SetDeliveryStreamARN(v string) *CreateDeliveryStreamOutput {
+	s.DeliveryStreamARN = &v
+	return s
 }
 
 // Contains the parameters for DeleteDeliveryStream.
@@ -929,6 +1007,12 @@ func (s *DeleteDeliveryStreamInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *DeleteDeliveryStreamInput) SetDeliveryStreamName(v string) *DeleteDeliveryStreamInput {
+	s.DeliveryStreamName = &v
+	return s
 }
 
 // Contains the output of DeleteDeliveryStream.
@@ -1001,6 +1085,54 @@ func (s DeliveryStreamDescription) GoString() string {
 	return s.String()
 }
 
+// SetCreateTimestamp sets the CreateTimestamp field's value.
+func (s *DeliveryStreamDescription) SetCreateTimestamp(v time.Time) *DeliveryStreamDescription {
+	s.CreateTimestamp = &v
+	return s
+}
+
+// SetDeliveryStreamARN sets the DeliveryStreamARN field's value.
+func (s *DeliveryStreamDescription) SetDeliveryStreamARN(v string) *DeliveryStreamDescription {
+	s.DeliveryStreamARN = &v
+	return s
+}
+
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *DeliveryStreamDescription) SetDeliveryStreamName(v string) *DeliveryStreamDescription {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetDeliveryStreamStatus sets the DeliveryStreamStatus field's value.
+func (s *DeliveryStreamDescription) SetDeliveryStreamStatus(v string) *DeliveryStreamDescription {
+	s.DeliveryStreamStatus = &v
+	return s
+}
+
+// SetDestinations sets the Destinations field's value.
+func (s *DeliveryStreamDescription) SetDestinations(v []*DestinationDescription) *DeliveryStreamDescription {
+	s.Destinations = v
+	return s
+}
+
+// SetHasMoreDestinations sets the HasMoreDestinations field's value.
+func (s *DeliveryStreamDescription) SetHasMoreDestinations(v bool) *DeliveryStreamDescription {
+	s.HasMoreDestinations = &v
+	return s
+}
+
+// SetLastUpdateTimestamp sets the LastUpdateTimestamp field's value.
+func (s *DeliveryStreamDescription) SetLastUpdateTimestamp(v time.Time) *DeliveryStreamDescription {
+	s.LastUpdateTimestamp = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *DeliveryStreamDescription) SetVersionId(v string) *DeliveryStreamDescription {
+	s.VersionId = &v
+	return s
+}
+
 // Contains the parameters for DescribeDeliveryStream.
 type DescribeDeliveryStreamInput struct {
 	_ struct{} `type:"structure"`
@@ -1051,6 +1183,24 @@ func (s *DescribeDeliveryStreamInput) Validate() error {
 	return nil
 }
 
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *DescribeDeliveryStreamInput) SetDeliveryStreamName(v string) *DescribeDeliveryStreamInput {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetExclusiveStartDestinationId sets the ExclusiveStartDestinationId field's value.
+func (s *DescribeDeliveryStreamInput) SetExclusiveStartDestinationId(v string) *DescribeDeliveryStreamInput {
+	s.ExclusiveStartDestinationId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeDeliveryStreamInput) SetLimit(v int64) *DescribeDeliveryStreamInput {
+	s.Limit = &v
+	return s
+}
+
 // Contains the output of DescribeDeliveryStream.
 type DescribeDeliveryStreamOutput struct {
 	_ struct{} `type:"structure"`
@@ -1069,6 +1219,12 @@ func (s DescribeDeliveryStreamOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDeliveryStreamOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeliveryStreamDescription sets the DeliveryStreamDescription field's value.
+func (s *DescribeDeliveryStreamOutput) SetDeliveryStreamDescription(v *DeliveryStreamDescription) *DescribeDeliveryStreamOutput {
+	s.DeliveryStreamDescription = v
+	return s
 }
 
 // Describes the destination for a delivery stream.
@@ -1098,6 +1254,30 @@ func (s DestinationDescription) String() string {
 // GoString returns the string representation
 func (s DestinationDescription) GoString() string {
 	return s.String()
+}
+
+// SetDestinationId sets the DestinationId field's value.
+func (s *DestinationDescription) SetDestinationId(v string) *DestinationDescription {
+	s.DestinationId = &v
+	return s
+}
+
+// SetElasticsearchDestinationDescription sets the ElasticsearchDestinationDescription field's value.
+func (s *DestinationDescription) SetElasticsearchDestinationDescription(v *ElasticsearchDestinationDescription) *DestinationDescription {
+	s.ElasticsearchDestinationDescription = v
+	return s
+}
+
+// SetRedshiftDestinationDescription sets the RedshiftDestinationDescription field's value.
+func (s *DestinationDescription) SetRedshiftDestinationDescription(v *RedshiftDestinationDescription) *DestinationDescription {
+	s.RedshiftDestinationDescription = v
+	return s
+}
+
+// SetS3DestinationDescription sets the S3DestinationDescription field's value.
+func (s *DestinationDescription) SetS3DestinationDescription(v *S3DestinationDescription) *DestinationDescription {
+	s.S3DestinationDescription = v
+	return s
 }
 
 // Describes the buffering to perform before delivering data to the Amazon ES
@@ -1142,6 +1322,18 @@ func (s *ElasticsearchBufferingHints) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIntervalInSeconds sets the IntervalInSeconds field's value.
+func (s *ElasticsearchBufferingHints) SetIntervalInSeconds(v int64) *ElasticsearchBufferingHints {
+	s.IntervalInSeconds = &v
+	return s
+}
+
+// SetSizeInMBs sets the SizeInMBs field's value.
+func (s *ElasticsearchBufferingHints) SetSizeInMBs(v int64) *ElasticsearchBufferingHints {
+	s.SizeInMBs = &v
+	return s
 }
 
 // Describes the configuration of a destination in Amazon ES.
@@ -1262,6 +1454,66 @@ func (s *ElasticsearchDestinationConfiguration) Validate() error {
 	return nil
 }
 
+// SetBufferingHints sets the BufferingHints field's value.
+func (s *ElasticsearchDestinationConfiguration) SetBufferingHints(v *ElasticsearchBufferingHints) *ElasticsearchDestinationConfiguration {
+	s.BufferingHints = v
+	return s
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *ElasticsearchDestinationConfiguration) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *ElasticsearchDestinationConfiguration {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetDomainARN sets the DomainARN field's value.
+func (s *ElasticsearchDestinationConfiguration) SetDomainARN(v string) *ElasticsearchDestinationConfiguration {
+	s.DomainARN = &v
+	return s
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *ElasticsearchDestinationConfiguration) SetIndexName(v string) *ElasticsearchDestinationConfiguration {
+	s.IndexName = &v
+	return s
+}
+
+// SetIndexRotationPeriod sets the IndexRotationPeriod field's value.
+func (s *ElasticsearchDestinationConfiguration) SetIndexRotationPeriod(v string) *ElasticsearchDestinationConfiguration {
+	s.IndexRotationPeriod = &v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *ElasticsearchDestinationConfiguration) SetRetryOptions(v *ElasticsearchRetryOptions) *ElasticsearchDestinationConfiguration {
+	s.RetryOptions = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *ElasticsearchDestinationConfiguration) SetRoleARN(v string) *ElasticsearchDestinationConfiguration {
+	s.RoleARN = &v
+	return s
+}
+
+// SetS3BackupMode sets the S3BackupMode field's value.
+func (s *ElasticsearchDestinationConfiguration) SetS3BackupMode(v string) *ElasticsearchDestinationConfiguration {
+	s.S3BackupMode = &v
+	return s
+}
+
+// SetS3Configuration sets the S3Configuration field's value.
+func (s *ElasticsearchDestinationConfiguration) SetS3Configuration(v *S3DestinationConfiguration) *ElasticsearchDestinationConfiguration {
+	s.S3Configuration = v
+	return s
+}
+
+// SetTypeName sets the TypeName field's value.
+func (s *ElasticsearchDestinationConfiguration) SetTypeName(v string) *ElasticsearchDestinationConfiguration {
+	s.TypeName = &v
+	return s
+}
+
 // The destination description in Amazon ES.
 type ElasticsearchDestinationDescription struct {
 	_ struct{} `type:"structure"`
@@ -1305,6 +1557,66 @@ func (s ElasticsearchDestinationDescription) String() string {
 // GoString returns the string representation
 func (s ElasticsearchDestinationDescription) GoString() string {
 	return s.String()
+}
+
+// SetBufferingHints sets the BufferingHints field's value.
+func (s *ElasticsearchDestinationDescription) SetBufferingHints(v *ElasticsearchBufferingHints) *ElasticsearchDestinationDescription {
+	s.BufferingHints = v
+	return s
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *ElasticsearchDestinationDescription) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *ElasticsearchDestinationDescription {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetDomainARN sets the DomainARN field's value.
+func (s *ElasticsearchDestinationDescription) SetDomainARN(v string) *ElasticsearchDestinationDescription {
+	s.DomainARN = &v
+	return s
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *ElasticsearchDestinationDescription) SetIndexName(v string) *ElasticsearchDestinationDescription {
+	s.IndexName = &v
+	return s
+}
+
+// SetIndexRotationPeriod sets the IndexRotationPeriod field's value.
+func (s *ElasticsearchDestinationDescription) SetIndexRotationPeriod(v string) *ElasticsearchDestinationDescription {
+	s.IndexRotationPeriod = &v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *ElasticsearchDestinationDescription) SetRetryOptions(v *ElasticsearchRetryOptions) *ElasticsearchDestinationDescription {
+	s.RetryOptions = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *ElasticsearchDestinationDescription) SetRoleARN(v string) *ElasticsearchDestinationDescription {
+	s.RoleARN = &v
+	return s
+}
+
+// SetS3BackupMode sets the S3BackupMode field's value.
+func (s *ElasticsearchDestinationDescription) SetS3BackupMode(v string) *ElasticsearchDestinationDescription {
+	s.S3BackupMode = &v
+	return s
+}
+
+// SetS3DestinationDescription sets the S3DestinationDescription field's value.
+func (s *ElasticsearchDestinationDescription) SetS3DestinationDescription(v *S3DestinationDescription) *ElasticsearchDestinationDescription {
+	s.S3DestinationDescription = v
+	return s
+}
+
+// SetTypeName sets the TypeName field's value.
+func (s *ElasticsearchDestinationDescription) SetTypeName(v string) *ElasticsearchDestinationDescription {
+	s.TypeName = &v
+	return s
 }
 
 // Describes an update for a destination in Amazon ES.
@@ -1390,6 +1702,60 @@ func (s *ElasticsearchDestinationUpdate) Validate() error {
 	return nil
 }
 
+// SetBufferingHints sets the BufferingHints field's value.
+func (s *ElasticsearchDestinationUpdate) SetBufferingHints(v *ElasticsearchBufferingHints) *ElasticsearchDestinationUpdate {
+	s.BufferingHints = v
+	return s
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *ElasticsearchDestinationUpdate) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *ElasticsearchDestinationUpdate {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetDomainARN sets the DomainARN field's value.
+func (s *ElasticsearchDestinationUpdate) SetDomainARN(v string) *ElasticsearchDestinationUpdate {
+	s.DomainARN = &v
+	return s
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *ElasticsearchDestinationUpdate) SetIndexName(v string) *ElasticsearchDestinationUpdate {
+	s.IndexName = &v
+	return s
+}
+
+// SetIndexRotationPeriod sets the IndexRotationPeriod field's value.
+func (s *ElasticsearchDestinationUpdate) SetIndexRotationPeriod(v string) *ElasticsearchDestinationUpdate {
+	s.IndexRotationPeriod = &v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *ElasticsearchDestinationUpdate) SetRetryOptions(v *ElasticsearchRetryOptions) *ElasticsearchDestinationUpdate {
+	s.RetryOptions = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *ElasticsearchDestinationUpdate) SetRoleARN(v string) *ElasticsearchDestinationUpdate {
+	s.RoleARN = &v
+	return s
+}
+
+// SetS3Update sets the S3Update field's value.
+func (s *ElasticsearchDestinationUpdate) SetS3Update(v *S3DestinationUpdate) *ElasticsearchDestinationUpdate {
+	s.S3Update = v
+	return s
+}
+
+// SetTypeName sets the TypeName field's value.
+func (s *ElasticsearchDestinationUpdate) SetTypeName(v string) *ElasticsearchDestinationUpdate {
+	s.TypeName = &v
+	return s
+}
+
 // Configures retry behavior in the event that Firehose is unable to deliver
 // documents to Amazon ES.
 type ElasticsearchRetryOptions struct {
@@ -1411,6 +1777,12 @@ func (s ElasticsearchRetryOptions) String() string {
 // GoString returns the string representation
 func (s ElasticsearchRetryOptions) GoString() string {
 	return s.String()
+}
+
+// SetDurationInSeconds sets the DurationInSeconds field's value.
+func (s *ElasticsearchRetryOptions) SetDurationInSeconds(v int64) *ElasticsearchRetryOptions {
+	s.DurationInSeconds = &v
+	return s
 }
 
 // Describes the encryption for a destination in Amazon S3.
@@ -1450,6 +1822,18 @@ func (s *EncryptionConfiguration) Validate() error {
 	return nil
 }
 
+// SetKMSEncryptionConfig sets the KMSEncryptionConfig field's value.
+func (s *EncryptionConfiguration) SetKMSEncryptionConfig(v *KMSEncryptionConfig) *EncryptionConfiguration {
+	s.KMSEncryptionConfig = v
+	return s
+}
+
+// SetNoEncryptionConfig sets the NoEncryptionConfig field's value.
+func (s *EncryptionConfiguration) SetNoEncryptionConfig(v string) *EncryptionConfiguration {
+	s.NoEncryptionConfig = &v
+	return s
+}
+
 // Describes an encryption key for a destination in Amazon S3.
 type KMSEncryptionConfig struct {
 	_ struct{} `type:"structure"`
@@ -1485,6 +1869,12 @@ func (s *KMSEncryptionConfig) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAWSKMSKeyARN sets the AWSKMSKeyARN field's value.
+func (s *KMSEncryptionConfig) SetAWSKMSKeyARN(v string) *KMSEncryptionConfig {
+	s.AWSKMSKeyARN = &v
+	return s
 }
 
 // Contains the parameters for ListDeliveryStreams.
@@ -1524,6 +1914,18 @@ func (s *ListDeliveryStreamsInput) Validate() error {
 	return nil
 }
 
+// SetExclusiveStartDeliveryStreamName sets the ExclusiveStartDeliveryStreamName field's value.
+func (s *ListDeliveryStreamsInput) SetExclusiveStartDeliveryStreamName(v string) *ListDeliveryStreamsInput {
+	s.ExclusiveStartDeliveryStreamName = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListDeliveryStreamsInput) SetLimit(v int64) *ListDeliveryStreamsInput {
+	s.Limit = &v
+	return s
+}
+
 // Contains the output of ListDeliveryStreams.
 type ListDeliveryStreamsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1547,6 +1949,18 @@ func (s ListDeliveryStreamsOutput) String() string {
 // GoString returns the string representation
 func (s ListDeliveryStreamsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeliveryStreamNames sets the DeliveryStreamNames field's value.
+func (s *ListDeliveryStreamsOutput) SetDeliveryStreamNames(v []*string) *ListDeliveryStreamsOutput {
+	s.DeliveryStreamNames = v
+	return s
+}
+
+// SetHasMoreDeliveryStreams sets the HasMoreDeliveryStreams field's value.
+func (s *ListDeliveryStreamsOutput) SetHasMoreDeliveryStreams(v bool) *ListDeliveryStreamsOutput {
+	s.HasMoreDeliveryStreams = &v
+	return s
 }
 
 // Contains the parameters for PutRecordBatch.
@@ -1606,6 +2020,18 @@ func (s *PutRecordBatchInput) Validate() error {
 	return nil
 }
 
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *PutRecordBatchInput) SetDeliveryStreamName(v string) *PutRecordBatchInput {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetRecords sets the Records field's value.
+func (s *PutRecordBatchInput) SetRecords(v []*Record) *PutRecordBatchInput {
+	s.Records = v
+	return s
+}
+
 // Contains the output of PutRecordBatch.
 type PutRecordBatchOutput struct {
 	_ struct{} `type:"structure"`
@@ -1630,6 +2056,18 @@ func (s PutRecordBatchOutput) String() string {
 // GoString returns the string representation
 func (s PutRecordBatchOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedPutCount sets the FailedPutCount field's value.
+func (s *PutRecordBatchOutput) SetFailedPutCount(v int64) *PutRecordBatchOutput {
+	s.FailedPutCount = &v
+	return s
+}
+
+// SetRequestResponses sets the RequestResponses field's value.
+func (s *PutRecordBatchOutput) SetRequestResponses(v []*PutRecordBatchResponseEntry) *PutRecordBatchOutput {
+	s.RequestResponses = v
+	return s
 }
 
 // Contains the result for an individual record from a PutRecordBatch request.
@@ -1657,6 +2095,24 @@ func (s PutRecordBatchResponseEntry) String() string {
 // GoString returns the string representation
 func (s PutRecordBatchResponseEntry) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *PutRecordBatchResponseEntry) SetErrorCode(v string) *PutRecordBatchResponseEntry {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *PutRecordBatchResponseEntry) SetErrorMessage(v string) *PutRecordBatchResponseEntry {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetRecordId sets the RecordId field's value.
+func (s *PutRecordBatchResponseEntry) SetRecordId(v string) *PutRecordBatchResponseEntry {
+	s.RecordId = &v
+	return s
 }
 
 // Contains the parameters for PutRecord.
@@ -1708,6 +2164,18 @@ func (s *PutRecordInput) Validate() error {
 	return nil
 }
 
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *PutRecordInput) SetDeliveryStreamName(v string) *PutRecordInput {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetRecord sets the Record field's value.
+func (s *PutRecordInput) SetRecord(v *Record) *PutRecordInput {
+	s.Record = v
+	return s
+}
+
 // Contains the output of PutRecord.
 type PutRecordOutput struct {
 	_ struct{} `type:"structure"`
@@ -1726,6 +2194,12 @@ func (s PutRecordOutput) String() string {
 // GoString returns the string representation
 func (s PutRecordOutput) GoString() string {
 	return s.String()
+}
+
+// SetRecordId sets the RecordId field's value.
+func (s *PutRecordOutput) SetRecordId(v string) *PutRecordOutput {
+	s.RecordId = &v
+	return s
 }
 
 // The unit of data in a delivery stream.
@@ -1762,6 +2236,12 @@ func (s *Record) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetData sets the Data field's value.
+func (s *Record) SetData(v []byte) *Record {
+	s.Data = v
+	return s
 }
 
 // Describes the configuration of a destination in Amazon Redshift.
@@ -1871,6 +2351,54 @@ func (s *RedshiftDestinationConfiguration) Validate() error {
 	return nil
 }
 
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *RedshiftDestinationConfiguration) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *RedshiftDestinationConfiguration {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetClusterJDBCURL sets the ClusterJDBCURL field's value.
+func (s *RedshiftDestinationConfiguration) SetClusterJDBCURL(v string) *RedshiftDestinationConfiguration {
+	s.ClusterJDBCURL = &v
+	return s
+}
+
+// SetCopyCommand sets the CopyCommand field's value.
+func (s *RedshiftDestinationConfiguration) SetCopyCommand(v *CopyCommand) *RedshiftDestinationConfiguration {
+	s.CopyCommand = v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *RedshiftDestinationConfiguration) SetPassword(v string) *RedshiftDestinationConfiguration {
+	s.Password = &v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *RedshiftDestinationConfiguration) SetRetryOptions(v *RedshiftRetryOptions) *RedshiftDestinationConfiguration {
+	s.RetryOptions = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *RedshiftDestinationConfiguration) SetRoleARN(v string) *RedshiftDestinationConfiguration {
+	s.RoleARN = &v
+	return s
+}
+
+// SetS3Configuration sets the S3Configuration field's value.
+func (s *RedshiftDestinationConfiguration) SetS3Configuration(v *S3DestinationConfiguration) *RedshiftDestinationConfiguration {
+	s.S3Configuration = v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *RedshiftDestinationConfiguration) SetUsername(v string) *RedshiftDestinationConfiguration {
+	s.Username = &v
+	return s
+}
+
 // Describes a destination in Amazon Redshift.
 type RedshiftDestinationDescription struct {
 	_ struct{} `type:"structure"`
@@ -1916,6 +2444,48 @@ func (s RedshiftDestinationDescription) String() string {
 // GoString returns the string representation
 func (s RedshiftDestinationDescription) GoString() string {
 	return s.String()
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *RedshiftDestinationDescription) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *RedshiftDestinationDescription {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetClusterJDBCURL sets the ClusterJDBCURL field's value.
+func (s *RedshiftDestinationDescription) SetClusterJDBCURL(v string) *RedshiftDestinationDescription {
+	s.ClusterJDBCURL = &v
+	return s
+}
+
+// SetCopyCommand sets the CopyCommand field's value.
+func (s *RedshiftDestinationDescription) SetCopyCommand(v *CopyCommand) *RedshiftDestinationDescription {
+	s.CopyCommand = v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *RedshiftDestinationDescription) SetRetryOptions(v *RedshiftRetryOptions) *RedshiftDestinationDescription {
+	s.RetryOptions = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *RedshiftDestinationDescription) SetRoleARN(v string) *RedshiftDestinationDescription {
+	s.RoleARN = &v
+	return s
+}
+
+// SetS3DestinationDescription sets the S3DestinationDescription field's value.
+func (s *RedshiftDestinationDescription) SetS3DestinationDescription(v *S3DestinationDescription) *RedshiftDestinationDescription {
+	s.S3DestinationDescription = v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *RedshiftDestinationDescription) SetUsername(v string) *RedshiftDestinationDescription {
+	s.Username = &v
+	return s
 }
 
 // Describes an update for a destination in Amazon Redshift.
@@ -1994,6 +2564,54 @@ func (s *RedshiftDestinationUpdate) Validate() error {
 	return nil
 }
 
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *RedshiftDestinationUpdate) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *RedshiftDestinationUpdate {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetClusterJDBCURL sets the ClusterJDBCURL field's value.
+func (s *RedshiftDestinationUpdate) SetClusterJDBCURL(v string) *RedshiftDestinationUpdate {
+	s.ClusterJDBCURL = &v
+	return s
+}
+
+// SetCopyCommand sets the CopyCommand field's value.
+func (s *RedshiftDestinationUpdate) SetCopyCommand(v *CopyCommand) *RedshiftDestinationUpdate {
+	s.CopyCommand = v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *RedshiftDestinationUpdate) SetPassword(v string) *RedshiftDestinationUpdate {
+	s.Password = &v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *RedshiftDestinationUpdate) SetRetryOptions(v *RedshiftRetryOptions) *RedshiftDestinationUpdate {
+	s.RetryOptions = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *RedshiftDestinationUpdate) SetRoleARN(v string) *RedshiftDestinationUpdate {
+	s.RoleARN = &v
+	return s
+}
+
+// SetS3Update sets the S3Update field's value.
+func (s *RedshiftDestinationUpdate) SetS3Update(v *S3DestinationUpdate) *RedshiftDestinationUpdate {
+	s.S3Update = v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *RedshiftDestinationUpdate) SetUsername(v string) *RedshiftDestinationUpdate {
+	s.Username = &v
+	return s
+}
+
 // Configures retry behavior in the event that Firehose is unable to deliver
 // documents to Amazon Redshift.
 type RedshiftRetryOptions struct {
@@ -2015,6 +2633,12 @@ func (s RedshiftRetryOptions) String() string {
 // GoString returns the string representation
 func (s RedshiftRetryOptions) GoString() string {
 	return s.String()
+}
+
+// SetDurationInSeconds sets the DurationInSeconds field's value.
+func (s *RedshiftRetryOptions) SetDurationInSeconds(v int64) *RedshiftRetryOptions {
+	s.DurationInSeconds = &v
+	return s
 }
 
 // Describes the configuration of a destination in Amazon S3.
@@ -2100,6 +2724,48 @@ func (s *S3DestinationConfiguration) Validate() error {
 	return nil
 }
 
+// SetBucketARN sets the BucketARN field's value.
+func (s *S3DestinationConfiguration) SetBucketARN(v string) *S3DestinationConfiguration {
+	s.BucketARN = &v
+	return s
+}
+
+// SetBufferingHints sets the BufferingHints field's value.
+func (s *S3DestinationConfiguration) SetBufferingHints(v *BufferingHints) *S3DestinationConfiguration {
+	s.BufferingHints = v
+	return s
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *S3DestinationConfiguration) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *S3DestinationConfiguration {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetCompressionFormat sets the CompressionFormat field's value.
+func (s *S3DestinationConfiguration) SetCompressionFormat(v string) *S3DestinationConfiguration {
+	s.CompressionFormat = &v
+	return s
+}
+
+// SetEncryptionConfiguration sets the EncryptionConfiguration field's value.
+func (s *S3DestinationConfiguration) SetEncryptionConfiguration(v *EncryptionConfiguration) *S3DestinationConfiguration {
+	s.EncryptionConfiguration = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *S3DestinationConfiguration) SetPrefix(v string) *S3DestinationConfiguration {
+	s.Prefix = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *S3DestinationConfiguration) SetRoleARN(v string) *S3DestinationConfiguration {
+	s.RoleARN = &v
+	return s
+}
+
 // Describes a destination in Amazon S3.
 type S3DestinationDescription struct {
 	_ struct{} `type:"structure"`
@@ -2151,6 +2817,48 @@ func (s S3DestinationDescription) String() string {
 // GoString returns the string representation
 func (s S3DestinationDescription) GoString() string {
 	return s.String()
+}
+
+// SetBucketARN sets the BucketARN field's value.
+func (s *S3DestinationDescription) SetBucketARN(v string) *S3DestinationDescription {
+	s.BucketARN = &v
+	return s
+}
+
+// SetBufferingHints sets the BufferingHints field's value.
+func (s *S3DestinationDescription) SetBufferingHints(v *BufferingHints) *S3DestinationDescription {
+	s.BufferingHints = v
+	return s
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *S3DestinationDescription) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *S3DestinationDescription {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetCompressionFormat sets the CompressionFormat field's value.
+func (s *S3DestinationDescription) SetCompressionFormat(v string) *S3DestinationDescription {
+	s.CompressionFormat = &v
+	return s
+}
+
+// SetEncryptionConfiguration sets the EncryptionConfiguration field's value.
+func (s *S3DestinationDescription) SetEncryptionConfiguration(v *EncryptionConfiguration) *S3DestinationDescription {
+	s.EncryptionConfiguration = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *S3DestinationDescription) SetPrefix(v string) *S3DestinationDescription {
+	s.Prefix = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *S3DestinationDescription) SetRoleARN(v string) *S3DestinationDescription {
+	s.RoleARN = &v
+	return s
 }
 
 // Describes an update for a destination in Amazon S3.
@@ -2224,6 +2932,48 @@ func (s *S3DestinationUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucketARN sets the BucketARN field's value.
+func (s *S3DestinationUpdate) SetBucketARN(v string) *S3DestinationUpdate {
+	s.BucketARN = &v
+	return s
+}
+
+// SetBufferingHints sets the BufferingHints field's value.
+func (s *S3DestinationUpdate) SetBufferingHints(v *BufferingHints) *S3DestinationUpdate {
+	s.BufferingHints = v
+	return s
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *S3DestinationUpdate) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *S3DestinationUpdate {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetCompressionFormat sets the CompressionFormat field's value.
+func (s *S3DestinationUpdate) SetCompressionFormat(v string) *S3DestinationUpdate {
+	s.CompressionFormat = &v
+	return s
+}
+
+// SetEncryptionConfiguration sets the EncryptionConfiguration field's value.
+func (s *S3DestinationUpdate) SetEncryptionConfiguration(v *EncryptionConfiguration) *S3DestinationUpdate {
+	s.EncryptionConfiguration = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *S3DestinationUpdate) SetPrefix(v string) *S3DestinationUpdate {
+	s.Prefix = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *S3DestinationUpdate) SetRoleARN(v string) *S3DestinationUpdate {
+	s.RoleARN = &v
+	return s
 }
 
 // Contains the parameters for UpdateDestination.
@@ -2311,6 +3061,42 @@ func (s *UpdateDestinationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCurrentDeliveryStreamVersionId sets the CurrentDeliveryStreamVersionId field's value.
+func (s *UpdateDestinationInput) SetCurrentDeliveryStreamVersionId(v string) *UpdateDestinationInput {
+	s.CurrentDeliveryStreamVersionId = &v
+	return s
+}
+
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *UpdateDestinationInput) SetDeliveryStreamName(v string) *UpdateDestinationInput {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetDestinationId sets the DestinationId field's value.
+func (s *UpdateDestinationInput) SetDestinationId(v string) *UpdateDestinationInput {
+	s.DestinationId = &v
+	return s
+}
+
+// SetElasticsearchDestinationUpdate sets the ElasticsearchDestinationUpdate field's value.
+func (s *UpdateDestinationInput) SetElasticsearchDestinationUpdate(v *ElasticsearchDestinationUpdate) *UpdateDestinationInput {
+	s.ElasticsearchDestinationUpdate = v
+	return s
+}
+
+// SetRedshiftDestinationUpdate sets the RedshiftDestinationUpdate field's value.
+func (s *UpdateDestinationInput) SetRedshiftDestinationUpdate(v *RedshiftDestinationUpdate) *UpdateDestinationInput {
+	s.RedshiftDestinationUpdate = v
+	return s
+}
+
+// SetS3DestinationUpdate sets the S3DestinationUpdate field's value.
+func (s *UpdateDestinationInput) SetS3DestinationUpdate(v *S3DestinationUpdate) *UpdateDestinationInput {
+	s.S3DestinationUpdate = v
+	return s
 }
 
 // Contains the output of UpdateDestination.

--- a/service/gamelift/api.go
+++ b/service/gamelift/api.go
@@ -3566,6 +3566,42 @@ func (s Alias) GoString() string {
 	return s.String()
 }
 
+// SetAliasId sets the AliasId field's value.
+func (s *Alias) SetAliasId(v string) *Alias {
+	s.AliasId = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *Alias) SetCreationTime(v time.Time) *Alias {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Alias) SetDescription(v string) *Alias {
+	s.Description = &v
+	return s
+}
+
+// SetLastUpdatedTime sets the LastUpdatedTime field's value.
+func (s *Alias) SetLastUpdatedTime(v time.Time) *Alias {
+	s.LastUpdatedTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Alias) SetName(v string) *Alias {
+	s.Name = &v
+	return s
+}
+
+// SetRoutingStrategy sets the RoutingStrategy field's value.
+func (s *Alias) SetRoutingStrategy(v *RoutingStrategy) *Alias {
+	s.RoutingStrategy = v
+	return s
+}
+
 // AWS access credentials required to upload game build files to Amazon GameLift.
 // These credentials are generated with CreateBuild, and are valid for a limited
 // time. If they expire before you upload your game build, get a new set by
@@ -3591,6 +3627,24 @@ func (s AwsCredentials) String() string {
 // GoString returns the string representation
 func (s AwsCredentials) GoString() string {
 	return s.String()
+}
+
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *AwsCredentials) SetAccessKeyId(v string) *AwsCredentials {
+	s.AccessKeyId = &v
+	return s
+}
+
+// SetSecretAccessKey sets the SecretAccessKey field's value.
+func (s *AwsCredentials) SetSecretAccessKey(v string) *AwsCredentials {
+	s.SecretAccessKey = &v
+	return s
+}
+
+// SetSessionToken sets the SessionToken field's value.
+func (s *AwsCredentials) SetSessionToken(v string) *AwsCredentials {
+	s.SessionToken = &v
+	return s
 }
 
 // Properties describing a game build.
@@ -3646,6 +3700,48 @@ func (s Build) GoString() string {
 	return s.String()
 }
 
+// SetBuildId sets the BuildId field's value.
+func (s *Build) SetBuildId(v string) *Build {
+	s.BuildId = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *Build) SetCreationTime(v time.Time) *Build {
+	s.CreationTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Build) SetName(v string) *Build {
+	s.Name = &v
+	return s
+}
+
+// SetOperatingSystem sets the OperatingSystem field's value.
+func (s *Build) SetOperatingSystem(v string) *Build {
+	s.OperatingSystem = &v
+	return s
+}
+
+// SetSizeOnDisk sets the SizeOnDisk field's value.
+func (s *Build) SetSizeOnDisk(v int64) *Build {
+	s.SizeOnDisk = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Build) SetStatus(v string) *Build {
+	s.Status = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *Build) SetVersion(v string) *Build {
+	s.Version = &v
+	return s
+}
+
 // Represents the input for a request action.
 type CreateAliasInput struct {
 	_ struct{} `type:"structure"`
@@ -3697,6 +3793,24 @@ func (s *CreateAliasInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateAliasInput) SetDescription(v string) *CreateAliasInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateAliasInput) SetName(v string) *CreateAliasInput {
+	s.Name = &v
+	return s
+}
+
+// SetRoutingStrategy sets the RoutingStrategy field's value.
+func (s *CreateAliasInput) SetRoutingStrategy(v *RoutingStrategy) *CreateAliasInput {
+	s.RoutingStrategy = v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type CreateAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -3713,6 +3827,12 @@ func (s CreateAliasOutput) String() string {
 // GoString returns the string representation
 func (s CreateAliasOutput) GoString() string {
 	return s.String()
+}
+
+// SetAlias sets the Alias field's value.
+func (s *CreateAliasOutput) SetAlias(v *Alias) *CreateAliasOutput {
+	s.Alias = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -3769,6 +3889,30 @@ func (s *CreateBuildInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *CreateBuildInput) SetName(v string) *CreateBuildInput {
+	s.Name = &v
+	return s
+}
+
+// SetOperatingSystem sets the OperatingSystem field's value.
+func (s *CreateBuildInput) SetOperatingSystem(v string) *CreateBuildInput {
+	s.OperatingSystem = &v
+	return s
+}
+
+// SetStorageLocation sets the StorageLocation field's value.
+func (s *CreateBuildInput) SetStorageLocation(v *S3Location) *CreateBuildInput {
+	s.StorageLocation = v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *CreateBuildInput) SetVersion(v string) *CreateBuildInput {
+	s.Version = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type CreateBuildOutput struct {
 	_ struct{} `type:"structure"`
@@ -3793,6 +3937,24 @@ func (s CreateBuildOutput) String() string {
 // GoString returns the string representation
 func (s CreateBuildOutput) GoString() string {
 	return s.String()
+}
+
+// SetBuild sets the Build field's value.
+func (s *CreateBuildOutput) SetBuild(v *Build) *CreateBuildOutput {
+	s.Build = v
+	return s
+}
+
+// SetStorageLocation sets the StorageLocation field's value.
+func (s *CreateBuildOutput) SetStorageLocation(v *S3Location) *CreateBuildOutput {
+	s.StorageLocation = v
+	return s
+}
+
+// SetUploadCredentials sets the UploadCredentials field's value.
+func (s *CreateBuildOutput) SetUploadCredentials(v *AwsCredentials) *CreateBuildOutput {
+	s.UploadCredentials = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -3939,6 +4101,72 @@ func (s *CreateFleetInput) Validate() error {
 	return nil
 }
 
+// SetBuildId sets the BuildId field's value.
+func (s *CreateFleetInput) SetBuildId(v string) *CreateFleetInput {
+	s.BuildId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateFleetInput) SetDescription(v string) *CreateFleetInput {
+	s.Description = &v
+	return s
+}
+
+// SetEC2InboundPermissions sets the EC2InboundPermissions field's value.
+func (s *CreateFleetInput) SetEC2InboundPermissions(v []*IpPermission) *CreateFleetInput {
+	s.EC2InboundPermissions = v
+	return s
+}
+
+// SetEC2InstanceType sets the EC2InstanceType field's value.
+func (s *CreateFleetInput) SetEC2InstanceType(v string) *CreateFleetInput {
+	s.EC2InstanceType = &v
+	return s
+}
+
+// SetLogPaths sets the LogPaths field's value.
+func (s *CreateFleetInput) SetLogPaths(v []*string) *CreateFleetInput {
+	s.LogPaths = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateFleetInput) SetName(v string) *CreateFleetInput {
+	s.Name = &v
+	return s
+}
+
+// SetNewGameSessionProtectionPolicy sets the NewGameSessionProtectionPolicy field's value.
+func (s *CreateFleetInput) SetNewGameSessionProtectionPolicy(v string) *CreateFleetInput {
+	s.NewGameSessionProtectionPolicy = &v
+	return s
+}
+
+// SetResourceCreationLimitPolicy sets the ResourceCreationLimitPolicy field's value.
+func (s *CreateFleetInput) SetResourceCreationLimitPolicy(v *ResourceCreationLimitPolicy) *CreateFleetInput {
+	s.ResourceCreationLimitPolicy = v
+	return s
+}
+
+// SetRuntimeConfiguration sets the RuntimeConfiguration field's value.
+func (s *CreateFleetInput) SetRuntimeConfiguration(v *RuntimeConfiguration) *CreateFleetInput {
+	s.RuntimeConfiguration = v
+	return s
+}
+
+// SetServerLaunchParameters sets the ServerLaunchParameters field's value.
+func (s *CreateFleetInput) SetServerLaunchParameters(v string) *CreateFleetInput {
+	s.ServerLaunchParameters = &v
+	return s
+}
+
+// SetServerLaunchPath sets the ServerLaunchPath field's value.
+func (s *CreateFleetInput) SetServerLaunchPath(v string) *CreateFleetInput {
+	s.ServerLaunchPath = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type CreateFleetOutput struct {
 	_ struct{} `type:"structure"`
@@ -3955,6 +4183,12 @@ func (s CreateFleetOutput) String() string {
 // GoString returns the string representation
 func (s CreateFleetOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetAttributes sets the FleetAttributes field's value.
+func (s *CreateFleetOutput) SetFleetAttributes(v *FleetAttributes) *CreateFleetOutput {
+	s.FleetAttributes = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4040,6 +4274,48 @@ func (s *CreateGameSessionInput) Validate() error {
 	return nil
 }
 
+// SetAliasId sets the AliasId field's value.
+func (s *CreateGameSessionInput) SetAliasId(v string) *CreateGameSessionInput {
+	s.AliasId = &v
+	return s
+}
+
+// SetCreatorId sets the CreatorId field's value.
+func (s *CreateGameSessionInput) SetCreatorId(v string) *CreateGameSessionInput {
+	s.CreatorId = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *CreateGameSessionInput) SetFleetId(v string) *CreateGameSessionInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetGameProperties sets the GameProperties field's value.
+func (s *CreateGameSessionInput) SetGameProperties(v []*GameProperty) *CreateGameSessionInput {
+	s.GameProperties = v
+	return s
+}
+
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *CreateGameSessionInput) SetGameSessionId(v string) *CreateGameSessionInput {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetMaximumPlayerSessionCount sets the MaximumPlayerSessionCount field's value.
+func (s *CreateGameSessionInput) SetMaximumPlayerSessionCount(v int64) *CreateGameSessionInput {
+	s.MaximumPlayerSessionCount = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateGameSessionInput) SetName(v string) *CreateGameSessionInput {
+	s.Name = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type CreateGameSessionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4056,6 +4332,12 @@ func (s CreateGameSessionOutput) String() string {
 // GoString returns the string representation
 func (s CreateGameSessionOutput) GoString() string {
 	return s.String()
+}
+
+// SetGameSession sets the GameSession field's value.
+func (s *CreateGameSessionOutput) SetGameSession(v *GameSession) *CreateGameSessionOutput {
+	s.GameSession = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4108,6 +4390,18 @@ func (s *CreatePlayerSessionInput) Validate() error {
 	return nil
 }
 
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *CreatePlayerSessionInput) SetGameSessionId(v string) *CreatePlayerSessionInput {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetPlayerId sets the PlayerId field's value.
+func (s *CreatePlayerSessionInput) SetPlayerId(v string) *CreatePlayerSessionInput {
+	s.PlayerId = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type CreatePlayerSessionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4124,6 +4418,12 @@ func (s CreatePlayerSessionOutput) String() string {
 // GoString returns the string representation
 func (s CreatePlayerSessionOutput) GoString() string {
 	return s.String()
+}
+
+// SetPlayerSession sets the PlayerSession field's value.
+func (s *CreatePlayerSessionOutput) SetPlayerSession(v *PlayerSession) *CreatePlayerSessionOutput {
+	s.PlayerSession = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4176,6 +4476,18 @@ func (s *CreatePlayerSessionsInput) Validate() error {
 	return nil
 }
 
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *CreatePlayerSessionsInput) SetGameSessionId(v string) *CreatePlayerSessionsInput {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetPlayerIds sets the PlayerIds field's value.
+func (s *CreatePlayerSessionsInput) SetPlayerIds(v []*string) *CreatePlayerSessionsInput {
+	s.PlayerIds = v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type CreatePlayerSessionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4192,6 +4504,12 @@ func (s CreatePlayerSessionsOutput) String() string {
 // GoString returns the string representation
 func (s CreatePlayerSessionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetPlayerSessions sets the PlayerSessions field's value.
+func (s *CreatePlayerSessionsOutput) SetPlayerSessions(v []*PlayerSession) *CreatePlayerSessionsOutput {
+	s.PlayerSessions = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4225,6 +4543,12 @@ func (s *DeleteAliasInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAliasId sets the AliasId field's value.
+func (s *DeleteAliasInput) SetAliasId(v string) *DeleteAliasInput {
+	s.AliasId = &v
+	return s
 }
 
 type DeleteAliasOutput struct {
@@ -4274,6 +4598,12 @@ func (s *DeleteBuildInput) Validate() error {
 	return nil
 }
 
+// SetBuildId sets the BuildId field's value.
+func (s *DeleteBuildInput) SetBuildId(v string) *DeleteBuildInput {
+	s.BuildId = &v
+	return s
+}
+
 type DeleteBuildOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4319,6 +4649,12 @@ func (s *DeleteFleetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *DeleteFleetInput) SetFleetId(v string) *DeleteFleetInput {
+	s.FleetId = &v
+	return s
 }
 
 type DeleteFleetOutput struct {
@@ -4380,6 +4716,18 @@ func (s *DeleteScalingPolicyInput) Validate() error {
 	return nil
 }
 
+// SetFleetId sets the FleetId field's value.
+func (s *DeleteScalingPolicyInput) SetFleetId(v string) *DeleteScalingPolicyInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteScalingPolicyInput) SetName(v string) *DeleteScalingPolicyInput {
+	s.Name = &v
+	return s
+}
+
 type DeleteScalingPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4427,6 +4775,12 @@ func (s *DescribeAliasInput) Validate() error {
 	return nil
 }
 
+// SetAliasId sets the AliasId field's value.
+func (s *DescribeAliasInput) SetAliasId(v string) *DescribeAliasInput {
+	s.AliasId = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -4443,6 +4797,12 @@ func (s DescribeAliasOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAliasOutput) GoString() string {
 	return s.String()
+}
+
+// SetAlias sets the Alias field's value.
+func (s *DescribeAliasOutput) SetAlias(v *Alias) *DescribeAliasOutput {
+	s.Alias = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4478,6 +4838,12 @@ func (s *DescribeBuildInput) Validate() error {
 	return nil
 }
 
+// SetBuildId sets the BuildId field's value.
+func (s *DescribeBuildInput) SetBuildId(v string) *DescribeBuildInput {
+	s.BuildId = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeBuildOutput struct {
 	_ struct{} `type:"structure"`
@@ -4494,6 +4860,12 @@ func (s DescribeBuildOutput) String() string {
 // GoString returns the string representation
 func (s DescribeBuildOutput) GoString() string {
 	return s.String()
+}
+
+// SetBuild sets the Build field's value.
+func (s *DescribeBuildOutput) SetBuild(v *Build) *DescribeBuildOutput {
+	s.Build = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4519,6 +4891,12 @@ func (s DescribeEC2InstanceLimitsInput) GoString() string {
 	return s.String()
 }
 
+// SetEC2InstanceType sets the EC2InstanceType field's value.
+func (s *DescribeEC2InstanceLimitsInput) SetEC2InstanceType(v string) *DescribeEC2InstanceLimitsInput {
+	s.EC2InstanceType = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeEC2InstanceLimitsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4536,6 +4914,12 @@ func (s DescribeEC2InstanceLimitsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEC2InstanceLimitsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEC2InstanceLimits sets the EC2InstanceLimits field's value.
+func (s *DescribeEC2InstanceLimitsOutput) SetEC2InstanceLimits(v []*EC2InstanceLimit) *DescribeEC2InstanceLimitsOutput {
+	s.EC2InstanceLimits = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4587,6 +4971,24 @@ func (s *DescribeFleetAttributesInput) Validate() error {
 	return nil
 }
 
+// SetFleetIds sets the FleetIds field's value.
+func (s *DescribeFleetAttributesInput) SetFleetIds(v []*string) *DescribeFleetAttributesInput {
+	s.FleetIds = v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeFleetAttributesInput) SetLimit(v int64) *DescribeFleetAttributesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFleetAttributesInput) SetNextToken(v string) *DescribeFleetAttributesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeFleetAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4608,6 +5010,18 @@ func (s DescribeFleetAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeFleetAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetAttributes sets the FleetAttributes field's value.
+func (s *DescribeFleetAttributesOutput) SetFleetAttributes(v []*FleetAttributes) *DescribeFleetAttributesOutput {
+	s.FleetAttributes = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFleetAttributesOutput) SetNextToken(v string) *DescribeFleetAttributesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4660,6 +5074,24 @@ func (s *DescribeFleetCapacityInput) Validate() error {
 	return nil
 }
 
+// SetFleetIds sets the FleetIds field's value.
+func (s *DescribeFleetCapacityInput) SetFleetIds(v []*string) *DescribeFleetCapacityInput {
+	s.FleetIds = v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeFleetCapacityInput) SetLimit(v int64) *DescribeFleetCapacityInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFleetCapacityInput) SetNextToken(v string) *DescribeFleetCapacityInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeFleetCapacityOutput struct {
 	_ struct{} `type:"structure"`
@@ -4682,6 +5114,18 @@ func (s DescribeFleetCapacityOutput) String() string {
 // GoString returns the string representation
 func (s DescribeFleetCapacityOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetCapacity sets the FleetCapacity field's value.
+func (s *DescribeFleetCapacityOutput) SetFleetCapacity(v []*FleetCapacity) *DescribeFleetCapacityOutput {
+	s.FleetCapacity = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFleetCapacityOutput) SetNextToken(v string) *DescribeFleetCapacityOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4743,6 +5187,36 @@ func (s *DescribeFleetEventsInput) Validate() error {
 	return nil
 }
 
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeFleetEventsInput) SetEndTime(v time.Time) *DescribeFleetEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *DescribeFleetEventsInput) SetFleetId(v string) *DescribeFleetEventsInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeFleetEventsInput) SetLimit(v int64) *DescribeFleetEventsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFleetEventsInput) SetNextToken(v string) *DescribeFleetEventsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeFleetEventsInput) SetStartTime(v time.Time) *DescribeFleetEventsInput {
+	s.StartTime = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeFleetEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4763,6 +5237,18 @@ func (s DescribeFleetEventsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeFleetEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *DescribeFleetEventsOutput) SetEvents(v []*Event) *DescribeFleetEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFleetEventsOutput) SetNextToken(v string) *DescribeFleetEventsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4798,6 +5284,12 @@ func (s *DescribeFleetPortSettingsInput) Validate() error {
 	return nil
 }
 
+// SetFleetId sets the FleetId field's value.
+func (s *DescribeFleetPortSettingsInput) SetFleetId(v string) *DescribeFleetPortSettingsInput {
+	s.FleetId = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeFleetPortSettingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4814,6 +5306,12 @@ func (s DescribeFleetPortSettingsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeFleetPortSettingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetInboundPermissions sets the InboundPermissions field's value.
+func (s *DescribeFleetPortSettingsOutput) SetInboundPermissions(v []*IpPermission) *DescribeFleetPortSettingsOutput {
+	s.InboundPermissions = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4865,6 +5363,24 @@ func (s *DescribeFleetUtilizationInput) Validate() error {
 	return nil
 }
 
+// SetFleetIds sets the FleetIds field's value.
+func (s *DescribeFleetUtilizationInput) SetFleetIds(v []*string) *DescribeFleetUtilizationInput {
+	s.FleetIds = v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeFleetUtilizationInput) SetLimit(v int64) *DescribeFleetUtilizationInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFleetUtilizationInput) SetNextToken(v string) *DescribeFleetUtilizationInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeFleetUtilizationOutput struct {
 	_ struct{} `type:"structure"`
@@ -4886,6 +5402,18 @@ func (s DescribeFleetUtilizationOutput) String() string {
 // GoString returns the string representation
 func (s DescribeFleetUtilizationOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetUtilization sets the FleetUtilization field's value.
+func (s *DescribeFleetUtilizationOutput) SetFleetUtilization(v []*FleetUtilization) *DescribeFleetUtilizationOutput {
+	s.FleetUtilization = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeFleetUtilizationOutput) SetNextToken(v string) *DescribeFleetUtilizationOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -4953,6 +5481,42 @@ func (s *DescribeGameSessionDetailsInput) Validate() error {
 	return nil
 }
 
+// SetAliasId sets the AliasId field's value.
+func (s *DescribeGameSessionDetailsInput) SetAliasId(v string) *DescribeGameSessionDetailsInput {
+	s.AliasId = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *DescribeGameSessionDetailsInput) SetFleetId(v string) *DescribeGameSessionDetailsInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *DescribeGameSessionDetailsInput) SetGameSessionId(v string) *DescribeGameSessionDetailsInput {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeGameSessionDetailsInput) SetLimit(v int64) *DescribeGameSessionDetailsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeGameSessionDetailsInput) SetNextToken(v string) *DescribeGameSessionDetailsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatusFilter sets the StatusFilter field's value.
+func (s *DescribeGameSessionDetailsInput) SetStatusFilter(v string) *DescribeGameSessionDetailsInput {
+	s.StatusFilter = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeGameSessionDetailsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4974,6 +5538,18 @@ func (s DescribeGameSessionDetailsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeGameSessionDetailsOutput) GoString() string {
 	return s.String()
+}
+
+// SetGameSessionDetails sets the GameSessionDetails field's value.
+func (s *DescribeGameSessionDetailsOutput) SetGameSessionDetails(v []*GameSessionDetail) *DescribeGameSessionDetailsOutput {
+	s.GameSessionDetails = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeGameSessionDetailsOutput) SetNextToken(v string) *DescribeGameSessionDetailsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -5041,6 +5617,42 @@ func (s *DescribeGameSessionsInput) Validate() error {
 	return nil
 }
 
+// SetAliasId sets the AliasId field's value.
+func (s *DescribeGameSessionsInput) SetAliasId(v string) *DescribeGameSessionsInput {
+	s.AliasId = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *DescribeGameSessionsInput) SetFleetId(v string) *DescribeGameSessionsInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *DescribeGameSessionsInput) SetGameSessionId(v string) *DescribeGameSessionsInput {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeGameSessionsInput) SetLimit(v int64) *DescribeGameSessionsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeGameSessionsInput) SetNextToken(v string) *DescribeGameSessionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatusFilter sets the StatusFilter field's value.
+func (s *DescribeGameSessionsInput) SetStatusFilter(v string) *DescribeGameSessionsInput {
+	s.StatusFilter = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeGameSessionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5062,6 +5674,18 @@ func (s DescribeGameSessionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeGameSessionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetGameSessions sets the GameSessions field's value.
+func (s *DescribeGameSessionsOutput) SetGameSessions(v []*GameSession) *DescribeGameSessionsOutput {
+	s.GameSessions = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeGameSessionsOutput) SetNextToken(v string) *DescribeGameSessionsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -5117,6 +5741,30 @@ func (s *DescribeInstancesInput) Validate() error {
 	return nil
 }
 
+// SetFleetId sets the FleetId field's value.
+func (s *DescribeInstancesInput) SetFleetId(v string) *DescribeInstancesInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeInstancesInput) SetInstanceId(v string) *DescribeInstancesInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeInstancesInput) SetLimit(v int64) *DescribeInstancesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstancesInput) SetNextToken(v string) *DescribeInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5137,6 +5785,18 @@ func (s DescribeInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstances sets the Instances field's value.
+func (s *DescribeInstancesOutput) SetInstances(v []*Instance) *DescribeInstancesOutput {
+	s.Instances = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstancesOutput) SetNextToken(v string) *DescribeInstancesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -5218,6 +5878,42 @@ func (s *DescribePlayerSessionsInput) Validate() error {
 	return nil
 }
 
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *DescribePlayerSessionsInput) SetGameSessionId(v string) *DescribePlayerSessionsInput {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribePlayerSessionsInput) SetLimit(v int64) *DescribePlayerSessionsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribePlayerSessionsInput) SetNextToken(v string) *DescribePlayerSessionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPlayerId sets the PlayerId field's value.
+func (s *DescribePlayerSessionsInput) SetPlayerId(v string) *DescribePlayerSessionsInput {
+	s.PlayerId = &v
+	return s
+}
+
+// SetPlayerSessionId sets the PlayerSessionId field's value.
+func (s *DescribePlayerSessionsInput) SetPlayerSessionId(v string) *DescribePlayerSessionsInput {
+	s.PlayerSessionId = &v
+	return s
+}
+
+// SetPlayerSessionStatusFilter sets the PlayerSessionStatusFilter field's value.
+func (s *DescribePlayerSessionsInput) SetPlayerSessionStatusFilter(v string) *DescribePlayerSessionsInput {
+	s.PlayerSessionStatusFilter = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribePlayerSessionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5239,6 +5935,18 @@ func (s DescribePlayerSessionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribePlayerSessionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribePlayerSessionsOutput) SetNextToken(v string) *DescribePlayerSessionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPlayerSessions sets the PlayerSessions field's value.
+func (s *DescribePlayerSessionsOutput) SetPlayerSessions(v []*PlayerSession) *DescribePlayerSessionsOutput {
+	s.PlayerSessions = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -5274,6 +5982,12 @@ func (s *DescribeRuntimeConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetFleetId sets the FleetId field's value.
+func (s *DescribeRuntimeConfigurationInput) SetFleetId(v string) *DescribeRuntimeConfigurationInput {
+	s.FleetId = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeRuntimeConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -5291,6 +6005,12 @@ func (s DescribeRuntimeConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRuntimeConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetRuntimeConfiguration sets the RuntimeConfiguration field's value.
+func (s *DescribeRuntimeConfigurationOutput) SetRuntimeConfiguration(v *RuntimeConfiguration) *DescribeRuntimeConfigurationOutput {
+	s.RuntimeConfiguration = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -5361,6 +6081,30 @@ func (s *DescribeScalingPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetFleetId sets the FleetId field's value.
+func (s *DescribeScalingPoliciesInput) SetFleetId(v string) *DescribeScalingPoliciesInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeScalingPoliciesInput) SetLimit(v int64) *DescribeScalingPoliciesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalingPoliciesInput) SetNextToken(v string) *DescribeScalingPoliciesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatusFilter sets the StatusFilter field's value.
+func (s *DescribeScalingPoliciesInput) SetStatusFilter(v string) *DescribeScalingPoliciesInput {
+	s.StatusFilter = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type DescribeScalingPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5381,6 +6125,18 @@ func (s DescribeScalingPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeScalingPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeScalingPoliciesOutput) SetNextToken(v string) *DescribeScalingPoliciesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetScalingPolicies sets the ScalingPolicies field's value.
+func (s *DescribeScalingPoliciesOutput) SetScalingPolicies(v []*ScalingPolicy) *DescribeScalingPoliciesOutput {
+	s.ScalingPolicies = v
+	return s
 }
 
 // Current status of fleet capacity. The number of active instances should match
@@ -5425,6 +6181,48 @@ func (s EC2InstanceCounts) GoString() string {
 	return s.String()
 }
 
+// SetACTIVE sets the ACTIVE field's value.
+func (s *EC2InstanceCounts) SetACTIVE(v int64) *EC2InstanceCounts {
+	s.ACTIVE = &v
+	return s
+}
+
+// SetDESIRED sets the DESIRED field's value.
+func (s *EC2InstanceCounts) SetDESIRED(v int64) *EC2InstanceCounts {
+	s.DESIRED = &v
+	return s
+}
+
+// SetIDLE sets the IDLE field's value.
+func (s *EC2InstanceCounts) SetIDLE(v int64) *EC2InstanceCounts {
+	s.IDLE = &v
+	return s
+}
+
+// SetMAXIMUM sets the MAXIMUM field's value.
+func (s *EC2InstanceCounts) SetMAXIMUM(v int64) *EC2InstanceCounts {
+	s.MAXIMUM = &v
+	return s
+}
+
+// SetMINIMUM sets the MINIMUM field's value.
+func (s *EC2InstanceCounts) SetMINIMUM(v int64) *EC2InstanceCounts {
+	s.MINIMUM = &v
+	return s
+}
+
+// SetPENDING sets the PENDING field's value.
+func (s *EC2InstanceCounts) SetPENDING(v int64) *EC2InstanceCounts {
+	s.PENDING = &v
+	return s
+}
+
+// SetTERMINATING sets the TERMINATING field's value.
+func (s *EC2InstanceCounts) SetTERMINATING(v int64) *EC2InstanceCounts {
+	s.TERMINATING = &v
+	return s
+}
+
 // Maximum number of instances allowed based on the Amazon Elastic Compute Cloud
 // (Amazon EC2) instance type. Instance limits can be retrieved by calling DescribeEC2InstanceLimits.
 type EC2InstanceLimit struct {
@@ -5453,6 +6251,24 @@ func (s EC2InstanceLimit) String() string {
 // GoString returns the string representation
 func (s EC2InstanceLimit) GoString() string {
 	return s.String()
+}
+
+// SetCurrentInstances sets the CurrentInstances field's value.
+func (s *EC2InstanceLimit) SetCurrentInstances(v int64) *EC2InstanceLimit {
+	s.CurrentInstances = &v
+	return s
+}
+
+// SetEC2InstanceType sets the EC2InstanceType field's value.
+func (s *EC2InstanceLimit) SetEC2InstanceType(v string) *EC2InstanceLimit {
+	s.EC2InstanceType = &v
+	return s
+}
+
+// SetInstanceLimit sets the InstanceLimit field's value.
+func (s *EC2InstanceLimit) SetInstanceLimit(v int64) *EC2InstanceLimit {
+	s.InstanceLimit = &v
+	return s
 }
 
 // Log entry describing an event involving an Amazon GameLift resource (such
@@ -5485,6 +6301,36 @@ func (s Event) String() string {
 // GoString returns the string representation
 func (s Event) GoString() string {
 	return s.String()
+}
+
+// SetEventCode sets the EventCode field's value.
+func (s *Event) SetEventCode(v string) *Event {
+	s.EventCode = &v
+	return s
+}
+
+// SetEventId sets the EventId field's value.
+func (s *Event) SetEventId(v string) *Event {
+	s.EventId = &v
+	return s
+}
+
+// SetEventTime sets the EventTime field's value.
+func (s *Event) SetEventTime(v time.Time) *Event {
+	s.EventTime = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Event) SetMessage(v string) *Event {
+	s.Message = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *Event) SetResourceId(v string) *Event {
+	s.ResourceId = &v
+	return s
 }
 
 // General properties describing a fleet.
@@ -5582,6 +6428,84 @@ func (s FleetAttributes) GoString() string {
 	return s.String()
 }
 
+// SetBuildId sets the BuildId field's value.
+func (s *FleetAttributes) SetBuildId(v string) *FleetAttributes {
+	s.BuildId = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *FleetAttributes) SetCreationTime(v time.Time) *FleetAttributes {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *FleetAttributes) SetDescription(v string) *FleetAttributes {
+	s.Description = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *FleetAttributes) SetFleetId(v string) *FleetAttributes {
+	s.FleetId = &v
+	return s
+}
+
+// SetLogPaths sets the LogPaths field's value.
+func (s *FleetAttributes) SetLogPaths(v []*string) *FleetAttributes {
+	s.LogPaths = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *FleetAttributes) SetName(v string) *FleetAttributes {
+	s.Name = &v
+	return s
+}
+
+// SetNewGameSessionProtectionPolicy sets the NewGameSessionProtectionPolicy field's value.
+func (s *FleetAttributes) SetNewGameSessionProtectionPolicy(v string) *FleetAttributes {
+	s.NewGameSessionProtectionPolicy = &v
+	return s
+}
+
+// SetOperatingSystem sets the OperatingSystem field's value.
+func (s *FleetAttributes) SetOperatingSystem(v string) *FleetAttributes {
+	s.OperatingSystem = &v
+	return s
+}
+
+// SetResourceCreationLimitPolicy sets the ResourceCreationLimitPolicy field's value.
+func (s *FleetAttributes) SetResourceCreationLimitPolicy(v *ResourceCreationLimitPolicy) *FleetAttributes {
+	s.ResourceCreationLimitPolicy = v
+	return s
+}
+
+// SetServerLaunchParameters sets the ServerLaunchParameters field's value.
+func (s *FleetAttributes) SetServerLaunchParameters(v string) *FleetAttributes {
+	s.ServerLaunchParameters = &v
+	return s
+}
+
+// SetServerLaunchPath sets the ServerLaunchPath field's value.
+func (s *FleetAttributes) SetServerLaunchPath(v string) *FleetAttributes {
+	s.ServerLaunchPath = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *FleetAttributes) SetStatus(v string) *FleetAttributes {
+	s.Status = &v
+	return s
+}
+
+// SetTerminationTime sets the TerminationTime field's value.
+func (s *FleetAttributes) SetTerminationTime(v time.Time) *FleetAttributes {
+	s.TerminationTime = &v
+	return s
+}
+
 // Information about the fleet's capacity. Fleet capacity is measured in EC2
 // instances. By default, new fleets have a capacity of one instance, but can
 // be updated as needed. The maximum number of instances for a fleet is determined
@@ -5611,6 +6535,24 @@ func (s FleetCapacity) String() string {
 // GoString returns the string representation
 func (s FleetCapacity) GoString() string {
 	return s.String()
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *FleetCapacity) SetFleetId(v string) *FleetCapacity {
+	s.FleetId = &v
+	return s
+}
+
+// SetInstanceCounts sets the InstanceCounts field's value.
+func (s *FleetCapacity) SetInstanceCounts(v *EC2InstanceCounts) *FleetCapacity {
+	s.InstanceCounts = v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *FleetCapacity) SetInstanceType(v string) *FleetCapacity {
+	s.InstanceType = &v
+	return s
 }
 
 // Current status of fleet utilization, including the number of game and player
@@ -5646,6 +6588,36 @@ func (s FleetUtilization) String() string {
 // GoString returns the string representation
 func (s FleetUtilization) GoString() string {
 	return s.String()
+}
+
+// SetActiveGameSessionCount sets the ActiveGameSessionCount field's value.
+func (s *FleetUtilization) SetActiveGameSessionCount(v int64) *FleetUtilization {
+	s.ActiveGameSessionCount = &v
+	return s
+}
+
+// SetActiveServerProcessCount sets the ActiveServerProcessCount field's value.
+func (s *FleetUtilization) SetActiveServerProcessCount(v int64) *FleetUtilization {
+	s.ActiveServerProcessCount = &v
+	return s
+}
+
+// SetCurrentPlayerSessionCount sets the CurrentPlayerSessionCount field's value.
+func (s *FleetUtilization) SetCurrentPlayerSessionCount(v int64) *FleetUtilization {
+	s.CurrentPlayerSessionCount = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *FleetUtilization) SetFleetId(v string) *FleetUtilization {
+	s.FleetId = &v
+	return s
+}
+
+// SetMaximumPlayerSessionCount sets the MaximumPlayerSessionCount field's value.
+func (s *FleetUtilization) SetMaximumPlayerSessionCount(v int64) *FleetUtilization {
+	s.MaximumPlayerSessionCount = &v
+	return s
 }
 
 // Set of key-value pairs containing information a server process requires to
@@ -5690,6 +6662,18 @@ func (s *GameProperty) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *GameProperty) SetKey(v string) *GameProperty {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *GameProperty) SetValue(v string) *GameProperty {
+	s.Value = &v
+	return s
 }
 
 // Properties describing a game session.
@@ -5757,6 +6741,84 @@ func (s GameSession) GoString() string {
 	return s.String()
 }
 
+// SetCreationTime sets the CreationTime field's value.
+func (s *GameSession) SetCreationTime(v time.Time) *GameSession {
+	s.CreationTime = &v
+	return s
+}
+
+// SetCreatorId sets the CreatorId field's value.
+func (s *GameSession) SetCreatorId(v string) *GameSession {
+	s.CreatorId = &v
+	return s
+}
+
+// SetCurrentPlayerSessionCount sets the CurrentPlayerSessionCount field's value.
+func (s *GameSession) SetCurrentPlayerSessionCount(v int64) *GameSession {
+	s.CurrentPlayerSessionCount = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *GameSession) SetFleetId(v string) *GameSession {
+	s.FleetId = &v
+	return s
+}
+
+// SetGameProperties sets the GameProperties field's value.
+func (s *GameSession) SetGameProperties(v []*GameProperty) *GameSession {
+	s.GameProperties = v
+	return s
+}
+
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *GameSession) SetGameSessionId(v string) *GameSession {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *GameSession) SetIpAddress(v string) *GameSession {
+	s.IpAddress = &v
+	return s
+}
+
+// SetMaximumPlayerSessionCount sets the MaximumPlayerSessionCount field's value.
+func (s *GameSession) SetMaximumPlayerSessionCount(v int64) *GameSession {
+	s.MaximumPlayerSessionCount = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GameSession) SetName(v string) *GameSession {
+	s.Name = &v
+	return s
+}
+
+// SetPlayerSessionCreationPolicy sets the PlayerSessionCreationPolicy field's value.
+func (s *GameSession) SetPlayerSessionCreationPolicy(v string) *GameSession {
+	s.PlayerSessionCreationPolicy = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *GameSession) SetPort(v int64) *GameSession {
+	s.Port = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GameSession) SetStatus(v string) *GameSession {
+	s.Status = &v
+	return s
+}
+
+// SetTerminationTime sets the TerminationTime field's value.
+func (s *GameSession) SetTerminationTime(v time.Time) *GameSession {
+	s.TerminationTime = &v
+	return s
+}
+
 // A game session's properties and the protection policy currently in force.
 type GameSessionDetail struct {
 	_ struct{} `type:"structure"`
@@ -5782,6 +6844,18 @@ func (s GameSessionDetail) String() string {
 // GoString returns the string representation
 func (s GameSessionDetail) GoString() string {
 	return s.String()
+}
+
+// SetGameSession sets the GameSession field's value.
+func (s *GameSessionDetail) SetGameSession(v *GameSession) *GameSessionDetail {
+	s.GameSession = v
+	return s
+}
+
+// SetProtectionPolicy sets the ProtectionPolicy field's value.
+func (s *GameSessionDetail) SetProtectionPolicy(v string) *GameSessionDetail {
+	s.ProtectionPolicy = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -5823,6 +6897,12 @@ func (s *GetGameSessionLogUrlInput) Validate() error {
 	return nil
 }
 
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *GetGameSessionLogUrlInput) SetGameSessionId(v string) *GetGameSessionLogUrlInput {
+	s.GameSessionId = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type GetGameSessionLogUrlOutput struct {
 	_ struct{} `type:"structure"`
@@ -5839,6 +6919,12 @@ func (s GetGameSessionLogUrlOutput) String() string {
 // GoString returns the string representation
 func (s GetGameSessionLogUrlOutput) GoString() string {
 	return s.String()
+}
+
+// SetPreSignedUrl sets the PreSignedUrl field's value.
+func (s *GetGameSessionLogUrlOutput) SetPreSignedUrl(v string) *GetGameSessionLogUrlOutput {
+	s.PreSignedUrl = &v
+	return s
 }
 
 // Properties describing an instance of a virtual computing resource that is
@@ -5889,6 +6975,48 @@ func (s Instance) String() string {
 // GoString returns the string representation
 func (s Instance) GoString() string {
 	return s.String()
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *Instance) SetCreationTime(v time.Time) *Instance {
+	s.CreationTime = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *Instance) SetFleetId(v string) *Instance {
+	s.FleetId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Instance) SetInstanceId(v string) *Instance {
+	s.InstanceId = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *Instance) SetIpAddress(v string) *Instance {
+	s.IpAddress = &v
+	return s
+}
+
+// SetOperatingSystem sets the OperatingSystem field's value.
+func (s *Instance) SetOperatingSystem(v string) *Instance {
+	s.OperatingSystem = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Instance) SetStatus(v string) *Instance {
+	s.Status = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Instance) SetType(v string) *Instance {
+	s.Type = &v
+	return s
 }
 
 // A range of IP addresses and port settings that allow inbound traffic to connect
@@ -5961,6 +7089,30 @@ func (s *IpPermission) Validate() error {
 	return nil
 }
 
+// SetFromPort sets the FromPort field's value.
+func (s *IpPermission) SetFromPort(v int64) *IpPermission {
+	s.FromPort = &v
+	return s
+}
+
+// SetIpRange sets the IpRange field's value.
+func (s *IpPermission) SetIpRange(v string) *IpPermission {
+	s.IpRange = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *IpPermission) SetProtocol(v string) *IpPermission {
+	s.Protocol = &v
+	return s
+}
+
+// SetToPort sets the ToPort field's value.
+func (s *IpPermission) SetToPort(v int64) *IpPermission {
+	s.ToPort = &v
+	return s
+}
+
 // Represents the input for a request action.
 type ListAliasesInput struct {
 	_ struct{} `type:"structure"`
@@ -6022,6 +7174,30 @@ func (s *ListAliasesInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListAliasesInput) SetLimit(v int64) *ListAliasesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ListAliasesInput) SetName(v string) *ListAliasesInput {
+	s.Name = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAliasesInput) SetNextToken(v string) *ListAliasesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRoutingStrategyType sets the RoutingStrategyType field's value.
+func (s *ListAliasesInput) SetRoutingStrategyType(v string) *ListAliasesInput {
+	s.RoutingStrategyType = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type ListAliasesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6042,6 +7218,18 @@ func (s ListAliasesOutput) String() string {
 // GoString returns the string representation
 func (s ListAliasesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAliases sets the Aliases field's value.
+func (s *ListAliasesOutput) SetAliases(v []*Alias) *ListAliasesOutput {
+	s.Aliases = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAliasesOutput) SetNextToken(v string) *ListAliasesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -6100,6 +7288,24 @@ func (s *ListBuildsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListBuildsInput) SetLimit(v int64) *ListBuildsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListBuildsInput) SetNextToken(v string) *ListBuildsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListBuildsInput) SetStatus(v string) *ListBuildsInput {
+	s.Status = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type ListBuildsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6120,6 +7326,18 @@ func (s ListBuildsOutput) String() string {
 // GoString returns the string representation
 func (s ListBuildsOutput) GoString() string {
 	return s.String()
+}
+
+// SetBuilds sets the Builds field's value.
+func (s *ListBuildsOutput) SetBuilds(v []*Build) *ListBuildsOutput {
+	s.Builds = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListBuildsOutput) SetNextToken(v string) *ListBuildsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -6167,6 +7385,24 @@ func (s *ListFleetsInput) Validate() error {
 	return nil
 }
 
+// SetBuildId sets the BuildId field's value.
+func (s *ListFleetsInput) SetBuildId(v string) *ListFleetsInput {
+	s.BuildId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListFleetsInput) SetLimit(v int64) *ListFleetsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListFleetsInput) SetNextToken(v string) *ListFleetsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type ListFleetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6189,6 +7425,18 @@ func (s ListFleetsOutput) String() string {
 // GoString returns the string representation
 func (s ListFleetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetIds sets the FleetIds field's value.
+func (s *ListFleetsOutput) SetFleetIds(v []*string) *ListFleetsOutput {
+	s.FleetIds = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListFleetsOutput) SetNextToken(v string) *ListFleetsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Properties describing a player session.
@@ -6248,6 +7496,60 @@ func (s PlayerSession) String() string {
 // GoString returns the string representation
 func (s PlayerSession) GoString() string {
 	return s.String()
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *PlayerSession) SetCreationTime(v time.Time) *PlayerSession {
+	s.CreationTime = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *PlayerSession) SetFleetId(v string) *PlayerSession {
+	s.FleetId = &v
+	return s
+}
+
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *PlayerSession) SetGameSessionId(v string) *PlayerSession {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *PlayerSession) SetIpAddress(v string) *PlayerSession {
+	s.IpAddress = &v
+	return s
+}
+
+// SetPlayerId sets the PlayerId field's value.
+func (s *PlayerSession) SetPlayerId(v string) *PlayerSession {
+	s.PlayerId = &v
+	return s
+}
+
+// SetPlayerSessionId sets the PlayerSessionId field's value.
+func (s *PlayerSession) SetPlayerSessionId(v string) *PlayerSession {
+	s.PlayerSessionId = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *PlayerSession) SetPort(v int64) *PlayerSession {
+	s.Port = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *PlayerSession) SetStatus(v string) *PlayerSession {
+	s.Status = &v
+	return s
+}
+
+// SetTerminationTime sets the TerminationTime field's value.
+func (s *PlayerSession) SetTerminationTime(v time.Time) *PlayerSession {
+	s.TerminationTime = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -6378,6 +7680,54 @@ func (s *PutScalingPolicyInput) Validate() error {
 	return nil
 }
 
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *PutScalingPolicyInput) SetComparisonOperator(v string) *PutScalingPolicyInput {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetEvaluationPeriods sets the EvaluationPeriods field's value.
+func (s *PutScalingPolicyInput) SetEvaluationPeriods(v int64) *PutScalingPolicyInput {
+	s.EvaluationPeriods = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *PutScalingPolicyInput) SetFleetId(v string) *PutScalingPolicyInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *PutScalingPolicyInput) SetMetricName(v string) *PutScalingPolicyInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PutScalingPolicyInput) SetName(v string) *PutScalingPolicyInput {
+	s.Name = &v
+	return s
+}
+
+// SetScalingAdjustment sets the ScalingAdjustment field's value.
+func (s *PutScalingPolicyInput) SetScalingAdjustment(v int64) *PutScalingPolicyInput {
+	s.ScalingAdjustment = &v
+	return s
+}
+
+// SetScalingAdjustmentType sets the ScalingAdjustmentType field's value.
+func (s *PutScalingPolicyInput) SetScalingAdjustmentType(v string) *PutScalingPolicyInput {
+	s.ScalingAdjustmentType = &v
+	return s
+}
+
+// SetThreshold sets the Threshold field's value.
+func (s *PutScalingPolicyInput) SetThreshold(v float64) *PutScalingPolicyInput {
+	s.Threshold = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type PutScalingPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -6395,6 +7745,12 @@ func (s PutScalingPolicyOutput) String() string {
 // GoString returns the string representation
 func (s PutScalingPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *PutScalingPolicyOutput) SetName(v string) *PutScalingPolicyOutput {
+	s.Name = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -6430,6 +7786,12 @@ func (s *RequestUploadCredentialsInput) Validate() error {
 	return nil
 }
 
+// SetBuildId sets the BuildId field's value.
+func (s *RequestUploadCredentialsInput) SetBuildId(v string) *RequestUploadCredentialsInput {
+	s.BuildId = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type RequestUploadCredentialsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6451,6 +7813,18 @@ func (s RequestUploadCredentialsOutput) String() string {
 // GoString returns the string representation
 func (s RequestUploadCredentialsOutput) GoString() string {
 	return s.String()
+}
+
+// SetStorageLocation sets the StorageLocation field's value.
+func (s *RequestUploadCredentialsOutput) SetStorageLocation(v *S3Location) *RequestUploadCredentialsOutput {
+	s.StorageLocation = v
+	return s
+}
+
+// SetUploadCredentials sets the UploadCredentials field's value.
+func (s *RequestUploadCredentialsOutput) SetUploadCredentials(v *AwsCredentials) *RequestUploadCredentialsOutput {
+	s.UploadCredentials = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -6486,6 +7860,12 @@ func (s *ResolveAliasInput) Validate() error {
 	return nil
 }
 
+// SetAliasId sets the AliasId field's value.
+func (s *ResolveAliasInput) SetAliasId(v string) *ResolveAliasInput {
+	s.AliasId = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type ResolveAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -6502,6 +7882,12 @@ func (s ResolveAliasOutput) String() string {
 // GoString returns the string representation
 func (s ResolveAliasOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *ResolveAliasOutput) SetFleetId(v string) *ResolveAliasOutput {
+	s.FleetId = &v
+	return s
 }
 
 // Policy that limits the number of game sessions a player can create on the
@@ -6536,6 +7922,18 @@ func (s ResourceCreationLimitPolicy) GoString() string {
 	return s.String()
 }
 
+// SetNewGameSessionsPerCreator sets the NewGameSessionsPerCreator field's value.
+func (s *ResourceCreationLimitPolicy) SetNewGameSessionsPerCreator(v int64) *ResourceCreationLimitPolicy {
+	s.NewGameSessionsPerCreator = &v
+	return s
+}
+
+// SetPolicyPeriodInMinutes sets the PolicyPeriodInMinutes field's value.
+func (s *ResourceCreationLimitPolicy) SetPolicyPeriodInMinutes(v int64) *ResourceCreationLimitPolicy {
+	s.PolicyPeriodInMinutes = &v
+	return s
+}
+
 // Routing configuration for a fleet alias.
 type RoutingStrategy struct {
 	_ struct{} `type:"structure"`
@@ -6567,6 +7965,24 @@ func (s RoutingStrategy) String() string {
 // GoString returns the string representation
 func (s RoutingStrategy) GoString() string {
 	return s.String()
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *RoutingStrategy) SetFleetId(v string) *RoutingStrategy {
+	s.FleetId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *RoutingStrategy) SetMessage(v string) *RoutingStrategy {
+	s.Message = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *RoutingStrategy) SetType(v string) *RoutingStrategy {
+	s.Type = &v
+	return s
 }
 
 // Collection of server process configurations that describe what processes
@@ -6628,6 +8044,12 @@ func (s *RuntimeConfiguration) Validate() error {
 	return nil
 }
 
+// SetServerProcesses sets the ServerProcesses field's value.
+func (s *RuntimeConfiguration) SetServerProcesses(v []*ServerProcess) *RuntimeConfiguration {
+	s.ServerProcesses = v
+	return s
+}
+
 // Location in Amazon Simple Storage Service (Amazon S3) where a build's files
 // are stored. This location is assigned in response to a CreateBuild call,
 // and is always in the same region as the service used to create the build.
@@ -6673,6 +8095,24 @@ func (s *S3Location) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *S3Location) SetBucket(v string) *S3Location {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *S3Location) SetKey(v string) *S3Location {
+	s.Key = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *S3Location) SetRoleArn(v string) *S3Location {
+	s.RoleArn = &v
+	return s
 }
 
 // Rule that controls how a fleet is scaled. Scaling policies are uniquely identified
@@ -6764,6 +8204,60 @@ func (s ScalingPolicy) String() string {
 // GoString returns the string representation
 func (s ScalingPolicy) GoString() string {
 	return s.String()
+}
+
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *ScalingPolicy) SetComparisonOperator(v string) *ScalingPolicy {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetEvaluationPeriods sets the EvaluationPeriods field's value.
+func (s *ScalingPolicy) SetEvaluationPeriods(v int64) *ScalingPolicy {
+	s.EvaluationPeriods = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *ScalingPolicy) SetFleetId(v string) *ScalingPolicy {
+	s.FleetId = &v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *ScalingPolicy) SetMetricName(v string) *ScalingPolicy {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ScalingPolicy) SetName(v string) *ScalingPolicy {
+	s.Name = &v
+	return s
+}
+
+// SetScalingAdjustment sets the ScalingAdjustment field's value.
+func (s *ScalingPolicy) SetScalingAdjustment(v int64) *ScalingPolicy {
+	s.ScalingAdjustment = &v
+	return s
+}
+
+// SetScalingAdjustmentType sets the ScalingAdjustmentType field's value.
+func (s *ScalingPolicy) SetScalingAdjustmentType(v string) *ScalingPolicy {
+	s.ScalingAdjustmentType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ScalingPolicy) SetStatus(v string) *ScalingPolicy {
+	s.Status = &v
+	return s
+}
+
+// SetThreshold sets the Threshold field's value.
+func (s *ScalingPolicy) SetThreshold(v float64) *ScalingPolicy {
+	s.Threshold = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -6877,6 +8371,42 @@ func (s *SearchGameSessionsInput) Validate() error {
 	return nil
 }
 
+// SetAliasId sets the AliasId field's value.
+func (s *SearchGameSessionsInput) SetAliasId(v string) *SearchGameSessionsInput {
+	s.AliasId = &v
+	return s
+}
+
+// SetFilterExpression sets the FilterExpression field's value.
+func (s *SearchGameSessionsInput) SetFilterExpression(v string) *SearchGameSessionsInput {
+	s.FilterExpression = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *SearchGameSessionsInput) SetFleetId(v string) *SearchGameSessionsInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *SearchGameSessionsInput) SetLimit(v int64) *SearchGameSessionsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SearchGameSessionsInput) SetNextToken(v string) *SearchGameSessionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSortExpression sets the SortExpression field's value.
+func (s *SearchGameSessionsInput) SetSortExpression(v string) *SearchGameSessionsInput {
+	s.SortExpression = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type SearchGameSessionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6898,6 +8428,18 @@ func (s SearchGameSessionsOutput) String() string {
 // GoString returns the string representation
 func (s SearchGameSessionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetGameSessions sets the GameSessions field's value.
+func (s *SearchGameSessionsOutput) SetGameSessions(v []*GameSession) *SearchGameSessionsOutput {
+	s.GameSessions = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SearchGameSessionsOutput) SetNextToken(v string) *SearchGameSessionsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // A set of instructions for launching server processes on each instance in
@@ -6960,6 +8502,24 @@ func (s *ServerProcess) Validate() error {
 	return nil
 }
 
+// SetConcurrentExecutions sets the ConcurrentExecutions field's value.
+func (s *ServerProcess) SetConcurrentExecutions(v int64) *ServerProcess {
+	s.ConcurrentExecutions = &v
+	return s
+}
+
+// SetLaunchPath sets the LaunchPath field's value.
+func (s *ServerProcess) SetLaunchPath(v string) *ServerProcess {
+	s.LaunchPath = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ServerProcess) SetParameters(v string) *ServerProcess {
+	s.Parameters = &v
+	return s
+}
+
 // Represents the input for a request action.
 type UpdateAliasInput struct {
 	_ struct{} `type:"structure"`
@@ -7009,6 +8569,30 @@ func (s *UpdateAliasInput) Validate() error {
 	return nil
 }
 
+// SetAliasId sets the AliasId field's value.
+func (s *UpdateAliasInput) SetAliasId(v string) *UpdateAliasInput {
+	s.AliasId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateAliasInput) SetDescription(v string) *UpdateAliasInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateAliasInput) SetName(v string) *UpdateAliasInput {
+	s.Name = &v
+	return s
+}
+
+// SetRoutingStrategy sets the RoutingStrategy field's value.
+func (s *UpdateAliasInput) SetRoutingStrategy(v *RoutingStrategy) *UpdateAliasInput {
+	s.RoutingStrategy = v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type UpdateAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -7025,6 +8609,12 @@ func (s UpdateAliasOutput) String() string {
 // GoString returns the string representation
 func (s UpdateAliasOutput) GoString() string {
 	return s.String()
+}
+
+// SetAlias sets the Alias field's value.
+func (s *UpdateAliasOutput) SetAlias(v *Alias) *UpdateAliasOutput {
+	s.Alias = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -7074,6 +8664,24 @@ func (s *UpdateBuildInput) Validate() error {
 	return nil
 }
 
+// SetBuildId sets the BuildId field's value.
+func (s *UpdateBuildInput) SetBuildId(v string) *UpdateBuildInput {
+	s.BuildId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateBuildInput) SetName(v string) *UpdateBuildInput {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *UpdateBuildInput) SetVersion(v string) *UpdateBuildInput {
+	s.Version = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type UpdateBuildOutput struct {
 	_ struct{} `type:"structure"`
@@ -7090,6 +8698,12 @@ func (s UpdateBuildOutput) String() string {
 // GoString returns the string representation
 func (s UpdateBuildOutput) GoString() string {
 	return s.String()
+}
+
+// SetBuild sets the Build field's value.
+func (s *UpdateBuildOutput) SetBuild(v *Build) *UpdateBuildOutput {
+	s.Build = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -7153,6 +8767,36 @@ func (s *UpdateFleetAttributesInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *UpdateFleetAttributesInput) SetDescription(v string) *UpdateFleetAttributesInput {
+	s.Description = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *UpdateFleetAttributesInput) SetFleetId(v string) *UpdateFleetAttributesInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateFleetAttributesInput) SetName(v string) *UpdateFleetAttributesInput {
+	s.Name = &v
+	return s
+}
+
+// SetNewGameSessionProtectionPolicy sets the NewGameSessionProtectionPolicy field's value.
+func (s *UpdateFleetAttributesInput) SetNewGameSessionProtectionPolicy(v string) *UpdateFleetAttributesInput {
+	s.NewGameSessionProtectionPolicy = &v
+	return s
+}
+
+// SetResourceCreationLimitPolicy sets the ResourceCreationLimitPolicy field's value.
+func (s *UpdateFleetAttributesInput) SetResourceCreationLimitPolicy(v *ResourceCreationLimitPolicy) *UpdateFleetAttributesInput {
+	s.ResourceCreationLimitPolicy = v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type UpdateFleetAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7169,6 +8813,12 @@ func (s UpdateFleetAttributesOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFleetAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *UpdateFleetAttributesOutput) SetFleetId(v string) *UpdateFleetAttributesOutput {
+	s.FleetId = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -7215,6 +8865,30 @@ func (s *UpdateFleetCapacityInput) Validate() error {
 	return nil
 }
 
+// SetDesiredInstances sets the DesiredInstances field's value.
+func (s *UpdateFleetCapacityInput) SetDesiredInstances(v int64) *UpdateFleetCapacityInput {
+	s.DesiredInstances = &v
+	return s
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *UpdateFleetCapacityInput) SetFleetId(v string) *UpdateFleetCapacityInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetMaxSize sets the MaxSize field's value.
+func (s *UpdateFleetCapacityInput) SetMaxSize(v int64) *UpdateFleetCapacityInput {
+	s.MaxSize = &v
+	return s
+}
+
+// SetMinSize sets the MinSize field's value.
+func (s *UpdateFleetCapacityInput) SetMinSize(v int64) *UpdateFleetCapacityInput {
+	s.MinSize = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type UpdateFleetCapacityOutput struct {
 	_ struct{} `type:"structure"`
@@ -7231,6 +8905,12 @@ func (s UpdateFleetCapacityOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFleetCapacityOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *UpdateFleetCapacityOutput) SetFleetId(v string) *UpdateFleetCapacityOutput {
+	s.FleetId = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -7292,6 +8972,24 @@ func (s *UpdateFleetPortSettingsInput) Validate() error {
 	return nil
 }
 
+// SetFleetId sets the FleetId field's value.
+func (s *UpdateFleetPortSettingsInput) SetFleetId(v string) *UpdateFleetPortSettingsInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetInboundPermissionAuthorizations sets the InboundPermissionAuthorizations field's value.
+func (s *UpdateFleetPortSettingsInput) SetInboundPermissionAuthorizations(v []*IpPermission) *UpdateFleetPortSettingsInput {
+	s.InboundPermissionAuthorizations = v
+	return s
+}
+
+// SetInboundPermissionRevocations sets the InboundPermissionRevocations field's value.
+func (s *UpdateFleetPortSettingsInput) SetInboundPermissionRevocations(v []*IpPermission) *UpdateFleetPortSettingsInput {
+	s.InboundPermissionRevocations = v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type UpdateFleetPortSettingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7308,6 +9006,12 @@ func (s UpdateFleetPortSettingsOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFleetPortSettingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFleetId sets the FleetId field's value.
+func (s *UpdateFleetPortSettingsOutput) SetFleetId(v string) *UpdateFleetPortSettingsOutput {
+	s.FleetId = &v
+	return s
 }
 
 // Represents the input for a request action.
@@ -7372,6 +9076,36 @@ func (s *UpdateGameSessionInput) Validate() error {
 	return nil
 }
 
+// SetGameSessionId sets the GameSessionId field's value.
+func (s *UpdateGameSessionInput) SetGameSessionId(v string) *UpdateGameSessionInput {
+	s.GameSessionId = &v
+	return s
+}
+
+// SetMaximumPlayerSessionCount sets the MaximumPlayerSessionCount field's value.
+func (s *UpdateGameSessionInput) SetMaximumPlayerSessionCount(v int64) *UpdateGameSessionInput {
+	s.MaximumPlayerSessionCount = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateGameSessionInput) SetName(v string) *UpdateGameSessionInput {
+	s.Name = &v
+	return s
+}
+
+// SetPlayerSessionCreationPolicy sets the PlayerSessionCreationPolicy field's value.
+func (s *UpdateGameSessionInput) SetPlayerSessionCreationPolicy(v string) *UpdateGameSessionInput {
+	s.PlayerSessionCreationPolicy = &v
+	return s
+}
+
+// SetProtectionPolicy sets the ProtectionPolicy field's value.
+func (s *UpdateGameSessionInput) SetProtectionPolicy(v string) *UpdateGameSessionInput {
+	s.ProtectionPolicy = &v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type UpdateGameSessionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7388,6 +9122,12 @@ func (s UpdateGameSessionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateGameSessionOutput) GoString() string {
 	return s.String()
+}
+
+// SetGameSession sets the GameSession field's value.
+func (s *UpdateGameSessionOutput) SetGameSession(v *GameSession) *UpdateGameSessionOutput {
+	s.GameSession = v
+	return s
 }
 
 // Represents the input for a request action.
@@ -7441,6 +9181,18 @@ func (s *UpdateRuntimeConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetFleetId sets the FleetId field's value.
+func (s *UpdateRuntimeConfigurationInput) SetFleetId(v string) *UpdateRuntimeConfigurationInput {
+	s.FleetId = &v
+	return s
+}
+
+// SetRuntimeConfiguration sets the RuntimeConfiguration field's value.
+func (s *UpdateRuntimeConfigurationInput) SetRuntimeConfiguration(v *RuntimeConfiguration) *UpdateRuntimeConfigurationInput {
+	s.RuntimeConfiguration = v
+	return s
+}
+
 // Represents the returned data in response to a request action.
 type UpdateRuntimeConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -7458,6 +9210,12 @@ func (s UpdateRuntimeConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s UpdateRuntimeConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetRuntimeConfiguration sets the RuntimeConfiguration field's value.
+func (s *UpdateRuntimeConfigurationOutput) SetRuntimeConfiguration(v *RuntimeConfiguration) *UpdateRuntimeConfigurationOutput {
+	s.RuntimeConfiguration = v
+	return s
 }
 
 const (

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -3242,6 +3242,24 @@ func (s *AbortMultipartUploadInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *AbortMultipartUploadInput) SetAccountId(v string) *AbortMultipartUploadInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *AbortMultipartUploadInput) SetUploadId(v string) *AbortMultipartUploadInput {
+	s.UploadId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *AbortMultipartUploadInput) SetVaultName(v string) *AbortMultipartUploadInput {
+	s.VaultName = &v
+	return s
+}
+
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3300,6 +3318,18 @@ func (s *AbortVaultLockInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *AbortVaultLockInput) SetAccountId(v string) *AbortVaultLockInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *AbortVaultLockInput) SetVaultName(v string) *AbortVaultLockInput {
+	s.VaultName = &v
+	return s
 }
 
 type AbortVaultLockOutput struct {
@@ -3365,6 +3395,24 @@ func (s *AddTagsToVaultInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *AddTagsToVaultInput) SetAccountId(v string) *AddTagsToVaultInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToVaultInput) SetTags(v map[string]*string) *AddTagsToVaultInput {
+	s.Tags = v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *AddTagsToVaultInput) SetVaultName(v string) *AddTagsToVaultInput {
+	s.VaultName = &v
+	return s
+}
+
 type AddTagsToVaultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3405,6 +3453,24 @@ func (s ArchiveCreationOutput) String() string {
 // GoString returns the string representation
 func (s ArchiveCreationOutput) GoString() string {
 	return s.String()
+}
+
+// SetArchiveId sets the ArchiveId field's value.
+func (s *ArchiveCreationOutput) SetArchiveId(v string) *ArchiveCreationOutput {
+	s.ArchiveId = &v
+	return s
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *ArchiveCreationOutput) SetChecksum(v string) *ArchiveCreationOutput {
+	s.Checksum = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *ArchiveCreationOutput) SetLocation(v string) *ArchiveCreationOutput {
+	s.Location = &v
+	return s
 }
 
 // Provides options to complete a multipart upload operation. This informs Amazon
@@ -3474,6 +3540,36 @@ func (s *CompleteMultipartUploadInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *CompleteMultipartUploadInput) SetAccountId(v string) *CompleteMultipartUploadInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetArchiveSize sets the ArchiveSize field's value.
+func (s *CompleteMultipartUploadInput) SetArchiveSize(v string) *CompleteMultipartUploadInput {
+	s.ArchiveSize = &v
+	return s
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *CompleteMultipartUploadInput) SetChecksum(v string) *CompleteMultipartUploadInput {
+	s.Checksum = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *CompleteMultipartUploadInput) SetUploadId(v string) *CompleteMultipartUploadInput {
+	s.UploadId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *CompleteMultipartUploadInput) SetVaultName(v string) *CompleteMultipartUploadInput {
+	s.VaultName = &v
+	return s
+}
+
 // The input values for CompleteVaultLock.
 type CompleteVaultLockInput struct {
 	_ struct{} `type:"structure"`
@@ -3526,6 +3622,24 @@ func (s *CompleteVaultLockInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *CompleteVaultLockInput) SetAccountId(v string) *CompleteVaultLockInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetLockId sets the LockId field's value.
+func (s *CompleteVaultLockInput) SetLockId(v string) *CompleteVaultLockInput {
+	s.LockId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *CompleteVaultLockInput) SetVaultName(v string) *CompleteVaultLockInput {
+	s.VaultName = &v
+	return s
 }
 
 type CompleteVaultLockOutput struct {
@@ -3588,6 +3702,18 @@ func (s *CreateVaultInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *CreateVaultInput) SetAccountId(v string) *CreateVaultInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *CreateVaultInput) SetVaultName(v string) *CreateVaultInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type CreateVaultOutput struct {
 	_ struct{} `type:"structure"`
@@ -3604,6 +3730,12 @@ func (s CreateVaultOutput) String() string {
 // GoString returns the string representation
 func (s CreateVaultOutput) GoString() string {
 	return s.String()
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateVaultOutput) SetLocation(v string) *CreateVaultOutput {
+	s.Location = &v
+	return s
 }
 
 // Data retrieval policy.
@@ -3623,6 +3755,12 @@ func (s DataRetrievalPolicy) String() string {
 // GoString returns the string representation
 func (s DataRetrievalPolicy) GoString() string {
 	return s.String()
+}
+
+// SetRules sets the Rules field's value.
+func (s *DataRetrievalPolicy) SetRules(v []*DataRetrievalRule) *DataRetrievalPolicy {
+	s.Rules = v
+	return s
 }
 
 // Data retrieval policy rule.
@@ -3650,6 +3788,18 @@ func (s DataRetrievalRule) String() string {
 // GoString returns the string representation
 func (s DataRetrievalRule) GoString() string {
 	return s.String()
+}
+
+// SetBytesPerHour sets the BytesPerHour field's value.
+func (s *DataRetrievalRule) SetBytesPerHour(v int64) *DataRetrievalRule {
+	s.BytesPerHour = &v
+	return s
+}
+
+// SetStrategy sets the Strategy field's value.
+func (s *DataRetrievalRule) SetStrategy(v string) *DataRetrievalRule {
+	s.Strategy = &v
+	return s
 }
 
 // Provides options for deleting an archive from an Amazon Glacier vault.
@@ -3703,6 +3853,24 @@ func (s *DeleteArchiveInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteArchiveInput) SetAccountId(v string) *DeleteArchiveInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetArchiveId sets the ArchiveId field's value.
+func (s *DeleteArchiveInput) SetArchiveId(v string) *DeleteArchiveInput {
+	s.ArchiveId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *DeleteArchiveInput) SetVaultName(v string) *DeleteArchiveInput {
+	s.VaultName = &v
+	return s
 }
 
 type DeleteArchiveOutput struct {
@@ -3764,6 +3932,18 @@ func (s *DeleteVaultAccessPolicyInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteVaultAccessPolicyInput) SetAccountId(v string) *DeleteVaultAccessPolicyInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *DeleteVaultAccessPolicyInput) SetVaultName(v string) *DeleteVaultAccessPolicyInput {
+	s.VaultName = &v
+	return s
+}
+
 type DeleteVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3823,6 +4003,18 @@ func (s *DeleteVaultInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteVaultInput) SetAccountId(v string) *DeleteVaultInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *DeleteVaultInput) SetVaultName(v string) *DeleteVaultInput {
+	s.VaultName = &v
+	return s
+}
+
 // Provides options for deleting a vault notification configuration from an
 // Amazon Glacier vault.
 type DeleteVaultNotificationsInput struct {
@@ -3867,6 +4059,18 @@ func (s *DeleteVaultNotificationsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteVaultNotificationsInput) SetAccountId(v string) *DeleteVaultNotificationsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *DeleteVaultNotificationsInput) SetVaultName(v string) *DeleteVaultNotificationsInput {
+	s.VaultName = &v
+	return s
 }
 
 type DeleteVaultNotificationsOutput struct {
@@ -3950,6 +4154,24 @@ func (s *DescribeJobInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DescribeJobInput) SetAccountId(v string) *DescribeJobInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *DescribeJobInput) SetJobId(v string) *DescribeJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *DescribeJobInput) SetVaultName(v string) *DescribeJobInput {
+	s.VaultName = &v
+	return s
+}
+
 // Provides options for retrieving metadata for a specific vault in Amazon Glacier.
 type DescribeVaultInput struct {
 	_ struct{} `type:"structure"`
@@ -3995,6 +4217,18 @@ func (s *DescribeVaultInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *DescribeVaultInput) SetAccountId(v string) *DescribeVaultInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *DescribeVaultInput) SetVaultName(v string) *DescribeVaultInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type DescribeVaultOutput struct {
 	_ struct{} `type:"structure"`
@@ -4032,6 +4266,42 @@ func (s DescribeVaultOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVaultOutput) GoString() string {
 	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *DescribeVaultOutput) SetCreationDate(v string) *DescribeVaultOutput {
+	s.CreationDate = &v
+	return s
+}
+
+// SetLastInventoryDate sets the LastInventoryDate field's value.
+func (s *DescribeVaultOutput) SetLastInventoryDate(v string) *DescribeVaultOutput {
+	s.LastInventoryDate = &v
+	return s
+}
+
+// SetNumberOfArchives sets the NumberOfArchives field's value.
+func (s *DescribeVaultOutput) SetNumberOfArchives(v int64) *DescribeVaultOutput {
+	s.NumberOfArchives = &v
+	return s
+}
+
+// SetSizeInBytes sets the SizeInBytes field's value.
+func (s *DescribeVaultOutput) SetSizeInBytes(v int64) *DescribeVaultOutput {
+	s.SizeInBytes = &v
+	return s
+}
+
+// SetVaultARN sets the VaultARN field's value.
+func (s *DescribeVaultOutput) SetVaultARN(v string) *DescribeVaultOutput {
+	s.VaultARN = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *DescribeVaultOutput) SetVaultName(v string) *DescribeVaultOutput {
+	s.VaultName = &v
+	return s
 }
 
 // Input for GetDataRetrievalPolicy.
@@ -4072,6 +4342,12 @@ func (s *GetDataRetrievalPolicyInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *GetDataRetrievalPolicyInput) SetAccountId(v string) *GetDataRetrievalPolicyInput {
+	s.AccountId = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to the GetDataRetrievalPolicy request.
 type GetDataRetrievalPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -4088,6 +4364,12 @@ func (s GetDataRetrievalPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetDataRetrievalPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetDataRetrievalPolicyOutput) SetPolicy(v *DataRetrievalPolicy) *GetDataRetrievalPolicyOutput {
+	s.Policy = v
+	return s
 }
 
 // Provides options for downloading output of an Amazon Glacier job.
@@ -4148,6 +4430,30 @@ func (s *GetJobOutputInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *GetJobOutputInput) SetAccountId(v string) *GetJobOutputInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *GetJobOutputInput) SetJobId(v string) *GetJobOutputInput {
+	s.JobId = &v
+	return s
+}
+
+// SetRange sets the Range field's value.
+func (s *GetJobOutputInput) SetRange(v string) *GetJobOutputInput {
+	s.Range = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *GetJobOutputInput) SetVaultName(v string) *GetJobOutputInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetJobOutputOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -4203,6 +4509,48 @@ func (s GetJobOutputOutput) GoString() string {
 	return s.String()
 }
 
+// SetAcceptRanges sets the AcceptRanges field's value.
+func (s *GetJobOutputOutput) SetAcceptRanges(v string) *GetJobOutputOutput {
+	s.AcceptRanges = &v
+	return s
+}
+
+// SetArchiveDescription sets the ArchiveDescription field's value.
+func (s *GetJobOutputOutput) SetArchiveDescription(v string) *GetJobOutputOutput {
+	s.ArchiveDescription = &v
+	return s
+}
+
+// SetBody sets the Body field's value.
+func (s *GetJobOutputOutput) SetBody(v io.ReadCloser) *GetJobOutputOutput {
+	s.Body = v
+	return s
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *GetJobOutputOutput) SetChecksum(v string) *GetJobOutputOutput {
+	s.Checksum = &v
+	return s
+}
+
+// SetContentRange sets the ContentRange field's value.
+func (s *GetJobOutputOutput) SetContentRange(v string) *GetJobOutputOutput {
+	s.ContentRange = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *GetJobOutputOutput) SetContentType(v string) *GetJobOutputOutput {
+	s.ContentType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetJobOutputOutput) SetStatus(v int64) *GetJobOutputOutput {
+	s.Status = &v
+	return s
+}
+
 // Input for GetVaultAccessPolicy.
 type GetVaultAccessPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -4248,6 +4596,18 @@ func (s *GetVaultAccessPolicyInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *GetVaultAccessPolicyInput) SetAccountId(v string) *GetVaultAccessPolicyInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *GetVaultAccessPolicyInput) SetVaultName(v string) *GetVaultAccessPolicyInput {
+	s.VaultName = &v
+	return s
+}
+
 // Output for GetVaultAccessPolicy.
 type GetVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure" payload:"Policy"`
@@ -4264,6 +4624,12 @@ func (s GetVaultAccessPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetVaultAccessPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetVaultAccessPolicyOutput) SetPolicy(v *VaultAccessPolicy) *GetVaultAccessPolicyOutput {
+	s.Policy = v
+	return s
 }
 
 // The input values for GetVaultLock.
@@ -4311,6 +4677,18 @@ func (s *GetVaultLockInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *GetVaultLockInput) SetAccountId(v string) *GetVaultLockInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *GetVaultLockInput) SetVaultName(v string) *GetVaultLockInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetVaultLockOutput struct {
 	_ struct{} `type:"structure"`
@@ -4338,6 +4716,30 @@ func (s GetVaultLockOutput) String() string {
 // GoString returns the string representation
 func (s GetVaultLockOutput) GoString() string {
 	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *GetVaultLockOutput) SetCreationDate(v string) *GetVaultLockOutput {
+	s.CreationDate = &v
+	return s
+}
+
+// SetExpirationDate sets the ExpirationDate field's value.
+func (s *GetVaultLockOutput) SetExpirationDate(v string) *GetVaultLockOutput {
+	s.ExpirationDate = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetVaultLockOutput) SetPolicy(v string) *GetVaultLockOutput {
+	s.Policy = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *GetVaultLockOutput) SetState(v string) *GetVaultLockOutput {
+	s.State = &v
+	return s
 }
 
 // Provides options for retrieving the notification configuration set on an
@@ -4386,6 +4788,18 @@ func (s *GetVaultNotificationsInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *GetVaultNotificationsInput) SetAccountId(v string) *GetVaultNotificationsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *GetVaultNotificationsInput) SetVaultName(v string) *GetVaultNotificationsInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetVaultNotificationsOutput struct {
 	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
@@ -4402,6 +4816,12 @@ func (s GetVaultNotificationsOutput) String() string {
 // GoString returns the string representation
 func (s GetVaultNotificationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetVaultNotificationConfig sets the VaultNotificationConfig field's value.
+func (s *GetVaultNotificationsOutput) SetVaultNotificationConfig(v *VaultNotificationConfig) *GetVaultNotificationsOutput {
+	s.VaultNotificationConfig = v
+	return s
 }
 
 // Provides options for initiating an Amazon Glacier job.
@@ -4452,6 +4872,24 @@ func (s *InitiateJobInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *InitiateJobInput) SetAccountId(v string) *InitiateJobInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetJobParameters sets the JobParameters field's value.
+func (s *InitiateJobInput) SetJobParameters(v *JobParameters) *InitiateJobInput {
+	s.JobParameters = v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *InitiateJobInput) SetVaultName(v string) *InitiateJobInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type InitiateJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -4471,6 +4909,18 @@ func (s InitiateJobOutput) String() string {
 // GoString returns the string representation
 func (s InitiateJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobId sets the JobId field's value.
+func (s *InitiateJobOutput) SetJobId(v string) *InitiateJobOutput {
+	s.JobId = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *InitiateJobOutput) SetLocation(v string) *InitiateJobOutput {
+	s.Location = &v
+	return s
 }
 
 // Provides options for initiating a multipart upload to an Amazon Glacier vault.
@@ -4530,6 +4980,30 @@ func (s *InitiateMultipartUploadInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *InitiateMultipartUploadInput) SetAccountId(v string) *InitiateMultipartUploadInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetArchiveDescription sets the ArchiveDescription field's value.
+func (s *InitiateMultipartUploadInput) SetArchiveDescription(v string) *InitiateMultipartUploadInput {
+	s.ArchiveDescription = &v
+	return s
+}
+
+// SetPartSize sets the PartSize field's value.
+func (s *InitiateMultipartUploadInput) SetPartSize(v string) *InitiateMultipartUploadInput {
+	s.PartSize = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *InitiateMultipartUploadInput) SetVaultName(v string) *InitiateMultipartUploadInput {
+	s.VaultName = &v
+	return s
+}
+
 // The Amazon Glacier response to your request.
 type InitiateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -4550,6 +5024,18 @@ func (s InitiateMultipartUploadOutput) String() string {
 // GoString returns the string representation
 func (s InitiateMultipartUploadOutput) GoString() string {
 	return s.String()
+}
+
+// SetLocation sets the Location field's value.
+func (s *InitiateMultipartUploadOutput) SetLocation(v string) *InitiateMultipartUploadOutput {
+	s.Location = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *InitiateMultipartUploadOutput) SetUploadId(v string) *InitiateMultipartUploadOutput {
+	s.UploadId = &v
+	return s
 }
 
 // The input values for InitiateVaultLock.
@@ -4601,6 +5087,24 @@ func (s *InitiateVaultLockInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *InitiateVaultLockInput) SetAccountId(v string) *InitiateVaultLockInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *InitiateVaultLockInput) SetPolicy(v *VaultLockPolicy) *InitiateVaultLockInput {
+	s.Policy = v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *InitiateVaultLockInput) SetVaultName(v string) *InitiateVaultLockInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type InitiateVaultLockOutput struct {
 	_ struct{} `type:"structure"`
@@ -4617,6 +5121,12 @@ func (s InitiateVaultLockOutput) String() string {
 // GoString returns the string representation
 func (s InitiateVaultLockOutput) GoString() string {
 	return s.String()
+}
+
+// SetLockId sets the LockId field's value.
+func (s *InitiateVaultLockOutput) SetLockId(v string) *InitiateVaultLockOutput {
+	s.LockId = &v
+	return s
 }
 
 // Describes the options for a range inventory retrieval job.
@@ -4661,6 +5171,36 @@ func (s InventoryRetrievalJobDescription) GoString() string {
 	return s.String()
 }
 
+// SetEndDate sets the EndDate field's value.
+func (s *InventoryRetrievalJobDescription) SetEndDate(v string) *InventoryRetrievalJobDescription {
+	s.EndDate = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *InventoryRetrievalJobDescription) SetFormat(v string) *InventoryRetrievalJobDescription {
+	s.Format = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *InventoryRetrievalJobDescription) SetLimit(v string) *InventoryRetrievalJobDescription {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *InventoryRetrievalJobDescription) SetMarker(v string) *InventoryRetrievalJobDescription {
+	s.Marker = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *InventoryRetrievalJobDescription) SetStartDate(v string) *InventoryRetrievalJobDescription {
+	s.StartDate = &v
+	return s
+}
+
 // Provides options for specifying a range inventory retrieval job.
 type InventoryRetrievalJobInput struct {
 	_ struct{} `type:"structure"`
@@ -4694,6 +5234,30 @@ func (s InventoryRetrievalJobInput) String() string {
 // GoString returns the string representation
 func (s InventoryRetrievalJobInput) GoString() string {
 	return s.String()
+}
+
+// SetEndDate sets the EndDate field's value.
+func (s *InventoryRetrievalJobInput) SetEndDate(v string) *InventoryRetrievalJobInput {
+	s.EndDate = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *InventoryRetrievalJobInput) SetLimit(v string) *InventoryRetrievalJobInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *InventoryRetrievalJobInput) SetMarker(v string) *InventoryRetrievalJobInput {
+	s.Marker = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *InventoryRetrievalJobInput) SetStartDate(v string) *InventoryRetrievalJobInput {
+	s.StartDate = &v
+	return s
 }
 
 // Describes an Amazon Glacier job.
@@ -4789,6 +5353,108 @@ func (s JobDescription) GoString() string {
 	return s.String()
 }
 
+// SetAction sets the Action field's value.
+func (s *JobDescription) SetAction(v string) *JobDescription {
+	s.Action = &v
+	return s
+}
+
+// SetArchiveId sets the ArchiveId field's value.
+func (s *JobDescription) SetArchiveId(v string) *JobDescription {
+	s.ArchiveId = &v
+	return s
+}
+
+// SetArchiveSHA256TreeHash sets the ArchiveSHA256TreeHash field's value.
+func (s *JobDescription) SetArchiveSHA256TreeHash(v string) *JobDescription {
+	s.ArchiveSHA256TreeHash = &v
+	return s
+}
+
+// SetArchiveSizeInBytes sets the ArchiveSizeInBytes field's value.
+func (s *JobDescription) SetArchiveSizeInBytes(v int64) *JobDescription {
+	s.ArchiveSizeInBytes = &v
+	return s
+}
+
+// SetCompleted sets the Completed field's value.
+func (s *JobDescription) SetCompleted(v bool) *JobDescription {
+	s.Completed = &v
+	return s
+}
+
+// SetCompletionDate sets the CompletionDate field's value.
+func (s *JobDescription) SetCompletionDate(v string) *JobDescription {
+	s.CompletionDate = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *JobDescription) SetCreationDate(v string) *JobDescription {
+	s.CreationDate = &v
+	return s
+}
+
+// SetInventoryRetrievalParameters sets the InventoryRetrievalParameters field's value.
+func (s *JobDescription) SetInventoryRetrievalParameters(v *InventoryRetrievalJobDescription) *JobDescription {
+	s.InventoryRetrievalParameters = v
+	return s
+}
+
+// SetInventorySizeInBytes sets the InventorySizeInBytes field's value.
+func (s *JobDescription) SetInventorySizeInBytes(v int64) *JobDescription {
+	s.InventorySizeInBytes = &v
+	return s
+}
+
+// SetJobDescription sets the JobDescription field's value.
+func (s *JobDescription) SetJobDescription(v string) *JobDescription {
+	s.JobDescription = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *JobDescription) SetJobId(v string) *JobDescription {
+	s.JobId = &v
+	return s
+}
+
+// SetRetrievalByteRange sets the RetrievalByteRange field's value.
+func (s *JobDescription) SetRetrievalByteRange(v string) *JobDescription {
+	s.RetrievalByteRange = &v
+	return s
+}
+
+// SetSHA256TreeHash sets the SHA256TreeHash field's value.
+func (s *JobDescription) SetSHA256TreeHash(v string) *JobDescription {
+	s.SHA256TreeHash = &v
+	return s
+}
+
+// SetSNSTopic sets the SNSTopic field's value.
+func (s *JobDescription) SetSNSTopic(v string) *JobDescription {
+	s.SNSTopic = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *JobDescription) SetStatusCode(v string) *JobDescription {
+	s.StatusCode = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *JobDescription) SetStatusMessage(v string) *JobDescription {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetVaultARN sets the VaultARN field's value.
+func (s *JobDescription) SetVaultARN(v string) *JobDescription {
+	s.VaultARN = &v
+	return s
+}
+
 // Provides options for defining a job.
 type JobParameters struct {
 	_ struct{} `type:"structure"`
@@ -4842,6 +5508,48 @@ func (s JobParameters) String() string {
 // GoString returns the string representation
 func (s JobParameters) GoString() string {
 	return s.String()
+}
+
+// SetArchiveId sets the ArchiveId field's value.
+func (s *JobParameters) SetArchiveId(v string) *JobParameters {
+	s.ArchiveId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *JobParameters) SetDescription(v string) *JobParameters {
+	s.Description = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *JobParameters) SetFormat(v string) *JobParameters {
+	s.Format = &v
+	return s
+}
+
+// SetInventoryRetrievalParameters sets the InventoryRetrievalParameters field's value.
+func (s *JobParameters) SetInventoryRetrievalParameters(v *InventoryRetrievalJobInput) *JobParameters {
+	s.InventoryRetrievalParameters = v
+	return s
+}
+
+// SetRetrievalByteRange sets the RetrievalByteRange field's value.
+func (s *JobParameters) SetRetrievalByteRange(v string) *JobParameters {
+	s.RetrievalByteRange = &v
+	return s
+}
+
+// SetSNSTopic sets the SNSTopic field's value.
+func (s *JobParameters) SetSNSTopic(v string) *JobParameters {
+	s.SNSTopic = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *JobParameters) SetType(v string) *JobParameters {
+	s.Type = &v
+	return s
 }
 
 // Provides options for retrieving a job list for an Amazon Glacier vault.
@@ -4906,6 +5614,42 @@ func (s *ListJobsInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *ListJobsInput) SetAccountId(v string) *ListJobsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetCompleted sets the Completed field's value.
+func (s *ListJobsInput) SetCompleted(v string) *ListJobsInput {
+	s.Completed = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListJobsInput) SetLimit(v string) *ListJobsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListJobsInput) SetMarker(v string) *ListJobsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetStatuscode sets the Statuscode field's value.
+func (s *ListJobsInput) SetStatuscode(v string) *ListJobsInput {
+	s.Statuscode = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *ListJobsInput) SetVaultName(v string) *ListJobsInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4927,6 +5671,18 @@ func (s ListJobsOutput) String() string {
 // GoString returns the string representation
 func (s ListJobsOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobList sets the JobList field's value.
+func (s *ListJobsOutput) SetJobList(v []*JobDescription) *ListJobsOutput {
+	s.JobList = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListJobsOutput) SetMarker(v string) *ListJobsOutput {
+	s.Marker = &v
+	return s
 }
 
 // Provides options for retrieving list of in-progress multipart uploads for
@@ -4986,6 +5742,30 @@ func (s *ListMultipartUploadsInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *ListMultipartUploadsInput) SetAccountId(v string) *ListMultipartUploadsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListMultipartUploadsInput) SetLimit(v string) *ListMultipartUploadsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListMultipartUploadsInput) SetMarker(v string) *ListMultipartUploadsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *ListMultipartUploadsInput) SetVaultName(v string) *ListMultipartUploadsInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListMultipartUploadsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5007,6 +5787,18 @@ func (s ListMultipartUploadsOutput) String() string {
 // GoString returns the string representation
 func (s ListMultipartUploadsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListMultipartUploadsOutput) SetMarker(v string) *ListMultipartUploadsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetUploadsList sets the UploadsList field's value.
+func (s *ListMultipartUploadsOutput) SetUploadsList(v []*UploadListElement) *ListMultipartUploadsOutput {
+	s.UploadsList = v
+	return s
 }
 
 // Provides options for retrieving a list of parts of an archive that have been
@@ -5074,6 +5866,36 @@ func (s *ListPartsInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *ListPartsInput) SetAccountId(v string) *ListPartsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListPartsInput) SetLimit(v string) *ListPartsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPartsInput) SetMarker(v string) *ListPartsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *ListPartsInput) SetUploadId(v string) *ListPartsInput {
+	s.UploadId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *ListPartsInput) SetVaultName(v string) *ListPartsInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListPartsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5112,6 +5934,48 @@ func (s ListPartsOutput) String() string {
 // GoString returns the string representation
 func (s ListPartsOutput) GoString() string {
 	return s.String()
+}
+
+// SetArchiveDescription sets the ArchiveDescription field's value.
+func (s *ListPartsOutput) SetArchiveDescription(v string) *ListPartsOutput {
+	s.ArchiveDescription = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *ListPartsOutput) SetCreationDate(v string) *ListPartsOutput {
+	s.CreationDate = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPartsOutput) SetMarker(v string) *ListPartsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetMultipartUploadId sets the MultipartUploadId field's value.
+func (s *ListPartsOutput) SetMultipartUploadId(v string) *ListPartsOutput {
+	s.MultipartUploadId = &v
+	return s
+}
+
+// SetPartSizeInBytes sets the PartSizeInBytes field's value.
+func (s *ListPartsOutput) SetPartSizeInBytes(v int64) *ListPartsOutput {
+	s.PartSizeInBytes = &v
+	return s
+}
+
+// SetParts sets the Parts field's value.
+func (s *ListPartsOutput) SetParts(v []*PartListElement) *ListPartsOutput {
+	s.Parts = v
+	return s
+}
+
+// SetVaultARN sets the VaultARN field's value.
+func (s *ListPartsOutput) SetVaultARN(v string) *ListPartsOutput {
+	s.VaultARN = &v
+	return s
 }
 
 // The input value for ListTagsForVaultInput.
@@ -5159,6 +6023,18 @@ func (s *ListTagsForVaultInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *ListTagsForVaultInput) SetAccountId(v string) *ListTagsForVaultInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *ListTagsForVaultInput) SetVaultName(v string) *ListTagsForVaultInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListTagsForVaultOutput struct {
 	_ struct{} `type:"structure"`
@@ -5175,6 +6051,12 @@ func (s ListTagsForVaultOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForVaultOutput) GoString() string {
 	return s.String()
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForVaultOutput) SetTags(v map[string]*string) *ListTagsForVaultOutput {
+	s.Tags = v
+	return s
 }
 
 // Provides options to retrieve the vault list owned by the calling user's account.
@@ -5224,6 +6106,24 @@ func (s *ListVaultsInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *ListVaultsInput) SetAccountId(v string) *ListVaultsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListVaultsInput) SetLimit(v string) *ListVaultsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListVaultsInput) SetMarker(v string) *ListVaultsInput {
+	s.Marker = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListVaultsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5246,6 +6146,18 @@ func (s ListVaultsOutput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListVaultsOutput) SetMarker(v string) *ListVaultsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetVaultList sets the VaultList field's value.
+func (s *ListVaultsOutput) SetVaultList(v []*DescribeVaultOutput) *ListVaultsOutput {
+	s.VaultList = v
+	return s
+}
+
 // A list of the part sizes of the multipart upload.
 type PartListElement struct {
 	_ struct{} `type:"structure"`
@@ -5266,6 +6178,18 @@ func (s PartListElement) String() string {
 // GoString returns the string representation
 func (s PartListElement) GoString() string {
 	return s.String()
+}
+
+// SetRangeInBytes sets the RangeInBytes field's value.
+func (s *PartListElement) SetRangeInBytes(v string) *PartListElement {
+	s.RangeInBytes = &v
+	return s
+}
+
+// SetSHA256TreeHash sets the SHA256TreeHash field's value.
+func (s *PartListElement) SetSHA256TreeHash(v string) *PartListElement {
+	s.SHA256TreeHash = &v
+	return s
 }
 
 // The input value for RemoveTagsFromVaultInput.
@@ -5314,6 +6238,24 @@ func (s *RemoveTagsFromVaultInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *RemoveTagsFromVaultInput) SetAccountId(v string) *RemoveTagsFromVaultInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsFromVaultInput) SetTagKeys(v []*string) *RemoveTagsFromVaultInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *RemoveTagsFromVaultInput) SetVaultName(v string) *RemoveTagsFromVaultInput {
+	s.VaultName = &v
+	return s
 }
 
 type RemoveTagsFromVaultOutput struct {
@@ -5369,6 +6311,18 @@ func (s *SetDataRetrievalPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *SetDataRetrievalPolicyInput) SetAccountId(v string) *SetDataRetrievalPolicyInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *SetDataRetrievalPolicyInput) SetPolicy(v *DataRetrievalPolicy) *SetDataRetrievalPolicyInput {
+	s.Policy = v
+	return s
 }
 
 type SetDataRetrievalPolicyOutput struct {
@@ -5433,6 +6387,24 @@ func (s *SetVaultAccessPolicyInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *SetVaultAccessPolicyInput) SetAccountId(v string) *SetVaultAccessPolicyInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *SetVaultAccessPolicyInput) SetPolicy(v *VaultAccessPolicy) *SetVaultAccessPolicyInput {
+	s.Policy = v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *SetVaultAccessPolicyInput) SetVaultName(v string) *SetVaultAccessPolicyInput {
+	s.VaultName = &v
+	return s
+}
+
 type SetVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5494,6 +6466,24 @@ func (s *SetVaultNotificationsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *SetVaultNotificationsInput) SetAccountId(v string) *SetVaultNotificationsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *SetVaultNotificationsInput) SetVaultName(v string) *SetVaultNotificationsInput {
+	s.VaultName = &v
+	return s
+}
+
+// SetVaultNotificationConfig sets the VaultNotificationConfig field's value.
+func (s *SetVaultNotificationsInput) SetVaultNotificationConfig(v *VaultNotificationConfig) *SetVaultNotificationsInput {
+	s.VaultNotificationConfig = v
+	return s
 }
 
 type SetVaultNotificationsOutput struct {
@@ -5564,6 +6554,36 @@ func (s *UploadArchiveInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *UploadArchiveInput) SetAccountId(v string) *UploadArchiveInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetArchiveDescription sets the ArchiveDescription field's value.
+func (s *UploadArchiveInput) SetArchiveDescription(v string) *UploadArchiveInput {
+	s.ArchiveDescription = &v
+	return s
+}
+
+// SetBody sets the Body field's value.
+func (s *UploadArchiveInput) SetBody(v io.ReadSeeker) *UploadArchiveInput {
+	s.Body = v
+	return s
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *UploadArchiveInput) SetChecksum(v string) *UploadArchiveInput {
+	s.Checksum = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *UploadArchiveInput) SetVaultName(v string) *UploadArchiveInput {
+	s.VaultName = &v
+	return s
+}
+
 // A list of in-progress multipart uploads for a vault.
 type UploadListElement struct {
 	_ struct{} `type:"structure"`
@@ -5595,6 +6615,36 @@ func (s UploadListElement) String() string {
 // GoString returns the string representation
 func (s UploadListElement) GoString() string {
 	return s.String()
+}
+
+// SetArchiveDescription sets the ArchiveDescription field's value.
+func (s *UploadListElement) SetArchiveDescription(v string) *UploadListElement {
+	s.ArchiveDescription = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *UploadListElement) SetCreationDate(v string) *UploadListElement {
+	s.CreationDate = &v
+	return s
+}
+
+// SetMultipartUploadId sets the MultipartUploadId field's value.
+func (s *UploadListElement) SetMultipartUploadId(v string) *UploadListElement {
+	s.MultipartUploadId = &v
+	return s
+}
+
+// SetPartSizeInBytes sets the PartSizeInBytes field's value.
+func (s *UploadListElement) SetPartSizeInBytes(v int64) *UploadListElement {
+	s.PartSizeInBytes = &v
+	return s
+}
+
+// SetVaultARN sets the VaultARN field's value.
+func (s *UploadListElement) SetVaultARN(v string) *UploadListElement {
+	s.VaultARN = &v
+	return s
 }
 
 // Provides options to upload a part of an archive in a multipart upload operation.
@@ -5662,6 +6712,42 @@ func (s *UploadMultipartPartInput) Validate() error {
 	return nil
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *UploadMultipartPartInput) SetAccountId(v string) *UploadMultipartPartInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBody sets the Body field's value.
+func (s *UploadMultipartPartInput) SetBody(v io.ReadSeeker) *UploadMultipartPartInput {
+	s.Body = v
+	return s
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *UploadMultipartPartInput) SetChecksum(v string) *UploadMultipartPartInput {
+	s.Checksum = &v
+	return s
+}
+
+// SetRange sets the Range field's value.
+func (s *UploadMultipartPartInput) SetRange(v string) *UploadMultipartPartInput {
+	s.Range = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *UploadMultipartPartInput) SetUploadId(v string) *UploadMultipartPartInput {
+	s.UploadId = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *UploadMultipartPartInput) SetVaultName(v string) *UploadMultipartPartInput {
+	s.VaultName = &v
+	return s
+}
+
 // Contains the Amazon Glacier response to your request.
 type UploadMultipartPartOutput struct {
 	_ struct{} `type:"structure"`
@@ -5678,6 +6764,12 @@ func (s UploadMultipartPartOutput) String() string {
 // GoString returns the string representation
 func (s UploadMultipartPartOutput) GoString() string {
 	return s.String()
+}
+
+// SetChecksum sets the Checksum field's value.
+func (s *UploadMultipartPartOutput) SetChecksum(v string) *UploadMultipartPartOutput {
+	s.Checksum = &v
+	return s
 }
 
 // Contains the vault access policy.
@@ -5698,6 +6790,12 @@ func (s VaultAccessPolicy) GoString() string {
 	return s.String()
 }
 
+// SetPolicy sets the Policy field's value.
+func (s *VaultAccessPolicy) SetPolicy(v string) *VaultAccessPolicy {
+	s.Policy = &v
+	return s
+}
+
 // Contains the vault lock policy.
 type VaultLockPolicy struct {
 	_ struct{} `type:"structure"`
@@ -5714,6 +6812,12 @@ func (s VaultLockPolicy) String() string {
 // GoString returns the string representation
 func (s VaultLockPolicy) GoString() string {
 	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *VaultLockPolicy) SetPolicy(v string) *VaultLockPolicy {
+	s.Policy = &v
+	return s
 }
 
 // Represents a vault's notification configuration.
@@ -5737,6 +6841,18 @@ func (s VaultNotificationConfig) String() string {
 // GoString returns the string representation
 func (s VaultNotificationConfig) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *VaultNotificationConfig) SetEvents(v []*string) *VaultNotificationConfig {
+	s.Events = v
+	return s
+}
+
+// SetSNSTopic sets the SNSTopic field's value.
+func (s *VaultNotificationConfig) SetSNSTopic(v string) *VaultNotificationConfig {
+	s.SNSTopic = &v
+	return s
 }
 
 const (

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -10120,6 +10120,36 @@ func (s AccessKey) GoString() string {
 	return s.String()
 }
 
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *AccessKey) SetAccessKeyId(v string) *AccessKey {
+	s.AccessKeyId = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *AccessKey) SetCreateDate(v time.Time) *AccessKey {
+	s.CreateDate = &v
+	return s
+}
+
+// SetSecretAccessKey sets the SecretAccessKey field's value.
+func (s *AccessKey) SetSecretAccessKey(v string) *AccessKey {
+	s.SecretAccessKey = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AccessKey) SetStatus(v string) *AccessKey {
+	s.Status = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *AccessKey) SetUserName(v string) *AccessKey {
+	s.UserName = &v
+	return s
+}
+
 // Contains information about the last time an AWS access key was used.
 //
 // This data type is used as a response element in the GetAccessKeyLastUsed
@@ -10180,6 +10210,24 @@ func (s AccessKeyLastUsed) GoString() string {
 	return s.String()
 }
 
+// SetLastUsedDate sets the LastUsedDate field's value.
+func (s *AccessKeyLastUsed) SetLastUsedDate(v time.Time) *AccessKeyLastUsed {
+	s.LastUsedDate = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *AccessKeyLastUsed) SetRegion(v string) *AccessKeyLastUsed {
+	s.Region = &v
+	return s
+}
+
+// SetServiceName sets the ServiceName field's value.
+func (s *AccessKeyLastUsed) SetServiceName(v string) *AccessKeyLastUsed {
+	s.ServiceName = &v
+	return s
+}
+
 // Contains information about an AWS access key, without its secret key.
 //
 // This data type is used as a response element in the ListAccessKeys action.
@@ -10208,6 +10256,30 @@ func (s AccessKeyMetadata) String() string {
 // GoString returns the string representation
 func (s AccessKeyMetadata) GoString() string {
 	return s.String()
+}
+
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *AccessKeyMetadata) SetAccessKeyId(v string) *AccessKeyMetadata {
+	s.AccessKeyId = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *AccessKeyMetadata) SetCreateDate(v time.Time) *AccessKeyMetadata {
+	s.CreateDate = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AccessKeyMetadata) SetStatus(v string) *AccessKeyMetadata {
+	s.Status = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *AccessKeyMetadata) SetUserName(v string) *AccessKeyMetadata {
+	s.UserName = &v
+	return s
 }
 
 type AddClientIDToOpenIDConnectProviderInput struct {
@@ -10257,6 +10329,18 @@ func (s *AddClientIDToOpenIDConnectProviderInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClientID sets the ClientID field's value.
+func (s *AddClientIDToOpenIDConnectProviderInput) SetClientID(v string) *AddClientIDToOpenIDConnectProviderInput {
+	s.ClientID = &v
+	return s
+}
+
+// SetOpenIDConnectProviderArn sets the OpenIDConnectProviderArn field's value.
+func (s *AddClientIDToOpenIDConnectProviderInput) SetOpenIDConnectProviderArn(v string) *AddClientIDToOpenIDConnectProviderInput {
+	s.OpenIDConnectProviderArn = &v
+	return s
 }
 
 type AddClientIDToOpenIDConnectProviderOutput struct {
@@ -10327,6 +10411,18 @@ func (s *AddRoleToInstanceProfileInput) Validate() error {
 	return nil
 }
 
+// SetInstanceProfileName sets the InstanceProfileName field's value.
+func (s *AddRoleToInstanceProfileInput) SetInstanceProfileName(v string) *AddRoleToInstanceProfileInput {
+	s.InstanceProfileName = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *AddRoleToInstanceProfileInput) SetRoleName(v string) *AddRoleToInstanceProfileInput {
+	s.RoleName = &v
+	return s
+}
+
 type AddRoleToInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10393,6 +10489,18 @@ func (s *AddUserToGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *AddUserToGroupInput) SetGroupName(v string) *AddUserToGroupInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *AddUserToGroupInput) SetUserName(v string) *AddUserToGroupInput {
+	s.UserName = &v
+	return s
 }
 
 type AddUserToGroupOutput struct {
@@ -10463,6 +10571,18 @@ func (s *AttachGroupPolicyInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *AttachGroupPolicyInput) SetGroupName(v string) *AttachGroupPolicyInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *AttachGroupPolicyInput) SetPolicyArn(v string) *AttachGroupPolicyInput {
+	s.PolicyArn = &v
+	return s
+}
+
 type AttachGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10529,6 +10649,18 @@ func (s *AttachRolePolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *AttachRolePolicyInput) SetPolicyArn(v string) *AttachRolePolicyInput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *AttachRolePolicyInput) SetRoleName(v string) *AttachRolePolicyInput {
+	s.RoleName = &v
+	return s
 }
 
 type AttachRolePolicyOutput struct {
@@ -10599,6 +10731,18 @@ func (s *AttachUserPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *AttachUserPolicyInput) SetPolicyArn(v string) *AttachUserPolicyInput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *AttachUserPolicyInput) SetUserName(v string) *AttachUserPolicyInput {
+	s.UserName = &v
+	return s
+}
+
 type AttachUserPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10645,6 +10789,18 @@ func (s AttachedPolicy) String() string {
 // GoString returns the string representation
 func (s AttachedPolicy) GoString() string {
 	return s.String()
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *AttachedPolicy) SetPolicyArn(v string) *AttachedPolicy {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *AttachedPolicy) SetPolicyName(v string) *AttachedPolicy {
+	s.PolicyName = &v
+	return s
 }
 
 type ChangePasswordInput struct {
@@ -10701,6 +10857,18 @@ func (s *ChangePasswordInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetNewPassword sets the NewPassword field's value.
+func (s *ChangePasswordInput) SetNewPassword(v string) *ChangePasswordInput {
+	s.NewPassword = &v
+	return s
+}
+
+// SetOldPassword sets the OldPassword field's value.
+func (s *ChangePasswordInput) SetOldPassword(v string) *ChangePasswordInput {
+	s.OldPassword = &v
+	return s
 }
 
 type ChangePasswordOutput struct {
@@ -10764,6 +10932,24 @@ func (s *ContextEntry) Validate() error {
 	return nil
 }
 
+// SetContextKeyName sets the ContextKeyName field's value.
+func (s *ContextEntry) SetContextKeyName(v string) *ContextEntry {
+	s.ContextKeyName = &v
+	return s
+}
+
+// SetContextKeyType sets the ContextKeyType field's value.
+func (s *ContextEntry) SetContextKeyType(v string) *ContextEntry {
+	s.ContextKeyType = &v
+	return s
+}
+
+// SetContextKeyValues sets the ContextKeyValues field's value.
+func (s *ContextEntry) SetContextKeyValues(v []*string) *ContextEntry {
+	s.ContextKeyValues = v
+	return s
+}
+
 type CreateAccessKeyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -10798,6 +10984,12 @@ func (s *CreateAccessKeyInput) Validate() error {
 	return nil
 }
 
+// SetUserName sets the UserName field's value.
+func (s *CreateAccessKeyInput) SetUserName(v string) *CreateAccessKeyInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful CreateAccessKey request.
 type CreateAccessKeyOutput struct {
 	_ struct{} `type:"structure"`
@@ -10816,6 +11008,12 @@ func (s CreateAccessKeyOutput) String() string {
 // GoString returns the string representation
 func (s CreateAccessKeyOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccessKey sets the AccessKey field's value.
+func (s *CreateAccessKeyOutput) SetAccessKey(v *AccessKey) *CreateAccessKeyOutput {
+	s.AccessKey = v
+	return s
 }
 
 type CreateAccountAliasInput struct {
@@ -10856,6 +11054,12 @@ func (s *CreateAccountAliasInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountAlias sets the AccountAlias field's value.
+func (s *CreateAccountAliasInput) SetAccountAlias(v string) *CreateAccountAliasInput {
+	s.AccountAlias = &v
+	return s
 }
 
 type CreateAccountAliasOutput struct {
@@ -10930,6 +11134,18 @@ func (s *CreateGroupInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *CreateGroupInput) SetGroupName(v string) *CreateGroupInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *CreateGroupInput) SetPath(v string) *CreateGroupInput {
+	s.Path = &v
+	return s
+}
+
 // Contains the response to a successful CreateGroup request.
 type CreateGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -10948,6 +11164,12 @@ func (s CreateGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetGroup sets the Group field's value.
+func (s *CreateGroupOutput) SetGroup(v *Group) *CreateGroupOutput {
+	s.Group = v
+	return s
 }
 
 type CreateInstanceProfileInput struct {
@@ -11006,6 +11228,18 @@ func (s *CreateInstanceProfileInput) Validate() error {
 	return nil
 }
 
+// SetInstanceProfileName sets the InstanceProfileName field's value.
+func (s *CreateInstanceProfileInput) SetInstanceProfileName(v string) *CreateInstanceProfileInput {
+	s.InstanceProfileName = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *CreateInstanceProfileInput) SetPath(v string) *CreateInstanceProfileInput {
+	s.Path = &v
+	return s
+}
+
 // Contains the response to a successful CreateInstanceProfile request.
 type CreateInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
@@ -11024,6 +11258,12 @@ func (s CreateInstanceProfileOutput) String() string {
 // GoString returns the string representation
 func (s CreateInstanceProfileOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceProfile sets the InstanceProfile field's value.
+func (s *CreateInstanceProfileOutput) SetInstanceProfile(v *InstanceProfile) *CreateInstanceProfileOutput {
+	s.InstanceProfile = v
+	return s
 }
 
 type CreateLoginProfileInput struct {
@@ -11089,6 +11329,24 @@ func (s *CreateLoginProfileInput) Validate() error {
 	return nil
 }
 
+// SetPassword sets the Password field's value.
+func (s *CreateLoginProfileInput) SetPassword(v string) *CreateLoginProfileInput {
+	s.Password = &v
+	return s
+}
+
+// SetPasswordResetRequired sets the PasswordResetRequired field's value.
+func (s *CreateLoginProfileInput) SetPasswordResetRequired(v bool) *CreateLoginProfileInput {
+	s.PasswordResetRequired = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *CreateLoginProfileInput) SetUserName(v string) *CreateLoginProfileInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful CreateLoginProfile request.
 type CreateLoginProfileOutput struct {
 	_ struct{} `type:"structure"`
@@ -11107,6 +11365,12 @@ func (s CreateLoginProfileOutput) String() string {
 // GoString returns the string representation
 func (s CreateLoginProfileOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoginProfile sets the LoginProfile field's value.
+func (s *CreateLoginProfileOutput) SetLoginProfile(v *LoginProfile) *CreateLoginProfileOutput {
+	s.LoginProfile = v
+	return s
 }
 
 type CreateOpenIDConnectProviderInput struct {
@@ -11191,6 +11455,24 @@ func (s *CreateOpenIDConnectProviderInput) Validate() error {
 	return nil
 }
 
+// SetClientIDList sets the ClientIDList field's value.
+func (s *CreateOpenIDConnectProviderInput) SetClientIDList(v []*string) *CreateOpenIDConnectProviderInput {
+	s.ClientIDList = v
+	return s
+}
+
+// SetThumbprintList sets the ThumbprintList field's value.
+func (s *CreateOpenIDConnectProviderInput) SetThumbprintList(v []*string) *CreateOpenIDConnectProviderInput {
+	s.ThumbprintList = v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *CreateOpenIDConnectProviderInput) SetUrl(v string) *CreateOpenIDConnectProviderInput {
+	s.Url = &v
+	return s
+}
+
 // Contains the response to a successful CreateOpenIDConnectProvider request.
 type CreateOpenIDConnectProviderOutput struct {
 	_ struct{} `type:"structure"`
@@ -11208,6 +11490,12 @@ func (s CreateOpenIDConnectProviderOutput) String() string {
 // GoString returns the string representation
 func (s CreateOpenIDConnectProviderOutput) GoString() string {
 	return s.String()
+}
+
+// SetOpenIDConnectProviderArn sets the OpenIDConnectProviderArn field's value.
+func (s *CreateOpenIDConnectProviderOutput) SetOpenIDConnectProviderArn(v string) *CreateOpenIDConnectProviderOutput {
+	s.OpenIDConnectProviderArn = &v
+	return s
 }
 
 type CreatePolicyInput struct {
@@ -11291,6 +11579,30 @@ func (s *CreatePolicyInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreatePolicyInput) SetDescription(v string) *CreatePolicyInput {
+	s.Description = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *CreatePolicyInput) SetPath(v string) *CreatePolicyInput {
+	s.Path = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *CreatePolicyInput) SetPolicyDocument(v string) *CreatePolicyInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *CreatePolicyInput) SetPolicyName(v string) *CreatePolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 // Contains the response to a successful CreatePolicy request.
 type CreatePolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -11307,6 +11619,12 @@ func (s CreatePolicyOutput) String() string {
 // GoString returns the string representation
 func (s CreatePolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *CreatePolicyOutput) SetPolicy(v *Policy) *CreatePolicyOutput {
+	s.Policy = v
+	return s
 }
 
 type CreatePolicyVersionInput struct {
@@ -11378,6 +11696,24 @@ func (s *CreatePolicyVersionInput) Validate() error {
 	return nil
 }
 
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *CreatePolicyVersionInput) SetPolicyArn(v string) *CreatePolicyVersionInput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *CreatePolicyVersionInput) SetPolicyDocument(v string) *CreatePolicyVersionInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetSetAsDefault sets the SetAsDefault field's value.
+func (s *CreatePolicyVersionInput) SetSetAsDefault(v bool) *CreatePolicyVersionInput {
+	s.SetAsDefault = &v
+	return s
+}
+
 // Contains the response to a successful CreatePolicyVersion request.
 type CreatePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11394,6 +11730,12 @@ func (s CreatePolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s CreatePolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyVersion sets the PolicyVersion field's value.
+func (s *CreatePolicyVersionOutput) SetPolicyVersion(v *PolicyVersion) *CreatePolicyVersionOutput {
+	s.PolicyVersion = v
+	return s
 }
 
 type CreateRoleInput struct {
@@ -11472,6 +11814,24 @@ func (s *CreateRoleInput) Validate() error {
 	return nil
 }
 
+// SetAssumeRolePolicyDocument sets the AssumeRolePolicyDocument field's value.
+func (s *CreateRoleInput) SetAssumeRolePolicyDocument(v string) *CreateRoleInput {
+	s.AssumeRolePolicyDocument = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *CreateRoleInput) SetPath(v string) *CreateRoleInput {
+	s.Path = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *CreateRoleInput) SetRoleName(v string) *CreateRoleInput {
+	s.RoleName = &v
+	return s
+}
+
 // Contains the response to a successful CreateRole request.
 type CreateRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -11490,6 +11850,12 @@ func (s CreateRoleOutput) String() string {
 // GoString returns the string representation
 func (s CreateRoleOutput) GoString() string {
 	return s.String()
+}
+
+// SetRole sets the Role field's value.
+func (s *CreateRoleOutput) SetRole(v *Role) *CreateRoleOutput {
+	s.Role = v
+	return s
 }
 
 type CreateSAMLProviderInput struct {
@@ -11549,6 +11915,18 @@ func (s *CreateSAMLProviderInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *CreateSAMLProviderInput) SetName(v string) *CreateSAMLProviderInput {
+	s.Name = &v
+	return s
+}
+
+// SetSAMLMetadataDocument sets the SAMLMetadataDocument field's value.
+func (s *CreateSAMLProviderInput) SetSAMLMetadataDocument(v string) *CreateSAMLProviderInput {
+	s.SAMLMetadataDocument = &v
+	return s
+}
+
 // Contains the response to a successful CreateSAMLProvider request.
 type CreateSAMLProviderOutput struct {
 	_ struct{} `type:"structure"`
@@ -11565,6 +11943,12 @@ func (s CreateSAMLProviderOutput) String() string {
 // GoString returns the string representation
 func (s CreateSAMLProviderOutput) GoString() string {
 	return s.String()
+}
+
+// SetSAMLProviderArn sets the SAMLProviderArn field's value.
+func (s *CreateSAMLProviderOutput) SetSAMLProviderArn(v string) *CreateSAMLProviderOutput {
+	s.SAMLProviderArn = &v
+	return s
 }
 
 type CreateUserInput struct {
@@ -11625,6 +12009,18 @@ func (s *CreateUserInput) Validate() error {
 	return nil
 }
 
+// SetPath sets the Path field's value.
+func (s *CreateUserInput) SetPath(v string) *CreateUserInput {
+	s.Path = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *CreateUserInput) SetUserName(v string) *CreateUserInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful CreateUser request.
 type CreateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -11641,6 +12037,12 @@ func (s CreateUserOutput) String() string {
 // GoString returns the string representation
 func (s CreateUserOutput) GoString() string {
 	return s.String()
+}
+
+// SetUser sets the User field's value.
+func (s *CreateUserOutput) SetUser(v *User) *CreateUserOutput {
+	s.User = v
+	return s
 }
 
 type CreateVirtualMFADeviceInput struct {
@@ -11700,6 +12102,18 @@ func (s *CreateVirtualMFADeviceInput) Validate() error {
 	return nil
 }
 
+// SetPath sets the Path field's value.
+func (s *CreateVirtualMFADeviceInput) SetPath(v string) *CreateVirtualMFADeviceInput {
+	s.Path = &v
+	return s
+}
+
+// SetVirtualMFADeviceName sets the VirtualMFADeviceName field's value.
+func (s *CreateVirtualMFADeviceInput) SetVirtualMFADeviceName(v string) *CreateVirtualMFADeviceInput {
+	s.VirtualMFADeviceName = &v
+	return s
+}
+
 // Contains the response to a successful CreateVirtualMFADevice request.
 type CreateVirtualMFADeviceOutput struct {
 	_ struct{} `type:"structure"`
@@ -11718,6 +12132,12 @@ func (s CreateVirtualMFADeviceOutput) String() string {
 // GoString returns the string representation
 func (s CreateVirtualMFADeviceOutput) GoString() string {
 	return s.String()
+}
+
+// SetVirtualMFADevice sets the VirtualMFADevice field's value.
+func (s *CreateVirtualMFADeviceOutput) SetVirtualMFADevice(v *VirtualMFADevice) *CreateVirtualMFADeviceOutput {
+	s.VirtualMFADevice = v
+	return s
 }
 
 type DeactivateMFADeviceInput struct {
@@ -11773,6 +12193,18 @@ func (s *DeactivateMFADeviceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *DeactivateMFADeviceInput) SetSerialNumber(v string) *DeactivateMFADeviceInput {
+	s.SerialNumber = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DeactivateMFADeviceInput) SetUserName(v string) *DeactivateMFADeviceInput {
+	s.UserName = &v
+	return s
 }
 
 type DeactivateMFADeviceOutput struct {
@@ -11839,6 +12271,18 @@ func (s *DeleteAccessKeyInput) Validate() error {
 	return nil
 }
 
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *DeleteAccessKeyInput) SetAccessKeyId(v string) *DeleteAccessKeyInput {
+	s.AccessKeyId = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DeleteAccessKeyInput) SetUserName(v string) *DeleteAccessKeyInput {
+	s.UserName = &v
+	return s
+}
+
 type DeleteAccessKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11891,6 +12335,12 @@ func (s *DeleteAccountAliasInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccountAlias sets the AccountAlias field's value.
+func (s *DeleteAccountAliasInput) SetAccountAlias(v string) *DeleteAccountAliasInput {
+	s.AccountAlias = &v
+	return s
 }
 
 type DeleteAccountAliasOutput struct {
@@ -11974,6 +12424,12 @@ func (s *DeleteGroupInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *DeleteGroupInput) SetGroupName(v string) *DeleteGroupInput {
+	s.GroupName = &v
+	return s
+}
+
 type DeleteGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12043,6 +12499,18 @@ func (s *DeleteGroupPolicyInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *DeleteGroupPolicyInput) SetGroupName(v string) *DeleteGroupPolicyInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeleteGroupPolicyInput) SetPolicyName(v string) *DeleteGroupPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 type DeleteGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12094,6 +12562,12 @@ func (s *DeleteInstanceProfileInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceProfileName sets the InstanceProfileName field's value.
+func (s *DeleteInstanceProfileInput) SetInstanceProfileName(v string) *DeleteInstanceProfileInput {
+	s.InstanceProfileName = &v
+	return s
 }
 
 type DeleteInstanceProfileOutput struct {
@@ -12149,6 +12623,12 @@ func (s *DeleteLoginProfileInput) Validate() error {
 	return nil
 }
 
+// SetUserName sets the UserName field's value.
+func (s *DeleteLoginProfileInput) SetUserName(v string) *DeleteLoginProfileInput {
+	s.UserName = &v
+	return s
+}
+
 type DeleteLoginProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12198,6 +12678,12 @@ func (s *DeleteOpenIDConnectProviderInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetOpenIDConnectProviderArn sets the OpenIDConnectProviderArn field's value.
+func (s *DeleteOpenIDConnectProviderInput) SetOpenIDConnectProviderArn(v string) *DeleteOpenIDConnectProviderInput {
+	s.OpenIDConnectProviderArn = &v
+	return s
 }
 
 type DeleteOpenIDConnectProviderOutput struct {
@@ -12251,6 +12737,12 @@ func (s *DeletePolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *DeletePolicyInput) SetPolicyArn(v string) *DeletePolicyInput {
+	s.PolicyArn = &v
+	return s
 }
 
 type DeletePolicyOutput struct {
@@ -12324,6 +12816,18 @@ func (s *DeletePolicyVersionInput) Validate() error {
 	return nil
 }
 
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *DeletePolicyVersionInput) SetPolicyArn(v string) *DeletePolicyVersionInput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *DeletePolicyVersionInput) SetVersionId(v string) *DeletePolicyVersionInput {
+	s.VersionId = &v
+	return s
+}
+
 type DeletePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12375,6 +12879,12 @@ func (s *DeleteRoleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *DeleteRoleInput) SetRoleName(v string) *DeleteRoleInput {
+	s.RoleName = &v
+	return s
 }
 
 type DeleteRoleOutput struct {
@@ -12446,6 +12956,18 @@ func (s *DeleteRolePolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeleteRolePolicyInput) SetPolicyName(v string) *DeleteRolePolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *DeleteRolePolicyInput) SetRoleName(v string) *DeleteRolePolicyInput {
+	s.RoleName = &v
+	return s
+}
+
 type DeleteRolePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12493,6 +13015,12 @@ func (s *DeleteSAMLProviderInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetSAMLProviderArn sets the SAMLProviderArn field's value.
+func (s *DeleteSAMLProviderInput) SetSAMLProviderArn(v string) *DeleteSAMLProviderInput {
+	s.SAMLProviderArn = &v
+	return s
 }
 
 type DeleteSAMLProviderOutput struct {
@@ -12563,6 +13091,18 @@ func (s *DeleteSSHPublicKeyInput) Validate() error {
 	return nil
 }
 
+// SetSSHPublicKeyId sets the SSHPublicKeyId field's value.
+func (s *DeleteSSHPublicKeyInput) SetSSHPublicKeyId(v string) *DeleteSSHPublicKeyInput {
+	s.SSHPublicKeyId = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DeleteSSHPublicKeyInput) SetUserName(v string) *DeleteSSHPublicKeyInput {
+	s.UserName = &v
+	return s
+}
+
 type DeleteSSHPublicKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12614,6 +13154,12 @@ func (s *DeleteServerCertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetServerCertificateName sets the ServerCertificateName field's value.
+func (s *DeleteServerCertificateInput) SetServerCertificateName(v string) *DeleteServerCertificateInput {
+	s.ServerCertificateName = &v
+	return s
 }
 
 type DeleteServerCertificateOutput struct {
@@ -12679,6 +13225,18 @@ func (s *DeleteSigningCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateId sets the CertificateId field's value.
+func (s *DeleteSigningCertificateInput) SetCertificateId(v string) *DeleteSigningCertificateInput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DeleteSigningCertificateInput) SetUserName(v string) *DeleteSigningCertificateInput {
+	s.UserName = &v
+	return s
+}
+
 type DeleteSigningCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12730,6 +13288,12 @@ func (s *DeleteUserInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DeleteUserInput) SetUserName(v string) *DeleteUserInput {
+	s.UserName = &v
+	return s
 }
 
 type DeleteUserOutput struct {
@@ -12801,6 +13365,18 @@ func (s *DeleteUserPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeleteUserPolicyInput) SetPolicyName(v string) *DeleteUserPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DeleteUserPolicyInput) SetUserName(v string) *DeleteUserPolicyInput {
+	s.UserName = &v
+	return s
+}
+
 type DeleteUserPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12853,6 +13429,12 @@ func (s *DeleteVirtualMFADeviceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *DeleteVirtualMFADeviceInput) SetSerialNumber(v string) *DeleteVirtualMFADeviceInput {
+	s.SerialNumber = &v
+	return s
 }
 
 type DeleteVirtualMFADeviceOutput struct {
@@ -12923,6 +13505,18 @@ func (s *DetachGroupPolicyInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *DetachGroupPolicyInput) SetGroupName(v string) *DetachGroupPolicyInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *DetachGroupPolicyInput) SetPolicyArn(v string) *DetachGroupPolicyInput {
+	s.PolicyArn = &v
+	return s
+}
+
 type DetachGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12991,6 +13585,18 @@ func (s *DetachRolePolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *DetachRolePolicyInput) SetPolicyArn(v string) *DetachRolePolicyInput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *DetachRolePolicyInput) SetRoleName(v string) *DetachRolePolicyInput {
+	s.RoleName = &v
+	return s
+}
+
 type DetachRolePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13057,6 +13663,18 @@ func (s *DetachUserPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *DetachUserPolicyInput) SetPolicyArn(v string) *DetachUserPolicyInput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DetachUserPolicyInput) SetUserName(v string) *DetachUserPolicyInput {
+	s.UserName = &v
+	return s
 }
 
 type DetachUserPolicyOutput struct {
@@ -13154,6 +13772,30 @@ func (s *EnableMFADeviceInput) Validate() error {
 	return nil
 }
 
+// SetAuthenticationCode1 sets the AuthenticationCode1 field's value.
+func (s *EnableMFADeviceInput) SetAuthenticationCode1(v string) *EnableMFADeviceInput {
+	s.AuthenticationCode1 = &v
+	return s
+}
+
+// SetAuthenticationCode2 sets the AuthenticationCode2 field's value.
+func (s *EnableMFADeviceInput) SetAuthenticationCode2(v string) *EnableMFADeviceInput {
+	s.AuthenticationCode2 = &v
+	return s
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *EnableMFADeviceInput) SetSerialNumber(v string) *EnableMFADeviceInput {
+	s.SerialNumber = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *EnableMFADeviceInput) SetUserName(v string) *EnableMFADeviceInput {
+	s.UserName = &v
+	return s
+}
+
 type EnableMFADeviceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13227,6 +13869,48 @@ func (s EvaluationResult) GoString() string {
 	return s.String()
 }
 
+// SetEvalActionName sets the EvalActionName field's value.
+func (s *EvaluationResult) SetEvalActionName(v string) *EvaluationResult {
+	s.EvalActionName = &v
+	return s
+}
+
+// SetEvalDecision sets the EvalDecision field's value.
+func (s *EvaluationResult) SetEvalDecision(v string) *EvaluationResult {
+	s.EvalDecision = &v
+	return s
+}
+
+// SetEvalDecisionDetails sets the EvalDecisionDetails field's value.
+func (s *EvaluationResult) SetEvalDecisionDetails(v map[string]*string) *EvaluationResult {
+	s.EvalDecisionDetails = v
+	return s
+}
+
+// SetEvalResourceName sets the EvalResourceName field's value.
+func (s *EvaluationResult) SetEvalResourceName(v string) *EvaluationResult {
+	s.EvalResourceName = &v
+	return s
+}
+
+// SetMatchedStatements sets the MatchedStatements field's value.
+func (s *EvaluationResult) SetMatchedStatements(v []*Statement) *EvaluationResult {
+	s.MatchedStatements = v
+	return s
+}
+
+// SetMissingContextValues sets the MissingContextValues field's value.
+func (s *EvaluationResult) SetMissingContextValues(v []*string) *EvaluationResult {
+	s.MissingContextValues = v
+	return s
+}
+
+// SetResourceSpecificResults sets the ResourceSpecificResults field's value.
+func (s *EvaluationResult) SetResourceSpecificResults(v []*ResourceSpecificResult) *EvaluationResult {
+	s.ResourceSpecificResults = v
+	return s
+}
+
 type GenerateCredentialReportInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13260,6 +13944,18 @@ func (s GenerateCredentialReportOutput) String() string {
 // GoString returns the string representation
 func (s GenerateCredentialReportOutput) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *GenerateCredentialReportOutput) SetDescription(v string) *GenerateCredentialReportOutput {
+	s.Description = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *GenerateCredentialReportOutput) SetState(v string) *GenerateCredentialReportOutput {
+	s.State = &v
+	return s
 }
 
 type GetAccessKeyLastUsedInput struct {
@@ -13301,6 +13997,12 @@ func (s *GetAccessKeyLastUsedInput) Validate() error {
 	return nil
 }
 
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *GetAccessKeyLastUsedInput) SetAccessKeyId(v string) *GetAccessKeyLastUsedInput {
+	s.AccessKeyId = &v
+	return s
+}
+
 // Contains the response to a successful GetAccessKeyLastUsed request. It is
 // also returned as a member of the AccessKeyMetaData structure returned by
 // the ListAccessKeys action.
@@ -13322,6 +14024,18 @@ func (s GetAccessKeyLastUsedOutput) String() string {
 // GoString returns the string representation
 func (s GetAccessKeyLastUsedOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccessKeyLastUsed sets the AccessKeyLastUsed field's value.
+func (s *GetAccessKeyLastUsedOutput) SetAccessKeyLastUsed(v *AccessKeyLastUsed) *GetAccessKeyLastUsedOutput {
+	s.AccessKeyLastUsed = v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *GetAccessKeyLastUsedOutput) SetUserName(v string) *GetAccessKeyLastUsedOutput {
+	s.UserName = &v
+	return s
 }
 
 type GetAccountAuthorizationDetailsInput struct {
@@ -13380,6 +14094,24 @@ func (s *GetAccountAuthorizationDetailsInput) Validate() error {
 	return nil
 }
 
+// SetFilter sets the Filter field's value.
+func (s *GetAccountAuthorizationDetailsInput) SetFilter(v []*string) *GetAccountAuthorizationDetailsInput {
+	s.Filter = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *GetAccountAuthorizationDetailsInput) SetMarker(v string) *GetAccountAuthorizationDetailsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *GetAccountAuthorizationDetailsInput) SetMaxItems(v int64) *GetAccountAuthorizationDetailsInput {
+	s.MaxItems = &v
+	return s
+}
+
 // Contains the response to a successful GetAccountAuthorizationDetails request.
 type GetAccountAuthorizationDetailsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13419,6 +14151,42 @@ func (s GetAccountAuthorizationDetailsOutput) GoString() string {
 	return s.String()
 }
 
+// SetGroupDetailList sets the GroupDetailList field's value.
+func (s *GetAccountAuthorizationDetailsOutput) SetGroupDetailList(v []*GroupDetail) *GetAccountAuthorizationDetailsOutput {
+	s.GroupDetailList = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *GetAccountAuthorizationDetailsOutput) SetIsTruncated(v bool) *GetAccountAuthorizationDetailsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *GetAccountAuthorizationDetailsOutput) SetMarker(v string) *GetAccountAuthorizationDetailsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *GetAccountAuthorizationDetailsOutput) SetPolicies(v []*ManagedPolicyDetail) *GetAccountAuthorizationDetailsOutput {
+	s.Policies = v
+	return s
+}
+
+// SetRoleDetailList sets the RoleDetailList field's value.
+func (s *GetAccountAuthorizationDetailsOutput) SetRoleDetailList(v []*RoleDetail) *GetAccountAuthorizationDetailsOutput {
+	s.RoleDetailList = v
+	return s
+}
+
+// SetUserDetailList sets the UserDetailList field's value.
+func (s *GetAccountAuthorizationDetailsOutput) SetUserDetailList(v []*UserDetail) *GetAccountAuthorizationDetailsOutput {
+	s.UserDetailList = v
+	return s
+}
+
 type GetAccountPasswordPolicyInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13456,6 +14224,12 @@ func (s GetAccountPasswordPolicyOutput) GoString() string {
 	return s.String()
 }
 
+// SetPasswordPolicy sets the PasswordPolicy field's value.
+func (s *GetAccountPasswordPolicyOutput) SetPasswordPolicy(v *PasswordPolicy) *GetAccountPasswordPolicyOutput {
+	s.PasswordPolicy = v
+	return s
+}
+
 type GetAccountSummaryInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13487,6 +14261,12 @@ func (s GetAccountSummaryOutput) String() string {
 // GoString returns the string representation
 func (s GetAccountSummaryOutput) GoString() string {
 	return s.String()
+}
+
+// SetSummaryMap sets the SummaryMap field's value.
+func (s *GetAccountSummaryOutput) SetSummaryMap(v map[string]*int64) *GetAccountSummaryOutput {
+	s.SummaryMap = v
+	return s
 }
 
 type GetContextKeysForCustomPolicyInput struct {
@@ -13529,6 +14309,12 @@ func (s *GetContextKeysForCustomPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyInputList sets the PolicyInputList field's value.
+func (s *GetContextKeysForCustomPolicyInput) SetPolicyInputList(v []*string) *GetContextKeysForCustomPolicyInput {
+	s.PolicyInputList = v
+	return s
+}
+
 // Contains the response to a successful GetContextKeysForPrincipalPolicy or
 // GetContextKeysForCustomPolicy request.
 type GetContextKeysForPolicyResponse struct {
@@ -13546,6 +14332,12 @@ func (s GetContextKeysForPolicyResponse) String() string {
 // GoString returns the string representation
 func (s GetContextKeysForPolicyResponse) GoString() string {
 	return s.String()
+}
+
+// SetContextKeyNames sets the ContextKeyNames field's value.
+func (s *GetContextKeysForPolicyResponse) SetContextKeyNames(v []*string) *GetContextKeysForPolicyResponse {
+	s.ContextKeyNames = v
+	return s
 }
 
 type GetContextKeysForPrincipalPolicyInput struct {
@@ -13603,6 +14395,18 @@ func (s *GetContextKeysForPrincipalPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyInputList sets the PolicyInputList field's value.
+func (s *GetContextKeysForPrincipalPolicyInput) SetPolicyInputList(v []*string) *GetContextKeysForPrincipalPolicyInput {
+	s.PolicyInputList = v
+	return s
+}
+
+// SetPolicySourceArn sets the PolicySourceArn field's value.
+func (s *GetContextKeysForPrincipalPolicyInput) SetPolicySourceArn(v string) *GetContextKeysForPrincipalPolicyInput {
+	s.PolicySourceArn = &v
+	return s
+}
+
 type GetCredentialReportInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13642,6 +14446,24 @@ func (s GetCredentialReportOutput) String() string {
 // GoString returns the string representation
 func (s GetCredentialReportOutput) GoString() string {
 	return s.String()
+}
+
+// SetContent sets the Content field's value.
+func (s *GetCredentialReportOutput) SetContent(v []byte) *GetCredentialReportOutput {
+	s.Content = v
+	return s
+}
+
+// SetGeneratedTime sets the GeneratedTime field's value.
+func (s *GetCredentialReportOutput) SetGeneratedTime(v time.Time) *GetCredentialReportOutput {
+	s.GeneratedTime = &v
+	return s
+}
+
+// SetReportFormat sets the ReportFormat field's value.
+func (s *GetCredentialReportOutput) SetReportFormat(v string) *GetCredentialReportOutput {
+	s.ReportFormat = &v
+	return s
 }
 
 type GetGroupInput struct {
@@ -13706,6 +14528,24 @@ func (s *GetGroupInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *GetGroupInput) SetGroupName(v string) *GetGroupInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *GetGroupInput) SetMarker(v string) *GetGroupInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *GetGroupInput) SetMaxItems(v int64) *GetGroupInput {
+	s.MaxItems = &v
+	return s
+}
+
 // Contains the response to a successful GetGroup request.
 type GetGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -13741,6 +14581,30 @@ func (s GetGroupOutput) String() string {
 // GoString returns the string representation
 func (s GetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetGroup sets the Group field's value.
+func (s *GetGroupOutput) SetGroup(v *Group) *GetGroupOutput {
+	s.Group = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *GetGroupOutput) SetIsTruncated(v bool) *GetGroupOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *GetGroupOutput) SetMarker(v string) *GetGroupOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetUsers sets the Users field's value.
+func (s *GetGroupOutput) SetUsers(v []*User) *GetGroupOutput {
+	s.Users = v
+	return s
 }
 
 type GetGroupPolicyInput struct {
@@ -13797,6 +14661,18 @@ func (s *GetGroupPolicyInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *GetGroupPolicyInput) SetGroupName(v string) *GetGroupPolicyInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetGroupPolicyInput) SetPolicyName(v string) *GetGroupPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 // Contains the response to a successful GetGroupPolicy request.
 type GetGroupPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -13825,6 +14701,24 @@ func (s GetGroupPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetGroupPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *GetGroupPolicyOutput) SetGroupName(v string) *GetGroupPolicyOutput {
+	s.GroupName = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *GetGroupPolicyOutput) SetPolicyDocument(v string) *GetGroupPolicyOutput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetGroupPolicyOutput) SetPolicyName(v string) *GetGroupPolicyOutput {
+	s.PolicyName = &v
+	return s
 }
 
 type GetInstanceProfileInput struct {
@@ -13866,6 +14760,12 @@ func (s *GetInstanceProfileInput) Validate() error {
 	return nil
 }
 
+// SetInstanceProfileName sets the InstanceProfileName field's value.
+func (s *GetInstanceProfileInput) SetInstanceProfileName(v string) *GetInstanceProfileInput {
+	s.InstanceProfileName = &v
+	return s
+}
+
 // Contains the response to a successful GetInstanceProfile request.
 type GetInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
@@ -13884,6 +14784,12 @@ func (s GetInstanceProfileOutput) String() string {
 // GoString returns the string representation
 func (s GetInstanceProfileOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceProfile sets the InstanceProfile field's value.
+func (s *GetInstanceProfileOutput) SetInstanceProfile(v *InstanceProfile) *GetInstanceProfileOutput {
+	s.InstanceProfile = v
+	return s
 }
 
 type GetLoginProfileInput struct {
@@ -13925,6 +14831,12 @@ func (s *GetLoginProfileInput) Validate() error {
 	return nil
 }
 
+// SetUserName sets the UserName field's value.
+func (s *GetLoginProfileInput) SetUserName(v string) *GetLoginProfileInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful GetLoginProfile request.
 type GetLoginProfileOutput struct {
 	_ struct{} `type:"structure"`
@@ -13943,6 +14855,12 @@ func (s GetLoginProfileOutput) String() string {
 // GoString returns the string representation
 func (s GetLoginProfileOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoginProfile sets the LoginProfile field's value.
+func (s *GetLoginProfileOutput) SetLoginProfile(v *LoginProfile) *GetLoginProfileOutput {
+	s.LoginProfile = v
+	return s
 }
 
 type GetOpenIDConnectProviderInput struct {
@@ -13986,6 +14904,12 @@ func (s *GetOpenIDConnectProviderInput) Validate() error {
 	return nil
 }
 
+// SetOpenIDConnectProviderArn sets the OpenIDConnectProviderArn field's value.
+func (s *GetOpenIDConnectProviderInput) SetOpenIDConnectProviderArn(v string) *GetOpenIDConnectProviderInput {
+	s.OpenIDConnectProviderArn = &v
+	return s
+}
+
 // Contains the response to a successful GetOpenIDConnectProvider request.
 type GetOpenIDConnectProviderOutput struct {
 	_ struct{} `type:"structure"`
@@ -14015,6 +14939,30 @@ func (s GetOpenIDConnectProviderOutput) String() string {
 // GoString returns the string representation
 func (s GetOpenIDConnectProviderOutput) GoString() string {
 	return s.String()
+}
+
+// SetClientIDList sets the ClientIDList field's value.
+func (s *GetOpenIDConnectProviderOutput) SetClientIDList(v []*string) *GetOpenIDConnectProviderOutput {
+	s.ClientIDList = v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *GetOpenIDConnectProviderOutput) SetCreateDate(v time.Time) *GetOpenIDConnectProviderOutput {
+	s.CreateDate = &v
+	return s
+}
+
+// SetThumbprintList sets the ThumbprintList field's value.
+func (s *GetOpenIDConnectProviderOutput) SetThumbprintList(v []*string) *GetOpenIDConnectProviderOutput {
+	s.ThumbprintList = v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *GetOpenIDConnectProviderOutput) SetUrl(v string) *GetOpenIDConnectProviderOutput {
+	s.Url = &v
+	return s
 }
 
 type GetPolicyInput struct {
@@ -14057,6 +15005,12 @@ func (s *GetPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *GetPolicyInput) SetPolicyArn(v string) *GetPolicyInput {
+	s.PolicyArn = &v
+	return s
+}
+
 // Contains the response to a successful GetPolicy request.
 type GetPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -14073,6 +15027,12 @@ func (s GetPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetPolicyOutput) SetPolicy(v *Policy) *GetPolicyOutput {
+	s.Policy = v
+	return s
 }
 
 type GetPolicyVersionInput struct {
@@ -14128,6 +15088,18 @@ func (s *GetPolicyVersionInput) Validate() error {
 	return nil
 }
 
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *GetPolicyVersionInput) SetPolicyArn(v string) *GetPolicyVersionInput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *GetPolicyVersionInput) SetVersionId(v string) *GetPolicyVersionInput {
+	s.VersionId = &v
+	return s
+}
+
 // Contains the response to a successful GetPolicyVersion request.
 type GetPolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -14144,6 +15116,12 @@ func (s GetPolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s GetPolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyVersion sets the PolicyVersion field's value.
+func (s *GetPolicyVersionOutput) SetPolicyVersion(v *PolicyVersion) *GetPolicyVersionOutput {
+	s.PolicyVersion = v
+	return s
 }
 
 type GetRoleInput struct {
@@ -14185,6 +15163,12 @@ func (s *GetRoleInput) Validate() error {
 	return nil
 }
 
+// SetRoleName sets the RoleName field's value.
+func (s *GetRoleInput) SetRoleName(v string) *GetRoleInput {
+	s.RoleName = &v
+	return s
+}
+
 // Contains the response to a successful GetRole request.
 type GetRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -14203,6 +15187,12 @@ func (s GetRoleOutput) String() string {
 // GoString returns the string representation
 func (s GetRoleOutput) GoString() string {
 	return s.String()
+}
+
+// SetRole sets the Role field's value.
+func (s *GetRoleOutput) SetRole(v *Role) *GetRoleOutput {
+	s.Role = v
+	return s
 }
 
 type GetRolePolicyInput struct {
@@ -14259,6 +15249,18 @@ func (s *GetRolePolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetRolePolicyInput) SetPolicyName(v string) *GetRolePolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *GetRolePolicyInput) SetRoleName(v string) *GetRolePolicyInput {
+	s.RoleName = &v
+	return s
+}
+
 // Contains the response to a successful GetRolePolicy request.
 type GetRolePolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -14287,6 +15289,24 @@ func (s GetRolePolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetRolePolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *GetRolePolicyOutput) SetPolicyDocument(v string) *GetRolePolicyOutput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetRolePolicyOutput) SetPolicyName(v string) *GetRolePolicyOutput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *GetRolePolicyOutput) SetRoleName(v string) *GetRolePolicyOutput {
+	s.RoleName = &v
+	return s
 }
 
 type GetSAMLProviderInput struct {
@@ -14329,6 +15349,12 @@ func (s *GetSAMLProviderInput) Validate() error {
 	return nil
 }
 
+// SetSAMLProviderArn sets the SAMLProviderArn field's value.
+func (s *GetSAMLProviderInput) SetSAMLProviderArn(v string) *GetSAMLProviderInput {
+	s.SAMLProviderArn = &v
+	return s
+}
+
 // Contains the response to a successful GetSAMLProvider request.
 type GetSAMLProviderOutput struct {
 	_ struct{} `type:"structure"`
@@ -14351,6 +15377,24 @@ func (s GetSAMLProviderOutput) String() string {
 // GoString returns the string representation
 func (s GetSAMLProviderOutput) GoString() string {
 	return s.String()
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *GetSAMLProviderOutput) SetCreateDate(v time.Time) *GetSAMLProviderOutput {
+	s.CreateDate = &v
+	return s
+}
+
+// SetSAMLMetadataDocument sets the SAMLMetadataDocument field's value.
+func (s *GetSAMLProviderOutput) SetSAMLMetadataDocument(v string) *GetSAMLProviderOutput {
+	s.SAMLMetadataDocument = &v
+	return s
+}
+
+// SetValidUntil sets the ValidUntil field's value.
+func (s *GetSAMLProviderOutput) SetValidUntil(v time.Time) *GetSAMLProviderOutput {
+	s.ValidUntil = &v
+	return s
 }
 
 type GetSSHPublicKeyInput struct {
@@ -14417,6 +15461,24 @@ func (s *GetSSHPublicKeyInput) Validate() error {
 	return nil
 }
 
+// SetEncoding sets the Encoding field's value.
+func (s *GetSSHPublicKeyInput) SetEncoding(v string) *GetSSHPublicKeyInput {
+	s.Encoding = &v
+	return s
+}
+
+// SetSSHPublicKeyId sets the SSHPublicKeyId field's value.
+func (s *GetSSHPublicKeyInput) SetSSHPublicKeyId(v string) *GetSSHPublicKeyInput {
+	s.SSHPublicKeyId = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *GetSSHPublicKeyInput) SetUserName(v string) *GetSSHPublicKeyInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful GetSSHPublicKey request.
 type GetSSHPublicKeyOutput struct {
 	_ struct{} `type:"structure"`
@@ -14433,6 +15495,12 @@ func (s GetSSHPublicKeyOutput) String() string {
 // GoString returns the string representation
 func (s GetSSHPublicKeyOutput) GoString() string {
 	return s.String()
+}
+
+// SetSSHPublicKey sets the SSHPublicKey field's value.
+func (s *GetSSHPublicKeyOutput) SetSSHPublicKey(v *SSHPublicKey) *GetSSHPublicKeyOutput {
+	s.SSHPublicKey = v
+	return s
 }
 
 type GetServerCertificateInput struct {
@@ -14474,6 +15542,12 @@ func (s *GetServerCertificateInput) Validate() error {
 	return nil
 }
 
+// SetServerCertificateName sets the ServerCertificateName field's value.
+func (s *GetServerCertificateInput) SetServerCertificateName(v string) *GetServerCertificateInput {
+	s.ServerCertificateName = &v
+	return s
+}
+
 // Contains the response to a successful GetServerCertificate request.
 type GetServerCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -14492,6 +15566,12 @@ func (s GetServerCertificateOutput) String() string {
 // GoString returns the string representation
 func (s GetServerCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetServerCertificate sets the ServerCertificate field's value.
+func (s *GetServerCertificateOutput) SetServerCertificate(v *ServerCertificate) *GetServerCertificateOutput {
+	s.ServerCertificate = v
+	return s
 }
 
 type GetUserInput struct {
@@ -14530,6 +15610,12 @@ func (s *GetUserInput) Validate() error {
 	return nil
 }
 
+// SetUserName sets the UserName field's value.
+func (s *GetUserInput) SetUserName(v string) *GetUserInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful GetUser request.
 type GetUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -14548,6 +15634,12 @@ func (s GetUserOutput) String() string {
 // GoString returns the string representation
 func (s GetUserOutput) GoString() string {
 	return s.String()
+}
+
+// SetUser sets the User field's value.
+func (s *GetUserOutput) SetUser(v *User) *GetUserOutput {
+	s.User = v
+	return s
 }
 
 type GetUserPolicyInput struct {
@@ -14604,6 +15696,18 @@ func (s *GetUserPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetUserPolicyInput) SetPolicyName(v string) *GetUserPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *GetUserPolicyInput) SetUserName(v string) *GetUserPolicyInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful GetUserPolicy request.
 type GetUserPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -14632,6 +15736,24 @@ func (s GetUserPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetUserPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *GetUserPolicyOutput) SetPolicyDocument(v string) *GetUserPolicyOutput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetUserPolicyOutput) SetPolicyName(v string) *GetUserPolicyOutput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *GetUserPolicyOutput) SetUserName(v string) *GetUserPolicyOutput {
+	s.UserName = &v
+	return s
 }
 
 // Contains information about an IAM group entity.
@@ -14689,6 +15811,36 @@ func (s Group) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Group) SetArn(v string) *Group {
+	s.Arn = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *Group) SetCreateDate(v time.Time) *Group {
+	s.CreateDate = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *Group) SetGroupId(v string) *Group {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *Group) SetGroupName(v string) *Group {
+	s.GroupName = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *Group) SetPath(v string) *Group {
+	s.Path = &v
+	return s
+}
+
 // Contains information about an IAM group, including all of the group's policies.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
@@ -14735,6 +15887,48 @@ func (s GroupDetail) String() string {
 // GoString returns the string representation
 func (s GroupDetail) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *GroupDetail) SetArn(v string) *GroupDetail {
+	s.Arn = &v
+	return s
+}
+
+// SetAttachedManagedPolicies sets the AttachedManagedPolicies field's value.
+func (s *GroupDetail) SetAttachedManagedPolicies(v []*AttachedPolicy) *GroupDetail {
+	s.AttachedManagedPolicies = v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *GroupDetail) SetCreateDate(v time.Time) *GroupDetail {
+	s.CreateDate = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *GroupDetail) SetGroupId(v string) *GroupDetail {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *GroupDetail) SetGroupName(v string) *GroupDetail {
+	s.GroupName = &v
+	return s
+}
+
+// SetGroupPolicyList sets the GroupPolicyList field's value.
+func (s *GroupDetail) SetGroupPolicyList(v []*PolicyDetail) *GroupDetail {
+	s.GroupPolicyList = v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *GroupDetail) SetPath(v string) *GroupDetail {
+	s.Path = &v
+	return s
 }
 
 // Contains information about an instance profile.
@@ -14799,6 +15993,42 @@ func (s InstanceProfile) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *InstanceProfile) SetArn(v string) *InstanceProfile {
+	s.Arn = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *InstanceProfile) SetCreateDate(v time.Time) *InstanceProfile {
+	s.CreateDate = &v
+	return s
+}
+
+// SetInstanceProfileId sets the InstanceProfileId field's value.
+func (s *InstanceProfile) SetInstanceProfileId(v string) *InstanceProfile {
+	s.InstanceProfileId = &v
+	return s
+}
+
+// SetInstanceProfileName sets the InstanceProfileName field's value.
+func (s *InstanceProfile) SetInstanceProfileName(v string) *InstanceProfile {
+	s.InstanceProfileName = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *InstanceProfile) SetPath(v string) *InstanceProfile {
+	s.Path = &v
+	return s
+}
+
+// SetRoles sets the Roles field's value.
+func (s *InstanceProfile) SetRoles(v []*Role) *InstanceProfile {
+	s.Roles = v
+	return s
+}
+
 type ListAccessKeysInput struct {
 	_ struct{} `type:"structure"`
 
@@ -14856,6 +16086,24 @@ func (s *ListAccessKeysInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListAccessKeysInput) SetMarker(v string) *ListAccessKeysInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListAccessKeysInput) SetMaxItems(v int64) *ListAccessKeysInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *ListAccessKeysInput) SetUserName(v string) *ListAccessKeysInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful ListAccessKeys request.
 type ListAccessKeysOutput struct {
 	_ struct{} `type:"structure"`
@@ -14886,6 +16134,24 @@ func (s ListAccessKeysOutput) String() string {
 // GoString returns the string representation
 func (s ListAccessKeysOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccessKeyMetadata sets the AccessKeyMetadata field's value.
+func (s *ListAccessKeysOutput) SetAccessKeyMetadata(v []*AccessKeyMetadata) *ListAccessKeysOutput {
+	s.AccessKeyMetadata = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListAccessKeysOutput) SetIsTruncated(v bool) *ListAccessKeysOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAccessKeysOutput) SetMarker(v string) *ListAccessKeysOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListAccountAliasesInput struct {
@@ -14935,6 +16201,18 @@ func (s *ListAccountAliasesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListAccountAliasesInput) SetMarker(v string) *ListAccountAliasesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListAccountAliasesInput) SetMaxItems(v int64) *ListAccountAliasesInput {
+	s.MaxItems = &v
+	return s
+}
+
 // Contains the response to a successful ListAccountAliases request.
 type ListAccountAliasesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14966,6 +16244,24 @@ func (s ListAccountAliasesOutput) String() string {
 // GoString returns the string representation
 func (s ListAccountAliasesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccountAliases sets the AccountAliases field's value.
+func (s *ListAccountAliasesOutput) SetAccountAliases(v []*string) *ListAccountAliasesOutput {
+	s.AccountAliases = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListAccountAliasesOutput) SetIsTruncated(v bool) *ListAccountAliasesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAccountAliasesOutput) SetMarker(v string) *ListAccountAliasesOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListAttachedGroupPoliciesInput struct {
@@ -15041,6 +16337,30 @@ func (s *ListAttachedGroupPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *ListAttachedGroupPoliciesInput) SetGroupName(v string) *ListAttachedGroupPoliciesInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAttachedGroupPoliciesInput) SetMarker(v string) *ListAttachedGroupPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListAttachedGroupPoliciesInput) SetMaxItems(v int64) *ListAttachedGroupPoliciesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListAttachedGroupPoliciesInput) SetPathPrefix(v string) *ListAttachedGroupPoliciesInput {
+	s.PathPrefix = &v
+	return s
+}
+
 // Contains the response to a successful ListAttachedGroupPolicies request.
 type ListAttachedGroupPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15069,6 +16389,24 @@ func (s ListAttachedGroupPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListAttachedGroupPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttachedPolicies sets the AttachedPolicies field's value.
+func (s *ListAttachedGroupPoliciesOutput) SetAttachedPolicies(v []*AttachedPolicy) *ListAttachedGroupPoliciesOutput {
+	s.AttachedPolicies = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListAttachedGroupPoliciesOutput) SetIsTruncated(v bool) *ListAttachedGroupPoliciesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAttachedGroupPoliciesOutput) SetMarker(v string) *ListAttachedGroupPoliciesOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListAttachedRolePoliciesInput struct {
@@ -15143,6 +16481,30 @@ func (s *ListAttachedRolePoliciesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListAttachedRolePoliciesInput) SetMarker(v string) *ListAttachedRolePoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListAttachedRolePoliciesInput) SetMaxItems(v int64) *ListAttachedRolePoliciesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListAttachedRolePoliciesInput) SetPathPrefix(v string) *ListAttachedRolePoliciesInput {
+	s.PathPrefix = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *ListAttachedRolePoliciesInput) SetRoleName(v string) *ListAttachedRolePoliciesInput {
+	s.RoleName = &v
+	return s
+}
+
 // Contains the response to a successful ListAttachedRolePolicies request.
 type ListAttachedRolePoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15171,6 +16533,24 @@ func (s ListAttachedRolePoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListAttachedRolePoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttachedPolicies sets the AttachedPolicies field's value.
+func (s *ListAttachedRolePoliciesOutput) SetAttachedPolicies(v []*AttachedPolicy) *ListAttachedRolePoliciesOutput {
+	s.AttachedPolicies = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListAttachedRolePoliciesOutput) SetIsTruncated(v bool) *ListAttachedRolePoliciesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAttachedRolePoliciesOutput) SetMarker(v string) *ListAttachedRolePoliciesOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListAttachedUserPoliciesInput struct {
@@ -15245,6 +16625,30 @@ func (s *ListAttachedUserPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListAttachedUserPoliciesInput) SetMarker(v string) *ListAttachedUserPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListAttachedUserPoliciesInput) SetMaxItems(v int64) *ListAttachedUserPoliciesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListAttachedUserPoliciesInput) SetPathPrefix(v string) *ListAttachedUserPoliciesInput {
+	s.PathPrefix = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *ListAttachedUserPoliciesInput) SetUserName(v string) *ListAttachedUserPoliciesInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful ListAttachedUserPolicies request.
 type ListAttachedUserPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15273,6 +16677,24 @@ func (s ListAttachedUserPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListAttachedUserPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttachedPolicies sets the AttachedPolicies field's value.
+func (s *ListAttachedUserPoliciesOutput) SetAttachedPolicies(v []*AttachedPolicy) *ListAttachedUserPoliciesOutput {
+	s.AttachedPolicies = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListAttachedUserPoliciesOutput) SetIsTruncated(v bool) *ListAttachedUserPoliciesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAttachedUserPoliciesOutput) SetMarker(v string) *ListAttachedUserPoliciesOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListEntitiesForPolicyInput struct {
@@ -15358,6 +16780,36 @@ func (s *ListEntitiesForPolicyInput) Validate() error {
 	return nil
 }
 
+// SetEntityFilter sets the EntityFilter field's value.
+func (s *ListEntitiesForPolicyInput) SetEntityFilter(v string) *ListEntitiesForPolicyInput {
+	s.EntityFilter = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListEntitiesForPolicyInput) SetMarker(v string) *ListEntitiesForPolicyInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListEntitiesForPolicyInput) SetMaxItems(v int64) *ListEntitiesForPolicyInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListEntitiesForPolicyInput) SetPathPrefix(v string) *ListEntitiesForPolicyInput {
+	s.PathPrefix = &v
+	return s
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *ListEntitiesForPolicyInput) SetPolicyArn(v string) *ListEntitiesForPolicyInput {
+	s.PolicyArn = &v
+	return s
+}
+
 // Contains the response to a successful ListEntitiesForPolicy request.
 type ListEntitiesForPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -15392,6 +16844,36 @@ func (s ListEntitiesForPolicyOutput) String() string {
 // GoString returns the string representation
 func (s ListEntitiesForPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListEntitiesForPolicyOutput) SetIsTruncated(v bool) *ListEntitiesForPolicyOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListEntitiesForPolicyOutput) SetMarker(v string) *ListEntitiesForPolicyOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPolicyGroups sets the PolicyGroups field's value.
+func (s *ListEntitiesForPolicyOutput) SetPolicyGroups(v []*PolicyGroup) *ListEntitiesForPolicyOutput {
+	s.PolicyGroups = v
+	return s
+}
+
+// SetPolicyRoles sets the PolicyRoles field's value.
+func (s *ListEntitiesForPolicyOutput) SetPolicyRoles(v []*PolicyRole) *ListEntitiesForPolicyOutput {
+	s.PolicyRoles = v
+	return s
+}
+
+// SetPolicyUsers sets the PolicyUsers field's value.
+func (s *ListEntitiesForPolicyOutput) SetPolicyUsers(v []*PolicyUser) *ListEntitiesForPolicyOutput {
+	s.PolicyUsers = v
+	return s
 }
 
 type ListGroupPoliciesInput struct {
@@ -15456,6 +16938,24 @@ func (s *ListGroupPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *ListGroupPoliciesInput) SetGroupName(v string) *ListGroupPoliciesInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListGroupPoliciesInput) SetMarker(v string) *ListGroupPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListGroupPoliciesInput) SetMaxItems(v int64) *ListGroupPoliciesInput {
+	s.MaxItems = &v
+	return s
+}
+
 // Contains the response to a successful ListGroupPolicies request.
 type ListGroupPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15486,6 +16986,24 @@ func (s ListGroupPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListGroupPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListGroupPoliciesOutput) SetIsTruncated(v bool) *ListGroupPoliciesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListGroupPoliciesOutput) SetMarker(v string) *ListGroupPoliciesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *ListGroupPoliciesOutput) SetPolicyNames(v []*string) *ListGroupPoliciesOutput {
+	s.PolicyNames = v
+	return s
 }
 
 type ListGroupsForUserInput struct {
@@ -15550,6 +17068,24 @@ func (s *ListGroupsForUserInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListGroupsForUserInput) SetMarker(v string) *ListGroupsForUserInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListGroupsForUserInput) SetMaxItems(v int64) *ListGroupsForUserInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *ListGroupsForUserInput) SetUserName(v string) *ListGroupsForUserInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful ListGroupsForUser request.
 type ListGroupsForUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -15580,6 +17116,24 @@ func (s ListGroupsForUserOutput) String() string {
 // GoString returns the string representation
 func (s ListGroupsForUserOutput) GoString() string {
 	return s.String()
+}
+
+// SetGroups sets the Groups field's value.
+func (s *ListGroupsForUserOutput) SetGroups(v []*Group) *ListGroupsForUserOutput {
+	s.Groups = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListGroupsForUserOutput) SetIsTruncated(v bool) *ListGroupsForUserOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListGroupsForUserOutput) SetMarker(v string) *ListGroupsForUserOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListGroupsInput struct {
@@ -15644,6 +17198,24 @@ func (s *ListGroupsInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListGroupsInput) SetMarker(v string) *ListGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListGroupsInput) SetMaxItems(v int64) *ListGroupsInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListGroupsInput) SetPathPrefix(v string) *ListGroupsInput {
+	s.PathPrefix = &v
+	return s
+}
+
 // Contains the response to a successful ListGroups request.
 type ListGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -15674,6 +17246,24 @@ func (s ListGroupsOutput) String() string {
 // GoString returns the string representation
 func (s ListGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetGroups sets the Groups field's value.
+func (s *ListGroupsOutput) SetGroups(v []*Group) *ListGroupsOutput {
+	s.Groups = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListGroupsOutput) SetIsTruncated(v bool) *ListGroupsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListGroupsOutput) SetMarker(v string) *ListGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListInstanceProfilesForRoleInput struct {
@@ -15738,6 +17328,24 @@ func (s *ListInstanceProfilesForRoleInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListInstanceProfilesForRoleInput) SetMarker(v string) *ListInstanceProfilesForRoleInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListInstanceProfilesForRoleInput) SetMaxItems(v int64) *ListInstanceProfilesForRoleInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *ListInstanceProfilesForRoleInput) SetRoleName(v string) *ListInstanceProfilesForRoleInput {
+	s.RoleName = &v
+	return s
+}
+
 // Contains the response to a successful ListInstanceProfilesForRole request.
 type ListInstanceProfilesForRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -15768,6 +17376,24 @@ func (s ListInstanceProfilesForRoleOutput) String() string {
 // GoString returns the string representation
 func (s ListInstanceProfilesForRoleOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceProfiles sets the InstanceProfiles field's value.
+func (s *ListInstanceProfilesForRoleOutput) SetInstanceProfiles(v []*InstanceProfile) *ListInstanceProfilesForRoleOutput {
+	s.InstanceProfiles = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListInstanceProfilesForRoleOutput) SetIsTruncated(v bool) *ListInstanceProfilesForRoleOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListInstanceProfilesForRoleOutput) SetMarker(v string) *ListInstanceProfilesForRoleOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListInstanceProfilesInput struct {
@@ -15832,6 +17458,24 @@ func (s *ListInstanceProfilesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListInstanceProfilesInput) SetMarker(v string) *ListInstanceProfilesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListInstanceProfilesInput) SetMaxItems(v int64) *ListInstanceProfilesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListInstanceProfilesInput) SetPathPrefix(v string) *ListInstanceProfilesInput {
+	s.PathPrefix = &v
+	return s
+}
+
 // Contains the response to a successful ListInstanceProfiles request.
 type ListInstanceProfilesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15862,6 +17506,24 @@ func (s ListInstanceProfilesOutput) String() string {
 // GoString returns the string representation
 func (s ListInstanceProfilesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceProfiles sets the InstanceProfiles field's value.
+func (s *ListInstanceProfilesOutput) SetInstanceProfiles(v []*InstanceProfile) *ListInstanceProfilesOutput {
+	s.InstanceProfiles = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListInstanceProfilesOutput) SetIsTruncated(v bool) *ListInstanceProfilesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListInstanceProfilesOutput) SetMarker(v string) *ListInstanceProfilesOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListMFADevicesInput struct {
@@ -15921,6 +17583,24 @@ func (s *ListMFADevicesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListMFADevicesInput) SetMarker(v string) *ListMFADevicesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListMFADevicesInput) SetMaxItems(v int64) *ListMFADevicesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *ListMFADevicesInput) SetUserName(v string) *ListMFADevicesInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful ListMFADevices request.
 type ListMFADevicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15953,6 +17633,24 @@ func (s ListMFADevicesOutput) GoString() string {
 	return s.String()
 }
 
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListMFADevicesOutput) SetIsTruncated(v bool) *ListMFADevicesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMFADevices sets the MFADevices field's value.
+func (s *ListMFADevicesOutput) SetMFADevices(v []*MFADevice) *ListMFADevicesOutput {
+	s.MFADevices = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListMFADevicesOutput) SetMarker(v string) *ListMFADevicesOutput {
+	s.Marker = &v
+	return s
+}
+
 type ListOpenIDConnectProvidersInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -15983,6 +17681,12 @@ func (s ListOpenIDConnectProvidersOutput) String() string {
 // GoString returns the string representation
 func (s ListOpenIDConnectProvidersOutput) GoString() string {
 	return s.String()
+}
+
+// SetOpenIDConnectProviderList sets the OpenIDConnectProviderList field's value.
+func (s *ListOpenIDConnectProvidersOutput) SetOpenIDConnectProviderList(v []*OpenIDConnectProviderListEntry) *ListOpenIDConnectProvidersOutput {
+	s.OpenIDConnectProviderList = v
+	return s
 }
 
 type ListPoliciesInput struct {
@@ -16057,6 +17761,36 @@ func (s *ListPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListPoliciesInput) SetMarker(v string) *ListPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListPoliciesInput) SetMaxItems(v int64) *ListPoliciesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetOnlyAttached sets the OnlyAttached field's value.
+func (s *ListPoliciesInput) SetOnlyAttached(v bool) *ListPoliciesInput {
+	s.OnlyAttached = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListPoliciesInput) SetPathPrefix(v string) *ListPoliciesInput {
+	s.PathPrefix = &v
+	return s
+}
+
+// SetScope sets the Scope field's value.
+func (s *ListPoliciesInput) SetScope(v string) *ListPoliciesInput {
+	s.Scope = &v
+	return s
+}
+
 // Contains the response to a successful ListPolicies request.
 type ListPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16085,6 +17819,24 @@ func (s ListPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListPoliciesOutput) SetIsTruncated(v bool) *ListPoliciesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPoliciesOutput) SetMarker(v string) *ListPoliciesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *ListPoliciesOutput) SetPolicies(v []*Policy) *ListPoliciesOutput {
+	s.Policies = v
+	return s
 }
 
 type ListPolicyVersionsInput struct {
@@ -16149,6 +17901,24 @@ func (s *ListPolicyVersionsInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListPolicyVersionsInput) SetMarker(v string) *ListPolicyVersionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListPolicyVersionsInput) SetMaxItems(v int64) *ListPolicyVersionsInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *ListPolicyVersionsInput) SetPolicyArn(v string) *ListPolicyVersionsInput {
+	s.PolicyArn = &v
+	return s
+}
+
 // Contains the response to a successful ListPolicyVersions request.
 type ListPolicyVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -16181,6 +17951,24 @@ func (s ListPolicyVersionsOutput) String() string {
 // GoString returns the string representation
 func (s ListPolicyVersionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListPolicyVersionsOutput) SetIsTruncated(v bool) *ListPolicyVersionsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPolicyVersionsOutput) SetMarker(v string) *ListPolicyVersionsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetVersions sets the Versions field's value.
+func (s *ListPolicyVersionsOutput) SetVersions(v []*PolicyVersion) *ListPolicyVersionsOutput {
+	s.Versions = v
+	return s
 }
 
 type ListRolePoliciesInput struct {
@@ -16245,6 +18033,24 @@ func (s *ListRolePoliciesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListRolePoliciesInput) SetMarker(v string) *ListRolePoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListRolePoliciesInput) SetMaxItems(v int64) *ListRolePoliciesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *ListRolePoliciesInput) SetRoleName(v string) *ListRolePoliciesInput {
+	s.RoleName = &v
+	return s
+}
+
 // Contains the response to a successful ListRolePolicies request.
 type ListRolePoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16275,6 +18081,24 @@ func (s ListRolePoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListRolePoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListRolePoliciesOutput) SetIsTruncated(v bool) *ListRolePoliciesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListRolePoliciesOutput) SetMarker(v string) *ListRolePoliciesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *ListRolePoliciesOutput) SetPolicyNames(v []*string) *ListRolePoliciesOutput {
+	s.PolicyNames = v
+	return s
 }
 
 type ListRolesInput struct {
@@ -16339,6 +18163,24 @@ func (s *ListRolesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListRolesInput) SetMarker(v string) *ListRolesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListRolesInput) SetMaxItems(v int64) *ListRolesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListRolesInput) SetPathPrefix(v string) *ListRolesInput {
+	s.PathPrefix = &v
+	return s
+}
+
 // Contains the response to a successful ListRoles request.
 type ListRolesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16371,6 +18213,24 @@ func (s ListRolesOutput) GoString() string {
 	return s.String()
 }
 
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListRolesOutput) SetIsTruncated(v bool) *ListRolesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListRolesOutput) SetMarker(v string) *ListRolesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetRoles sets the Roles field's value.
+func (s *ListRolesOutput) SetRoles(v []*Role) *ListRolesOutput {
+	s.Roles = v
+	return s
+}
+
 type ListSAMLProvidersInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -16401,6 +18261,12 @@ func (s ListSAMLProvidersOutput) String() string {
 // GoString returns the string representation
 func (s ListSAMLProvidersOutput) GoString() string {
 	return s.String()
+}
+
+// SetSAMLProviderList sets the SAMLProviderList field's value.
+func (s *ListSAMLProvidersOutput) SetSAMLProviderList(v []*SAMLProviderListEntry) *ListSAMLProvidersOutput {
+	s.SAMLProviderList = v
+	return s
 }
 
 type ListSSHPublicKeysInput struct {
@@ -16462,6 +18328,24 @@ func (s *ListSSHPublicKeysInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListSSHPublicKeysInput) SetMarker(v string) *ListSSHPublicKeysInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListSSHPublicKeysInput) SetMaxItems(v int64) *ListSSHPublicKeysInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *ListSSHPublicKeysInput) SetUserName(v string) *ListSSHPublicKeysInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful ListSSHPublicKeys request.
 type ListSSHPublicKeysOutput struct {
 	_ struct{} `type:"structure"`
@@ -16490,6 +18374,24 @@ func (s ListSSHPublicKeysOutput) String() string {
 // GoString returns the string representation
 func (s ListSSHPublicKeysOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListSSHPublicKeysOutput) SetIsTruncated(v bool) *ListSSHPublicKeysOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListSSHPublicKeysOutput) SetMarker(v string) *ListSSHPublicKeysOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSSHPublicKeys sets the SSHPublicKeys field's value.
+func (s *ListSSHPublicKeysOutput) SetSSHPublicKeys(v []*SSHPublicKeyMetadata) *ListSSHPublicKeysOutput {
+	s.SSHPublicKeys = v
+	return s
 }
 
 type ListServerCertificatesInput struct {
@@ -16554,6 +18456,24 @@ func (s *ListServerCertificatesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListServerCertificatesInput) SetMarker(v string) *ListServerCertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListServerCertificatesInput) SetMaxItems(v int64) *ListServerCertificatesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListServerCertificatesInput) SetPathPrefix(v string) *ListServerCertificatesInput {
+	s.PathPrefix = &v
+	return s
+}
+
 // Contains the response to a successful ListServerCertificates request.
 type ListServerCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16584,6 +18504,24 @@ func (s ListServerCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s ListServerCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListServerCertificatesOutput) SetIsTruncated(v bool) *ListServerCertificatesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListServerCertificatesOutput) SetMarker(v string) *ListServerCertificatesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetServerCertificateMetadataList sets the ServerCertificateMetadataList field's value.
+func (s *ListServerCertificatesOutput) SetServerCertificateMetadataList(v []*ServerCertificateMetadata) *ListServerCertificatesOutput {
+	s.ServerCertificateMetadataList = v
+	return s
 }
 
 type ListSigningCertificatesInput struct {
@@ -16643,6 +18581,24 @@ func (s *ListSigningCertificatesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListSigningCertificatesInput) SetMarker(v string) *ListSigningCertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListSigningCertificatesInput) SetMaxItems(v int64) *ListSigningCertificatesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *ListSigningCertificatesInput) SetUserName(v string) *ListSigningCertificatesInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful ListSigningCertificates request.
 type ListSigningCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16673,6 +18629,24 @@ func (s ListSigningCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s ListSigningCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *ListSigningCertificatesOutput) SetCertificates(v []*SigningCertificate) *ListSigningCertificatesOutput {
+	s.Certificates = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListSigningCertificatesOutput) SetIsTruncated(v bool) *ListSigningCertificatesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListSigningCertificatesOutput) SetMarker(v string) *ListSigningCertificatesOutput {
+	s.Marker = &v
+	return s
 }
 
 type ListUserPoliciesInput struct {
@@ -16737,6 +18711,24 @@ func (s *ListUserPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListUserPoliciesInput) SetMarker(v string) *ListUserPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListUserPoliciesInput) SetMaxItems(v int64) *ListUserPoliciesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *ListUserPoliciesInput) SetUserName(v string) *ListUserPoliciesInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful ListUserPolicies request.
 type ListUserPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16767,6 +18759,24 @@ func (s ListUserPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListUserPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListUserPoliciesOutput) SetIsTruncated(v bool) *ListUserPoliciesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListUserPoliciesOutput) SetMarker(v string) *ListUserPoliciesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *ListUserPoliciesOutput) SetPolicyNames(v []*string) *ListUserPoliciesOutput {
+	s.PolicyNames = v
+	return s
 }
 
 type ListUsersInput struct {
@@ -16831,6 +18841,24 @@ func (s *ListUsersInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListUsersInput) SetMarker(v string) *ListUsersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListUsersInput) SetMaxItems(v int64) *ListUsersInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPathPrefix sets the PathPrefix field's value.
+func (s *ListUsersInput) SetPathPrefix(v string) *ListUsersInput {
+	s.PathPrefix = &v
+	return s
+}
+
 // Contains the response to a successful ListUsers request.
 type ListUsersOutput struct {
 	_ struct{} `type:"structure"`
@@ -16861,6 +18889,24 @@ func (s ListUsersOutput) String() string {
 // GoString returns the string representation
 func (s ListUsersOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListUsersOutput) SetIsTruncated(v bool) *ListUsersOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListUsersOutput) SetMarker(v string) *ListUsersOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetUsers sets the Users field's value.
+func (s *ListUsersOutput) SetUsers(v []*User) *ListUsersOutput {
+	s.Users = v
+	return s
 }
 
 type ListVirtualMFADevicesInput struct {
@@ -16915,6 +18961,24 @@ func (s *ListVirtualMFADevicesInput) Validate() error {
 	return nil
 }
 
+// SetAssignmentStatus sets the AssignmentStatus field's value.
+func (s *ListVirtualMFADevicesInput) SetAssignmentStatus(v string) *ListVirtualMFADevicesInput {
+	s.AssignmentStatus = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListVirtualMFADevicesInput) SetMarker(v string) *ListVirtualMFADevicesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListVirtualMFADevicesInput) SetMaxItems(v int64) *ListVirtualMFADevicesInput {
+	s.MaxItems = &v
+	return s
+}
+
 // Contains the response to a successful ListVirtualMFADevices request.
 type ListVirtualMFADevicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16946,6 +19010,24 @@ func (s ListVirtualMFADevicesOutput) String() string {
 // GoString returns the string representation
 func (s ListVirtualMFADevicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListVirtualMFADevicesOutput) SetIsTruncated(v bool) *ListVirtualMFADevicesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListVirtualMFADevicesOutput) SetMarker(v string) *ListVirtualMFADevicesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetVirtualMFADevices sets the VirtualMFADevices field's value.
+func (s *ListVirtualMFADevicesOutput) SetVirtualMFADevices(v []*VirtualMFADevice) *ListVirtualMFADevicesOutput {
+	s.VirtualMFADevices = v
+	return s
 }
 
 // Contains the user name and password create date for a user.
@@ -16980,6 +19062,24 @@ func (s LoginProfile) GoString() string {
 	return s.String()
 }
 
+// SetCreateDate sets the CreateDate field's value.
+func (s *LoginProfile) SetCreateDate(v time.Time) *LoginProfile {
+	s.CreateDate = &v
+	return s
+}
+
+// SetPasswordResetRequired sets the PasswordResetRequired field's value.
+func (s *LoginProfile) SetPasswordResetRequired(v bool) *LoginProfile {
+	s.PasswordResetRequired = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *LoginProfile) SetUserName(v string) *LoginProfile {
+	s.UserName = &v
+	return s
+}
+
 // Contains information about an MFA device.
 //
 // This data type is used as a response element in the ListMFADevices action.
@@ -17011,6 +19111,24 @@ func (s MFADevice) String() string {
 // GoString returns the string representation
 func (s MFADevice) GoString() string {
 	return s.String()
+}
+
+// SetEnableDate sets the EnableDate field's value.
+func (s *MFADevice) SetEnableDate(v time.Time) *MFADevice {
+	s.EnableDate = &v
+	return s
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *MFADevice) SetSerialNumber(v string) *MFADevice {
+	s.SerialNumber = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *MFADevice) SetUserName(v string) *MFADevice {
+	s.UserName = &v
+	return s
 }
 
 // Contains information about a managed policy, including the policy's ARN,
@@ -17093,6 +19211,72 @@ func (s ManagedPolicyDetail) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *ManagedPolicyDetail) SetArn(v string) *ManagedPolicyDetail {
+	s.Arn = &v
+	return s
+}
+
+// SetAttachmentCount sets the AttachmentCount field's value.
+func (s *ManagedPolicyDetail) SetAttachmentCount(v int64) *ManagedPolicyDetail {
+	s.AttachmentCount = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *ManagedPolicyDetail) SetCreateDate(v time.Time) *ManagedPolicyDetail {
+	s.CreateDate = &v
+	return s
+}
+
+// SetDefaultVersionId sets the DefaultVersionId field's value.
+func (s *ManagedPolicyDetail) SetDefaultVersionId(v string) *ManagedPolicyDetail {
+	s.DefaultVersionId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ManagedPolicyDetail) SetDescription(v string) *ManagedPolicyDetail {
+	s.Description = &v
+	return s
+}
+
+// SetIsAttachable sets the IsAttachable field's value.
+func (s *ManagedPolicyDetail) SetIsAttachable(v bool) *ManagedPolicyDetail {
+	s.IsAttachable = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *ManagedPolicyDetail) SetPath(v string) *ManagedPolicyDetail {
+	s.Path = &v
+	return s
+}
+
+// SetPolicyId sets the PolicyId field's value.
+func (s *ManagedPolicyDetail) SetPolicyId(v string) *ManagedPolicyDetail {
+	s.PolicyId = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *ManagedPolicyDetail) SetPolicyName(v string) *ManagedPolicyDetail {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyVersionList sets the PolicyVersionList field's value.
+func (s *ManagedPolicyDetail) SetPolicyVersionList(v []*PolicyVersion) *ManagedPolicyDetail {
+	s.PolicyVersionList = v
+	return s
+}
+
+// SetUpdateDate sets the UpdateDate field's value.
+func (s *ManagedPolicyDetail) SetUpdateDate(v time.Time) *ManagedPolicyDetail {
+	s.UpdateDate = &v
+	return s
+}
+
 // Contains the Amazon Resource Name (ARN) for an IAM OpenID Connect provider.
 type OpenIDConnectProviderListEntry struct {
 	_ struct{} `type:"structure"`
@@ -17113,6 +19297,12 @@ func (s OpenIDConnectProviderListEntry) String() string {
 // GoString returns the string representation
 func (s OpenIDConnectProviderListEntry) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *OpenIDConnectProviderListEntry) SetArn(v string) *OpenIDConnectProviderListEntry {
+	s.Arn = &v
+	return s
 }
 
 // Contains information about the account password policy.
@@ -17165,6 +19355,66 @@ func (s PasswordPolicy) String() string {
 // GoString returns the string representation
 func (s PasswordPolicy) GoString() string {
 	return s.String()
+}
+
+// SetAllowUsersToChangePassword sets the AllowUsersToChangePassword field's value.
+func (s *PasswordPolicy) SetAllowUsersToChangePassword(v bool) *PasswordPolicy {
+	s.AllowUsersToChangePassword = &v
+	return s
+}
+
+// SetExpirePasswords sets the ExpirePasswords field's value.
+func (s *PasswordPolicy) SetExpirePasswords(v bool) *PasswordPolicy {
+	s.ExpirePasswords = &v
+	return s
+}
+
+// SetHardExpiry sets the HardExpiry field's value.
+func (s *PasswordPolicy) SetHardExpiry(v bool) *PasswordPolicy {
+	s.HardExpiry = &v
+	return s
+}
+
+// SetMaxPasswordAge sets the MaxPasswordAge field's value.
+func (s *PasswordPolicy) SetMaxPasswordAge(v int64) *PasswordPolicy {
+	s.MaxPasswordAge = &v
+	return s
+}
+
+// SetMinimumPasswordLength sets the MinimumPasswordLength field's value.
+func (s *PasswordPolicy) SetMinimumPasswordLength(v int64) *PasswordPolicy {
+	s.MinimumPasswordLength = &v
+	return s
+}
+
+// SetPasswordReusePrevention sets the PasswordReusePrevention field's value.
+func (s *PasswordPolicy) SetPasswordReusePrevention(v int64) *PasswordPolicy {
+	s.PasswordReusePrevention = &v
+	return s
+}
+
+// SetRequireLowercaseCharacters sets the RequireLowercaseCharacters field's value.
+func (s *PasswordPolicy) SetRequireLowercaseCharacters(v bool) *PasswordPolicy {
+	s.RequireLowercaseCharacters = &v
+	return s
+}
+
+// SetRequireNumbers sets the RequireNumbers field's value.
+func (s *PasswordPolicy) SetRequireNumbers(v bool) *PasswordPolicy {
+	s.RequireNumbers = &v
+	return s
+}
+
+// SetRequireSymbols sets the RequireSymbols field's value.
+func (s *PasswordPolicy) SetRequireSymbols(v bool) *PasswordPolicy {
+	s.RequireSymbols = &v
+	return s
+}
+
+// SetRequireUppercaseCharacters sets the RequireUppercaseCharacters field's value.
+func (s *PasswordPolicy) SetRequireUppercaseCharacters(v bool) *PasswordPolicy {
+	s.RequireUppercaseCharacters = &v
+	return s
 }
 
 // Contains information about a managed policy.
@@ -17240,6 +19490,66 @@ func (s Policy) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Policy) SetArn(v string) *Policy {
+	s.Arn = &v
+	return s
+}
+
+// SetAttachmentCount sets the AttachmentCount field's value.
+func (s *Policy) SetAttachmentCount(v int64) *Policy {
+	s.AttachmentCount = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *Policy) SetCreateDate(v time.Time) *Policy {
+	s.CreateDate = &v
+	return s
+}
+
+// SetDefaultVersionId sets the DefaultVersionId field's value.
+func (s *Policy) SetDefaultVersionId(v string) *Policy {
+	s.DefaultVersionId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Policy) SetDescription(v string) *Policy {
+	s.Description = &v
+	return s
+}
+
+// SetIsAttachable sets the IsAttachable field's value.
+func (s *Policy) SetIsAttachable(v bool) *Policy {
+	s.IsAttachable = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *Policy) SetPath(v string) *Policy {
+	s.Path = &v
+	return s
+}
+
+// SetPolicyId sets the PolicyId field's value.
+func (s *Policy) SetPolicyId(v string) *Policy {
+	s.PolicyId = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *Policy) SetPolicyName(v string) *Policy {
+	s.PolicyName = &v
+	return s
+}
+
+// SetUpdateDate sets the UpdateDate field's value.
+func (s *Policy) SetUpdateDate(v time.Time) *Policy {
+	s.UpdateDate = &v
+	return s
+}
+
 // Contains information about an IAM policy, including the policy document.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
@@ -17262,6 +19572,18 @@ func (s PolicyDetail) String() string {
 // GoString returns the string representation
 func (s PolicyDetail) GoString() string {
 	return s.String()
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *PolicyDetail) SetPolicyDocument(v string) *PolicyDetail {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *PolicyDetail) SetPolicyName(v string) *PolicyDetail {
+	s.PolicyName = &v
+	return s
 }
 
 // Contains information about a group that a managed policy is attached to.
@@ -17294,6 +19616,18 @@ func (s PolicyGroup) GoString() string {
 	return s.String()
 }
 
+// SetGroupId sets the GroupId field's value.
+func (s *PolicyGroup) SetGroupId(v string) *PolicyGroup {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *PolicyGroup) SetGroupName(v string) *PolicyGroup {
+	s.GroupName = &v
+	return s
+}
+
 // Contains information about a role that a managed policy is attached to.
 //
 // This data type is used as a response element in the ListEntitiesForPolicy
@@ -17324,6 +19658,18 @@ func (s PolicyRole) GoString() string {
 	return s.String()
 }
 
+// SetRoleId sets the RoleId field's value.
+func (s *PolicyRole) SetRoleId(v string) *PolicyRole {
+	s.RoleId = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *PolicyRole) SetRoleName(v string) *PolicyRole {
+	s.RoleName = &v
+	return s
+}
+
 // Contains information about a user that a managed policy is attached to.
 //
 // This data type is used as a response element in the ListEntitiesForPolicy
@@ -17352,6 +19698,18 @@ func (s PolicyUser) String() string {
 // GoString returns the string representation
 func (s PolicyUser) GoString() string {
 	return s.String()
+}
+
+// SetUserId sets the UserId field's value.
+func (s *PolicyUser) SetUserId(v string) *PolicyUser {
+	s.UserId = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *PolicyUser) SetUserName(v string) *PolicyUser {
+	s.UserName = &v
+	return s
 }
 
 // Contains information about a version of a managed policy.
@@ -17397,6 +19755,30 @@ func (s PolicyVersion) GoString() string {
 	return s.String()
 }
 
+// SetCreateDate sets the CreateDate field's value.
+func (s *PolicyVersion) SetCreateDate(v time.Time) *PolicyVersion {
+	s.CreateDate = &v
+	return s
+}
+
+// SetDocument sets the Document field's value.
+func (s *PolicyVersion) SetDocument(v string) *PolicyVersion {
+	s.Document = &v
+	return s
+}
+
+// SetIsDefaultVersion sets the IsDefaultVersion field's value.
+func (s *PolicyVersion) SetIsDefaultVersion(v bool) *PolicyVersion {
+	s.IsDefaultVersion = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *PolicyVersion) SetVersionId(v string) *PolicyVersion {
+	s.VersionId = &v
+	return s
+}
+
 // Contains the row and column of a location of a Statement element in a policy
 // document.
 //
@@ -17419,6 +19801,18 @@ func (s Position) String() string {
 // GoString returns the string representation
 func (s Position) GoString() string {
 	return s.String()
+}
+
+// SetColumn sets the Column field's value.
+func (s *Position) SetColumn(v int64) *Position {
+	s.Column = &v
+	return s
+}
+
+// SetLine sets the Line field's value.
+func (s *Position) SetLine(v int64) *Position {
+	s.Line = &v
+	return s
 }
 
 type PutGroupPolicyInput struct {
@@ -17490,6 +19884,24 @@ func (s *PutGroupPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *PutGroupPolicyInput) SetGroupName(v string) *PutGroupPolicyInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *PutGroupPolicyInput) SetPolicyDocument(v string) *PutGroupPolicyInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *PutGroupPolicyInput) SetPolicyName(v string) *PutGroupPolicyInput {
+	s.PolicyName = &v
+	return s
 }
 
 type PutGroupPolicyOutput struct {
@@ -17577,6 +19989,24 @@ func (s *PutRolePolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *PutRolePolicyInput) SetPolicyDocument(v string) *PutRolePolicyInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *PutRolePolicyInput) SetPolicyName(v string) *PutRolePolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *PutRolePolicyInput) SetRoleName(v string) *PutRolePolicyInput {
+	s.RoleName = &v
+	return s
+}
+
 type PutRolePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -17662,6 +20092,24 @@ func (s *PutUserPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *PutUserPolicyInput) SetPolicyDocument(v string) *PutUserPolicyInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *PutUserPolicyInput) SetPolicyName(v string) *PutUserPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *PutUserPolicyInput) SetUserName(v string) *PutUserPolicyInput {
+	s.UserName = &v
+	return s
+}
+
 type PutUserPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -17727,6 +20175,18 @@ func (s *RemoveClientIDFromOpenIDConnectProviderInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClientID sets the ClientID field's value.
+func (s *RemoveClientIDFromOpenIDConnectProviderInput) SetClientID(v string) *RemoveClientIDFromOpenIDConnectProviderInput {
+	s.ClientID = &v
+	return s
+}
+
+// SetOpenIDConnectProviderArn sets the OpenIDConnectProviderArn field's value.
+func (s *RemoveClientIDFromOpenIDConnectProviderInput) SetOpenIDConnectProviderArn(v string) *RemoveClientIDFromOpenIDConnectProviderInput {
+	s.OpenIDConnectProviderArn = &v
+	return s
 }
 
 type RemoveClientIDFromOpenIDConnectProviderOutput struct {
@@ -17797,6 +20257,18 @@ func (s *RemoveRoleFromInstanceProfileInput) Validate() error {
 	return nil
 }
 
+// SetInstanceProfileName sets the InstanceProfileName field's value.
+func (s *RemoveRoleFromInstanceProfileInput) SetInstanceProfileName(v string) *RemoveRoleFromInstanceProfileInput {
+	s.InstanceProfileName = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *RemoveRoleFromInstanceProfileInput) SetRoleName(v string) *RemoveRoleFromInstanceProfileInput {
+	s.RoleName = &v
+	return s
+}
+
 type RemoveRoleFromInstanceProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -17865,6 +20337,18 @@ func (s *RemoveUserFromGroupInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *RemoveUserFromGroupInput) SetGroupName(v string) *RemoveUserFromGroupInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *RemoveUserFromGroupInput) SetUserName(v string) *RemoveUserFromGroupInput {
+	s.UserName = &v
+	return s
+}
+
 type RemoveUserFromGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -17930,6 +20414,36 @@ func (s ResourceSpecificResult) String() string {
 // GoString returns the string representation
 func (s ResourceSpecificResult) GoString() string {
 	return s.String()
+}
+
+// SetEvalDecisionDetails sets the EvalDecisionDetails field's value.
+func (s *ResourceSpecificResult) SetEvalDecisionDetails(v map[string]*string) *ResourceSpecificResult {
+	s.EvalDecisionDetails = v
+	return s
+}
+
+// SetEvalResourceDecision sets the EvalResourceDecision field's value.
+func (s *ResourceSpecificResult) SetEvalResourceDecision(v string) *ResourceSpecificResult {
+	s.EvalResourceDecision = &v
+	return s
+}
+
+// SetEvalResourceName sets the EvalResourceName field's value.
+func (s *ResourceSpecificResult) SetEvalResourceName(v string) *ResourceSpecificResult {
+	s.EvalResourceName = &v
+	return s
+}
+
+// SetMatchedStatements sets the MatchedStatements field's value.
+func (s *ResourceSpecificResult) SetMatchedStatements(v []*Statement) *ResourceSpecificResult {
+	s.MatchedStatements = v
+	return s
+}
+
+// SetMissingContextValues sets the MissingContextValues field's value.
+func (s *ResourceSpecificResult) SetMissingContextValues(v []*string) *ResourceSpecificResult {
+	s.MissingContextValues = v
+	return s
 }
 
 type ResyncMFADeviceInput struct {
@@ -18012,6 +20526,30 @@ func (s *ResyncMFADeviceInput) Validate() error {
 	return nil
 }
 
+// SetAuthenticationCode1 sets the AuthenticationCode1 field's value.
+func (s *ResyncMFADeviceInput) SetAuthenticationCode1(v string) *ResyncMFADeviceInput {
+	s.AuthenticationCode1 = &v
+	return s
+}
+
+// SetAuthenticationCode2 sets the AuthenticationCode2 field's value.
+func (s *ResyncMFADeviceInput) SetAuthenticationCode2(v string) *ResyncMFADeviceInput {
+	s.AuthenticationCode2 = &v
+	return s
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *ResyncMFADeviceInput) SetSerialNumber(v string) *ResyncMFADeviceInput {
+	s.SerialNumber = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *ResyncMFADeviceInput) SetUserName(v string) *ResyncMFADeviceInput {
+	s.UserName = &v
+	return s
+}
+
 type ResyncMFADeviceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -18084,6 +20622,42 @@ func (s Role) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *Role) SetArn(v string) *Role {
+	s.Arn = &v
+	return s
+}
+
+// SetAssumeRolePolicyDocument sets the AssumeRolePolicyDocument field's value.
+func (s *Role) SetAssumeRolePolicyDocument(v string) *Role {
+	s.AssumeRolePolicyDocument = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *Role) SetCreateDate(v time.Time) *Role {
+	s.CreateDate = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *Role) SetPath(v string) *Role {
+	s.Path = &v
+	return s
+}
+
+// SetRoleId sets the RoleId field's value.
+func (s *Role) SetRoleId(v string) *Role {
+	s.RoleId = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *Role) SetRoleName(v string) *Role {
+	s.RoleName = &v
+	return s
+}
+
 // Contains information about an IAM role, including all of the role's policies.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
@@ -18140,6 +20714,60 @@ func (s RoleDetail) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *RoleDetail) SetArn(v string) *RoleDetail {
+	s.Arn = &v
+	return s
+}
+
+// SetAssumeRolePolicyDocument sets the AssumeRolePolicyDocument field's value.
+func (s *RoleDetail) SetAssumeRolePolicyDocument(v string) *RoleDetail {
+	s.AssumeRolePolicyDocument = &v
+	return s
+}
+
+// SetAttachedManagedPolicies sets the AttachedManagedPolicies field's value.
+func (s *RoleDetail) SetAttachedManagedPolicies(v []*AttachedPolicy) *RoleDetail {
+	s.AttachedManagedPolicies = v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *RoleDetail) SetCreateDate(v time.Time) *RoleDetail {
+	s.CreateDate = &v
+	return s
+}
+
+// SetInstanceProfileList sets the InstanceProfileList field's value.
+func (s *RoleDetail) SetInstanceProfileList(v []*InstanceProfile) *RoleDetail {
+	s.InstanceProfileList = v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *RoleDetail) SetPath(v string) *RoleDetail {
+	s.Path = &v
+	return s
+}
+
+// SetRoleId sets the RoleId field's value.
+func (s *RoleDetail) SetRoleId(v string) *RoleDetail {
+	s.RoleId = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *RoleDetail) SetRoleName(v string) *RoleDetail {
+	s.RoleName = &v
+	return s
+}
+
+// SetRolePolicyList sets the RolePolicyList field's value.
+func (s *RoleDetail) SetRolePolicyList(v []*PolicyDetail) *RoleDetail {
+	s.RolePolicyList = v
+	return s
+}
+
 // Contains the list of SAML providers for this account.
 type SAMLProviderListEntry struct {
 	_ struct{} `type:"structure"`
@@ -18162,6 +20790,24 @@ func (s SAMLProviderListEntry) String() string {
 // GoString returns the string representation
 func (s SAMLProviderListEntry) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *SAMLProviderListEntry) SetArn(v string) *SAMLProviderListEntry {
+	s.Arn = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *SAMLProviderListEntry) SetCreateDate(v time.Time) *SAMLProviderListEntry {
+	s.CreateDate = &v
+	return s
+}
+
+// SetValidUntil sets the ValidUntil field's value.
+func (s *SAMLProviderListEntry) SetValidUntil(v time.Time) *SAMLProviderListEntry {
+	s.ValidUntil = &v
+	return s
 }
 
 // Contains information about an SSH public key.
@@ -18212,6 +20858,42 @@ func (s SSHPublicKey) GoString() string {
 	return s.String()
 }
 
+// SetFingerprint sets the Fingerprint field's value.
+func (s *SSHPublicKey) SetFingerprint(v string) *SSHPublicKey {
+	s.Fingerprint = &v
+	return s
+}
+
+// SetSSHPublicKeyBody sets the SSHPublicKeyBody field's value.
+func (s *SSHPublicKey) SetSSHPublicKeyBody(v string) *SSHPublicKey {
+	s.SSHPublicKeyBody = &v
+	return s
+}
+
+// SetSSHPublicKeyId sets the SSHPublicKeyId field's value.
+func (s *SSHPublicKey) SetSSHPublicKeyId(v string) *SSHPublicKey {
+	s.SSHPublicKeyId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SSHPublicKey) SetStatus(v string) *SSHPublicKey {
+	s.Status = &v
+	return s
+}
+
+// SetUploadDate sets the UploadDate field's value.
+func (s *SSHPublicKey) SetUploadDate(v time.Time) *SSHPublicKey {
+	s.UploadDate = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *SSHPublicKey) SetUserName(v string) *SSHPublicKey {
+	s.UserName = &v
+	return s
+}
+
 // Contains information about an SSH public key, without the key's body or fingerprint.
 //
 // This data type is used as a response element in the ListSSHPublicKeys action.
@@ -18251,6 +20933,30 @@ func (s SSHPublicKeyMetadata) GoString() string {
 	return s.String()
 }
 
+// SetSSHPublicKeyId sets the SSHPublicKeyId field's value.
+func (s *SSHPublicKeyMetadata) SetSSHPublicKeyId(v string) *SSHPublicKeyMetadata {
+	s.SSHPublicKeyId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SSHPublicKeyMetadata) SetStatus(v string) *SSHPublicKeyMetadata {
+	s.Status = &v
+	return s
+}
+
+// SetUploadDate sets the UploadDate field's value.
+func (s *SSHPublicKeyMetadata) SetUploadDate(v time.Time) *SSHPublicKeyMetadata {
+	s.UploadDate = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *SSHPublicKeyMetadata) SetUserName(v string) *SSHPublicKeyMetadata {
+	s.UserName = &v
+	return s
+}
+
 // Contains information about a server certificate.
 //
 // This data type is used as a response element in the GetServerCertificate
@@ -18281,6 +20987,24 @@ func (s ServerCertificate) String() string {
 // GoString returns the string representation
 func (s ServerCertificate) GoString() string {
 	return s.String()
+}
+
+// SetCertificateBody sets the CertificateBody field's value.
+func (s *ServerCertificate) SetCertificateBody(v string) *ServerCertificate {
+	s.CertificateBody = &v
+	return s
+}
+
+// SetCertificateChain sets the CertificateChain field's value.
+func (s *ServerCertificate) SetCertificateChain(v string) *ServerCertificate {
+	s.CertificateChain = &v
+	return s
+}
+
+// SetServerCertificateMetadata sets the ServerCertificateMetadata field's value.
+func (s *ServerCertificate) SetServerCertificateMetadata(v *ServerCertificateMetadata) *ServerCertificate {
+	s.ServerCertificateMetadata = v
+	return s
 }
 
 // Contains information about a server certificate without its certificate body,
@@ -18335,6 +21059,42 @@ func (s ServerCertificateMetadata) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *ServerCertificateMetadata) SetArn(v string) *ServerCertificateMetadata {
+	s.Arn = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *ServerCertificateMetadata) SetExpiration(v time.Time) *ServerCertificateMetadata {
+	s.Expiration = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *ServerCertificateMetadata) SetPath(v string) *ServerCertificateMetadata {
+	s.Path = &v
+	return s
+}
+
+// SetServerCertificateId sets the ServerCertificateId field's value.
+func (s *ServerCertificateMetadata) SetServerCertificateId(v string) *ServerCertificateMetadata {
+	s.ServerCertificateId = &v
+	return s
+}
+
+// SetServerCertificateName sets the ServerCertificateName field's value.
+func (s *ServerCertificateMetadata) SetServerCertificateName(v string) *ServerCertificateMetadata {
+	s.ServerCertificateName = &v
+	return s
+}
+
+// SetUploadDate sets the UploadDate field's value.
+func (s *ServerCertificateMetadata) SetUploadDate(v time.Time) *ServerCertificateMetadata {
+	s.UploadDate = &v
+	return s
+}
+
 type SetDefaultPolicyVersionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -18385,6 +21145,18 @@ func (s *SetDefaultPolicyVersionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *SetDefaultPolicyVersionInput) SetPolicyArn(v string) *SetDefaultPolicyVersionInput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *SetDefaultPolicyVersionInput) SetVersionId(v string) *SetDefaultPolicyVersionInput {
+	s.VersionId = &v
+	return s
 }
 
 type SetDefaultPolicyVersionOutput struct {
@@ -18441,6 +21213,36 @@ func (s SigningCertificate) String() string {
 // GoString returns the string representation
 func (s SigningCertificate) GoString() string {
 	return s.String()
+}
+
+// SetCertificateBody sets the CertificateBody field's value.
+func (s *SigningCertificate) SetCertificateBody(v string) *SigningCertificate {
+	s.CertificateBody = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *SigningCertificate) SetCertificateId(v string) *SigningCertificate {
+	s.CertificateId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SigningCertificate) SetStatus(v string) *SigningCertificate {
+	s.Status = &v
+	return s
+}
+
+// SetUploadDate sets the UploadDate field's value.
+func (s *SigningCertificate) SetUploadDate(v time.Time) *SigningCertificate {
+	s.UploadDate = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *SigningCertificate) SetUserName(v string) *SigningCertificate {
+	s.UserName = &v
+	return s
 }
 
 type SimulateCustomPolicyInput struct {
@@ -18637,6 +21439,66 @@ func (s *SimulateCustomPolicyInput) Validate() error {
 	return nil
 }
 
+// SetActionNames sets the ActionNames field's value.
+func (s *SimulateCustomPolicyInput) SetActionNames(v []*string) *SimulateCustomPolicyInput {
+	s.ActionNames = v
+	return s
+}
+
+// SetCallerArn sets the CallerArn field's value.
+func (s *SimulateCustomPolicyInput) SetCallerArn(v string) *SimulateCustomPolicyInput {
+	s.CallerArn = &v
+	return s
+}
+
+// SetContextEntries sets the ContextEntries field's value.
+func (s *SimulateCustomPolicyInput) SetContextEntries(v []*ContextEntry) *SimulateCustomPolicyInput {
+	s.ContextEntries = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *SimulateCustomPolicyInput) SetMarker(v string) *SimulateCustomPolicyInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *SimulateCustomPolicyInput) SetMaxItems(v int64) *SimulateCustomPolicyInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPolicyInputList sets the PolicyInputList field's value.
+func (s *SimulateCustomPolicyInput) SetPolicyInputList(v []*string) *SimulateCustomPolicyInput {
+	s.PolicyInputList = v
+	return s
+}
+
+// SetResourceArns sets the ResourceArns field's value.
+func (s *SimulateCustomPolicyInput) SetResourceArns(v []*string) *SimulateCustomPolicyInput {
+	s.ResourceArns = v
+	return s
+}
+
+// SetResourceHandlingOption sets the ResourceHandlingOption field's value.
+func (s *SimulateCustomPolicyInput) SetResourceHandlingOption(v string) *SimulateCustomPolicyInput {
+	s.ResourceHandlingOption = &v
+	return s
+}
+
+// SetResourceOwner sets the ResourceOwner field's value.
+func (s *SimulateCustomPolicyInput) SetResourceOwner(v string) *SimulateCustomPolicyInput {
+	s.ResourceOwner = &v
+	return s
+}
+
+// SetResourcePolicy sets the ResourcePolicy field's value.
+func (s *SimulateCustomPolicyInput) SetResourcePolicy(v string) *SimulateCustomPolicyInput {
+	s.ResourcePolicy = &v
+	return s
+}
+
 // Contains the response to a successful SimulatePrincipalPolicy or SimulateCustomPolicy
 // request.
 type SimulatePolicyResponse struct {
@@ -18666,6 +21528,24 @@ func (s SimulatePolicyResponse) String() string {
 // GoString returns the string representation
 func (s SimulatePolicyResponse) GoString() string {
 	return s.String()
+}
+
+// SetEvaluationResults sets the EvaluationResults field's value.
+func (s *SimulatePolicyResponse) SetEvaluationResults(v []*EvaluationResult) *SimulatePolicyResponse {
+	s.EvaluationResults = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *SimulatePolicyResponse) SetIsTruncated(v bool) *SimulatePolicyResponse {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *SimulatePolicyResponse) SetMarker(v string) *SimulatePolicyResponse {
+	s.Marker = &v
+	return s
 }
 
 type SimulatePrincipalPolicyInput struct {
@@ -18879,6 +21759,72 @@ func (s *SimulatePrincipalPolicyInput) Validate() error {
 	return nil
 }
 
+// SetActionNames sets the ActionNames field's value.
+func (s *SimulatePrincipalPolicyInput) SetActionNames(v []*string) *SimulatePrincipalPolicyInput {
+	s.ActionNames = v
+	return s
+}
+
+// SetCallerArn sets the CallerArn field's value.
+func (s *SimulatePrincipalPolicyInput) SetCallerArn(v string) *SimulatePrincipalPolicyInput {
+	s.CallerArn = &v
+	return s
+}
+
+// SetContextEntries sets the ContextEntries field's value.
+func (s *SimulatePrincipalPolicyInput) SetContextEntries(v []*ContextEntry) *SimulatePrincipalPolicyInput {
+	s.ContextEntries = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *SimulatePrincipalPolicyInput) SetMarker(v string) *SimulatePrincipalPolicyInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *SimulatePrincipalPolicyInput) SetMaxItems(v int64) *SimulatePrincipalPolicyInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetPolicyInputList sets the PolicyInputList field's value.
+func (s *SimulatePrincipalPolicyInput) SetPolicyInputList(v []*string) *SimulatePrincipalPolicyInput {
+	s.PolicyInputList = v
+	return s
+}
+
+// SetPolicySourceArn sets the PolicySourceArn field's value.
+func (s *SimulatePrincipalPolicyInput) SetPolicySourceArn(v string) *SimulatePrincipalPolicyInput {
+	s.PolicySourceArn = &v
+	return s
+}
+
+// SetResourceArns sets the ResourceArns field's value.
+func (s *SimulatePrincipalPolicyInput) SetResourceArns(v []*string) *SimulatePrincipalPolicyInput {
+	s.ResourceArns = v
+	return s
+}
+
+// SetResourceHandlingOption sets the ResourceHandlingOption field's value.
+func (s *SimulatePrincipalPolicyInput) SetResourceHandlingOption(v string) *SimulatePrincipalPolicyInput {
+	s.ResourceHandlingOption = &v
+	return s
+}
+
+// SetResourceOwner sets the ResourceOwner field's value.
+func (s *SimulatePrincipalPolicyInput) SetResourceOwner(v string) *SimulatePrincipalPolicyInput {
+	s.ResourceOwner = &v
+	return s
+}
+
+// SetResourcePolicy sets the ResourcePolicy field's value.
+func (s *SimulatePrincipalPolicyInput) SetResourcePolicy(v string) *SimulatePrincipalPolicyInput {
+	s.ResourcePolicy = &v
+	return s
+}
+
 // Contains a reference to a Statement element in a policy document that determines
 // the result of the simulation.
 //
@@ -18908,6 +21854,30 @@ func (s Statement) String() string {
 // GoString returns the string representation
 func (s Statement) GoString() string {
 	return s.String()
+}
+
+// SetEndPosition sets the EndPosition field's value.
+func (s *Statement) SetEndPosition(v *Position) *Statement {
+	s.EndPosition = v
+	return s
+}
+
+// SetSourcePolicyId sets the SourcePolicyId field's value.
+func (s *Statement) SetSourcePolicyId(v string) *Statement {
+	s.SourcePolicyId = &v
+	return s
+}
+
+// SetSourcePolicyType sets the SourcePolicyType field's value.
+func (s *Statement) SetSourcePolicyType(v string) *Statement {
+	s.SourcePolicyType = &v
+	return s
+}
+
+// SetStartPosition sets the StartPosition field's value.
+func (s *Statement) SetStartPosition(v *Position) *Statement {
+	s.StartPosition = v
+	return s
 }
 
 type UpdateAccessKeyInput struct {
@@ -18967,6 +21937,24 @@ func (s *UpdateAccessKeyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *UpdateAccessKeyInput) SetAccessKeyId(v string) *UpdateAccessKeyInput {
+	s.AccessKeyId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UpdateAccessKeyInput) SetStatus(v string) *UpdateAccessKeyInput {
+	s.Status = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *UpdateAccessKeyInput) SetUserName(v string) *UpdateAccessKeyInput {
+	s.UserName = &v
+	return s
 }
 
 type UpdateAccessKeyOutput struct {
@@ -19073,6 +22061,60 @@ func (s *UpdateAccountPasswordPolicyInput) Validate() error {
 	return nil
 }
 
+// SetAllowUsersToChangePassword sets the AllowUsersToChangePassword field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetAllowUsersToChangePassword(v bool) *UpdateAccountPasswordPolicyInput {
+	s.AllowUsersToChangePassword = &v
+	return s
+}
+
+// SetHardExpiry sets the HardExpiry field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetHardExpiry(v bool) *UpdateAccountPasswordPolicyInput {
+	s.HardExpiry = &v
+	return s
+}
+
+// SetMaxPasswordAge sets the MaxPasswordAge field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetMaxPasswordAge(v int64) *UpdateAccountPasswordPolicyInput {
+	s.MaxPasswordAge = &v
+	return s
+}
+
+// SetMinimumPasswordLength sets the MinimumPasswordLength field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetMinimumPasswordLength(v int64) *UpdateAccountPasswordPolicyInput {
+	s.MinimumPasswordLength = &v
+	return s
+}
+
+// SetPasswordReusePrevention sets the PasswordReusePrevention field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetPasswordReusePrevention(v int64) *UpdateAccountPasswordPolicyInput {
+	s.PasswordReusePrevention = &v
+	return s
+}
+
+// SetRequireLowercaseCharacters sets the RequireLowercaseCharacters field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetRequireLowercaseCharacters(v bool) *UpdateAccountPasswordPolicyInput {
+	s.RequireLowercaseCharacters = &v
+	return s
+}
+
+// SetRequireNumbers sets the RequireNumbers field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetRequireNumbers(v bool) *UpdateAccountPasswordPolicyInput {
+	s.RequireNumbers = &v
+	return s
+}
+
+// SetRequireSymbols sets the RequireSymbols field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetRequireSymbols(v bool) *UpdateAccountPasswordPolicyInput {
+	s.RequireSymbols = &v
+	return s
+}
+
+// SetRequireUppercaseCharacters sets the RequireUppercaseCharacters field's value.
+func (s *UpdateAccountPasswordPolicyInput) SetRequireUppercaseCharacters(v bool) *UpdateAccountPasswordPolicyInput {
+	s.RequireUppercaseCharacters = &v
+	return s
+}
+
 type UpdateAccountPasswordPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19141,6 +22183,18 @@ func (s *UpdateAssumeRolePolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *UpdateAssumeRolePolicyInput) SetPolicyDocument(v string) *UpdateAssumeRolePolicyInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *UpdateAssumeRolePolicyInput) SetRoleName(v string) *UpdateAssumeRolePolicyInput {
+	s.RoleName = &v
+	return s
 }
 
 type UpdateAssumeRolePolicyOutput struct {
@@ -19219,6 +22273,24 @@ func (s *UpdateGroupInput) Validate() error {
 	return nil
 }
 
+// SetGroupName sets the GroupName field's value.
+func (s *UpdateGroupInput) SetGroupName(v string) *UpdateGroupInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetNewGroupName sets the NewGroupName field's value.
+func (s *UpdateGroupInput) SetNewGroupName(v string) *UpdateGroupInput {
+	s.NewGroupName = &v
+	return s
+}
+
+// SetNewPath sets the NewPath field's value.
+func (s *UpdateGroupInput) SetNewPath(v string) *UpdateGroupInput {
+	s.NewPath = &v
+	return s
+}
+
 type UpdateGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19290,6 +22362,24 @@ func (s *UpdateLoginProfileInput) Validate() error {
 	return nil
 }
 
+// SetPassword sets the Password field's value.
+func (s *UpdateLoginProfileInput) SetPassword(v string) *UpdateLoginProfileInput {
+	s.Password = &v
+	return s
+}
+
+// SetPasswordResetRequired sets the PasswordResetRequired field's value.
+func (s *UpdateLoginProfileInput) SetPasswordResetRequired(v bool) *UpdateLoginProfileInput {
+	s.PasswordResetRequired = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *UpdateLoginProfileInput) SetUserName(v string) *UpdateLoginProfileInput {
+	s.UserName = &v
+	return s
+}
+
 type UpdateLoginProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19352,6 +22442,18 @@ func (s *UpdateOpenIDConnectProviderThumbprintInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetOpenIDConnectProviderArn sets the OpenIDConnectProviderArn field's value.
+func (s *UpdateOpenIDConnectProviderThumbprintInput) SetOpenIDConnectProviderArn(v string) *UpdateOpenIDConnectProviderThumbprintInput {
+	s.OpenIDConnectProviderArn = &v
+	return s
+}
+
+// SetThumbprintList sets the ThumbprintList field's value.
+func (s *UpdateOpenIDConnectProviderThumbprintInput) SetThumbprintList(v []*string) *UpdateOpenIDConnectProviderThumbprintInput {
+	s.ThumbprintList = v
+	return s
 }
 
 type UpdateOpenIDConnectProviderThumbprintOutput struct {
@@ -19422,6 +22524,18 @@ func (s *UpdateSAMLProviderInput) Validate() error {
 	return nil
 }
 
+// SetSAMLMetadataDocument sets the SAMLMetadataDocument field's value.
+func (s *UpdateSAMLProviderInput) SetSAMLMetadataDocument(v string) *UpdateSAMLProviderInput {
+	s.SAMLMetadataDocument = &v
+	return s
+}
+
+// SetSAMLProviderArn sets the SAMLProviderArn field's value.
+func (s *UpdateSAMLProviderInput) SetSAMLProviderArn(v string) *UpdateSAMLProviderInput {
+	s.SAMLProviderArn = &v
+	return s
+}
+
 // Contains the response to a successful UpdateSAMLProvider request.
 type UpdateSAMLProviderOutput struct {
 	_ struct{} `type:"structure"`
@@ -19438,6 +22552,12 @@ func (s UpdateSAMLProviderOutput) String() string {
 // GoString returns the string representation
 func (s UpdateSAMLProviderOutput) GoString() string {
 	return s.String()
+}
+
+// SetSAMLProviderArn sets the SAMLProviderArn field's value.
+func (s *UpdateSAMLProviderOutput) SetSAMLProviderArn(v string) *UpdateSAMLProviderOutput {
+	s.SAMLProviderArn = &v
+	return s
 }
 
 type UpdateSSHPublicKeyInput struct {
@@ -19502,6 +22622,24 @@ func (s *UpdateSSHPublicKeyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetSSHPublicKeyId sets the SSHPublicKeyId field's value.
+func (s *UpdateSSHPublicKeyInput) SetSSHPublicKeyId(v string) *UpdateSSHPublicKeyInput {
+	s.SSHPublicKeyId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UpdateSSHPublicKeyInput) SetStatus(v string) *UpdateSSHPublicKeyInput {
+	s.Status = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *UpdateSSHPublicKeyInput) SetUserName(v string) *UpdateSSHPublicKeyInput {
+	s.UserName = &v
+	return s
 }
 
 type UpdateSSHPublicKeyOutput struct {
@@ -19582,6 +22720,24 @@ func (s *UpdateServerCertificateInput) Validate() error {
 	return nil
 }
 
+// SetNewPath sets the NewPath field's value.
+func (s *UpdateServerCertificateInput) SetNewPath(v string) *UpdateServerCertificateInput {
+	s.NewPath = &v
+	return s
+}
+
+// SetNewServerCertificateName sets the NewServerCertificateName field's value.
+func (s *UpdateServerCertificateInput) SetNewServerCertificateName(v string) *UpdateServerCertificateInput {
+	s.NewServerCertificateName = &v
+	return s
+}
+
+// SetServerCertificateName sets the ServerCertificateName field's value.
+func (s *UpdateServerCertificateInput) SetServerCertificateName(v string) *UpdateServerCertificateInput {
+	s.ServerCertificateName = &v
+	return s
+}
+
 type UpdateServerCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19653,6 +22809,24 @@ func (s *UpdateSigningCertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *UpdateSigningCertificateInput) SetCertificateId(v string) *UpdateSigningCertificateInput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UpdateSigningCertificateInput) SetStatus(v string) *UpdateSigningCertificateInput {
+	s.Status = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *UpdateSigningCertificateInput) SetUserName(v string) *UpdateSigningCertificateInput {
+	s.UserName = &v
+	return s
 }
 
 type UpdateSigningCertificateOutput struct {
@@ -19733,6 +22907,24 @@ func (s *UpdateUserInput) Validate() error {
 	return nil
 }
 
+// SetNewPath sets the NewPath field's value.
+func (s *UpdateUserInput) SetNewPath(v string) *UpdateUserInput {
+	s.NewPath = &v
+	return s
+}
+
+// SetNewUserName sets the NewUserName field's value.
+func (s *UpdateUserInput) SetNewUserName(v string) *UpdateUserInput {
+	s.NewUserName = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *UpdateUserInput) SetUserName(v string) *UpdateUserInput {
+	s.UserName = &v
+	return s
+}
+
 type UpdateUserOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -19804,6 +22996,18 @@ func (s *UploadSSHPublicKeyInput) Validate() error {
 	return nil
 }
 
+// SetSSHPublicKeyBody sets the SSHPublicKeyBody field's value.
+func (s *UploadSSHPublicKeyInput) SetSSHPublicKeyBody(v string) *UploadSSHPublicKeyInput {
+	s.SSHPublicKeyBody = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *UploadSSHPublicKeyInput) SetUserName(v string) *UploadSSHPublicKeyInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful UploadSSHPublicKey request.
 type UploadSSHPublicKeyOutput struct {
 	_ struct{} `type:"structure"`
@@ -19820,6 +23024,12 @@ func (s UploadSSHPublicKeyOutput) String() string {
 // GoString returns the string representation
 func (s UploadSSHPublicKeyOutput) GoString() string {
 	return s.String()
+}
+
+// SetSSHPublicKey sets the SSHPublicKey field's value.
+func (s *UploadSSHPublicKeyOutput) SetSSHPublicKey(v *SSHPublicKey) *UploadSSHPublicKeyOutput {
+	s.SSHPublicKey = v
+	return s
 }
 
 type UploadServerCertificateInput struct {
@@ -19929,6 +23139,36 @@ func (s *UploadServerCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateBody sets the CertificateBody field's value.
+func (s *UploadServerCertificateInput) SetCertificateBody(v string) *UploadServerCertificateInput {
+	s.CertificateBody = &v
+	return s
+}
+
+// SetCertificateChain sets the CertificateChain field's value.
+func (s *UploadServerCertificateInput) SetCertificateChain(v string) *UploadServerCertificateInput {
+	s.CertificateChain = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *UploadServerCertificateInput) SetPath(v string) *UploadServerCertificateInput {
+	s.Path = &v
+	return s
+}
+
+// SetPrivateKey sets the PrivateKey field's value.
+func (s *UploadServerCertificateInput) SetPrivateKey(v string) *UploadServerCertificateInput {
+	s.PrivateKey = &v
+	return s
+}
+
+// SetServerCertificateName sets the ServerCertificateName field's value.
+func (s *UploadServerCertificateInput) SetServerCertificateName(v string) *UploadServerCertificateInput {
+	s.ServerCertificateName = &v
+	return s
+}
+
 // Contains the response to a successful UploadServerCertificate request.
 type UploadServerCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -19946,6 +23186,12 @@ func (s UploadServerCertificateOutput) String() string {
 // GoString returns the string representation
 func (s UploadServerCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetServerCertificateMetadata sets the ServerCertificateMetadata field's value.
+func (s *UploadServerCertificateOutput) SetServerCertificateMetadata(v *ServerCertificateMetadata) *UploadServerCertificateOutput {
+	s.ServerCertificateMetadata = v
+	return s
 }
 
 type UploadSigningCertificateInput struct {
@@ -19999,6 +23245,18 @@ func (s *UploadSigningCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateBody sets the CertificateBody field's value.
+func (s *UploadSigningCertificateInput) SetCertificateBody(v string) *UploadSigningCertificateInput {
+	s.CertificateBody = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *UploadSigningCertificateInput) SetUserName(v string) *UploadSigningCertificateInput {
+	s.UserName = &v
+	return s
+}
+
 // Contains the response to a successful UploadSigningCertificate request.
 type UploadSigningCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -20017,6 +23275,12 @@ func (s UploadSigningCertificateOutput) String() string {
 // GoString returns the string representation
 func (s UploadSigningCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificate sets the Certificate field's value.
+func (s *UploadSigningCertificateOutput) SetCertificate(v *SigningCertificate) *UploadSigningCertificateOutput {
+	s.Certificate = v
+	return s
 }
 
 // Contains information about an IAM user entity.
@@ -20092,6 +23356,42 @@ func (s User) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *User) SetArn(v string) *User {
+	s.Arn = &v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *User) SetCreateDate(v time.Time) *User {
+	s.CreateDate = &v
+	return s
+}
+
+// SetPasswordLastUsed sets the PasswordLastUsed field's value.
+func (s *User) SetPasswordLastUsed(v time.Time) *User {
+	s.PasswordLastUsed = &v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *User) SetPath(v string) *User {
+	s.Path = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *User) SetUserId(v string) *User {
+	s.UserId = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *User) SetUserName(v string) *User {
+	s.UserName = &v
+	return s
+}
+
 // Contains information about an IAM user, including all the user's policies
 // and all the IAM groups the user is in.
 //
@@ -20144,6 +23444,54 @@ func (s UserDetail) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *UserDetail) SetArn(v string) *UserDetail {
+	s.Arn = &v
+	return s
+}
+
+// SetAttachedManagedPolicies sets the AttachedManagedPolicies field's value.
+func (s *UserDetail) SetAttachedManagedPolicies(v []*AttachedPolicy) *UserDetail {
+	s.AttachedManagedPolicies = v
+	return s
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *UserDetail) SetCreateDate(v time.Time) *UserDetail {
+	s.CreateDate = &v
+	return s
+}
+
+// SetGroupList sets the GroupList field's value.
+func (s *UserDetail) SetGroupList(v []*string) *UserDetail {
+	s.GroupList = v
+	return s
+}
+
+// SetPath sets the Path field's value.
+func (s *UserDetail) SetPath(v string) *UserDetail {
+	s.Path = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *UserDetail) SetUserId(v string) *UserDetail {
+	s.UserId = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *UserDetail) SetUserName(v string) *UserDetail {
+	s.UserName = &v
+	return s
+}
+
+// SetUserPolicyList sets the UserPolicyList field's value.
+func (s *UserDetail) SetUserPolicyList(v []*PolicyDetail) *UserDetail {
+	s.UserPolicyList = v
+	return s
+}
+
 // Contains information about a virtual MFA device.
 type VirtualMFADevice struct {
 	_ struct{} `type:"structure"`
@@ -20190,6 +23538,36 @@ func (s VirtualMFADevice) String() string {
 // GoString returns the string representation
 func (s VirtualMFADevice) GoString() string {
 	return s.String()
+}
+
+// SetBase32StringSeed sets the Base32StringSeed field's value.
+func (s *VirtualMFADevice) SetBase32StringSeed(v []byte) *VirtualMFADevice {
+	s.Base32StringSeed = v
+	return s
+}
+
+// SetEnableDate sets the EnableDate field's value.
+func (s *VirtualMFADevice) SetEnableDate(v time.Time) *VirtualMFADevice {
+	s.EnableDate = &v
+	return s
+}
+
+// SetQRCodePNG sets the QRCodePNG field's value.
+func (s *VirtualMFADevice) SetQRCodePNG(v []byte) *VirtualMFADevice {
+	s.QRCodePNG = v
+	return s
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *VirtualMFADevice) SetSerialNumber(v string) *VirtualMFADevice {
+	s.SerialNumber = &v
+	return s
+}
+
+// SetUser sets the User field's value.
+func (s *VirtualMFADevice) SetUser(v *User) *VirtualMFADevice {
+	s.User = v
+	return s
 }
 
 const (

--- a/service/inspector/api.go
+++ b/service/inspector/api.go
@@ -2498,6 +2498,18 @@ func (s *AddAttributesToFindingsInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *AddAttributesToFindingsInput) SetAttributes(v []*Attribute) *AddAttributesToFindingsInput {
+	s.Attributes = v
+	return s
+}
+
+// SetFindingArns sets the FindingArns field's value.
+func (s *AddAttributesToFindingsInput) SetFindingArns(v []*string) *AddAttributesToFindingsInput {
+	s.FindingArns = v
+	return s
+}
+
 type AddAttributesToFindingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2516,6 +2528,12 @@ func (s AddAttributesToFindingsOutput) String() string {
 // GoString returns the string representation
 func (s AddAttributesToFindingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedItems sets the FailedItems field's value.
+func (s *AddAttributesToFindingsOutput) SetFailedItems(v map[string]*FailedItemDetails) *AddAttributesToFindingsOutput {
+	s.FailedItems = v
+	return s
 }
 
 // Used in the exception error that is thrown if you start an assessment run
@@ -2544,6 +2562,18 @@ func (s AgentAlreadyRunningAssessment) String() string {
 // GoString returns the string representation
 func (s AgentAlreadyRunningAssessment) GoString() string {
 	return s.String()
+}
+
+// SetAgentId sets the AgentId field's value.
+func (s *AgentAlreadyRunningAssessment) SetAgentId(v string) *AgentAlreadyRunningAssessment {
+	s.AgentId = &v
+	return s
+}
+
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *AgentAlreadyRunningAssessment) SetAssessmentRunArn(v string) *AgentAlreadyRunningAssessment {
+	s.AssessmentRunArn = &v
+	return s
 }
 
 // Contains information about an Amazon Inspector agent. This data type is used
@@ -2589,6 +2619,18 @@ func (s *AgentFilter) Validate() error {
 	return nil
 }
 
+// SetAgentHealthCodes sets the AgentHealthCodes field's value.
+func (s *AgentFilter) SetAgentHealthCodes(v []*string) *AgentFilter {
+	s.AgentHealthCodes = v
+	return s
+}
+
+// SetAgentHealths sets the AgentHealths field's value.
+func (s *AgentFilter) SetAgentHealths(v []*string) *AgentFilter {
+	s.AgentHealths = v
+	return s
+}
+
 // Used as a response element in the PreviewAgents action.
 type AgentPreview struct {
 	_ struct{} `type:"structure"`
@@ -2610,6 +2652,18 @@ func (s AgentPreview) String() string {
 // GoString returns the string representation
 func (s AgentPreview) GoString() string {
 	return s.String()
+}
+
+// SetAgentId sets the AgentId field's value.
+func (s *AgentPreview) SetAgentId(v string) *AgentPreview {
+	s.AgentId = &v
+	return s
+}
+
+// SetAutoScalingGroup sets the AutoScalingGroup field's value.
+func (s *AgentPreview) SetAutoScalingGroup(v string) *AgentPreview {
+	s.AutoScalingGroup = &v
+	return s
 }
 
 // A snapshot of an Amazon Inspector assessment run that contains the findings
@@ -2700,6 +2754,90 @@ func (s AssessmentRun) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *AssessmentRun) SetArn(v string) *AssessmentRun {
+	s.Arn = &v
+	return s
+}
+
+// SetAssessmentTemplateArn sets the AssessmentTemplateArn field's value.
+func (s *AssessmentRun) SetAssessmentTemplateArn(v string) *AssessmentRun {
+	s.AssessmentTemplateArn = &v
+	return s
+}
+
+// SetCompletedAt sets the CompletedAt field's value.
+func (s *AssessmentRun) SetCompletedAt(v time.Time) *AssessmentRun {
+	s.CompletedAt = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *AssessmentRun) SetCreatedAt(v time.Time) *AssessmentRun {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDataCollected sets the DataCollected field's value.
+func (s *AssessmentRun) SetDataCollected(v bool) *AssessmentRun {
+	s.DataCollected = &v
+	return s
+}
+
+// SetDurationInSeconds sets the DurationInSeconds field's value.
+func (s *AssessmentRun) SetDurationInSeconds(v int64) *AssessmentRun {
+	s.DurationInSeconds = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AssessmentRun) SetName(v string) *AssessmentRun {
+	s.Name = &v
+	return s
+}
+
+// SetNotifications sets the Notifications field's value.
+func (s *AssessmentRun) SetNotifications(v []*AssessmentRunNotification) *AssessmentRun {
+	s.Notifications = v
+	return s
+}
+
+// SetRulesPackageArns sets the RulesPackageArns field's value.
+func (s *AssessmentRun) SetRulesPackageArns(v []*string) *AssessmentRun {
+	s.RulesPackageArns = v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *AssessmentRun) SetStartedAt(v time.Time) *AssessmentRun {
+	s.StartedAt = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *AssessmentRun) SetState(v string) *AssessmentRun {
+	s.State = &v
+	return s
+}
+
+// SetStateChangedAt sets the StateChangedAt field's value.
+func (s *AssessmentRun) SetStateChangedAt(v time.Time) *AssessmentRun {
+	s.StateChangedAt = &v
+	return s
+}
+
+// SetStateChanges sets the StateChanges field's value.
+func (s *AssessmentRun) SetStateChanges(v []*AssessmentRunStateChange) *AssessmentRun {
+	s.StateChanges = v
+	return s
+}
+
+// SetUserAttributesForFindings sets the UserAttributesForFindings field's value.
+func (s *AssessmentRun) SetUserAttributesForFindings(v []*Attribute) *AssessmentRun {
+	s.UserAttributesForFindings = v
+	return s
+}
+
 // Contains information about an Amazon Inspector agent. This data type is used
 // as a response element in the ListAssessmentRunAgents action.
 type AssessmentRunAgent struct {
@@ -2746,6 +2884,48 @@ func (s AssessmentRunAgent) String() string {
 // GoString returns the string representation
 func (s AssessmentRunAgent) GoString() string {
 	return s.String()
+}
+
+// SetAgentHealth sets the AgentHealth field's value.
+func (s *AssessmentRunAgent) SetAgentHealth(v string) *AssessmentRunAgent {
+	s.AgentHealth = &v
+	return s
+}
+
+// SetAgentHealthCode sets the AgentHealthCode field's value.
+func (s *AssessmentRunAgent) SetAgentHealthCode(v string) *AssessmentRunAgent {
+	s.AgentHealthCode = &v
+	return s
+}
+
+// SetAgentHealthDetails sets the AgentHealthDetails field's value.
+func (s *AssessmentRunAgent) SetAgentHealthDetails(v string) *AssessmentRunAgent {
+	s.AgentHealthDetails = &v
+	return s
+}
+
+// SetAgentId sets the AgentId field's value.
+func (s *AssessmentRunAgent) SetAgentId(v string) *AssessmentRunAgent {
+	s.AgentId = &v
+	return s
+}
+
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *AssessmentRunAgent) SetAssessmentRunArn(v string) *AssessmentRunAgent {
+	s.AssessmentRunArn = &v
+	return s
+}
+
+// SetAutoScalingGroup sets the AutoScalingGroup field's value.
+func (s *AssessmentRunAgent) SetAutoScalingGroup(v string) *AssessmentRunAgent {
+	s.AutoScalingGroup = &v
+	return s
+}
+
+// SetTelemetryMetadata sets the TelemetryMetadata field's value.
+func (s *AssessmentRunAgent) SetTelemetryMetadata(v []*TelemetryMetadata) *AssessmentRunAgent {
+	s.TelemetryMetadata = v
+	return s
 }
 
 // Used as the request parameter in the ListAssessmentRuns action.
@@ -2818,6 +2998,48 @@ func (s *AssessmentRunFilter) Validate() error {
 	return nil
 }
 
+// SetCompletionTimeRange sets the CompletionTimeRange field's value.
+func (s *AssessmentRunFilter) SetCompletionTimeRange(v *TimestampRange) *AssessmentRunFilter {
+	s.CompletionTimeRange = v
+	return s
+}
+
+// SetDurationRange sets the DurationRange field's value.
+func (s *AssessmentRunFilter) SetDurationRange(v *DurationRange) *AssessmentRunFilter {
+	s.DurationRange = v
+	return s
+}
+
+// SetNamePattern sets the NamePattern field's value.
+func (s *AssessmentRunFilter) SetNamePattern(v string) *AssessmentRunFilter {
+	s.NamePattern = &v
+	return s
+}
+
+// SetRulesPackageArns sets the RulesPackageArns field's value.
+func (s *AssessmentRunFilter) SetRulesPackageArns(v []*string) *AssessmentRunFilter {
+	s.RulesPackageArns = v
+	return s
+}
+
+// SetStartTimeRange sets the StartTimeRange field's value.
+func (s *AssessmentRunFilter) SetStartTimeRange(v *TimestampRange) *AssessmentRunFilter {
+	s.StartTimeRange = v
+	return s
+}
+
+// SetStateChangeTimeRange sets the StateChangeTimeRange field's value.
+func (s *AssessmentRunFilter) SetStateChangeTimeRange(v *TimestampRange) *AssessmentRunFilter {
+	s.StateChangeTimeRange = v
+	return s
+}
+
+// SetStates sets the States field's value.
+func (s *AssessmentRunFilter) SetStates(v []*string) *AssessmentRunFilter {
+	s.States = v
+	return s
+}
+
 // Used as one of the elements of the AssessmentRun data type.
 type AssessmentRunNotification struct {
 	_ struct{} `type:"structure"`
@@ -2856,6 +3078,42 @@ func (s AssessmentRunNotification) GoString() string {
 	return s.String()
 }
 
+// SetDate sets the Date field's value.
+func (s *AssessmentRunNotification) SetDate(v time.Time) *AssessmentRunNotification {
+	s.Date = &v
+	return s
+}
+
+// SetError sets the Error field's value.
+func (s *AssessmentRunNotification) SetError(v bool) *AssessmentRunNotification {
+	s.Error = &v
+	return s
+}
+
+// SetEvent sets the Event field's value.
+func (s *AssessmentRunNotification) SetEvent(v string) *AssessmentRunNotification {
+	s.Event = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *AssessmentRunNotification) SetMessage(v string) *AssessmentRunNotification {
+	s.Message = &v
+	return s
+}
+
+// SetSnsPublishStatusCode sets the SnsPublishStatusCode field's value.
+func (s *AssessmentRunNotification) SetSnsPublishStatusCode(v string) *AssessmentRunNotification {
+	s.SnsPublishStatusCode = &v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *AssessmentRunNotification) SetSnsTopicArn(v string) *AssessmentRunNotification {
+	s.SnsTopicArn = &v
+	return s
+}
+
 // Used as one of the elements of the AssessmentRun data type.
 type AssessmentRunStateChange struct {
 	_ struct{} `type:"structure"`
@@ -2879,6 +3137,18 @@ func (s AssessmentRunStateChange) String() string {
 // GoString returns the string representation
 func (s AssessmentRunStateChange) GoString() string {
 	return s.String()
+}
+
+// SetState sets the State field's value.
+func (s *AssessmentRunStateChange) SetState(v string) *AssessmentRunStateChange {
+	s.State = &v
+	return s
+}
+
+// SetStateChangedAt sets the StateChangedAt field's value.
+func (s *AssessmentRunStateChange) SetStateChangedAt(v time.Time) *AssessmentRunStateChange {
+	s.StateChangedAt = &v
+	return s
 }
 
 // Contains information about an Amazon Inspector application. This data type
@@ -2923,6 +3193,36 @@ func (s AssessmentTarget) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *AssessmentTarget) SetArn(v string) *AssessmentTarget {
+	s.Arn = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *AssessmentTarget) SetCreatedAt(v time.Time) *AssessmentTarget {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AssessmentTarget) SetName(v string) *AssessmentTarget {
+	s.Name = &v
+	return s
+}
+
+// SetResourceGroupArn sets the ResourceGroupArn field's value.
+func (s *AssessmentTarget) SetResourceGroupArn(v string) *AssessmentTarget {
+	s.ResourceGroupArn = &v
+	return s
+}
+
+// SetUpdatedAt sets the UpdatedAt field's value.
+func (s *AssessmentTarget) SetUpdatedAt(v time.Time) *AssessmentTarget {
+	s.UpdatedAt = &v
+	return s
+}
+
 // Used as the request parameter in the ListAssessmentTargets action.
 type AssessmentTargetFilter struct {
 	_ struct{} `type:"structure"`
@@ -2954,6 +3254,12 @@ func (s *AssessmentTargetFilter) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAssessmentTargetNamePattern sets the AssessmentTargetNamePattern field's value.
+func (s *AssessmentTargetFilter) SetAssessmentTargetNamePattern(v string) *AssessmentTargetFilter {
+	s.AssessmentTargetNamePattern = &v
+	return s
 }
 
 // Contains information about an Amazon Inspector assessment template. This
@@ -3011,6 +3317,48 @@ func (s AssessmentTemplate) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *AssessmentTemplate) SetArn(v string) *AssessmentTemplate {
+	s.Arn = &v
+	return s
+}
+
+// SetAssessmentTargetArn sets the AssessmentTargetArn field's value.
+func (s *AssessmentTemplate) SetAssessmentTargetArn(v string) *AssessmentTemplate {
+	s.AssessmentTargetArn = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *AssessmentTemplate) SetCreatedAt(v time.Time) *AssessmentTemplate {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDurationInSeconds sets the DurationInSeconds field's value.
+func (s *AssessmentTemplate) SetDurationInSeconds(v int64) *AssessmentTemplate {
+	s.DurationInSeconds = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AssessmentTemplate) SetName(v string) *AssessmentTemplate {
+	s.Name = &v
+	return s
+}
+
+// SetRulesPackageArns sets the RulesPackageArns field's value.
+func (s *AssessmentTemplate) SetRulesPackageArns(v []*string) *AssessmentTemplate {
+	s.RulesPackageArns = v
+	return s
+}
+
+// SetUserAttributesForFindings sets the UserAttributesForFindings field's value.
+func (s *AssessmentTemplate) SetUserAttributesForFindings(v []*Attribute) *AssessmentTemplate {
+	s.UserAttributesForFindings = v
+	return s
+}
+
 // Used as the request parameter in the ListAssessmentTemplates action.
 type AssessmentTemplateFilter struct {
 	_ struct{} `type:"structure"`
@@ -3059,6 +3407,24 @@ func (s *AssessmentTemplateFilter) Validate() error {
 	return nil
 }
 
+// SetDurationRange sets the DurationRange field's value.
+func (s *AssessmentTemplateFilter) SetDurationRange(v *DurationRange) *AssessmentTemplateFilter {
+	s.DurationRange = v
+	return s
+}
+
+// SetNamePattern sets the NamePattern field's value.
+func (s *AssessmentTemplateFilter) SetNamePattern(v string) *AssessmentTemplateFilter {
+	s.NamePattern = &v
+	return s
+}
+
+// SetRulesPackageArns sets the RulesPackageArns field's value.
+func (s *AssessmentTemplateFilter) SetRulesPackageArns(v []*string) *AssessmentTemplateFilter {
+	s.RulesPackageArns = v
+	return s
+}
+
 // A collection of attributes of the host from which the finding is generated.
 type AssetAttributes struct {
 	_ struct{} `type:"structure"`
@@ -3094,6 +3460,42 @@ func (s AssetAttributes) String() string {
 // GoString returns the string representation
 func (s AssetAttributes) GoString() string {
 	return s.String()
+}
+
+// SetAgentId sets the AgentId field's value.
+func (s *AssetAttributes) SetAgentId(v string) *AssetAttributes {
+	s.AgentId = &v
+	return s
+}
+
+// SetAmiId sets the AmiId field's value.
+func (s *AssetAttributes) SetAmiId(v string) *AssetAttributes {
+	s.AmiId = &v
+	return s
+}
+
+// SetAutoScalingGroup sets the AutoScalingGroup field's value.
+func (s *AssetAttributes) SetAutoScalingGroup(v string) *AssetAttributes {
+	s.AutoScalingGroup = &v
+	return s
+}
+
+// SetHostname sets the Hostname field's value.
+func (s *AssetAttributes) SetHostname(v string) *AssetAttributes {
+	s.Hostname = &v
+	return s
+}
+
+// SetIpv4Addresses sets the Ipv4Addresses field's value.
+func (s *AssetAttributes) SetIpv4Addresses(v []*string) *AssetAttributes {
+	s.Ipv4Addresses = v
+	return s
+}
+
+// SetSchemaVersion sets the SchemaVersion field's value.
+func (s *AssetAttributes) SetSchemaVersion(v int64) *AssetAttributes {
+	s.SchemaVersion = &v
+	return s
 }
 
 // This data type is used as a request parameter in the AddAttributesToFindings
@@ -3137,6 +3539,18 @@ func (s *Attribute) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Attribute) SetKey(v string) *Attribute {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Attribute) SetValue(v string) *Attribute {
+	s.Value = &v
+	return s
 }
 
 type CreateAssessmentTargetInput struct {
@@ -3187,6 +3601,18 @@ func (s *CreateAssessmentTargetInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentTargetName sets the AssessmentTargetName field's value.
+func (s *CreateAssessmentTargetInput) SetAssessmentTargetName(v string) *CreateAssessmentTargetInput {
+	s.AssessmentTargetName = &v
+	return s
+}
+
+// SetResourceGroupArn sets the ResourceGroupArn field's value.
+func (s *CreateAssessmentTargetInput) SetResourceGroupArn(v string) *CreateAssessmentTargetInput {
+	s.ResourceGroupArn = &v
+	return s
+}
+
 type CreateAssessmentTargetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3204,6 +3630,12 @@ func (s CreateAssessmentTargetOutput) String() string {
 // GoString returns the string representation
 func (s CreateAssessmentTargetOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentTargetArn sets the AssessmentTargetArn field's value.
+func (s *CreateAssessmentTargetOutput) SetAssessmentTargetArn(v string) *CreateAssessmentTargetOutput {
+	s.AssessmentTargetArn = &v
+	return s
 }
 
 type CreateAssessmentTemplateInput struct {
@@ -3291,6 +3723,36 @@ func (s *CreateAssessmentTemplateInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentTargetArn sets the AssessmentTargetArn field's value.
+func (s *CreateAssessmentTemplateInput) SetAssessmentTargetArn(v string) *CreateAssessmentTemplateInput {
+	s.AssessmentTargetArn = &v
+	return s
+}
+
+// SetAssessmentTemplateName sets the AssessmentTemplateName field's value.
+func (s *CreateAssessmentTemplateInput) SetAssessmentTemplateName(v string) *CreateAssessmentTemplateInput {
+	s.AssessmentTemplateName = &v
+	return s
+}
+
+// SetDurationInSeconds sets the DurationInSeconds field's value.
+func (s *CreateAssessmentTemplateInput) SetDurationInSeconds(v int64) *CreateAssessmentTemplateInput {
+	s.DurationInSeconds = &v
+	return s
+}
+
+// SetRulesPackageArns sets the RulesPackageArns field's value.
+func (s *CreateAssessmentTemplateInput) SetRulesPackageArns(v []*string) *CreateAssessmentTemplateInput {
+	s.RulesPackageArns = v
+	return s
+}
+
+// SetUserAttributesForFindings sets the UserAttributesForFindings field's value.
+func (s *CreateAssessmentTemplateInput) SetUserAttributesForFindings(v []*Attribute) *CreateAssessmentTemplateInput {
+	s.UserAttributesForFindings = v
+	return s
+}
+
 type CreateAssessmentTemplateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3308,6 +3770,12 @@ func (s CreateAssessmentTemplateOutput) String() string {
 // GoString returns the string representation
 func (s CreateAssessmentTemplateOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentTemplateArn sets the AssessmentTemplateArn field's value.
+func (s *CreateAssessmentTemplateOutput) SetAssessmentTemplateArn(v string) *CreateAssessmentTemplateOutput {
+	s.AssessmentTemplateArn = &v
+	return s
 }
 
 type CreateResourceGroupInput struct {
@@ -3357,6 +3825,12 @@ func (s *CreateResourceGroupInput) Validate() error {
 	return nil
 }
 
+// SetResourceGroupTags sets the ResourceGroupTags field's value.
+func (s *CreateResourceGroupInput) SetResourceGroupTags(v []*ResourceGroupTag) *CreateResourceGroupInput {
+	s.ResourceGroupTags = v
+	return s
+}
+
 type CreateResourceGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3374,6 +3848,12 @@ func (s CreateResourceGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateResourceGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourceGroupArn sets the ResourceGroupArn field's value.
+func (s *CreateResourceGroupOutput) SetResourceGroupArn(v string) *CreateResourceGroupOutput {
+	s.ResourceGroupArn = &v
+	return s
 }
 
 type DeleteAssessmentRunInput struct {
@@ -3409,6 +3889,12 @@ func (s *DeleteAssessmentRunInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *DeleteAssessmentRunInput) SetAssessmentRunArn(v string) *DeleteAssessmentRunInput {
+	s.AssessmentRunArn = &v
+	return s
 }
 
 type DeleteAssessmentRunOutput struct {
@@ -3460,6 +3946,12 @@ func (s *DeleteAssessmentTargetInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentTargetArn sets the AssessmentTargetArn field's value.
+func (s *DeleteAssessmentTargetInput) SetAssessmentTargetArn(v string) *DeleteAssessmentTargetInput {
+	s.AssessmentTargetArn = &v
+	return s
+}
+
 type DeleteAssessmentTargetOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3507,6 +3999,12 @@ func (s *DeleteAssessmentTemplateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAssessmentTemplateArn sets the AssessmentTemplateArn field's value.
+func (s *DeleteAssessmentTemplateInput) SetAssessmentTemplateArn(v string) *DeleteAssessmentTemplateInput {
+	s.AssessmentTemplateArn = &v
+	return s
 }
 
 type DeleteAssessmentTemplateOutput struct {
@@ -3558,6 +4056,12 @@ func (s *DescribeAssessmentRunsInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentRunArns sets the AssessmentRunArns field's value.
+func (s *DescribeAssessmentRunsInput) SetAssessmentRunArns(v []*string) *DescribeAssessmentRunsInput {
+	s.AssessmentRunArns = v
+	return s
+}
+
 type DescribeAssessmentRunsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3581,6 +4085,18 @@ func (s DescribeAssessmentRunsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAssessmentRunsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentRuns sets the AssessmentRuns field's value.
+func (s *DescribeAssessmentRunsOutput) SetAssessmentRuns(v []*AssessmentRun) *DescribeAssessmentRunsOutput {
+	s.AssessmentRuns = v
+	return s
+}
+
+// SetFailedItems sets the FailedItems field's value.
+func (s *DescribeAssessmentRunsOutput) SetFailedItems(v map[string]*FailedItemDetails) *DescribeAssessmentRunsOutput {
+	s.FailedItems = v
+	return s
 }
 
 type DescribeAssessmentTargetsInput struct {
@@ -3618,6 +4134,12 @@ func (s *DescribeAssessmentTargetsInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentTargetArns sets the AssessmentTargetArns field's value.
+func (s *DescribeAssessmentTargetsInput) SetAssessmentTargetArns(v []*string) *DescribeAssessmentTargetsInput {
+	s.AssessmentTargetArns = v
+	return s
+}
+
 type DescribeAssessmentTargetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3641,6 +4163,18 @@ func (s DescribeAssessmentTargetsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAssessmentTargetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentTargets sets the AssessmentTargets field's value.
+func (s *DescribeAssessmentTargetsOutput) SetAssessmentTargets(v []*AssessmentTarget) *DescribeAssessmentTargetsOutput {
+	s.AssessmentTargets = v
+	return s
+}
+
+// SetFailedItems sets the FailedItems field's value.
+func (s *DescribeAssessmentTargetsOutput) SetFailedItems(v map[string]*FailedItemDetails) *DescribeAssessmentTargetsOutput {
+	s.FailedItems = v
+	return s
 }
 
 type DescribeAssessmentTemplatesInput struct {
@@ -3678,6 +4212,12 @@ func (s *DescribeAssessmentTemplatesInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentTemplateArns sets the AssessmentTemplateArns field's value.
+func (s *DescribeAssessmentTemplatesInput) SetAssessmentTemplateArns(v []*string) *DescribeAssessmentTemplatesInput {
+	s.AssessmentTemplateArns = v
+	return s
+}
+
 type DescribeAssessmentTemplatesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3701,6 +4241,18 @@ func (s DescribeAssessmentTemplatesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAssessmentTemplatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentTemplates sets the AssessmentTemplates field's value.
+func (s *DescribeAssessmentTemplatesOutput) SetAssessmentTemplates(v []*AssessmentTemplate) *DescribeAssessmentTemplatesOutput {
+	s.AssessmentTemplates = v
+	return s
+}
+
+// SetFailedItems sets the FailedItems field's value.
+func (s *DescribeAssessmentTemplatesOutput) SetFailedItems(v map[string]*FailedItemDetails) *DescribeAssessmentTemplatesOutput {
+	s.FailedItems = v
+	return s
 }
 
 type DescribeCrossAccountAccessRoleInput struct {
@@ -3748,6 +4300,24 @@ func (s DescribeCrossAccountAccessRoleOutput) GoString() string {
 	return s.String()
 }
 
+// SetRegisteredAt sets the RegisteredAt field's value.
+func (s *DescribeCrossAccountAccessRoleOutput) SetRegisteredAt(v time.Time) *DescribeCrossAccountAccessRoleOutput {
+	s.RegisteredAt = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *DescribeCrossAccountAccessRoleOutput) SetRoleArn(v string) *DescribeCrossAccountAccessRoleOutput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetValid sets the Valid field's value.
+func (s *DescribeCrossAccountAccessRoleOutput) SetValid(v bool) *DescribeCrossAccountAccessRoleOutput {
+	s.Valid = &v
+	return s
+}
+
 type DescribeFindingsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3787,6 +4357,18 @@ func (s *DescribeFindingsInput) Validate() error {
 	return nil
 }
 
+// SetFindingArns sets the FindingArns field's value.
+func (s *DescribeFindingsInput) SetFindingArns(v []*string) *DescribeFindingsInput {
+	s.FindingArns = v
+	return s
+}
+
+// SetLocale sets the Locale field's value.
+func (s *DescribeFindingsInput) SetLocale(v string) *DescribeFindingsInput {
+	s.Locale = &v
+	return s
+}
+
 type DescribeFindingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3810,6 +4392,18 @@ func (s DescribeFindingsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeFindingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedItems sets the FailedItems field's value.
+func (s *DescribeFindingsOutput) SetFailedItems(v map[string]*FailedItemDetails) *DescribeFindingsOutput {
+	s.FailedItems = v
+	return s
+}
+
+// SetFindings sets the Findings field's value.
+func (s *DescribeFindingsOutput) SetFindings(v []*Finding) *DescribeFindingsOutput {
+	s.Findings = v
+	return s
 }
 
 type DescribeResourceGroupsInput struct {
@@ -3847,6 +4441,12 @@ func (s *DescribeResourceGroupsInput) Validate() error {
 	return nil
 }
 
+// SetResourceGroupArns sets the ResourceGroupArns field's value.
+func (s *DescribeResourceGroupsInput) SetResourceGroupArns(v []*string) *DescribeResourceGroupsInput {
+	s.ResourceGroupArns = v
+	return s
+}
+
 type DescribeResourceGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3870,6 +4470,18 @@ func (s DescribeResourceGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeResourceGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedItems sets the FailedItems field's value.
+func (s *DescribeResourceGroupsOutput) SetFailedItems(v map[string]*FailedItemDetails) *DescribeResourceGroupsOutput {
+	s.FailedItems = v
+	return s
+}
+
+// SetResourceGroups sets the ResourceGroups field's value.
+func (s *DescribeResourceGroupsOutput) SetResourceGroups(v []*ResourceGroup) *DescribeResourceGroupsOutput {
+	s.ResourceGroups = v
+	return s
 }
 
 type DescribeRulesPackagesInput struct {
@@ -3910,6 +4522,18 @@ func (s *DescribeRulesPackagesInput) Validate() error {
 	return nil
 }
 
+// SetLocale sets the Locale field's value.
+func (s *DescribeRulesPackagesInput) SetLocale(v string) *DescribeRulesPackagesInput {
+	s.Locale = &v
+	return s
+}
+
+// SetRulesPackageArns sets the RulesPackageArns field's value.
+func (s *DescribeRulesPackagesInput) SetRulesPackageArns(v []*string) *DescribeRulesPackagesInput {
+	s.RulesPackageArns = v
+	return s
+}
+
 type DescribeRulesPackagesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3933,6 +4557,18 @@ func (s DescribeRulesPackagesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRulesPackagesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedItems sets the FailedItems field's value.
+func (s *DescribeRulesPackagesOutput) SetFailedItems(v map[string]*FailedItemDetails) *DescribeRulesPackagesOutput {
+	s.FailedItems = v
+	return s
+}
+
+// SetRulesPackages sets the RulesPackages field's value.
+func (s *DescribeRulesPackagesOutput) SetRulesPackages(v []*RulesPackage) *DescribeRulesPackagesOutput {
+	s.RulesPackages = v
+	return s
 }
 
 // This data type is used in the AssessmentTemplateFilter data type.
@@ -3973,6 +4609,18 @@ func (s *DurationRange) Validate() error {
 	return nil
 }
 
+// SetMaxSeconds sets the MaxSeconds field's value.
+func (s *DurationRange) SetMaxSeconds(v int64) *DurationRange {
+	s.MaxSeconds = &v
+	return s
+}
+
+// SetMinSeconds sets the MinSeconds field's value.
+func (s *DurationRange) SetMinSeconds(v int64) *DurationRange {
+	s.MinSeconds = &v
+	return s
+}
+
 // This data type is used in the Subscription data type.
 type EventSubscription struct {
 	_ struct{} `type:"structure"`
@@ -3999,6 +4647,18 @@ func (s EventSubscription) GoString() string {
 	return s.String()
 }
 
+// SetEvent sets the Event field's value.
+func (s *EventSubscription) SetEvent(v string) *EventSubscription {
+	s.Event = &v
+	return s
+}
+
+// SetSubscribedAt sets the SubscribedAt field's value.
+func (s *EventSubscription) SetSubscribedAt(v time.Time) *EventSubscription {
+	s.SubscribedAt = &v
+	return s
+}
+
 // Includes details about the failed items.
 type FailedItemDetails struct {
 	_ struct{} `type:"structure"`
@@ -4023,6 +4683,18 @@ func (s FailedItemDetails) String() string {
 // GoString returns the string representation
 func (s FailedItemDetails) GoString() string {
 	return s.String()
+}
+
+// SetFailureCode sets the FailureCode field's value.
+func (s *FailedItemDetails) SetFailureCode(v string) *FailedItemDetails {
+	s.FailureCode = &v
+	return s
+}
+
+// SetRetryable sets the Retryable field's value.
+func (s *FailedItemDetails) SetRetryable(v bool) *FailedItemDetails {
+	s.Retryable = &v
+	return s
 }
 
 // Contains information about an Amazon Inspector finding. This data type is
@@ -4103,6 +4775,114 @@ func (s Finding) String() string {
 // GoString returns the string representation
 func (s Finding) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Finding) SetArn(v string) *Finding {
+	s.Arn = &v
+	return s
+}
+
+// SetAssetAttributes sets the AssetAttributes field's value.
+func (s *Finding) SetAssetAttributes(v *AssetAttributes) *Finding {
+	s.AssetAttributes = v
+	return s
+}
+
+// SetAssetType sets the AssetType field's value.
+func (s *Finding) SetAssetType(v string) *Finding {
+	s.AssetType = &v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *Finding) SetAttributes(v []*Attribute) *Finding {
+	s.Attributes = v
+	return s
+}
+
+// SetConfidence sets the Confidence field's value.
+func (s *Finding) SetConfidence(v int64) *Finding {
+	s.Confidence = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Finding) SetCreatedAt(v time.Time) *Finding {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Finding) SetDescription(v string) *Finding {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Finding) SetId(v string) *Finding {
+	s.Id = &v
+	return s
+}
+
+// SetIndicatorOfCompromise sets the IndicatorOfCompromise field's value.
+func (s *Finding) SetIndicatorOfCompromise(v bool) *Finding {
+	s.IndicatorOfCompromise = &v
+	return s
+}
+
+// SetNumericSeverity sets the NumericSeverity field's value.
+func (s *Finding) SetNumericSeverity(v float64) *Finding {
+	s.NumericSeverity = &v
+	return s
+}
+
+// SetRecommendation sets the Recommendation field's value.
+func (s *Finding) SetRecommendation(v string) *Finding {
+	s.Recommendation = &v
+	return s
+}
+
+// SetSchemaVersion sets the SchemaVersion field's value.
+func (s *Finding) SetSchemaVersion(v int64) *Finding {
+	s.SchemaVersion = &v
+	return s
+}
+
+// SetService sets the Service field's value.
+func (s *Finding) SetService(v string) *Finding {
+	s.Service = &v
+	return s
+}
+
+// SetServiceAttributes sets the ServiceAttributes field's value.
+func (s *Finding) SetServiceAttributes(v *ServiceAttributes) *Finding {
+	s.ServiceAttributes = v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *Finding) SetSeverity(v string) *Finding {
+	s.Severity = &v
+	return s
+}
+
+// SetTitle sets the Title field's value.
+func (s *Finding) SetTitle(v string) *Finding {
+	s.Title = &v
+	return s
+}
+
+// SetUpdatedAt sets the UpdatedAt field's value.
+func (s *Finding) SetUpdatedAt(v time.Time) *Finding {
+	s.UpdatedAt = &v
+	return s
+}
+
+// SetUserAttributes sets the UserAttributes field's value.
+func (s *Finding) SetUserAttributes(v []*Attribute) *Finding {
+	s.UserAttributes = v
+	return s
 }
 
 // This data type is used as a request parameter in the ListFindings action.
@@ -4188,6 +4968,54 @@ func (s *FindingFilter) Validate() error {
 	return nil
 }
 
+// SetAgentIds sets the AgentIds field's value.
+func (s *FindingFilter) SetAgentIds(v []*string) *FindingFilter {
+	s.AgentIds = v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *FindingFilter) SetAttributes(v []*Attribute) *FindingFilter {
+	s.Attributes = v
+	return s
+}
+
+// SetAutoScalingGroups sets the AutoScalingGroups field's value.
+func (s *FindingFilter) SetAutoScalingGroups(v []*string) *FindingFilter {
+	s.AutoScalingGroups = v
+	return s
+}
+
+// SetCreationTimeRange sets the CreationTimeRange field's value.
+func (s *FindingFilter) SetCreationTimeRange(v *TimestampRange) *FindingFilter {
+	s.CreationTimeRange = v
+	return s
+}
+
+// SetRuleNames sets the RuleNames field's value.
+func (s *FindingFilter) SetRuleNames(v []*string) *FindingFilter {
+	s.RuleNames = v
+	return s
+}
+
+// SetRulesPackageArns sets the RulesPackageArns field's value.
+func (s *FindingFilter) SetRulesPackageArns(v []*string) *FindingFilter {
+	s.RulesPackageArns = v
+	return s
+}
+
+// SetSeverities sets the Severities field's value.
+func (s *FindingFilter) SetSeverities(v []*string) *FindingFilter {
+	s.Severities = v
+	return s
+}
+
+// SetUserAttributes sets the UserAttributes field's value.
+func (s *FindingFilter) SetUserAttributes(v []*Attribute) *FindingFilter {
+	s.UserAttributes = v
+	return s
+}
+
 type GetTelemetryMetadataInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4224,6 +5052,12 @@ func (s *GetTelemetryMetadataInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *GetTelemetryMetadataInput) SetAssessmentRunArn(v string) *GetTelemetryMetadataInput {
+	s.AssessmentRunArn = &v
+	return s
+}
+
 type GetTelemetryMetadataOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4241,6 +5075,12 @@ func (s GetTelemetryMetadataOutput) String() string {
 // GoString returns the string representation
 func (s GetTelemetryMetadataOutput) GoString() string {
 	return s.String()
+}
+
+// SetTelemetryMetadata sets the TelemetryMetadata field's value.
+func (s *GetTelemetryMetadataOutput) SetTelemetryMetadata(v []*TelemetryMetadata) *GetTelemetryMetadataOutput {
+	s.TelemetryMetadata = v
+	return s
 }
 
 type ListAssessmentRunAgentsInput struct {
@@ -4304,6 +5144,30 @@ func (s *ListAssessmentRunAgentsInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *ListAssessmentRunAgentsInput) SetAssessmentRunArn(v string) *ListAssessmentRunAgentsInput {
+	s.AssessmentRunArn = &v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *ListAssessmentRunAgentsInput) SetFilter(v *AgentFilter) *ListAssessmentRunAgentsInput {
+	s.Filter = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListAssessmentRunAgentsInput) SetMaxResults(v int64) *ListAssessmentRunAgentsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssessmentRunAgentsInput) SetNextToken(v string) *ListAssessmentRunAgentsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListAssessmentRunAgentsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4327,6 +5191,18 @@ func (s ListAssessmentRunAgentsOutput) String() string {
 // GoString returns the string representation
 func (s ListAssessmentRunAgentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentRunAgents sets the AssessmentRunAgents field's value.
+func (s *ListAssessmentRunAgentsOutput) SetAssessmentRunAgents(v []*AssessmentRunAgent) *ListAssessmentRunAgentsOutput {
+	s.AssessmentRunAgents = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssessmentRunAgentsOutput) SetNextToken(v string) *ListAssessmentRunAgentsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListAssessmentRunsInput struct {
@@ -4383,6 +5259,30 @@ func (s *ListAssessmentRunsInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentTemplateArns sets the AssessmentTemplateArns field's value.
+func (s *ListAssessmentRunsInput) SetAssessmentTemplateArns(v []*string) *ListAssessmentRunsInput {
+	s.AssessmentTemplateArns = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *ListAssessmentRunsInput) SetFilter(v *AssessmentRunFilter) *ListAssessmentRunsInput {
+	s.Filter = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListAssessmentRunsInput) SetMaxResults(v int64) *ListAssessmentRunsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssessmentRunsInput) SetNextToken(v string) *ListAssessmentRunsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListAssessmentRunsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4407,6 +5307,18 @@ func (s ListAssessmentRunsOutput) String() string {
 // GoString returns the string representation
 func (s ListAssessmentRunsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentRunArns sets the AssessmentRunArns field's value.
+func (s *ListAssessmentRunsOutput) SetAssessmentRunArns(v []*string) *ListAssessmentRunsOutput {
+	s.AssessmentRunArns = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssessmentRunsOutput) SetNextToken(v string) *ListAssessmentRunsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListAssessmentTargetsInput struct {
@@ -4459,6 +5371,24 @@ func (s *ListAssessmentTargetsInput) Validate() error {
 	return nil
 }
 
+// SetFilter sets the Filter field's value.
+func (s *ListAssessmentTargetsInput) SetFilter(v *AssessmentTargetFilter) *ListAssessmentTargetsInput {
+	s.Filter = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListAssessmentTargetsInput) SetMaxResults(v int64) *ListAssessmentTargetsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssessmentTargetsInput) SetNextToken(v string) *ListAssessmentTargetsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListAssessmentTargetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4483,6 +5413,18 @@ func (s ListAssessmentTargetsOutput) String() string {
 // GoString returns the string representation
 func (s ListAssessmentTargetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentTargetArns sets the AssessmentTargetArns field's value.
+func (s *ListAssessmentTargetsOutput) SetAssessmentTargetArns(v []*string) *ListAssessmentTargetsOutput {
+	s.AssessmentTargetArns = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssessmentTargetsOutput) SetNextToken(v string) *ListAssessmentTargetsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListAssessmentTemplatesInput struct {
@@ -4539,6 +5481,30 @@ func (s *ListAssessmentTemplatesInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentTargetArns sets the AssessmentTargetArns field's value.
+func (s *ListAssessmentTemplatesInput) SetAssessmentTargetArns(v []*string) *ListAssessmentTemplatesInput {
+	s.AssessmentTargetArns = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *ListAssessmentTemplatesInput) SetFilter(v *AssessmentTemplateFilter) *ListAssessmentTemplatesInput {
+	s.Filter = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListAssessmentTemplatesInput) SetMaxResults(v int64) *ListAssessmentTemplatesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssessmentTemplatesInput) SetNextToken(v string) *ListAssessmentTemplatesInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListAssessmentTemplatesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4562,6 +5528,18 @@ func (s ListAssessmentTemplatesOutput) String() string {
 // GoString returns the string representation
 func (s ListAssessmentTemplatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentTemplateArns sets the AssessmentTemplateArns field's value.
+func (s *ListAssessmentTemplatesOutput) SetAssessmentTemplateArns(v []*string) *ListAssessmentTemplatesOutput {
+	s.AssessmentTemplateArns = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssessmentTemplatesOutput) SetNextToken(v string) *ListAssessmentTemplatesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListEventSubscriptionsInput struct {
@@ -4608,6 +5586,24 @@ func (s *ListEventSubscriptionsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListEventSubscriptionsInput) SetMaxResults(v int64) *ListEventSubscriptionsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListEventSubscriptionsInput) SetNextToken(v string) *ListEventSubscriptionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *ListEventSubscriptionsInput) SetResourceArn(v string) *ListEventSubscriptionsInput {
+	s.ResourceArn = &v
+	return s
+}
+
 type ListEventSubscriptionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4631,6 +5627,18 @@ func (s ListEventSubscriptionsOutput) String() string {
 // GoString returns the string representation
 func (s ListEventSubscriptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListEventSubscriptionsOutput) SetNextToken(v string) *ListEventSubscriptionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSubscriptions sets the Subscriptions field's value.
+func (s *ListEventSubscriptionsOutput) SetSubscriptions(v []*Subscription) *ListEventSubscriptionsOutput {
+	s.Subscriptions = v
+	return s
 }
 
 type ListFindingsInput struct {
@@ -4687,6 +5695,30 @@ func (s *ListFindingsInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentRunArns sets the AssessmentRunArns field's value.
+func (s *ListFindingsInput) SetAssessmentRunArns(v []*string) *ListFindingsInput {
+	s.AssessmentRunArns = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *ListFindingsInput) SetFilter(v *FindingFilter) *ListFindingsInput {
+	s.Filter = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListFindingsInput) SetMaxResults(v int64) *ListFindingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListFindingsInput) SetNextToken(v string) *ListFindingsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListFindingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4710,6 +5742,18 @@ func (s ListFindingsOutput) String() string {
 // GoString returns the string representation
 func (s ListFindingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFindingArns sets the FindingArns field's value.
+func (s *ListFindingsOutput) SetFindingArns(v []*string) *ListFindingsOutput {
+	s.FindingArns = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListFindingsOutput) SetNextToken(v string) *ListFindingsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListRulesPackagesInput struct {
@@ -4749,6 +5793,18 @@ func (s *ListRulesPackagesInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListRulesPackagesInput) SetMaxResults(v int64) *ListRulesPackagesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRulesPackagesInput) SetNextToken(v string) *ListRulesPackagesInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListRulesPackagesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4772,6 +5828,18 @@ func (s ListRulesPackagesOutput) String() string {
 // GoString returns the string representation
 func (s ListRulesPackagesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListRulesPackagesOutput) SetNextToken(v string) *ListRulesPackagesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRulesPackageArns sets the RulesPackageArns field's value.
+func (s *ListRulesPackagesOutput) SetRulesPackageArns(v []*string) *ListRulesPackagesOutput {
+	s.RulesPackageArns = v
+	return s
 }
 
 type ListTagsForResourceInput struct {
@@ -4809,6 +5877,12 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceArn sets the ResourceArn field's value.
+func (s *ListTagsForResourceInput) SetResourceArn(v string) *ListTagsForResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4826,6 +5900,12 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput {
+	s.Tags = v
+	return s
 }
 
 type PreviewAgentsInput struct {
@@ -4876,6 +5956,24 @@ func (s *PreviewAgentsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *PreviewAgentsInput) SetMaxResults(v int64) *PreviewAgentsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *PreviewAgentsInput) SetNextToken(v string) *PreviewAgentsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPreviewAgentsArn sets the PreviewAgentsArn field's value.
+func (s *PreviewAgentsInput) SetPreviewAgentsArn(v string) *PreviewAgentsInput {
+	s.PreviewAgentsArn = &v
+	return s
+}
+
 type PreviewAgentsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4899,6 +5997,18 @@ func (s PreviewAgentsOutput) String() string {
 // GoString returns the string representation
 func (s PreviewAgentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAgentPreviews sets the AgentPreviews field's value.
+func (s *PreviewAgentsOutput) SetAgentPreviews(v []*AgentPreview) *PreviewAgentsOutput {
+	s.AgentPreviews = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *PreviewAgentsOutput) SetNextToken(v string) *PreviewAgentsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type RegisterCrossAccountAccessRoleInput struct {
@@ -4935,6 +6045,12 @@ func (s *RegisterCrossAccountAccessRoleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *RegisterCrossAccountAccessRoleInput) SetRoleArn(v string) *RegisterCrossAccountAccessRoleInput {
+	s.RoleArn = &v
+	return s
 }
 
 type RegisterCrossAccountAccessRoleOutput struct {
@@ -4994,6 +6110,18 @@ func (s *RemoveAttributesFromFindingsInput) Validate() error {
 	return nil
 }
 
+// SetAttributeKeys sets the AttributeKeys field's value.
+func (s *RemoveAttributesFromFindingsInput) SetAttributeKeys(v []*string) *RemoveAttributesFromFindingsInput {
+	s.AttributeKeys = v
+	return s
+}
+
+// SetFindingArns sets the FindingArns field's value.
+func (s *RemoveAttributesFromFindingsInput) SetFindingArns(v []*string) *RemoveAttributesFromFindingsInput {
+	s.FindingArns = v
+	return s
+}
+
 type RemoveAttributesFromFindingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5012,6 +6140,12 @@ func (s RemoveAttributesFromFindingsOutput) String() string {
 // GoString returns the string representation
 func (s RemoveAttributesFromFindingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedItems sets the FailedItems field's value.
+func (s *RemoveAttributesFromFindingsOutput) SetFailedItems(v map[string]*FailedItemDetails) *RemoveAttributesFromFindingsOutput {
+	s.FailedItems = v
+	return s
 }
 
 // Contains information about a resource group. The resource group defines a
@@ -5046,6 +6180,24 @@ func (s ResourceGroup) String() string {
 // GoString returns the string representation
 func (s ResourceGroup) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *ResourceGroup) SetArn(v string) *ResourceGroup {
+	s.Arn = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *ResourceGroup) SetCreatedAt(v time.Time) *ResourceGroup {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ResourceGroup) SetTags(v []*ResourceGroupTag) *ResourceGroup {
+	s.Tags = v
+	return s
 }
 
 // This data type is used as one of the elements of the ResourceGroup data type.
@@ -5090,6 +6242,18 @@ func (s *ResourceGroupTag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *ResourceGroupTag) SetKey(v string) *ResourceGroupTag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ResourceGroupTag) SetValue(v string) *ResourceGroupTag {
+	s.Value = &v
+	return s
+}
+
 // Contains information about an Amazon Inspector rules package. This data type
 // is used as the response element in the DescribeRulesPackages action.
 type RulesPackage struct {
@@ -5129,6 +6293,36 @@ func (s RulesPackage) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *RulesPackage) SetArn(v string) *RulesPackage {
+	s.Arn = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *RulesPackage) SetDescription(v string) *RulesPackage {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RulesPackage) SetName(v string) *RulesPackage {
+	s.Name = &v
+	return s
+}
+
+// SetProvider sets the Provider field's value.
+func (s *RulesPackage) SetProvider(v string) *RulesPackage {
+	s.Provider = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *RulesPackage) SetVersion(v string) *RulesPackage {
+	s.Version = &v
+	return s
+}
+
 // This data type is used in the Finding data type.
 type ServiceAttributes struct {
 	_ struct{} `type:"structure"`
@@ -5153,6 +6347,24 @@ func (s ServiceAttributes) String() string {
 // GoString returns the string representation
 func (s ServiceAttributes) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *ServiceAttributes) SetAssessmentRunArn(v string) *ServiceAttributes {
+	s.AssessmentRunArn = &v
+	return s
+}
+
+// SetRulesPackageArn sets the RulesPackageArn field's value.
+func (s *ServiceAttributes) SetRulesPackageArn(v string) *ServiceAttributes {
+	s.RulesPackageArn = &v
+	return s
+}
+
+// SetSchemaVersion sets the SchemaVersion field's value.
+func (s *ServiceAttributes) SetSchemaVersion(v int64) *ServiceAttributes {
+	s.SchemaVersion = &v
+	return s
 }
 
 type SetTagsForResourceInput struct {
@@ -5202,6 +6414,18 @@ func (s *SetTagsForResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *SetTagsForResourceInput) SetResourceArn(v string) *SetTagsForResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *SetTagsForResourceInput) SetTags(v []*Tag) *SetTagsForResourceInput {
+	s.Tags = v
+	return s
 }
 
 type SetTagsForResourceOutput struct {
@@ -5262,6 +6486,18 @@ func (s *StartAssessmentRunInput) Validate() error {
 	return nil
 }
 
+// SetAssessmentRunName sets the AssessmentRunName field's value.
+func (s *StartAssessmentRunInput) SetAssessmentRunName(v string) *StartAssessmentRunInput {
+	s.AssessmentRunName = &v
+	return s
+}
+
+// SetAssessmentTemplateArn sets the AssessmentTemplateArn field's value.
+func (s *StartAssessmentRunInput) SetAssessmentTemplateArn(v string) *StartAssessmentRunInput {
+	s.AssessmentTemplateArn = &v
+	return s
+}
+
 type StartAssessmentRunOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5279,6 +6515,12 @@ func (s StartAssessmentRunOutput) String() string {
 // GoString returns the string representation
 func (s StartAssessmentRunOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *StartAssessmentRunOutput) SetAssessmentRunArn(v string) *StartAssessmentRunOutput {
+	s.AssessmentRunArn = &v
+	return s
 }
 
 type StopAssessmentRunInput struct {
@@ -5314,6 +6556,12 @@ func (s *StopAssessmentRunInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *StopAssessmentRunInput) SetAssessmentRunArn(v string) *StopAssessmentRunInput {
+	s.AssessmentRunArn = &v
+	return s
 }
 
 type StopAssessmentRunOutput struct {
@@ -5385,6 +6633,24 @@ func (s *SubscribeToEventInput) Validate() error {
 	return nil
 }
 
+// SetEvent sets the Event field's value.
+func (s *SubscribeToEventInput) SetEvent(v string) *SubscribeToEventInput {
+	s.Event = &v
+	return s
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *SubscribeToEventInput) SetResourceArn(v string) *SubscribeToEventInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *SubscribeToEventInput) SetTopicArn(v string) *SubscribeToEventInput {
+	s.TopicArn = &v
+	return s
+}
+
 type SubscribeToEventOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5432,6 +6698,24 @@ func (s Subscription) GoString() string {
 	return s.String()
 }
 
+// SetEventSubscriptions sets the EventSubscriptions field's value.
+func (s *Subscription) SetEventSubscriptions(v []*EventSubscription) *Subscription {
+	s.EventSubscriptions = v
+	return s
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *Subscription) SetResourceArn(v string) *Subscription {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *Subscription) SetTopicArn(v string) *Subscription {
+	s.TopicArn = &v
+	return s
+}
+
 // A key and value pair. This data type is used as a request parameter in the
 // SetTagsForResource action and a response element in the ListTagsForResource
 // action.
@@ -5476,6 +6760,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // The metadata about the Amazon Inspector application data metrics collected
 // by the agent. This data type is used as the response element in the GetTelemetryMetadata
 // action.
@@ -5506,6 +6802,24 @@ func (s TelemetryMetadata) GoString() string {
 	return s.String()
 }
 
+// SetCount sets the Count field's value.
+func (s *TelemetryMetadata) SetCount(v int64) *TelemetryMetadata {
+	s.Count = &v
+	return s
+}
+
+// SetDataSize sets the DataSize field's value.
+func (s *TelemetryMetadata) SetDataSize(v int64) *TelemetryMetadata {
+	s.DataSize = &v
+	return s
+}
+
+// SetMessageType sets the MessageType field's value.
+func (s *TelemetryMetadata) SetMessageType(v string) *TelemetryMetadata {
+	s.MessageType = &v
+	return s
+}
+
 // This data type is used in the AssessmentRunFilter data type.
 type TimestampRange struct {
 	_ struct{} `type:"structure"`
@@ -5525,6 +6839,18 @@ func (s TimestampRange) String() string {
 // GoString returns the string representation
 func (s TimestampRange) GoString() string {
 	return s.String()
+}
+
+// SetBeginDate sets the BeginDate field's value.
+func (s *TimestampRange) SetBeginDate(v time.Time) *TimestampRange {
+	s.BeginDate = &v
+	return s
+}
+
+// SetEndDate sets the EndDate field's value.
+func (s *TimestampRange) SetEndDate(v time.Time) *TimestampRange {
+	s.EndDate = &v
+	return s
 }
 
 type UnsubscribeFromEventInput struct {
@@ -5580,6 +6906,24 @@ func (s *UnsubscribeFromEventInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEvent sets the Event field's value.
+func (s *UnsubscribeFromEventInput) SetEvent(v string) *UnsubscribeFromEventInput {
+	s.Event = &v
+	return s
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *UnsubscribeFromEventInput) SetResourceArn(v string) *UnsubscribeFromEventInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *UnsubscribeFromEventInput) SetTopicArn(v string) *UnsubscribeFromEventInput {
+	s.TopicArn = &v
+	return s
 }
 
 type UnsubscribeFromEventOutput struct {
@@ -5652,6 +6996,24 @@ func (s *UpdateAssessmentTargetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAssessmentTargetArn sets the AssessmentTargetArn field's value.
+func (s *UpdateAssessmentTargetInput) SetAssessmentTargetArn(v string) *UpdateAssessmentTargetInput {
+	s.AssessmentTargetArn = &v
+	return s
+}
+
+// SetAssessmentTargetName sets the AssessmentTargetName field's value.
+func (s *UpdateAssessmentTargetInput) SetAssessmentTargetName(v string) *UpdateAssessmentTargetInput {
+	s.AssessmentTargetName = &v
+	return s
+}
+
+// SetResourceGroupArn sets the ResourceGroupArn field's value.
+func (s *UpdateAssessmentTargetInput) SetResourceGroupArn(v string) *UpdateAssessmentTargetInput {
+	s.ResourceGroupArn = &v
+	return s
 }
 
 type UpdateAssessmentTargetOutput struct {

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -4710,6 +4710,18 @@ func (s *AcceptCertificateTransferInput) Validate() error {
 	return nil
 }
 
+// SetCertificateId sets the CertificateId field's value.
+func (s *AcceptCertificateTransferInput) SetCertificateId(v string) *AcceptCertificateTransferInput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetSetAsActive sets the SetAsActive field's value.
+func (s *AcceptCertificateTransferInput) SetSetAsActive(v bool) *AcceptCertificateTransferInput {
+	s.SetAsActive = &v
+	return s
+}
+
 type AcceptCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4847,6 +4859,78 @@ func (s *Action) Validate() error {
 	return nil
 }
 
+// SetCloudwatchAlarm sets the CloudwatchAlarm field's value.
+func (s *Action) SetCloudwatchAlarm(v *CloudwatchAlarmAction) *Action {
+	s.CloudwatchAlarm = v
+	return s
+}
+
+// SetCloudwatchMetric sets the CloudwatchMetric field's value.
+func (s *Action) SetCloudwatchMetric(v *CloudwatchMetricAction) *Action {
+	s.CloudwatchMetric = v
+	return s
+}
+
+// SetDynamoDB sets the DynamoDB field's value.
+func (s *Action) SetDynamoDB(v *DynamoDBAction) *Action {
+	s.DynamoDB = v
+	return s
+}
+
+// SetDynamoDBv2 sets the DynamoDBv2 field's value.
+func (s *Action) SetDynamoDBv2(v *DynamoDBv2Action) *Action {
+	s.DynamoDBv2 = v
+	return s
+}
+
+// SetElasticsearch sets the Elasticsearch field's value.
+func (s *Action) SetElasticsearch(v *ElasticsearchAction) *Action {
+	s.Elasticsearch = v
+	return s
+}
+
+// SetFirehose sets the Firehose field's value.
+func (s *Action) SetFirehose(v *FirehoseAction) *Action {
+	s.Firehose = v
+	return s
+}
+
+// SetKinesis sets the Kinesis field's value.
+func (s *Action) SetKinesis(v *KinesisAction) *Action {
+	s.Kinesis = v
+	return s
+}
+
+// SetLambda sets the Lambda field's value.
+func (s *Action) SetLambda(v *LambdaAction) *Action {
+	s.Lambda = v
+	return s
+}
+
+// SetRepublish sets the Republish field's value.
+func (s *Action) SetRepublish(v *RepublishAction) *Action {
+	s.Republish = v
+	return s
+}
+
+// SetS3 sets the S3 field's value.
+func (s *Action) SetS3(v *S3Action) *Action {
+	s.S3 = v
+	return s
+}
+
+// SetSns sets the Sns field's value.
+func (s *Action) SetSns(v *SnsAction) *Action {
+	s.Sns = v
+	return s
+}
+
+// SetSqs sets the Sqs field's value.
+func (s *Action) SetSqs(v *SqsAction) *Action {
+	s.Sqs = v
+	return s
+}
+
 // The input for the AttachPrincipalPolicy operation.
 type AttachPrincipalPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -4890,6 +4974,18 @@ func (s *AttachPrincipalPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *AttachPrincipalPolicyInput) SetPolicyName(v string) *AttachPrincipalPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPrincipal sets the Principal field's value.
+func (s *AttachPrincipalPolicyInput) SetPrincipal(v string) *AttachPrincipalPolicyInput {
+	s.Principal = &v
+	return s
 }
 
 type AttachPrincipalPolicyOutput struct {
@@ -4950,6 +5046,18 @@ func (s *AttachThingPrincipalInput) Validate() error {
 	return nil
 }
 
+// SetPrincipal sets the Principal field's value.
+func (s *AttachThingPrincipalInput) SetPrincipal(v string) *AttachThingPrincipalInput {
+	s.Principal = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *AttachThingPrincipalInput) SetThingName(v string) *AttachThingPrincipalInput {
+	s.ThingName = &v
+	return s
+}
+
 // The output from the AttachThingPrincipal operation.
 type AttachThingPrincipalOutput struct {
 	_ struct{} `type:"structure"`
@@ -4994,6 +5102,18 @@ func (s AttributePayload) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *AttributePayload) SetAttributes(v map[string]*string) *AttributePayload {
+	s.Attributes = v
+	return s
+}
+
+// SetMerge sets the Merge field's value.
+func (s *AttributePayload) SetMerge(v bool) *AttributePayload {
+	s.Merge = &v
+	return s
+}
+
 // A CA certificate.
 type CACertificate struct {
 	_ struct{} `type:"structure"`
@@ -5021,6 +5141,30 @@ func (s CACertificate) String() string {
 // GoString returns the string representation
 func (s CACertificate) GoString() string {
 	return s.String()
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *CACertificate) SetCertificateArn(v string) *CACertificate {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *CACertificate) SetCertificateId(v string) *CACertificate {
+	s.CertificateId = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *CACertificate) SetCreationDate(v time.Time) *CACertificate {
+	s.CreationDate = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CACertificate) SetStatus(v string) *CACertificate {
+	s.Status = &v
+	return s
 }
 
 // Describes a CA certificate.
@@ -5060,6 +5204,48 @@ func (s CACertificateDescription) GoString() string {
 	return s.String()
 }
 
+// SetAutoRegistrationStatus sets the AutoRegistrationStatus field's value.
+func (s *CACertificateDescription) SetAutoRegistrationStatus(v string) *CACertificateDescription {
+	s.AutoRegistrationStatus = &v
+	return s
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *CACertificateDescription) SetCertificateArn(v string) *CACertificateDescription {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *CACertificateDescription) SetCertificateId(v string) *CACertificateDescription {
+	s.CertificateId = &v
+	return s
+}
+
+// SetCertificatePem sets the CertificatePem field's value.
+func (s *CACertificateDescription) SetCertificatePem(v string) *CACertificateDescription {
+	s.CertificatePem = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *CACertificateDescription) SetCreationDate(v time.Time) *CACertificateDescription {
+	s.CreationDate = &v
+	return s
+}
+
+// SetOwnedBy sets the OwnedBy field's value.
+func (s *CACertificateDescription) SetOwnedBy(v string) *CACertificateDescription {
+	s.OwnedBy = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CACertificateDescription) SetStatus(v string) *CACertificateDescription {
+	s.Status = &v
+	return s
+}
+
 // The input for the CancelCertificateTransfer operation.
 type CancelCertificateTransferInput struct {
 	_ struct{} `type:"structure"`
@@ -5094,6 +5280,12 @@ func (s *CancelCertificateTransferInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *CancelCertificateTransferInput) SetCertificateId(v string) *CancelCertificateTransferInput {
+	s.CertificateId = &v
+	return s
 }
 
 type CancelCertificateTransferOutput struct {
@@ -5139,6 +5331,30 @@ func (s Certificate) GoString() string {
 	return s.String()
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *Certificate) SetCertificateArn(v string) *Certificate {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *Certificate) SetCertificateId(v string) *Certificate {
+	s.CertificateId = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *Certificate) SetCreationDate(v time.Time) *Certificate {
+	s.CreationDate = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Certificate) SetStatus(v string) *Certificate {
+	s.Status = &v
+	return s
+}
+
 // Describes a certificate.
 type CertificateDescription struct {
 	_ struct{} `type:"structure"`
@@ -5182,6 +5398,66 @@ func (s CertificateDescription) String() string {
 // GoString returns the string representation
 func (s CertificateDescription) GoString() string {
 	return s.String()
+}
+
+// SetCaCertificateId sets the CaCertificateId field's value.
+func (s *CertificateDescription) SetCaCertificateId(v string) *CertificateDescription {
+	s.CaCertificateId = &v
+	return s
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *CertificateDescription) SetCertificateArn(v string) *CertificateDescription {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *CertificateDescription) SetCertificateId(v string) *CertificateDescription {
+	s.CertificateId = &v
+	return s
+}
+
+// SetCertificatePem sets the CertificatePem field's value.
+func (s *CertificateDescription) SetCertificatePem(v string) *CertificateDescription {
+	s.CertificatePem = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *CertificateDescription) SetCreationDate(v time.Time) *CertificateDescription {
+	s.CreationDate = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *CertificateDescription) SetLastModifiedDate(v time.Time) *CertificateDescription {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetOwnedBy sets the OwnedBy field's value.
+func (s *CertificateDescription) SetOwnedBy(v string) *CertificateDescription {
+	s.OwnedBy = &v
+	return s
+}
+
+// SetPreviousOwnedBy sets the PreviousOwnedBy field's value.
+func (s *CertificateDescription) SetPreviousOwnedBy(v string) *CertificateDescription {
+	s.PreviousOwnedBy = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CertificateDescription) SetStatus(v string) *CertificateDescription {
+	s.Status = &v
+	return s
+}
+
+// SetTransferData sets the TransferData field's value.
+func (s *CertificateDescription) SetTransferData(v *TransferData) *CertificateDescription {
+	s.TransferData = v
+	return s
 }
 
 // Describes an action that updates a CloudWatch alarm.
@@ -5239,6 +5515,30 @@ func (s *CloudwatchAlarmAction) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAlarmName sets the AlarmName field's value.
+func (s *CloudwatchAlarmAction) SetAlarmName(v string) *CloudwatchAlarmAction {
+	s.AlarmName = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *CloudwatchAlarmAction) SetRoleArn(v string) *CloudwatchAlarmAction {
+	s.RoleArn = &v
+	return s
+}
+
+// SetStateReason sets the StateReason field's value.
+func (s *CloudwatchAlarmAction) SetStateReason(v string) *CloudwatchAlarmAction {
+	s.StateReason = &v
+	return s
+}
+
+// SetStateValue sets the StateValue field's value.
+func (s *CloudwatchAlarmAction) SetStateValue(v string) *CloudwatchAlarmAction {
+	s.StateValue = &v
+	return s
 }
 
 // Describes an action that captures a CloudWatch metric.
@@ -5310,6 +5610,42 @@ func (s *CloudwatchMetricAction) Validate() error {
 	return nil
 }
 
+// SetMetricName sets the MetricName field's value.
+func (s *CloudwatchMetricAction) SetMetricName(v string) *CloudwatchMetricAction {
+	s.MetricName = &v
+	return s
+}
+
+// SetMetricNamespace sets the MetricNamespace field's value.
+func (s *CloudwatchMetricAction) SetMetricNamespace(v string) *CloudwatchMetricAction {
+	s.MetricNamespace = &v
+	return s
+}
+
+// SetMetricTimestamp sets the MetricTimestamp field's value.
+func (s *CloudwatchMetricAction) SetMetricTimestamp(v string) *CloudwatchMetricAction {
+	s.MetricTimestamp = &v
+	return s
+}
+
+// SetMetricUnit sets the MetricUnit field's value.
+func (s *CloudwatchMetricAction) SetMetricUnit(v string) *CloudwatchMetricAction {
+	s.MetricUnit = &v
+	return s
+}
+
+// SetMetricValue sets the MetricValue field's value.
+func (s *CloudwatchMetricAction) SetMetricValue(v string) *CloudwatchMetricAction {
+	s.MetricValue = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *CloudwatchMetricAction) SetRoleArn(v string) *CloudwatchMetricAction {
+	s.RoleArn = &v
+	return s
+}
+
 // The input for the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrInput struct {
 	_ struct{} `type:"structure"`
@@ -5349,6 +5685,18 @@ func (s *CreateCertificateFromCsrInput) Validate() error {
 	return nil
 }
 
+// SetCertificateSigningRequest sets the CertificateSigningRequest field's value.
+func (s *CreateCertificateFromCsrInput) SetCertificateSigningRequest(v string) *CreateCertificateFromCsrInput {
+	s.CertificateSigningRequest = &v
+	return s
+}
+
+// SetSetAsActive sets the SetAsActive field's value.
+func (s *CreateCertificateFromCsrInput) SetSetAsActive(v bool) *CreateCertificateFromCsrInput {
+	s.SetAsActive = &v
+	return s
+}
+
 // The output from the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrOutput struct {
 	_ struct{} `type:"structure"`
@@ -5375,6 +5723,24 @@ func (s CreateCertificateFromCsrOutput) GoString() string {
 	return s.String()
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *CreateCertificateFromCsrOutput) SetCertificateArn(v string) *CreateCertificateFromCsrOutput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *CreateCertificateFromCsrOutput) SetCertificateId(v string) *CreateCertificateFromCsrOutput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetCertificatePem sets the CertificatePem field's value.
+func (s *CreateCertificateFromCsrOutput) SetCertificatePem(v string) *CreateCertificateFromCsrOutput {
+	s.CertificatePem = &v
+	return s
+}
+
 // The input for the CreateKeysAndCertificate operation.
 type CreateKeysAndCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -5391,6 +5757,12 @@ func (s CreateKeysAndCertificateInput) String() string {
 // GoString returns the string representation
 func (s CreateKeysAndCertificateInput) GoString() string {
 	return s.String()
+}
+
+// SetSetAsActive sets the SetAsActive field's value.
+func (s *CreateKeysAndCertificateInput) SetSetAsActive(v bool) *CreateKeysAndCertificateInput {
+	s.SetAsActive = &v
+	return s
 }
 
 // The output of the CreateKeysAndCertificate operation.
@@ -5419,6 +5791,30 @@ func (s CreateKeysAndCertificateOutput) String() string {
 // GoString returns the string representation
 func (s CreateKeysAndCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *CreateKeysAndCertificateOutput) SetCertificateArn(v string) *CreateKeysAndCertificateOutput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *CreateKeysAndCertificateOutput) SetCertificateId(v string) *CreateKeysAndCertificateOutput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetCertificatePem sets the CertificatePem field's value.
+func (s *CreateKeysAndCertificateOutput) SetCertificatePem(v string) *CreateKeysAndCertificateOutput {
+	s.CertificatePem = &v
+	return s
+}
+
+// SetKeyPair sets the KeyPair field's value.
+func (s *CreateKeysAndCertificateOutput) SetKeyPair(v *KeyPair) *CreateKeysAndCertificateOutput {
+	s.KeyPair = v
+	return s
 }
 
 // The input for the CreatePolicy operation.
@@ -5466,6 +5862,18 @@ func (s *CreatePolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *CreatePolicyInput) SetPolicyDocument(v string) *CreatePolicyInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *CreatePolicyInput) SetPolicyName(v string) *CreatePolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 // The output from the CreatePolicy operation.
 type CreatePolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -5491,6 +5899,30 @@ func (s CreatePolicyOutput) String() string {
 // GoString returns the string representation
 func (s CreatePolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *CreatePolicyOutput) SetPolicyArn(v string) *CreatePolicyOutput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *CreatePolicyOutput) SetPolicyDocument(v string) *CreatePolicyOutput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *CreatePolicyOutput) SetPolicyName(v string) *CreatePolicyOutput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyVersionId sets the PolicyVersionId field's value.
+func (s *CreatePolicyOutput) SetPolicyVersionId(v string) *CreatePolicyOutput {
+	s.PolicyVersionId = &v
+	return s
 }
 
 // The input for the CreatePolicyVersion operation.
@@ -5543,6 +5975,24 @@ func (s *CreatePolicyVersionInput) Validate() error {
 	return nil
 }
 
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *CreatePolicyVersionInput) SetPolicyDocument(v string) *CreatePolicyVersionInput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *CreatePolicyVersionInput) SetPolicyName(v string) *CreatePolicyVersionInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetSetAsDefault sets the SetAsDefault field's value.
+func (s *CreatePolicyVersionInput) SetSetAsDefault(v bool) *CreatePolicyVersionInput {
+	s.SetAsDefault = &v
+	return s
+}
+
 // The output of the CreatePolicyVersion operation.
 type CreatePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5568,6 +6018,30 @@ func (s CreatePolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s CreatePolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsDefaultVersion sets the IsDefaultVersion field's value.
+func (s *CreatePolicyVersionOutput) SetIsDefaultVersion(v bool) *CreatePolicyVersionOutput {
+	s.IsDefaultVersion = &v
+	return s
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *CreatePolicyVersionOutput) SetPolicyArn(v string) *CreatePolicyVersionOutput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *CreatePolicyVersionOutput) SetPolicyDocument(v string) *CreatePolicyVersionOutput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyVersionId sets the PolicyVersionId field's value.
+func (s *CreatePolicyVersionOutput) SetPolicyVersionId(v string) *CreatePolicyVersionOutput {
+	s.PolicyVersionId = &v
+	return s
 }
 
 // The input for the CreateThing operation.
@@ -5618,6 +6092,24 @@ func (s *CreateThingInput) Validate() error {
 	return nil
 }
 
+// SetAttributePayload sets the AttributePayload field's value.
+func (s *CreateThingInput) SetAttributePayload(v *AttributePayload) *CreateThingInput {
+	s.AttributePayload = v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *CreateThingInput) SetThingName(v string) *CreateThingInput {
+	s.ThingName = &v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *CreateThingInput) SetThingTypeName(v string) *CreateThingInput {
+	s.ThingTypeName = &v
+	return s
+}
+
 // The output of the CreateThing operation.
 type CreateThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -5637,6 +6129,18 @@ func (s CreateThingOutput) String() string {
 // GoString returns the string representation
 func (s CreateThingOutput) GoString() string {
 	return s.String()
+}
+
+// SetThingArn sets the ThingArn field's value.
+func (s *CreateThingOutput) SetThingArn(v string) *CreateThingOutput {
+	s.ThingArn = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *CreateThingOutput) SetThingName(v string) *CreateThingOutput {
+	s.ThingName = &v
+	return s
 }
 
 // The input for the CreateThingType operation.
@@ -5680,6 +6184,18 @@ func (s *CreateThingTypeInput) Validate() error {
 	return nil
 }
 
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *CreateThingTypeInput) SetThingTypeName(v string) *CreateThingTypeInput {
+	s.ThingTypeName = &v
+	return s
+}
+
+// SetThingTypeProperties sets the ThingTypeProperties field's value.
+func (s *CreateThingTypeInput) SetThingTypeProperties(v *ThingTypeProperties) *CreateThingTypeInput {
+	s.ThingTypeProperties = v
+	return s
+}
+
 // The output of the CreateThingType operation.
 type CreateThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -5699,6 +6215,18 @@ func (s CreateThingTypeOutput) String() string {
 // GoString returns the string representation
 func (s CreateThingTypeOutput) GoString() string {
 	return s.String()
+}
+
+// SetThingTypeArn sets the ThingTypeArn field's value.
+func (s *CreateThingTypeOutput) SetThingTypeArn(v string) *CreateThingTypeOutput {
+	s.ThingTypeArn = &v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *CreateThingTypeOutput) SetThingTypeName(v string) *CreateThingTypeOutput {
+	s.ThingTypeName = &v
+	return s
 }
 
 // The input for the CreateTopicRule operation.
@@ -5750,6 +6278,18 @@ func (s *CreateTopicRuleInput) Validate() error {
 	return nil
 }
 
+// SetRuleName sets the RuleName field's value.
+func (s *CreateTopicRuleInput) SetRuleName(v string) *CreateTopicRuleInput {
+	s.RuleName = &v
+	return s
+}
+
+// SetTopicRulePayload sets the TopicRulePayload field's value.
+func (s *CreateTopicRuleInput) SetTopicRulePayload(v *TopicRulePayload) *CreateTopicRuleInput {
+	s.TopicRulePayload = v
+	return s
+}
+
 type CreateTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5798,6 +6338,12 @@ func (s *DeleteCACertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *DeleteCACertificateInput) SetCertificateId(v string) *DeleteCACertificateInput {
+	s.CertificateId = &v
+	return s
 }
 
 // The output for the DeleteCACertificate operation.
@@ -5851,6 +6397,12 @@ func (s *DeleteCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateId sets the CertificateId field's value.
+func (s *DeleteCertificateInput) SetCertificateId(v string) *DeleteCertificateInput {
+	s.CertificateId = &v
+	return s
+}
+
 type DeleteCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5899,6 +6451,12 @@ func (s *DeletePolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeletePolicyInput) SetPolicyName(v string) *DeletePolicyInput {
+	s.PolicyName = &v
+	return s
 }
 
 type DeletePolicyOutput struct {
@@ -5957,6 +6515,18 @@ func (s *DeletePolicyVersionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeletePolicyVersionInput) SetPolicyName(v string) *DeletePolicyVersionInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyVersionId sets the PolicyVersionId field's value.
+func (s *DeletePolicyVersionInput) SetPolicyVersionId(v string) *DeletePolicyVersionInput {
+	s.PolicyVersionId = &v
+	return s
 }
 
 type DeletePolicyVersionOutput struct {
@@ -6044,6 +6614,18 @@ func (s *DeleteThingInput) Validate() error {
 	return nil
 }
 
+// SetExpectedVersion sets the ExpectedVersion field's value.
+func (s *DeleteThingInput) SetExpectedVersion(v int64) *DeleteThingInput {
+	s.ExpectedVersion = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *DeleteThingInput) SetThingName(v string) *DeleteThingInput {
+	s.ThingName = &v
+	return s
+}
+
 // The output of the DeleteThing operation.
 type DeleteThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -6095,6 +6677,12 @@ func (s *DeleteThingTypeInput) Validate() error {
 	return nil
 }
 
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *DeleteThingTypeInput) SetThingTypeName(v string) *DeleteThingTypeInput {
+	s.ThingTypeName = &v
+	return s
+}
+
 // The output for the DeleteThingType operation.
 type DeleteThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -6144,6 +6732,12 @@ func (s *DeleteTopicRuleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRuleName sets the RuleName field's value.
+func (s *DeleteTopicRuleInput) SetRuleName(v string) *DeleteTopicRuleInput {
+	s.RuleName = &v
+	return s
 }
 
 type DeleteTopicRuleOutput struct {
@@ -6200,6 +6794,18 @@ func (s *DeprecateThingTypeInput) Validate() error {
 	return nil
 }
 
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *DeprecateThingTypeInput) SetThingTypeName(v string) *DeprecateThingTypeInput {
+	s.ThingTypeName = &v
+	return s
+}
+
+// SetUndoDeprecate sets the UndoDeprecate field's value.
+func (s *DeprecateThingTypeInput) SetUndoDeprecate(v bool) *DeprecateThingTypeInput {
+	s.UndoDeprecate = &v
+	return s
+}
+
 // The output for the DeprecateThingType operation.
 type DeprecateThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -6251,6 +6857,12 @@ func (s *DescribeCACertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateId sets the CertificateId field's value.
+func (s *DescribeCACertificateInput) SetCertificateId(v string) *DescribeCACertificateInput {
+	s.CertificateId = &v
+	return s
+}
+
 // The output from the DescribeCACertificate operation.
 type DescribeCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -6267,6 +6879,12 @@ func (s DescribeCACertificateOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCACertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateDescription sets the CertificateDescription field's value.
+func (s *DescribeCACertificateOutput) SetCertificateDescription(v *CACertificateDescription) *DescribeCACertificateOutput {
+	s.CertificateDescription = v
+	return s
 }
 
 // The input for the DescribeCertificate operation.
@@ -6305,6 +6923,12 @@ func (s *DescribeCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateId sets the CertificateId field's value.
+func (s *DescribeCertificateInput) SetCertificateId(v string) *DescribeCertificateInput {
+	s.CertificateId = &v
+	return s
+}
+
 // The output of the DescribeCertificate operation.
 type DescribeCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -6321,6 +6945,12 @@ func (s DescribeCertificateOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateDescription sets the CertificateDescription field's value.
+func (s *DescribeCertificateOutput) SetCertificateDescription(v *CertificateDescription) *DescribeCertificateOutput {
+	s.CertificateDescription = v
+	return s
 }
 
 // The input for the DescribeEndpoint operation.
@@ -6354,6 +6984,12 @@ func (s DescribeEndpointOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetEndpointAddress sets the EndpointAddress field's value.
+func (s *DescribeEndpointOutput) SetEndpointAddress(v string) *DescribeEndpointOutput {
+	s.EndpointAddress = &v
+	return s
 }
 
 // The input for the DescribeThing operation.
@@ -6392,6 +7028,12 @@ func (s *DescribeThingInput) Validate() error {
 	return nil
 }
 
+// SetThingName sets the ThingName field's value.
+func (s *DescribeThingInput) SetThingName(v string) *DescribeThingInput {
+	s.ThingName = &v
+	return s
+}
+
 // The output from the DescribeThing operation.
 type DescribeThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -6424,6 +7066,36 @@ func (s DescribeThingOutput) String() string {
 // GoString returns the string representation
 func (s DescribeThingOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *DescribeThingOutput) SetAttributes(v map[string]*string) *DescribeThingOutput {
+	s.Attributes = v
+	return s
+}
+
+// SetDefaultClientId sets the DefaultClientId field's value.
+func (s *DescribeThingOutput) SetDefaultClientId(v string) *DescribeThingOutput {
+	s.DefaultClientId = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *DescribeThingOutput) SetThingName(v string) *DescribeThingOutput {
+	s.ThingName = &v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *DescribeThingOutput) SetThingTypeName(v string) *DescribeThingOutput {
+	s.ThingTypeName = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *DescribeThingOutput) SetVersion(v int64) *DescribeThingOutput {
+	s.Version = &v
+	return s
 }
 
 // The input for the DescribeThingType operation.
@@ -6462,6 +7134,12 @@ func (s *DescribeThingTypeInput) Validate() error {
 	return nil
 }
 
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *DescribeThingTypeInput) SetThingTypeName(v string) *DescribeThingTypeInput {
+	s.ThingTypeName = &v
+	return s
+}
+
 // The output for the DescribeThingType operation.
 type DescribeThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -6487,6 +7165,24 @@ func (s DescribeThingTypeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeThingTypeOutput) GoString() string {
 	return s.String()
+}
+
+// SetThingTypeMetadata sets the ThingTypeMetadata field's value.
+func (s *DescribeThingTypeOutput) SetThingTypeMetadata(v *ThingTypeMetadata) *DescribeThingTypeOutput {
+	s.ThingTypeMetadata = v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *DescribeThingTypeOutput) SetThingTypeName(v string) *DescribeThingTypeOutput {
+	s.ThingTypeName = &v
+	return s
+}
+
+// SetThingTypeProperties sets the ThingTypeProperties field's value.
+func (s *DescribeThingTypeOutput) SetThingTypeProperties(v *ThingTypeProperties) *DescribeThingTypeOutput {
+	s.ThingTypeProperties = v
+	return s
 }
 
 // The input for the DetachPrincipalPolicy operation.
@@ -6534,6 +7230,18 @@ func (s *DetachPrincipalPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DetachPrincipalPolicyInput) SetPolicyName(v string) *DetachPrincipalPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPrincipal sets the Principal field's value.
+func (s *DetachPrincipalPolicyInput) SetPrincipal(v string) *DetachPrincipalPolicyInput {
+	s.Principal = &v
+	return s
 }
 
 type DetachPrincipalPolicyOutput struct {
@@ -6596,6 +7304,18 @@ func (s *DetachThingPrincipalInput) Validate() error {
 	return nil
 }
 
+// SetPrincipal sets the Principal field's value.
+func (s *DetachThingPrincipalInput) SetPrincipal(v string) *DetachThingPrincipalInput {
+	s.Principal = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *DetachThingPrincipalInput) SetThingName(v string) *DetachThingPrincipalInput {
+	s.ThingName = &v
+	return s
+}
+
 // The output from the DetachThingPrincipal operation.
 type DetachThingPrincipalOutput struct {
 	_ struct{} `type:"structure"`
@@ -6645,6 +7365,12 @@ func (s *DisableTopicRuleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRuleName sets the RuleName field's value.
+func (s *DisableTopicRuleInput) SetRuleName(v string) *DisableTopicRuleInput {
+	s.RuleName = &v
+	return s
 }
 
 type DisableTopicRuleOutput struct {
@@ -6754,6 +7480,66 @@ func (s *DynamoDBAction) Validate() error {
 	return nil
 }
 
+// SetHashKeyField sets the HashKeyField field's value.
+func (s *DynamoDBAction) SetHashKeyField(v string) *DynamoDBAction {
+	s.HashKeyField = &v
+	return s
+}
+
+// SetHashKeyType sets the HashKeyType field's value.
+func (s *DynamoDBAction) SetHashKeyType(v string) *DynamoDBAction {
+	s.HashKeyType = &v
+	return s
+}
+
+// SetHashKeyValue sets the HashKeyValue field's value.
+func (s *DynamoDBAction) SetHashKeyValue(v string) *DynamoDBAction {
+	s.HashKeyValue = &v
+	return s
+}
+
+// SetOperation sets the Operation field's value.
+func (s *DynamoDBAction) SetOperation(v string) *DynamoDBAction {
+	s.Operation = &v
+	return s
+}
+
+// SetPayloadField sets the PayloadField field's value.
+func (s *DynamoDBAction) SetPayloadField(v string) *DynamoDBAction {
+	s.PayloadField = &v
+	return s
+}
+
+// SetRangeKeyField sets the RangeKeyField field's value.
+func (s *DynamoDBAction) SetRangeKeyField(v string) *DynamoDBAction {
+	s.RangeKeyField = &v
+	return s
+}
+
+// SetRangeKeyType sets the RangeKeyType field's value.
+func (s *DynamoDBAction) SetRangeKeyType(v string) *DynamoDBAction {
+	s.RangeKeyType = &v
+	return s
+}
+
+// SetRangeKeyValue sets the RangeKeyValue field's value.
+func (s *DynamoDBAction) SetRangeKeyValue(v string) *DynamoDBAction {
+	s.RangeKeyValue = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *DynamoDBAction) SetRoleArn(v string) *DynamoDBAction {
+	s.RoleArn = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *DynamoDBAction) SetTableName(v string) *DynamoDBAction {
+	s.TableName = &v
+	return s
+}
+
 // Describes an action to write to a DynamoDB table.
 //
 // This DynamoDB action writes each attribute in the message payload into it's
@@ -6798,6 +7584,18 @@ func (s *DynamoDBv2Action) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPutItem sets the PutItem field's value.
+func (s *DynamoDBv2Action) SetPutItem(v *PutItemInput) *DynamoDBv2Action {
+	s.PutItem = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *DynamoDBv2Action) SetRoleArn(v string) *DynamoDBv2Action {
+	s.RoleArn = &v
+	return s
 }
 
 // Describes an action that writes data to an Amazon Elasticsearch Service domain.
@@ -6865,6 +7663,36 @@ func (s *ElasticsearchAction) Validate() error {
 	return nil
 }
 
+// SetEndpoint sets the Endpoint field's value.
+func (s *ElasticsearchAction) SetEndpoint(v string) *ElasticsearchAction {
+	s.Endpoint = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ElasticsearchAction) SetId(v string) *ElasticsearchAction {
+	s.Id = &v
+	return s
+}
+
+// SetIndex sets the Index field's value.
+func (s *ElasticsearchAction) SetIndex(v string) *ElasticsearchAction {
+	s.Index = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *ElasticsearchAction) SetRoleArn(v string) *ElasticsearchAction {
+	s.RoleArn = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ElasticsearchAction) SetType(v string) *ElasticsearchAction {
+	s.Type = &v
+	return s
+}
+
 // The input for the EnableTopicRuleRequest operation.
 type EnableTopicRuleInput struct {
 	_ struct{} `type:"structure"`
@@ -6899,6 +7727,12 @@ func (s *EnableTopicRuleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRuleName sets the RuleName field's value.
+func (s *EnableTopicRuleInput) SetRuleName(v string) *EnableTopicRuleInput {
+	s.RuleName = &v
+	return s
 }
 
 type EnableTopicRuleOutput struct {
@@ -6961,6 +7795,24 @@ func (s *FirehoseAction) Validate() error {
 	return nil
 }
 
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *FirehoseAction) SetDeliveryStreamName(v string) *FirehoseAction {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *FirehoseAction) SetRoleArn(v string) *FirehoseAction {
+	s.RoleArn = &v
+	return s
+}
+
+// SetSeparator sets the Separator field's value.
+func (s *FirehoseAction) SetSeparator(v string) *FirehoseAction {
+	s.Separator = &v
+	return s
+}
+
 // The input for the GetLoggingOptions operation.
 type GetLoggingOptionsInput struct {
 	_ struct{} `type:"structure"`
@@ -6995,6 +7847,18 @@ func (s GetLoggingOptionsOutput) String() string {
 // GoString returns the string representation
 func (s GetLoggingOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *GetLoggingOptionsOutput) SetLogLevel(v string) *GetLoggingOptionsOutput {
+	s.LogLevel = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *GetLoggingOptionsOutput) SetRoleArn(v string) *GetLoggingOptionsOutput {
+	s.RoleArn = &v
+	return s
 }
 
 // The input for the GetPolicy operation.
@@ -7033,6 +7897,12 @@ func (s *GetPolicyInput) Validate() error {
 	return nil
 }
 
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetPolicyInput) SetPolicyName(v string) *GetPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 // The output from the GetPolicy operation.
 type GetPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -7058,6 +7928,30 @@ func (s GetPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetDefaultVersionId sets the DefaultVersionId field's value.
+func (s *GetPolicyOutput) SetDefaultVersionId(v string) *GetPolicyOutput {
+	s.DefaultVersionId = &v
+	return s
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *GetPolicyOutput) SetPolicyArn(v string) *GetPolicyOutput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *GetPolicyOutput) SetPolicyDocument(v string) *GetPolicyOutput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetPolicyOutput) SetPolicyName(v string) *GetPolicyOutput {
+	s.PolicyName = &v
+	return s
 }
 
 // The input for the GetPolicyVersion operation.
@@ -7104,6 +7998,18 @@ func (s *GetPolicyVersionInput) Validate() error {
 	return nil
 }
 
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetPolicyVersionInput) SetPolicyName(v string) *GetPolicyVersionInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyVersionId sets the PolicyVersionId field's value.
+func (s *GetPolicyVersionInput) SetPolicyVersionId(v string) *GetPolicyVersionInput {
+	s.PolicyVersionId = &v
+	return s
+}
+
 // The output from the GetPolicyVersion operation.
 type GetPolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7132,6 +8038,36 @@ func (s GetPolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s GetPolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsDefaultVersion sets the IsDefaultVersion field's value.
+func (s *GetPolicyVersionOutput) SetIsDefaultVersion(v bool) *GetPolicyVersionOutput {
+	s.IsDefaultVersion = &v
+	return s
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *GetPolicyVersionOutput) SetPolicyArn(v string) *GetPolicyVersionOutput {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *GetPolicyVersionOutput) SetPolicyDocument(v string) *GetPolicyVersionOutput {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetPolicyVersionOutput) SetPolicyName(v string) *GetPolicyVersionOutput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyVersionId sets the PolicyVersionId field's value.
+func (s *GetPolicyVersionOutput) SetPolicyVersionId(v string) *GetPolicyVersionOutput {
+	s.PolicyVersionId = &v
+	return s
 }
 
 // The input to the GetRegistrationCode operation.
@@ -7165,6 +8101,12 @@ func (s GetRegistrationCodeOutput) String() string {
 // GoString returns the string representation
 func (s GetRegistrationCodeOutput) GoString() string {
 	return s.String()
+}
+
+// SetRegistrationCode sets the RegistrationCode field's value.
+func (s *GetRegistrationCodeOutput) SetRegistrationCode(v string) *GetRegistrationCodeOutput {
+	s.RegistrationCode = &v
+	return s
 }
 
 // The input for the GetTopicRule operation.
@@ -7203,6 +8145,12 @@ func (s *GetTopicRuleInput) Validate() error {
 	return nil
 }
 
+// SetRuleName sets the RuleName field's value.
+func (s *GetTopicRuleInput) SetRuleName(v string) *GetTopicRuleInput {
+	s.RuleName = &v
+	return s
+}
+
 // The output from the GetTopicRule operation.
 type GetTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -7224,6 +8172,18 @@ func (s GetTopicRuleOutput) GoString() string {
 	return s.String()
 }
 
+// SetRule sets the Rule field's value.
+func (s *GetTopicRuleOutput) SetRule(v *TopicRule) *GetTopicRuleOutput {
+	s.Rule = v
+	return s
+}
+
+// SetRuleArn sets the RuleArn field's value.
+func (s *GetTopicRuleOutput) SetRuleArn(v string) *GetTopicRuleOutput {
+	s.RuleArn = &v
+	return s
+}
+
 // Describes a key pair.
 type KeyPair struct {
 	_ struct{} `type:"structure"`
@@ -7243,6 +8203,18 @@ func (s KeyPair) String() string {
 // GoString returns the string representation
 func (s KeyPair) GoString() string {
 	return s.String()
+}
+
+// SetPrivateKey sets the PrivateKey field's value.
+func (s *KeyPair) SetPrivateKey(v string) *KeyPair {
+	s.PrivateKey = &v
+	return s
+}
+
+// SetPublicKey sets the PublicKey field's value.
+func (s *KeyPair) SetPublicKey(v string) *KeyPair {
+	s.PublicKey = &v
+	return s
 }
 
 // Describes an action to write data to an Amazon Kinesis stream.
@@ -7289,6 +8261,24 @@ func (s *KinesisAction) Validate() error {
 	return nil
 }
 
+// SetPartitionKey sets the PartitionKey field's value.
+func (s *KinesisAction) SetPartitionKey(v string) *KinesisAction {
+	s.PartitionKey = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *KinesisAction) SetRoleArn(v string) *KinesisAction {
+	s.RoleArn = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *KinesisAction) SetStreamName(v string) *KinesisAction {
+	s.StreamName = &v
+	return s
+}
+
 // Describes an action to invoke a Lambda function.
 type LambdaAction struct {
 	_ struct{} `type:"structure"`
@@ -7320,6 +8310,12 @@ func (s *LambdaAction) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFunctionArn sets the FunctionArn field's value.
+func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
+	s.FunctionArn = &v
+	return s
 }
 
 // Input for the ListCACertificates operation.
@@ -7359,6 +8355,24 @@ func (s *ListCACertificatesInput) Validate() error {
 	return nil
 }
 
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListCACertificatesInput) SetAscendingOrder(v bool) *ListCACertificatesInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListCACertificatesInput) SetMarker(v string) *ListCACertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListCACertificatesInput) SetPageSize(v int64) *ListCACertificatesInput {
+	s.PageSize = &v
+	return s
+}
+
 // The output from the ListCACertificates operation.
 type ListCACertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7378,6 +8392,18 @@ func (s ListCACertificatesOutput) String() string {
 // GoString returns the string representation
 func (s ListCACertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *ListCACertificatesOutput) SetCertificates(v []*CACertificate) *ListCACertificatesOutput {
+	s.Certificates = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListCACertificatesOutput) SetNextMarker(v string) *ListCACertificatesOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // The input to the ListCertificatesByCA operation.
@@ -7430,6 +8456,30 @@ func (s *ListCertificatesByCAInput) Validate() error {
 	return nil
 }
 
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListCertificatesByCAInput) SetAscendingOrder(v bool) *ListCertificatesByCAInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetCaCertificateId sets the CaCertificateId field's value.
+func (s *ListCertificatesByCAInput) SetCaCertificateId(v string) *ListCertificatesByCAInput {
+	s.CaCertificateId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListCertificatesByCAInput) SetMarker(v string) *ListCertificatesByCAInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListCertificatesByCAInput) SetPageSize(v int64) *ListCertificatesByCAInput {
+	s.PageSize = &v
+	return s
+}
+
 // The output of the ListCertificatesByCA operation.
 type ListCertificatesByCAOutput struct {
 	_ struct{} `type:"structure"`
@@ -7450,6 +8500,18 @@ func (s ListCertificatesByCAOutput) String() string {
 // GoString returns the string representation
 func (s ListCertificatesByCAOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *ListCertificatesByCAOutput) SetCertificates(v []*Certificate) *ListCertificatesByCAOutput {
+	s.Certificates = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListCertificatesByCAOutput) SetNextMarker(v string) *ListCertificatesByCAOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // The input for the ListCertificates operation.
@@ -7490,6 +8552,24 @@ func (s *ListCertificatesInput) Validate() error {
 	return nil
 }
 
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListCertificatesInput) SetAscendingOrder(v bool) *ListCertificatesInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListCertificatesInput) SetMarker(v string) *ListCertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListCertificatesInput) SetPageSize(v int64) *ListCertificatesInput {
+	s.PageSize = &v
+	return s
+}
+
 // The output of the ListCertificates operation.
 type ListCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7510,6 +8590,18 @@ func (s ListCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s ListCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *ListCertificatesOutput) SetCertificates(v []*Certificate) *ListCertificatesOutput {
+	s.Certificates = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListCertificatesOutput) SetNextMarker(v string) *ListCertificatesOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // The input to the ListOutgoingCertificates operation.
@@ -7550,6 +8642,24 @@ func (s *ListOutgoingCertificatesInput) Validate() error {
 	return nil
 }
 
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListOutgoingCertificatesInput) SetAscendingOrder(v bool) *ListOutgoingCertificatesInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListOutgoingCertificatesInput) SetMarker(v string) *ListOutgoingCertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListOutgoingCertificatesInput) SetPageSize(v int64) *ListOutgoingCertificatesInput {
+	s.PageSize = &v
+	return s
+}
+
 // The output from the ListOutgoingCertificates operation.
 type ListOutgoingCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7569,6 +8679,18 @@ func (s ListOutgoingCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s ListOutgoingCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListOutgoingCertificatesOutput) SetNextMarker(v string) *ListOutgoingCertificatesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetOutgoingCertificates sets the OutgoingCertificates field's value.
+func (s *ListOutgoingCertificatesOutput) SetOutgoingCertificates(v []*OutgoingCertificate) *ListOutgoingCertificatesOutput {
+	s.OutgoingCertificates = v
+	return s
 }
 
 // The input for the ListPolicies operation.
@@ -7609,6 +8731,24 @@ func (s *ListPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListPoliciesInput) SetAscendingOrder(v bool) *ListPoliciesInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPoliciesInput) SetMarker(v string) *ListPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListPoliciesInput) SetPageSize(v int64) *ListPoliciesInput {
+	s.PageSize = &v
+	return s
+}
+
 // The output from the ListPolicies operation.
 type ListPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7629,6 +8769,18 @@ func (s ListPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListPoliciesOutput) SetNextMarker(v string) *ListPoliciesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *ListPoliciesOutput) SetPolicies(v []*Policy) *ListPoliciesOutput {
+	s.Policies = v
+	return s
 }
 
 // The input for the ListPolicyPrincipals operation.
@@ -7680,6 +8832,30 @@ func (s *ListPolicyPrincipalsInput) Validate() error {
 	return nil
 }
 
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListPolicyPrincipalsInput) SetAscendingOrder(v bool) *ListPolicyPrincipalsInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPolicyPrincipalsInput) SetMarker(v string) *ListPolicyPrincipalsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListPolicyPrincipalsInput) SetPageSize(v int64) *ListPolicyPrincipalsInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *ListPolicyPrincipalsInput) SetPolicyName(v string) *ListPolicyPrincipalsInput {
+	s.PolicyName = &v
+	return s
+}
+
 // The output from the ListPolicyPrincipals operation.
 type ListPolicyPrincipalsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7700,6 +8876,18 @@ func (s ListPolicyPrincipalsOutput) String() string {
 // GoString returns the string representation
 func (s ListPolicyPrincipalsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListPolicyPrincipalsOutput) SetNextMarker(v string) *ListPolicyPrincipalsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetPrincipals sets the Principals field's value.
+func (s *ListPolicyPrincipalsOutput) SetPrincipals(v []*string) *ListPolicyPrincipalsOutput {
+	s.Principals = v
+	return s
 }
 
 // The input for the ListPolicyVersions operation.
@@ -7738,6 +8926,12 @@ func (s *ListPolicyVersionsInput) Validate() error {
 	return nil
 }
 
+// SetPolicyName sets the PolicyName field's value.
+func (s *ListPolicyVersionsInput) SetPolicyName(v string) *ListPolicyVersionsInput {
+	s.PolicyName = &v
+	return s
+}
+
 // The output from the ListPolicyVersions operation.
 type ListPolicyVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7754,6 +8948,12 @@ func (s ListPolicyVersionsOutput) String() string {
 // GoString returns the string representation
 func (s ListPolicyVersionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyVersions sets the PolicyVersions field's value.
+func (s *ListPolicyVersionsOutput) SetPolicyVersions(v []*PolicyVersion) *ListPolicyVersionsOutput {
+	s.PolicyVersions = v
+	return s
 }
 
 // The input for the ListPrincipalPolicies operation.
@@ -7802,6 +9002,30 @@ func (s *ListPrincipalPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListPrincipalPoliciesInput) SetAscendingOrder(v bool) *ListPrincipalPoliciesInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListPrincipalPoliciesInput) SetMarker(v string) *ListPrincipalPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListPrincipalPoliciesInput) SetPageSize(v int64) *ListPrincipalPoliciesInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPrincipal sets the Principal field's value.
+func (s *ListPrincipalPoliciesInput) SetPrincipal(v string) *ListPrincipalPoliciesInput {
+	s.Principal = &v
+	return s
+}
+
 // The output from the ListPrincipalPolicies operation.
 type ListPrincipalPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7822,6 +9046,18 @@ func (s ListPrincipalPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListPrincipalPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListPrincipalPoliciesOutput) SetNextMarker(v string) *ListPrincipalPoliciesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *ListPrincipalPoliciesOutput) SetPolicies(v []*Policy) *ListPrincipalPoliciesOutput {
+	s.Policies = v
+	return s
 }
 
 // The input for the ListPrincipalThings operation.
@@ -7867,6 +9103,24 @@ func (s *ListPrincipalThingsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListPrincipalThingsInput) SetMaxResults(v int64) *ListPrincipalThingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPrincipalThingsInput) SetNextToken(v string) *ListPrincipalThingsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPrincipal sets the Principal field's value.
+func (s *ListPrincipalThingsInput) SetPrincipal(v string) *ListPrincipalThingsInput {
+	s.Principal = &v
+	return s
+}
+
 // The output from the ListPrincipalThings operation.
 type ListPrincipalThingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7887,6 +9141,18 @@ func (s ListPrincipalThingsOutput) String() string {
 // GoString returns the string representation
 func (s ListPrincipalThingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPrincipalThingsOutput) SetNextToken(v string) *ListPrincipalThingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThings sets the Things field's value.
+func (s *ListPrincipalThingsOutput) SetThings(v []*string) *ListPrincipalThingsOutput {
+	s.Things = v
+	return s
 }
 
 // The input for the ListThingPrincipal operation.
@@ -7925,6 +9191,12 @@ func (s *ListThingPrincipalsInput) Validate() error {
 	return nil
 }
 
+// SetThingName sets the ThingName field's value.
+func (s *ListThingPrincipalsInput) SetThingName(v string) *ListThingPrincipalsInput {
+	s.ThingName = &v
+	return s
+}
+
 // The output from the ListThingPrincipals operation.
 type ListThingPrincipalsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7941,6 +9213,12 @@ func (s ListThingPrincipalsOutput) String() string {
 // GoString returns the string representation
 func (s ListThingPrincipalsOutput) GoString() string {
 	return s.String()
+}
+
+// SetPrincipals sets the Principals field's value.
+func (s *ListThingPrincipalsOutput) SetPrincipals(v []*string) *ListThingPrincipalsOutput {
+	s.Principals = v
+	return s
 }
 
 // The input for the ListThingTypes operation.
@@ -7984,6 +9262,24 @@ func (s *ListThingTypesInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListThingTypesInput) SetMaxResults(v int64) *ListThingTypesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingTypesInput) SetNextToken(v string) *ListThingTypesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *ListThingTypesInput) SetThingTypeName(v string) *ListThingTypesInput {
+	s.ThingTypeName = &v
+	return s
+}
+
 // The output for the ListThingTypes operation.
 type ListThingTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8004,6 +9300,18 @@ func (s ListThingTypesOutput) String() string {
 // GoString returns the string representation
 func (s ListThingTypesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingTypesOutput) SetNextToken(v string) *ListThingTypesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThingTypes sets the ThingTypes field's value.
+func (s *ListThingTypesOutput) SetThingTypes(v []*ThingTypeDefinition) *ListThingTypesOutput {
+	s.ThingTypes = v
+	return s
 }
 
 // The input for the ListThings operation.
@@ -8053,6 +9361,36 @@ func (s *ListThingsInput) Validate() error {
 	return nil
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *ListThingsInput) SetAttributeName(v string) *ListThingsInput {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValue sets the AttributeValue field's value.
+func (s *ListThingsInput) SetAttributeValue(v string) *ListThingsInput {
+	s.AttributeValue = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListThingsInput) SetMaxResults(v int64) *ListThingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingsInput) SetNextToken(v string) *ListThingsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *ListThingsInput) SetThingTypeName(v string) *ListThingsInput {
+	s.ThingTypeName = &v
+	return s
+}
+
 // The output from the ListThings operation.
 type ListThingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8073,6 +9411,18 @@ func (s ListThingsOutput) String() string {
 // GoString returns the string representation
 func (s ListThingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingsOutput) SetNextToken(v string) *ListThingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThings sets the Things field's value.
+func (s *ListThingsOutput) SetThings(v []*ThingAttribute) *ListThingsOutput {
+	s.Things = v
+	return s
 }
 
 // The input for the ListTopicRules operation.
@@ -8115,6 +9465,30 @@ func (s *ListTopicRulesInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListTopicRulesInput) SetMaxResults(v int64) *ListTopicRulesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTopicRulesInput) SetNextToken(v string) *ListTopicRulesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRuleDisabled sets the RuleDisabled field's value.
+func (s *ListTopicRulesInput) SetRuleDisabled(v bool) *ListTopicRulesInput {
+	s.RuleDisabled = &v
+	return s
+}
+
+// SetTopic sets the Topic field's value.
+func (s *ListTopicRulesInput) SetTopic(v string) *ListTopicRulesInput {
+	s.Topic = &v
+	return s
+}
+
 // The output from the ListTopicRules operation.
 type ListTopicRulesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8134,6 +9508,18 @@ func (s ListTopicRulesOutput) String() string {
 // GoString returns the string representation
 func (s ListTopicRulesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTopicRulesOutput) SetNextToken(v string) *ListTopicRulesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *ListTopicRulesOutput) SetRules(v []*TopicRuleListItem) *ListTopicRulesOutput {
+	s.Rules = v
+	return s
 }
 
 // Describes the logging options payload.
@@ -8172,6 +9558,18 @@ func (s *LoggingOptionsPayload) Validate() error {
 	return nil
 }
 
+// SetLogLevel sets the LogLevel field's value.
+func (s *LoggingOptionsPayload) SetLogLevel(v string) *LoggingOptionsPayload {
+	s.LogLevel = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *LoggingOptionsPayload) SetRoleArn(v string) *LoggingOptionsPayload {
+	s.RoleArn = &v
+	return s
+}
+
 // A certificate that has been transfered but not yet accepted.
 type OutgoingCertificate struct {
 	_ struct{} `type:"structure"`
@@ -8205,6 +9603,42 @@ func (s OutgoingCertificate) GoString() string {
 	return s.String()
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *OutgoingCertificate) SetCertificateArn(v string) *OutgoingCertificate {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *OutgoingCertificate) SetCertificateId(v string) *OutgoingCertificate {
+	s.CertificateId = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *OutgoingCertificate) SetCreationDate(v time.Time) *OutgoingCertificate {
+	s.CreationDate = &v
+	return s
+}
+
+// SetTransferDate sets the TransferDate field's value.
+func (s *OutgoingCertificate) SetTransferDate(v time.Time) *OutgoingCertificate {
+	s.TransferDate = &v
+	return s
+}
+
+// SetTransferMessage sets the TransferMessage field's value.
+func (s *OutgoingCertificate) SetTransferMessage(v string) *OutgoingCertificate {
+	s.TransferMessage = &v
+	return s
+}
+
+// SetTransferredTo sets the TransferredTo field's value.
+func (s *OutgoingCertificate) SetTransferredTo(v string) *OutgoingCertificate {
+	s.TransferredTo = &v
+	return s
+}
+
 // Describes an AWS IoT policy.
 type Policy struct {
 	_ struct{} `type:"structure"`
@@ -8224,6 +9658,18 @@ func (s Policy) String() string {
 // GoString returns the string representation
 func (s Policy) GoString() string {
 	return s.String()
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *Policy) SetPolicyArn(v string) *Policy {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *Policy) SetPolicyName(v string) *Policy {
+	s.PolicyName = &v
+	return s
 }
 
 // Describes a policy version.
@@ -8248,6 +9694,24 @@ func (s PolicyVersion) String() string {
 // GoString returns the string representation
 func (s PolicyVersion) GoString() string {
 	return s.String()
+}
+
+// SetCreateDate sets the CreateDate field's value.
+func (s *PolicyVersion) SetCreateDate(v time.Time) *PolicyVersion {
+	s.CreateDate = &v
+	return s
+}
+
+// SetIsDefaultVersion sets the IsDefaultVersion field's value.
+func (s *PolicyVersion) SetIsDefaultVersion(v bool) *PolicyVersion {
+	s.IsDefaultVersion = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *PolicyVersion) SetVersionId(v string) *PolicyVersion {
+	s.VersionId = &v
+	return s
 }
 
 // The input for the DynamoActionVS action that specifies the DynamoDB table
@@ -8282,6 +9746,12 @@ func (s *PutItemInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetTableName sets the TableName field's value.
+func (s *PutItemInput) SetTableName(v string) *PutItemInput {
+	s.TableName = &v
+	return s
 }
 
 // The input to the RegisterCACertificate operation.
@@ -8337,6 +9807,30 @@ func (s *RegisterCACertificateInput) Validate() error {
 	return nil
 }
 
+// SetAllowAutoRegistration sets the AllowAutoRegistration field's value.
+func (s *RegisterCACertificateInput) SetAllowAutoRegistration(v bool) *RegisterCACertificateInput {
+	s.AllowAutoRegistration = &v
+	return s
+}
+
+// SetCaCertificate sets the CaCertificate field's value.
+func (s *RegisterCACertificateInput) SetCaCertificate(v string) *RegisterCACertificateInput {
+	s.CaCertificate = &v
+	return s
+}
+
+// SetSetAsActive sets the SetAsActive field's value.
+func (s *RegisterCACertificateInput) SetSetAsActive(v bool) *RegisterCACertificateInput {
+	s.SetAsActive = &v
+	return s
+}
+
+// SetVerificationCertificate sets the VerificationCertificate field's value.
+func (s *RegisterCACertificateInput) SetVerificationCertificate(v string) *RegisterCACertificateInput {
+	s.VerificationCertificate = &v
+	return s
+}
+
 // The output from the RegisterCACertificateResponse operation.
 type RegisterCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -8356,6 +9850,18 @@ func (s RegisterCACertificateOutput) String() string {
 // GoString returns the string representation
 func (s RegisterCACertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *RegisterCACertificateOutput) SetCertificateArn(v string) *RegisterCACertificateOutput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *RegisterCACertificateOutput) SetCertificateId(v string) *RegisterCACertificateOutput {
+	s.CertificateId = &v
+	return s
 }
 
 // The input to the RegisterCertificate operation.
@@ -8405,6 +9911,30 @@ func (s *RegisterCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCaCertificatePem sets the CaCertificatePem field's value.
+func (s *RegisterCertificateInput) SetCaCertificatePem(v string) *RegisterCertificateInput {
+	s.CaCertificatePem = &v
+	return s
+}
+
+// SetCertificatePem sets the CertificatePem field's value.
+func (s *RegisterCertificateInput) SetCertificatePem(v string) *RegisterCertificateInput {
+	s.CertificatePem = &v
+	return s
+}
+
+// SetSetAsActive sets the SetAsActive field's value.
+func (s *RegisterCertificateInput) SetSetAsActive(v bool) *RegisterCertificateInput {
+	s.SetAsActive = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *RegisterCertificateInput) SetStatus(v string) *RegisterCertificateInput {
+	s.Status = &v
+	return s
+}
+
 // The output from the RegisterCertificate operation.
 type RegisterCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -8424,6 +9954,18 @@ func (s RegisterCertificateOutput) String() string {
 // GoString returns the string representation
 func (s RegisterCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *RegisterCertificateOutput) SetCertificateArn(v string) *RegisterCertificateOutput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *RegisterCertificateOutput) SetCertificateId(v string) *RegisterCertificateOutput {
+	s.CertificateId = &v
+	return s
 }
 
 // The input for the RejectCertificateTransfer operation.
@@ -8463,6 +10005,18 @@ func (s *RejectCertificateTransferInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *RejectCertificateTransferInput) SetCertificateId(v string) *RejectCertificateTransferInput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetRejectReason sets the RejectReason field's value.
+func (s *RejectCertificateTransferInput) SetRejectReason(v string) *RejectCertificateTransferInput {
+	s.RejectReason = &v
+	return s
 }
 
 type RejectCertificateTransferOutput struct {
@@ -8528,6 +10082,18 @@ func (s *ReplaceTopicRuleInput) Validate() error {
 	return nil
 }
 
+// SetRuleName sets the RuleName field's value.
+func (s *ReplaceTopicRuleInput) SetRuleName(v string) *ReplaceTopicRuleInput {
+	s.RuleName = &v
+	return s
+}
+
+// SetTopicRulePayload sets the TopicRulePayload field's value.
+func (s *ReplaceTopicRuleInput) SetTopicRulePayload(v *TopicRulePayload) *ReplaceTopicRuleInput {
+	s.TopicRulePayload = v
+	return s
+}
+
 type ReplaceTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8583,6 +10149,18 @@ func (s *RepublishAction) Validate() error {
 	return nil
 }
 
+// SetRoleArn sets the RoleArn field's value.
+func (s *RepublishAction) SetRoleArn(v string) *RepublishAction {
+	s.RoleArn = &v
+	return s
+}
+
+// SetTopic sets the Topic field's value.
+func (s *RepublishAction) SetTopic(v string) *RepublishAction {
+	s.Topic = &v
+	return s
+}
+
 // Describes an action to write data to an Amazon S3 bucket.
 type S3Action struct {
 	_ struct{} `type:"structure"`
@@ -8636,6 +10214,30 @@ func (s *S3Action) Validate() error {
 	return nil
 }
 
+// SetBucketName sets the BucketName field's value.
+func (s *S3Action) SetBucketName(v string) *S3Action {
+	s.BucketName = &v
+	return s
+}
+
+// SetCannedAcl sets the CannedAcl field's value.
+func (s *S3Action) SetCannedAcl(v string) *S3Action {
+	s.CannedAcl = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *S3Action) SetKey(v string) *S3Action {
+	s.Key = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *S3Action) SetRoleArn(v string) *S3Action {
+	s.RoleArn = &v
+	return s
+}
+
 // The input for the SetDefaultPolicyVersion operation.
 type SetDefaultPolicyVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8678,6 +10280,18 @@ func (s *SetDefaultPolicyVersionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *SetDefaultPolicyVersionInput) SetPolicyName(v string) *SetDefaultPolicyVersionInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetPolicyVersionId sets the PolicyVersionId field's value.
+func (s *SetDefaultPolicyVersionInput) SetPolicyVersionId(v string) *SetDefaultPolicyVersionInput {
+	s.PolicyVersionId = &v
+	return s
 }
 
 type SetDefaultPolicyVersionOutput struct {
@@ -8730,6 +10344,12 @@ func (s *SetLoggingOptionsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLoggingOptionsPayload sets the LoggingOptionsPayload field's value.
+func (s *SetLoggingOptionsInput) SetLoggingOptionsPayload(v *LoggingOptionsPayload) *SetLoggingOptionsInput {
+	s.LoggingOptionsPayload = v
+	return s
 }
 
 type SetLoggingOptionsOutput struct {
@@ -8794,6 +10414,24 @@ func (s *SnsAction) Validate() error {
 	return nil
 }
 
+// SetMessageFormat sets the MessageFormat field's value.
+func (s *SnsAction) SetMessageFormat(v string) *SnsAction {
+	s.MessageFormat = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *SnsAction) SetRoleArn(v string) *SnsAction {
+	s.RoleArn = &v
+	return s
+}
+
+// SetTargetArn sets the TargetArn field's value.
+func (s *SnsAction) SetTargetArn(v string) *SnsAction {
+	s.TargetArn = &v
+	return s
+}
+
 // Describes an action to publish data to an Amazon SQS queue.
 type SqsAction struct {
 	_ struct{} `type:"structure"`
@@ -8838,6 +10476,24 @@ func (s *SqsAction) Validate() error {
 	return nil
 }
 
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *SqsAction) SetQueueUrl(v string) *SqsAction {
+	s.QueueUrl = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *SqsAction) SetRoleArn(v string) *SqsAction {
+	s.RoleArn = &v
+	return s
+}
+
+// SetUseBase64 sets the UseBase64 field's value.
+func (s *SqsAction) SetUseBase64(v bool) *SqsAction {
+	s.UseBase64 = &v
+	return s
+}
+
 // The properties of the thing, including thing name, thing type name, and a
 // list of thing attributes.
 type ThingAttribute struct {
@@ -8866,6 +10522,30 @@ func (s ThingAttribute) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *ThingAttribute) SetAttributes(v map[string]*string) *ThingAttribute {
+	s.Attributes = v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *ThingAttribute) SetThingName(v string) *ThingAttribute {
+	s.ThingName = &v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *ThingAttribute) SetThingTypeName(v string) *ThingAttribute {
+	s.ThingTypeName = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *ThingAttribute) SetVersion(v int64) *ThingAttribute {
+	s.Version = &v
+	return s
+}
+
 // The definition of the thing type, including thing type name and description.
 type ThingTypeDefinition struct {
 	_ struct{} `type:"structure"`
@@ -8890,6 +10570,24 @@ func (s ThingTypeDefinition) String() string {
 // GoString returns the string representation
 func (s ThingTypeDefinition) GoString() string {
 	return s.String()
+}
+
+// SetThingTypeMetadata sets the ThingTypeMetadata field's value.
+func (s *ThingTypeDefinition) SetThingTypeMetadata(v *ThingTypeMetadata) *ThingTypeDefinition {
+	s.ThingTypeMetadata = v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *ThingTypeDefinition) SetThingTypeName(v string) *ThingTypeDefinition {
+	s.ThingTypeName = &v
+	return s
+}
+
+// SetThingTypeProperties sets the ThingTypeProperties field's value.
+func (s *ThingTypeDefinition) SetThingTypeProperties(v *ThingTypeProperties) *ThingTypeDefinition {
+	s.ThingTypeProperties = v
+	return s
 }
 
 // The ThingTypeMetadata contains additional information about the thing type
@@ -8919,6 +10617,24 @@ func (s ThingTypeMetadata) GoString() string {
 	return s.String()
 }
 
+// SetCreationDate sets the CreationDate field's value.
+func (s *ThingTypeMetadata) SetCreationDate(v time.Time) *ThingTypeMetadata {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDeprecated sets the Deprecated field's value.
+func (s *ThingTypeMetadata) SetDeprecated(v bool) *ThingTypeMetadata {
+	s.Deprecated = &v
+	return s
+}
+
+// SetDeprecationDate sets the DeprecationDate field's value.
+func (s *ThingTypeMetadata) SetDeprecationDate(v time.Time) *ThingTypeMetadata {
+	s.DeprecationDate = &v
+	return s
+}
+
 // The ThingTypeProperties contains information about the thing type including:
 // a thing type description, and a list of searchable thing attribute names.
 type ThingTypeProperties struct {
@@ -8939,6 +10655,18 @@ func (s ThingTypeProperties) String() string {
 // GoString returns the string representation
 func (s ThingTypeProperties) GoString() string {
 	return s.String()
+}
+
+// SetSearchableAttributes sets the SearchableAttributes field's value.
+func (s *ThingTypeProperties) SetSearchableAttributes(v []*string) *ThingTypeProperties {
+	s.SearchableAttributes = v
+	return s
+}
+
+// SetThingTypeDescription sets the ThingTypeDescription field's value.
+func (s *ThingTypeProperties) SetThingTypeDescription(v string) *ThingTypeProperties {
+	s.ThingTypeDescription = &v
+	return s
 }
 
 // Describes a rule.
@@ -8978,6 +10706,48 @@ func (s TopicRule) GoString() string {
 	return s.String()
 }
 
+// SetActions sets the Actions field's value.
+func (s *TopicRule) SetActions(v []*Action) *TopicRule {
+	s.Actions = v
+	return s
+}
+
+// SetAwsIotSqlVersion sets the AwsIotSqlVersion field's value.
+func (s *TopicRule) SetAwsIotSqlVersion(v string) *TopicRule {
+	s.AwsIotSqlVersion = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *TopicRule) SetCreatedAt(v time.Time) *TopicRule {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *TopicRule) SetDescription(v string) *TopicRule {
+	s.Description = &v
+	return s
+}
+
+// SetRuleDisabled sets the RuleDisabled field's value.
+func (s *TopicRule) SetRuleDisabled(v bool) *TopicRule {
+	s.RuleDisabled = &v
+	return s
+}
+
+// SetRuleName sets the RuleName field's value.
+func (s *TopicRule) SetRuleName(v string) *TopicRule {
+	s.RuleName = &v
+	return s
+}
+
+// SetSql sets the Sql field's value.
+func (s *TopicRule) SetSql(v string) *TopicRule {
+	s.Sql = &v
+	return s
+}
+
 // Describes a rule.
 type TopicRuleListItem struct {
 	_ struct{} `type:"structure"`
@@ -9006,6 +10776,36 @@ func (s TopicRuleListItem) String() string {
 // GoString returns the string representation
 func (s TopicRuleListItem) GoString() string {
 	return s.String()
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *TopicRuleListItem) SetCreatedAt(v time.Time) *TopicRuleListItem {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetRuleArn sets the RuleArn field's value.
+func (s *TopicRuleListItem) SetRuleArn(v string) *TopicRuleListItem {
+	s.RuleArn = &v
+	return s
+}
+
+// SetRuleDisabled sets the RuleDisabled field's value.
+func (s *TopicRuleListItem) SetRuleDisabled(v bool) *TopicRuleListItem {
+	s.RuleDisabled = &v
+	return s
+}
+
+// SetRuleName sets the RuleName field's value.
+func (s *TopicRuleListItem) SetRuleName(v string) *TopicRuleListItem {
+	s.RuleName = &v
+	return s
+}
+
+// SetTopicPattern sets the TopicPattern field's value.
+func (s *TopicRuleListItem) SetTopicPattern(v string) *TopicRuleListItem {
+	s.TopicPattern = &v
+	return s
 }
 
 // Describes a rule.
@@ -9070,6 +10870,36 @@ func (s *TopicRulePayload) Validate() error {
 	return nil
 }
 
+// SetActions sets the Actions field's value.
+func (s *TopicRulePayload) SetActions(v []*Action) *TopicRulePayload {
+	s.Actions = v
+	return s
+}
+
+// SetAwsIotSqlVersion sets the AwsIotSqlVersion field's value.
+func (s *TopicRulePayload) SetAwsIotSqlVersion(v string) *TopicRulePayload {
+	s.AwsIotSqlVersion = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *TopicRulePayload) SetDescription(v string) *TopicRulePayload {
+	s.Description = &v
+	return s
+}
+
+// SetRuleDisabled sets the RuleDisabled field's value.
+func (s *TopicRulePayload) SetRuleDisabled(v bool) *TopicRulePayload {
+	s.RuleDisabled = &v
+	return s
+}
+
+// SetSql sets the Sql field's value.
+func (s *TopicRulePayload) SetSql(v string) *TopicRulePayload {
+	s.Sql = &v
+	return s
+}
+
 // The input for the TransferCertificate operation.
 type TransferCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -9117,6 +10947,24 @@ func (s *TransferCertificateInput) Validate() error {
 	return nil
 }
 
+// SetCertificateId sets the CertificateId field's value.
+func (s *TransferCertificateInput) SetCertificateId(v string) *TransferCertificateInput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetTargetAwsAccount sets the TargetAwsAccount field's value.
+func (s *TransferCertificateInput) SetTargetAwsAccount(v string) *TransferCertificateInput {
+	s.TargetAwsAccount = &v
+	return s
+}
+
+// SetTransferMessage sets the TransferMessage field's value.
+func (s *TransferCertificateInput) SetTransferMessage(v string) *TransferCertificateInput {
+	s.TransferMessage = &v
+	return s
+}
+
 // The output from the TransferCertificate operation.
 type TransferCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -9133,6 +10981,12 @@ func (s TransferCertificateOutput) String() string {
 // GoString returns the string representation
 func (s TransferCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetTransferredCertificateArn sets the TransferredCertificateArn field's value.
+func (s *TransferCertificateOutput) SetTransferredCertificateArn(v string) *TransferCertificateOutput {
+	s.TransferredCertificateArn = &v
+	return s
 }
 
 // Data used to transfer a certificate to an AWS account.
@@ -9163,6 +11017,36 @@ func (s TransferData) String() string {
 // GoString returns the string representation
 func (s TransferData) GoString() string {
 	return s.String()
+}
+
+// SetAcceptDate sets the AcceptDate field's value.
+func (s *TransferData) SetAcceptDate(v time.Time) *TransferData {
+	s.AcceptDate = &v
+	return s
+}
+
+// SetRejectDate sets the RejectDate field's value.
+func (s *TransferData) SetRejectDate(v time.Time) *TransferData {
+	s.RejectDate = &v
+	return s
+}
+
+// SetRejectReason sets the RejectReason field's value.
+func (s *TransferData) SetRejectReason(v string) *TransferData {
+	s.RejectReason = &v
+	return s
+}
+
+// SetTransferDate sets the TransferDate field's value.
+func (s *TransferData) SetTransferDate(v time.Time) *TransferData {
+	s.TransferDate = &v
+	return s
+}
+
+// SetTransferMessage sets the TransferMessage field's value.
+func (s *TransferData) SetTransferMessage(v string) *TransferData {
+	s.TransferMessage = &v
+	return s
 }
 
 // The input to the UpdateCACertificate operation.
@@ -9209,6 +11093,24 @@ func (s *UpdateCACertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *UpdateCACertificateInput) SetCertificateId(v string) *UpdateCACertificateInput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetNewAutoRegistrationStatus sets the NewAutoRegistrationStatus field's value.
+func (s *UpdateCACertificateInput) SetNewAutoRegistrationStatus(v string) *UpdateCACertificateInput {
+	s.NewAutoRegistrationStatus = &v
+	return s
+}
+
+// SetNewStatus sets the NewStatus field's value.
+func (s *UpdateCACertificateInput) SetNewStatus(v string) *UpdateCACertificateInput {
+	s.NewStatus = &v
+	return s
 }
 
 type UpdateCACertificateOutput struct {
@@ -9274,6 +11176,18 @@ func (s *UpdateCertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificateId sets the CertificateId field's value.
+func (s *UpdateCertificateInput) SetCertificateId(v string) *UpdateCertificateInput {
+	s.CertificateId = &v
+	return s
+}
+
+// SetNewStatus sets the NewStatus field's value.
+func (s *UpdateCertificateInput) SetNewStatus(v string) *UpdateCertificateInput {
+	s.NewStatus = &v
+	return s
 }
 
 type UpdateCertificateOutput struct {
@@ -9346,6 +11260,36 @@ func (s *UpdateThingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributePayload sets the AttributePayload field's value.
+func (s *UpdateThingInput) SetAttributePayload(v *AttributePayload) *UpdateThingInput {
+	s.AttributePayload = v
+	return s
+}
+
+// SetExpectedVersion sets the ExpectedVersion field's value.
+func (s *UpdateThingInput) SetExpectedVersion(v int64) *UpdateThingInput {
+	s.ExpectedVersion = &v
+	return s
+}
+
+// SetRemoveThingType sets the RemoveThingType field's value.
+func (s *UpdateThingInput) SetRemoveThingType(v bool) *UpdateThingInput {
+	s.RemoveThingType = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *UpdateThingInput) SetThingName(v string) *UpdateThingInput {
+	s.ThingName = &v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *UpdateThingInput) SetThingTypeName(v string) *UpdateThingInput {
+	s.ThingTypeName = &v
+	return s
 }
 
 // The output from the UpdateThing operation.

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -391,6 +391,12 @@ func (s *DeleteThingShadowInput) Validate() error {
 	return nil
 }
 
+// SetThingName sets the ThingName field's value.
+func (s *DeleteThingShadowInput) SetThingName(v string) *DeleteThingShadowInput {
+	s.ThingName = &v
+	return s
+}
+
 // The output from the DeleteThingShadow operation.
 type DeleteThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -409,6 +415,12 @@ func (s DeleteThingShadowOutput) String() string {
 // GoString returns the string representation
 func (s DeleteThingShadowOutput) GoString() string {
 	return s.String()
+}
+
+// SetPayload sets the Payload field's value.
+func (s *DeleteThingShadowOutput) SetPayload(v []byte) *DeleteThingShadowOutput {
+	s.Payload = v
+	return s
 }
 
 // The input for the GetThingShadow operation.
@@ -447,6 +459,12 @@ func (s *GetThingShadowInput) Validate() error {
 	return nil
 }
 
+// SetThingName sets the ThingName field's value.
+func (s *GetThingShadowInput) SetThingName(v string) *GetThingShadowInput {
+	s.ThingName = &v
+	return s
+}
+
 // The output from the GetThingShadow operation.
 type GetThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -463,6 +481,12 @@ func (s GetThingShadowOutput) String() string {
 // GoString returns the string representation
 func (s GetThingShadowOutput) GoString() string {
 	return s.String()
+}
+
+// SetPayload sets the Payload field's value.
+func (s *GetThingShadowOutput) SetPayload(v []byte) *GetThingShadowOutput {
+	s.Payload = v
+	return s
 }
 
 // The input for the Publish operation.
@@ -502,6 +526,24 @@ func (s *PublishInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPayload sets the Payload field's value.
+func (s *PublishInput) SetPayload(v []byte) *PublishInput {
+	s.Payload = v
+	return s
+}
+
+// SetQos sets the Qos field's value.
+func (s *PublishInput) SetQos(v int64) *PublishInput {
+	s.Qos = &v
+	return s
+}
+
+// SetTopic sets the Topic field's value.
+func (s *PublishInput) SetTopic(v string) *PublishInput {
+	s.Topic = &v
+	return s
 }
 
 type PublishOutput struct {
@@ -562,6 +604,18 @@ func (s *UpdateThingShadowInput) Validate() error {
 	return nil
 }
 
+// SetPayload sets the Payload field's value.
+func (s *UpdateThingShadowInput) SetPayload(v []byte) *UpdateThingShadowInput {
+	s.Payload = v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *UpdateThingShadowInput) SetThingName(v string) *UpdateThingShadowInput {
+	s.ThingName = &v
+	return s
+}
+
 // The output from the UpdateThingShadow operation.
 type UpdateThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -578,4 +632,10 @@ func (s UpdateThingShadowOutput) String() string {
 // GoString returns the string representation
 func (s UpdateThingShadowOutput) GoString() string {
 	return s.String()
+}
+
+// SetPayload sets the Payload field's value.
+func (s *UpdateThingShadowOutput) SetPayload(v []byte) *UpdateThingShadowOutput {
+	s.Payload = v
+	return s
 }

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -1811,6 +1811,18 @@ func (s *AddTagsToStreamInput) Validate() error {
 	return nil
 }
 
+// SetStreamName sets the StreamName field's value.
+func (s *AddTagsToStreamInput) SetStreamName(v string) *AddTagsToStreamInput {
+	s.StreamName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToStreamInput) SetTags(v map[string]*string) *AddTagsToStreamInput {
+	s.Tags = v
+	return s
+}
+
 type AddTagsToStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1880,6 +1892,18 @@ func (s *CreateStreamInput) Validate() error {
 	return nil
 }
 
+// SetShardCount sets the ShardCount field's value.
+func (s *CreateStreamInput) SetShardCount(v int64) *CreateStreamInput {
+	s.ShardCount = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *CreateStreamInput) SetStreamName(v string) *CreateStreamInput {
+	s.StreamName = &v
+	return s
+}
+
 type CreateStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1942,6 +1966,18 @@ func (s *DecreaseStreamRetentionPeriodInput) Validate() error {
 	return nil
 }
 
+// SetRetentionPeriodHours sets the RetentionPeriodHours field's value.
+func (s *DecreaseStreamRetentionPeriodInput) SetRetentionPeriodHours(v int64) *DecreaseStreamRetentionPeriodInput {
+	s.RetentionPeriodHours = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *DecreaseStreamRetentionPeriodInput) SetStreamName(v string) *DecreaseStreamRetentionPeriodInput {
+	s.StreamName = &v
+	return s
+}
+
 type DecreaseStreamRetentionPeriodOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1990,6 +2026,12 @@ func (s *DeleteStreamInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *DeleteStreamInput) SetStreamName(v string) *DeleteStreamInput {
+	s.StreamName = &v
+	return s
 }
 
 type DeleteStreamOutput struct {
@@ -2054,6 +2096,24 @@ func (s *DescribeStreamInput) Validate() error {
 	return nil
 }
 
+// SetExclusiveStartShardId sets the ExclusiveStartShardId field's value.
+func (s *DescribeStreamInput) SetExclusiveStartShardId(v string) *DescribeStreamInput {
+	s.ExclusiveStartShardId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeStreamInput) SetLimit(v int64) *DescribeStreamInput {
+	s.Limit = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *DescribeStreamInput) SetStreamName(v string) *DescribeStreamInput {
+	s.StreamName = &v
+	return s
+}
+
 // Represents the output for DescribeStream.
 type DescribeStreamOutput struct {
 	_ struct{} `type:"structure"`
@@ -2073,6 +2133,12 @@ func (s DescribeStreamOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStreamOutput) GoString() string {
 	return s.String()
+}
+
+// SetStreamDescription sets the StreamDescription field's value.
+func (s *DescribeStreamOutput) SetStreamDescription(v *StreamDescription) *DescribeStreamOutput {
+	s.StreamDescription = v
+	return s
 }
 
 // Represents the input for DisableEnhancedMonitoring.
@@ -2137,6 +2203,18 @@ func (s *DisableEnhancedMonitoringInput) Validate() error {
 	return nil
 }
 
+// SetShardLevelMetrics sets the ShardLevelMetrics field's value.
+func (s *DisableEnhancedMonitoringInput) SetShardLevelMetrics(v []*string) *DisableEnhancedMonitoringInput {
+	s.ShardLevelMetrics = v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *DisableEnhancedMonitoringInput) SetStreamName(v string) *DisableEnhancedMonitoringInput {
+	s.StreamName = &v
+	return s
+}
+
 // Represents the input for EnableEnhancedMonitoring.
 type EnableEnhancedMonitoringInput struct {
 	_ struct{} `type:"structure"`
@@ -2199,6 +2277,18 @@ func (s *EnableEnhancedMonitoringInput) Validate() error {
 	return nil
 }
 
+// SetShardLevelMetrics sets the ShardLevelMetrics field's value.
+func (s *EnableEnhancedMonitoringInput) SetShardLevelMetrics(v []*string) *EnableEnhancedMonitoringInput {
+	s.ShardLevelMetrics = v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *EnableEnhancedMonitoringInput) SetStreamName(v string) *EnableEnhancedMonitoringInput {
+	s.StreamName = &v
+	return s
+}
+
 // Represents enhanced metrics types.
 type EnhancedMetrics struct {
 	_ struct{} `type:"structure"`
@@ -2232,6 +2322,12 @@ func (s EnhancedMetrics) GoString() string {
 	return s.String()
 }
 
+// SetShardLevelMetrics sets the ShardLevelMetrics field's value.
+func (s *EnhancedMetrics) SetShardLevelMetrics(v []*string) *EnhancedMetrics {
+	s.ShardLevelMetrics = v
+	return s
+}
+
 // Represents the output for EnableEnhancedMonitoring and DisableEnhancedMonitoring.
 type EnhancedMonitoringOutput struct {
 	_ struct{} `type:"structure"`
@@ -2256,6 +2352,24 @@ func (s EnhancedMonitoringOutput) String() string {
 // GoString returns the string representation
 func (s EnhancedMonitoringOutput) GoString() string {
 	return s.String()
+}
+
+// SetCurrentShardLevelMetrics sets the CurrentShardLevelMetrics field's value.
+func (s *EnhancedMonitoringOutput) SetCurrentShardLevelMetrics(v []*string) *EnhancedMonitoringOutput {
+	s.CurrentShardLevelMetrics = v
+	return s
+}
+
+// SetDesiredShardLevelMetrics sets the DesiredShardLevelMetrics field's value.
+func (s *EnhancedMonitoringOutput) SetDesiredShardLevelMetrics(v []*string) *EnhancedMonitoringOutput {
+	s.DesiredShardLevelMetrics = v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *EnhancedMonitoringOutput) SetStreamName(v string) *EnhancedMonitoringOutput {
+	s.StreamName = &v
+	return s
 }
 
 // Represents the input for GetRecords.
@@ -2303,6 +2417,18 @@ func (s *GetRecordsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *GetRecordsInput) SetLimit(v int64) *GetRecordsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetShardIterator sets the ShardIterator field's value.
+func (s *GetRecordsInput) SetShardIterator(v string) *GetRecordsInput {
+	s.ShardIterator = &v
+	return s
+}
+
 // Represents the output for GetRecords.
 type GetRecordsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2332,6 +2458,24 @@ func (s GetRecordsOutput) String() string {
 // GoString returns the string representation
 func (s GetRecordsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMillisBehindLatest sets the MillisBehindLatest field's value.
+func (s *GetRecordsOutput) SetMillisBehindLatest(v int64) *GetRecordsOutput {
+	s.MillisBehindLatest = &v
+	return s
+}
+
+// SetNextShardIterator sets the NextShardIterator field's value.
+func (s *GetRecordsOutput) SetNextShardIterator(v string) *GetRecordsOutput {
+	s.NextShardIterator = &v
+	return s
+}
+
+// SetRecords sets the Records field's value.
+func (s *GetRecordsOutput) SetRecords(v []*Record) *GetRecordsOutput {
+	s.Records = v
+	return s
 }
 
 // Represents the input for GetShardIterator.
@@ -2417,6 +2561,36 @@ func (s *GetShardIteratorInput) Validate() error {
 	return nil
 }
 
+// SetShardId sets the ShardId field's value.
+func (s *GetShardIteratorInput) SetShardId(v string) *GetShardIteratorInput {
+	s.ShardId = &v
+	return s
+}
+
+// SetShardIteratorType sets the ShardIteratorType field's value.
+func (s *GetShardIteratorInput) SetShardIteratorType(v string) *GetShardIteratorInput {
+	s.ShardIteratorType = &v
+	return s
+}
+
+// SetStartingSequenceNumber sets the StartingSequenceNumber field's value.
+func (s *GetShardIteratorInput) SetStartingSequenceNumber(v string) *GetShardIteratorInput {
+	s.StartingSequenceNumber = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *GetShardIteratorInput) SetStreamName(v string) *GetShardIteratorInput {
+	s.StreamName = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *GetShardIteratorInput) SetTimestamp(v time.Time) *GetShardIteratorInput {
+	s.Timestamp = &v
+	return s
+}
+
 // Represents the output for GetShardIterator.
 type GetShardIteratorOutput struct {
 	_ struct{} `type:"structure"`
@@ -2435,6 +2609,12 @@ func (s GetShardIteratorOutput) String() string {
 // GoString returns the string representation
 func (s GetShardIteratorOutput) GoString() string {
 	return s.String()
+}
+
+// SetShardIterator sets the ShardIterator field's value.
+func (s *GetShardIteratorOutput) SetShardIterator(v string) *GetShardIteratorOutput {
+	s.ShardIterator = &v
+	return s
 }
 
 // The range of possible hash key values for the shard, which is a set of ordered
@@ -2461,6 +2641,18 @@ func (s HashKeyRange) String() string {
 // GoString returns the string representation
 func (s HashKeyRange) GoString() string {
 	return s.String()
+}
+
+// SetEndingHashKey sets the EndingHashKey field's value.
+func (s *HashKeyRange) SetEndingHashKey(v string) *HashKeyRange {
+	s.EndingHashKey = &v
+	return s
+}
+
+// SetStartingHashKey sets the StartingHashKey field's value.
+func (s *HashKeyRange) SetStartingHashKey(v string) *HashKeyRange {
+	s.StartingHashKey = &v
+	return s
 }
 
 // Represents the input for IncreaseStreamRetentionPeriod.
@@ -2509,6 +2701,18 @@ func (s *IncreaseStreamRetentionPeriodInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRetentionPeriodHours sets the RetentionPeriodHours field's value.
+func (s *IncreaseStreamRetentionPeriodInput) SetRetentionPeriodHours(v int64) *IncreaseStreamRetentionPeriodInput {
+	s.RetentionPeriodHours = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *IncreaseStreamRetentionPeriodInput) SetStreamName(v string) *IncreaseStreamRetentionPeriodInput {
+	s.StreamName = &v
+	return s
 }
 
 type IncreaseStreamRetentionPeriodOutput struct {
@@ -2562,6 +2766,18 @@ func (s *ListStreamsInput) Validate() error {
 	return nil
 }
 
+// SetExclusiveStartStreamName sets the ExclusiveStartStreamName field's value.
+func (s *ListStreamsInput) SetExclusiveStartStreamName(v string) *ListStreamsInput {
+	s.ExclusiveStartStreamName = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListStreamsInput) SetLimit(v int64) *ListStreamsInput {
+	s.Limit = &v
+	return s
+}
+
 // Represents the output for ListStreams.
 type ListStreamsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2586,6 +2802,18 @@ func (s ListStreamsOutput) String() string {
 // GoString returns the string representation
 func (s ListStreamsOutput) GoString() string {
 	return s.String()
+}
+
+// SetHasMoreStreams sets the HasMoreStreams field's value.
+func (s *ListStreamsOutput) SetHasMoreStreams(v bool) *ListStreamsOutput {
+	s.HasMoreStreams = &v
+	return s
+}
+
+// SetStreamNames sets the StreamNames field's value.
+func (s *ListStreamsOutput) SetStreamNames(v []*string) *ListStreamsOutput {
+	s.StreamNames = v
+	return s
 }
 
 // Represents the input for ListTagsForStream.
@@ -2639,6 +2867,24 @@ func (s *ListTagsForStreamInput) Validate() error {
 	return nil
 }
 
+// SetExclusiveStartTagKey sets the ExclusiveStartTagKey field's value.
+func (s *ListTagsForStreamInput) SetExclusiveStartTagKey(v string) *ListTagsForStreamInput {
+	s.ExclusiveStartTagKey = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListTagsForStreamInput) SetLimit(v int64) *ListTagsForStreamInput {
+	s.Limit = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *ListTagsForStreamInput) SetStreamName(v string) *ListTagsForStreamInput {
+	s.StreamName = &v
+	return s
+}
+
 // Represents the output for ListTagsForStream.
 type ListTagsForStreamOutput struct {
 	_ struct{} `type:"structure"`
@@ -2664,6 +2910,18 @@ func (s ListTagsForStreamOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForStreamOutput) GoString() string {
 	return s.String()
+}
+
+// SetHasMoreTags sets the HasMoreTags field's value.
+func (s *ListTagsForStreamOutput) SetHasMoreTags(v bool) *ListTagsForStreamOutput {
+	s.HasMoreTags = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForStreamOutput) SetTags(v []*Tag) *ListTagsForStreamOutput {
+	s.Tags = v
+	return s
 }
 
 // Represents the input for MergeShards.
@@ -2722,6 +2980,24 @@ func (s *MergeShardsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAdjacentShardToMerge sets the AdjacentShardToMerge field's value.
+func (s *MergeShardsInput) SetAdjacentShardToMerge(v string) *MergeShardsInput {
+	s.AdjacentShardToMerge = &v
+	return s
+}
+
+// SetShardToMerge sets the ShardToMerge field's value.
+func (s *MergeShardsInput) SetShardToMerge(v string) *MergeShardsInput {
+	s.ShardToMerge = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *MergeShardsInput) SetStreamName(v string) *MergeShardsInput {
+	s.StreamName = &v
+	return s
 }
 
 type MergeShardsOutput struct {
@@ -2816,6 +3092,36 @@ func (s *PutRecordInput) Validate() error {
 	return nil
 }
 
+// SetData sets the Data field's value.
+func (s *PutRecordInput) SetData(v []byte) *PutRecordInput {
+	s.Data = v
+	return s
+}
+
+// SetExplicitHashKey sets the ExplicitHashKey field's value.
+func (s *PutRecordInput) SetExplicitHashKey(v string) *PutRecordInput {
+	s.ExplicitHashKey = &v
+	return s
+}
+
+// SetPartitionKey sets the PartitionKey field's value.
+func (s *PutRecordInput) SetPartitionKey(v string) *PutRecordInput {
+	s.PartitionKey = &v
+	return s
+}
+
+// SetSequenceNumberForOrdering sets the SequenceNumberForOrdering field's value.
+func (s *PutRecordInput) SetSequenceNumberForOrdering(v string) *PutRecordInput {
+	s.SequenceNumberForOrdering = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *PutRecordInput) SetStreamName(v string) *PutRecordInput {
+	s.StreamName = &v
+	return s
+}
+
 // Represents the output for PutRecord.
 type PutRecordOutput struct {
 	_ struct{} `type:"structure"`
@@ -2842,6 +3148,18 @@ func (s PutRecordOutput) String() string {
 // GoString returns the string representation
 func (s PutRecordOutput) GoString() string {
 	return s.String()
+}
+
+// SetSequenceNumber sets the SequenceNumber field's value.
+func (s *PutRecordOutput) SetSequenceNumber(v string) *PutRecordOutput {
+	s.SequenceNumber = &v
+	return s
+}
+
+// SetShardId sets the ShardId field's value.
+func (s *PutRecordOutput) SetShardId(v string) *PutRecordOutput {
+	s.ShardId = &v
+	return s
 }
 
 // A PutRecords request.
@@ -2901,6 +3219,18 @@ func (s *PutRecordsInput) Validate() error {
 	return nil
 }
 
+// SetRecords sets the Records field's value.
+func (s *PutRecordsInput) SetRecords(v []*PutRecordsRequestEntry) *PutRecordsInput {
+	s.Records = v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *PutRecordsInput) SetStreamName(v string) *PutRecordsInput {
+	s.StreamName = &v
+	return s
+}
+
 // PutRecords results.
 type PutRecordsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2926,6 +3256,18 @@ func (s PutRecordsOutput) String() string {
 // GoString returns the string representation
 func (s PutRecordsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedRecordCount sets the FailedRecordCount field's value.
+func (s *PutRecordsOutput) SetFailedRecordCount(v int64) *PutRecordsOutput {
+	s.FailedRecordCount = &v
+	return s
+}
+
+// SetRecords sets the Records field's value.
+func (s *PutRecordsOutput) SetRecords(v []*PutRecordsResultEntry) *PutRecordsOutput {
+	s.Records = v
+	return s
 }
 
 // Represents the output for PutRecords.
@@ -2988,6 +3330,24 @@ func (s *PutRecordsRequestEntry) Validate() error {
 	return nil
 }
 
+// SetData sets the Data field's value.
+func (s *PutRecordsRequestEntry) SetData(v []byte) *PutRecordsRequestEntry {
+	s.Data = v
+	return s
+}
+
+// SetExplicitHashKey sets the ExplicitHashKey field's value.
+func (s *PutRecordsRequestEntry) SetExplicitHashKey(v string) *PutRecordsRequestEntry {
+	s.ExplicitHashKey = &v
+	return s
+}
+
+// SetPartitionKey sets the PartitionKey field's value.
+func (s *PutRecordsRequestEntry) SetPartitionKey(v string) *PutRecordsRequestEntry {
+	s.PartitionKey = &v
+	return s
+}
+
 // Represents the result of an individual record from a PutRecords request.
 // A record that is successfully added to a stream includes SequenceNumber and
 // ShardId in the result. A record that fails to be added to the stream includes
@@ -3020,6 +3380,30 @@ func (s PutRecordsResultEntry) String() string {
 // GoString returns the string representation
 func (s PutRecordsResultEntry) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *PutRecordsResultEntry) SetErrorCode(v string) *PutRecordsResultEntry {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *PutRecordsResultEntry) SetErrorMessage(v string) *PutRecordsResultEntry {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetSequenceNumber sets the SequenceNumber field's value.
+func (s *PutRecordsResultEntry) SetSequenceNumber(v string) *PutRecordsResultEntry {
+	s.SequenceNumber = &v
+	return s
+}
+
+// SetShardId sets the ShardId field's value.
+func (s *PutRecordsResultEntry) SetShardId(v string) *PutRecordsResultEntry {
+	s.ShardId = &v
+	return s
 }
 
 // The unit of data of the Amazon Kinesis stream, which is composed of a sequence
@@ -3060,6 +3444,30 @@ func (s Record) String() string {
 // GoString returns the string representation
 func (s Record) GoString() string {
 	return s.String()
+}
+
+// SetApproximateArrivalTimestamp sets the ApproximateArrivalTimestamp field's value.
+func (s *Record) SetApproximateArrivalTimestamp(v time.Time) *Record {
+	s.ApproximateArrivalTimestamp = &v
+	return s
+}
+
+// SetData sets the Data field's value.
+func (s *Record) SetData(v []byte) *Record {
+	s.Data = v
+	return s
+}
+
+// SetPartitionKey sets the PartitionKey field's value.
+func (s *Record) SetPartitionKey(v string) *Record {
+	s.PartitionKey = &v
+	return s
+}
+
+// SetSequenceNumber sets the SequenceNumber field's value.
+func (s *Record) SetSequenceNumber(v string) *Record {
+	s.SequenceNumber = &v
+	return s
 }
 
 // Represents the input for RemoveTagsFromStream.
@@ -3109,6 +3517,18 @@ func (s *RemoveTagsFromStreamInput) Validate() error {
 	return nil
 }
 
+// SetStreamName sets the StreamName field's value.
+func (s *RemoveTagsFromStreamInput) SetStreamName(v string) *RemoveTagsFromStreamInput {
+	s.StreamName = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsFromStreamInput) SetTagKeys(v []*string) *RemoveTagsFromStreamInput {
+	s.TagKeys = v
+	return s
+}
+
 type RemoveTagsFromStreamOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3147,6 +3567,18 @@ func (s SequenceNumberRange) GoString() string {
 	return s.String()
 }
 
+// SetEndingSequenceNumber sets the EndingSequenceNumber field's value.
+func (s *SequenceNumberRange) SetEndingSequenceNumber(v string) *SequenceNumberRange {
+	s.EndingSequenceNumber = &v
+	return s
+}
+
+// SetStartingSequenceNumber sets the StartingSequenceNumber field's value.
+func (s *SequenceNumberRange) SetStartingSequenceNumber(v string) *SequenceNumberRange {
+	s.StartingSequenceNumber = &v
+	return s
+}
+
 // A uniquely identified group of data records in an Amazon Kinesis stream.
 type Shard struct {
 	_ struct{} `type:"structure"`
@@ -3182,6 +3614,36 @@ func (s Shard) String() string {
 // GoString returns the string representation
 func (s Shard) GoString() string {
 	return s.String()
+}
+
+// SetAdjacentParentShardId sets the AdjacentParentShardId field's value.
+func (s *Shard) SetAdjacentParentShardId(v string) *Shard {
+	s.AdjacentParentShardId = &v
+	return s
+}
+
+// SetHashKeyRange sets the HashKeyRange field's value.
+func (s *Shard) SetHashKeyRange(v *HashKeyRange) *Shard {
+	s.HashKeyRange = v
+	return s
+}
+
+// SetParentShardId sets the ParentShardId field's value.
+func (s *Shard) SetParentShardId(v string) *Shard {
+	s.ParentShardId = &v
+	return s
+}
+
+// SetSequenceNumberRange sets the SequenceNumberRange field's value.
+func (s *Shard) SetSequenceNumberRange(v *SequenceNumberRange) *Shard {
+	s.SequenceNumberRange = v
+	return s
+}
+
+// SetShardId sets the ShardId field's value.
+func (s *Shard) SetShardId(v string) *Shard {
+	s.ShardId = &v
+	return s
 }
 
 // Represents the input for SplitShard.
@@ -3243,6 +3705,24 @@ func (s *SplitShardInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetNewStartingHashKey sets the NewStartingHashKey field's value.
+func (s *SplitShardInput) SetNewStartingHashKey(v string) *SplitShardInput {
+	s.NewStartingHashKey = &v
+	return s
+}
+
+// SetShardToSplit sets the ShardToSplit field's value.
+func (s *SplitShardInput) SetShardToSplit(v string) *SplitShardInput {
+	s.ShardToSplit = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *SplitShardInput) SetStreamName(v string) *SplitShardInput {
+	s.StreamName = &v
+	return s
 }
 
 type SplitShardOutput struct {
@@ -3321,6 +3801,48 @@ func (s StreamDescription) GoString() string {
 	return s.String()
 }
 
+// SetEnhancedMonitoring sets the EnhancedMonitoring field's value.
+func (s *StreamDescription) SetEnhancedMonitoring(v []*EnhancedMetrics) *StreamDescription {
+	s.EnhancedMonitoring = v
+	return s
+}
+
+// SetHasMoreShards sets the HasMoreShards field's value.
+func (s *StreamDescription) SetHasMoreShards(v bool) *StreamDescription {
+	s.HasMoreShards = &v
+	return s
+}
+
+// SetRetentionPeriodHours sets the RetentionPeriodHours field's value.
+func (s *StreamDescription) SetRetentionPeriodHours(v int64) *StreamDescription {
+	s.RetentionPeriodHours = &v
+	return s
+}
+
+// SetShards sets the Shards field's value.
+func (s *StreamDescription) SetShards(v []*Shard) *StreamDescription {
+	s.Shards = v
+	return s
+}
+
+// SetStreamARN sets the StreamARN field's value.
+func (s *StreamDescription) SetStreamARN(v string) *StreamDescription {
+	s.StreamARN = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *StreamDescription) SetStreamName(v string) *StreamDescription {
+	s.StreamName = &v
+	return s
+}
+
+// SetStreamStatus sets the StreamStatus field's value.
+func (s *StreamDescription) SetStreamStatus(v string) *StreamDescription {
+	s.StreamStatus = &v
+	return s
+}
+
 // Metadata assigned to the stream, consisting of a key-value pair.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -3345,6 +3867,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 const (

--- a/service/kinesisanalytics/api.go
+++ b/service/kinesisanalytics/api.go
@@ -1156,6 +1156,24 @@ func (s *AddApplicationInputInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *AddApplicationInputInput) SetApplicationName(v string) *AddApplicationInputInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCurrentApplicationVersionId sets the CurrentApplicationVersionId field's value.
+func (s *AddApplicationInputInput) SetCurrentApplicationVersionId(v int64) *AddApplicationInputInput {
+	s.CurrentApplicationVersionId = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *AddApplicationInputInput) SetInput(v *Input) *AddApplicationInputInput {
+	s.Input = v
+	return s
+}
+
 type AddApplicationInputOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1233,6 +1251,24 @@ func (s *AddApplicationOutputInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *AddApplicationOutputInput) SetApplicationName(v string) *AddApplicationOutputInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCurrentApplicationVersionId sets the CurrentApplicationVersionId field's value.
+func (s *AddApplicationOutputInput) SetCurrentApplicationVersionId(v int64) *AddApplicationOutputInput {
+	s.CurrentApplicationVersionId = &v
+	return s
+}
+
+// SetOutput sets the Output field's value.
+func (s *AddApplicationOutputInput) SetOutput(v *Output) *AddApplicationOutputInput {
+	s.Output = v
+	return s
 }
 
 type AddApplicationOutputOutput struct {
@@ -1316,6 +1352,24 @@ func (s *AddApplicationReferenceDataSourceInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *AddApplicationReferenceDataSourceInput) SetApplicationName(v string) *AddApplicationReferenceDataSourceInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCurrentApplicationVersionId sets the CurrentApplicationVersionId field's value.
+func (s *AddApplicationReferenceDataSourceInput) SetCurrentApplicationVersionId(v int64) *AddApplicationReferenceDataSourceInput {
+	s.CurrentApplicationVersionId = &v
+	return s
+}
+
+// SetReferenceDataSource sets the ReferenceDataSource field's value.
+func (s *AddApplicationReferenceDataSourceInput) SetReferenceDataSource(v *ReferenceDataSource) *AddApplicationReferenceDataSourceInput {
+	s.ReferenceDataSource = v
+	return s
+}
+
 type AddApplicationReferenceDataSourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1391,6 +1445,72 @@ func (s ApplicationDetail) GoString() string {
 	return s.String()
 }
 
+// SetApplicationARN sets the ApplicationARN field's value.
+func (s *ApplicationDetail) SetApplicationARN(v string) *ApplicationDetail {
+	s.ApplicationARN = &v
+	return s
+}
+
+// SetApplicationCode sets the ApplicationCode field's value.
+func (s *ApplicationDetail) SetApplicationCode(v string) *ApplicationDetail {
+	s.ApplicationCode = &v
+	return s
+}
+
+// SetApplicationDescription sets the ApplicationDescription field's value.
+func (s *ApplicationDetail) SetApplicationDescription(v string) *ApplicationDetail {
+	s.ApplicationDescription = &v
+	return s
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ApplicationDetail) SetApplicationName(v string) *ApplicationDetail {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetApplicationStatus sets the ApplicationStatus field's value.
+func (s *ApplicationDetail) SetApplicationStatus(v string) *ApplicationDetail {
+	s.ApplicationStatus = &v
+	return s
+}
+
+// SetApplicationVersionId sets the ApplicationVersionId field's value.
+func (s *ApplicationDetail) SetApplicationVersionId(v int64) *ApplicationDetail {
+	s.ApplicationVersionId = &v
+	return s
+}
+
+// SetCreateTimestamp sets the CreateTimestamp field's value.
+func (s *ApplicationDetail) SetCreateTimestamp(v time.Time) *ApplicationDetail {
+	s.CreateTimestamp = &v
+	return s
+}
+
+// SetInputDescriptions sets the InputDescriptions field's value.
+func (s *ApplicationDetail) SetInputDescriptions(v []*InputDescription) *ApplicationDetail {
+	s.InputDescriptions = v
+	return s
+}
+
+// SetLastUpdateTimestamp sets the LastUpdateTimestamp field's value.
+func (s *ApplicationDetail) SetLastUpdateTimestamp(v time.Time) *ApplicationDetail {
+	s.LastUpdateTimestamp = &v
+	return s
+}
+
+// SetOutputDescriptions sets the OutputDescriptions field's value.
+func (s *ApplicationDetail) SetOutputDescriptions(v []*OutputDescription) *ApplicationDetail {
+	s.OutputDescriptions = v
+	return s
+}
+
+// SetReferenceDataSourceDescriptions sets the ReferenceDataSourceDescriptions field's value.
+func (s *ApplicationDetail) SetReferenceDataSourceDescriptions(v []*ReferenceDataSourceDescription) *ApplicationDetail {
+	s.ReferenceDataSourceDescriptions = v
+	return s
+}
+
 // Provides application summary information, including the application Amazon
 // Resource Name (ARN), name, and status.
 type ApplicationSummary struct {
@@ -1420,6 +1540,24 @@ func (s ApplicationSummary) String() string {
 // GoString returns the string representation
 func (s ApplicationSummary) GoString() string {
 	return s.String()
+}
+
+// SetApplicationARN sets the ApplicationARN field's value.
+func (s *ApplicationSummary) SetApplicationARN(v string) *ApplicationSummary {
+	s.ApplicationARN = &v
+	return s
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *ApplicationSummary) SetApplicationName(v string) *ApplicationSummary {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetApplicationStatus sets the ApplicationStatus field's value.
+func (s *ApplicationSummary) SetApplicationStatus(v string) *ApplicationSummary {
+	s.ApplicationStatus = &v
+	return s
 }
 
 // Describes updates to apply to an existing Kinesis Analytics application.
@@ -1489,6 +1627,30 @@ func (s *ApplicationUpdate) Validate() error {
 	return nil
 }
 
+// SetApplicationCodeUpdate sets the ApplicationCodeUpdate field's value.
+func (s *ApplicationUpdate) SetApplicationCodeUpdate(v string) *ApplicationUpdate {
+	s.ApplicationCodeUpdate = &v
+	return s
+}
+
+// SetInputUpdates sets the InputUpdates field's value.
+func (s *ApplicationUpdate) SetInputUpdates(v []*InputUpdate) *ApplicationUpdate {
+	s.InputUpdates = v
+	return s
+}
+
+// SetOutputUpdates sets the OutputUpdates field's value.
+func (s *ApplicationUpdate) SetOutputUpdates(v []*OutputUpdate) *ApplicationUpdate {
+	s.OutputUpdates = v
+	return s
+}
+
+// SetReferenceDataSourceUpdates sets the ReferenceDataSourceUpdates field's value.
+func (s *ApplicationUpdate) SetReferenceDataSourceUpdates(v []*ReferenceDataSourceUpdate) *ApplicationUpdate {
+	s.ReferenceDataSourceUpdates = v
+	return s
+}
+
 // Provides additional mapping information when the record format uses delimiters,
 // such as CSV. For example, the following sample records use CSV format, where
 // the records use the '\n' as the row delimiter and a comma (",") as the column
@@ -1536,6 +1698,18 @@ func (s *CSVMappingParameters) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRecordColumnDelimiter sets the RecordColumnDelimiter field's value.
+func (s *CSVMappingParameters) SetRecordColumnDelimiter(v string) *CSVMappingParameters {
+	s.RecordColumnDelimiter = &v
+	return s
+}
+
+// SetRecordRowDelimiter sets the RecordRowDelimiter field's value.
+func (s *CSVMappingParameters) SetRecordRowDelimiter(v string) *CSVMappingParameters {
+	s.RecordRowDelimiter = &v
+	return s
 }
 
 // TBD
@@ -1646,6 +1820,36 @@ func (s *CreateApplicationInput) Validate() error {
 	return nil
 }
 
+// SetApplicationCode sets the ApplicationCode field's value.
+func (s *CreateApplicationInput) SetApplicationCode(v string) *CreateApplicationInput {
+	s.ApplicationCode = &v
+	return s
+}
+
+// SetApplicationDescription sets the ApplicationDescription field's value.
+func (s *CreateApplicationInput) SetApplicationDescription(v string) *CreateApplicationInput {
+	s.ApplicationDescription = &v
+	return s
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *CreateApplicationInput) SetApplicationName(v string) *CreateApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetInputs sets the Inputs field's value.
+func (s *CreateApplicationInput) SetInputs(v []*Input) *CreateApplicationInput {
+	s.Inputs = v
+	return s
+}
+
+// SetOutputs sets the Outputs field's value.
+func (s *CreateApplicationInput) SetOutputs(v []*Output) *CreateApplicationInput {
+	s.Outputs = v
+	return s
+}
+
 // TBD
 type CreateApplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -1666,6 +1870,12 @@ func (s CreateApplicationOutput) String() string {
 // GoString returns the string representation
 func (s CreateApplicationOutput) GoString() string {
 	return s.String()
+}
+
+// SetApplicationSummary sets the ApplicationSummary field's value.
+func (s *CreateApplicationOutput) SetApplicationSummary(v *ApplicationSummary) *CreateApplicationOutput {
+	s.ApplicationSummary = v
+	return s
 }
 
 type DeleteApplicationInput struct {
@@ -1709,6 +1919,18 @@ func (s *DeleteApplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteApplicationInput) SetApplicationName(v string) *DeleteApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCreateTimestamp sets the CreateTimestamp field's value.
+func (s *DeleteApplicationInput) SetCreateTimestamp(v time.Time) *DeleteApplicationInput {
+	s.CreateTimestamp = &v
+	return s
 }
 
 type DeleteApplicationOutput struct {
@@ -1789,6 +2011,24 @@ func (s *DeleteApplicationOutputInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteApplicationOutputInput) SetApplicationName(v string) *DeleteApplicationOutputInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCurrentApplicationVersionId sets the CurrentApplicationVersionId field's value.
+func (s *DeleteApplicationOutputInput) SetCurrentApplicationVersionId(v int64) *DeleteApplicationOutputInput {
+	s.CurrentApplicationVersionId = &v
+	return s
+}
+
+// SetOutputId sets the OutputId field's value.
+func (s *DeleteApplicationOutputInput) SetOutputId(v string) *DeleteApplicationOutputInput {
+	s.OutputId = &v
+	return s
+}
+
 type DeleteApplicationOutputOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1865,6 +2105,24 @@ func (s *DeleteApplicationReferenceDataSourceInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteApplicationReferenceDataSourceInput) SetApplicationName(v string) *DeleteApplicationReferenceDataSourceInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCurrentApplicationVersionId sets the CurrentApplicationVersionId field's value.
+func (s *DeleteApplicationReferenceDataSourceInput) SetCurrentApplicationVersionId(v int64) *DeleteApplicationReferenceDataSourceInput {
+	s.CurrentApplicationVersionId = &v
+	return s
+}
+
+// SetReferenceId sets the ReferenceId field's value.
+func (s *DeleteApplicationReferenceDataSourceInput) SetReferenceId(v string) *DeleteApplicationReferenceDataSourceInput {
+	s.ReferenceId = &v
+	return s
+}
+
 type DeleteApplicationReferenceDataSourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1914,6 +2172,12 @@ func (s *DescribeApplicationInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DescribeApplicationInput) SetApplicationName(v string) *DescribeApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
 type DescribeApplicationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1935,6 +2199,12 @@ func (s DescribeApplicationOutput) GoString() string {
 	return s.String()
 }
 
+// SetApplicationDetail sets the ApplicationDetail field's value.
+func (s *DescribeApplicationOutput) SetApplicationDetail(v *ApplicationDetail) *DescribeApplicationOutput {
+	s.ApplicationDetail = v
+	return s
+}
+
 // Describes the data format when records are written to the destination. For
 // more information, see Configuring Application Output (http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-output.html).
 type DestinationSchema struct {
@@ -1952,6 +2222,12 @@ func (s DestinationSchema) String() string {
 // GoString returns the string representation
 func (s DestinationSchema) GoString() string {
 	return s.String()
+}
+
+// SetRecordFormatType sets the RecordFormatType field's value.
+func (s *DestinationSchema) SetRecordFormatType(v string) *DestinationSchema {
+	s.RecordFormatType = &v
+	return s
 }
 
 type DiscoverInputSchemaInput struct {
@@ -2010,6 +2286,24 @@ func (s *DiscoverInputSchemaInput) Validate() error {
 	return nil
 }
 
+// SetInputStartingPositionConfiguration sets the InputStartingPositionConfiguration field's value.
+func (s *DiscoverInputSchemaInput) SetInputStartingPositionConfiguration(v *InputStartingPositionConfiguration) *DiscoverInputSchemaInput {
+	s.InputStartingPositionConfiguration = v
+	return s
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *DiscoverInputSchemaInput) SetResourceARN(v string) *DiscoverInputSchemaInput {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *DiscoverInputSchemaInput) SetRoleARN(v string) *DiscoverInputSchemaInput {
+	s.RoleARN = &v
+	return s
+}
+
 type DiscoverInputSchemaOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2034,6 +2328,24 @@ func (s DiscoverInputSchemaOutput) String() string {
 // GoString returns the string representation
 func (s DiscoverInputSchemaOutput) GoString() string {
 	return s.String()
+}
+
+// SetInputSchema sets the InputSchema field's value.
+func (s *DiscoverInputSchemaOutput) SetInputSchema(v *SourceSchema) *DiscoverInputSchemaOutput {
+	s.InputSchema = v
+	return s
+}
+
+// SetParsedInputRecords sets the ParsedInputRecords field's value.
+func (s *DiscoverInputSchemaOutput) SetParsedInputRecords(v [][]*string) *DiscoverInputSchemaOutput {
+	s.ParsedInputRecords = v
+	return s
+}
+
+// SetRawInputRecords sets the RawInputRecords field's value.
+func (s *DiscoverInputSchemaOutput) SetRawInputRecords(v []*string) *DiscoverInputSchemaOutput {
+	s.RawInputRecords = v
+	return s
 }
 
 // When you configure the application input, you specify the streaming source,
@@ -2127,6 +2439,36 @@ func (s *Input) Validate() error {
 	return nil
 }
 
+// SetInputParallelism sets the InputParallelism field's value.
+func (s *Input) SetInputParallelism(v *InputParallelism) *Input {
+	s.InputParallelism = v
+	return s
+}
+
+// SetInputSchema sets the InputSchema field's value.
+func (s *Input) SetInputSchema(v *SourceSchema) *Input {
+	s.InputSchema = v
+	return s
+}
+
+// SetKinesisFirehoseInput sets the KinesisFirehoseInput field's value.
+func (s *Input) SetKinesisFirehoseInput(v *KinesisFirehoseInput) *Input {
+	s.KinesisFirehoseInput = v
+	return s
+}
+
+// SetKinesisStreamsInput sets the KinesisStreamsInput field's value.
+func (s *Input) SetKinesisStreamsInput(v *KinesisStreamsInput) *Input {
+	s.KinesisStreamsInput = v
+	return s
+}
+
+// SetNamePrefix sets the NamePrefix field's value.
+func (s *Input) SetNamePrefix(v string) *Input {
+	s.NamePrefix = &v
+	return s
+}
+
 // When you start your application, you provide this configuration, which identifies
 // the input source and the point in the input source at which you want the
 // application to start processing records.
@@ -2172,6 +2514,18 @@ func (s *InputConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *InputConfiguration) SetId(v string) *InputConfiguration {
+	s.Id = &v
+	return s
+}
+
+// SetInputStartingPositionConfiguration sets the InputStartingPositionConfiguration field's value.
+func (s *InputConfiguration) SetInputStartingPositionConfiguration(v *InputStartingPositionConfiguration) *InputConfiguration {
+	s.InputStartingPositionConfiguration = v
+	return s
 }
 
 // Describes the application input configuration. For more information, see
@@ -2222,6 +2576,54 @@ func (s InputDescription) GoString() string {
 	return s.String()
 }
 
+// SetInAppStreamNames sets the InAppStreamNames field's value.
+func (s *InputDescription) SetInAppStreamNames(v []*string) *InputDescription {
+	s.InAppStreamNames = v
+	return s
+}
+
+// SetInputId sets the InputId field's value.
+func (s *InputDescription) SetInputId(v string) *InputDescription {
+	s.InputId = &v
+	return s
+}
+
+// SetInputParallelism sets the InputParallelism field's value.
+func (s *InputDescription) SetInputParallelism(v *InputParallelism) *InputDescription {
+	s.InputParallelism = v
+	return s
+}
+
+// SetInputSchema sets the InputSchema field's value.
+func (s *InputDescription) SetInputSchema(v *SourceSchema) *InputDescription {
+	s.InputSchema = v
+	return s
+}
+
+// SetInputStartingPositionConfiguration sets the InputStartingPositionConfiguration field's value.
+func (s *InputDescription) SetInputStartingPositionConfiguration(v *InputStartingPositionConfiguration) *InputDescription {
+	s.InputStartingPositionConfiguration = v
+	return s
+}
+
+// SetKinesisFirehoseInputDescription sets the KinesisFirehoseInputDescription field's value.
+func (s *InputDescription) SetKinesisFirehoseInputDescription(v *KinesisFirehoseInputDescription) *InputDescription {
+	s.KinesisFirehoseInputDescription = v
+	return s
+}
+
+// SetKinesisStreamsInputDescription sets the KinesisStreamsInputDescription field's value.
+func (s *InputDescription) SetKinesisStreamsInputDescription(v *KinesisStreamsInputDescription) *InputDescription {
+	s.KinesisStreamsInputDescription = v
+	return s
+}
+
+// SetNamePrefix sets the NamePrefix field's value.
+func (s *InputDescription) SetNamePrefix(v string) *InputDescription {
+	s.NamePrefix = &v
+	return s
+}
+
 // Describes the number of in-application streams to create for a given streaming
 // source. For information about parallellism, see Configuring Application Input
 // (http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html).
@@ -2256,6 +2658,12 @@ func (s *InputParallelism) Validate() error {
 	return nil
 }
 
+// SetCount sets the Count field's value.
+func (s *InputParallelism) SetCount(v int64) *InputParallelism {
+	s.Count = &v
+	return s
+}
+
 // Provides updates to the parallelism count.
 type InputParallelismUpdate struct {
 	_ struct{} `type:"structure"`
@@ -2285,6 +2693,12 @@ func (s *InputParallelismUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCountUpdate sets the CountUpdate field's value.
+func (s *InputParallelismUpdate) SetCountUpdate(v int64) *InputParallelismUpdate {
+	s.CountUpdate = &v
+	return s
 }
 
 // Describes updates for the application's input schema.
@@ -2342,6 +2756,24 @@ func (s *InputSchemaUpdate) Validate() error {
 	return nil
 }
 
+// SetRecordColumnUpdates sets the RecordColumnUpdates field's value.
+func (s *InputSchemaUpdate) SetRecordColumnUpdates(v []*RecordColumn) *InputSchemaUpdate {
+	s.RecordColumnUpdates = v
+	return s
+}
+
+// SetRecordEncodingUpdate sets the RecordEncodingUpdate field's value.
+func (s *InputSchemaUpdate) SetRecordEncodingUpdate(v string) *InputSchemaUpdate {
+	s.RecordEncodingUpdate = &v
+	return s
+}
+
+// SetRecordFormatUpdate sets the RecordFormatUpdate field's value.
+func (s *InputSchemaUpdate) SetRecordFormatUpdate(v *RecordFormat) *InputSchemaUpdate {
+	s.RecordFormatUpdate = v
+	return s
+}
+
 // Describes the point at which the application reads from the streaming source.
 type InputStartingPositionConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -2367,6 +2799,12 @@ func (s InputStartingPositionConfiguration) String() string {
 // GoString returns the string representation
 func (s InputStartingPositionConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetInputStartingPosition sets the InputStartingPosition field's value.
+func (s *InputStartingPositionConfiguration) SetInputStartingPosition(v string) *InputStartingPositionConfiguration {
+	s.InputStartingPosition = &v
+	return s
 }
 
 // Describes updates to a specific input configuration (identified by the InputId
@@ -2451,6 +2889,42 @@ func (s *InputUpdate) Validate() error {
 	return nil
 }
 
+// SetInputId sets the InputId field's value.
+func (s *InputUpdate) SetInputId(v string) *InputUpdate {
+	s.InputId = &v
+	return s
+}
+
+// SetInputParallelismUpdate sets the InputParallelismUpdate field's value.
+func (s *InputUpdate) SetInputParallelismUpdate(v *InputParallelismUpdate) *InputUpdate {
+	s.InputParallelismUpdate = v
+	return s
+}
+
+// SetInputSchemaUpdate sets the InputSchemaUpdate field's value.
+func (s *InputUpdate) SetInputSchemaUpdate(v *InputSchemaUpdate) *InputUpdate {
+	s.InputSchemaUpdate = v
+	return s
+}
+
+// SetKinesisFirehoseInputUpdate sets the KinesisFirehoseInputUpdate field's value.
+func (s *InputUpdate) SetKinesisFirehoseInputUpdate(v *KinesisFirehoseInputUpdate) *InputUpdate {
+	s.KinesisFirehoseInputUpdate = v
+	return s
+}
+
+// SetKinesisStreamsInputUpdate sets the KinesisStreamsInputUpdate field's value.
+func (s *InputUpdate) SetKinesisStreamsInputUpdate(v *KinesisStreamsInputUpdate) *InputUpdate {
+	s.KinesisStreamsInputUpdate = v
+	return s
+}
+
+// SetNamePrefixUpdate sets the NamePrefixUpdate field's value.
+func (s *InputUpdate) SetNamePrefixUpdate(v string) *InputUpdate {
+	s.NamePrefixUpdate = &v
+	return s
+}
+
 // Provides additional mapping information when JSON is the record format on
 // the streaming source.
 type JSONMappingParameters struct {
@@ -2488,6 +2962,12 @@ func (s *JSONMappingParameters) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRecordRowPath sets the RecordRowPath field's value.
+func (s *JSONMappingParameters) SetRecordRowPath(v string) *JSONMappingParameters {
+	s.RecordRowPath = &v
+	return s
 }
 
 // Identifies an Amazon Kinesis Firehose delivery stream as the streaming source.
@@ -2542,6 +3022,18 @@ func (s *KinesisFirehoseInput) Validate() error {
 	return nil
 }
 
+// SetResourceARN sets the ResourceARN field's value.
+func (s *KinesisFirehoseInput) SetResourceARN(v string) *KinesisFirehoseInput {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *KinesisFirehoseInput) SetRoleARN(v string) *KinesisFirehoseInput {
+	s.RoleARN = &v
+	return s
+}
+
 // Describes the Amazon Kinesis Firehose delivery stream that is configured
 // as the streaming source in the application input configuration.
 type KinesisFirehoseInputDescription struct {
@@ -2562,6 +3054,18 @@ func (s KinesisFirehoseInputDescription) String() string {
 // GoString returns the string representation
 func (s KinesisFirehoseInputDescription) GoString() string {
 	return s.String()
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *KinesisFirehoseInputDescription) SetResourceARN(v string) *KinesisFirehoseInputDescription {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *KinesisFirehoseInputDescription) SetRoleARN(v string) *KinesisFirehoseInputDescription {
+	s.RoleARN = &v
+	return s
 }
 
 // When updating application input configuration, provides information about
@@ -2602,6 +3106,18 @@ func (s *KinesisFirehoseInputUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceARNUpdate sets the ResourceARNUpdate field's value.
+func (s *KinesisFirehoseInputUpdate) SetResourceARNUpdate(v string) *KinesisFirehoseInputUpdate {
+	s.ResourceARNUpdate = &v
+	return s
+}
+
+// SetRoleARNUpdate sets the RoleARNUpdate field's value.
+func (s *KinesisFirehoseInputUpdate) SetRoleARNUpdate(v string) *KinesisFirehoseInputUpdate {
+	s.RoleARNUpdate = &v
+	return s
 }
 
 // When configuring application output, identifies an Amazon Kinesis Firehose
@@ -2656,6 +3172,18 @@ func (s *KinesisFirehoseOutput) Validate() error {
 	return nil
 }
 
+// SetResourceARN sets the ResourceARN field's value.
+func (s *KinesisFirehoseOutput) SetResourceARN(v string) *KinesisFirehoseOutput {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *KinesisFirehoseOutput) SetRoleARN(v string) *KinesisFirehoseOutput {
+	s.RoleARN = &v
+	return s
+}
+
 // For an application output, describes the Amazon Kinesis Firehose delivery
 // stream configured as its destination.
 type KinesisFirehoseOutputDescription struct {
@@ -2677,6 +3205,18 @@ func (s KinesisFirehoseOutputDescription) String() string {
 // GoString returns the string representation
 func (s KinesisFirehoseOutputDescription) GoString() string {
 	return s.String()
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *KinesisFirehoseOutputDescription) SetResourceARN(v string) *KinesisFirehoseOutputDescription {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *KinesisFirehoseOutputDescription) SetRoleARN(v string) *KinesisFirehoseOutputDescription {
+	s.RoleARN = &v
+	return s
 }
 
 // When updating an output configuration using the UpdateApplication operation,
@@ -2718,6 +3258,18 @@ func (s *KinesisFirehoseOutputUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceARNUpdate sets the ResourceARNUpdate field's value.
+func (s *KinesisFirehoseOutputUpdate) SetResourceARNUpdate(v string) *KinesisFirehoseOutputUpdate {
+	s.ResourceARNUpdate = &v
+	return s
+}
+
+// SetRoleARNUpdate sets the RoleARNUpdate field's value.
+func (s *KinesisFirehoseOutputUpdate) SetRoleARNUpdate(v string) *KinesisFirehoseOutputUpdate {
+	s.RoleARNUpdate = &v
+	return s
 }
 
 // Identifies an Amazon Kinesis stream as the streaming source. You provide
@@ -2771,6 +3323,18 @@ func (s *KinesisStreamsInput) Validate() error {
 	return nil
 }
 
+// SetResourceARN sets the ResourceARN field's value.
+func (s *KinesisStreamsInput) SetResourceARN(v string) *KinesisStreamsInput {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *KinesisStreamsInput) SetRoleARN(v string) *KinesisStreamsInput {
+	s.RoleARN = &v
+	return s
+}
+
 // Describes the Amazon Kinesis stream that is configured as the streaming source
 // in the application input configuration.
 type KinesisStreamsInputDescription struct {
@@ -2792,6 +3356,18 @@ func (s KinesisStreamsInputDescription) String() string {
 // GoString returns the string representation
 func (s KinesisStreamsInputDescription) GoString() string {
 	return s.String()
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *KinesisStreamsInputDescription) SetResourceARN(v string) *KinesisStreamsInputDescription {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *KinesisStreamsInputDescription) SetRoleARN(v string) *KinesisStreamsInputDescription {
+	s.RoleARN = &v
+	return s
 }
 
 // When updating application input configuration, provides information about
@@ -2832,6 +3408,18 @@ func (s *KinesisStreamsInputUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceARNUpdate sets the ResourceARNUpdate field's value.
+func (s *KinesisStreamsInputUpdate) SetResourceARNUpdate(v string) *KinesisStreamsInputUpdate {
+	s.ResourceARNUpdate = &v
+	return s
+}
+
+// SetRoleARNUpdate sets the RoleARNUpdate field's value.
+func (s *KinesisStreamsInputUpdate) SetRoleARNUpdate(v string) *KinesisStreamsInputUpdate {
+	s.RoleARNUpdate = &v
+	return s
 }
 
 // When configuring application output, identifies a Amazon Kinesis stream as
@@ -2886,6 +3474,18 @@ func (s *KinesisStreamsOutput) Validate() error {
 	return nil
 }
 
+// SetResourceARN sets the ResourceARN field's value.
+func (s *KinesisStreamsOutput) SetResourceARN(v string) *KinesisStreamsOutput {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *KinesisStreamsOutput) SetRoleARN(v string) *KinesisStreamsOutput {
+	s.RoleARN = &v
+	return s
+}
+
 // For an application output, describes the Amazon Kinesis stream configured
 // as its destination.
 type KinesisStreamsOutputDescription struct {
@@ -2907,6 +3507,18 @@ func (s KinesisStreamsOutputDescription) String() string {
 // GoString returns the string representation
 func (s KinesisStreamsOutputDescription) GoString() string {
 	return s.String()
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *KinesisStreamsOutputDescription) SetResourceARN(v string) *KinesisStreamsOutputDescription {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *KinesisStreamsOutputDescription) SetRoleARN(v string) *KinesisStreamsOutputDescription {
+	s.RoleARN = &v
+	return s
 }
 
 // When updating an output configuration using the UpdateApplication operation,
@@ -2950,6 +3562,18 @@ func (s *KinesisStreamsOutputUpdate) Validate() error {
 	return nil
 }
 
+// SetResourceARNUpdate sets the ResourceARNUpdate field's value.
+func (s *KinesisStreamsOutputUpdate) SetResourceARNUpdate(v string) *KinesisStreamsOutputUpdate {
+	s.ResourceARNUpdate = &v
+	return s
+}
+
+// SetRoleARNUpdate sets the RoleARNUpdate field's value.
+func (s *KinesisStreamsOutputUpdate) SetRoleARNUpdate(v string) *KinesisStreamsOutputUpdate {
+	s.RoleARNUpdate = &v
+	return s
+}
+
 type ListApplicationsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2989,6 +3613,18 @@ func (s *ListApplicationsInput) Validate() error {
 	return nil
 }
 
+// SetExclusiveStartApplicationName sets the ExclusiveStartApplicationName field's value.
+func (s *ListApplicationsInput) SetExclusiveStartApplicationName(v string) *ListApplicationsInput {
+	s.ExclusiveStartApplicationName = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListApplicationsInput) SetLimit(v int64) *ListApplicationsInput {
+	s.Limit = &v
+	return s
+}
+
 type ListApplicationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3011,6 +3647,18 @@ func (s ListApplicationsOutput) String() string {
 // GoString returns the string representation
 func (s ListApplicationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetApplicationSummaries sets the ApplicationSummaries field's value.
+func (s *ListApplicationsOutput) SetApplicationSummaries(v []*ApplicationSummary) *ListApplicationsOutput {
+	s.ApplicationSummaries = v
+	return s
+}
+
+// SetHasMoreApplications sets the HasMoreApplications field's value.
+func (s *ListApplicationsOutput) SetHasMoreApplications(v bool) *ListApplicationsOutput {
+	s.HasMoreApplications = &v
+	return s
 }
 
 // When configuring application input at the time of creating or updating an
@@ -3057,6 +3705,18 @@ func (s *MappingParameters) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCSVMappingParameters sets the CSVMappingParameters field's value.
+func (s *MappingParameters) SetCSVMappingParameters(v *CSVMappingParameters) *MappingParameters {
+	s.CSVMappingParameters = v
+	return s
+}
+
+// SetJSONMappingParameters sets the JSONMappingParameters field's value.
+func (s *MappingParameters) SetJSONMappingParameters(v *JSONMappingParameters) *MappingParameters {
+	s.JSONMappingParameters = v
+	return s
 }
 
 // Describes application output configuration in which you identify an in-application
@@ -3123,6 +3783,30 @@ func (s *Output) Validate() error {
 	return nil
 }
 
+// SetDestinationSchema sets the DestinationSchema field's value.
+func (s *Output) SetDestinationSchema(v *DestinationSchema) *Output {
+	s.DestinationSchema = v
+	return s
+}
+
+// SetKinesisFirehoseOutput sets the KinesisFirehoseOutput field's value.
+func (s *Output) SetKinesisFirehoseOutput(v *KinesisFirehoseOutput) *Output {
+	s.KinesisFirehoseOutput = v
+	return s
+}
+
+// SetKinesisStreamsOutput sets the KinesisStreamsOutput field's value.
+func (s *Output) SetKinesisStreamsOutput(v *KinesisStreamsOutput) *Output {
+	s.KinesisStreamsOutput = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Output) SetName(v string) *Output {
+	s.Name = &v
+	return s
+}
+
 // Describes the application output configuration, which includes the in-application
 // stream name and the destination where the stream data is written. The destination
 // can be an Amazon Kinesis stream or an Amazon Kinesis Firehose delivery stream.
@@ -3155,6 +3839,36 @@ func (s OutputDescription) String() string {
 // GoString returns the string representation
 func (s OutputDescription) GoString() string {
 	return s.String()
+}
+
+// SetDestinationSchema sets the DestinationSchema field's value.
+func (s *OutputDescription) SetDestinationSchema(v *DestinationSchema) *OutputDescription {
+	s.DestinationSchema = v
+	return s
+}
+
+// SetKinesisFirehoseOutputDescription sets the KinesisFirehoseOutputDescription field's value.
+func (s *OutputDescription) SetKinesisFirehoseOutputDescription(v *KinesisFirehoseOutputDescription) *OutputDescription {
+	s.KinesisFirehoseOutputDescription = v
+	return s
+}
+
+// SetKinesisStreamsOutputDescription sets the KinesisStreamsOutputDescription field's value.
+func (s *OutputDescription) SetKinesisStreamsOutputDescription(v *KinesisStreamsOutputDescription) *OutputDescription {
+	s.KinesisStreamsOutputDescription = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *OutputDescription) SetName(v string) *OutputDescription {
+	s.Name = &v
+	return s
+}
+
+// SetOutputId sets the OutputId field's value.
+func (s *OutputDescription) SetOutputId(v string) *OutputDescription {
+	s.OutputId = &v
+	return s
 }
 
 // Describes updates to the output configuration identified by the OutputId.
@@ -3221,6 +3935,36 @@ func (s *OutputUpdate) Validate() error {
 	return nil
 }
 
+// SetDestinationSchemaUpdate sets the DestinationSchemaUpdate field's value.
+func (s *OutputUpdate) SetDestinationSchemaUpdate(v *DestinationSchema) *OutputUpdate {
+	s.DestinationSchemaUpdate = v
+	return s
+}
+
+// SetKinesisFirehoseOutputUpdate sets the KinesisFirehoseOutputUpdate field's value.
+func (s *OutputUpdate) SetKinesisFirehoseOutputUpdate(v *KinesisFirehoseOutputUpdate) *OutputUpdate {
+	s.KinesisFirehoseOutputUpdate = v
+	return s
+}
+
+// SetKinesisStreamsOutputUpdate sets the KinesisStreamsOutputUpdate field's value.
+func (s *OutputUpdate) SetKinesisStreamsOutputUpdate(v *KinesisStreamsOutputUpdate) *OutputUpdate {
+	s.KinesisStreamsOutputUpdate = v
+	return s
+}
+
+// SetNameUpdate sets the NameUpdate field's value.
+func (s *OutputUpdate) SetNameUpdate(v string) *OutputUpdate {
+	s.NameUpdate = &v
+	return s
+}
+
+// SetOutputId sets the OutputId field's value.
+func (s *OutputUpdate) SetOutputId(v string) *OutputUpdate {
+	s.OutputId = &v
+	return s
+}
+
 // Describes the mapping of each data element in the streaming source to the
 // corresponding column in the in-application stream.
 //
@@ -3270,6 +4014,24 @@ func (s *RecordColumn) Validate() error {
 	return nil
 }
 
+// SetMapping sets the Mapping field's value.
+func (s *RecordColumn) SetMapping(v string) *RecordColumn {
+	s.Mapping = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RecordColumn) SetName(v string) *RecordColumn {
+	s.Name = &v
+	return s
+}
+
+// SetSqlType sets the SqlType field's value.
+func (s *RecordColumn) SetSqlType(v string) *RecordColumn {
+	s.SqlType = &v
+	return s
+}
+
 // Describes the record format and relevant mapping information that should
 // be applied to schematize the records on the stream.
 type RecordFormat struct {
@@ -3313,6 +4075,18 @@ func (s *RecordFormat) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMappingParameters sets the MappingParameters field's value.
+func (s *RecordFormat) SetMappingParameters(v *MappingParameters) *RecordFormat {
+	s.MappingParameters = v
+	return s
+}
+
+// SetRecordFormatType sets the RecordFormatType field's value.
+func (s *RecordFormat) SetRecordFormatType(v string) *RecordFormat {
+	s.RecordFormatType = &v
+	return s
 }
 
 // Describes the reference data source by providing the source information (S3
@@ -3382,6 +4156,24 @@ func (s *ReferenceDataSource) Validate() error {
 	return nil
 }
 
+// SetReferenceSchema sets the ReferenceSchema field's value.
+func (s *ReferenceDataSource) SetReferenceSchema(v *SourceSchema) *ReferenceDataSource {
+	s.ReferenceSchema = v
+	return s
+}
+
+// SetS3ReferenceDataSource sets the S3ReferenceDataSource field's value.
+func (s *ReferenceDataSource) SetS3ReferenceDataSource(v *S3ReferenceDataSource) *ReferenceDataSource {
+	s.S3ReferenceDataSource = v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *ReferenceDataSource) SetTableName(v string) *ReferenceDataSource {
+	s.TableName = &v
+	return s
+}
+
 // Describes the reference data source configured for an application.
 type ReferenceDataSourceDescription struct {
 	_ struct{} `type:"structure"`
@@ -3420,6 +4212,30 @@ func (s ReferenceDataSourceDescription) String() string {
 // GoString returns the string representation
 func (s ReferenceDataSourceDescription) GoString() string {
 	return s.String()
+}
+
+// SetReferenceId sets the ReferenceId field's value.
+func (s *ReferenceDataSourceDescription) SetReferenceId(v string) *ReferenceDataSourceDescription {
+	s.ReferenceId = &v
+	return s
+}
+
+// SetReferenceSchema sets the ReferenceSchema field's value.
+func (s *ReferenceDataSourceDescription) SetReferenceSchema(v *SourceSchema) *ReferenceDataSourceDescription {
+	s.ReferenceSchema = v
+	return s
+}
+
+// SetS3ReferenceDataSourceDescription sets the S3ReferenceDataSourceDescription field's value.
+func (s *ReferenceDataSourceDescription) SetS3ReferenceDataSourceDescription(v *S3ReferenceDataSourceDescription) *ReferenceDataSourceDescription {
+	s.S3ReferenceDataSourceDescription = v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *ReferenceDataSourceDescription) SetTableName(v string) *ReferenceDataSourceDescription {
+	s.TableName = &v
+	return s
 }
 
 // When you update a reference data source configuration for an application,
@@ -3488,6 +4304,30 @@ func (s *ReferenceDataSourceUpdate) Validate() error {
 	return nil
 }
 
+// SetReferenceId sets the ReferenceId field's value.
+func (s *ReferenceDataSourceUpdate) SetReferenceId(v string) *ReferenceDataSourceUpdate {
+	s.ReferenceId = &v
+	return s
+}
+
+// SetReferenceSchemaUpdate sets the ReferenceSchemaUpdate field's value.
+func (s *ReferenceDataSourceUpdate) SetReferenceSchemaUpdate(v *SourceSchema) *ReferenceDataSourceUpdate {
+	s.ReferenceSchemaUpdate = v
+	return s
+}
+
+// SetS3ReferenceDataSourceUpdate sets the S3ReferenceDataSourceUpdate field's value.
+func (s *ReferenceDataSourceUpdate) SetS3ReferenceDataSourceUpdate(v *S3ReferenceDataSourceUpdate) *ReferenceDataSourceUpdate {
+	s.S3ReferenceDataSourceUpdate = v
+	return s
+}
+
+// SetTableNameUpdate sets the TableNameUpdate field's value.
+func (s *ReferenceDataSourceUpdate) SetTableNameUpdate(v string) *ReferenceDataSourceUpdate {
+	s.TableNameUpdate = &v
+	return s
+}
+
 // Identifies the S3 bucket and object that contains the reference data. Also
 // identifies the IAM role Amazon Kinesis Analytics can assume to read this
 // object on your behalf.
@@ -3552,6 +4392,24 @@ func (s *S3ReferenceDataSource) Validate() error {
 	return nil
 }
 
+// SetBucketARN sets the BucketARN field's value.
+func (s *S3ReferenceDataSource) SetBucketARN(v string) *S3ReferenceDataSource {
+	s.BucketARN = &v
+	return s
+}
+
+// SetFileKey sets the FileKey field's value.
+func (s *S3ReferenceDataSource) SetFileKey(v string) *S3ReferenceDataSource {
+	s.FileKey = &v
+	return s
+}
+
+// SetReferenceRoleARN sets the ReferenceRoleARN field's value.
+func (s *S3ReferenceDataSource) SetReferenceRoleARN(v string) *S3ReferenceDataSource {
+	s.ReferenceRoleARN = &v
+	return s
+}
+
 // Provides the bucket name and object key name that stores the reference data.
 type S3ReferenceDataSourceDescription struct {
 	_ struct{} `type:"structure"`
@@ -3582,6 +4440,24 @@ func (s S3ReferenceDataSourceDescription) String() string {
 // GoString returns the string representation
 func (s S3ReferenceDataSourceDescription) GoString() string {
 	return s.String()
+}
+
+// SetBucketARN sets the BucketARN field's value.
+func (s *S3ReferenceDataSourceDescription) SetBucketARN(v string) *S3ReferenceDataSourceDescription {
+	s.BucketARN = &v
+	return s
+}
+
+// SetFileKey sets the FileKey field's value.
+func (s *S3ReferenceDataSourceDescription) SetFileKey(v string) *S3ReferenceDataSourceDescription {
+	s.FileKey = &v
+	return s
+}
+
+// SetReferenceRoleARN sets the ReferenceRoleARN field's value.
+func (s *S3ReferenceDataSourceDescription) SetReferenceRoleARN(v string) *S3ReferenceDataSourceDescription {
+	s.ReferenceRoleARN = &v
+	return s
 }
 
 // Describes the S3 bucket name, object key name, and IAM role that Amazon Kinesis
@@ -3625,6 +4501,24 @@ func (s *S3ReferenceDataSourceUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucketARNUpdate sets the BucketARNUpdate field's value.
+func (s *S3ReferenceDataSourceUpdate) SetBucketARNUpdate(v string) *S3ReferenceDataSourceUpdate {
+	s.BucketARNUpdate = &v
+	return s
+}
+
+// SetFileKeyUpdate sets the FileKeyUpdate field's value.
+func (s *S3ReferenceDataSourceUpdate) SetFileKeyUpdate(v string) *S3ReferenceDataSourceUpdate {
+	s.FileKeyUpdate = &v
+	return s
+}
+
+// SetReferenceRoleARNUpdate sets the ReferenceRoleARNUpdate field's value.
+func (s *S3ReferenceDataSourceUpdate) SetReferenceRoleARNUpdate(v string) *S3ReferenceDataSourceUpdate {
+	s.ReferenceRoleARNUpdate = &v
+	return s
 }
 
 // Describes the format of the data in the streaming source, and how each data
@@ -3691,6 +4585,24 @@ func (s *SourceSchema) Validate() error {
 	return nil
 }
 
+// SetRecordColumns sets the RecordColumns field's value.
+func (s *SourceSchema) SetRecordColumns(v []*RecordColumn) *SourceSchema {
+	s.RecordColumns = v
+	return s
+}
+
+// SetRecordEncoding sets the RecordEncoding field's value.
+func (s *SourceSchema) SetRecordEncoding(v string) *SourceSchema {
+	s.RecordEncoding = &v
+	return s
+}
+
+// SetRecordFormat sets the RecordFormat field's value.
+func (s *SourceSchema) SetRecordFormat(v *RecordFormat) *SourceSchema {
+	s.RecordFormat = v
+	return s
+}
+
 type StartApplicationInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3747,6 +4659,18 @@ func (s *StartApplicationInput) Validate() error {
 	return nil
 }
 
+// SetApplicationName sets the ApplicationName field's value.
+func (s *StartApplicationInput) SetApplicationName(v string) *StartApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetInputConfigurations sets the InputConfigurations field's value.
+func (s *StartApplicationInput) SetInputConfigurations(v []*InputConfiguration) *StartApplicationInput {
+	s.InputConfigurations = v
+	return s
+}
+
 type StartApplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3794,6 +4718,12 @@ func (s *StopApplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *StopApplicationInput) SetApplicationName(v string) *StopApplicationInput {
+	s.ApplicationName = &v
+	return s
 }
 
 type StopApplicationOutput struct {
@@ -3868,6 +4798,24 @@ func (s *UpdateApplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *UpdateApplicationInput) SetApplicationName(v string) *UpdateApplicationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetApplicationUpdate sets the ApplicationUpdate field's value.
+func (s *UpdateApplicationInput) SetApplicationUpdate(v *ApplicationUpdate) *UpdateApplicationInput {
+	s.ApplicationUpdate = v
+	return s
+}
+
+// SetCurrentApplicationVersionId sets the CurrentApplicationVersionId field's value.
+func (s *UpdateApplicationInput) SetCurrentApplicationVersionId(v int64) *UpdateApplicationInput {
+	s.CurrentApplicationVersionId = &v
+	return s
 }
 
 type UpdateApplicationOutput struct {

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -3201,6 +3201,24 @@ func (s AliasListEntry) GoString() string {
 	return s.String()
 }
 
+// SetAliasArn sets the AliasArn field's value.
+func (s *AliasListEntry) SetAliasArn(v string) *AliasListEntry {
+	s.AliasArn = &v
+	return s
+}
+
+// SetAliasName sets the AliasName field's value.
+func (s *AliasListEntry) SetAliasName(v string) *AliasListEntry {
+	s.AliasName = &v
+	return s
+}
+
+// SetTargetKeyId sets the TargetKeyId field's value.
+func (s *AliasListEntry) SetTargetKeyId(v string) *AliasListEntry {
+	s.TargetKeyId = &v
+	return s
+}
+
 type CancelKeyDeletionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3247,6 +3265,12 @@ func (s *CancelKeyDeletionInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *CancelKeyDeletionInput) SetKeyId(v string) *CancelKeyDeletionInput {
+	s.KeyId = &v
+	return s
+}
+
 type CancelKeyDeletionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3262,6 +3286,12 @@ func (s CancelKeyDeletionOutput) String() string {
 // GoString returns the string representation
 func (s CancelKeyDeletionOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *CancelKeyDeletionOutput) SetKeyId(v string) *CancelKeyDeletionOutput {
+	s.KeyId = &v
+	return s
 }
 
 type CreateAliasInput struct {
@@ -3316,6 +3346,18 @@ func (s *CreateAliasInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAliasName sets the AliasName field's value.
+func (s *CreateAliasInput) SetAliasName(v string) *CreateAliasInput {
+	s.AliasName = &v
+	return s
+}
+
+// SetTargetKeyId sets the TargetKeyId field's value.
+func (s *CreateAliasInput) SetTargetKeyId(v string) *CreateAliasInput {
+	s.TargetKeyId = &v
+	return s
 }
 
 type CreateAliasOutput struct {
@@ -3461,6 +3503,48 @@ func (s *CreateGrantInput) Validate() error {
 	return nil
 }
 
+// SetConstraints sets the Constraints field's value.
+func (s *CreateGrantInput) SetConstraints(v *GrantConstraints) *CreateGrantInput {
+	s.Constraints = v
+	return s
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *CreateGrantInput) SetGrantTokens(v []*string) *CreateGrantInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetGranteePrincipal sets the GranteePrincipal field's value.
+func (s *CreateGrantInput) SetGranteePrincipal(v string) *CreateGrantInput {
+	s.GranteePrincipal = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *CreateGrantInput) SetKeyId(v string) *CreateGrantInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateGrantInput) SetName(v string) *CreateGrantInput {
+	s.Name = &v
+	return s
+}
+
+// SetOperations sets the Operations field's value.
+func (s *CreateGrantInput) SetOperations(v []*string) *CreateGrantInput {
+	s.Operations = v
+	return s
+}
+
+// SetRetiringPrincipal sets the RetiringPrincipal field's value.
+func (s *CreateGrantInput) SetRetiringPrincipal(v string) *CreateGrantInput {
+	s.RetiringPrincipal = &v
+	return s
+}
+
 type CreateGrantOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3484,6 +3568,18 @@ func (s CreateGrantOutput) String() string {
 // GoString returns the string representation
 func (s CreateGrantOutput) GoString() string {
 	return s.String()
+}
+
+// SetGrantId sets the GrantId field's value.
+func (s *CreateGrantOutput) SetGrantId(v string) *CreateGrantOutput {
+	s.GrantId = &v
+	return s
+}
+
+// SetGrantToken sets the GrantToken field's value.
+func (s *CreateGrantOutput) SetGrantToken(v string) *CreateGrantOutput {
+	s.GrantToken = &v
+	return s
 }
 
 type CreateKeyInput struct {
@@ -3577,6 +3673,36 @@ func (s *CreateKeyInput) Validate() error {
 	return nil
 }
 
+// SetBypassPolicyLockoutSafetyCheck sets the BypassPolicyLockoutSafetyCheck field's value.
+func (s *CreateKeyInput) SetBypassPolicyLockoutSafetyCheck(v bool) *CreateKeyInput {
+	s.BypassPolicyLockoutSafetyCheck = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateKeyInput) SetDescription(v string) *CreateKeyInput {
+	s.Description = &v
+	return s
+}
+
+// SetKeyUsage sets the KeyUsage field's value.
+func (s *CreateKeyInput) SetKeyUsage(v string) *CreateKeyInput {
+	s.KeyUsage = &v
+	return s
+}
+
+// SetOrigin sets the Origin field's value.
+func (s *CreateKeyInput) SetOrigin(v string) *CreateKeyInput {
+	s.Origin = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *CreateKeyInput) SetPolicy(v string) *CreateKeyInput {
+	s.Policy = &v
+	return s
+}
+
 type CreateKeyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3592,6 +3718,12 @@ func (s CreateKeyOutput) String() string {
 // GoString returns the string representation
 func (s CreateKeyOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeyMetadata sets the KeyMetadata field's value.
+func (s *CreateKeyOutput) SetKeyMetadata(v *KeyMetadata) *CreateKeyOutput {
+	s.KeyMetadata = v
+	return s
 }
 
 type DecryptInput struct {
@@ -3642,6 +3774,24 @@ func (s *DecryptInput) Validate() error {
 	return nil
 }
 
+// SetCiphertextBlob sets the CiphertextBlob field's value.
+func (s *DecryptInput) SetCiphertextBlob(v []byte) *DecryptInput {
+	s.CiphertextBlob = v
+	return s
+}
+
+// SetEncryptionContext sets the EncryptionContext field's value.
+func (s *DecryptInput) SetEncryptionContext(v map[string]*string) *DecryptInput {
+	s.EncryptionContext = v
+	return s
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *DecryptInput) SetGrantTokens(v []*string) *DecryptInput {
+	s.GrantTokens = v
+	return s
+}
+
 type DecryptOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3664,6 +3814,18 @@ func (s DecryptOutput) String() string {
 // GoString returns the string representation
 func (s DecryptOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *DecryptOutput) SetKeyId(v string) *DecryptOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPlaintext sets the Plaintext field's value.
+func (s *DecryptOutput) SetPlaintext(v []byte) *DecryptOutput {
+	s.Plaintext = v
+	return s
 }
 
 type DeleteAliasInput struct {
@@ -3700,6 +3862,12 @@ func (s *DeleteAliasInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAliasName sets the AliasName field's value.
+func (s *DeleteAliasInput) SetAliasName(v string) *DeleteAliasInput {
+	s.AliasName = &v
+	return s
 }
 
 type DeleteAliasOutput struct {
@@ -3757,6 +3925,12 @@ func (s *DeleteImportedKeyMaterialInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *DeleteImportedKeyMaterialInput) SetKeyId(v string) *DeleteImportedKeyMaterialInput {
+	s.KeyId = &v
+	return s
 }
 
 type DeleteImportedKeyMaterialOutput struct {
@@ -3824,6 +3998,18 @@ func (s *DescribeKeyInput) Validate() error {
 	return nil
 }
 
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *DescribeKeyInput) SetGrantTokens(v []*string) *DescribeKeyInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *DescribeKeyInput) SetKeyId(v string) *DescribeKeyInput {
+	s.KeyId = &v
+	return s
+}
+
 type DescribeKeyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3839,6 +4025,12 @@ func (s DescribeKeyOutput) String() string {
 // GoString returns the string representation
 func (s DescribeKeyOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeyMetadata sets the KeyMetadata field's value.
+func (s *DescribeKeyOutput) SetKeyMetadata(v *KeyMetadata) *DescribeKeyOutput {
+	s.KeyMetadata = v
+	return s
 }
 
 type DisableKeyInput struct {
@@ -3880,6 +4072,12 @@ func (s *DisableKeyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *DisableKeyInput) SetKeyId(v string) *DisableKeyInput {
+	s.KeyId = &v
+	return s
 }
 
 type DisableKeyOutput struct {
@@ -3936,6 +4134,12 @@ func (s *DisableKeyRotationInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *DisableKeyRotationInput) SetKeyId(v string) *DisableKeyRotationInput {
+	s.KeyId = &v
+	return s
+}
+
 type DisableKeyRotationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3990,6 +4194,12 @@ func (s *EnableKeyInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *EnableKeyInput) SetKeyId(v string) *EnableKeyInput {
+	s.KeyId = &v
+	return s
+}
+
 type EnableKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4042,6 +4252,12 @@ func (s *EnableKeyRotationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *EnableKeyRotationInput) SetKeyId(v string) *EnableKeyRotationInput {
+	s.KeyId = &v
+	return s
 }
 
 type EnableKeyRotationOutput struct {
@@ -4128,6 +4344,30 @@ func (s *EncryptInput) Validate() error {
 	return nil
 }
 
+// SetEncryptionContext sets the EncryptionContext field's value.
+func (s *EncryptInput) SetEncryptionContext(v map[string]*string) *EncryptInput {
+	s.EncryptionContext = v
+	return s
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *EncryptInput) SetGrantTokens(v []*string) *EncryptInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *EncryptInput) SetKeyId(v string) *EncryptInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPlaintext sets the Plaintext field's value.
+func (s *EncryptInput) SetPlaintext(v []byte) *EncryptInput {
+	s.Plaintext = v
+	return s
+}
+
 type EncryptOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4149,6 +4389,18 @@ func (s EncryptOutput) String() string {
 // GoString returns the string representation
 func (s EncryptOutput) GoString() string {
 	return s.String()
+}
+
+// SetCiphertextBlob sets the CiphertextBlob field's value.
+func (s *EncryptOutput) SetCiphertextBlob(v []byte) *EncryptOutput {
+	s.CiphertextBlob = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *EncryptOutput) SetKeyId(v string) *EncryptOutput {
+	s.KeyId = &v
+	return s
 }
 
 type GenerateDataKeyInput struct {
@@ -4224,6 +4476,36 @@ func (s *GenerateDataKeyInput) Validate() error {
 	return nil
 }
 
+// SetEncryptionContext sets the EncryptionContext field's value.
+func (s *GenerateDataKeyInput) SetEncryptionContext(v map[string]*string) *GenerateDataKeyInput {
+	s.EncryptionContext = v
+	return s
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *GenerateDataKeyInput) SetGrantTokens(v []*string) *GenerateDataKeyInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GenerateDataKeyInput) SetKeyId(v string) *GenerateDataKeyInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeySpec sets the KeySpec field's value.
+func (s *GenerateDataKeyInput) SetKeySpec(v string) *GenerateDataKeyInput {
+	s.KeySpec = &v
+	return s
+}
+
+// SetNumberOfBytes sets the NumberOfBytes field's value.
+func (s *GenerateDataKeyInput) SetNumberOfBytes(v int64) *GenerateDataKeyInput {
+	s.NumberOfBytes = &v
+	return s
+}
+
 type GenerateDataKeyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4251,6 +4533,24 @@ func (s GenerateDataKeyOutput) String() string {
 // GoString returns the string representation
 func (s GenerateDataKeyOutput) GoString() string {
 	return s.String()
+}
+
+// SetCiphertextBlob sets the CiphertextBlob field's value.
+func (s *GenerateDataKeyOutput) SetCiphertextBlob(v []byte) *GenerateDataKeyOutput {
+	s.CiphertextBlob = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GenerateDataKeyOutput) SetKeyId(v string) *GenerateDataKeyOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPlaintext sets the Plaintext field's value.
+func (s *GenerateDataKeyOutput) SetPlaintext(v []byte) *GenerateDataKeyOutput {
+	s.Plaintext = v
+	return s
 }
 
 type GenerateDataKeyWithoutPlaintextInput struct {
@@ -4326,6 +4626,36 @@ func (s *GenerateDataKeyWithoutPlaintextInput) Validate() error {
 	return nil
 }
 
+// SetEncryptionContext sets the EncryptionContext field's value.
+func (s *GenerateDataKeyWithoutPlaintextInput) SetEncryptionContext(v map[string]*string) *GenerateDataKeyWithoutPlaintextInput {
+	s.EncryptionContext = v
+	return s
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *GenerateDataKeyWithoutPlaintextInput) SetGrantTokens(v []*string) *GenerateDataKeyWithoutPlaintextInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GenerateDataKeyWithoutPlaintextInput) SetKeyId(v string) *GenerateDataKeyWithoutPlaintextInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeySpec sets the KeySpec field's value.
+func (s *GenerateDataKeyWithoutPlaintextInput) SetKeySpec(v string) *GenerateDataKeyWithoutPlaintextInput {
+	s.KeySpec = &v
+	return s
+}
+
+// SetNumberOfBytes sets the NumberOfBytes field's value.
+func (s *GenerateDataKeyWithoutPlaintextInput) SetNumberOfBytes(v int64) *GenerateDataKeyWithoutPlaintextInput {
+	s.NumberOfBytes = &v
+	return s
+}
+
 type GenerateDataKeyWithoutPlaintextOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4347,6 +4677,18 @@ func (s GenerateDataKeyWithoutPlaintextOutput) String() string {
 // GoString returns the string representation
 func (s GenerateDataKeyWithoutPlaintextOutput) GoString() string {
 	return s.String()
+}
+
+// SetCiphertextBlob sets the CiphertextBlob field's value.
+func (s *GenerateDataKeyWithoutPlaintextOutput) SetCiphertextBlob(v []byte) *GenerateDataKeyWithoutPlaintextOutput {
+	s.CiphertextBlob = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GenerateDataKeyWithoutPlaintextOutput) SetKeyId(v string) *GenerateDataKeyWithoutPlaintextOutput {
+	s.KeyId = &v
+	return s
 }
 
 type GenerateRandomInput struct {
@@ -4379,6 +4721,12 @@ func (s *GenerateRandomInput) Validate() error {
 	return nil
 }
 
+// SetNumberOfBytes sets the NumberOfBytes field's value.
+func (s *GenerateRandomInput) SetNumberOfBytes(v int64) *GenerateRandomInput {
+	s.NumberOfBytes = &v
+	return s
+}
+
 type GenerateRandomOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4396,6 +4744,12 @@ func (s GenerateRandomOutput) String() string {
 // GoString returns the string representation
 func (s GenerateRandomOutput) GoString() string {
 	return s.String()
+}
+
+// SetPlaintext sets the Plaintext field's value.
+func (s *GenerateRandomOutput) SetPlaintext(v []byte) *GenerateRandomOutput {
+	s.Plaintext = v
+	return s
 }
 
 type GetKeyPolicyInput struct {
@@ -4450,6 +4804,18 @@ func (s *GetKeyPolicyInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *GetKeyPolicyInput) SetKeyId(v string) *GetKeyPolicyInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *GetKeyPolicyInput) SetPolicyName(v string) *GetKeyPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 type GetKeyPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4465,6 +4831,12 @@ func (s GetKeyPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetKeyPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetKeyPolicyOutput) SetPolicy(v string) *GetKeyPolicyOutput {
+	s.Policy = &v
+	return s
 }
 
 type GetKeyRotationStatusInput struct {
@@ -4507,6 +4879,12 @@ func (s *GetKeyRotationStatusInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *GetKeyRotationStatusInput) SetKeyId(v string) *GetKeyRotationStatusInput {
+	s.KeyId = &v
+	return s
+}
+
 type GetKeyRotationStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4522,6 +4900,12 @@ func (s GetKeyRotationStatusOutput) String() string {
 // GoString returns the string representation
 func (s GetKeyRotationStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeyRotationEnabled sets the KeyRotationEnabled field's value.
+func (s *GetKeyRotationStatusOutput) SetKeyRotationEnabled(v bool) *GetKeyRotationStatusOutput {
+	s.KeyRotationEnabled = &v
+	return s
 }
 
 type GetParametersForImportInput struct {
@@ -4587,6 +4971,24 @@ func (s *GetParametersForImportInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *GetParametersForImportInput) SetKeyId(v string) *GetParametersForImportInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetWrappingAlgorithm sets the WrappingAlgorithm field's value.
+func (s *GetParametersForImportInput) SetWrappingAlgorithm(v string) *GetParametersForImportInput {
+	s.WrappingAlgorithm = &v
+	return s
+}
+
+// SetWrappingKeySpec sets the WrappingKeySpec field's value.
+func (s *GetParametersForImportInput) SetWrappingKeySpec(v string) *GetParametersForImportInput {
+	s.WrappingKeySpec = &v
+	return s
+}
+
 type GetParametersForImportOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4619,6 +5021,30 @@ func (s GetParametersForImportOutput) String() string {
 // GoString returns the string representation
 func (s GetParametersForImportOutput) GoString() string {
 	return s.String()
+}
+
+// SetImportToken sets the ImportToken field's value.
+func (s *GetParametersForImportOutput) SetImportToken(v []byte) *GetParametersForImportOutput {
+	s.ImportToken = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GetParametersForImportOutput) SetKeyId(v string) *GetParametersForImportOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetParametersValidTo sets the ParametersValidTo field's value.
+func (s *GetParametersForImportOutput) SetParametersValidTo(v time.Time) *GetParametersForImportOutput {
+	s.ParametersValidTo = &v
+	return s
+}
+
+// SetPublicKey sets the PublicKey field's value.
+func (s *GetParametersForImportOutput) SetPublicKey(v []byte) *GetParametersForImportOutput {
+	s.PublicKey = v
+	return s
 }
 
 // A structure for specifying the conditions under which the operations permitted
@@ -4654,6 +5080,18 @@ func (s GrantConstraints) String() string {
 // GoString returns the string representation
 func (s GrantConstraints) GoString() string {
 	return s.String()
+}
+
+// SetEncryptionContextEquals sets the EncryptionContextEquals field's value.
+func (s *GrantConstraints) SetEncryptionContextEquals(v map[string]*string) *GrantConstraints {
+	s.EncryptionContextEquals = v
+	return s
+}
+
+// SetEncryptionContextSubset sets the EncryptionContextSubset field's value.
+func (s *GrantConstraints) SetEncryptionContextSubset(v map[string]*string) *GrantConstraints {
+	s.EncryptionContextSubset = v
+	return s
 }
 
 // Contains information about an entry in a list of grants.
@@ -4698,6 +5136,60 @@ func (s GrantListEntry) String() string {
 // GoString returns the string representation
 func (s GrantListEntry) GoString() string {
 	return s.String()
+}
+
+// SetConstraints sets the Constraints field's value.
+func (s *GrantListEntry) SetConstraints(v *GrantConstraints) *GrantListEntry {
+	s.Constraints = v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *GrantListEntry) SetCreationDate(v time.Time) *GrantListEntry {
+	s.CreationDate = &v
+	return s
+}
+
+// SetGrantId sets the GrantId field's value.
+func (s *GrantListEntry) SetGrantId(v string) *GrantListEntry {
+	s.GrantId = &v
+	return s
+}
+
+// SetGranteePrincipal sets the GranteePrincipal field's value.
+func (s *GrantListEntry) SetGranteePrincipal(v string) *GrantListEntry {
+	s.GranteePrincipal = &v
+	return s
+}
+
+// SetIssuingAccount sets the IssuingAccount field's value.
+func (s *GrantListEntry) SetIssuingAccount(v string) *GrantListEntry {
+	s.IssuingAccount = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *GrantListEntry) SetKeyId(v string) *GrantListEntry {
+	s.KeyId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GrantListEntry) SetName(v string) *GrantListEntry {
+	s.Name = &v
+	return s
+}
+
+// SetOperations sets the Operations field's value.
+func (s *GrantListEntry) SetOperations(v []*string) *GrantListEntry {
+	s.Operations = v
+	return s
+}
+
+// SetRetiringPrincipal sets the RetiringPrincipal field's value.
+func (s *GrantListEntry) SetRetiringPrincipal(v string) *GrantListEntry {
+	s.RetiringPrincipal = &v
+	return s
 }
 
 type ImportKeyMaterialInput struct {
@@ -4784,6 +5276,36 @@ func (s *ImportKeyMaterialInput) Validate() error {
 	return nil
 }
 
+// SetEncryptedKeyMaterial sets the EncryptedKeyMaterial field's value.
+func (s *ImportKeyMaterialInput) SetEncryptedKeyMaterial(v []byte) *ImportKeyMaterialInput {
+	s.EncryptedKeyMaterial = v
+	return s
+}
+
+// SetExpirationModel sets the ExpirationModel field's value.
+func (s *ImportKeyMaterialInput) SetExpirationModel(v string) *ImportKeyMaterialInput {
+	s.ExpirationModel = &v
+	return s
+}
+
+// SetImportToken sets the ImportToken field's value.
+func (s *ImportKeyMaterialInput) SetImportToken(v []byte) *ImportKeyMaterialInput {
+	s.ImportToken = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *ImportKeyMaterialInput) SetKeyId(v string) *ImportKeyMaterialInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetValidTo sets the ValidTo field's value.
+func (s *ImportKeyMaterialInput) SetValidTo(v time.Time) *ImportKeyMaterialInput {
+	s.ValidTo = &v
+	return s
+}
+
 type ImportKeyMaterialOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4817,6 +5339,18 @@ func (s KeyListEntry) String() string {
 // GoString returns the string representation
 func (s KeyListEntry) GoString() string {
 	return s.String()
+}
+
+// SetKeyArn sets the KeyArn field's value.
+func (s *KeyListEntry) SetKeyArn(v string) *KeyListEntry {
+	s.KeyArn = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *KeyListEntry) SetKeyId(v string) *KeyListEntry {
+	s.KeyId = &v
+	return s
 }
 
 // Contains metadata about a customer master key (CMK).
@@ -4892,6 +5426,78 @@ func (s KeyMetadata) GoString() string {
 	return s.String()
 }
 
+// SetAWSAccountId sets the AWSAccountId field's value.
+func (s *KeyMetadata) SetAWSAccountId(v string) *KeyMetadata {
+	s.AWSAccountId = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *KeyMetadata) SetArn(v string) *KeyMetadata {
+	s.Arn = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *KeyMetadata) SetCreationDate(v time.Time) *KeyMetadata {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDeletionDate sets the DeletionDate field's value.
+func (s *KeyMetadata) SetDeletionDate(v time.Time) *KeyMetadata {
+	s.DeletionDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *KeyMetadata) SetDescription(v string) *KeyMetadata {
+	s.Description = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *KeyMetadata) SetEnabled(v bool) *KeyMetadata {
+	s.Enabled = &v
+	return s
+}
+
+// SetExpirationModel sets the ExpirationModel field's value.
+func (s *KeyMetadata) SetExpirationModel(v string) *KeyMetadata {
+	s.ExpirationModel = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *KeyMetadata) SetKeyId(v string) *KeyMetadata {
+	s.KeyId = &v
+	return s
+}
+
+// SetKeyState sets the KeyState field's value.
+func (s *KeyMetadata) SetKeyState(v string) *KeyMetadata {
+	s.KeyState = &v
+	return s
+}
+
+// SetKeyUsage sets the KeyUsage field's value.
+func (s *KeyMetadata) SetKeyUsage(v string) *KeyMetadata {
+	s.KeyUsage = &v
+	return s
+}
+
+// SetOrigin sets the Origin field's value.
+func (s *KeyMetadata) SetOrigin(v string) *KeyMetadata {
+	s.Origin = &v
+	return s
+}
+
+// SetValidTo sets the ValidTo field's value.
+func (s *KeyMetadata) SetValidTo(v time.Time) *KeyMetadata {
+	s.ValidTo = &v
+	return s
+}
+
 type ListAliasesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4935,6 +5541,18 @@ func (s *ListAliasesInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListAliasesInput) SetLimit(v int64) *ListAliasesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAliasesInput) SetMarker(v string) *ListAliasesInput {
+	s.Marker = &v
+	return s
+}
+
 type ListAliasesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4959,6 +5577,24 @@ func (s ListAliasesOutput) String() string {
 // GoString returns the string representation
 func (s ListAliasesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAliases sets the Aliases field's value.
+func (s *ListAliasesOutput) SetAliases(v []*AliasListEntry) *ListAliasesOutput {
+	s.Aliases = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListAliasesOutput) SetNextMarker(v string) *ListAliasesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetTruncated sets the Truncated field's value.
+func (s *ListAliasesOutput) SetTruncated(v bool) *ListAliasesOutput {
+	s.Truncated = &v
+	return s
 }
 
 type ListGrantsInput struct {
@@ -5020,6 +5656,24 @@ func (s *ListGrantsInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *ListGrantsInput) SetKeyId(v string) *ListGrantsInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListGrantsInput) SetLimit(v int64) *ListGrantsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListGrantsInput) SetMarker(v string) *ListGrantsInput {
+	s.Marker = &v
+	return s
+}
+
 type ListGrantsResponse struct {
 	_ struct{} `type:"structure"`
 
@@ -5044,6 +5698,24 @@ func (s ListGrantsResponse) String() string {
 // GoString returns the string representation
 func (s ListGrantsResponse) GoString() string {
 	return s.String()
+}
+
+// SetGrants sets the Grants field's value.
+func (s *ListGrantsResponse) SetGrants(v []*GrantListEntry) *ListGrantsResponse {
+	s.Grants = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListGrantsResponse) SetNextMarker(v string) *ListGrantsResponse {
+	s.NextMarker = &v
+	return s
+}
+
+// SetTruncated sets the Truncated field's value.
+func (s *ListGrantsResponse) SetTruncated(v bool) *ListGrantsResponse {
+	s.Truncated = &v
+	return s
 }
 
 type ListKeyPoliciesInput struct {
@@ -5112,6 +5784,24 @@ func (s *ListKeyPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *ListKeyPoliciesInput) SetKeyId(v string) *ListKeyPoliciesInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListKeyPoliciesInput) SetLimit(v int64) *ListKeyPoliciesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListKeyPoliciesInput) SetMarker(v string) *ListKeyPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
 type ListKeyPoliciesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5137,6 +5827,24 @@ func (s ListKeyPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListKeyPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListKeyPoliciesOutput) SetNextMarker(v string) *ListKeyPoliciesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *ListKeyPoliciesOutput) SetPolicyNames(v []*string) *ListKeyPoliciesOutput {
+	s.PolicyNames = v
+	return s
+}
+
+// SetTruncated sets the Truncated field's value.
+func (s *ListKeyPoliciesOutput) SetTruncated(v bool) *ListKeyPoliciesOutput {
+	s.Truncated = &v
+	return s
 }
 
 type ListKeysInput struct {
@@ -5182,6 +5890,18 @@ func (s *ListKeysInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListKeysInput) SetLimit(v int64) *ListKeysInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListKeysInput) SetMarker(v string) *ListKeysInput {
+	s.Marker = &v
+	return s
+}
+
 type ListKeysOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5206,6 +5926,24 @@ func (s ListKeysOutput) String() string {
 // GoString returns the string representation
 func (s ListKeysOutput) GoString() string {
 	return s.String()
+}
+
+// SetKeys sets the Keys field's value.
+func (s *ListKeysOutput) SetKeys(v []*KeyListEntry) *ListKeysOutput {
+	s.Keys = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListKeysOutput) SetNextMarker(v string) *ListKeysOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetTruncated sets the Truncated field's value.
+func (s *ListKeysOutput) SetTruncated(v bool) *ListKeysOutput {
+	s.Truncated = &v
+	return s
 }
 
 type ListRetirableGrantsInput struct {
@@ -5267,6 +6005,24 @@ func (s *ListRetirableGrantsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListRetirableGrantsInput) SetLimit(v int64) *ListRetirableGrantsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListRetirableGrantsInput) SetMarker(v string) *ListRetirableGrantsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetRetiringPrincipal sets the RetiringPrincipal field's value.
+func (s *ListRetirableGrantsInput) SetRetiringPrincipal(v string) *ListRetirableGrantsInput {
+	s.RetiringPrincipal = &v
+	return s
 }
 
 type PutKeyPolicyInput struct {
@@ -5367,6 +6123,30 @@ func (s *PutKeyPolicyInput) Validate() error {
 	return nil
 }
 
+// SetBypassPolicyLockoutSafetyCheck sets the BypassPolicyLockoutSafetyCheck field's value.
+func (s *PutKeyPolicyInput) SetBypassPolicyLockoutSafetyCheck(v bool) *PutKeyPolicyInput {
+	s.BypassPolicyLockoutSafetyCheck = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *PutKeyPolicyInput) SetKeyId(v string) *PutKeyPolicyInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *PutKeyPolicyInput) SetPolicy(v string) *PutKeyPolicyInput {
+	s.Policy = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *PutKeyPolicyInput) SetPolicyName(v string) *PutKeyPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 type PutKeyPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5452,6 +6232,36 @@ func (s *ReEncryptInput) Validate() error {
 	return nil
 }
 
+// SetCiphertextBlob sets the CiphertextBlob field's value.
+func (s *ReEncryptInput) SetCiphertextBlob(v []byte) *ReEncryptInput {
+	s.CiphertextBlob = v
+	return s
+}
+
+// SetDestinationEncryptionContext sets the DestinationEncryptionContext field's value.
+func (s *ReEncryptInput) SetDestinationEncryptionContext(v map[string]*string) *ReEncryptInput {
+	s.DestinationEncryptionContext = v
+	return s
+}
+
+// SetDestinationKeyId sets the DestinationKeyId field's value.
+func (s *ReEncryptInput) SetDestinationKeyId(v string) *ReEncryptInput {
+	s.DestinationKeyId = &v
+	return s
+}
+
+// SetGrantTokens sets the GrantTokens field's value.
+func (s *ReEncryptInput) SetGrantTokens(v []*string) *ReEncryptInput {
+	s.GrantTokens = v
+	return s
+}
+
+// SetSourceEncryptionContext sets the SourceEncryptionContext field's value.
+func (s *ReEncryptInput) SetSourceEncryptionContext(v map[string]*string) *ReEncryptInput {
+	s.SourceEncryptionContext = v
+	return s
+}
+
 type ReEncryptOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5476,6 +6286,24 @@ func (s ReEncryptOutput) String() string {
 // GoString returns the string representation
 func (s ReEncryptOutput) GoString() string {
 	return s.String()
+}
+
+// SetCiphertextBlob sets the CiphertextBlob field's value.
+func (s *ReEncryptOutput) SetCiphertextBlob(v []byte) *ReEncryptOutput {
+	s.CiphertextBlob = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *ReEncryptOutput) SetKeyId(v string) *ReEncryptOutput {
+	s.KeyId = &v
+	return s
+}
+
+// SetSourceKeyId sets the SourceKeyId field's value.
+func (s *ReEncryptOutput) SetSourceKeyId(v string) *ReEncryptOutput {
+	s.SourceKeyId = &v
+	return s
 }
 
 type RetireGrantInput struct {
@@ -5527,6 +6355,24 @@ func (s *RetireGrantInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGrantId sets the GrantId field's value.
+func (s *RetireGrantInput) SetGrantId(v string) *RetireGrantInput {
+	s.GrantId = &v
+	return s
+}
+
+// SetGrantToken sets the GrantToken field's value.
+func (s *RetireGrantInput) SetGrantToken(v string) *RetireGrantInput {
+	s.GrantToken = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *RetireGrantInput) SetKeyId(v string) *RetireGrantInput {
+	s.KeyId = &v
+	return s
 }
 
 type RetireGrantOutput struct {
@@ -5593,6 +6439,18 @@ func (s *RevokeGrantInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGrantId sets the GrantId field's value.
+func (s *RevokeGrantInput) SetGrantId(v string) *RevokeGrantInput {
+	s.GrantId = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *RevokeGrantInput) SetKeyId(v string) *RevokeGrantInput {
+	s.KeyId = &v
+	return s
 }
 
 type RevokeGrantOutput struct {
@@ -5664,6 +6522,18 @@ func (s *ScheduleKeyDeletionInput) Validate() error {
 	return nil
 }
 
+// SetKeyId sets the KeyId field's value.
+func (s *ScheduleKeyDeletionInput) SetKeyId(v string) *ScheduleKeyDeletionInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetPendingWindowInDays sets the PendingWindowInDays field's value.
+func (s *ScheduleKeyDeletionInput) SetPendingWindowInDays(v int64) *ScheduleKeyDeletionInput {
+	s.PendingWindowInDays = &v
+	return s
+}
+
 type ScheduleKeyDeletionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5683,6 +6553,18 @@ func (s ScheduleKeyDeletionOutput) String() string {
 // GoString returns the string representation
 func (s ScheduleKeyDeletionOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeletionDate sets the DeletionDate field's value.
+func (s *ScheduleKeyDeletionOutput) SetDeletionDate(v time.Time) *ScheduleKeyDeletionOutput {
+	s.DeletionDate = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *ScheduleKeyDeletionOutput) SetKeyId(v string) *ScheduleKeyDeletionOutput {
+	s.KeyId = &v
+	return s
 }
 
 type UpdateAliasInput struct {
@@ -5740,6 +6622,18 @@ func (s *UpdateAliasInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAliasName sets the AliasName field's value.
+func (s *UpdateAliasInput) SetAliasName(v string) *UpdateAliasInput {
+	s.AliasName = &v
+	return s
+}
+
+// SetTargetKeyId sets the TargetKeyId field's value.
+func (s *UpdateAliasInput) SetTargetKeyId(v string) *UpdateAliasInput {
+	s.TargetKeyId = &v
+	return s
 }
 
 type UpdateAliasOutput struct {
@@ -5802,6 +6696,18 @@ func (s *UpdateKeyDescriptionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateKeyDescriptionInput) SetDescription(v string) *UpdateKeyDescriptionInput {
+	s.Description = &v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *UpdateKeyDescriptionInput) SetKeyId(v string) *UpdateKeyDescriptionInput {
+	s.KeyId = &v
+	return s
 }
 
 type UpdateKeyDescriptionOutput struct {

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -2288,6 +2288,54 @@ func (s *AddPermissionInput) Validate() error {
 	return nil
 }
 
+// SetAction sets the Action field's value.
+func (s *AddPermissionInput) SetAction(v string) *AddPermissionInput {
+	s.Action = &v
+	return s
+}
+
+// SetEventSourceToken sets the EventSourceToken field's value.
+func (s *AddPermissionInput) SetEventSourceToken(v string) *AddPermissionInput {
+	s.EventSourceToken = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *AddPermissionInput) SetFunctionName(v string) *AddPermissionInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetPrincipal sets the Principal field's value.
+func (s *AddPermissionInput) SetPrincipal(v string) *AddPermissionInput {
+	s.Principal = &v
+	return s
+}
+
+// SetQualifier sets the Qualifier field's value.
+func (s *AddPermissionInput) SetQualifier(v string) *AddPermissionInput {
+	s.Qualifier = &v
+	return s
+}
+
+// SetSourceAccount sets the SourceAccount field's value.
+func (s *AddPermissionInput) SetSourceAccount(v string) *AddPermissionInput {
+	s.SourceAccount = &v
+	return s
+}
+
+// SetSourceArn sets the SourceArn field's value.
+func (s *AddPermissionInput) SetSourceArn(v string) *AddPermissionInput {
+	s.SourceArn = &v
+	return s
+}
+
+// SetStatementId sets the StatementId field's value.
+func (s *AddPermissionInput) SetStatementId(v string) *AddPermissionInput {
+	s.StatementId = &v
+	return s
+}
+
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2305,6 +2353,12 @@ func (s AddPermissionOutput) String() string {
 // GoString returns the string representation
 func (s AddPermissionOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatement sets the Statement field's value.
+func (s *AddPermissionOutput) SetStatement(v string) *AddPermissionOutput {
+	s.Statement = &v
+	return s
 }
 
 // Provides configuration information about a Lambda function version alias.
@@ -2334,6 +2388,30 @@ func (s AliasConfiguration) String() string {
 // GoString returns the string representation
 func (s AliasConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetAliasArn sets the AliasArn field's value.
+func (s *AliasConfiguration) SetAliasArn(v string) *AliasConfiguration {
+	s.AliasArn = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *AliasConfiguration) SetDescription(v string) *AliasConfiguration {
+	s.Description = &v
+	return s
+}
+
+// SetFunctionVersion sets the FunctionVersion field's value.
+func (s *AliasConfiguration) SetFunctionVersion(v string) *AliasConfiguration {
+	s.FunctionVersion = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AliasConfiguration) SetName(v string) *AliasConfiguration {
+	s.Name = &v
+	return s
 }
 
 type CreateAliasInput struct {
@@ -2394,6 +2472,30 @@ func (s *CreateAliasInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateAliasInput) SetDescription(v string) *CreateAliasInput {
+	s.Description = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *CreateAliasInput) SetFunctionName(v string) *CreateAliasInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetFunctionVersion sets the FunctionVersion field's value.
+func (s *CreateAliasInput) SetFunctionVersion(v string) *CreateAliasInput {
+	s.FunctionVersion = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateAliasInput) SetName(v string) *CreateAliasInput {
+	s.Name = &v
+	return s
 }
 
 type CreateEventSourceMappingInput struct {
@@ -2477,6 +2579,36 @@ func (s *CreateEventSourceMappingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBatchSize sets the BatchSize field's value.
+func (s *CreateEventSourceMappingInput) SetBatchSize(v int64) *CreateEventSourceMappingInput {
+	s.BatchSize = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *CreateEventSourceMappingInput) SetEnabled(v bool) *CreateEventSourceMappingInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventSourceArn sets the EventSourceArn field's value.
+func (s *CreateEventSourceMappingInput) SetEventSourceArn(v string) *CreateEventSourceMappingInput {
+	s.EventSourceArn = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *CreateEventSourceMappingInput) SetFunctionName(v string) *CreateEventSourceMappingInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetStartingPosition sets the StartingPosition field's value.
+func (s *CreateEventSourceMappingInput) SetStartingPosition(v string) *CreateEventSourceMappingInput {
+	s.StartingPosition = &v
+	return s
 }
 
 type CreateFunctionInput struct {
@@ -2594,6 +2726,66 @@ func (s *CreateFunctionInput) Validate() error {
 	return nil
 }
 
+// SetCode sets the Code field's value.
+func (s *CreateFunctionInput) SetCode(v *FunctionCode) *CreateFunctionInput {
+	s.Code = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateFunctionInput) SetDescription(v string) *CreateFunctionInput {
+	s.Description = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *CreateFunctionInput) SetFunctionName(v string) *CreateFunctionInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetHandler sets the Handler field's value.
+func (s *CreateFunctionInput) SetHandler(v string) *CreateFunctionInput {
+	s.Handler = &v
+	return s
+}
+
+// SetMemorySize sets the MemorySize field's value.
+func (s *CreateFunctionInput) SetMemorySize(v int64) *CreateFunctionInput {
+	s.MemorySize = &v
+	return s
+}
+
+// SetPublish sets the Publish field's value.
+func (s *CreateFunctionInput) SetPublish(v bool) *CreateFunctionInput {
+	s.Publish = &v
+	return s
+}
+
+// SetRole sets the Role field's value.
+func (s *CreateFunctionInput) SetRole(v string) *CreateFunctionInput {
+	s.Role = &v
+	return s
+}
+
+// SetRuntime sets the Runtime field's value.
+func (s *CreateFunctionInput) SetRuntime(v string) *CreateFunctionInput {
+	s.Runtime = &v
+	return s
+}
+
+// SetTimeout sets the Timeout field's value.
+func (s *CreateFunctionInput) SetTimeout(v int64) *CreateFunctionInput {
+	s.Timeout = &v
+	return s
+}
+
+// SetVpcConfig sets the VpcConfig field's value.
+func (s *CreateFunctionInput) SetVpcConfig(v *VpcConfig) *CreateFunctionInput {
+	s.VpcConfig = v
+	return s
+}
+
 type DeleteAliasInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2641,6 +2833,18 @@ func (s *DeleteAliasInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *DeleteAliasInput) SetFunctionName(v string) *DeleteAliasInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteAliasInput) SetName(v string) *DeleteAliasInput {
+	s.Name = &v
+	return s
+}
+
 type DeleteAliasOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2685,6 +2889,12 @@ func (s *DeleteEventSourceMappingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUUID sets the UUID field's value.
+func (s *DeleteEventSourceMappingInput) SetUUID(v string) *DeleteEventSourceMappingInput {
+	s.UUID = &v
+	return s
 }
 
 type DeleteFunctionInput struct {
@@ -2749,6 +2959,18 @@ func (s *DeleteFunctionInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *DeleteFunctionInput) SetFunctionName(v string) *DeleteFunctionInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetQualifier sets the Qualifier field's value.
+func (s *DeleteFunctionInput) SetQualifier(v string) *DeleteFunctionInput {
+	s.Qualifier = &v
+	return s
+}
+
 type DeleteFunctionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2807,6 +3029,54 @@ func (s EventSourceMappingConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetBatchSize sets the BatchSize field's value.
+func (s *EventSourceMappingConfiguration) SetBatchSize(v int64) *EventSourceMappingConfiguration {
+	s.BatchSize = &v
+	return s
+}
+
+// SetEventSourceArn sets the EventSourceArn field's value.
+func (s *EventSourceMappingConfiguration) SetEventSourceArn(v string) *EventSourceMappingConfiguration {
+	s.EventSourceArn = &v
+	return s
+}
+
+// SetFunctionArn sets the FunctionArn field's value.
+func (s *EventSourceMappingConfiguration) SetFunctionArn(v string) *EventSourceMappingConfiguration {
+	s.FunctionArn = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *EventSourceMappingConfiguration) SetLastModified(v time.Time) *EventSourceMappingConfiguration {
+	s.LastModified = &v
+	return s
+}
+
+// SetLastProcessingResult sets the LastProcessingResult field's value.
+func (s *EventSourceMappingConfiguration) SetLastProcessingResult(v string) *EventSourceMappingConfiguration {
+	s.LastProcessingResult = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *EventSourceMappingConfiguration) SetState(v string) *EventSourceMappingConfiguration {
+	s.State = &v
+	return s
+}
+
+// SetStateTransitionReason sets the StateTransitionReason field's value.
+func (s *EventSourceMappingConfiguration) SetStateTransitionReason(v string) *EventSourceMappingConfiguration {
+	s.StateTransitionReason = &v
+	return s
+}
+
+// SetUUID sets the UUID field's value.
+func (s *EventSourceMappingConfiguration) SetUUID(v string) *EventSourceMappingConfiguration {
+	s.UUID = &v
+	return s
+}
+
 // The code for the Lambda function.
 type FunctionCode struct {
 	_ struct{} `type:"structure"`
@@ -2862,6 +3132,30 @@ func (s *FunctionCode) Validate() error {
 	return nil
 }
 
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *FunctionCode) SetS3Bucket(v string) *FunctionCode {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetS3Key sets the S3Key field's value.
+func (s *FunctionCode) SetS3Key(v string) *FunctionCode {
+	s.S3Key = &v
+	return s
+}
+
+// SetS3ObjectVersion sets the S3ObjectVersion field's value.
+func (s *FunctionCode) SetS3ObjectVersion(v string) *FunctionCode {
+	s.S3ObjectVersion = &v
+	return s
+}
+
+// SetZipFile sets the ZipFile field's value.
+func (s *FunctionCode) SetZipFile(v []byte) *FunctionCode {
+	s.ZipFile = v
+	return s
+}
+
 // The object for the Lambda function location.
 type FunctionCodeLocation struct {
 	_ struct{} `type:"structure"`
@@ -2882,6 +3176,18 @@ func (s FunctionCodeLocation) String() string {
 // GoString returns the string representation
 func (s FunctionCodeLocation) GoString() string {
 	return s.String()
+}
+
+// SetLocation sets the Location field's value.
+func (s *FunctionCodeLocation) SetLocation(v string) *FunctionCodeLocation {
+	s.Location = &v
+	return s
+}
+
+// SetRepositoryType sets the RepositoryType field's value.
+func (s *FunctionCodeLocation) SetRepositoryType(v string) *FunctionCodeLocation {
+	s.RepositoryType = &v
+	return s
 }
 
 // A complex type that describes function metadata.
@@ -2945,6 +3251,84 @@ func (s FunctionConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetCodeSha256 sets the CodeSha256 field's value.
+func (s *FunctionConfiguration) SetCodeSha256(v string) *FunctionConfiguration {
+	s.CodeSha256 = &v
+	return s
+}
+
+// SetCodeSize sets the CodeSize field's value.
+func (s *FunctionConfiguration) SetCodeSize(v int64) *FunctionConfiguration {
+	s.CodeSize = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *FunctionConfiguration) SetDescription(v string) *FunctionConfiguration {
+	s.Description = &v
+	return s
+}
+
+// SetFunctionArn sets the FunctionArn field's value.
+func (s *FunctionConfiguration) SetFunctionArn(v string) *FunctionConfiguration {
+	s.FunctionArn = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *FunctionConfiguration) SetFunctionName(v string) *FunctionConfiguration {
+	s.FunctionName = &v
+	return s
+}
+
+// SetHandler sets the Handler field's value.
+func (s *FunctionConfiguration) SetHandler(v string) *FunctionConfiguration {
+	s.Handler = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *FunctionConfiguration) SetLastModified(v string) *FunctionConfiguration {
+	s.LastModified = &v
+	return s
+}
+
+// SetMemorySize sets the MemorySize field's value.
+func (s *FunctionConfiguration) SetMemorySize(v int64) *FunctionConfiguration {
+	s.MemorySize = &v
+	return s
+}
+
+// SetRole sets the Role field's value.
+func (s *FunctionConfiguration) SetRole(v string) *FunctionConfiguration {
+	s.Role = &v
+	return s
+}
+
+// SetRuntime sets the Runtime field's value.
+func (s *FunctionConfiguration) SetRuntime(v string) *FunctionConfiguration {
+	s.Runtime = &v
+	return s
+}
+
+// SetTimeout sets the Timeout field's value.
+func (s *FunctionConfiguration) SetTimeout(v int64) *FunctionConfiguration {
+	s.Timeout = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *FunctionConfiguration) SetVersion(v string) *FunctionConfiguration {
+	s.Version = &v
+	return s
+}
+
+// SetVpcConfig sets the VpcConfig field's value.
+func (s *FunctionConfiguration) SetVpcConfig(v *VpcConfigResponse) *FunctionConfiguration {
+	s.VpcConfig = v
+	return s
+}
+
 type GetAliasInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2993,6 +3377,18 @@ func (s *GetAliasInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *GetAliasInput) SetFunctionName(v string) *GetAliasInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetAliasInput) SetName(v string) *GetAliasInput {
+	s.Name = &v
+	return s
+}
+
 type GetEventSourceMappingInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3023,6 +3419,12 @@ func (s *GetEventSourceMappingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetUUID sets the UUID field's value.
+func (s *GetEventSourceMappingInput) SetUUID(v string) *GetEventSourceMappingInput {
+	s.UUID = &v
+	return s
 }
 
 type GetFunctionConfigurationInput struct {
@@ -3080,6 +3482,18 @@ func (s *GetFunctionConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *GetFunctionConfigurationInput) SetFunctionName(v string) *GetFunctionConfigurationInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetQualifier sets the Qualifier field's value.
+func (s *GetFunctionConfigurationInput) SetQualifier(v string) *GetFunctionConfigurationInput {
+	s.Qualifier = &v
+	return s
+}
+
 type GetFunctionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3133,6 +3547,18 @@ func (s *GetFunctionInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *GetFunctionInput) SetFunctionName(v string) *GetFunctionInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetQualifier sets the Qualifier field's value.
+func (s *GetFunctionInput) SetQualifier(v string) *GetFunctionInput {
+	s.Qualifier = &v
+	return s
+}
+
 // This response contains the object for the Lambda function location (see .
 type GetFunctionOutput struct {
 	_ struct{} `type:"structure"`
@@ -3152,6 +3578,18 @@ func (s GetFunctionOutput) String() string {
 // GoString returns the string representation
 func (s GetFunctionOutput) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *GetFunctionOutput) SetCode(v *FunctionCodeLocation) *GetFunctionOutput {
+	s.Code = v
+	return s
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *GetFunctionOutput) SetConfiguration(v *FunctionConfiguration) *GetFunctionOutput {
+	s.Configuration = v
+	return s
 }
 
 type GetPolicyInput struct {
@@ -3207,6 +3645,18 @@ func (s *GetPolicyInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *GetPolicyInput) SetFunctionName(v string) *GetPolicyInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetQualifier sets the Qualifier field's value.
+func (s *GetPolicyInput) SetQualifier(v string) *GetPolicyInput {
+	s.Qualifier = &v
+	return s
+}
+
 type GetPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3224,6 +3674,12 @@ func (s GetPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetPolicyOutput) SetPolicy(v string) *GetPolicyOutput {
+	s.Policy = &v
+	return s
 }
 
 type InvokeAsyncInput struct {
@@ -3269,6 +3725,18 @@ func (s *InvokeAsyncInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *InvokeAsyncInput) SetFunctionName(v string) *InvokeAsyncInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetInvokeArgs sets the InvokeArgs field's value.
+func (s *InvokeAsyncInput) SetInvokeArgs(v io.ReadSeeker) *InvokeAsyncInput {
+	s.InvokeArgs = v
+	return s
+}
+
 // Upon success, it returns empty response. Otherwise, throws an exception.
 type InvokeAsyncOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -3285,6 +3753,12 @@ func (s InvokeAsyncOutput) String() string {
 // GoString returns the string representation
 func (s InvokeAsyncOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *InvokeAsyncOutput) SetStatus(v int64) *InvokeAsyncOutput {
+	s.Status = &v
+	return s
 }
 
 type InvokeInput struct {
@@ -3368,6 +3842,42 @@ func (s *InvokeInput) Validate() error {
 	return nil
 }
 
+// SetClientContext sets the ClientContext field's value.
+func (s *InvokeInput) SetClientContext(v string) *InvokeInput {
+	s.ClientContext = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *InvokeInput) SetFunctionName(v string) *InvokeInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetInvocationType sets the InvocationType field's value.
+func (s *InvokeInput) SetInvocationType(v string) *InvokeInput {
+	s.InvocationType = &v
+	return s
+}
+
+// SetLogType sets the LogType field's value.
+func (s *InvokeInput) SetLogType(v string) *InvokeInput {
+	s.LogType = &v
+	return s
+}
+
+// SetPayload sets the Payload field's value.
+func (s *InvokeInput) SetPayload(v []byte) *InvokeInput {
+	s.Payload = v
+	return s
+}
+
+// SetQualifier sets the Qualifier field's value.
+func (s *InvokeInput) SetQualifier(v string) *InvokeInput {
+	s.Qualifier = &v
+	return s
+}
+
 // Upon success, returns an empty response. Otherwise, throws an exception.
 type InvokeOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -3408,6 +3918,30 @@ func (s InvokeOutput) String() string {
 // GoString returns the string representation
 func (s InvokeOutput) GoString() string {
 	return s.String()
+}
+
+// SetFunctionError sets the FunctionError field's value.
+func (s *InvokeOutput) SetFunctionError(v string) *InvokeOutput {
+	s.FunctionError = &v
+	return s
+}
+
+// SetLogResult sets the LogResult field's value.
+func (s *InvokeOutput) SetLogResult(v string) *InvokeOutput {
+	s.LogResult = &v
+	return s
+}
+
+// SetPayload sets the Payload field's value.
+func (s *InvokeOutput) SetPayload(v []byte) *InvokeOutput {
+	s.Payload = v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *InvokeOutput) SetStatusCode(v int64) *InvokeOutput {
+	s.StatusCode = &v
+	return s
 }
 
 type ListAliasesInput struct {
@@ -3464,6 +3998,30 @@ func (s *ListAliasesInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *ListAliasesInput) SetFunctionName(v string) *ListAliasesInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetFunctionVersion sets the FunctionVersion field's value.
+func (s *ListAliasesInput) SetFunctionVersion(v string) *ListAliasesInput {
+	s.FunctionVersion = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAliasesInput) SetMarker(v string) *ListAliasesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListAliasesInput) SetMaxItems(v int64) *ListAliasesInput {
+	s.MaxItems = &v
+	return s
+}
+
 type ListAliasesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3482,6 +4040,18 @@ func (s ListAliasesOutput) String() string {
 // GoString returns the string representation
 func (s ListAliasesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAliases sets the Aliases field's value.
+func (s *ListAliasesOutput) SetAliases(v []*AliasConfiguration) *ListAliasesOutput {
+	s.Aliases = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListAliasesOutput) SetNextMarker(v string) *ListAliasesOutput {
+	s.NextMarker = &v
+	return s
 }
 
 type ListEventSourceMappingsInput struct {
@@ -3539,6 +4109,30 @@ func (s *ListEventSourceMappingsInput) Validate() error {
 	return nil
 }
 
+// SetEventSourceArn sets the EventSourceArn field's value.
+func (s *ListEventSourceMappingsInput) SetEventSourceArn(v string) *ListEventSourceMappingsInput {
+	s.EventSourceArn = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *ListEventSourceMappingsInput) SetFunctionName(v string) *ListEventSourceMappingsInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListEventSourceMappingsInput) SetMarker(v string) *ListEventSourceMappingsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListEventSourceMappingsInput) SetMaxItems(v int64) *ListEventSourceMappingsInput {
+	s.MaxItems = &v
+	return s
+}
+
 // Contains a list of event sources (see )
 type ListEventSourceMappingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3558,6 +4152,18 @@ func (s ListEventSourceMappingsOutput) String() string {
 // GoString returns the string representation
 func (s ListEventSourceMappingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSourceMappings sets the EventSourceMappings field's value.
+func (s *ListEventSourceMappingsOutput) SetEventSourceMappings(v []*EventSourceMappingConfiguration) *ListEventSourceMappingsOutput {
+	s.EventSourceMappings = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListEventSourceMappingsOutput) SetNextMarker(v string) *ListEventSourceMappingsOutput {
+	s.NextMarker = &v
+	return s
 }
 
 type ListFunctionsInput struct {
@@ -3595,6 +4201,18 @@ func (s *ListFunctionsInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListFunctionsInput) SetMarker(v string) *ListFunctionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListFunctionsInput) SetMaxItems(v int64) *ListFunctionsInput {
+	s.MaxItems = &v
+	return s
+}
+
 // Contains a list of AWS Lambda function configurations (see FunctionConfiguration.
 type ListFunctionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3614,6 +4232,18 @@ func (s ListFunctionsOutput) String() string {
 // GoString returns the string representation
 func (s ListFunctionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetFunctions sets the Functions field's value.
+func (s *ListFunctionsOutput) SetFunctions(v []*FunctionConfiguration) *ListFunctionsOutput {
+	s.Functions = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListFunctionsOutput) SetNextMarker(v string) *ListFunctionsOutput {
+	s.NextMarker = &v
+	return s
 }
 
 type ListVersionsByFunctionInput struct {
@@ -3667,6 +4297,24 @@ func (s *ListVersionsByFunctionInput) Validate() error {
 	return nil
 }
 
+// SetFunctionName sets the FunctionName field's value.
+func (s *ListVersionsByFunctionInput) SetFunctionName(v string) *ListVersionsByFunctionInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListVersionsByFunctionInput) SetMarker(v string) *ListVersionsByFunctionInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListVersionsByFunctionInput) SetMaxItems(v int64) *ListVersionsByFunctionInput {
+	s.MaxItems = &v
+	return s
+}
+
 type ListVersionsByFunctionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3685,6 +4333,18 @@ func (s ListVersionsByFunctionOutput) String() string {
 // GoString returns the string representation
 func (s ListVersionsByFunctionOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListVersionsByFunctionOutput) SetNextMarker(v string) *ListVersionsByFunctionOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetVersions sets the Versions field's value.
+func (s *ListVersionsByFunctionOutput) SetVersions(v []*FunctionConfiguration) *ListVersionsByFunctionOutput {
+	s.Versions = v
+	return s
 }
 
 type PublishVersionInput struct {
@@ -3735,6 +4395,24 @@ func (s *PublishVersionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCodeSha256 sets the CodeSha256 field's value.
+func (s *PublishVersionInput) SetCodeSha256(v string) *PublishVersionInput {
+	s.CodeSha256 = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *PublishVersionInput) SetDescription(v string) *PublishVersionInput {
+	s.Description = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *PublishVersionInput) SetFunctionName(v string) *PublishVersionInput {
+	s.FunctionName = &v
+	return s
 }
 
 type RemovePermissionInput struct {
@@ -3796,6 +4474,24 @@ func (s *RemovePermissionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *RemovePermissionInput) SetFunctionName(v string) *RemovePermissionInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetQualifier sets the Qualifier field's value.
+func (s *RemovePermissionInput) SetQualifier(v string) *RemovePermissionInput {
+	s.Qualifier = &v
+	return s
+}
+
+// SetStatementId sets the StatementId field's value.
+func (s *RemovePermissionInput) SetStatementId(v string) *RemovePermissionInput {
+	s.StatementId = &v
+	return s
 }
 
 type RemovePermissionOutput struct {
@@ -3868,6 +4564,30 @@ func (s *UpdateAliasInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *UpdateAliasInput) SetDescription(v string) *UpdateAliasInput {
+	s.Description = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *UpdateAliasInput) SetFunctionName(v string) *UpdateAliasInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetFunctionVersion sets the FunctionVersion field's value.
+func (s *UpdateAliasInput) SetFunctionVersion(v string) *UpdateAliasInput {
+	s.FunctionVersion = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateAliasInput) SetName(v string) *UpdateAliasInput {
+	s.Name = &v
+	return s
+}
+
 type UpdateEventSourceMappingInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3927,6 +4647,30 @@ func (s *UpdateEventSourceMappingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBatchSize sets the BatchSize field's value.
+func (s *UpdateEventSourceMappingInput) SetBatchSize(v int64) *UpdateEventSourceMappingInput {
+	s.BatchSize = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *UpdateEventSourceMappingInput) SetEnabled(v bool) *UpdateEventSourceMappingInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *UpdateEventSourceMappingInput) SetFunctionName(v string) *UpdateEventSourceMappingInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetUUID sets the UUID field's value.
+func (s *UpdateEventSourceMappingInput) SetUUID(v string) *UpdateEventSourceMappingInput {
+	s.UUID = &v
+	return s
 }
 
 type UpdateFunctionCodeInput struct {
@@ -4002,6 +4746,42 @@ func (s *UpdateFunctionCodeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *UpdateFunctionCodeInput) SetFunctionName(v string) *UpdateFunctionCodeInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetPublish sets the Publish field's value.
+func (s *UpdateFunctionCodeInput) SetPublish(v bool) *UpdateFunctionCodeInput {
+	s.Publish = &v
+	return s
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *UpdateFunctionCodeInput) SetS3Bucket(v string) *UpdateFunctionCodeInput {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetS3Key sets the S3Key field's value.
+func (s *UpdateFunctionCodeInput) SetS3Key(v string) *UpdateFunctionCodeInput {
+	s.S3Key = &v
+	return s
+}
+
+// SetS3ObjectVersion sets the S3ObjectVersion field's value.
+func (s *UpdateFunctionCodeInput) SetS3ObjectVersion(v string) *UpdateFunctionCodeInput {
+	s.S3ObjectVersion = &v
+	return s
+}
+
+// SetZipFile sets the ZipFile field's value.
+func (s *UpdateFunctionCodeInput) SetZipFile(v []byte) *UpdateFunctionCodeInput {
+	s.ZipFile = v
+	return s
 }
 
 type UpdateFunctionConfigurationInput struct {
@@ -4088,6 +4868,54 @@ func (s *UpdateFunctionConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *UpdateFunctionConfigurationInput) SetDescription(v string) *UpdateFunctionConfigurationInput {
+	s.Description = &v
+	return s
+}
+
+// SetFunctionName sets the FunctionName field's value.
+func (s *UpdateFunctionConfigurationInput) SetFunctionName(v string) *UpdateFunctionConfigurationInput {
+	s.FunctionName = &v
+	return s
+}
+
+// SetHandler sets the Handler field's value.
+func (s *UpdateFunctionConfigurationInput) SetHandler(v string) *UpdateFunctionConfigurationInput {
+	s.Handler = &v
+	return s
+}
+
+// SetMemorySize sets the MemorySize field's value.
+func (s *UpdateFunctionConfigurationInput) SetMemorySize(v int64) *UpdateFunctionConfigurationInput {
+	s.MemorySize = &v
+	return s
+}
+
+// SetRole sets the Role field's value.
+func (s *UpdateFunctionConfigurationInput) SetRole(v string) *UpdateFunctionConfigurationInput {
+	s.Role = &v
+	return s
+}
+
+// SetRuntime sets the Runtime field's value.
+func (s *UpdateFunctionConfigurationInput) SetRuntime(v string) *UpdateFunctionConfigurationInput {
+	s.Runtime = &v
+	return s
+}
+
+// SetTimeout sets the Timeout field's value.
+func (s *UpdateFunctionConfigurationInput) SetTimeout(v int64) *UpdateFunctionConfigurationInput {
+	s.Timeout = &v
+	return s
+}
+
+// SetVpcConfig sets the VpcConfig field's value.
+func (s *UpdateFunctionConfigurationInput) SetVpcConfig(v *VpcConfig) *UpdateFunctionConfigurationInput {
+	s.VpcConfig = v
+	return s
+}
+
 // If your Lambda function accesses resources in a VPC, you provide this parameter
 // identifying the list of security group IDs and subnet IDs. These must belong
 // to the same VPC. You must provide at least one security group and one subnet
@@ -4112,6 +4940,18 @@ func (s VpcConfig) GoString() string {
 	return s.String()
 }
 
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *VpcConfig) SetSecurityGroupIds(v []*string) *VpcConfig {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *VpcConfig) SetSubnetIds(v []*string) *VpcConfig {
+	s.SubnetIds = v
+	return s
+}
+
 // VPC configuration associated with your Lambda function.
 type VpcConfigResponse struct {
 	_ struct{} `type:"structure"`
@@ -4134,6 +4974,24 @@ func (s VpcConfigResponse) String() string {
 // GoString returns the string representation
 func (s VpcConfigResponse) GoString() string {
 	return s.String()
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *VpcConfigResponse) SetSecurityGroupIds(v []*string) *VpcConfigResponse {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *VpcConfigResponse) SetSubnetIds(v []*string) *VpcConfigResponse {
+	s.SubnetIds = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *VpcConfigResponse) SetVpcId(v string) *VpcConfigResponse {
+	s.VpcId = &v
+	return s
 }
 
 const (

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -2371,6 +2371,24 @@ func (s *AddTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *AddTagsInput) SetResourceId(v string) *AddTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *AddTagsInput) SetResourceType(v string) *AddTagsInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsInput) SetTags(v []*Tag) *AddTagsInput {
+	s.Tags = v
+	return s
+}
+
 // Amazon ML returns the following elements.
 type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2390,6 +2408,18 @@ func (s AddTagsOutput) String() string {
 // GoString returns the string representation
 func (s AddTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *AddTagsOutput) SetResourceId(v string) *AddTagsOutput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *AddTagsOutput) SetResourceType(v string) *AddTagsOutput {
+	s.ResourceType = &v
+	return s
 }
 
 // Represents the output of a GetBatchPrediction operation.
@@ -2477,6 +2507,102 @@ func (s BatchPrediction) GoString() string {
 	return s.String()
 }
 
+// SetBatchPredictionDataSourceId sets the BatchPredictionDataSourceId field's value.
+func (s *BatchPrediction) SetBatchPredictionDataSourceId(v string) *BatchPrediction {
+	s.BatchPredictionDataSourceId = &v
+	return s
+}
+
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *BatchPrediction) SetBatchPredictionId(v string) *BatchPrediction {
+	s.BatchPredictionId = &v
+	return s
+}
+
+// SetComputeTime sets the ComputeTime field's value.
+func (s *BatchPrediction) SetComputeTime(v int64) *BatchPrediction {
+	s.ComputeTime = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *BatchPrediction) SetCreatedAt(v time.Time) *BatchPrediction {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCreatedByIamUser sets the CreatedByIamUser field's value.
+func (s *BatchPrediction) SetCreatedByIamUser(v string) *BatchPrediction {
+	s.CreatedByIamUser = &v
+	return s
+}
+
+// SetFinishedAt sets the FinishedAt field's value.
+func (s *BatchPrediction) SetFinishedAt(v time.Time) *BatchPrediction {
+	s.FinishedAt = &v
+	return s
+}
+
+// SetInputDataLocationS3 sets the InputDataLocationS3 field's value.
+func (s *BatchPrediction) SetInputDataLocationS3(v string) *BatchPrediction {
+	s.InputDataLocationS3 = &v
+	return s
+}
+
+// SetInvalidRecordCount sets the InvalidRecordCount field's value.
+func (s *BatchPrediction) SetInvalidRecordCount(v int64) *BatchPrediction {
+	s.InvalidRecordCount = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *BatchPrediction) SetLastUpdatedAt(v time.Time) *BatchPrediction {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *BatchPrediction) SetMLModelId(v string) *BatchPrediction {
+	s.MLModelId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *BatchPrediction) SetMessage(v string) *BatchPrediction {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *BatchPrediction) SetName(v string) *BatchPrediction {
+	s.Name = &v
+	return s
+}
+
+// SetOutputUri sets the OutputUri field's value.
+func (s *BatchPrediction) SetOutputUri(v string) *BatchPrediction {
+	s.OutputUri = &v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *BatchPrediction) SetStartedAt(v time.Time) *BatchPrediction {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *BatchPrediction) SetStatus(v string) *BatchPrediction {
+	s.Status = &v
+	return s
+}
+
+// SetTotalRecordCount sets the TotalRecordCount field's value.
+func (s *BatchPrediction) SetTotalRecordCount(v int64) *BatchPrediction {
+	s.TotalRecordCount = &v
+	return s
+}
+
 type CreateBatchPredictionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2552,6 +2678,36 @@ func (s *CreateBatchPredictionInput) Validate() error {
 	return nil
 }
 
+// SetBatchPredictionDataSourceId sets the BatchPredictionDataSourceId field's value.
+func (s *CreateBatchPredictionInput) SetBatchPredictionDataSourceId(v string) *CreateBatchPredictionInput {
+	s.BatchPredictionDataSourceId = &v
+	return s
+}
+
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *CreateBatchPredictionInput) SetBatchPredictionId(v string) *CreateBatchPredictionInput {
+	s.BatchPredictionId = &v
+	return s
+}
+
+// SetBatchPredictionName sets the BatchPredictionName field's value.
+func (s *CreateBatchPredictionInput) SetBatchPredictionName(v string) *CreateBatchPredictionInput {
+	s.BatchPredictionName = &v
+	return s
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *CreateBatchPredictionInput) SetMLModelId(v string) *CreateBatchPredictionInput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetOutputUri sets the OutputUri field's value.
+func (s *CreateBatchPredictionInput) SetOutputUri(v string) *CreateBatchPredictionInput {
+	s.OutputUri = &v
+	return s
+}
+
 // Represents the output of a CreateBatchPrediction operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -2574,6 +2730,12 @@ func (s CreateBatchPredictionOutput) String() string {
 // GoString returns the string representation
 func (s CreateBatchPredictionOutput) GoString() string {
 	return s.String()
+}
+
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *CreateBatchPredictionOutput) SetBatchPredictionId(v string) *CreateBatchPredictionOutput {
+	s.BatchPredictionId = &v
+	return s
 }
 
 type CreateDataSourceFromRDSInput struct {
@@ -2647,6 +2809,36 @@ func (s *CreateDataSourceFromRDSInput) Validate() error {
 	return nil
 }
 
+// SetComputeStatistics sets the ComputeStatistics field's value.
+func (s *CreateDataSourceFromRDSInput) SetComputeStatistics(v bool) *CreateDataSourceFromRDSInput {
+	s.ComputeStatistics = &v
+	return s
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *CreateDataSourceFromRDSInput) SetDataSourceId(v string) *CreateDataSourceFromRDSInput {
+	s.DataSourceId = &v
+	return s
+}
+
+// SetDataSourceName sets the DataSourceName field's value.
+func (s *CreateDataSourceFromRDSInput) SetDataSourceName(v string) *CreateDataSourceFromRDSInput {
+	s.DataSourceName = &v
+	return s
+}
+
+// SetRDSData sets the RDSData field's value.
+func (s *CreateDataSourceFromRDSInput) SetRDSData(v *RDSDataSpec) *CreateDataSourceFromRDSInput {
+	s.RDSData = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *CreateDataSourceFromRDSInput) SetRoleARN(v string) *CreateDataSourceFromRDSInput {
+	s.RoleARN = &v
+	return s
+}
+
 // Represents the output of a CreateDataSourceFromRDS operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -2672,6 +2864,12 @@ func (s CreateDataSourceFromRDSOutput) String() string {
 // GoString returns the string representation
 func (s CreateDataSourceFromRDSOutput) GoString() string {
 	return s.String()
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *CreateDataSourceFromRDSOutput) SetDataSourceId(v string) *CreateDataSourceFromRDSOutput {
+	s.DataSourceId = &v
+	return s
 }
 
 type CreateDataSourceFromRedshiftInput struct {
@@ -2773,6 +2971,36 @@ func (s *CreateDataSourceFromRedshiftInput) Validate() error {
 	return nil
 }
 
+// SetComputeStatistics sets the ComputeStatistics field's value.
+func (s *CreateDataSourceFromRedshiftInput) SetComputeStatistics(v bool) *CreateDataSourceFromRedshiftInput {
+	s.ComputeStatistics = &v
+	return s
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *CreateDataSourceFromRedshiftInput) SetDataSourceId(v string) *CreateDataSourceFromRedshiftInput {
+	s.DataSourceId = &v
+	return s
+}
+
+// SetDataSourceName sets the DataSourceName field's value.
+func (s *CreateDataSourceFromRedshiftInput) SetDataSourceName(v string) *CreateDataSourceFromRedshiftInput {
+	s.DataSourceName = &v
+	return s
+}
+
+// SetDataSpec sets the DataSpec field's value.
+func (s *CreateDataSourceFromRedshiftInput) SetDataSpec(v *RedshiftDataSpec) *CreateDataSourceFromRedshiftInput {
+	s.DataSpec = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *CreateDataSourceFromRedshiftInput) SetRoleARN(v string) *CreateDataSourceFromRedshiftInput {
+	s.RoleARN = &v
+	return s
+}
+
 // Represents the output of a CreateDataSourceFromRedshift operation, and is
 // an acknowledgement that Amazon ML received the request.
 //
@@ -2795,6 +3023,12 @@ func (s CreateDataSourceFromRedshiftOutput) String() string {
 // GoString returns the string representation
 func (s CreateDataSourceFromRedshiftOutput) GoString() string {
 	return s.String()
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *CreateDataSourceFromRedshiftOutput) SetDataSourceId(v string) *CreateDataSourceFromRedshiftOutput {
+	s.DataSourceId = &v
+	return s
 }
 
 type CreateDataSourceFromS3Input struct {
@@ -2866,6 +3100,30 @@ func (s *CreateDataSourceFromS3Input) Validate() error {
 	return nil
 }
 
+// SetComputeStatistics sets the ComputeStatistics field's value.
+func (s *CreateDataSourceFromS3Input) SetComputeStatistics(v bool) *CreateDataSourceFromS3Input {
+	s.ComputeStatistics = &v
+	return s
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *CreateDataSourceFromS3Input) SetDataSourceId(v string) *CreateDataSourceFromS3Input {
+	s.DataSourceId = &v
+	return s
+}
+
+// SetDataSourceName sets the DataSourceName field's value.
+func (s *CreateDataSourceFromS3Input) SetDataSourceName(v string) *CreateDataSourceFromS3Input {
+	s.DataSourceName = &v
+	return s
+}
+
+// SetDataSpec sets the DataSpec field's value.
+func (s *CreateDataSourceFromS3Input) SetDataSpec(v *S3DataSpec) *CreateDataSourceFromS3Input {
+	s.DataSpec = v
+	return s
+}
+
 // Represents the output of a CreateDataSourceFromS3 operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -2887,6 +3145,12 @@ func (s CreateDataSourceFromS3Output) String() string {
 // GoString returns the string representation
 func (s CreateDataSourceFromS3Output) GoString() string {
 	return s.String()
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *CreateDataSourceFromS3Output) SetDataSourceId(v string) *CreateDataSourceFromS3Output {
+	s.DataSourceId = &v
+	return s
 }
 
 type CreateEvaluationInput struct {
@@ -2953,6 +3217,30 @@ func (s *CreateEvaluationInput) Validate() error {
 	return nil
 }
 
+// SetEvaluationDataSourceId sets the EvaluationDataSourceId field's value.
+func (s *CreateEvaluationInput) SetEvaluationDataSourceId(v string) *CreateEvaluationInput {
+	s.EvaluationDataSourceId = &v
+	return s
+}
+
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *CreateEvaluationInput) SetEvaluationId(v string) *CreateEvaluationInput {
+	s.EvaluationId = &v
+	return s
+}
+
+// SetEvaluationName sets the EvaluationName field's value.
+func (s *CreateEvaluationInput) SetEvaluationName(v string) *CreateEvaluationInput {
+	s.EvaluationName = &v
+	return s
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *CreateEvaluationInput) SetMLModelId(v string) *CreateEvaluationInput {
+	s.MLModelId = &v
+	return s
+}
+
 // Represents the output of a CreateEvaluation operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -2974,6 +3262,12 @@ func (s CreateEvaluationOutput) String() string {
 // GoString returns the string representation
 func (s CreateEvaluationOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *CreateEvaluationOutput) SetEvaluationId(v string) *CreateEvaluationOutput {
+	s.EvaluationId = &v
+	return s
 }
 
 type CreateMLModelInput struct {
@@ -3091,6 +3385,48 @@ func (s *CreateMLModelInput) Validate() error {
 	return nil
 }
 
+// SetMLModelId sets the MLModelId field's value.
+func (s *CreateMLModelInput) SetMLModelId(v string) *CreateMLModelInput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetMLModelName sets the MLModelName field's value.
+func (s *CreateMLModelInput) SetMLModelName(v string) *CreateMLModelInput {
+	s.MLModelName = &v
+	return s
+}
+
+// SetMLModelType sets the MLModelType field's value.
+func (s *CreateMLModelInput) SetMLModelType(v string) *CreateMLModelInput {
+	s.MLModelType = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *CreateMLModelInput) SetParameters(v map[string]*string) *CreateMLModelInput {
+	s.Parameters = v
+	return s
+}
+
+// SetRecipe sets the Recipe field's value.
+func (s *CreateMLModelInput) SetRecipe(v string) *CreateMLModelInput {
+	s.Recipe = &v
+	return s
+}
+
+// SetRecipeUri sets the RecipeUri field's value.
+func (s *CreateMLModelInput) SetRecipeUri(v string) *CreateMLModelInput {
+	s.RecipeUri = &v
+	return s
+}
+
+// SetTrainingDataSourceId sets the TrainingDataSourceId field's value.
+func (s *CreateMLModelInput) SetTrainingDataSourceId(v string) *CreateMLModelInput {
+	s.TrainingDataSourceId = &v
+	return s
+}
+
 // Represents the output of a CreateMLModel operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -3112,6 +3448,12 @@ func (s CreateMLModelOutput) String() string {
 // GoString returns the string representation
 func (s CreateMLModelOutput) GoString() string {
 	return s.String()
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *CreateMLModelOutput) SetMLModelId(v string) *CreateMLModelOutput {
+	s.MLModelId = &v
+	return s
 }
 
 type CreateRealtimeEndpointInput struct {
@@ -3149,6 +3491,12 @@ func (s *CreateRealtimeEndpointInput) Validate() error {
 	return nil
 }
 
+// SetMLModelId sets the MLModelId field's value.
+func (s *CreateRealtimeEndpointInput) SetMLModelId(v string) *CreateRealtimeEndpointInput {
+	s.MLModelId = &v
+	return s
+}
+
 // Represents the output of an CreateRealtimeEndpoint operation.
 //
 // The result contains the MLModelId and the endpoint information for the MLModel.
@@ -3174,6 +3522,18 @@ func (s CreateRealtimeEndpointOutput) String() string {
 // GoString returns the string representation
 func (s CreateRealtimeEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *CreateRealtimeEndpointOutput) SetMLModelId(v string) *CreateRealtimeEndpointOutput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetRealtimeEndpointInfo sets the RealtimeEndpointInfo field's value.
+func (s *CreateRealtimeEndpointOutput) SetRealtimeEndpointInfo(v *RealtimeEndpointInfo) *CreateRealtimeEndpointOutput {
+	s.RealtimeEndpointInfo = v
+	return s
 }
 
 // Represents the output of the GetDataSource operation.
@@ -3266,6 +3626,114 @@ func (s DataSource) GoString() string {
 	return s.String()
 }
 
+// SetComputeStatistics sets the ComputeStatistics field's value.
+func (s *DataSource) SetComputeStatistics(v bool) *DataSource {
+	s.ComputeStatistics = &v
+	return s
+}
+
+// SetComputeTime sets the ComputeTime field's value.
+func (s *DataSource) SetComputeTime(v int64) *DataSource {
+	s.ComputeTime = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *DataSource) SetCreatedAt(v time.Time) *DataSource {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCreatedByIamUser sets the CreatedByIamUser field's value.
+func (s *DataSource) SetCreatedByIamUser(v string) *DataSource {
+	s.CreatedByIamUser = &v
+	return s
+}
+
+// SetDataLocationS3 sets the DataLocationS3 field's value.
+func (s *DataSource) SetDataLocationS3(v string) *DataSource {
+	s.DataLocationS3 = &v
+	return s
+}
+
+// SetDataRearrangement sets the DataRearrangement field's value.
+func (s *DataSource) SetDataRearrangement(v string) *DataSource {
+	s.DataRearrangement = &v
+	return s
+}
+
+// SetDataSizeInBytes sets the DataSizeInBytes field's value.
+func (s *DataSource) SetDataSizeInBytes(v int64) *DataSource {
+	s.DataSizeInBytes = &v
+	return s
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *DataSource) SetDataSourceId(v string) *DataSource {
+	s.DataSourceId = &v
+	return s
+}
+
+// SetFinishedAt sets the FinishedAt field's value.
+func (s *DataSource) SetFinishedAt(v time.Time) *DataSource {
+	s.FinishedAt = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *DataSource) SetLastUpdatedAt(v time.Time) *DataSource {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *DataSource) SetMessage(v string) *DataSource {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DataSource) SetName(v string) *DataSource {
+	s.Name = &v
+	return s
+}
+
+// SetNumberOfFiles sets the NumberOfFiles field's value.
+func (s *DataSource) SetNumberOfFiles(v int64) *DataSource {
+	s.NumberOfFiles = &v
+	return s
+}
+
+// SetRDSMetadata sets the RDSMetadata field's value.
+func (s *DataSource) SetRDSMetadata(v *RDSMetadata) *DataSource {
+	s.RDSMetadata = v
+	return s
+}
+
+// SetRedshiftMetadata sets the RedshiftMetadata field's value.
+func (s *DataSource) SetRedshiftMetadata(v *RedshiftMetadata) *DataSource {
+	s.RedshiftMetadata = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *DataSource) SetRoleARN(v string) *DataSource {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *DataSource) SetStartedAt(v time.Time) *DataSource {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DataSource) SetStatus(v string) *DataSource {
+	s.Status = &v
+	return s
+}
+
 type DeleteBatchPredictionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3301,6 +3769,12 @@ func (s *DeleteBatchPredictionInput) Validate() error {
 	return nil
 }
 
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *DeleteBatchPredictionInput) SetBatchPredictionId(v string) *DeleteBatchPredictionInput {
+	s.BatchPredictionId = &v
+	return s
+}
+
 // Represents the output of a DeleteBatchPrediction operation.
 //
 // You can use the GetBatchPrediction operation and check the value of the Status
@@ -3321,6 +3795,12 @@ func (s DeleteBatchPredictionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBatchPredictionOutput) GoString() string {
 	return s.String()
+}
+
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *DeleteBatchPredictionOutput) SetBatchPredictionId(v string) *DeleteBatchPredictionOutput {
+	s.BatchPredictionId = &v
+	return s
 }
 
 type DeleteDataSourceInput struct {
@@ -3358,6 +3838,12 @@ func (s *DeleteDataSourceInput) Validate() error {
 	return nil
 }
 
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *DeleteDataSourceInput) SetDataSourceId(v string) *DeleteDataSourceInput {
+	s.DataSourceId = &v
+	return s
+}
+
 // Represents the output of a DeleteDataSource operation.
 type DeleteDataSourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -3375,6 +3861,12 @@ func (s DeleteDataSourceOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDataSourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *DeleteDataSourceOutput) SetDataSourceId(v string) *DeleteDataSourceOutput {
+	s.DataSourceId = &v
+	return s
 }
 
 type DeleteEvaluationInput struct {
@@ -3412,6 +3904,12 @@ func (s *DeleteEvaluationInput) Validate() error {
 	return nil
 }
 
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *DeleteEvaluationInput) SetEvaluationId(v string) *DeleteEvaluationInput {
+	s.EvaluationId = &v
+	return s
+}
+
 // Represents the output of a DeleteEvaluation operation. The output indicates
 // that Amazon Machine Learning (Amazon ML) received the request.
 //
@@ -3433,6 +3931,12 @@ func (s DeleteEvaluationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteEvaluationOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *DeleteEvaluationOutput) SetEvaluationId(v string) *DeleteEvaluationOutput {
+	s.EvaluationId = &v
+	return s
 }
 
 type DeleteMLModelInput struct {
@@ -3470,6 +3974,12 @@ func (s *DeleteMLModelInput) Validate() error {
 	return nil
 }
 
+// SetMLModelId sets the MLModelId field's value.
+func (s *DeleteMLModelInput) SetMLModelId(v string) *DeleteMLModelInput {
+	s.MLModelId = &v
+	return s
+}
+
 // Represents the output of a DeleteMLModel operation.
 //
 // You can use the GetMLModel operation and check the value of the Status parameter
@@ -3490,6 +4000,12 @@ func (s DeleteMLModelOutput) String() string {
 // GoString returns the string representation
 func (s DeleteMLModelOutput) GoString() string {
 	return s.String()
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *DeleteMLModelOutput) SetMLModelId(v string) *DeleteMLModelOutput {
+	s.MLModelId = &v
+	return s
 }
 
 type DeleteRealtimeEndpointInput struct {
@@ -3527,6 +4043,12 @@ func (s *DeleteRealtimeEndpointInput) Validate() error {
 	return nil
 }
 
+// SetMLModelId sets the MLModelId field's value.
+func (s *DeleteRealtimeEndpointInput) SetMLModelId(v string) *DeleteRealtimeEndpointInput {
+	s.MLModelId = &v
+	return s
+}
+
 // Represents the output of an DeleteRealtimeEndpoint operation.
 //
 // The result contains the MLModelId and the endpoint information for the MLModel.
@@ -3549,6 +4071,18 @@ func (s DeleteRealtimeEndpointOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRealtimeEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *DeleteRealtimeEndpointOutput) SetMLModelId(v string) *DeleteRealtimeEndpointOutput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetRealtimeEndpointInfo sets the RealtimeEndpointInfo field's value.
+func (s *DeleteRealtimeEndpointOutput) SetRealtimeEndpointInfo(v *RealtimeEndpointInfo) *DeleteRealtimeEndpointOutput {
+	s.RealtimeEndpointInfo = v
+	return s
 }
 
 type DeleteTagsInput struct {
@@ -3602,6 +4136,24 @@ func (s *DeleteTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteTagsInput) SetResourceId(v string) *DeleteTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *DeleteTagsInput) SetResourceType(v string) *DeleteTagsInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DeleteTagsInput) SetTagKeys(v []*string) *DeleteTagsInput {
+	s.TagKeys = v
+	return s
+}
+
 // Amazon ML returns the following elements.
 type DeleteTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3621,6 +4173,18 @@ func (s DeleteTagsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteTagsOutput) SetResourceId(v string) *DeleteTagsOutput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *DeleteTagsOutput) SetResourceType(v string) *DeleteTagsOutput {
+	s.ResourceType = &v
+	return s
 }
 
 type DescribeBatchPredictionsInput struct {
@@ -3722,6 +4286,72 @@ func (s *DescribeBatchPredictionsInput) Validate() error {
 	return nil
 }
 
+// SetEQ sets the EQ field's value.
+func (s *DescribeBatchPredictionsInput) SetEQ(v string) *DescribeBatchPredictionsInput {
+	s.EQ = &v
+	return s
+}
+
+// SetFilterVariable sets the FilterVariable field's value.
+func (s *DescribeBatchPredictionsInput) SetFilterVariable(v string) *DescribeBatchPredictionsInput {
+	s.FilterVariable = &v
+	return s
+}
+
+// SetGE sets the GE field's value.
+func (s *DescribeBatchPredictionsInput) SetGE(v string) *DescribeBatchPredictionsInput {
+	s.GE = &v
+	return s
+}
+
+// SetGT sets the GT field's value.
+func (s *DescribeBatchPredictionsInput) SetGT(v string) *DescribeBatchPredictionsInput {
+	s.GT = &v
+	return s
+}
+
+// SetLE sets the LE field's value.
+func (s *DescribeBatchPredictionsInput) SetLE(v string) *DescribeBatchPredictionsInput {
+	s.LE = &v
+	return s
+}
+
+// SetLT sets the LT field's value.
+func (s *DescribeBatchPredictionsInput) SetLT(v string) *DescribeBatchPredictionsInput {
+	s.LT = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeBatchPredictionsInput) SetLimit(v int64) *DescribeBatchPredictionsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNE sets the NE field's value.
+func (s *DescribeBatchPredictionsInput) SetNE(v string) *DescribeBatchPredictionsInput {
+	s.NE = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeBatchPredictionsInput) SetNextToken(v string) *DescribeBatchPredictionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *DescribeBatchPredictionsInput) SetPrefix(v string) *DescribeBatchPredictionsInput {
+	s.Prefix = &v
+	return s
+}
+
+// SetSortOrder sets the SortOrder field's value.
+func (s *DescribeBatchPredictionsInput) SetSortOrder(v string) *DescribeBatchPredictionsInput {
+	s.SortOrder = &v
+	return s
+}
+
 // Represents the output of a DescribeBatchPredictions operation. The content
 // is essentially a list of BatchPredictions.
 type DescribeBatchPredictionsOutput struct {
@@ -3743,6 +4373,18 @@ func (s DescribeBatchPredictionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeBatchPredictionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeBatchPredictionsOutput) SetNextToken(v string) *DescribeBatchPredictionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResults sets the Results field's value.
+func (s *DescribeBatchPredictionsOutput) SetResults(v []*BatchPrediction) *DescribeBatchPredictionsOutput {
+	s.Results = v
+	return s
 }
 
 type DescribeDataSourcesInput struct {
@@ -3835,6 +4477,72 @@ func (s *DescribeDataSourcesInput) Validate() error {
 	return nil
 }
 
+// SetEQ sets the EQ field's value.
+func (s *DescribeDataSourcesInput) SetEQ(v string) *DescribeDataSourcesInput {
+	s.EQ = &v
+	return s
+}
+
+// SetFilterVariable sets the FilterVariable field's value.
+func (s *DescribeDataSourcesInput) SetFilterVariable(v string) *DescribeDataSourcesInput {
+	s.FilterVariable = &v
+	return s
+}
+
+// SetGE sets the GE field's value.
+func (s *DescribeDataSourcesInput) SetGE(v string) *DescribeDataSourcesInput {
+	s.GE = &v
+	return s
+}
+
+// SetGT sets the GT field's value.
+func (s *DescribeDataSourcesInput) SetGT(v string) *DescribeDataSourcesInput {
+	s.GT = &v
+	return s
+}
+
+// SetLE sets the LE field's value.
+func (s *DescribeDataSourcesInput) SetLE(v string) *DescribeDataSourcesInput {
+	s.LE = &v
+	return s
+}
+
+// SetLT sets the LT field's value.
+func (s *DescribeDataSourcesInput) SetLT(v string) *DescribeDataSourcesInput {
+	s.LT = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeDataSourcesInput) SetLimit(v int64) *DescribeDataSourcesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNE sets the NE field's value.
+func (s *DescribeDataSourcesInput) SetNE(v string) *DescribeDataSourcesInput {
+	s.NE = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeDataSourcesInput) SetNextToken(v string) *DescribeDataSourcesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *DescribeDataSourcesInput) SetPrefix(v string) *DescribeDataSourcesInput {
+	s.Prefix = &v
+	return s
+}
+
+// SetSortOrder sets the SortOrder field's value.
+func (s *DescribeDataSourcesInput) SetSortOrder(v string) *DescribeDataSourcesInput {
+	s.SortOrder = &v
+	return s
+}
+
 // Represents the query results from a DescribeDataSources operation. The content
 // is essentially a list of DataSource.
 type DescribeDataSourcesOutput struct {
@@ -3856,6 +4564,18 @@ func (s DescribeDataSourcesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDataSourcesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeDataSourcesOutput) SetNextToken(v string) *DescribeDataSourcesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResults sets the Results field's value.
+func (s *DescribeDataSourcesOutput) SetResults(v []*DataSource) *DescribeDataSourcesOutput {
+	s.Results = v
+	return s
 }
 
 type DescribeEvaluationsInput struct {
@@ -3953,6 +4673,72 @@ func (s *DescribeEvaluationsInput) Validate() error {
 	return nil
 }
 
+// SetEQ sets the EQ field's value.
+func (s *DescribeEvaluationsInput) SetEQ(v string) *DescribeEvaluationsInput {
+	s.EQ = &v
+	return s
+}
+
+// SetFilterVariable sets the FilterVariable field's value.
+func (s *DescribeEvaluationsInput) SetFilterVariable(v string) *DescribeEvaluationsInput {
+	s.FilterVariable = &v
+	return s
+}
+
+// SetGE sets the GE field's value.
+func (s *DescribeEvaluationsInput) SetGE(v string) *DescribeEvaluationsInput {
+	s.GE = &v
+	return s
+}
+
+// SetGT sets the GT field's value.
+func (s *DescribeEvaluationsInput) SetGT(v string) *DescribeEvaluationsInput {
+	s.GT = &v
+	return s
+}
+
+// SetLE sets the LE field's value.
+func (s *DescribeEvaluationsInput) SetLE(v string) *DescribeEvaluationsInput {
+	s.LE = &v
+	return s
+}
+
+// SetLT sets the LT field's value.
+func (s *DescribeEvaluationsInput) SetLT(v string) *DescribeEvaluationsInput {
+	s.LT = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeEvaluationsInput) SetLimit(v int64) *DescribeEvaluationsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNE sets the NE field's value.
+func (s *DescribeEvaluationsInput) SetNE(v string) *DescribeEvaluationsInput {
+	s.NE = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeEvaluationsInput) SetNextToken(v string) *DescribeEvaluationsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *DescribeEvaluationsInput) SetPrefix(v string) *DescribeEvaluationsInput {
+	s.Prefix = &v
+	return s
+}
+
+// SetSortOrder sets the SortOrder field's value.
+func (s *DescribeEvaluationsInput) SetSortOrder(v string) *DescribeEvaluationsInput {
+	s.SortOrder = &v
+	return s
+}
+
 // Represents the query results from a DescribeEvaluations operation. The content
 // is essentially a list of Evaluation.
 type DescribeEvaluationsOutput struct {
@@ -3974,6 +4760,18 @@ func (s DescribeEvaluationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEvaluationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeEvaluationsOutput) SetNextToken(v string) *DescribeEvaluationsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResults sets the Results field's value.
+func (s *DescribeEvaluationsOutput) SetResults(v []*Evaluation) *DescribeEvaluationsOutput {
+	s.Results = v
+	return s
 }
 
 type DescribeMLModelsInput struct {
@@ -4075,6 +4873,72 @@ func (s *DescribeMLModelsInput) Validate() error {
 	return nil
 }
 
+// SetEQ sets the EQ field's value.
+func (s *DescribeMLModelsInput) SetEQ(v string) *DescribeMLModelsInput {
+	s.EQ = &v
+	return s
+}
+
+// SetFilterVariable sets the FilterVariable field's value.
+func (s *DescribeMLModelsInput) SetFilterVariable(v string) *DescribeMLModelsInput {
+	s.FilterVariable = &v
+	return s
+}
+
+// SetGE sets the GE field's value.
+func (s *DescribeMLModelsInput) SetGE(v string) *DescribeMLModelsInput {
+	s.GE = &v
+	return s
+}
+
+// SetGT sets the GT field's value.
+func (s *DescribeMLModelsInput) SetGT(v string) *DescribeMLModelsInput {
+	s.GT = &v
+	return s
+}
+
+// SetLE sets the LE field's value.
+func (s *DescribeMLModelsInput) SetLE(v string) *DescribeMLModelsInput {
+	s.LE = &v
+	return s
+}
+
+// SetLT sets the LT field's value.
+func (s *DescribeMLModelsInput) SetLT(v string) *DescribeMLModelsInput {
+	s.LT = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeMLModelsInput) SetLimit(v int64) *DescribeMLModelsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNE sets the NE field's value.
+func (s *DescribeMLModelsInput) SetNE(v string) *DescribeMLModelsInput {
+	s.NE = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeMLModelsInput) SetNextToken(v string) *DescribeMLModelsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *DescribeMLModelsInput) SetPrefix(v string) *DescribeMLModelsInput {
+	s.Prefix = &v
+	return s
+}
+
+// SetSortOrder sets the SortOrder field's value.
+func (s *DescribeMLModelsInput) SetSortOrder(v string) *DescribeMLModelsInput {
+	s.SortOrder = &v
+	return s
+}
+
 // Represents the output of a DescribeMLModels operation. The content is essentially
 // a list of MLModel.
 type DescribeMLModelsOutput struct {
@@ -4096,6 +4960,18 @@ func (s DescribeMLModelsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeMLModelsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeMLModelsOutput) SetNextToken(v string) *DescribeMLModelsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResults sets the Results field's value.
+func (s *DescribeMLModelsOutput) SetResults(v []*MLModel) *DescribeMLModelsOutput {
+	s.Results = v
+	return s
 }
 
 type DescribeTagsInput struct {
@@ -4141,6 +5017,18 @@ func (s *DescribeTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *DescribeTagsInput) SetResourceId(v string) *DescribeTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *DescribeTagsInput) SetResourceType(v string) *DescribeTagsInput {
+	s.ResourceType = &v
+	return s
+}
+
 // Amazon ML returns the following elements.
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4163,6 +5051,24 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DescribeTagsOutput) SetResourceId(v string) *DescribeTagsOutput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *DescribeTagsOutput) SetResourceType(v string) *DescribeTagsOutput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *DescribeTagsOutput) SetTags(v []*Tag) *DescribeTagsOutput {
+	s.Tags = v
+	return s
 }
 
 // Represents the output of GetEvaluation operation.
@@ -4254,6 +5160,90 @@ func (s Evaluation) GoString() string {
 	return s.String()
 }
 
+// SetComputeTime sets the ComputeTime field's value.
+func (s *Evaluation) SetComputeTime(v int64) *Evaluation {
+	s.ComputeTime = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Evaluation) SetCreatedAt(v time.Time) *Evaluation {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCreatedByIamUser sets the CreatedByIamUser field's value.
+func (s *Evaluation) SetCreatedByIamUser(v string) *Evaluation {
+	s.CreatedByIamUser = &v
+	return s
+}
+
+// SetEvaluationDataSourceId sets the EvaluationDataSourceId field's value.
+func (s *Evaluation) SetEvaluationDataSourceId(v string) *Evaluation {
+	s.EvaluationDataSourceId = &v
+	return s
+}
+
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *Evaluation) SetEvaluationId(v string) *Evaluation {
+	s.EvaluationId = &v
+	return s
+}
+
+// SetFinishedAt sets the FinishedAt field's value.
+func (s *Evaluation) SetFinishedAt(v time.Time) *Evaluation {
+	s.FinishedAt = &v
+	return s
+}
+
+// SetInputDataLocationS3 sets the InputDataLocationS3 field's value.
+func (s *Evaluation) SetInputDataLocationS3(v string) *Evaluation {
+	s.InputDataLocationS3 = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *Evaluation) SetLastUpdatedAt(v time.Time) *Evaluation {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *Evaluation) SetMLModelId(v string) *Evaluation {
+	s.MLModelId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Evaluation) SetMessage(v string) *Evaluation {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Evaluation) SetName(v string) *Evaluation {
+	s.Name = &v
+	return s
+}
+
+// SetPerformanceMetrics sets the PerformanceMetrics field's value.
+func (s *Evaluation) SetPerformanceMetrics(v *PerformanceMetrics) *Evaluation {
+	s.PerformanceMetrics = v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *Evaluation) SetStartedAt(v time.Time) *Evaluation {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Evaluation) SetStatus(v string) *Evaluation {
+	s.Status = &v
+	return s
+}
+
 type GetBatchPredictionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4287,6 +5277,12 @@ func (s *GetBatchPredictionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *GetBatchPredictionInput) SetBatchPredictionId(v string) *GetBatchPredictionInput {
+	s.BatchPredictionId = &v
+	return s
 }
 
 // Represents the output of a GetBatchPrediction operation and describes a BatchPrediction.
@@ -4381,6 +5377,108 @@ func (s GetBatchPredictionOutput) GoString() string {
 	return s.String()
 }
 
+// SetBatchPredictionDataSourceId sets the BatchPredictionDataSourceId field's value.
+func (s *GetBatchPredictionOutput) SetBatchPredictionDataSourceId(v string) *GetBatchPredictionOutput {
+	s.BatchPredictionDataSourceId = &v
+	return s
+}
+
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *GetBatchPredictionOutput) SetBatchPredictionId(v string) *GetBatchPredictionOutput {
+	s.BatchPredictionId = &v
+	return s
+}
+
+// SetComputeTime sets the ComputeTime field's value.
+func (s *GetBatchPredictionOutput) SetComputeTime(v int64) *GetBatchPredictionOutput {
+	s.ComputeTime = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *GetBatchPredictionOutput) SetCreatedAt(v time.Time) *GetBatchPredictionOutput {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCreatedByIamUser sets the CreatedByIamUser field's value.
+func (s *GetBatchPredictionOutput) SetCreatedByIamUser(v string) *GetBatchPredictionOutput {
+	s.CreatedByIamUser = &v
+	return s
+}
+
+// SetFinishedAt sets the FinishedAt field's value.
+func (s *GetBatchPredictionOutput) SetFinishedAt(v time.Time) *GetBatchPredictionOutput {
+	s.FinishedAt = &v
+	return s
+}
+
+// SetInputDataLocationS3 sets the InputDataLocationS3 field's value.
+func (s *GetBatchPredictionOutput) SetInputDataLocationS3(v string) *GetBatchPredictionOutput {
+	s.InputDataLocationS3 = &v
+	return s
+}
+
+// SetInvalidRecordCount sets the InvalidRecordCount field's value.
+func (s *GetBatchPredictionOutput) SetInvalidRecordCount(v int64) *GetBatchPredictionOutput {
+	s.InvalidRecordCount = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *GetBatchPredictionOutput) SetLastUpdatedAt(v time.Time) *GetBatchPredictionOutput {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetLogUri sets the LogUri field's value.
+func (s *GetBatchPredictionOutput) SetLogUri(v string) *GetBatchPredictionOutput {
+	s.LogUri = &v
+	return s
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *GetBatchPredictionOutput) SetMLModelId(v string) *GetBatchPredictionOutput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *GetBatchPredictionOutput) SetMessage(v string) *GetBatchPredictionOutput {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetBatchPredictionOutput) SetName(v string) *GetBatchPredictionOutput {
+	s.Name = &v
+	return s
+}
+
+// SetOutputUri sets the OutputUri field's value.
+func (s *GetBatchPredictionOutput) SetOutputUri(v string) *GetBatchPredictionOutput {
+	s.OutputUri = &v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *GetBatchPredictionOutput) SetStartedAt(v time.Time) *GetBatchPredictionOutput {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetBatchPredictionOutput) SetStatus(v string) *GetBatchPredictionOutput {
+	s.Status = &v
+	return s
+}
+
+// SetTotalRecordCount sets the TotalRecordCount field's value.
+func (s *GetBatchPredictionOutput) SetTotalRecordCount(v int64) *GetBatchPredictionOutput {
+	s.TotalRecordCount = &v
+	return s
+}
+
 type GetDataSourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4421,6 +5519,18 @@ func (s *GetDataSourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *GetDataSourceInput) SetDataSourceId(v string) *GetDataSourceInput {
+	s.DataSourceId = &v
+	return s
+}
+
+// SetVerbose sets the Verbose field's value.
+func (s *GetDataSourceInput) SetVerbose(v bool) *GetDataSourceInput {
+	s.Verbose = &v
+	return s
 }
 
 // Represents the output of a GetDataSource operation and describes a DataSource.
@@ -4524,6 +5634,126 @@ func (s GetDataSourceOutput) GoString() string {
 	return s.String()
 }
 
+// SetComputeStatistics sets the ComputeStatistics field's value.
+func (s *GetDataSourceOutput) SetComputeStatistics(v bool) *GetDataSourceOutput {
+	s.ComputeStatistics = &v
+	return s
+}
+
+// SetComputeTime sets the ComputeTime field's value.
+func (s *GetDataSourceOutput) SetComputeTime(v int64) *GetDataSourceOutput {
+	s.ComputeTime = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *GetDataSourceOutput) SetCreatedAt(v time.Time) *GetDataSourceOutput {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCreatedByIamUser sets the CreatedByIamUser field's value.
+func (s *GetDataSourceOutput) SetCreatedByIamUser(v string) *GetDataSourceOutput {
+	s.CreatedByIamUser = &v
+	return s
+}
+
+// SetDataLocationS3 sets the DataLocationS3 field's value.
+func (s *GetDataSourceOutput) SetDataLocationS3(v string) *GetDataSourceOutput {
+	s.DataLocationS3 = &v
+	return s
+}
+
+// SetDataRearrangement sets the DataRearrangement field's value.
+func (s *GetDataSourceOutput) SetDataRearrangement(v string) *GetDataSourceOutput {
+	s.DataRearrangement = &v
+	return s
+}
+
+// SetDataSizeInBytes sets the DataSizeInBytes field's value.
+func (s *GetDataSourceOutput) SetDataSizeInBytes(v int64) *GetDataSourceOutput {
+	s.DataSizeInBytes = &v
+	return s
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *GetDataSourceOutput) SetDataSourceId(v string) *GetDataSourceOutput {
+	s.DataSourceId = &v
+	return s
+}
+
+// SetDataSourceSchema sets the DataSourceSchema field's value.
+func (s *GetDataSourceOutput) SetDataSourceSchema(v string) *GetDataSourceOutput {
+	s.DataSourceSchema = &v
+	return s
+}
+
+// SetFinishedAt sets the FinishedAt field's value.
+func (s *GetDataSourceOutput) SetFinishedAt(v time.Time) *GetDataSourceOutput {
+	s.FinishedAt = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *GetDataSourceOutput) SetLastUpdatedAt(v time.Time) *GetDataSourceOutput {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetLogUri sets the LogUri field's value.
+func (s *GetDataSourceOutput) SetLogUri(v string) *GetDataSourceOutput {
+	s.LogUri = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *GetDataSourceOutput) SetMessage(v string) *GetDataSourceOutput {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetDataSourceOutput) SetName(v string) *GetDataSourceOutput {
+	s.Name = &v
+	return s
+}
+
+// SetNumberOfFiles sets the NumberOfFiles field's value.
+func (s *GetDataSourceOutput) SetNumberOfFiles(v int64) *GetDataSourceOutput {
+	s.NumberOfFiles = &v
+	return s
+}
+
+// SetRDSMetadata sets the RDSMetadata field's value.
+func (s *GetDataSourceOutput) SetRDSMetadata(v *RDSMetadata) *GetDataSourceOutput {
+	s.RDSMetadata = v
+	return s
+}
+
+// SetRedshiftMetadata sets the RedshiftMetadata field's value.
+func (s *GetDataSourceOutput) SetRedshiftMetadata(v *RedshiftMetadata) *GetDataSourceOutput {
+	s.RedshiftMetadata = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *GetDataSourceOutput) SetRoleARN(v string) *GetDataSourceOutput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *GetDataSourceOutput) SetStartedAt(v time.Time) *GetDataSourceOutput {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetDataSourceOutput) SetStatus(v string) *GetDataSourceOutput {
+	s.Status = &v
+	return s
+}
+
 type GetEvaluationInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4558,6 +5788,12 @@ func (s *GetEvaluationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *GetEvaluationInput) SetEvaluationId(v string) *GetEvaluationInput {
+	s.EvaluationId = &v
+	return s
 }
 
 // Represents the output of a GetEvaluation operation and describes an Evaluation.
@@ -4654,6 +5890,96 @@ func (s GetEvaluationOutput) GoString() string {
 	return s.String()
 }
 
+// SetComputeTime sets the ComputeTime field's value.
+func (s *GetEvaluationOutput) SetComputeTime(v int64) *GetEvaluationOutput {
+	s.ComputeTime = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *GetEvaluationOutput) SetCreatedAt(v time.Time) *GetEvaluationOutput {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCreatedByIamUser sets the CreatedByIamUser field's value.
+func (s *GetEvaluationOutput) SetCreatedByIamUser(v string) *GetEvaluationOutput {
+	s.CreatedByIamUser = &v
+	return s
+}
+
+// SetEvaluationDataSourceId sets the EvaluationDataSourceId field's value.
+func (s *GetEvaluationOutput) SetEvaluationDataSourceId(v string) *GetEvaluationOutput {
+	s.EvaluationDataSourceId = &v
+	return s
+}
+
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *GetEvaluationOutput) SetEvaluationId(v string) *GetEvaluationOutput {
+	s.EvaluationId = &v
+	return s
+}
+
+// SetFinishedAt sets the FinishedAt field's value.
+func (s *GetEvaluationOutput) SetFinishedAt(v time.Time) *GetEvaluationOutput {
+	s.FinishedAt = &v
+	return s
+}
+
+// SetInputDataLocationS3 sets the InputDataLocationS3 field's value.
+func (s *GetEvaluationOutput) SetInputDataLocationS3(v string) *GetEvaluationOutput {
+	s.InputDataLocationS3 = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *GetEvaluationOutput) SetLastUpdatedAt(v time.Time) *GetEvaluationOutput {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetLogUri sets the LogUri field's value.
+func (s *GetEvaluationOutput) SetLogUri(v string) *GetEvaluationOutput {
+	s.LogUri = &v
+	return s
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *GetEvaluationOutput) SetMLModelId(v string) *GetEvaluationOutput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *GetEvaluationOutput) SetMessage(v string) *GetEvaluationOutput {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetEvaluationOutput) SetName(v string) *GetEvaluationOutput {
+	s.Name = &v
+	return s
+}
+
+// SetPerformanceMetrics sets the PerformanceMetrics field's value.
+func (s *GetEvaluationOutput) SetPerformanceMetrics(v *PerformanceMetrics) *GetEvaluationOutput {
+	s.PerformanceMetrics = v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *GetEvaluationOutput) SetStartedAt(v time.Time) *GetEvaluationOutput {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetEvaluationOutput) SetStatus(v string) *GetEvaluationOutput {
+	s.Status = &v
+	return s
+}
+
 type GetMLModelInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4694,6 +6020,18 @@ func (s *GetMLModelInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *GetMLModelInput) SetMLModelId(v string) *GetMLModelInput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetVerbose sets the Verbose field's value.
+func (s *GetMLModelInput) SetVerbose(v bool) *GetMLModelInput {
+	s.Verbose = &v
+	return s
 }
 
 // Represents the output of a GetMLModel operation, and provides detailed information
@@ -4849,6 +6187,132 @@ func (s GetMLModelOutput) GoString() string {
 	return s.String()
 }
 
+// SetComputeTime sets the ComputeTime field's value.
+func (s *GetMLModelOutput) SetComputeTime(v int64) *GetMLModelOutput {
+	s.ComputeTime = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *GetMLModelOutput) SetCreatedAt(v time.Time) *GetMLModelOutput {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCreatedByIamUser sets the CreatedByIamUser field's value.
+func (s *GetMLModelOutput) SetCreatedByIamUser(v string) *GetMLModelOutput {
+	s.CreatedByIamUser = &v
+	return s
+}
+
+// SetEndpointInfo sets the EndpointInfo field's value.
+func (s *GetMLModelOutput) SetEndpointInfo(v *RealtimeEndpointInfo) *GetMLModelOutput {
+	s.EndpointInfo = v
+	return s
+}
+
+// SetFinishedAt sets the FinishedAt field's value.
+func (s *GetMLModelOutput) SetFinishedAt(v time.Time) *GetMLModelOutput {
+	s.FinishedAt = &v
+	return s
+}
+
+// SetInputDataLocationS3 sets the InputDataLocationS3 field's value.
+func (s *GetMLModelOutput) SetInputDataLocationS3(v string) *GetMLModelOutput {
+	s.InputDataLocationS3 = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *GetMLModelOutput) SetLastUpdatedAt(v time.Time) *GetMLModelOutput {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetLogUri sets the LogUri field's value.
+func (s *GetMLModelOutput) SetLogUri(v string) *GetMLModelOutput {
+	s.LogUri = &v
+	return s
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *GetMLModelOutput) SetMLModelId(v string) *GetMLModelOutput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetMLModelType sets the MLModelType field's value.
+func (s *GetMLModelOutput) SetMLModelType(v string) *GetMLModelOutput {
+	s.MLModelType = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *GetMLModelOutput) SetMessage(v string) *GetMLModelOutput {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetMLModelOutput) SetName(v string) *GetMLModelOutput {
+	s.Name = &v
+	return s
+}
+
+// SetRecipe sets the Recipe field's value.
+func (s *GetMLModelOutput) SetRecipe(v string) *GetMLModelOutput {
+	s.Recipe = &v
+	return s
+}
+
+// SetSchema sets the Schema field's value.
+func (s *GetMLModelOutput) SetSchema(v string) *GetMLModelOutput {
+	s.Schema = &v
+	return s
+}
+
+// SetScoreThreshold sets the ScoreThreshold field's value.
+func (s *GetMLModelOutput) SetScoreThreshold(v float64) *GetMLModelOutput {
+	s.ScoreThreshold = &v
+	return s
+}
+
+// SetScoreThresholdLastUpdatedAt sets the ScoreThresholdLastUpdatedAt field's value.
+func (s *GetMLModelOutput) SetScoreThresholdLastUpdatedAt(v time.Time) *GetMLModelOutput {
+	s.ScoreThresholdLastUpdatedAt = &v
+	return s
+}
+
+// SetSizeInBytes sets the SizeInBytes field's value.
+func (s *GetMLModelOutput) SetSizeInBytes(v int64) *GetMLModelOutput {
+	s.SizeInBytes = &v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *GetMLModelOutput) SetStartedAt(v time.Time) *GetMLModelOutput {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetMLModelOutput) SetStatus(v string) *GetMLModelOutput {
+	s.Status = &v
+	return s
+}
+
+// SetTrainingDataSourceId sets the TrainingDataSourceId field's value.
+func (s *GetMLModelOutput) SetTrainingDataSourceId(v string) *GetMLModelOutput {
+	s.TrainingDataSourceId = &v
+	return s
+}
+
+// SetTrainingParameters sets the TrainingParameters field's value.
+func (s *GetMLModelOutput) SetTrainingParameters(v map[string]*string) *GetMLModelOutput {
+	s.TrainingParameters = v
+	return s
+}
+
 // Represents the output of a GetMLModel operation.
 //
 // The content consists of the detailed metadata and the current status of the
@@ -4984,6 +6448,120 @@ func (s MLModel) GoString() string {
 	return s.String()
 }
 
+// SetAlgorithm sets the Algorithm field's value.
+func (s *MLModel) SetAlgorithm(v string) *MLModel {
+	s.Algorithm = &v
+	return s
+}
+
+// SetComputeTime sets the ComputeTime field's value.
+func (s *MLModel) SetComputeTime(v int64) *MLModel {
+	s.ComputeTime = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *MLModel) SetCreatedAt(v time.Time) *MLModel {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCreatedByIamUser sets the CreatedByIamUser field's value.
+func (s *MLModel) SetCreatedByIamUser(v string) *MLModel {
+	s.CreatedByIamUser = &v
+	return s
+}
+
+// SetEndpointInfo sets the EndpointInfo field's value.
+func (s *MLModel) SetEndpointInfo(v *RealtimeEndpointInfo) *MLModel {
+	s.EndpointInfo = v
+	return s
+}
+
+// SetFinishedAt sets the FinishedAt field's value.
+func (s *MLModel) SetFinishedAt(v time.Time) *MLModel {
+	s.FinishedAt = &v
+	return s
+}
+
+// SetInputDataLocationS3 sets the InputDataLocationS3 field's value.
+func (s *MLModel) SetInputDataLocationS3(v string) *MLModel {
+	s.InputDataLocationS3 = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *MLModel) SetLastUpdatedAt(v time.Time) *MLModel {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *MLModel) SetMLModelId(v string) *MLModel {
+	s.MLModelId = &v
+	return s
+}
+
+// SetMLModelType sets the MLModelType field's value.
+func (s *MLModel) SetMLModelType(v string) *MLModel {
+	s.MLModelType = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *MLModel) SetMessage(v string) *MLModel {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *MLModel) SetName(v string) *MLModel {
+	s.Name = &v
+	return s
+}
+
+// SetScoreThreshold sets the ScoreThreshold field's value.
+func (s *MLModel) SetScoreThreshold(v float64) *MLModel {
+	s.ScoreThreshold = &v
+	return s
+}
+
+// SetScoreThresholdLastUpdatedAt sets the ScoreThresholdLastUpdatedAt field's value.
+func (s *MLModel) SetScoreThresholdLastUpdatedAt(v time.Time) *MLModel {
+	s.ScoreThresholdLastUpdatedAt = &v
+	return s
+}
+
+// SetSizeInBytes sets the SizeInBytes field's value.
+func (s *MLModel) SetSizeInBytes(v int64) *MLModel {
+	s.SizeInBytes = &v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *MLModel) SetStartedAt(v time.Time) *MLModel {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *MLModel) SetStatus(v string) *MLModel {
+	s.Status = &v
+	return s
+}
+
+// SetTrainingDataSourceId sets the TrainingDataSourceId field's value.
+func (s *MLModel) SetTrainingDataSourceId(v string) *MLModel {
+	s.TrainingDataSourceId = &v
+	return s
+}
+
+// SetTrainingParameters sets the TrainingParameters field's value.
+func (s *MLModel) SetTrainingParameters(v map[string]*string) *MLModel {
+	s.TrainingParameters = v
+	return s
+}
+
 // Measurements of how well the MLModel performed on known observations. One
 // of the following metrics is returned, based on the type of the MLModel:
 //
@@ -5013,6 +6591,12 @@ func (s PerformanceMetrics) String() string {
 // GoString returns the string representation
 func (s PerformanceMetrics) GoString() string {
 	return s.String()
+}
+
+// SetProperties sets the Properties field's value.
+func (s *PerformanceMetrics) SetProperties(v map[string]*string) *PerformanceMetrics {
+	s.Properties = v
+	return s
 }
 
 type PredictInput struct {
@@ -5064,6 +6648,24 @@ func (s *PredictInput) Validate() error {
 	return nil
 }
 
+// SetMLModelId sets the MLModelId field's value.
+func (s *PredictInput) SetMLModelId(v string) *PredictInput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetPredictEndpoint sets the PredictEndpoint field's value.
+func (s *PredictInput) SetPredictEndpoint(v string) *PredictInput {
+	s.PredictEndpoint = &v
+	return s
+}
+
+// SetRecord sets the Record field's value.
+func (s *PredictInput) SetRecord(v map[string]*string) *PredictInput {
+	s.Record = v
+	return s
+}
+
 type PredictOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5090,6 +6692,12 @@ func (s PredictOutput) String() string {
 // GoString returns the string representation
 func (s PredictOutput) GoString() string {
 	return s.String()
+}
+
+// SetPrediction sets the Prediction field's value.
+func (s *PredictOutput) SetPrediction(v *Prediction) *PredictOutput {
+	s.Prediction = v
+	return s
 }
 
 // The output from a Predict operation:
@@ -5128,6 +6736,30 @@ func (s Prediction) String() string {
 // GoString returns the string representation
 func (s Prediction) GoString() string {
 	return s.String()
+}
+
+// SetDetails sets the Details field's value.
+func (s *Prediction) SetDetails(v map[string]*string) *Prediction {
+	s.Details = v
+	return s
+}
+
+// SetPredictedLabel sets the PredictedLabel field's value.
+func (s *Prediction) SetPredictedLabel(v string) *Prediction {
+	s.PredictedLabel = &v
+	return s
+}
+
+// SetPredictedScores sets the PredictedScores field's value.
+func (s *Prediction) SetPredictedScores(v map[string]*float64) *Prediction {
+	s.PredictedScores = v
+	return s
+}
+
+// SetPredictedValue sets the PredictedValue field's value.
+func (s *Prediction) SetPredictedValue(v float64) *Prediction {
+	s.PredictedValue = &v
+	return s
 }
 
 // The data specification of an Amazon Relational Database Service (Amazon RDS)
@@ -5373,6 +7005,72 @@ func (s *RDSDataSpec) Validate() error {
 	return nil
 }
 
+// SetDataRearrangement sets the DataRearrangement field's value.
+func (s *RDSDataSpec) SetDataRearrangement(v string) *RDSDataSpec {
+	s.DataRearrangement = &v
+	return s
+}
+
+// SetDataSchema sets the DataSchema field's value.
+func (s *RDSDataSpec) SetDataSchema(v string) *RDSDataSpec {
+	s.DataSchema = &v
+	return s
+}
+
+// SetDataSchemaUri sets the DataSchemaUri field's value.
+func (s *RDSDataSpec) SetDataSchemaUri(v string) *RDSDataSpec {
+	s.DataSchemaUri = &v
+	return s
+}
+
+// SetDatabaseCredentials sets the DatabaseCredentials field's value.
+func (s *RDSDataSpec) SetDatabaseCredentials(v *RDSDatabaseCredentials) *RDSDataSpec {
+	s.DatabaseCredentials = v
+	return s
+}
+
+// SetDatabaseInformation sets the DatabaseInformation field's value.
+func (s *RDSDataSpec) SetDatabaseInformation(v *RDSDatabase) *RDSDataSpec {
+	s.DatabaseInformation = v
+	return s
+}
+
+// SetResourceRole sets the ResourceRole field's value.
+func (s *RDSDataSpec) SetResourceRole(v string) *RDSDataSpec {
+	s.ResourceRole = &v
+	return s
+}
+
+// SetS3StagingLocation sets the S3StagingLocation field's value.
+func (s *RDSDataSpec) SetS3StagingLocation(v string) *RDSDataSpec {
+	s.S3StagingLocation = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *RDSDataSpec) SetSecurityGroupIds(v []*string) *RDSDataSpec {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSelectSqlQuery sets the SelectSqlQuery field's value.
+func (s *RDSDataSpec) SetSelectSqlQuery(v string) *RDSDataSpec {
+	s.SelectSqlQuery = &v
+	return s
+}
+
+// SetServiceRole sets the ServiceRole field's value.
+func (s *RDSDataSpec) SetServiceRole(v string) *RDSDataSpec {
+	s.ServiceRole = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *RDSDataSpec) SetSubnetId(v string) *RDSDataSpec {
+	s.SubnetId = &v
+	return s
+}
+
 // The database details of an Amazon RDS database.
 type RDSDatabase struct {
 	_ struct{} `type:"structure"`
@@ -5418,6 +7116,18 @@ func (s *RDSDatabase) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *RDSDatabase) SetDatabaseName(v string) *RDSDatabase {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetInstanceIdentifier sets the InstanceIdentifier field's value.
+func (s *RDSDatabase) SetInstanceIdentifier(v string) *RDSDatabase {
+	s.InstanceIdentifier = &v
+	return s
 }
 
 // The database credentials to connect to a database on an RDS DB instance.
@@ -5471,6 +7181,18 @@ func (s *RDSDatabaseCredentials) Validate() error {
 	return nil
 }
 
+// SetPassword sets the Password field's value.
+func (s *RDSDatabaseCredentials) SetPassword(v string) *RDSDatabaseCredentials {
+	s.Password = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *RDSDatabaseCredentials) SetUsername(v string) *RDSDatabaseCredentials {
+	s.Username = &v
+	return s
+}
+
 // The datasource details that are specific to Amazon RDS.
 type RDSMetadata struct {
 	_ struct{} `type:"structure"`
@@ -5515,6 +7237,42 @@ func (s RDSMetadata) GoString() string {
 	return s.String()
 }
 
+// SetDataPipelineId sets the DataPipelineId field's value.
+func (s *RDSMetadata) SetDataPipelineId(v string) *RDSMetadata {
+	s.DataPipelineId = &v
+	return s
+}
+
+// SetDatabase sets the Database field's value.
+func (s *RDSMetadata) SetDatabase(v *RDSDatabase) *RDSMetadata {
+	s.Database = v
+	return s
+}
+
+// SetDatabaseUserName sets the DatabaseUserName field's value.
+func (s *RDSMetadata) SetDatabaseUserName(v string) *RDSMetadata {
+	s.DatabaseUserName = &v
+	return s
+}
+
+// SetResourceRole sets the ResourceRole field's value.
+func (s *RDSMetadata) SetResourceRole(v string) *RDSMetadata {
+	s.ResourceRole = &v
+	return s
+}
+
+// SetSelectSqlQuery sets the SelectSqlQuery field's value.
+func (s *RDSMetadata) SetSelectSqlQuery(v string) *RDSMetadata {
+	s.SelectSqlQuery = &v
+	return s
+}
+
+// SetServiceRole sets the ServiceRole field's value.
+func (s *RDSMetadata) SetServiceRole(v string) *RDSMetadata {
+	s.ServiceRole = &v
+	return s
+}
+
 // Describes the real-time endpoint information for an MLModel.
 type RealtimeEndpointInfo struct {
 	_ struct{} `type:"structure"`
@@ -5551,6 +7309,30 @@ func (s RealtimeEndpointInfo) String() string {
 // GoString returns the string representation
 func (s RealtimeEndpointInfo) GoString() string {
 	return s.String()
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *RealtimeEndpointInfo) SetCreatedAt(v time.Time) *RealtimeEndpointInfo {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetEndpointStatus sets the EndpointStatus field's value.
+func (s *RealtimeEndpointInfo) SetEndpointStatus(v string) *RealtimeEndpointInfo {
+	s.EndpointStatus = &v
+	return s
+}
+
+// SetEndpointUrl sets the EndpointUrl field's value.
+func (s *RealtimeEndpointInfo) SetEndpointUrl(v string) *RealtimeEndpointInfo {
+	s.EndpointUrl = &v
+	return s
+}
+
+// SetPeakRequestsPerSecond sets the PeakRequestsPerSecond field's value.
+func (s *RealtimeEndpointInfo) SetPeakRequestsPerSecond(v int64) *RealtimeEndpointInfo {
+	s.PeakRequestsPerSecond = &v
+	return s
 }
 
 // Describes the data specification of an Amazon Redshift DataSource.
@@ -5744,6 +7526,48 @@ func (s *RedshiftDataSpec) Validate() error {
 	return nil
 }
 
+// SetDataRearrangement sets the DataRearrangement field's value.
+func (s *RedshiftDataSpec) SetDataRearrangement(v string) *RedshiftDataSpec {
+	s.DataRearrangement = &v
+	return s
+}
+
+// SetDataSchema sets the DataSchema field's value.
+func (s *RedshiftDataSpec) SetDataSchema(v string) *RedshiftDataSpec {
+	s.DataSchema = &v
+	return s
+}
+
+// SetDataSchemaUri sets the DataSchemaUri field's value.
+func (s *RedshiftDataSpec) SetDataSchemaUri(v string) *RedshiftDataSpec {
+	s.DataSchemaUri = &v
+	return s
+}
+
+// SetDatabaseCredentials sets the DatabaseCredentials field's value.
+func (s *RedshiftDataSpec) SetDatabaseCredentials(v *RedshiftDatabaseCredentials) *RedshiftDataSpec {
+	s.DatabaseCredentials = v
+	return s
+}
+
+// SetDatabaseInformation sets the DatabaseInformation field's value.
+func (s *RedshiftDataSpec) SetDatabaseInformation(v *RedshiftDatabase) *RedshiftDataSpec {
+	s.DatabaseInformation = v
+	return s
+}
+
+// SetS3StagingLocation sets the S3StagingLocation field's value.
+func (s *RedshiftDataSpec) SetS3StagingLocation(v string) *RedshiftDataSpec {
+	s.S3StagingLocation = &v
+	return s
+}
+
+// SetSelectSqlQuery sets the SelectSqlQuery field's value.
+func (s *RedshiftDataSpec) SetSelectSqlQuery(v string) *RedshiftDataSpec {
+	s.SelectSqlQuery = &v
+	return s
+}
+
 // Describes the database details required to connect to an Amazon Redshift
 // database.
 type RedshiftDatabase struct {
@@ -5790,6 +7614,18 @@ func (s *RedshiftDatabase) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *RedshiftDatabase) SetClusterIdentifier(v string) *RedshiftDatabase {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *RedshiftDatabase) SetDatabaseName(v string) *RedshiftDatabase {
+	s.DatabaseName = &v
+	return s
 }
 
 // Describes the database credentials for connecting to a database on an Amazon
@@ -5846,6 +7682,18 @@ func (s *RedshiftDatabaseCredentials) Validate() error {
 	return nil
 }
 
+// SetPassword sets the Password field's value.
+func (s *RedshiftDatabaseCredentials) SetPassword(v string) *RedshiftDatabaseCredentials {
+	s.Password = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *RedshiftDatabaseCredentials) SetUsername(v string) *RedshiftDatabaseCredentials {
+	s.Username = &v
+	return s
+}
+
 // Describes the DataSource details specific to Amazon Redshift.
 type RedshiftMetadata struct {
 	_ struct{} `type:"structure"`
@@ -5873,6 +7721,24 @@ func (s RedshiftMetadata) String() string {
 // GoString returns the string representation
 func (s RedshiftMetadata) GoString() string {
 	return s.String()
+}
+
+// SetDatabaseUserName sets the DatabaseUserName field's value.
+func (s *RedshiftMetadata) SetDatabaseUserName(v string) *RedshiftMetadata {
+	s.DatabaseUserName = &v
+	return s
+}
+
+// SetRedshiftDatabase sets the RedshiftDatabase field's value.
+func (s *RedshiftMetadata) SetRedshiftDatabase(v *RedshiftDatabase) *RedshiftMetadata {
+	s.RedshiftDatabase = v
+	return s
+}
+
+// SetSelectSqlQuery sets the SelectSqlQuery field's value.
+func (s *RedshiftMetadata) SetSelectSqlQuery(v string) *RedshiftMetadata {
+	s.SelectSqlQuery = &v
+	return s
 }
 
 // Describes the data specification of a DataSource.
@@ -6029,6 +7895,30 @@ func (s *S3DataSpec) Validate() error {
 	return nil
 }
 
+// SetDataLocationS3 sets the DataLocationS3 field's value.
+func (s *S3DataSpec) SetDataLocationS3(v string) *S3DataSpec {
+	s.DataLocationS3 = &v
+	return s
+}
+
+// SetDataRearrangement sets the DataRearrangement field's value.
+func (s *S3DataSpec) SetDataRearrangement(v string) *S3DataSpec {
+	s.DataRearrangement = &v
+	return s
+}
+
+// SetDataSchema sets the DataSchema field's value.
+func (s *S3DataSpec) SetDataSchema(v string) *S3DataSpec {
+	s.DataSchema = &v
+	return s
+}
+
+// SetDataSchemaLocationS3 sets the DataSchemaLocationS3 field's value.
+func (s *S3DataSpec) SetDataSchemaLocationS3(v string) *S3DataSpec {
+	s.DataSchemaLocationS3 = &v
+	return s
+}
+
 // A custom key-value pair associated with an ML object, such as an ML model.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -6063,6 +7953,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 type UpdateBatchPredictionInput struct {
@@ -6108,6 +8010,18 @@ func (s *UpdateBatchPredictionInput) Validate() error {
 	return nil
 }
 
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *UpdateBatchPredictionInput) SetBatchPredictionId(v string) *UpdateBatchPredictionInput {
+	s.BatchPredictionId = &v
+	return s
+}
+
+// SetBatchPredictionName sets the BatchPredictionName field's value.
+func (s *UpdateBatchPredictionInput) SetBatchPredictionName(v string) *UpdateBatchPredictionInput {
+	s.BatchPredictionName = &v
+	return s
+}
+
 // Represents the output of an UpdateBatchPrediction operation.
 //
 // You can see the updated content by using the GetBatchPrediction operation.
@@ -6127,6 +8041,12 @@ func (s UpdateBatchPredictionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateBatchPredictionOutput) GoString() string {
 	return s.String()
+}
+
+// SetBatchPredictionId sets the BatchPredictionId field's value.
+func (s *UpdateBatchPredictionOutput) SetBatchPredictionId(v string) *UpdateBatchPredictionOutput {
+	s.BatchPredictionId = &v
+	return s
 }
 
 type UpdateDataSourceInput struct {
@@ -6173,6 +8093,18 @@ func (s *UpdateDataSourceInput) Validate() error {
 	return nil
 }
 
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *UpdateDataSourceInput) SetDataSourceId(v string) *UpdateDataSourceInput {
+	s.DataSourceId = &v
+	return s
+}
+
+// SetDataSourceName sets the DataSourceName field's value.
+func (s *UpdateDataSourceInput) SetDataSourceName(v string) *UpdateDataSourceInput {
+	s.DataSourceName = &v
+	return s
+}
+
 // Represents the output of an UpdateDataSource operation.
 //
 // You can see the updated content by using the GetBatchPrediction operation.
@@ -6192,6 +8124,12 @@ func (s UpdateDataSourceOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDataSourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDataSourceId sets the DataSourceId field's value.
+func (s *UpdateDataSourceOutput) SetDataSourceId(v string) *UpdateDataSourceOutput {
+	s.DataSourceId = &v
+	return s
 }
 
 type UpdateEvaluationInput struct {
@@ -6238,6 +8176,18 @@ func (s *UpdateEvaluationInput) Validate() error {
 	return nil
 }
 
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *UpdateEvaluationInput) SetEvaluationId(v string) *UpdateEvaluationInput {
+	s.EvaluationId = &v
+	return s
+}
+
+// SetEvaluationName sets the EvaluationName field's value.
+func (s *UpdateEvaluationInput) SetEvaluationName(v string) *UpdateEvaluationInput {
+	s.EvaluationName = &v
+	return s
+}
+
 // Represents the output of an UpdateEvaluation operation.
 //
 // You can see the updated content by using the GetEvaluation operation.
@@ -6257,6 +8207,12 @@ func (s UpdateEvaluationOutput) String() string {
 // GoString returns the string representation
 func (s UpdateEvaluationOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvaluationId sets the EvaluationId field's value.
+func (s *UpdateEvaluationOutput) SetEvaluationId(v string) *UpdateEvaluationOutput {
+	s.EvaluationId = &v
+	return s
 }
 
 type UpdateMLModelInput struct {
@@ -6305,6 +8261,24 @@ func (s *UpdateMLModelInput) Validate() error {
 	return nil
 }
 
+// SetMLModelId sets the MLModelId field's value.
+func (s *UpdateMLModelInput) SetMLModelId(v string) *UpdateMLModelInput {
+	s.MLModelId = &v
+	return s
+}
+
+// SetMLModelName sets the MLModelName field's value.
+func (s *UpdateMLModelInput) SetMLModelName(v string) *UpdateMLModelInput {
+	s.MLModelName = &v
+	return s
+}
+
+// SetScoreThreshold sets the ScoreThreshold field's value.
+func (s *UpdateMLModelInput) SetScoreThreshold(v float64) *UpdateMLModelInput {
+	s.ScoreThreshold = &v
+	return s
+}
+
 // Represents the output of an UpdateMLModel operation.
 //
 // You can see the updated content by using the GetMLModel operation.
@@ -6324,6 +8298,12 @@ func (s UpdateMLModelOutput) String() string {
 // GoString returns the string representation
 func (s UpdateMLModelOutput) GoString() string {
 	return s.String()
+}
+
+// SetMLModelId sets the MLModelId field's value.
+func (s *UpdateMLModelOutput) SetMLModelId(v string) *UpdateMLModelOutput {
+	s.MLModelId = &v
+	return s
 }
 
 // The function used to train an MLModel. Training choices supported by Amazon

--- a/service/marketplacecommerceanalytics/api.go
+++ b/service/marketplacecommerceanalytics/api.go
@@ -296,6 +296,48 @@ func (s *GenerateDataSetInput) Validate() error {
 	return nil
 }
 
+// SetCustomerDefinedValues sets the CustomerDefinedValues field's value.
+func (s *GenerateDataSetInput) SetCustomerDefinedValues(v map[string]*string) *GenerateDataSetInput {
+	s.CustomerDefinedValues = v
+	return s
+}
+
+// SetDataSetPublicationDate sets the DataSetPublicationDate field's value.
+func (s *GenerateDataSetInput) SetDataSetPublicationDate(v time.Time) *GenerateDataSetInput {
+	s.DataSetPublicationDate = &v
+	return s
+}
+
+// SetDataSetType sets the DataSetType field's value.
+func (s *GenerateDataSetInput) SetDataSetType(v string) *GenerateDataSetInput {
+	s.DataSetType = &v
+	return s
+}
+
+// SetDestinationS3BucketName sets the DestinationS3BucketName field's value.
+func (s *GenerateDataSetInput) SetDestinationS3BucketName(v string) *GenerateDataSetInput {
+	s.DestinationS3BucketName = &v
+	return s
+}
+
+// SetDestinationS3Prefix sets the DestinationS3Prefix field's value.
+func (s *GenerateDataSetInput) SetDestinationS3Prefix(v string) *GenerateDataSetInput {
+	s.DestinationS3Prefix = &v
+	return s
+}
+
+// SetRoleNameArn sets the RoleNameArn field's value.
+func (s *GenerateDataSetInput) SetRoleNameArn(v string) *GenerateDataSetInput {
+	s.RoleNameArn = &v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *GenerateDataSetInput) SetSnsTopicArn(v string) *GenerateDataSetInput {
+	s.SnsTopicArn = &v
+	return s
+}
+
 // Container for the result of the GenerateDataSet operation.
 type GenerateDataSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -314,6 +356,12 @@ func (s GenerateDataSetOutput) String() string {
 // GoString returns the string representation
 func (s GenerateDataSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetDataSetRequestId sets the DataSetRequestId field's value.
+func (s *GenerateDataSetOutput) SetDataSetRequestId(v string) *GenerateDataSetOutput {
+	s.DataSetRequestId = &v
+	return s
 }
 
 // Container for the parameters to the StartSupportDataExport operation.
@@ -423,6 +471,48 @@ func (s *StartSupportDataExportInput) Validate() error {
 	return nil
 }
 
+// SetCustomerDefinedValues sets the CustomerDefinedValues field's value.
+func (s *StartSupportDataExportInput) SetCustomerDefinedValues(v map[string]*string) *StartSupportDataExportInput {
+	s.CustomerDefinedValues = v
+	return s
+}
+
+// SetDataSetType sets the DataSetType field's value.
+func (s *StartSupportDataExportInput) SetDataSetType(v string) *StartSupportDataExportInput {
+	s.DataSetType = &v
+	return s
+}
+
+// SetDestinationS3BucketName sets the DestinationS3BucketName field's value.
+func (s *StartSupportDataExportInput) SetDestinationS3BucketName(v string) *StartSupportDataExportInput {
+	s.DestinationS3BucketName = &v
+	return s
+}
+
+// SetDestinationS3Prefix sets the DestinationS3Prefix field's value.
+func (s *StartSupportDataExportInput) SetDestinationS3Prefix(v string) *StartSupportDataExportInput {
+	s.DestinationS3Prefix = &v
+	return s
+}
+
+// SetFromDate sets the FromDate field's value.
+func (s *StartSupportDataExportInput) SetFromDate(v time.Time) *StartSupportDataExportInput {
+	s.FromDate = &v
+	return s
+}
+
+// SetRoleNameArn sets the RoleNameArn field's value.
+func (s *StartSupportDataExportInput) SetRoleNameArn(v string) *StartSupportDataExportInput {
+	s.RoleNameArn = &v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *StartSupportDataExportInput) SetSnsTopicArn(v string) *StartSupportDataExportInput {
+	s.SnsTopicArn = &v
+	return s
+}
+
 // Container for the result of the StartSupportDataExport operation.
 type StartSupportDataExportOutput struct {
 	_ struct{} `type:"structure"`
@@ -441,6 +531,12 @@ func (s StartSupportDataExportOutput) String() string {
 // GoString returns the string representation
 func (s StartSupportDataExportOutput) GoString() string {
 	return s.String()
+}
+
+// SetDataSetRequestId sets the DataSetRequestId field's value.
+func (s *StartSupportDataExportOutput) SetDataSetRequestId(v string) *StartSupportDataExportOutput {
+	s.DataSetRequestId = &v
+	return s
 }
 
 const (

--- a/service/marketplacemetering/api.go
+++ b/service/marketplacemetering/api.go
@@ -175,6 +175,36 @@ func (s *MeterUsageInput) Validate() error {
 	return nil
 }
 
+// SetDryRun sets the DryRun field's value.
+func (s *MeterUsageInput) SetDryRun(v bool) *MeterUsageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetProductCode sets the ProductCode field's value.
+func (s *MeterUsageInput) SetProductCode(v string) *MeterUsageInput {
+	s.ProductCode = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *MeterUsageInput) SetTimestamp(v time.Time) *MeterUsageInput {
+	s.Timestamp = &v
+	return s
+}
+
+// SetUsageDimension sets the UsageDimension field's value.
+func (s *MeterUsageInput) SetUsageDimension(v string) *MeterUsageInput {
+	s.UsageDimension = &v
+	return s
+}
+
+// SetUsageQuantity sets the UsageQuantity field's value.
+func (s *MeterUsageInput) SetUsageQuantity(v int64) *MeterUsageInput {
+	s.UsageQuantity = &v
+	return s
+}
+
 type MeterUsageOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -189,4 +219,10 @@ func (s MeterUsageOutput) String() string {
 // GoString returns the string representation
 func (s MeterUsageOutput) GoString() string {
 	return s.String()
+}
+
+// SetMeteringRecordId sets the MeteringRecordId field's value.
+func (s *MeterUsageOutput) SetMeteringRecordId(v string) *MeterUsageOutput {
+	s.MeteringRecordId = &v
+	return s
 }

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -152,6 +152,42 @@ func (s *Event) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *Event) SetAttributes(v map[string]*string) *Event {
+	s.Attributes = v
+	return s
+}
+
+// SetEventType sets the EventType field's value.
+func (s *Event) SetEventType(v string) *Event {
+	s.EventType = &v
+	return s
+}
+
+// SetMetrics sets the Metrics field's value.
+func (s *Event) SetMetrics(v map[string]*float64) *Event {
+	s.Metrics = v
+	return s
+}
+
+// SetSession sets the Session field's value.
+func (s *Event) SetSession(v *Session) *Event {
+	s.Session = v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *Event) SetTimestamp(v string) *Event {
+	s.Timestamp = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *Event) SetVersion(v string) *Event {
+	s.Version = &v
+	return s
+}
+
 // A container for the data needed for a PutEvent operation
 type PutEventsInput struct {
 	_ struct{} `type:"structure"`
@@ -205,6 +241,24 @@ func (s *PutEventsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClientContext sets the ClientContext field's value.
+func (s *PutEventsInput) SetClientContext(v string) *PutEventsInput {
+	s.ClientContext = &v
+	return s
+}
+
+// SetClientContextEncoding sets the ClientContextEncoding field's value.
+func (s *PutEventsInput) SetClientContextEncoding(v string) *PutEventsInput {
+	s.ClientContextEncoding = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *PutEventsInput) SetEvents(v []*Event) *PutEventsInput {
+	s.Events = v
+	return s
 }
 
 type PutEventsOutput struct {
@@ -261,4 +315,28 @@ func (s *Session) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDuration sets the Duration field's value.
+func (s *Session) SetDuration(v int64) *Session {
+	s.Duration = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *Session) SetId(v string) *Session {
+	s.Id = &v
+	return s
+}
+
+// SetStartTimestamp sets the StartTimestamp field's value.
+func (s *Session) SetStartTimestamp(v string) *Session {
+	s.StartTimestamp = &v
+	return s
+}
+
+// SetStopTimestamp sets the StopTimestamp field's value.
+func (s *Session) SetStopTimestamp(v string) *Session {
+	s.StopTimestamp = &v
+	return s
 }

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -5251,6 +5251,18 @@ func (s AgentVersion) GoString() string {
 	return s.String()
 }
 
+// SetConfigurationManager sets the ConfigurationManager field's value.
+func (s *AgentVersion) SetConfigurationManager(v *StackConfigurationManager) *AgentVersion {
+	s.ConfigurationManager = v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *AgentVersion) SetVersion(v string) *AgentVersion {
+	s.Version = &v
+	return s
+}
+
 // A description of the app.
 type App struct {
 	_ struct{} `type:"structure"`
@@ -5319,6 +5331,90 @@ func (s App) GoString() string {
 	return s.String()
 }
 
+// SetAppId sets the AppId field's value.
+func (s *App) SetAppId(v string) *App {
+	s.AppId = &v
+	return s
+}
+
+// SetAppSource sets the AppSource field's value.
+func (s *App) SetAppSource(v *Source) *App {
+	s.AppSource = v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *App) SetAttributes(v map[string]*string) *App {
+	s.Attributes = v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *App) SetCreatedAt(v string) *App {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDataSources sets the DataSources field's value.
+func (s *App) SetDataSources(v []*DataSource) *App {
+	s.DataSources = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *App) SetDescription(v string) *App {
+	s.Description = &v
+	return s
+}
+
+// SetDomains sets the Domains field's value.
+func (s *App) SetDomains(v []*string) *App {
+	s.Domains = v
+	return s
+}
+
+// SetEnableSsl sets the EnableSsl field's value.
+func (s *App) SetEnableSsl(v bool) *App {
+	s.EnableSsl = &v
+	return s
+}
+
+// SetEnvironment sets the Environment field's value.
+func (s *App) SetEnvironment(v []*EnvironmentVariable) *App {
+	s.Environment = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *App) SetName(v string) *App {
+	s.Name = &v
+	return s
+}
+
+// SetShortname sets the Shortname field's value.
+func (s *App) SetShortname(v string) *App {
+	s.Shortname = &v
+	return s
+}
+
+// SetSslConfiguration sets the SslConfiguration field's value.
+func (s *App) SetSslConfiguration(v *SslConfiguration) *App {
+	s.SslConfiguration = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *App) SetStackId(v string) *App {
+	s.StackId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *App) SetType(v string) *App {
+	s.Type = &v
+	return s
+}
+
 type AssignInstanceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5358,6 +5454,18 @@ func (s *AssignInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *AssignInstanceInput) SetInstanceId(v string) *AssignInstanceInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLayerIds sets the LayerIds field's value.
+func (s *AssignInstanceInput) SetLayerIds(v []*string) *AssignInstanceInput {
+	s.LayerIds = v
+	return s
 }
 
 type AssignInstanceOutput struct {
@@ -5409,6 +5517,18 @@ func (s *AssignVolumeInput) Validate() error {
 	return nil
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *AssignVolumeInput) SetInstanceId(v string) *AssignVolumeInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *AssignVolumeInput) SetVolumeId(v string) *AssignVolumeInput {
+	s.VolumeId = &v
+	return s
+}
+
 type AssignVolumeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5456,6 +5576,18 @@ func (s *AssociateElasticIpInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *AssociateElasticIpInput) SetElasticIp(v string) *AssociateElasticIpInput {
+	s.ElasticIp = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *AssociateElasticIpInput) SetInstanceId(v string) *AssociateElasticIpInput {
+	s.InstanceId = &v
+	return s
 }
 
 type AssociateElasticIpOutput struct {
@@ -5511,6 +5643,18 @@ func (s *AttachElasticLoadBalancerInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetElasticLoadBalancerName sets the ElasticLoadBalancerName field's value.
+func (s *AttachElasticLoadBalancerInput) SetElasticLoadBalancerName(v string) *AttachElasticLoadBalancerInput {
+	s.ElasticLoadBalancerName = &v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *AttachElasticLoadBalancerInput) SetLayerId(v string) *AttachElasticLoadBalancerInput {
+	s.LayerId = &v
+	return s
 }
 
 type AttachElasticLoadBalancerOutput struct {
@@ -5598,6 +5742,48 @@ func (s *AutoScalingThresholds) Validate() error {
 	return nil
 }
 
+// SetAlarms sets the Alarms field's value.
+func (s *AutoScalingThresholds) SetAlarms(v []*string) *AutoScalingThresholds {
+	s.Alarms = v
+	return s
+}
+
+// SetCpuThreshold sets the CpuThreshold field's value.
+func (s *AutoScalingThresholds) SetCpuThreshold(v float64) *AutoScalingThresholds {
+	s.CpuThreshold = &v
+	return s
+}
+
+// SetIgnoreMetricsTime sets the IgnoreMetricsTime field's value.
+func (s *AutoScalingThresholds) SetIgnoreMetricsTime(v int64) *AutoScalingThresholds {
+	s.IgnoreMetricsTime = &v
+	return s
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *AutoScalingThresholds) SetInstanceCount(v int64) *AutoScalingThresholds {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetLoadThreshold sets the LoadThreshold field's value.
+func (s *AutoScalingThresholds) SetLoadThreshold(v float64) *AutoScalingThresholds {
+	s.LoadThreshold = &v
+	return s
+}
+
+// SetMemoryThreshold sets the MemoryThreshold field's value.
+func (s *AutoScalingThresholds) SetMemoryThreshold(v float64) *AutoScalingThresholds {
+	s.MemoryThreshold = &v
+	return s
+}
+
+// SetThresholdsWaitTime sets the ThresholdsWaitTime field's value.
+func (s *AutoScalingThresholds) SetThresholdsWaitTime(v int64) *AutoScalingThresholds {
+	s.ThresholdsWaitTime = &v
+	return s
+}
+
 // Describes a block device mapping. This data type maps directly to the Amazon
 // EC2 BlockDeviceMapping (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
 // data type.
@@ -5630,6 +5816,30 @@ func (s BlockDeviceMapping) GoString() string {
 	return s.String()
 }
 
+// SetDeviceName sets the DeviceName field's value.
+func (s *BlockDeviceMapping) SetDeviceName(v string) *BlockDeviceMapping {
+	s.DeviceName = &v
+	return s
+}
+
+// SetEbs sets the Ebs field's value.
+func (s *BlockDeviceMapping) SetEbs(v *EbsBlockDevice) *BlockDeviceMapping {
+	s.Ebs = v
+	return s
+}
+
+// SetNoDevice sets the NoDevice field's value.
+func (s *BlockDeviceMapping) SetNoDevice(v string) *BlockDeviceMapping {
+	s.NoDevice = &v
+	return s
+}
+
+// SetVirtualName sets the VirtualName field's value.
+func (s *BlockDeviceMapping) SetVirtualName(v string) *BlockDeviceMapping {
+	s.VirtualName = &v
+	return s
+}
+
 // Describes the Chef configuration.
 type ChefConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -5649,6 +5859,18 @@ func (s ChefConfiguration) String() string {
 // GoString returns the string representation
 func (s ChefConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetBerkshelfVersion sets the BerkshelfVersion field's value.
+func (s *ChefConfiguration) SetBerkshelfVersion(v string) *ChefConfiguration {
+	s.BerkshelfVersion = &v
+	return s
+}
+
+// SetManageBerkshelf sets the ManageBerkshelf field's value.
+func (s *ChefConfiguration) SetManageBerkshelf(v bool) *ChefConfiguration {
+	s.ManageBerkshelf = &v
+	return s
 }
 
 type CloneStackInput struct {
@@ -5906,6 +6128,138 @@ func (s *CloneStackInput) Validate() error {
 	return nil
 }
 
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *CloneStackInput) SetAgentVersion(v string) *CloneStackInput {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *CloneStackInput) SetAttributes(v map[string]*string) *CloneStackInput {
+	s.Attributes = v
+	return s
+}
+
+// SetChefConfiguration sets the ChefConfiguration field's value.
+func (s *CloneStackInput) SetChefConfiguration(v *ChefConfiguration) *CloneStackInput {
+	s.ChefConfiguration = v
+	return s
+}
+
+// SetCloneAppIds sets the CloneAppIds field's value.
+func (s *CloneStackInput) SetCloneAppIds(v []*string) *CloneStackInput {
+	s.CloneAppIds = v
+	return s
+}
+
+// SetClonePermissions sets the ClonePermissions field's value.
+func (s *CloneStackInput) SetClonePermissions(v bool) *CloneStackInput {
+	s.ClonePermissions = &v
+	return s
+}
+
+// SetConfigurationManager sets the ConfigurationManager field's value.
+func (s *CloneStackInput) SetConfigurationManager(v *StackConfigurationManager) *CloneStackInput {
+	s.ConfigurationManager = v
+	return s
+}
+
+// SetCustomCookbooksSource sets the CustomCookbooksSource field's value.
+func (s *CloneStackInput) SetCustomCookbooksSource(v *Source) *CloneStackInput {
+	s.CustomCookbooksSource = v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *CloneStackInput) SetCustomJson(v string) *CloneStackInput {
+	s.CustomJson = &v
+	return s
+}
+
+// SetDefaultAvailabilityZone sets the DefaultAvailabilityZone field's value.
+func (s *CloneStackInput) SetDefaultAvailabilityZone(v string) *CloneStackInput {
+	s.DefaultAvailabilityZone = &v
+	return s
+}
+
+// SetDefaultInstanceProfileArn sets the DefaultInstanceProfileArn field's value.
+func (s *CloneStackInput) SetDefaultInstanceProfileArn(v string) *CloneStackInput {
+	s.DefaultInstanceProfileArn = &v
+	return s
+}
+
+// SetDefaultOs sets the DefaultOs field's value.
+func (s *CloneStackInput) SetDefaultOs(v string) *CloneStackInput {
+	s.DefaultOs = &v
+	return s
+}
+
+// SetDefaultRootDeviceType sets the DefaultRootDeviceType field's value.
+func (s *CloneStackInput) SetDefaultRootDeviceType(v string) *CloneStackInput {
+	s.DefaultRootDeviceType = &v
+	return s
+}
+
+// SetDefaultSshKeyName sets the DefaultSshKeyName field's value.
+func (s *CloneStackInput) SetDefaultSshKeyName(v string) *CloneStackInput {
+	s.DefaultSshKeyName = &v
+	return s
+}
+
+// SetDefaultSubnetId sets the DefaultSubnetId field's value.
+func (s *CloneStackInput) SetDefaultSubnetId(v string) *CloneStackInput {
+	s.DefaultSubnetId = &v
+	return s
+}
+
+// SetHostnameTheme sets the HostnameTheme field's value.
+func (s *CloneStackInput) SetHostnameTheme(v string) *CloneStackInput {
+	s.HostnameTheme = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CloneStackInput) SetName(v string) *CloneStackInput {
+	s.Name = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *CloneStackInput) SetRegion(v string) *CloneStackInput {
+	s.Region = &v
+	return s
+}
+
+// SetServiceRoleArn sets the ServiceRoleArn field's value.
+func (s *CloneStackInput) SetServiceRoleArn(v string) *CloneStackInput {
+	s.ServiceRoleArn = &v
+	return s
+}
+
+// SetSourceStackId sets the SourceStackId field's value.
+func (s *CloneStackInput) SetSourceStackId(v string) *CloneStackInput {
+	s.SourceStackId = &v
+	return s
+}
+
+// SetUseCustomCookbooks sets the UseCustomCookbooks field's value.
+func (s *CloneStackInput) SetUseCustomCookbooks(v bool) *CloneStackInput {
+	s.UseCustomCookbooks = &v
+	return s
+}
+
+// SetUseOpsworksSecurityGroups sets the UseOpsworksSecurityGroups field's value.
+func (s *CloneStackInput) SetUseOpsworksSecurityGroups(v bool) *CloneStackInput {
+	s.UseOpsworksSecurityGroups = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CloneStackInput) SetVpcId(v string) *CloneStackInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the response to a CloneStack request.
 type CloneStackOutput struct {
 	_ struct{} `type:"structure"`
@@ -5922,6 +6276,12 @@ func (s CloneStackOutput) String() string {
 // GoString returns the string representation
 func (s CloneStackOutput) GoString() string {
 	return s.String()
+}
+
+// SetStackId sets the StackId field's value.
+func (s *CloneStackOutput) SetStackId(v string) *CloneStackOutput {
+	s.StackId = &v
+	return s
 }
 
 // Describes a command.
@@ -5995,6 +6355,66 @@ func (s Command) String() string {
 // GoString returns the string representation
 func (s Command) GoString() string {
 	return s.String()
+}
+
+// SetAcknowledgedAt sets the AcknowledgedAt field's value.
+func (s *Command) SetAcknowledgedAt(v string) *Command {
+	s.AcknowledgedAt = &v
+	return s
+}
+
+// SetCommandId sets the CommandId field's value.
+func (s *Command) SetCommandId(v string) *Command {
+	s.CommandId = &v
+	return s
+}
+
+// SetCompletedAt sets the CompletedAt field's value.
+func (s *Command) SetCompletedAt(v string) *Command {
+	s.CompletedAt = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Command) SetCreatedAt(v string) *Command {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *Command) SetDeploymentId(v string) *Command {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetExitCode sets the ExitCode field's value.
+func (s *Command) SetExitCode(v int64) *Command {
+	s.ExitCode = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Command) SetInstanceId(v string) *Command {
+	s.InstanceId = &v
+	return s
+}
+
+// SetLogUrl sets the LogUrl field's value.
+func (s *Command) SetLogUrl(v string) *Command {
+	s.LogUrl = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Command) SetStatus(v string) *Command {
+	s.Status = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Command) SetType(v string) *Command {
+	s.Type = &v
+	return s
 }
 
 type CreateAppInput struct {
@@ -6105,6 +6525,78 @@ func (s *CreateAppInput) Validate() error {
 	return nil
 }
 
+// SetAppSource sets the AppSource field's value.
+func (s *CreateAppInput) SetAppSource(v *Source) *CreateAppInput {
+	s.AppSource = v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *CreateAppInput) SetAttributes(v map[string]*string) *CreateAppInput {
+	s.Attributes = v
+	return s
+}
+
+// SetDataSources sets the DataSources field's value.
+func (s *CreateAppInput) SetDataSources(v []*DataSource) *CreateAppInput {
+	s.DataSources = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateAppInput) SetDescription(v string) *CreateAppInput {
+	s.Description = &v
+	return s
+}
+
+// SetDomains sets the Domains field's value.
+func (s *CreateAppInput) SetDomains(v []*string) *CreateAppInput {
+	s.Domains = v
+	return s
+}
+
+// SetEnableSsl sets the EnableSsl field's value.
+func (s *CreateAppInput) SetEnableSsl(v bool) *CreateAppInput {
+	s.EnableSsl = &v
+	return s
+}
+
+// SetEnvironment sets the Environment field's value.
+func (s *CreateAppInput) SetEnvironment(v []*EnvironmentVariable) *CreateAppInput {
+	s.Environment = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateAppInput) SetName(v string) *CreateAppInput {
+	s.Name = &v
+	return s
+}
+
+// SetShortname sets the Shortname field's value.
+func (s *CreateAppInput) SetShortname(v string) *CreateAppInput {
+	s.Shortname = &v
+	return s
+}
+
+// SetSslConfiguration sets the SslConfiguration field's value.
+func (s *CreateAppInput) SetSslConfiguration(v *SslConfiguration) *CreateAppInput {
+	s.SslConfiguration = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *CreateAppInput) SetStackId(v string) *CreateAppInput {
+	s.StackId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CreateAppInput) SetType(v string) *CreateAppInput {
+	s.Type = &v
+	return s
+}
+
 // Contains the response to a CreateApp request.
 type CreateAppOutput struct {
 	_ struct{} `type:"structure"`
@@ -6121,6 +6613,12 @@ func (s CreateAppOutput) String() string {
 // GoString returns the string representation
 func (s CreateAppOutput) GoString() string {
 	return s.String()
+}
+
+// SetAppId sets the AppId field's value.
+func (s *CreateAppOutput) SetAppId(v string) *CreateAppOutput {
+	s.AppId = &v
+	return s
 }
 
 type CreateDeploymentInput struct {
@@ -6192,6 +6690,48 @@ func (s *CreateDeploymentInput) Validate() error {
 	return nil
 }
 
+// SetAppId sets the AppId field's value.
+func (s *CreateDeploymentInput) SetAppId(v string) *CreateDeploymentInput {
+	s.AppId = &v
+	return s
+}
+
+// SetCommand sets the Command field's value.
+func (s *CreateDeploymentInput) SetCommand(v *DeploymentCommand) *CreateDeploymentInput {
+	s.Command = v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *CreateDeploymentInput) SetComment(v string) *CreateDeploymentInput {
+	s.Comment = &v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *CreateDeploymentInput) SetCustomJson(v string) *CreateDeploymentInput {
+	s.CustomJson = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *CreateDeploymentInput) SetInstanceIds(v []*string) *CreateDeploymentInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetLayerIds sets the LayerIds field's value.
+func (s *CreateDeploymentInput) SetLayerIds(v []*string) *CreateDeploymentInput {
+	s.LayerIds = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *CreateDeploymentInput) SetStackId(v string) *CreateDeploymentInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a CreateDeployment request.
 type CreateDeploymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -6209,6 +6749,12 @@ func (s CreateDeploymentOutput) String() string {
 // GoString returns the string representation
 func (s CreateDeploymentOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *CreateDeploymentOutput) SetDeploymentId(v string) *CreateDeploymentOutput {
+	s.DeploymentId = &v
+	return s
 }
 
 type CreateInstanceInput struct {
@@ -6378,6 +6924,114 @@ func (s *CreateInstanceInput) Validate() error {
 	return nil
 }
 
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *CreateInstanceInput) SetAgentVersion(v string) *CreateInstanceInput {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetAmiId sets the AmiId field's value.
+func (s *CreateInstanceInput) SetAmiId(v string) *CreateInstanceInput {
+	s.AmiId = &v
+	return s
+}
+
+// SetArchitecture sets the Architecture field's value.
+func (s *CreateInstanceInput) SetArchitecture(v string) *CreateInstanceInput {
+	s.Architecture = &v
+	return s
+}
+
+// SetAutoScalingType sets the AutoScalingType field's value.
+func (s *CreateInstanceInput) SetAutoScalingType(v string) *CreateInstanceInput {
+	s.AutoScalingType = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *CreateInstanceInput) SetAvailabilityZone(v string) *CreateInstanceInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *CreateInstanceInput) SetBlockDeviceMappings(v []*BlockDeviceMapping) *CreateInstanceInput {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *CreateInstanceInput) SetEbsOptimized(v bool) *CreateInstanceInput {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetHostname sets the Hostname field's value.
+func (s *CreateInstanceInput) SetHostname(v string) *CreateInstanceInput {
+	s.Hostname = &v
+	return s
+}
+
+// SetInstallUpdatesOnBoot sets the InstallUpdatesOnBoot field's value.
+func (s *CreateInstanceInput) SetInstallUpdatesOnBoot(v bool) *CreateInstanceInput {
+	s.InstallUpdatesOnBoot = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *CreateInstanceInput) SetInstanceType(v string) *CreateInstanceInput {
+	s.InstanceType = &v
+	return s
+}
+
+// SetLayerIds sets the LayerIds field's value.
+func (s *CreateInstanceInput) SetLayerIds(v []*string) *CreateInstanceInput {
+	s.LayerIds = v
+	return s
+}
+
+// SetOs sets the Os field's value.
+func (s *CreateInstanceInput) SetOs(v string) *CreateInstanceInput {
+	s.Os = &v
+	return s
+}
+
+// SetRootDeviceType sets the RootDeviceType field's value.
+func (s *CreateInstanceInput) SetRootDeviceType(v string) *CreateInstanceInput {
+	s.RootDeviceType = &v
+	return s
+}
+
+// SetSshKeyName sets the SshKeyName field's value.
+func (s *CreateInstanceInput) SetSshKeyName(v string) *CreateInstanceInput {
+	s.SshKeyName = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *CreateInstanceInput) SetStackId(v string) *CreateInstanceInput {
+	s.StackId = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *CreateInstanceInput) SetSubnetId(v string) *CreateInstanceInput {
+	s.SubnetId = &v
+	return s
+}
+
+// SetTenancy sets the Tenancy field's value.
+func (s *CreateInstanceInput) SetTenancy(v string) *CreateInstanceInput {
+	s.Tenancy = &v
+	return s
+}
+
+// SetVirtualizationType sets the VirtualizationType field's value.
+func (s *CreateInstanceInput) SetVirtualizationType(v string) *CreateInstanceInput {
+	s.VirtualizationType = &v
+	return s
+}
+
 // Contains the response to a CreateInstance request.
 type CreateInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -6394,6 +7048,12 @@ func (s CreateInstanceOutput) String() string {
 // GoString returns the string representation
 func (s CreateInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CreateInstanceOutput) SetInstanceId(v string) *CreateInstanceOutput {
+	s.InstanceId = &v
+	return s
 }
 
 type CreateLayerInput struct {
@@ -6529,6 +7189,108 @@ func (s *CreateLayerInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *CreateLayerInput) SetAttributes(v map[string]*string) *CreateLayerInput {
+	s.Attributes = v
+	return s
+}
+
+// SetAutoAssignElasticIps sets the AutoAssignElasticIps field's value.
+func (s *CreateLayerInput) SetAutoAssignElasticIps(v bool) *CreateLayerInput {
+	s.AutoAssignElasticIps = &v
+	return s
+}
+
+// SetAutoAssignPublicIps sets the AutoAssignPublicIps field's value.
+func (s *CreateLayerInput) SetAutoAssignPublicIps(v bool) *CreateLayerInput {
+	s.AutoAssignPublicIps = &v
+	return s
+}
+
+// SetCustomInstanceProfileArn sets the CustomInstanceProfileArn field's value.
+func (s *CreateLayerInput) SetCustomInstanceProfileArn(v string) *CreateLayerInput {
+	s.CustomInstanceProfileArn = &v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *CreateLayerInput) SetCustomJson(v string) *CreateLayerInput {
+	s.CustomJson = &v
+	return s
+}
+
+// SetCustomRecipes sets the CustomRecipes field's value.
+func (s *CreateLayerInput) SetCustomRecipes(v *Recipes) *CreateLayerInput {
+	s.CustomRecipes = v
+	return s
+}
+
+// SetCustomSecurityGroupIds sets the CustomSecurityGroupIds field's value.
+func (s *CreateLayerInput) SetCustomSecurityGroupIds(v []*string) *CreateLayerInput {
+	s.CustomSecurityGroupIds = v
+	return s
+}
+
+// SetEnableAutoHealing sets the EnableAutoHealing field's value.
+func (s *CreateLayerInput) SetEnableAutoHealing(v bool) *CreateLayerInput {
+	s.EnableAutoHealing = &v
+	return s
+}
+
+// SetInstallUpdatesOnBoot sets the InstallUpdatesOnBoot field's value.
+func (s *CreateLayerInput) SetInstallUpdatesOnBoot(v bool) *CreateLayerInput {
+	s.InstallUpdatesOnBoot = &v
+	return s
+}
+
+// SetLifecycleEventConfiguration sets the LifecycleEventConfiguration field's value.
+func (s *CreateLayerInput) SetLifecycleEventConfiguration(v *LifecycleEventConfiguration) *CreateLayerInput {
+	s.LifecycleEventConfiguration = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateLayerInput) SetName(v string) *CreateLayerInput {
+	s.Name = &v
+	return s
+}
+
+// SetPackages sets the Packages field's value.
+func (s *CreateLayerInput) SetPackages(v []*string) *CreateLayerInput {
+	s.Packages = v
+	return s
+}
+
+// SetShortname sets the Shortname field's value.
+func (s *CreateLayerInput) SetShortname(v string) *CreateLayerInput {
+	s.Shortname = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *CreateLayerInput) SetStackId(v string) *CreateLayerInput {
+	s.StackId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *CreateLayerInput) SetType(v string) *CreateLayerInput {
+	s.Type = &v
+	return s
+}
+
+// SetUseEbsOptimizedInstances sets the UseEbsOptimizedInstances field's value.
+func (s *CreateLayerInput) SetUseEbsOptimizedInstances(v bool) *CreateLayerInput {
+	s.UseEbsOptimizedInstances = &v
+	return s
+}
+
+// SetVolumeConfigurations sets the VolumeConfigurations field's value.
+func (s *CreateLayerInput) SetVolumeConfigurations(v []*VolumeConfiguration) *CreateLayerInput {
+	s.VolumeConfigurations = v
+	return s
+}
+
 // Contains the response to a CreateLayer request.
 type CreateLayerOutput struct {
 	_ struct{} `type:"structure"`
@@ -6545,6 +7307,12 @@ func (s CreateLayerOutput) String() string {
 // GoString returns the string representation
 func (s CreateLayerOutput) GoString() string {
 	return s.String()
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *CreateLayerOutput) SetLayerId(v string) *CreateLayerOutput {
+	s.LayerId = &v
+	return s
 }
 
 type CreateStackInput struct {
@@ -6797,6 +7565,120 @@ func (s *CreateStackInput) Validate() error {
 	return nil
 }
 
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *CreateStackInput) SetAgentVersion(v string) *CreateStackInput {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *CreateStackInput) SetAttributes(v map[string]*string) *CreateStackInput {
+	s.Attributes = v
+	return s
+}
+
+// SetChefConfiguration sets the ChefConfiguration field's value.
+func (s *CreateStackInput) SetChefConfiguration(v *ChefConfiguration) *CreateStackInput {
+	s.ChefConfiguration = v
+	return s
+}
+
+// SetConfigurationManager sets the ConfigurationManager field's value.
+func (s *CreateStackInput) SetConfigurationManager(v *StackConfigurationManager) *CreateStackInput {
+	s.ConfigurationManager = v
+	return s
+}
+
+// SetCustomCookbooksSource sets the CustomCookbooksSource field's value.
+func (s *CreateStackInput) SetCustomCookbooksSource(v *Source) *CreateStackInput {
+	s.CustomCookbooksSource = v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *CreateStackInput) SetCustomJson(v string) *CreateStackInput {
+	s.CustomJson = &v
+	return s
+}
+
+// SetDefaultAvailabilityZone sets the DefaultAvailabilityZone field's value.
+func (s *CreateStackInput) SetDefaultAvailabilityZone(v string) *CreateStackInput {
+	s.DefaultAvailabilityZone = &v
+	return s
+}
+
+// SetDefaultInstanceProfileArn sets the DefaultInstanceProfileArn field's value.
+func (s *CreateStackInput) SetDefaultInstanceProfileArn(v string) *CreateStackInput {
+	s.DefaultInstanceProfileArn = &v
+	return s
+}
+
+// SetDefaultOs sets the DefaultOs field's value.
+func (s *CreateStackInput) SetDefaultOs(v string) *CreateStackInput {
+	s.DefaultOs = &v
+	return s
+}
+
+// SetDefaultRootDeviceType sets the DefaultRootDeviceType field's value.
+func (s *CreateStackInput) SetDefaultRootDeviceType(v string) *CreateStackInput {
+	s.DefaultRootDeviceType = &v
+	return s
+}
+
+// SetDefaultSshKeyName sets the DefaultSshKeyName field's value.
+func (s *CreateStackInput) SetDefaultSshKeyName(v string) *CreateStackInput {
+	s.DefaultSshKeyName = &v
+	return s
+}
+
+// SetDefaultSubnetId sets the DefaultSubnetId field's value.
+func (s *CreateStackInput) SetDefaultSubnetId(v string) *CreateStackInput {
+	s.DefaultSubnetId = &v
+	return s
+}
+
+// SetHostnameTheme sets the HostnameTheme field's value.
+func (s *CreateStackInput) SetHostnameTheme(v string) *CreateStackInput {
+	s.HostnameTheme = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateStackInput) SetName(v string) *CreateStackInput {
+	s.Name = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *CreateStackInput) SetRegion(v string) *CreateStackInput {
+	s.Region = &v
+	return s
+}
+
+// SetServiceRoleArn sets the ServiceRoleArn field's value.
+func (s *CreateStackInput) SetServiceRoleArn(v string) *CreateStackInput {
+	s.ServiceRoleArn = &v
+	return s
+}
+
+// SetUseCustomCookbooks sets the UseCustomCookbooks field's value.
+func (s *CreateStackInput) SetUseCustomCookbooks(v bool) *CreateStackInput {
+	s.UseCustomCookbooks = &v
+	return s
+}
+
+// SetUseOpsworksSecurityGroups sets the UseOpsworksSecurityGroups field's value.
+func (s *CreateStackInput) SetUseOpsworksSecurityGroups(v bool) *CreateStackInput {
+	s.UseOpsworksSecurityGroups = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *CreateStackInput) SetVpcId(v string) *CreateStackInput {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the response to a CreateStack request.
 type CreateStackOutput struct {
 	_ struct{} `type:"structure"`
@@ -6814,6 +7696,12 @@ func (s CreateStackOutput) String() string {
 // GoString returns the string representation
 func (s CreateStackOutput) GoString() string {
 	return s.String()
+}
+
+// SetStackId sets the StackId field's value.
+func (s *CreateStackOutput) SetStackId(v string) *CreateStackOutput {
+	s.StackId = &v
+	return s
 }
 
 type CreateUserProfileInput struct {
@@ -6862,6 +7750,30 @@ func (s *CreateUserProfileInput) Validate() error {
 	return nil
 }
 
+// SetAllowSelfManagement sets the AllowSelfManagement field's value.
+func (s *CreateUserProfileInput) SetAllowSelfManagement(v bool) *CreateUserProfileInput {
+	s.AllowSelfManagement = &v
+	return s
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *CreateUserProfileInput) SetIamUserArn(v string) *CreateUserProfileInput {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetSshPublicKey sets the SshPublicKey field's value.
+func (s *CreateUserProfileInput) SetSshPublicKey(v string) *CreateUserProfileInput {
+	s.SshPublicKey = &v
+	return s
+}
+
+// SetSshUsername sets the SshUsername field's value.
+func (s *CreateUserProfileInput) SetSshUsername(v string) *CreateUserProfileInput {
+	s.SshUsername = &v
+	return s
+}
+
 // Contains the response to a CreateUserProfile request.
 type CreateUserProfileOutput struct {
 	_ struct{} `type:"structure"`
@@ -6878,6 +7790,12 @@ func (s CreateUserProfileOutput) String() string {
 // GoString returns the string representation
 func (s CreateUserProfileOutput) GoString() string {
 	return s.String()
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *CreateUserProfileOutput) SetIamUserArn(v string) *CreateUserProfileOutput {
+	s.IamUserArn = &v
+	return s
 }
 
 // Describes an app's data source.
@@ -6903,6 +7821,24 @@ func (s DataSource) String() string {
 // GoString returns the string representation
 func (s DataSource) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *DataSource) SetArn(v string) *DataSource {
+	s.Arn = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *DataSource) SetDatabaseName(v string) *DataSource {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *DataSource) SetType(v string) *DataSource {
+	s.Type = &v
+	return s
 }
 
 type DeleteAppInput struct {
@@ -6935,6 +7871,12 @@ func (s *DeleteAppInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAppId sets the AppId field's value.
+func (s *DeleteAppInput) SetAppId(v string) *DeleteAppInput {
+	s.AppId = &v
+	return s
 }
 
 type DeleteAppOutput struct {
@@ -6989,6 +7931,24 @@ func (s *DeleteInstanceInput) Validate() error {
 	return nil
 }
 
+// SetDeleteElasticIp sets the DeleteElasticIp field's value.
+func (s *DeleteInstanceInput) SetDeleteElasticIp(v bool) *DeleteInstanceInput {
+	s.DeleteElasticIp = &v
+	return s
+}
+
+// SetDeleteVolumes sets the DeleteVolumes field's value.
+func (s *DeleteInstanceInput) SetDeleteVolumes(v bool) *DeleteInstanceInput {
+	s.DeleteVolumes = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *DeleteInstanceInput) SetInstanceId(v string) *DeleteInstanceInput {
+	s.InstanceId = &v
+	return s
+}
+
 type DeleteInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7033,6 +7993,12 @@ func (s *DeleteLayerInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *DeleteLayerInput) SetLayerId(v string) *DeleteLayerInput {
+	s.LayerId = &v
+	return s
 }
 
 type DeleteLayerOutput struct {
@@ -7081,6 +8047,12 @@ func (s *DeleteStackInput) Validate() error {
 	return nil
 }
 
+// SetStackId sets the StackId field's value.
+func (s *DeleteStackInput) SetStackId(v string) *DeleteStackInput {
+	s.StackId = &v
+	return s
+}
+
 type DeleteStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7125,6 +8097,12 @@ func (s *DeleteUserProfileInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *DeleteUserProfileInput) SetIamUserArn(v string) *DeleteUserProfileInput {
+	s.IamUserArn = &v
+	return s
 }
 
 type DeleteUserProfileOutput struct {
@@ -7203,6 +8181,78 @@ func (s Deployment) String() string {
 // GoString returns the string representation
 func (s Deployment) GoString() string {
 	return s.String()
+}
+
+// SetAppId sets the AppId field's value.
+func (s *Deployment) SetAppId(v string) *Deployment {
+	s.AppId = &v
+	return s
+}
+
+// SetCommand sets the Command field's value.
+func (s *Deployment) SetCommand(v *DeploymentCommand) *Deployment {
+	s.Command = v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *Deployment) SetComment(v string) *Deployment {
+	s.Comment = &v
+	return s
+}
+
+// SetCompletedAt sets the CompletedAt field's value.
+func (s *Deployment) SetCompletedAt(v string) *Deployment {
+	s.CompletedAt = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Deployment) SetCreatedAt(v string) *Deployment {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *Deployment) SetCustomJson(v string) *Deployment {
+	s.CustomJson = &v
+	return s
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *Deployment) SetDeploymentId(v string) *Deployment {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *Deployment) SetDuration(v int64) *Deployment {
+	s.Duration = &v
+	return s
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *Deployment) SetIamUserArn(v string) *Deployment {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *Deployment) SetInstanceIds(v []*string) *Deployment {
+	s.InstanceIds = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *Deployment) SetStackId(v string) *Deployment {
+	s.StackId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Deployment) SetStatus(v string) *Deployment {
+	s.Status = &v
+	return s
 }
 
 // Used to specify a stack or deployment command.
@@ -7295,6 +8345,18 @@ func (s *DeploymentCommand) Validate() error {
 	return nil
 }
 
+// SetArgs sets the Args field's value.
+func (s *DeploymentCommand) SetArgs(v map[string][]*string) *DeploymentCommand {
+	s.Args = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeploymentCommand) SetName(v string) *DeploymentCommand {
+	s.Name = &v
+	return s
+}
+
 type DeregisterEcsClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7325,6 +8387,12 @@ func (s *DeregisterEcsClusterInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEcsClusterArn sets the EcsClusterArn field's value.
+func (s *DeregisterEcsClusterInput) SetEcsClusterArn(v string) *DeregisterEcsClusterInput {
+	s.EcsClusterArn = &v
+	return s
 }
 
 type DeregisterEcsClusterOutput struct {
@@ -7373,6 +8441,12 @@ func (s *DeregisterElasticIpInput) Validate() error {
 	return nil
 }
 
+// SetElasticIp sets the ElasticIp field's value.
+func (s *DeregisterElasticIpInput) SetElasticIp(v string) *DeregisterElasticIpInput {
+	s.ElasticIp = &v
+	return s
+}
+
 type DeregisterElasticIpOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7419,6 +8493,12 @@ func (s *DeregisterInstanceInput) Validate() error {
 	return nil
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *DeregisterInstanceInput) SetInstanceId(v string) *DeregisterInstanceInput {
+	s.InstanceId = &v
+	return s
+}
+
 type DeregisterInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7463,6 +8543,12 @@ func (s *DeregisterRdsDbInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRdsDbInstanceArn sets the RdsDbInstanceArn field's value.
+func (s *DeregisterRdsDbInstanceInput) SetRdsDbInstanceArn(v string) *DeregisterRdsDbInstanceInput {
+	s.RdsDbInstanceArn = &v
+	return s
 }
 
 type DeregisterRdsDbInstanceOutput struct {
@@ -7513,6 +8599,12 @@ func (s *DeregisterVolumeInput) Validate() error {
 	return nil
 }
 
+// SetVolumeId sets the VolumeId field's value.
+func (s *DeregisterVolumeInput) SetVolumeId(v string) *DeregisterVolumeInput {
+	s.VolumeId = &v
+	return s
+}
+
 type DeregisterVolumeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7547,6 +8639,18 @@ func (s DescribeAgentVersionsInput) GoString() string {
 	return s.String()
 }
 
+// SetConfigurationManager sets the ConfigurationManager field's value.
+func (s *DescribeAgentVersionsInput) SetConfigurationManager(v *StackConfigurationManager) *DescribeAgentVersionsInput {
+	s.ConfigurationManager = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeAgentVersionsInput) SetStackId(v string) *DescribeAgentVersionsInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeAgentVersions request.
 type DescribeAgentVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7565,6 +8669,12 @@ func (s DescribeAgentVersionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAgentVersionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAgentVersions sets the AgentVersions field's value.
+func (s *DescribeAgentVersionsOutput) SetAgentVersions(v []*AgentVersion) *DescribeAgentVersionsOutput {
+	s.AgentVersions = v
+	return s
 }
 
 type DescribeAppsInput struct {
@@ -7590,6 +8700,18 @@ func (s DescribeAppsInput) GoString() string {
 	return s.String()
 }
 
+// SetAppIds sets the AppIds field's value.
+func (s *DescribeAppsInput) SetAppIds(v []*string) *DescribeAppsInput {
+	s.AppIds = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeAppsInput) SetStackId(v string) *DescribeAppsInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeApps request.
 type DescribeAppsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7606,6 +8728,12 @@ func (s DescribeAppsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAppsOutput) GoString() string {
 	return s.String()
+}
+
+// SetApps sets the Apps field's value.
+func (s *DescribeAppsOutput) SetApps(v []*App) *DescribeAppsOutput {
+	s.Apps = v
+	return s
 }
 
 type DescribeCommandsInput struct {
@@ -7635,6 +8763,24 @@ func (s DescribeCommandsInput) GoString() string {
 	return s.String()
 }
 
+// SetCommandIds sets the CommandIds field's value.
+func (s *DescribeCommandsInput) SetCommandIds(v []*string) *DescribeCommandsInput {
+	s.CommandIds = v
+	return s
+}
+
+// SetDeploymentId sets the DeploymentId field's value.
+func (s *DescribeCommandsInput) SetDeploymentId(v string) *DescribeCommandsInput {
+	s.DeploymentId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeCommandsInput) SetInstanceId(v string) *DescribeCommandsInput {
+	s.InstanceId = &v
+	return s
+}
+
 // Contains the response to a DescribeCommands request.
 type DescribeCommandsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7651,6 +8797,12 @@ func (s DescribeCommandsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCommandsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCommands sets the Commands field's value.
+func (s *DescribeCommandsOutput) SetCommands(v []*Command) *DescribeCommandsOutput {
+	s.Commands = v
+	return s
 }
 
 type DescribeDeploymentsInput struct {
@@ -7680,6 +8832,24 @@ func (s DescribeDeploymentsInput) GoString() string {
 	return s.String()
 }
 
+// SetAppId sets the AppId field's value.
+func (s *DescribeDeploymentsInput) SetAppId(v string) *DescribeDeploymentsInput {
+	s.AppId = &v
+	return s
+}
+
+// SetDeploymentIds sets the DeploymentIds field's value.
+func (s *DescribeDeploymentsInput) SetDeploymentIds(v []*string) *DescribeDeploymentsInput {
+	s.DeploymentIds = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeDeploymentsInput) SetStackId(v string) *DescribeDeploymentsInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeDeployments request.
 type DescribeDeploymentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7696,6 +8866,12 @@ func (s DescribeDeploymentsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDeploymentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeployments sets the Deployments field's value.
+func (s *DescribeDeploymentsOutput) SetDeployments(v []*Deployment) *DescribeDeploymentsOutput {
+	s.Deployments = v
+	return s
 }
 
 type DescribeEcsClustersInput struct {
@@ -7733,6 +8909,30 @@ func (s DescribeEcsClustersInput) GoString() string {
 	return s.String()
 }
 
+// SetEcsClusterArns sets the EcsClusterArns field's value.
+func (s *DescribeEcsClustersInput) SetEcsClusterArns(v []*string) *DescribeEcsClustersInput {
+	s.EcsClusterArns = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeEcsClustersInput) SetMaxResults(v int64) *DescribeEcsClustersInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeEcsClustersInput) SetNextToken(v string) *DescribeEcsClustersInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeEcsClustersInput) SetStackId(v string) *DescribeEcsClustersInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeEcsClusters request.
 type DescribeEcsClustersOutput struct {
 	_ struct{} `type:"structure"`
@@ -7755,6 +8955,18 @@ func (s DescribeEcsClustersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEcsClustersOutput) GoString() string {
 	return s.String()
+}
+
+// SetEcsClusters sets the EcsClusters field's value.
+func (s *DescribeEcsClustersOutput) SetEcsClusters(v []*EcsCluster) *DescribeEcsClustersOutput {
+	s.EcsClusters = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeEcsClustersOutput) SetNextToken(v string) *DescribeEcsClustersOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeElasticIpsInput struct {
@@ -7784,6 +8996,24 @@ func (s DescribeElasticIpsInput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeElasticIpsInput) SetInstanceId(v string) *DescribeElasticIpsInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetIps sets the Ips field's value.
+func (s *DescribeElasticIpsInput) SetIps(v []*string) *DescribeElasticIpsInput {
+	s.Ips = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeElasticIpsInput) SetStackId(v string) *DescribeElasticIpsInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeElasticIps request.
 type DescribeElasticIpsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7800,6 +9030,12 @@ func (s DescribeElasticIpsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeElasticIpsOutput) GoString() string {
 	return s.String()
+}
+
+// SetElasticIps sets the ElasticIps field's value.
+func (s *DescribeElasticIpsOutput) SetElasticIps(v []*ElasticIp) *DescribeElasticIpsOutput {
+	s.ElasticIps = v
+	return s
 }
 
 type DescribeElasticLoadBalancersInput struct {
@@ -7823,6 +9059,18 @@ func (s DescribeElasticLoadBalancersInput) GoString() string {
 	return s.String()
 }
 
+// SetLayerIds sets the LayerIds field's value.
+func (s *DescribeElasticLoadBalancersInput) SetLayerIds(v []*string) *DescribeElasticLoadBalancersInput {
+	s.LayerIds = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeElasticLoadBalancersInput) SetStackId(v string) *DescribeElasticLoadBalancersInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeElasticLoadBalancers request.
 type DescribeElasticLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
@@ -7840,6 +9088,12 @@ func (s DescribeElasticLoadBalancersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeElasticLoadBalancersOutput) GoString() string {
 	return s.String()
+}
+
+// SetElasticLoadBalancers sets the ElasticLoadBalancers field's value.
+func (s *DescribeElasticLoadBalancersOutput) SetElasticLoadBalancers(v []*ElasticLoadBalancer) *DescribeElasticLoadBalancersOutput {
+	s.ElasticLoadBalancers = v
+	return s
 }
 
 type DescribeInstancesInput struct {
@@ -7869,6 +9123,24 @@ func (s DescribeInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *DescribeInstancesInput) SetInstanceIds(v []*string) *DescribeInstancesInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *DescribeInstancesInput) SetLayerId(v string) *DescribeInstancesInput {
+	s.LayerId = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeInstancesInput) SetStackId(v string) *DescribeInstancesInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeInstances request.
 type DescribeInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7885,6 +9157,12 @@ func (s DescribeInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstances sets the Instances field's value.
+func (s *DescribeInstancesOutput) SetInstances(v []*Instance) *DescribeInstancesOutput {
+	s.Instances = v
+	return s
 }
 
 type DescribeLayersInput struct {
@@ -7909,6 +9187,18 @@ func (s DescribeLayersInput) GoString() string {
 	return s.String()
 }
 
+// SetLayerIds sets the LayerIds field's value.
+func (s *DescribeLayersInput) SetLayerIds(v []*string) *DescribeLayersInput {
+	s.LayerIds = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeLayersInput) SetStackId(v string) *DescribeLayersInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeLayers request.
 type DescribeLayersOutput struct {
 	_ struct{} `type:"structure"`
@@ -7925,6 +9215,12 @@ func (s DescribeLayersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLayersOutput) GoString() string {
 	return s.String()
+}
+
+// SetLayers sets the Layers field's value.
+func (s *DescribeLayersOutput) SetLayers(v []*Layer) *DescribeLayersOutput {
+	s.Layers = v
+	return s
 }
 
 type DescribeLoadBasedAutoScalingInput struct {
@@ -7959,6 +9255,12 @@ func (s *DescribeLoadBasedAutoScalingInput) Validate() error {
 	return nil
 }
 
+// SetLayerIds sets the LayerIds field's value.
+func (s *DescribeLoadBasedAutoScalingInput) SetLayerIds(v []*string) *DescribeLoadBasedAutoScalingInput {
+	s.LayerIds = v
+	return s
+}
+
 // Contains the response to a DescribeLoadBasedAutoScaling request.
 type DescribeLoadBasedAutoScalingOutput struct {
 	_ struct{} `type:"structure"`
@@ -7976,6 +9278,12 @@ func (s DescribeLoadBasedAutoScalingOutput) String() string {
 // GoString returns the string representation
 func (s DescribeLoadBasedAutoScalingOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoadBasedAutoScalingConfigurations sets the LoadBasedAutoScalingConfigurations field's value.
+func (s *DescribeLoadBasedAutoScalingOutput) SetLoadBasedAutoScalingConfigurations(v []*LoadBasedAutoScalingConfiguration) *DescribeLoadBasedAutoScalingOutput {
+	s.LoadBasedAutoScalingConfigurations = v
+	return s
 }
 
 type DescribeMyUserProfileInput struct {
@@ -8010,6 +9318,12 @@ func (s DescribeMyUserProfileOutput) GoString() string {
 	return s.String()
 }
 
+// SetUserProfile sets the UserProfile field's value.
+func (s *DescribeMyUserProfileOutput) SetUserProfile(v *SelfUserProfile) *DescribeMyUserProfileOutput {
+	s.UserProfile = v
+	return s
+}
+
 type DescribePermissionsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -8029,6 +9343,18 @@ func (s DescribePermissionsInput) String() string {
 // GoString returns the string representation
 func (s DescribePermissionsInput) GoString() string {
 	return s.String()
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *DescribePermissionsInput) SetIamUserArn(v string) *DescribePermissionsInput {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribePermissionsInput) SetStackId(v string) *DescribePermissionsInput {
+	s.StackId = &v
+	return s
 }
 
 // Contains the response to a DescribePermissions request.
@@ -8059,6 +9385,12 @@ func (s DescribePermissionsOutput) GoString() string {
 	return s.String()
 }
 
+// SetPermissions sets the Permissions field's value.
+func (s *DescribePermissionsOutput) SetPermissions(v []*Permission) *DescribePermissionsOutput {
+	s.Permissions = v
+	return s
+}
+
 type DescribeRaidArraysInput struct {
 	_ struct{} `type:"structure"`
 
@@ -8085,6 +9417,24 @@ func (s DescribeRaidArraysInput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeRaidArraysInput) SetInstanceId(v string) *DescribeRaidArraysInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetRaidArrayIds sets the RaidArrayIds field's value.
+func (s *DescribeRaidArraysInput) SetRaidArrayIds(v []*string) *DescribeRaidArraysInput {
+	s.RaidArrayIds = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeRaidArraysInput) SetStackId(v string) *DescribeRaidArraysInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeRaidArrays request.
 type DescribeRaidArraysOutput struct {
 	_ struct{} `type:"structure"`
@@ -8101,6 +9451,12 @@ func (s DescribeRaidArraysOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRaidArraysOutput) GoString() string {
 	return s.String()
+}
+
+// SetRaidArrays sets the RaidArrays field's value.
+func (s *DescribeRaidArraysOutput) SetRaidArrays(v []*RaidArray) *DescribeRaidArraysOutput {
+	s.RaidArrays = v
+	return s
 }
 
 type DescribeRdsDbInstancesInput struct {
@@ -8139,6 +9495,18 @@ func (s *DescribeRdsDbInstancesInput) Validate() error {
 	return nil
 }
 
+// SetRdsDbInstanceArns sets the RdsDbInstanceArns field's value.
+func (s *DescribeRdsDbInstancesInput) SetRdsDbInstanceArns(v []*string) *DescribeRdsDbInstancesInput {
+	s.RdsDbInstanceArns = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeRdsDbInstancesInput) SetStackId(v string) *DescribeRdsDbInstancesInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeRdsDbInstances request.
 type DescribeRdsDbInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8155,6 +9523,12 @@ func (s DescribeRdsDbInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRdsDbInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetRdsDbInstances sets the RdsDbInstances field's value.
+func (s *DescribeRdsDbInstancesOutput) SetRdsDbInstances(v []*RdsDbInstance) *DescribeRdsDbInstancesOutput {
+	s.RdsDbInstances = v
+	return s
 }
 
 type DescribeServiceErrorsInput struct {
@@ -8184,6 +9558,24 @@ func (s DescribeServiceErrorsInput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeServiceErrorsInput) SetInstanceId(v string) *DescribeServiceErrorsInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetServiceErrorIds sets the ServiceErrorIds field's value.
+func (s *DescribeServiceErrorsInput) SetServiceErrorIds(v []*string) *DescribeServiceErrorsInput {
+	s.ServiceErrorIds = v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeServiceErrorsInput) SetStackId(v string) *DescribeServiceErrorsInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeServiceErrors request.
 type DescribeServiceErrorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8200,6 +9592,12 @@ func (s DescribeServiceErrorsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeServiceErrorsOutput) GoString() string {
 	return s.String()
+}
+
+// SetServiceErrors sets the ServiceErrors field's value.
+func (s *DescribeServiceErrorsOutput) SetServiceErrors(v []*ServiceError) *DescribeServiceErrorsOutput {
+	s.ServiceErrors = v
+	return s
 }
 
 type DescribeStackProvisioningParametersInput struct {
@@ -8234,6 +9632,12 @@ func (s *DescribeStackProvisioningParametersInput) Validate() error {
 	return nil
 }
 
+// SetStackId sets the StackId field's value.
+func (s *DescribeStackProvisioningParametersInput) SetStackId(v string) *DescribeStackProvisioningParametersInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeStackProvisioningParameters request.
 type DescribeStackProvisioningParametersOutput struct {
 	_ struct{} `type:"structure"`
@@ -8253,6 +9657,18 @@ func (s DescribeStackProvisioningParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStackProvisioningParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetAgentInstallerUrl sets the AgentInstallerUrl field's value.
+func (s *DescribeStackProvisioningParametersOutput) SetAgentInstallerUrl(v string) *DescribeStackProvisioningParametersOutput {
+	s.AgentInstallerUrl = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *DescribeStackProvisioningParametersOutput) SetParameters(v map[string]*string) *DescribeStackProvisioningParametersOutput {
+	s.Parameters = v
+	return s
 }
 
 type DescribeStackSummaryInput struct {
@@ -8287,6 +9703,12 @@ func (s *DescribeStackSummaryInput) Validate() error {
 	return nil
 }
 
+// SetStackId sets the StackId field's value.
+func (s *DescribeStackSummaryInput) SetStackId(v string) *DescribeStackSummaryInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a DescribeStackSummary request.
 type DescribeStackSummaryOutput struct {
 	_ struct{} `type:"structure"`
@@ -8303,6 +9725,12 @@ func (s DescribeStackSummaryOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStackSummaryOutput) GoString() string {
 	return s.String()
+}
+
+// SetStackSummary sets the StackSummary field's value.
+func (s *DescribeStackSummaryOutput) SetStackSummary(v *StackSummary) *DescribeStackSummaryOutput {
+	s.StackSummary = v
+	return s
 }
 
 type DescribeStacksInput struct {
@@ -8323,6 +9751,12 @@ func (s DescribeStacksInput) GoString() string {
 	return s.String()
 }
 
+// SetStackIds sets the StackIds field's value.
+func (s *DescribeStacksInput) SetStackIds(v []*string) *DescribeStacksInput {
+	s.StackIds = v
+	return s
+}
+
 // Contains the response to a DescribeStacks request.
 type DescribeStacksOutput struct {
 	_ struct{} `type:"structure"`
@@ -8339,6 +9773,12 @@ func (s DescribeStacksOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStacksOutput) GoString() string {
 	return s.String()
+}
+
+// SetStacks sets the Stacks field's value.
+func (s *DescribeStacksOutput) SetStacks(v []*Stack) *DescribeStacksOutput {
+	s.Stacks = v
+	return s
 }
 
 type DescribeTimeBasedAutoScalingInput struct {
@@ -8373,6 +9813,12 @@ func (s *DescribeTimeBasedAutoScalingInput) Validate() error {
 	return nil
 }
 
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *DescribeTimeBasedAutoScalingInput) SetInstanceIds(v []*string) *DescribeTimeBasedAutoScalingInput {
+	s.InstanceIds = v
+	return s
+}
+
 // Contains the response to a DescribeTimeBasedAutoScaling request.
 type DescribeTimeBasedAutoScalingOutput struct {
 	_ struct{} `type:"structure"`
@@ -8392,6 +9838,12 @@ func (s DescribeTimeBasedAutoScalingOutput) GoString() string {
 	return s.String()
 }
 
+// SetTimeBasedAutoScalingConfigurations sets the TimeBasedAutoScalingConfigurations field's value.
+func (s *DescribeTimeBasedAutoScalingOutput) SetTimeBasedAutoScalingConfigurations(v []*TimeBasedAutoScalingConfiguration) *DescribeTimeBasedAutoScalingOutput {
+	s.TimeBasedAutoScalingConfigurations = v
+	return s
+}
+
 type DescribeUserProfilesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -8407,6 +9859,12 @@ func (s DescribeUserProfilesInput) String() string {
 // GoString returns the string representation
 func (s DescribeUserProfilesInput) GoString() string {
 	return s.String()
+}
+
+// SetIamUserArns sets the IamUserArns field's value.
+func (s *DescribeUserProfilesInput) SetIamUserArns(v []*string) *DescribeUserProfilesInput {
+	s.IamUserArns = v
+	return s
 }
 
 // Contains the response to a DescribeUserProfiles request.
@@ -8425,6 +9883,12 @@ func (s DescribeUserProfilesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeUserProfilesOutput) GoString() string {
 	return s.String()
+}
+
+// SetUserProfiles sets the UserProfiles field's value.
+func (s *DescribeUserProfilesOutput) SetUserProfiles(v []*UserProfile) *DescribeUserProfilesOutput {
+	s.UserProfiles = v
+	return s
 }
 
 type DescribeVolumesInput struct {
@@ -8457,6 +9921,30 @@ func (s DescribeVolumesInput) GoString() string {
 	return s.String()
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeVolumesInput) SetInstanceId(v string) *DescribeVolumesInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetRaidArrayId sets the RaidArrayId field's value.
+func (s *DescribeVolumesInput) SetRaidArrayId(v string) *DescribeVolumesInput {
+	s.RaidArrayId = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *DescribeVolumesInput) SetStackId(v string) *DescribeVolumesInput {
+	s.StackId = &v
+	return s
+}
+
+// SetVolumeIds sets the VolumeIds field's value.
+func (s *DescribeVolumesInput) SetVolumeIds(v []*string) *DescribeVolumesInput {
+	s.VolumeIds = v
+	return s
+}
+
 // Contains the response to a DescribeVolumes request.
 type DescribeVolumesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8473,6 +9961,12 @@ func (s DescribeVolumesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVolumesOutput) GoString() string {
 	return s.String()
+}
+
+// SetVolumes sets the Volumes field's value.
+func (s *DescribeVolumesOutput) SetVolumes(v []*Volume) *DescribeVolumesOutput {
+	s.Volumes = v
+	return s
 }
 
 type DetachElasticLoadBalancerInput struct {
@@ -8514,6 +10008,18 @@ func (s *DetachElasticLoadBalancerInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetElasticLoadBalancerName sets the ElasticLoadBalancerName field's value.
+func (s *DetachElasticLoadBalancerInput) SetElasticLoadBalancerName(v string) *DetachElasticLoadBalancerInput {
+	s.ElasticLoadBalancerName = &v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *DetachElasticLoadBalancerInput) SetLayerId(v string) *DetachElasticLoadBalancerInput {
+	s.LayerId = &v
+	return s
 }
 
 type DetachElasticLoadBalancerOutput struct {
@@ -8560,6 +10066,12 @@ func (s *DisassociateElasticIpInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *DisassociateElasticIpInput) SetElasticIp(v string) *DisassociateElasticIpInput {
+	s.ElasticIp = &v
+	return s
 }
 
 type DisassociateElasticIpOutput struct {
@@ -8610,6 +10122,36 @@ func (s EbsBlockDevice) GoString() string {
 	return s.String()
 }
 
+// SetDeleteOnTermination sets the DeleteOnTermination field's value.
+func (s *EbsBlockDevice) SetDeleteOnTermination(v bool) *EbsBlockDevice {
+	s.DeleteOnTermination = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *EbsBlockDevice) SetIops(v int64) *EbsBlockDevice {
+	s.Iops = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *EbsBlockDevice) SetSnapshotId(v string) *EbsBlockDevice {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetVolumeSize sets the VolumeSize field's value.
+func (s *EbsBlockDevice) SetVolumeSize(v int64) *EbsBlockDevice {
+	s.VolumeSize = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *EbsBlockDevice) SetVolumeType(v string) *EbsBlockDevice {
+	s.VolumeType = &v
+	return s
+}
+
 // Describes a registered Amazon ECS cluster.
 type EcsCluster struct {
 	_ struct{} `type:"structure"`
@@ -8635,6 +10177,30 @@ func (s EcsCluster) String() string {
 // GoString returns the string representation
 func (s EcsCluster) GoString() string {
 	return s.String()
+}
+
+// SetEcsClusterArn sets the EcsClusterArn field's value.
+func (s *EcsCluster) SetEcsClusterArn(v string) *EcsCluster {
+	s.EcsClusterArn = &v
+	return s
+}
+
+// SetEcsClusterName sets the EcsClusterName field's value.
+func (s *EcsCluster) SetEcsClusterName(v string) *EcsCluster {
+	s.EcsClusterName = &v
+	return s
+}
+
+// SetRegisteredAt sets the RegisteredAt field's value.
+func (s *EcsCluster) SetRegisteredAt(v string) *EcsCluster {
+	s.RegisteredAt = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *EcsCluster) SetStackId(v string) *EcsCluster {
+	s.StackId = &v
+	return s
 }
 
 // Describes an Elastic IP address.
@@ -8665,6 +10231,36 @@ func (s ElasticIp) String() string {
 // GoString returns the string representation
 func (s ElasticIp) GoString() string {
 	return s.String()
+}
+
+// SetDomain sets the Domain field's value.
+func (s *ElasticIp) SetDomain(v string) *ElasticIp {
+	s.Domain = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ElasticIp) SetInstanceId(v string) *ElasticIp {
+	s.InstanceId = &v
+	return s
+}
+
+// SetIp sets the Ip field's value.
+func (s *ElasticIp) SetIp(v string) *ElasticIp {
+	s.Ip = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ElasticIp) SetName(v string) *ElasticIp {
+	s.Name = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *ElasticIp) SetRegion(v string) *ElasticIp {
+	s.Region = &v
+	return s
 }
 
 // Describes an Elastic Load Balancing instance.
@@ -8708,6 +10304,60 @@ func (s ElasticLoadBalancer) String() string {
 // GoString returns the string representation
 func (s ElasticLoadBalancer) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *ElasticLoadBalancer) SetAvailabilityZones(v []*string) *ElasticLoadBalancer {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetDnsName sets the DnsName field's value.
+func (s *ElasticLoadBalancer) SetDnsName(v string) *ElasticLoadBalancer {
+	s.DnsName = &v
+	return s
+}
+
+// SetEc2InstanceIds sets the Ec2InstanceIds field's value.
+func (s *ElasticLoadBalancer) SetEc2InstanceIds(v []*string) *ElasticLoadBalancer {
+	s.Ec2InstanceIds = v
+	return s
+}
+
+// SetElasticLoadBalancerName sets the ElasticLoadBalancerName field's value.
+func (s *ElasticLoadBalancer) SetElasticLoadBalancerName(v string) *ElasticLoadBalancer {
+	s.ElasticLoadBalancerName = &v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *ElasticLoadBalancer) SetLayerId(v string) *ElasticLoadBalancer {
+	s.LayerId = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *ElasticLoadBalancer) SetRegion(v string) *ElasticLoadBalancer {
+	s.Region = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *ElasticLoadBalancer) SetStackId(v string) *ElasticLoadBalancer {
+	s.StackId = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *ElasticLoadBalancer) SetSubnetIds(v []*string) *ElasticLoadBalancer {
+	s.SubnetIds = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *ElasticLoadBalancer) SetVpcId(v string) *ElasticLoadBalancer {
+	s.VpcId = &v
+	return s
 }
 
 // Represents an app's environment variable.
@@ -8762,6 +10412,24 @@ func (s *EnvironmentVariable) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *EnvironmentVariable) SetKey(v string) *EnvironmentVariable {
+	s.Key = &v
+	return s
+}
+
+// SetSecure sets the Secure field's value.
+func (s *EnvironmentVariable) SetSecure(v bool) *EnvironmentVariable {
+	s.Secure = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *EnvironmentVariable) SetValue(v string) *EnvironmentVariable {
+	s.Value = &v
+	return s
+}
+
 type GetHostnameSuggestionInput struct {
 	_ struct{} `type:"structure"`
 
@@ -8794,6 +10462,12 @@ func (s *GetHostnameSuggestionInput) Validate() error {
 	return nil
 }
 
+// SetLayerId sets the LayerId field's value.
+func (s *GetHostnameSuggestionInput) SetLayerId(v string) *GetHostnameSuggestionInput {
+	s.LayerId = &v
+	return s
+}
+
 // Contains the response to a GetHostnameSuggestion request.
 type GetHostnameSuggestionOutput struct {
 	_ struct{} `type:"structure"`
@@ -8813,6 +10487,18 @@ func (s GetHostnameSuggestionOutput) String() string {
 // GoString returns the string representation
 func (s GetHostnameSuggestionOutput) GoString() string {
 	return s.String()
+}
+
+// SetHostname sets the Hostname field's value.
+func (s *GetHostnameSuggestionOutput) SetHostname(v string) *GetHostnameSuggestionOutput {
+	s.Hostname = &v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *GetHostnameSuggestionOutput) SetLayerId(v string) *GetHostnameSuggestionOutput {
+	s.LayerId = &v
+	return s
 }
 
 type GrantAccessInput struct {
@@ -8856,6 +10542,18 @@ func (s *GrantAccessInput) Validate() error {
 	return nil
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *GrantAccessInput) SetInstanceId(v string) *GrantAccessInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetValidForInMinutes sets the ValidForInMinutes field's value.
+func (s *GrantAccessInput) SetValidForInMinutes(v int64) *GrantAccessInput {
+	s.ValidForInMinutes = &v
+	return s
+}
+
 // Contains the response to a GrantAccess request.
 type GrantAccessOutput struct {
 	_ struct{} `type:"structure"`
@@ -8873,6 +10571,12 @@ func (s GrantAccessOutput) String() string {
 // GoString returns the string representation
 func (s GrantAccessOutput) GoString() string {
 	return s.String()
+}
+
+// SetTemporaryCredential sets the TemporaryCredential field's value.
+func (s *GrantAccessOutput) SetTemporaryCredential(v *TemporaryCredential) *GrantAccessOutput {
+	s.TemporaryCredential = v
+	return s
 }
 
 // Describes an instance.
@@ -9053,6 +10757,246 @@ func (s Instance) GoString() string {
 	return s.String()
 }
 
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *Instance) SetAgentVersion(v string) *Instance {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetAmiId sets the AmiId field's value.
+func (s *Instance) SetAmiId(v string) *Instance {
+	s.AmiId = &v
+	return s
+}
+
+// SetArchitecture sets the Architecture field's value.
+func (s *Instance) SetArchitecture(v string) *Instance {
+	s.Architecture = &v
+	return s
+}
+
+// SetAutoScalingType sets the AutoScalingType field's value.
+func (s *Instance) SetAutoScalingType(v string) *Instance {
+	s.AutoScalingType = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Instance) SetAvailabilityZone(v string) *Instance {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetBlockDeviceMappings sets the BlockDeviceMappings field's value.
+func (s *Instance) SetBlockDeviceMappings(v []*BlockDeviceMapping) *Instance {
+	s.BlockDeviceMappings = v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Instance) SetCreatedAt(v string) *Instance {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *Instance) SetEbsOptimized(v bool) *Instance {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetEc2InstanceId sets the Ec2InstanceId field's value.
+func (s *Instance) SetEc2InstanceId(v string) *Instance {
+	s.Ec2InstanceId = &v
+	return s
+}
+
+// SetEcsClusterArn sets the EcsClusterArn field's value.
+func (s *Instance) SetEcsClusterArn(v string) *Instance {
+	s.EcsClusterArn = &v
+	return s
+}
+
+// SetEcsContainerInstanceArn sets the EcsContainerInstanceArn field's value.
+func (s *Instance) SetEcsContainerInstanceArn(v string) *Instance {
+	s.EcsContainerInstanceArn = &v
+	return s
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *Instance) SetElasticIp(v string) *Instance {
+	s.ElasticIp = &v
+	return s
+}
+
+// SetHostname sets the Hostname field's value.
+func (s *Instance) SetHostname(v string) *Instance {
+	s.Hostname = &v
+	return s
+}
+
+// SetInfrastructureClass sets the InfrastructureClass field's value.
+func (s *Instance) SetInfrastructureClass(v string) *Instance {
+	s.InfrastructureClass = &v
+	return s
+}
+
+// SetInstallUpdatesOnBoot sets the InstallUpdatesOnBoot field's value.
+func (s *Instance) SetInstallUpdatesOnBoot(v bool) *Instance {
+	s.InstallUpdatesOnBoot = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Instance) SetInstanceId(v string) *Instance {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceProfileArn sets the InstanceProfileArn field's value.
+func (s *Instance) SetInstanceProfileArn(v string) *Instance {
+	s.InstanceProfileArn = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *Instance) SetInstanceType(v string) *Instance {
+	s.InstanceType = &v
+	return s
+}
+
+// SetLastServiceErrorId sets the LastServiceErrorId field's value.
+func (s *Instance) SetLastServiceErrorId(v string) *Instance {
+	s.LastServiceErrorId = &v
+	return s
+}
+
+// SetLayerIds sets the LayerIds field's value.
+func (s *Instance) SetLayerIds(v []*string) *Instance {
+	s.LayerIds = v
+	return s
+}
+
+// SetOs sets the Os field's value.
+func (s *Instance) SetOs(v string) *Instance {
+	s.Os = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *Instance) SetPlatform(v string) *Instance {
+	s.Platform = &v
+	return s
+}
+
+// SetPrivateDns sets the PrivateDns field's value.
+func (s *Instance) SetPrivateDns(v string) *Instance {
+	s.PrivateDns = &v
+	return s
+}
+
+// SetPrivateIp sets the PrivateIp field's value.
+func (s *Instance) SetPrivateIp(v string) *Instance {
+	s.PrivateIp = &v
+	return s
+}
+
+// SetPublicDns sets the PublicDns field's value.
+func (s *Instance) SetPublicDns(v string) *Instance {
+	s.PublicDns = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *Instance) SetPublicIp(v string) *Instance {
+	s.PublicIp = &v
+	return s
+}
+
+// SetRegisteredBy sets the RegisteredBy field's value.
+func (s *Instance) SetRegisteredBy(v string) *Instance {
+	s.RegisteredBy = &v
+	return s
+}
+
+// SetReportedAgentVersion sets the ReportedAgentVersion field's value.
+func (s *Instance) SetReportedAgentVersion(v string) *Instance {
+	s.ReportedAgentVersion = &v
+	return s
+}
+
+// SetReportedOs sets the ReportedOs field's value.
+func (s *Instance) SetReportedOs(v *ReportedOs) *Instance {
+	s.ReportedOs = v
+	return s
+}
+
+// SetRootDeviceType sets the RootDeviceType field's value.
+func (s *Instance) SetRootDeviceType(v string) *Instance {
+	s.RootDeviceType = &v
+	return s
+}
+
+// SetRootDeviceVolumeId sets the RootDeviceVolumeId field's value.
+func (s *Instance) SetRootDeviceVolumeId(v string) *Instance {
+	s.RootDeviceVolumeId = &v
+	return s
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *Instance) SetSecurityGroupIds(v []*string) *Instance {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSshHostDsaKeyFingerprint sets the SshHostDsaKeyFingerprint field's value.
+func (s *Instance) SetSshHostDsaKeyFingerprint(v string) *Instance {
+	s.SshHostDsaKeyFingerprint = &v
+	return s
+}
+
+// SetSshHostRsaKeyFingerprint sets the SshHostRsaKeyFingerprint field's value.
+func (s *Instance) SetSshHostRsaKeyFingerprint(v string) *Instance {
+	s.SshHostRsaKeyFingerprint = &v
+	return s
+}
+
+// SetSshKeyName sets the SshKeyName field's value.
+func (s *Instance) SetSshKeyName(v string) *Instance {
+	s.SshKeyName = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *Instance) SetStackId(v string) *Instance {
+	s.StackId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Instance) SetStatus(v string) *Instance {
+	s.Status = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *Instance) SetSubnetId(v string) *Instance {
+	s.SubnetId = &v
+	return s
+}
+
+// SetTenancy sets the Tenancy field's value.
+func (s *Instance) SetTenancy(v string) *Instance {
+	s.Tenancy = &v
+	return s
+}
+
+// SetVirtualizationType sets the VirtualizationType field's value.
+func (s *Instance) SetVirtualizationType(v string) *Instance {
+	s.VirtualizationType = &v
+	return s
+}
+
 // Contains a description of an Amazon EC2 instance from the Amazon EC2 metadata
 // service. For more information, see Instance Metadata and User Data (http://docs.aws.amazon.com/sdkfornet/latest/apidocs/Index.html).
 type InstanceIdentity struct {
@@ -9073,6 +11017,18 @@ func (s InstanceIdentity) String() string {
 // GoString returns the string representation
 func (s InstanceIdentity) GoString() string {
 	return s.String()
+}
+
+// SetDocument sets the Document field's value.
+func (s *InstanceIdentity) SetDocument(v string) *InstanceIdentity {
+	s.Document = &v
+	return s
+}
+
+// SetSignature sets the Signature field's value.
+func (s *InstanceIdentity) SetSignature(v string) *InstanceIdentity {
+	s.Signature = &v
+	return s
 }
 
 // Describes how many instances a stack has for each status.
@@ -9145,6 +11101,120 @@ func (s InstancesCount) String() string {
 // GoString returns the string representation
 func (s InstancesCount) GoString() string {
 	return s.String()
+}
+
+// SetAssigning sets the Assigning field's value.
+func (s *InstancesCount) SetAssigning(v int64) *InstancesCount {
+	s.Assigning = &v
+	return s
+}
+
+// SetBooting sets the Booting field's value.
+func (s *InstancesCount) SetBooting(v int64) *InstancesCount {
+	s.Booting = &v
+	return s
+}
+
+// SetConnectionLost sets the ConnectionLost field's value.
+func (s *InstancesCount) SetConnectionLost(v int64) *InstancesCount {
+	s.ConnectionLost = &v
+	return s
+}
+
+// SetDeregistering sets the Deregistering field's value.
+func (s *InstancesCount) SetDeregistering(v int64) *InstancesCount {
+	s.Deregistering = &v
+	return s
+}
+
+// SetOnline sets the Online field's value.
+func (s *InstancesCount) SetOnline(v int64) *InstancesCount {
+	s.Online = &v
+	return s
+}
+
+// SetPending sets the Pending field's value.
+func (s *InstancesCount) SetPending(v int64) *InstancesCount {
+	s.Pending = &v
+	return s
+}
+
+// SetRebooting sets the Rebooting field's value.
+func (s *InstancesCount) SetRebooting(v int64) *InstancesCount {
+	s.Rebooting = &v
+	return s
+}
+
+// SetRegistered sets the Registered field's value.
+func (s *InstancesCount) SetRegistered(v int64) *InstancesCount {
+	s.Registered = &v
+	return s
+}
+
+// SetRegistering sets the Registering field's value.
+func (s *InstancesCount) SetRegistering(v int64) *InstancesCount {
+	s.Registering = &v
+	return s
+}
+
+// SetRequested sets the Requested field's value.
+func (s *InstancesCount) SetRequested(v int64) *InstancesCount {
+	s.Requested = &v
+	return s
+}
+
+// SetRunningSetup sets the RunningSetup field's value.
+func (s *InstancesCount) SetRunningSetup(v int64) *InstancesCount {
+	s.RunningSetup = &v
+	return s
+}
+
+// SetSetupFailed sets the SetupFailed field's value.
+func (s *InstancesCount) SetSetupFailed(v int64) *InstancesCount {
+	s.SetupFailed = &v
+	return s
+}
+
+// SetShuttingDown sets the ShuttingDown field's value.
+func (s *InstancesCount) SetShuttingDown(v int64) *InstancesCount {
+	s.ShuttingDown = &v
+	return s
+}
+
+// SetStartFailed sets the StartFailed field's value.
+func (s *InstancesCount) SetStartFailed(v int64) *InstancesCount {
+	s.StartFailed = &v
+	return s
+}
+
+// SetStopped sets the Stopped field's value.
+func (s *InstancesCount) SetStopped(v int64) *InstancesCount {
+	s.Stopped = &v
+	return s
+}
+
+// SetStopping sets the Stopping field's value.
+func (s *InstancesCount) SetStopping(v int64) *InstancesCount {
+	s.Stopping = &v
+	return s
+}
+
+// SetTerminated sets the Terminated field's value.
+func (s *InstancesCount) SetTerminated(v int64) *InstancesCount {
+	s.Terminated = &v
+	return s
+}
+
+// SetTerminating sets the Terminating field's value.
+func (s *InstancesCount) SetTerminating(v int64) *InstancesCount {
+	s.Terminating = &v
+	return s
+}
+
+// SetUnassigning sets the Unassigning field's value.
+func (s *InstancesCount) SetUnassigning(v int64) *InstancesCount {
+	s.Unassigning = &v
+	return s
 }
 
 // Describes a layer.
@@ -9253,6 +11323,132 @@ func (s Layer) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *Layer) SetAttributes(v map[string]*string) *Layer {
+	s.Attributes = v
+	return s
+}
+
+// SetAutoAssignElasticIps sets the AutoAssignElasticIps field's value.
+func (s *Layer) SetAutoAssignElasticIps(v bool) *Layer {
+	s.AutoAssignElasticIps = &v
+	return s
+}
+
+// SetAutoAssignPublicIps sets the AutoAssignPublicIps field's value.
+func (s *Layer) SetAutoAssignPublicIps(v bool) *Layer {
+	s.AutoAssignPublicIps = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Layer) SetCreatedAt(v string) *Layer {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCustomInstanceProfileArn sets the CustomInstanceProfileArn field's value.
+func (s *Layer) SetCustomInstanceProfileArn(v string) *Layer {
+	s.CustomInstanceProfileArn = &v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *Layer) SetCustomJson(v string) *Layer {
+	s.CustomJson = &v
+	return s
+}
+
+// SetCustomRecipes sets the CustomRecipes field's value.
+func (s *Layer) SetCustomRecipes(v *Recipes) *Layer {
+	s.CustomRecipes = v
+	return s
+}
+
+// SetCustomSecurityGroupIds sets the CustomSecurityGroupIds field's value.
+func (s *Layer) SetCustomSecurityGroupIds(v []*string) *Layer {
+	s.CustomSecurityGroupIds = v
+	return s
+}
+
+// SetDefaultRecipes sets the DefaultRecipes field's value.
+func (s *Layer) SetDefaultRecipes(v *Recipes) *Layer {
+	s.DefaultRecipes = v
+	return s
+}
+
+// SetDefaultSecurityGroupNames sets the DefaultSecurityGroupNames field's value.
+func (s *Layer) SetDefaultSecurityGroupNames(v []*string) *Layer {
+	s.DefaultSecurityGroupNames = v
+	return s
+}
+
+// SetEnableAutoHealing sets the EnableAutoHealing field's value.
+func (s *Layer) SetEnableAutoHealing(v bool) *Layer {
+	s.EnableAutoHealing = &v
+	return s
+}
+
+// SetInstallUpdatesOnBoot sets the InstallUpdatesOnBoot field's value.
+func (s *Layer) SetInstallUpdatesOnBoot(v bool) *Layer {
+	s.InstallUpdatesOnBoot = &v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *Layer) SetLayerId(v string) *Layer {
+	s.LayerId = &v
+	return s
+}
+
+// SetLifecycleEventConfiguration sets the LifecycleEventConfiguration field's value.
+func (s *Layer) SetLifecycleEventConfiguration(v *LifecycleEventConfiguration) *Layer {
+	s.LifecycleEventConfiguration = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Layer) SetName(v string) *Layer {
+	s.Name = &v
+	return s
+}
+
+// SetPackages sets the Packages field's value.
+func (s *Layer) SetPackages(v []*string) *Layer {
+	s.Packages = v
+	return s
+}
+
+// SetShortname sets the Shortname field's value.
+func (s *Layer) SetShortname(v string) *Layer {
+	s.Shortname = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *Layer) SetStackId(v string) *Layer {
+	s.StackId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Layer) SetType(v string) *Layer {
+	s.Type = &v
+	return s
+}
+
+// SetUseEbsOptimizedInstances sets the UseEbsOptimizedInstances field's value.
+func (s *Layer) SetUseEbsOptimizedInstances(v bool) *Layer {
+	s.UseEbsOptimizedInstances = &v
+	return s
+}
+
+// SetVolumeConfigurations sets the VolumeConfigurations field's value.
+func (s *Layer) SetVolumeConfigurations(v []*VolumeConfiguration) *Layer {
+	s.VolumeConfigurations = v
+	return s
+}
+
 // Specifies the lifecycle event configuration
 type LifecycleEventConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -9269,6 +11465,12 @@ func (s LifecycleEventConfiguration) String() string {
 // GoString returns the string representation
 func (s LifecycleEventConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetShutdown sets the Shutdown field's value.
+func (s *LifecycleEventConfiguration) SetShutdown(v *ShutdownEventConfiguration) *LifecycleEventConfiguration {
+	s.Shutdown = v
+	return s
 }
 
 // Describes a layer's load-based auto scaling configuration.
@@ -9298,6 +11500,30 @@ func (s LoadBasedAutoScalingConfiguration) String() string {
 // GoString returns the string representation
 func (s LoadBasedAutoScalingConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetDownScaling sets the DownScaling field's value.
+func (s *LoadBasedAutoScalingConfiguration) SetDownScaling(v *AutoScalingThresholds) *LoadBasedAutoScalingConfiguration {
+	s.DownScaling = v
+	return s
+}
+
+// SetEnable sets the Enable field's value.
+func (s *LoadBasedAutoScalingConfiguration) SetEnable(v bool) *LoadBasedAutoScalingConfiguration {
+	s.Enable = &v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *LoadBasedAutoScalingConfiguration) SetLayerId(v string) *LoadBasedAutoScalingConfiguration {
+	s.LayerId = &v
+	return s
+}
+
+// SetUpScaling sets the UpScaling field's value.
+func (s *LoadBasedAutoScalingConfiguration) SetUpScaling(v *AutoScalingThresholds) *LoadBasedAutoScalingConfiguration {
+	s.UpScaling = v
+	return s
 }
 
 // Describes stack or user permissions.
@@ -9342,6 +11568,36 @@ func (s Permission) String() string {
 // GoString returns the string representation
 func (s Permission) GoString() string {
 	return s.String()
+}
+
+// SetAllowSsh sets the AllowSsh field's value.
+func (s *Permission) SetAllowSsh(v bool) *Permission {
+	s.AllowSsh = &v
+	return s
+}
+
+// SetAllowSudo sets the AllowSudo field's value.
+func (s *Permission) SetAllowSudo(v bool) *Permission {
+	s.AllowSudo = &v
+	return s
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *Permission) SetIamUserArn(v string) *Permission {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetLevel sets the Level field's value.
+func (s *Permission) SetLevel(v string) *Permission {
+	s.Level = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *Permission) SetStackId(v string) *Permission {
+	s.StackId = &v
+	return s
 }
 
 // Describes an instance's RAID array.
@@ -9399,6 +11655,84 @@ func (s RaidArray) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *RaidArray) SetAvailabilityZone(v string) *RaidArray {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *RaidArray) SetCreatedAt(v string) *RaidArray {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDevice sets the Device field's value.
+func (s *RaidArray) SetDevice(v string) *RaidArray {
+	s.Device = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *RaidArray) SetInstanceId(v string) *RaidArray {
+	s.InstanceId = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *RaidArray) SetIops(v int64) *RaidArray {
+	s.Iops = &v
+	return s
+}
+
+// SetMountPoint sets the MountPoint field's value.
+func (s *RaidArray) SetMountPoint(v string) *RaidArray {
+	s.MountPoint = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RaidArray) SetName(v string) *RaidArray {
+	s.Name = &v
+	return s
+}
+
+// SetNumberOfDisks sets the NumberOfDisks field's value.
+func (s *RaidArray) SetNumberOfDisks(v int64) *RaidArray {
+	s.NumberOfDisks = &v
+	return s
+}
+
+// SetRaidArrayId sets the RaidArrayId field's value.
+func (s *RaidArray) SetRaidArrayId(v string) *RaidArray {
+	s.RaidArrayId = &v
+	return s
+}
+
+// SetRaidLevel sets the RaidLevel field's value.
+func (s *RaidArray) SetRaidLevel(v int64) *RaidArray {
+	s.RaidLevel = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *RaidArray) SetSize(v int64) *RaidArray {
+	s.Size = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *RaidArray) SetStackId(v string) *RaidArray {
+	s.StackId = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *RaidArray) SetVolumeType(v string) *RaidArray {
+	s.VolumeType = &v
+	return s
+}
+
 // Describes an Amazon RDS instance.
 type RdsDbInstance struct {
 	_ struct{} `type:"structure"`
@@ -9443,6 +11777,60 @@ func (s RdsDbInstance) GoString() string {
 	return s.String()
 }
 
+// SetAddress sets the Address field's value.
+func (s *RdsDbInstance) SetAddress(v string) *RdsDbInstance {
+	s.Address = &v
+	return s
+}
+
+// SetDbInstanceIdentifier sets the DbInstanceIdentifier field's value.
+func (s *RdsDbInstance) SetDbInstanceIdentifier(v string) *RdsDbInstance {
+	s.DbInstanceIdentifier = &v
+	return s
+}
+
+// SetDbPassword sets the DbPassword field's value.
+func (s *RdsDbInstance) SetDbPassword(v string) *RdsDbInstance {
+	s.DbPassword = &v
+	return s
+}
+
+// SetDbUser sets the DbUser field's value.
+func (s *RdsDbInstance) SetDbUser(v string) *RdsDbInstance {
+	s.DbUser = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *RdsDbInstance) SetEngine(v string) *RdsDbInstance {
+	s.Engine = &v
+	return s
+}
+
+// SetMissingOnRds sets the MissingOnRds field's value.
+func (s *RdsDbInstance) SetMissingOnRds(v bool) *RdsDbInstance {
+	s.MissingOnRds = &v
+	return s
+}
+
+// SetRdsDbInstanceArn sets the RdsDbInstanceArn field's value.
+func (s *RdsDbInstance) SetRdsDbInstanceArn(v string) *RdsDbInstance {
+	s.RdsDbInstanceArn = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *RdsDbInstance) SetRegion(v string) *RdsDbInstance {
+	s.Region = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *RdsDbInstance) SetStackId(v string) *RdsDbInstance {
+	s.StackId = &v
+	return s
+}
+
 type RebootInstanceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -9473,6 +11861,12 @@ func (s *RebootInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *RebootInstanceInput) SetInstanceId(v string) *RebootInstanceInput {
+	s.InstanceId = &v
+	return s
 }
 
 type RebootInstanceOutput struct {
@@ -9529,6 +11923,36 @@ func (s Recipes) GoString() string {
 	return s.String()
 }
 
+// SetConfigure sets the Configure field's value.
+func (s *Recipes) SetConfigure(v []*string) *Recipes {
+	s.Configure = v
+	return s
+}
+
+// SetDeploy sets the Deploy field's value.
+func (s *Recipes) SetDeploy(v []*string) *Recipes {
+	s.Deploy = v
+	return s
+}
+
+// SetSetup sets the Setup field's value.
+func (s *Recipes) SetSetup(v []*string) *Recipes {
+	s.Setup = v
+	return s
+}
+
+// SetShutdown sets the Shutdown field's value.
+func (s *Recipes) SetShutdown(v []*string) *Recipes {
+	s.Shutdown = v
+	return s
+}
+
+// SetUndeploy sets the Undeploy field's value.
+func (s *Recipes) SetUndeploy(v []*string) *Recipes {
+	s.Undeploy = v
+	return s
+}
+
 type RegisterEcsClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -9569,6 +11993,18 @@ func (s *RegisterEcsClusterInput) Validate() error {
 	return nil
 }
 
+// SetEcsClusterArn sets the EcsClusterArn field's value.
+func (s *RegisterEcsClusterInput) SetEcsClusterArn(v string) *RegisterEcsClusterInput {
+	s.EcsClusterArn = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *RegisterEcsClusterInput) SetStackId(v string) *RegisterEcsClusterInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a RegisterEcsCluster request.
 type RegisterEcsClusterOutput struct {
 	_ struct{} `type:"structure"`
@@ -9585,6 +12021,12 @@ func (s RegisterEcsClusterOutput) String() string {
 // GoString returns the string representation
 func (s RegisterEcsClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetEcsClusterArn sets the EcsClusterArn field's value.
+func (s *RegisterEcsClusterOutput) SetEcsClusterArn(v string) *RegisterEcsClusterOutput {
+	s.EcsClusterArn = &v
+	return s
 }
 
 type RegisterElasticIpInput struct {
@@ -9627,6 +12069,18 @@ func (s *RegisterElasticIpInput) Validate() error {
 	return nil
 }
 
+// SetElasticIp sets the ElasticIp field's value.
+func (s *RegisterElasticIpInput) SetElasticIp(v string) *RegisterElasticIpInput {
+	s.ElasticIp = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *RegisterElasticIpInput) SetStackId(v string) *RegisterElasticIpInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a RegisterElasticIp request.
 type RegisterElasticIpOutput struct {
 	_ struct{} `type:"structure"`
@@ -9643,6 +12097,12 @@ func (s RegisterElasticIpOutput) String() string {
 // GoString returns the string representation
 func (s RegisterElasticIpOutput) GoString() string {
 	return s.String()
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *RegisterElasticIpOutput) SetElasticIp(v string) *RegisterElasticIpOutput {
+	s.ElasticIp = &v
+	return s
 }
 
 type RegisterInstanceInput struct {
@@ -9696,6 +12156,48 @@ func (s *RegisterInstanceInput) Validate() error {
 	return nil
 }
 
+// SetHostname sets the Hostname field's value.
+func (s *RegisterInstanceInput) SetHostname(v string) *RegisterInstanceInput {
+	s.Hostname = &v
+	return s
+}
+
+// SetInstanceIdentity sets the InstanceIdentity field's value.
+func (s *RegisterInstanceInput) SetInstanceIdentity(v *InstanceIdentity) *RegisterInstanceInput {
+	s.InstanceIdentity = v
+	return s
+}
+
+// SetPrivateIp sets the PrivateIp field's value.
+func (s *RegisterInstanceInput) SetPrivateIp(v string) *RegisterInstanceInput {
+	s.PrivateIp = &v
+	return s
+}
+
+// SetPublicIp sets the PublicIp field's value.
+func (s *RegisterInstanceInput) SetPublicIp(v string) *RegisterInstanceInput {
+	s.PublicIp = &v
+	return s
+}
+
+// SetRsaPublicKey sets the RsaPublicKey field's value.
+func (s *RegisterInstanceInput) SetRsaPublicKey(v string) *RegisterInstanceInput {
+	s.RsaPublicKey = &v
+	return s
+}
+
+// SetRsaPublicKeyFingerprint sets the RsaPublicKeyFingerprint field's value.
+func (s *RegisterInstanceInput) SetRsaPublicKeyFingerprint(v string) *RegisterInstanceInput {
+	s.RsaPublicKeyFingerprint = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *RegisterInstanceInput) SetStackId(v string) *RegisterInstanceInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a RegisterInstanceResult request.
 type RegisterInstanceOutput struct {
 	_ struct{} `type:"structure"`
@@ -9712,6 +12214,12 @@ func (s RegisterInstanceOutput) String() string {
 // GoString returns the string representation
 func (s RegisterInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *RegisterInstanceOutput) SetInstanceId(v string) *RegisterInstanceOutput {
+	s.InstanceId = &v
+	return s
 }
 
 type RegisterRdsDbInstanceInput struct {
@@ -9770,6 +12278,30 @@ func (s *RegisterRdsDbInstanceInput) Validate() error {
 	return nil
 }
 
+// SetDbPassword sets the DbPassword field's value.
+func (s *RegisterRdsDbInstanceInput) SetDbPassword(v string) *RegisterRdsDbInstanceInput {
+	s.DbPassword = &v
+	return s
+}
+
+// SetDbUser sets the DbUser field's value.
+func (s *RegisterRdsDbInstanceInput) SetDbUser(v string) *RegisterRdsDbInstanceInput {
+	s.DbUser = &v
+	return s
+}
+
+// SetRdsDbInstanceArn sets the RdsDbInstanceArn field's value.
+func (s *RegisterRdsDbInstanceInput) SetRdsDbInstanceArn(v string) *RegisterRdsDbInstanceInput {
+	s.RdsDbInstanceArn = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *RegisterRdsDbInstanceInput) SetStackId(v string) *RegisterRdsDbInstanceInput {
+	s.StackId = &v
+	return s
+}
+
 type RegisterRdsDbInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -9819,6 +12351,18 @@ func (s *RegisterVolumeInput) Validate() error {
 	return nil
 }
 
+// SetEc2VolumeId sets the Ec2VolumeId field's value.
+func (s *RegisterVolumeInput) SetEc2VolumeId(v string) *RegisterVolumeInput {
+	s.Ec2VolumeId = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *RegisterVolumeInput) SetStackId(v string) *RegisterVolumeInput {
+	s.StackId = &v
+	return s
+}
+
 // Contains the response to a RegisterVolume request.
 type RegisterVolumeOutput struct {
 	_ struct{} `type:"structure"`
@@ -9835,6 +12379,12 @@ func (s RegisterVolumeOutput) String() string {
 // GoString returns the string representation
 func (s RegisterVolumeOutput) GoString() string {
 	return s.String()
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *RegisterVolumeOutput) SetVolumeId(v string) *RegisterVolumeOutput {
+	s.VolumeId = &v
+	return s
 }
 
 // A registered instance's reported operating system.
@@ -9859,6 +12409,24 @@ func (s ReportedOs) String() string {
 // GoString returns the string representation
 func (s ReportedOs) GoString() string {
 	return s.String()
+}
+
+// SetFamily sets the Family field's value.
+func (s *ReportedOs) SetFamily(v string) *ReportedOs {
+	s.Family = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ReportedOs) SetName(v string) *ReportedOs {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *ReportedOs) SetVersion(v string) *ReportedOs {
+	s.Version = &v
+	return s
 }
 
 // Describes a user's SSH information.
@@ -9886,6 +12454,30 @@ func (s SelfUserProfile) String() string {
 // GoString returns the string representation
 func (s SelfUserProfile) GoString() string {
 	return s.String()
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *SelfUserProfile) SetIamUserArn(v string) *SelfUserProfile {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *SelfUserProfile) SetName(v string) *SelfUserProfile {
+	s.Name = &v
+	return s
+}
+
+// SetSshPublicKey sets the SshPublicKey field's value.
+func (s *SelfUserProfile) SetSshPublicKey(v string) *SelfUserProfile {
+	s.SshPublicKey = &v
+	return s
+}
+
+// SetSshUsername sets the SshUsername field's value.
+func (s *SelfUserProfile) SetSshUsername(v string) *SelfUserProfile {
+	s.SshUsername = &v
+	return s
 }
 
 // Describes an AWS OpsWorks service error.
@@ -9919,6 +12511,42 @@ func (s ServiceError) String() string {
 // GoString returns the string representation
 func (s ServiceError) GoString() string {
 	return s.String()
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *ServiceError) SetCreatedAt(v string) *ServiceError {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ServiceError) SetInstanceId(v string) *ServiceError {
+	s.InstanceId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *ServiceError) SetMessage(v string) *ServiceError {
+	s.Message = &v
+	return s
+}
+
+// SetServiceErrorId sets the ServiceErrorId field's value.
+func (s *ServiceError) SetServiceErrorId(v string) *ServiceError {
+	s.ServiceErrorId = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *ServiceError) SetStackId(v string) *ServiceError {
+	s.StackId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ServiceError) SetType(v string) *ServiceError {
+	s.Type = &v
+	return s
 }
 
 type SetLoadBasedAutoScalingInput struct {
@@ -9974,6 +12602,30 @@ func (s *SetLoadBasedAutoScalingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDownScaling sets the DownScaling field's value.
+func (s *SetLoadBasedAutoScalingInput) SetDownScaling(v *AutoScalingThresholds) *SetLoadBasedAutoScalingInput {
+	s.DownScaling = v
+	return s
+}
+
+// SetEnable sets the Enable field's value.
+func (s *SetLoadBasedAutoScalingInput) SetEnable(v bool) *SetLoadBasedAutoScalingInput {
+	s.Enable = &v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *SetLoadBasedAutoScalingInput) SetLayerId(v string) *SetLoadBasedAutoScalingInput {
+	s.LayerId = &v
+	return s
+}
+
+// SetUpScaling sets the UpScaling field's value.
+func (s *SetLoadBasedAutoScalingInput) SetUpScaling(v *AutoScalingThresholds) *SetLoadBasedAutoScalingInput {
+	s.UpScaling = v
+	return s
 }
 
 type SetLoadBasedAutoScalingOutput struct {
@@ -10053,6 +12705,36 @@ func (s *SetPermissionInput) Validate() error {
 	return nil
 }
 
+// SetAllowSsh sets the AllowSsh field's value.
+func (s *SetPermissionInput) SetAllowSsh(v bool) *SetPermissionInput {
+	s.AllowSsh = &v
+	return s
+}
+
+// SetAllowSudo sets the AllowSudo field's value.
+func (s *SetPermissionInput) SetAllowSudo(v bool) *SetPermissionInput {
+	s.AllowSudo = &v
+	return s
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *SetPermissionInput) SetIamUserArn(v string) *SetPermissionInput {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetLevel sets the Level field's value.
+func (s *SetPermissionInput) SetLevel(v string) *SetPermissionInput {
+	s.Level = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *SetPermissionInput) SetStackId(v string) *SetPermissionInput {
+	s.StackId = &v
+	return s
+}
+
 type SetPermissionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10102,6 +12784,18 @@ func (s *SetTimeBasedAutoScalingInput) Validate() error {
 	return nil
 }
 
+// SetAutoScalingSchedule sets the AutoScalingSchedule field's value.
+func (s *SetTimeBasedAutoScalingInput) SetAutoScalingSchedule(v *WeeklyAutoScalingSchedule) *SetTimeBasedAutoScalingInput {
+	s.AutoScalingSchedule = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *SetTimeBasedAutoScalingInput) SetInstanceId(v string) *SetTimeBasedAutoScalingInput {
+	s.InstanceId = &v
+	return s
+}
+
 type SetTimeBasedAutoScalingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10137,6 +12831,18 @@ func (s ShutdownEventConfiguration) String() string {
 // GoString returns the string representation
 func (s ShutdownEventConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetDelayUntilElbConnectionsDrained sets the DelayUntilElbConnectionsDrained field's value.
+func (s *ShutdownEventConfiguration) SetDelayUntilElbConnectionsDrained(v bool) *ShutdownEventConfiguration {
+	s.DelayUntilElbConnectionsDrained = &v
+	return s
+}
+
+// SetExecutionTimeout sets the ExecutionTimeout field's value.
+func (s *ShutdownEventConfiguration) SetExecutionTimeout(v int64) *ShutdownEventConfiguration {
+	s.ExecutionTimeout = &v
+	return s
 }
 
 // Contains the information required to retrieve an app or cookbook from a repository.
@@ -10197,6 +12903,42 @@ func (s Source) GoString() string {
 	return s.String()
 }
 
+// SetPassword sets the Password field's value.
+func (s *Source) SetPassword(v string) *Source {
+	s.Password = &v
+	return s
+}
+
+// SetRevision sets the Revision field's value.
+func (s *Source) SetRevision(v string) *Source {
+	s.Revision = &v
+	return s
+}
+
+// SetSshKey sets the SshKey field's value.
+func (s *Source) SetSshKey(v string) *Source {
+	s.SshKey = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Source) SetType(v string) *Source {
+	s.Type = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *Source) SetUrl(v string) *Source {
+	s.Url = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *Source) SetUsername(v string) *Source {
+	s.Username = &v
+	return s
+}
+
 // Describes an app's SSL configuration.
 type SslConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -10240,6 +12982,24 @@ func (s *SslConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCertificate sets the Certificate field's value.
+func (s *SslConfiguration) SetCertificate(v string) *SslConfiguration {
+	s.Certificate = &v
+	return s
+}
+
+// SetChain sets the Chain field's value.
+func (s *SslConfiguration) SetChain(v string) *SslConfiguration {
+	s.Chain = &v
+	return s
+}
+
+// SetPrivateKey sets the PrivateKey field's value.
+func (s *SslConfiguration) SetPrivateKey(v string) *SslConfiguration {
+	s.PrivateKey = &v
+	return s
 }
 
 // Describes a stack.
@@ -10343,6 +13103,138 @@ func (s Stack) GoString() string {
 	return s.String()
 }
 
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *Stack) SetAgentVersion(v string) *Stack {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *Stack) SetArn(v string) *Stack {
+	s.Arn = &v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *Stack) SetAttributes(v map[string]*string) *Stack {
+	s.Attributes = v
+	return s
+}
+
+// SetChefConfiguration sets the ChefConfiguration field's value.
+func (s *Stack) SetChefConfiguration(v *ChefConfiguration) *Stack {
+	s.ChefConfiguration = v
+	return s
+}
+
+// SetConfigurationManager sets the ConfigurationManager field's value.
+func (s *Stack) SetConfigurationManager(v *StackConfigurationManager) *Stack {
+	s.ConfigurationManager = v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Stack) SetCreatedAt(v string) *Stack {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetCustomCookbooksSource sets the CustomCookbooksSource field's value.
+func (s *Stack) SetCustomCookbooksSource(v *Source) *Stack {
+	s.CustomCookbooksSource = v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *Stack) SetCustomJson(v string) *Stack {
+	s.CustomJson = &v
+	return s
+}
+
+// SetDefaultAvailabilityZone sets the DefaultAvailabilityZone field's value.
+func (s *Stack) SetDefaultAvailabilityZone(v string) *Stack {
+	s.DefaultAvailabilityZone = &v
+	return s
+}
+
+// SetDefaultInstanceProfileArn sets the DefaultInstanceProfileArn field's value.
+func (s *Stack) SetDefaultInstanceProfileArn(v string) *Stack {
+	s.DefaultInstanceProfileArn = &v
+	return s
+}
+
+// SetDefaultOs sets the DefaultOs field's value.
+func (s *Stack) SetDefaultOs(v string) *Stack {
+	s.DefaultOs = &v
+	return s
+}
+
+// SetDefaultRootDeviceType sets the DefaultRootDeviceType field's value.
+func (s *Stack) SetDefaultRootDeviceType(v string) *Stack {
+	s.DefaultRootDeviceType = &v
+	return s
+}
+
+// SetDefaultSshKeyName sets the DefaultSshKeyName field's value.
+func (s *Stack) SetDefaultSshKeyName(v string) *Stack {
+	s.DefaultSshKeyName = &v
+	return s
+}
+
+// SetDefaultSubnetId sets the DefaultSubnetId field's value.
+func (s *Stack) SetDefaultSubnetId(v string) *Stack {
+	s.DefaultSubnetId = &v
+	return s
+}
+
+// SetHostnameTheme sets the HostnameTheme field's value.
+func (s *Stack) SetHostnameTheme(v string) *Stack {
+	s.HostnameTheme = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Stack) SetName(v string) *Stack {
+	s.Name = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *Stack) SetRegion(v string) *Stack {
+	s.Region = &v
+	return s
+}
+
+// SetServiceRoleArn sets the ServiceRoleArn field's value.
+func (s *Stack) SetServiceRoleArn(v string) *Stack {
+	s.ServiceRoleArn = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *Stack) SetStackId(v string) *Stack {
+	s.StackId = &v
+	return s
+}
+
+// SetUseCustomCookbooks sets the UseCustomCookbooks field's value.
+func (s *Stack) SetUseCustomCookbooks(v bool) *Stack {
+	s.UseCustomCookbooks = &v
+	return s
+}
+
+// SetUseOpsworksSecurityGroups sets the UseOpsworksSecurityGroups field's value.
+func (s *Stack) SetUseOpsworksSecurityGroups(v bool) *Stack {
+	s.UseOpsworksSecurityGroups = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *Stack) SetVpcId(v string) *Stack {
+	s.VpcId = &v
+	return s
+}
+
 // Describes the configuration manager.
 type StackConfigurationManager struct {
 	_ struct{} `type:"structure"`
@@ -10364,6 +13256,18 @@ func (s StackConfigurationManager) String() string {
 // GoString returns the string representation
 func (s StackConfigurationManager) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *StackConfigurationManager) SetName(v string) *StackConfigurationManager {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *StackConfigurationManager) SetVersion(v string) *StackConfigurationManager {
+	s.Version = &v
+	return s
 }
 
 // Summarizes the number of layers, instances, and apps in a stack.
@@ -10399,6 +13303,42 @@ func (s StackSummary) GoString() string {
 	return s.String()
 }
 
+// SetAppsCount sets the AppsCount field's value.
+func (s *StackSummary) SetAppsCount(v int64) *StackSummary {
+	s.AppsCount = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *StackSummary) SetArn(v string) *StackSummary {
+	s.Arn = &v
+	return s
+}
+
+// SetInstancesCount sets the InstancesCount field's value.
+func (s *StackSummary) SetInstancesCount(v *InstancesCount) *StackSummary {
+	s.InstancesCount = v
+	return s
+}
+
+// SetLayersCount sets the LayersCount field's value.
+func (s *StackSummary) SetLayersCount(v int64) *StackSummary {
+	s.LayersCount = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *StackSummary) SetName(v string) *StackSummary {
+	s.Name = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *StackSummary) SetStackId(v string) *StackSummary {
+	s.StackId = &v
+	return s
+}
+
 type StartInstanceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -10429,6 +13369,12 @@ func (s *StartInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *StartInstanceInput) SetInstanceId(v string) *StartInstanceInput {
+	s.InstanceId = &v
+	return s
 }
 
 type StartInstanceOutput struct {
@@ -10477,6 +13423,12 @@ func (s *StartStackInput) Validate() error {
 	return nil
 }
 
+// SetStackId sets the StackId field's value.
+func (s *StartStackInput) SetStackId(v string) *StartStackInput {
+	s.StackId = &v
+	return s
+}
+
 type StartStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10521,6 +13473,12 @@ func (s *StopInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *StopInstanceInput) SetInstanceId(v string) *StopInstanceInput {
+	s.InstanceId = &v
+	return s
 }
 
 type StopInstanceOutput struct {
@@ -10569,6 +13527,12 @@ func (s *StopStackInput) Validate() error {
 	return nil
 }
 
+// SetStackId sets the StackId field's value.
+func (s *StopStackInput) SetStackId(v string) *StopStackInput {
+	s.StackId = &v
+	return s
+}
+
 type StopStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10614,6 +13578,30 @@ func (s TemporaryCredential) GoString() string {
 	return s.String()
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *TemporaryCredential) SetInstanceId(v string) *TemporaryCredential {
+	s.InstanceId = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *TemporaryCredential) SetPassword(v string) *TemporaryCredential {
+	s.Password = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *TemporaryCredential) SetUsername(v string) *TemporaryCredential {
+	s.Username = &v
+	return s
+}
+
+// SetValidForInMinutes sets the ValidForInMinutes field's value.
+func (s *TemporaryCredential) SetValidForInMinutes(v int64) *TemporaryCredential {
+	s.ValidForInMinutes = &v
+	return s
+}
+
 // Describes an instance's time-based auto scaling configuration.
 type TimeBasedAutoScalingConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -10633,6 +13621,18 @@ func (s TimeBasedAutoScalingConfiguration) String() string {
 // GoString returns the string representation
 func (s TimeBasedAutoScalingConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetAutoScalingSchedule sets the AutoScalingSchedule field's value.
+func (s *TimeBasedAutoScalingConfiguration) SetAutoScalingSchedule(v *WeeklyAutoScalingSchedule) *TimeBasedAutoScalingConfiguration {
+	s.AutoScalingSchedule = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *TimeBasedAutoScalingConfiguration) SetInstanceId(v string) *TimeBasedAutoScalingConfiguration {
+	s.InstanceId = &v
+	return s
 }
 
 type UnassignInstanceInput struct {
@@ -10665,6 +13665,12 @@ func (s *UnassignInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *UnassignInstanceInput) SetInstanceId(v string) *UnassignInstanceInput {
+	s.InstanceId = &v
+	return s
 }
 
 type UnassignInstanceOutput struct {
@@ -10711,6 +13717,12 @@ func (s *UnassignVolumeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *UnassignVolumeInput) SetVolumeId(v string) *UnassignVolumeInput {
+	s.VolumeId = &v
+	return s
 }
 
 type UnassignVolumeOutput struct {
@@ -10818,6 +13830,72 @@ func (s *UpdateAppInput) Validate() error {
 	return nil
 }
 
+// SetAppId sets the AppId field's value.
+func (s *UpdateAppInput) SetAppId(v string) *UpdateAppInput {
+	s.AppId = &v
+	return s
+}
+
+// SetAppSource sets the AppSource field's value.
+func (s *UpdateAppInput) SetAppSource(v *Source) *UpdateAppInput {
+	s.AppSource = v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *UpdateAppInput) SetAttributes(v map[string]*string) *UpdateAppInput {
+	s.Attributes = v
+	return s
+}
+
+// SetDataSources sets the DataSources field's value.
+func (s *UpdateAppInput) SetDataSources(v []*DataSource) *UpdateAppInput {
+	s.DataSources = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateAppInput) SetDescription(v string) *UpdateAppInput {
+	s.Description = &v
+	return s
+}
+
+// SetDomains sets the Domains field's value.
+func (s *UpdateAppInput) SetDomains(v []*string) *UpdateAppInput {
+	s.Domains = v
+	return s
+}
+
+// SetEnableSsl sets the EnableSsl field's value.
+func (s *UpdateAppInput) SetEnableSsl(v bool) *UpdateAppInput {
+	s.EnableSsl = &v
+	return s
+}
+
+// SetEnvironment sets the Environment field's value.
+func (s *UpdateAppInput) SetEnvironment(v []*EnvironmentVariable) *UpdateAppInput {
+	s.Environment = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateAppInput) SetName(v string) *UpdateAppInput {
+	s.Name = &v
+	return s
+}
+
+// SetSslConfiguration sets the SslConfiguration field's value.
+func (s *UpdateAppInput) SetSslConfiguration(v *SslConfiguration) *UpdateAppInput {
+	s.SslConfiguration = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *UpdateAppInput) SetType(v string) *UpdateAppInput {
+	s.Type = &v
+	return s
+}
+
 type UpdateAppOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10865,6 +13943,18 @@ func (s *UpdateElasticIpInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *UpdateElasticIpInput) SetElasticIp(v string) *UpdateElasticIpInput {
+	s.ElasticIp = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateElasticIpInput) SetName(v string) *UpdateElasticIpInput {
+	s.Name = &v
+	return s
 }
 
 type UpdateElasticIpOutput struct {
@@ -11004,6 +14094,78 @@ func (s *UpdateInstanceInput) Validate() error {
 	return nil
 }
 
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *UpdateInstanceInput) SetAgentVersion(v string) *UpdateInstanceInput {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetAmiId sets the AmiId field's value.
+func (s *UpdateInstanceInput) SetAmiId(v string) *UpdateInstanceInput {
+	s.AmiId = &v
+	return s
+}
+
+// SetArchitecture sets the Architecture field's value.
+func (s *UpdateInstanceInput) SetArchitecture(v string) *UpdateInstanceInput {
+	s.Architecture = &v
+	return s
+}
+
+// SetAutoScalingType sets the AutoScalingType field's value.
+func (s *UpdateInstanceInput) SetAutoScalingType(v string) *UpdateInstanceInput {
+	s.AutoScalingType = &v
+	return s
+}
+
+// SetEbsOptimized sets the EbsOptimized field's value.
+func (s *UpdateInstanceInput) SetEbsOptimized(v bool) *UpdateInstanceInput {
+	s.EbsOptimized = &v
+	return s
+}
+
+// SetHostname sets the Hostname field's value.
+func (s *UpdateInstanceInput) SetHostname(v string) *UpdateInstanceInput {
+	s.Hostname = &v
+	return s
+}
+
+// SetInstallUpdatesOnBoot sets the InstallUpdatesOnBoot field's value.
+func (s *UpdateInstanceInput) SetInstallUpdatesOnBoot(v bool) *UpdateInstanceInput {
+	s.InstallUpdatesOnBoot = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *UpdateInstanceInput) SetInstanceId(v string) *UpdateInstanceInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *UpdateInstanceInput) SetInstanceType(v string) *UpdateInstanceInput {
+	s.InstanceType = &v
+	return s
+}
+
+// SetLayerIds sets the LayerIds field's value.
+func (s *UpdateInstanceInput) SetLayerIds(v []*string) *UpdateInstanceInput {
+	s.LayerIds = v
+	return s
+}
+
+// SetOs sets the Os field's value.
+func (s *UpdateInstanceInput) SetOs(v string) *UpdateInstanceInput {
+	s.Os = &v
+	return s
+}
+
+// SetSshKeyName sets the SshKeyName field's value.
+func (s *UpdateInstanceInput) SetSshKeyName(v string) *UpdateInstanceInput {
+	s.SshKeyName = &v
+	return s
+}
+
 type UpdateInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11124,6 +14286,102 @@ func (s *UpdateLayerInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *UpdateLayerInput) SetAttributes(v map[string]*string) *UpdateLayerInput {
+	s.Attributes = v
+	return s
+}
+
+// SetAutoAssignElasticIps sets the AutoAssignElasticIps field's value.
+func (s *UpdateLayerInput) SetAutoAssignElasticIps(v bool) *UpdateLayerInput {
+	s.AutoAssignElasticIps = &v
+	return s
+}
+
+// SetAutoAssignPublicIps sets the AutoAssignPublicIps field's value.
+func (s *UpdateLayerInput) SetAutoAssignPublicIps(v bool) *UpdateLayerInput {
+	s.AutoAssignPublicIps = &v
+	return s
+}
+
+// SetCustomInstanceProfileArn sets the CustomInstanceProfileArn field's value.
+func (s *UpdateLayerInput) SetCustomInstanceProfileArn(v string) *UpdateLayerInput {
+	s.CustomInstanceProfileArn = &v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *UpdateLayerInput) SetCustomJson(v string) *UpdateLayerInput {
+	s.CustomJson = &v
+	return s
+}
+
+// SetCustomRecipes sets the CustomRecipes field's value.
+func (s *UpdateLayerInput) SetCustomRecipes(v *Recipes) *UpdateLayerInput {
+	s.CustomRecipes = v
+	return s
+}
+
+// SetCustomSecurityGroupIds sets the CustomSecurityGroupIds field's value.
+func (s *UpdateLayerInput) SetCustomSecurityGroupIds(v []*string) *UpdateLayerInput {
+	s.CustomSecurityGroupIds = v
+	return s
+}
+
+// SetEnableAutoHealing sets the EnableAutoHealing field's value.
+func (s *UpdateLayerInput) SetEnableAutoHealing(v bool) *UpdateLayerInput {
+	s.EnableAutoHealing = &v
+	return s
+}
+
+// SetInstallUpdatesOnBoot sets the InstallUpdatesOnBoot field's value.
+func (s *UpdateLayerInput) SetInstallUpdatesOnBoot(v bool) *UpdateLayerInput {
+	s.InstallUpdatesOnBoot = &v
+	return s
+}
+
+// SetLayerId sets the LayerId field's value.
+func (s *UpdateLayerInput) SetLayerId(v string) *UpdateLayerInput {
+	s.LayerId = &v
+	return s
+}
+
+// SetLifecycleEventConfiguration sets the LifecycleEventConfiguration field's value.
+func (s *UpdateLayerInput) SetLifecycleEventConfiguration(v *LifecycleEventConfiguration) *UpdateLayerInput {
+	s.LifecycleEventConfiguration = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateLayerInput) SetName(v string) *UpdateLayerInput {
+	s.Name = &v
+	return s
+}
+
+// SetPackages sets the Packages field's value.
+func (s *UpdateLayerInput) SetPackages(v []*string) *UpdateLayerInput {
+	s.Packages = v
+	return s
+}
+
+// SetShortname sets the Shortname field's value.
+func (s *UpdateLayerInput) SetShortname(v string) *UpdateLayerInput {
+	s.Shortname = &v
+	return s
+}
+
+// SetUseEbsOptimizedInstances sets the UseEbsOptimizedInstances field's value.
+func (s *UpdateLayerInput) SetUseEbsOptimizedInstances(v bool) *UpdateLayerInput {
+	s.UseEbsOptimizedInstances = &v
+	return s
+}
+
+// SetVolumeConfigurations sets the VolumeConfigurations field's value.
+func (s *UpdateLayerInput) SetVolumeConfigurations(v []*VolumeConfiguration) *UpdateLayerInput {
+	s.VolumeConfigurations = v
+	return s
+}
+
 type UpdateLayerOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11153,6 +14411,12 @@ func (s UpdateMyUserProfileInput) String() string {
 // GoString returns the string representation
 func (s UpdateMyUserProfileInput) GoString() string {
 	return s.String()
+}
+
+// SetSshPublicKey sets the SshPublicKey field's value.
+func (s *UpdateMyUserProfileInput) SetSshPublicKey(v string) *UpdateMyUserProfileInput {
+	s.SshPublicKey = &v
+	return s
 }
 
 type UpdateMyUserProfileOutput struct {
@@ -11205,6 +14469,24 @@ func (s *UpdateRdsDbInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDbPassword sets the DbPassword field's value.
+func (s *UpdateRdsDbInstanceInput) SetDbPassword(v string) *UpdateRdsDbInstanceInput {
+	s.DbPassword = &v
+	return s
+}
+
+// SetDbUser sets the DbUser field's value.
+func (s *UpdateRdsDbInstanceInput) SetDbUser(v string) *UpdateRdsDbInstanceInput {
+	s.DbUser = &v
+	return s
+}
+
+// SetRdsDbInstanceArn sets the RdsDbInstanceArn field's value.
+func (s *UpdateRdsDbInstanceInput) SetRdsDbInstanceArn(v string) *UpdateRdsDbInstanceInput {
+	s.RdsDbInstanceArn = &v
+	return s
 }
 
 type UpdateRdsDbInstanceOutput struct {
@@ -11421,6 +14703,114 @@ func (s *UpdateStackInput) Validate() error {
 	return nil
 }
 
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *UpdateStackInput) SetAgentVersion(v string) *UpdateStackInput {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *UpdateStackInput) SetAttributes(v map[string]*string) *UpdateStackInput {
+	s.Attributes = v
+	return s
+}
+
+// SetChefConfiguration sets the ChefConfiguration field's value.
+func (s *UpdateStackInput) SetChefConfiguration(v *ChefConfiguration) *UpdateStackInput {
+	s.ChefConfiguration = v
+	return s
+}
+
+// SetConfigurationManager sets the ConfigurationManager field's value.
+func (s *UpdateStackInput) SetConfigurationManager(v *StackConfigurationManager) *UpdateStackInput {
+	s.ConfigurationManager = v
+	return s
+}
+
+// SetCustomCookbooksSource sets the CustomCookbooksSource field's value.
+func (s *UpdateStackInput) SetCustomCookbooksSource(v *Source) *UpdateStackInput {
+	s.CustomCookbooksSource = v
+	return s
+}
+
+// SetCustomJson sets the CustomJson field's value.
+func (s *UpdateStackInput) SetCustomJson(v string) *UpdateStackInput {
+	s.CustomJson = &v
+	return s
+}
+
+// SetDefaultAvailabilityZone sets the DefaultAvailabilityZone field's value.
+func (s *UpdateStackInput) SetDefaultAvailabilityZone(v string) *UpdateStackInput {
+	s.DefaultAvailabilityZone = &v
+	return s
+}
+
+// SetDefaultInstanceProfileArn sets the DefaultInstanceProfileArn field's value.
+func (s *UpdateStackInput) SetDefaultInstanceProfileArn(v string) *UpdateStackInput {
+	s.DefaultInstanceProfileArn = &v
+	return s
+}
+
+// SetDefaultOs sets the DefaultOs field's value.
+func (s *UpdateStackInput) SetDefaultOs(v string) *UpdateStackInput {
+	s.DefaultOs = &v
+	return s
+}
+
+// SetDefaultRootDeviceType sets the DefaultRootDeviceType field's value.
+func (s *UpdateStackInput) SetDefaultRootDeviceType(v string) *UpdateStackInput {
+	s.DefaultRootDeviceType = &v
+	return s
+}
+
+// SetDefaultSshKeyName sets the DefaultSshKeyName field's value.
+func (s *UpdateStackInput) SetDefaultSshKeyName(v string) *UpdateStackInput {
+	s.DefaultSshKeyName = &v
+	return s
+}
+
+// SetDefaultSubnetId sets the DefaultSubnetId field's value.
+func (s *UpdateStackInput) SetDefaultSubnetId(v string) *UpdateStackInput {
+	s.DefaultSubnetId = &v
+	return s
+}
+
+// SetHostnameTheme sets the HostnameTheme field's value.
+func (s *UpdateStackInput) SetHostnameTheme(v string) *UpdateStackInput {
+	s.HostnameTheme = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateStackInput) SetName(v string) *UpdateStackInput {
+	s.Name = &v
+	return s
+}
+
+// SetServiceRoleArn sets the ServiceRoleArn field's value.
+func (s *UpdateStackInput) SetServiceRoleArn(v string) *UpdateStackInput {
+	s.ServiceRoleArn = &v
+	return s
+}
+
+// SetStackId sets the StackId field's value.
+func (s *UpdateStackInput) SetStackId(v string) *UpdateStackInput {
+	s.StackId = &v
+	return s
+}
+
+// SetUseCustomCookbooks sets the UseCustomCookbooks field's value.
+func (s *UpdateStackInput) SetUseCustomCookbooks(v bool) *UpdateStackInput {
+	s.UseCustomCookbooks = &v
+	return s
+}
+
+// SetUseOpsworksSecurityGroups sets the UseOpsworksSecurityGroups field's value.
+func (s *UpdateStackInput) SetUseOpsworksSecurityGroups(v bool) *UpdateStackInput {
+	s.UseOpsworksSecurityGroups = &v
+	return s
+}
+
 type UpdateStackOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11481,6 +14871,30 @@ func (s *UpdateUserProfileInput) Validate() error {
 	return nil
 }
 
+// SetAllowSelfManagement sets the AllowSelfManagement field's value.
+func (s *UpdateUserProfileInput) SetAllowSelfManagement(v bool) *UpdateUserProfileInput {
+	s.AllowSelfManagement = &v
+	return s
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *UpdateUserProfileInput) SetIamUserArn(v string) *UpdateUserProfileInput {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetSshPublicKey sets the SshPublicKey field's value.
+func (s *UpdateUserProfileInput) SetSshPublicKey(v string) *UpdateUserProfileInput {
+	s.SshPublicKey = &v
+	return s
+}
+
+// SetSshUsername sets the SshUsername field's value.
+func (s *UpdateUserProfileInput) SetSshUsername(v string) *UpdateUserProfileInput {
+	s.SshUsername = &v
+	return s
+}
+
 type UpdateUserProfileOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11533,6 +14947,24 @@ func (s *UpdateVolumeInput) Validate() error {
 	return nil
 }
 
+// SetMountPoint sets the MountPoint field's value.
+func (s *UpdateVolumeInput) SetMountPoint(v string) *UpdateVolumeInput {
+	s.MountPoint = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateVolumeInput) SetName(v string) *UpdateVolumeInput {
+	s.Name = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *UpdateVolumeInput) SetVolumeId(v string) *UpdateVolumeInput {
+	s.VolumeId = &v
+	return s
+}
+
 type UpdateVolumeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11576,6 +15008,36 @@ func (s UserProfile) String() string {
 // GoString returns the string representation
 func (s UserProfile) GoString() string {
 	return s.String()
+}
+
+// SetAllowSelfManagement sets the AllowSelfManagement field's value.
+func (s *UserProfile) SetAllowSelfManagement(v bool) *UserProfile {
+	s.AllowSelfManagement = &v
+	return s
+}
+
+// SetIamUserArn sets the IamUserArn field's value.
+func (s *UserProfile) SetIamUserArn(v string) *UserProfile {
+	s.IamUserArn = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UserProfile) SetName(v string) *UserProfile {
+	s.Name = &v
+	return s
+}
+
+// SetSshPublicKey sets the SshPublicKey field's value.
+func (s *UserProfile) SetSshPublicKey(v string) *UserProfile {
+	s.SshPublicKey = &v
+	return s
+}
+
+// SetSshUsername sets the SshUsername field's value.
+func (s *UserProfile) SetSshUsername(v string) *UserProfile {
+	s.SshUsername = &v
+	return s
 }
 
 // Describes an instance's Amazon EBS volume.
@@ -11632,6 +15094,84 @@ func (s Volume) String() string {
 // GoString returns the string representation
 func (s Volume) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Volume) SetAvailabilityZone(v string) *Volume {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDevice sets the Device field's value.
+func (s *Volume) SetDevice(v string) *Volume {
+	s.Device = &v
+	return s
+}
+
+// SetEc2VolumeId sets the Ec2VolumeId field's value.
+func (s *Volume) SetEc2VolumeId(v string) *Volume {
+	s.Ec2VolumeId = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *Volume) SetInstanceId(v string) *Volume {
+	s.InstanceId = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *Volume) SetIops(v int64) *Volume {
+	s.Iops = &v
+	return s
+}
+
+// SetMountPoint sets the MountPoint field's value.
+func (s *Volume) SetMountPoint(v string) *Volume {
+	s.MountPoint = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Volume) SetName(v string) *Volume {
+	s.Name = &v
+	return s
+}
+
+// SetRaidArrayId sets the RaidArrayId field's value.
+func (s *Volume) SetRaidArrayId(v string) *Volume {
+	s.RaidArrayId = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *Volume) SetRegion(v string) *Volume {
+	s.Region = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *Volume) SetSize(v int64) *Volume {
+	s.Size = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Volume) SetStatus(v string) *Volume {
+	s.Status = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *Volume) SetVolumeId(v string) *Volume {
+	s.VolumeId = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *Volume) SetVolumeType(v string) *Volume {
+	s.VolumeType = &v
+	return s
 }
 
 // Describes an Amazon EBS volume configuration.
@@ -11698,6 +15238,42 @@ func (s *VolumeConfiguration) Validate() error {
 	return nil
 }
 
+// SetIops sets the Iops field's value.
+func (s *VolumeConfiguration) SetIops(v int64) *VolumeConfiguration {
+	s.Iops = &v
+	return s
+}
+
+// SetMountPoint sets the MountPoint field's value.
+func (s *VolumeConfiguration) SetMountPoint(v string) *VolumeConfiguration {
+	s.MountPoint = &v
+	return s
+}
+
+// SetNumberOfDisks sets the NumberOfDisks field's value.
+func (s *VolumeConfiguration) SetNumberOfDisks(v int64) *VolumeConfiguration {
+	s.NumberOfDisks = &v
+	return s
+}
+
+// SetRaidLevel sets the RaidLevel field's value.
+func (s *VolumeConfiguration) SetRaidLevel(v int64) *VolumeConfiguration {
+	s.RaidLevel = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *VolumeConfiguration) SetSize(v int64) *VolumeConfiguration {
+	s.Size = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *VolumeConfiguration) SetVolumeType(v string) *VolumeConfiguration {
+	s.VolumeType = &v
+	return s
+}
+
 // Describes a time-based instance's auto scaling schedule. The schedule consists
 // of a set of key-value pairs.
 //
@@ -11749,6 +15325,48 @@ func (s WeeklyAutoScalingSchedule) String() string {
 // GoString returns the string representation
 func (s WeeklyAutoScalingSchedule) GoString() string {
 	return s.String()
+}
+
+// SetFriday sets the Friday field's value.
+func (s *WeeklyAutoScalingSchedule) SetFriday(v map[string]*string) *WeeklyAutoScalingSchedule {
+	s.Friday = v
+	return s
+}
+
+// SetMonday sets the Monday field's value.
+func (s *WeeklyAutoScalingSchedule) SetMonday(v map[string]*string) *WeeklyAutoScalingSchedule {
+	s.Monday = v
+	return s
+}
+
+// SetSaturday sets the Saturday field's value.
+func (s *WeeklyAutoScalingSchedule) SetSaturday(v map[string]*string) *WeeklyAutoScalingSchedule {
+	s.Saturday = v
+	return s
+}
+
+// SetSunday sets the Sunday field's value.
+func (s *WeeklyAutoScalingSchedule) SetSunday(v map[string]*string) *WeeklyAutoScalingSchedule {
+	s.Sunday = v
+	return s
+}
+
+// SetThursday sets the Thursday field's value.
+func (s *WeeklyAutoScalingSchedule) SetThursday(v map[string]*string) *WeeklyAutoScalingSchedule {
+	s.Thursday = v
+	return s
+}
+
+// SetTuesday sets the Tuesday field's value.
+func (s *WeeklyAutoScalingSchedule) SetTuesday(v map[string]*string) *WeeklyAutoScalingSchedule {
+	s.Tuesday = v
+	return s
+}
+
+// SetWednesday sets the Wednesday field's value.
+func (s *WeeklyAutoScalingSchedule) SetWednesday(v map[string]*string) *WeeklyAutoScalingSchedule {
+	s.Wednesday = v
+	return s
 }
 
 const (

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -7290,6 +7290,24 @@ func (s AccountQuota) GoString() string {
 	return s.String()
 }
 
+// SetAccountQuotaName sets the AccountQuotaName field's value.
+func (s *AccountQuota) SetAccountQuotaName(v string) *AccountQuota {
+	s.AccountQuotaName = &v
+	return s
+}
+
+// SetMax sets the Max field's value.
+func (s *AccountQuota) SetMax(v int64) *AccountQuota {
+	s.Max = &v
+	return s
+}
+
+// SetUsed sets the Used field's value.
+func (s *AccountQuota) SetUsed(v int64) *AccountQuota {
+	s.Used = &v
+	return s
+}
+
 type AddRoleToDBClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7329,6 +7347,18 @@ func (s *AddRoleToDBClusterInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *AddRoleToDBClusterInput) SetDBClusterIdentifier(v string) *AddRoleToDBClusterInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *AddRoleToDBClusterInput) SetRoleArn(v string) *AddRoleToDBClusterInput {
+	s.RoleArn = &v
+	return s
 }
 
 type AddRoleToDBClusterOutput struct {
@@ -7402,6 +7432,18 @@ func (s *AddSourceIdentifierToSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *AddSourceIdentifierToSubscriptionInput) SetSourceIdentifier(v string) *AddSourceIdentifierToSubscriptionInput {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *AddSourceIdentifierToSubscriptionInput) SetSubscriptionName(v string) *AddSourceIdentifierToSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
 type AddSourceIdentifierToSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7418,6 +7460,12 @@ func (s AddSourceIdentifierToSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s AddSourceIdentifierToSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *AddSourceIdentifierToSubscriptionOutput) SetEventSubscription(v *EventSubscription) *AddSourceIdentifierToSubscriptionOutput {
+	s.EventSubscription = v
+	return s
 }
 
 type AddTagsToResourceInput struct {
@@ -7460,6 +7508,18 @@ func (s *AddTagsToResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *AddTagsToResourceInput) SetResourceName(v string) *AddTagsToResourceInput {
+	s.ResourceName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToResourceInput) SetTags(v []*Tag) *AddTagsToResourceInput {
+	s.Tags = v
+	return s
 }
 
 type AddTagsToResourceOutput struct {
@@ -7538,6 +7598,24 @@ func (s *ApplyPendingMaintenanceActionInput) Validate() error {
 	return nil
 }
 
+// SetApplyAction sets the ApplyAction field's value.
+func (s *ApplyPendingMaintenanceActionInput) SetApplyAction(v string) *ApplyPendingMaintenanceActionInput {
+	s.ApplyAction = &v
+	return s
+}
+
+// SetOptInType sets the OptInType field's value.
+func (s *ApplyPendingMaintenanceActionInput) SetOptInType(v string) *ApplyPendingMaintenanceActionInput {
+	s.OptInType = &v
+	return s
+}
+
+// SetResourceIdentifier sets the ResourceIdentifier field's value.
+func (s *ApplyPendingMaintenanceActionInput) SetResourceIdentifier(v string) *ApplyPendingMaintenanceActionInput {
+	s.ResourceIdentifier = &v
+	return s
+}
+
 type ApplyPendingMaintenanceActionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7553,6 +7631,12 @@ func (s ApplyPendingMaintenanceActionOutput) String() string {
 // GoString returns the string representation
 func (s ApplyPendingMaintenanceActionOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourcePendingMaintenanceActions sets the ResourcePendingMaintenanceActions field's value.
+func (s *ApplyPendingMaintenanceActionOutput) SetResourcePendingMaintenanceActions(v *ResourcePendingMaintenanceActions) *ApplyPendingMaintenanceActionOutput {
+	s.ResourcePendingMaintenanceActions = v
+	return s
 }
 
 type AuthorizeDBSecurityGroupIngressInput struct {
@@ -7607,6 +7691,36 @@ func (s *AuthorizeDBSecurityGroupIngressInput) Validate() error {
 	return nil
 }
 
+// SetCIDRIP sets the CIDRIP field's value.
+func (s *AuthorizeDBSecurityGroupIngressInput) SetCIDRIP(v string) *AuthorizeDBSecurityGroupIngressInput {
+	s.CIDRIP = &v
+	return s
+}
+
+// SetDBSecurityGroupName sets the DBSecurityGroupName field's value.
+func (s *AuthorizeDBSecurityGroupIngressInput) SetDBSecurityGroupName(v string) *AuthorizeDBSecurityGroupIngressInput {
+	s.DBSecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupId sets the EC2SecurityGroupId field's value.
+func (s *AuthorizeDBSecurityGroupIngressInput) SetEC2SecurityGroupId(v string) *AuthorizeDBSecurityGroupIngressInput {
+	s.EC2SecurityGroupId = &v
+	return s
+}
+
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *AuthorizeDBSecurityGroupIngressInput) SetEC2SecurityGroupName(v string) *AuthorizeDBSecurityGroupIngressInput {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *AuthorizeDBSecurityGroupIngressInput) SetEC2SecurityGroupOwnerId(v string) *AuthorizeDBSecurityGroupIngressInput {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
 type AuthorizeDBSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7635,6 +7749,12 @@ func (s AuthorizeDBSecurityGroupIngressOutput) GoString() string {
 	return s.String()
 }
 
+// SetDBSecurityGroup sets the DBSecurityGroup field's value.
+func (s *AuthorizeDBSecurityGroupIngressOutput) SetDBSecurityGroup(v *DBSecurityGroup) *AuthorizeDBSecurityGroupIngressOutput {
+	s.DBSecurityGroup = v
+	return s
+}
+
 // Contains Availability Zone information.
 //
 // This data type is used as an element in the following data type:
@@ -7655,6 +7775,12 @@ func (s AvailabilityZone) String() string {
 // GoString returns the string representation
 func (s AvailabilityZone) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *AvailabilityZone) SetName(v string) *AvailabilityZone {
+	s.Name = &v
+	return s
 }
 
 // A CA certificate for an AWS account.
@@ -7690,6 +7816,42 @@ func (s Certificate) GoString() string {
 	return s.String()
 }
 
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *Certificate) SetCertificateArn(v string) *Certificate {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetCertificateIdentifier sets the CertificateIdentifier field's value.
+func (s *Certificate) SetCertificateIdentifier(v string) *Certificate {
+	s.CertificateIdentifier = &v
+	return s
+}
+
+// SetCertificateType sets the CertificateType field's value.
+func (s *Certificate) SetCertificateType(v string) *Certificate {
+	s.CertificateType = &v
+	return s
+}
+
+// SetThumbprint sets the Thumbprint field's value.
+func (s *Certificate) SetThumbprint(v string) *Certificate {
+	s.Thumbprint = &v
+	return s
+}
+
+// SetValidFrom sets the ValidFrom field's value.
+func (s *Certificate) SetValidFrom(v time.Time) *Certificate {
+	s.ValidFrom = &v
+	return s
+}
+
+// SetValidTill sets the ValidTill field's value.
+func (s *Certificate) SetValidTill(v time.Time) *Certificate {
+	s.ValidTill = &v
+	return s
+}
+
 // This data type is used as a response element in the action DescribeDBEngineVersions.
 type CharacterSet struct {
 	_ struct{} `type:"structure"`
@@ -7709,6 +7871,18 @@ func (s CharacterSet) String() string {
 // GoString returns the string representation
 func (s CharacterSet) GoString() string {
 	return s.String()
+}
+
+// SetCharacterSetDescription sets the CharacterSetDescription field's value.
+func (s *CharacterSet) SetCharacterSetDescription(v string) *CharacterSet {
+	s.CharacterSetDescription = &v
+	return s
+}
+
+// SetCharacterSetName sets the CharacterSetName field's value.
+func (s *CharacterSet) SetCharacterSetName(v string) *CharacterSet {
+	s.CharacterSetName = &v
+	return s
 }
 
 type CopyDBClusterParameterGroupInput struct {
@@ -7787,6 +7961,30 @@ func (s *CopyDBClusterParameterGroupInput) Validate() error {
 	return nil
 }
 
+// SetSourceDBClusterParameterGroupIdentifier sets the SourceDBClusterParameterGroupIdentifier field's value.
+func (s *CopyDBClusterParameterGroupInput) SetSourceDBClusterParameterGroupIdentifier(v string) *CopyDBClusterParameterGroupInput {
+	s.SourceDBClusterParameterGroupIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CopyDBClusterParameterGroupInput) SetTags(v []*Tag) *CopyDBClusterParameterGroupInput {
+	s.Tags = v
+	return s
+}
+
+// SetTargetDBClusterParameterGroupDescription sets the TargetDBClusterParameterGroupDescription field's value.
+func (s *CopyDBClusterParameterGroupInput) SetTargetDBClusterParameterGroupDescription(v string) *CopyDBClusterParameterGroupInput {
+	s.TargetDBClusterParameterGroupDescription = &v
+	return s
+}
+
+// SetTargetDBClusterParameterGroupIdentifier sets the TargetDBClusterParameterGroupIdentifier field's value.
+func (s *CopyDBClusterParameterGroupInput) SetTargetDBClusterParameterGroupIdentifier(v string) *CopyDBClusterParameterGroupInput {
+	s.TargetDBClusterParameterGroupIdentifier = &v
+	return s
+}
+
 type CopyDBClusterParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7807,6 +8005,12 @@ func (s CopyDBClusterParameterGroupOutput) String() string {
 // GoString returns the string representation
 func (s CopyDBClusterParameterGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterParameterGroup sets the DBClusterParameterGroup field's value.
+func (s *CopyDBClusterParameterGroupOutput) SetDBClusterParameterGroup(v *DBClusterParameterGroup) *CopyDBClusterParameterGroupOutput {
+	s.DBClusterParameterGroup = v
+	return s
 }
 
 type CopyDBClusterSnapshotInput struct {
@@ -7874,6 +8078,24 @@ func (s *CopyDBClusterSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetSourceDBClusterSnapshotIdentifier sets the SourceDBClusterSnapshotIdentifier field's value.
+func (s *CopyDBClusterSnapshotInput) SetSourceDBClusterSnapshotIdentifier(v string) *CopyDBClusterSnapshotInput {
+	s.SourceDBClusterSnapshotIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CopyDBClusterSnapshotInput) SetTags(v []*Tag) *CopyDBClusterSnapshotInput {
+	s.Tags = v
+	return s
+}
+
+// SetTargetDBClusterSnapshotIdentifier sets the TargetDBClusterSnapshotIdentifier field's value.
+func (s *CopyDBClusterSnapshotInput) SetTargetDBClusterSnapshotIdentifier(v string) *CopyDBClusterSnapshotInput {
+	s.TargetDBClusterSnapshotIdentifier = &v
+	return s
+}
+
 type CopyDBClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7896,6 +8118,12 @@ func (s CopyDBClusterSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CopyDBClusterSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterSnapshot sets the DBClusterSnapshot field's value.
+func (s *CopyDBClusterSnapshotOutput) SetDBClusterSnapshot(v *DBClusterSnapshot) *CopyDBClusterSnapshotOutput {
+	s.DBClusterSnapshot = v
+	return s
 }
 
 type CopyDBParameterGroupInput struct {
@@ -7970,6 +8198,30 @@ func (s *CopyDBParameterGroupInput) Validate() error {
 	return nil
 }
 
+// SetSourceDBParameterGroupIdentifier sets the SourceDBParameterGroupIdentifier field's value.
+func (s *CopyDBParameterGroupInput) SetSourceDBParameterGroupIdentifier(v string) *CopyDBParameterGroupInput {
+	s.SourceDBParameterGroupIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CopyDBParameterGroupInput) SetTags(v []*Tag) *CopyDBParameterGroupInput {
+	s.Tags = v
+	return s
+}
+
+// SetTargetDBParameterGroupDescription sets the TargetDBParameterGroupDescription field's value.
+func (s *CopyDBParameterGroupInput) SetTargetDBParameterGroupDescription(v string) *CopyDBParameterGroupInput {
+	s.TargetDBParameterGroupDescription = &v
+	return s
+}
+
+// SetTargetDBParameterGroupIdentifier sets the TargetDBParameterGroupIdentifier field's value.
+func (s *CopyDBParameterGroupInput) SetTargetDBParameterGroupIdentifier(v string) *CopyDBParameterGroupInput {
+	s.TargetDBParameterGroupIdentifier = &v
+	return s
+}
+
 type CopyDBParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7989,6 +8241,12 @@ func (s CopyDBParameterGroupOutput) String() string {
 // GoString returns the string representation
 func (s CopyDBParameterGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBParameterGroup sets the DBParameterGroup field's value.
+func (s *CopyDBParameterGroupOutput) SetDBParameterGroup(v *DBParameterGroup) *CopyDBParameterGroupOutput {
+	s.DBParameterGroup = v
+	return s
 }
 
 type CopyDBSnapshotInput struct {
@@ -8085,6 +8343,36 @@ func (s *CopyDBSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetCopyTags sets the CopyTags field's value.
+func (s *CopyDBSnapshotInput) SetCopyTags(v bool) *CopyDBSnapshotInput {
+	s.CopyTags = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CopyDBSnapshotInput) SetKmsKeyId(v string) *CopyDBSnapshotInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetSourceDBSnapshotIdentifier sets the SourceDBSnapshotIdentifier field's value.
+func (s *CopyDBSnapshotInput) SetSourceDBSnapshotIdentifier(v string) *CopyDBSnapshotInput {
+	s.SourceDBSnapshotIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CopyDBSnapshotInput) SetTags(v []*Tag) *CopyDBSnapshotInput {
+	s.Tags = v
+	return s
+}
+
+// SetTargetDBSnapshotIdentifier sets the TargetDBSnapshotIdentifier field's value.
+func (s *CopyDBSnapshotInput) SetTargetDBSnapshotIdentifier(v string) *CopyDBSnapshotInput {
+	s.TargetDBSnapshotIdentifier = &v
+	return s
+}
+
 type CopyDBSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8106,6 +8394,12 @@ func (s CopyDBSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CopyDBSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSnapshot sets the DBSnapshot field's value.
+func (s *CopyDBSnapshotOutput) SetDBSnapshot(v *DBSnapshot) *CopyDBSnapshotOutput {
+	s.DBSnapshot = v
+	return s
 }
 
 type CopyOptionGroupInput struct {
@@ -8183,6 +8477,30 @@ func (s *CopyOptionGroupInput) Validate() error {
 	return nil
 }
 
+// SetSourceOptionGroupIdentifier sets the SourceOptionGroupIdentifier field's value.
+func (s *CopyOptionGroupInput) SetSourceOptionGroupIdentifier(v string) *CopyOptionGroupInput {
+	s.SourceOptionGroupIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CopyOptionGroupInput) SetTags(v []*Tag) *CopyOptionGroupInput {
+	s.Tags = v
+	return s
+}
+
+// SetTargetOptionGroupDescription sets the TargetOptionGroupDescription field's value.
+func (s *CopyOptionGroupInput) SetTargetOptionGroupDescription(v string) *CopyOptionGroupInput {
+	s.TargetOptionGroupDescription = &v
+	return s
+}
+
+// SetTargetOptionGroupIdentifier sets the TargetOptionGroupIdentifier field's value.
+func (s *CopyOptionGroupInput) SetTargetOptionGroupIdentifier(v string) *CopyOptionGroupInput {
+	s.TargetOptionGroupIdentifier = &v
+	return s
+}
+
 type CopyOptionGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8197,6 +8515,12 @@ func (s CopyOptionGroupOutput) String() string {
 // GoString returns the string representation
 func (s CopyOptionGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetOptionGroup sets the OptionGroup field's value.
+func (s *CopyOptionGroupOutput) SetOptionGroup(v *OptionGroup) *CopyOptionGroupOutput {
+	s.OptionGroup = v
+	return s
 }
 
 type CreateDBClusterInput struct {
@@ -8391,6 +8715,126 @@ func (s *CreateDBClusterInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *CreateDBClusterInput) SetAvailabilityZones(v []*string) *CreateDBClusterInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *CreateDBClusterInput) SetBackupRetentionPeriod(v int64) *CreateDBClusterInput {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetCharacterSetName sets the CharacterSetName field's value.
+func (s *CreateDBClusterInput) SetCharacterSetName(v string) *CreateDBClusterInput {
+	s.CharacterSetName = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *CreateDBClusterInput) SetDBClusterIdentifier(v string) *CreateDBClusterInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *CreateDBClusterInput) SetDBClusterParameterGroupName(v string) *CreateDBClusterInput {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *CreateDBClusterInput) SetDBSubnetGroupName(v string) *CreateDBClusterInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *CreateDBClusterInput) SetDatabaseName(v string) *CreateDBClusterInput {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *CreateDBClusterInput) SetEngine(v string) *CreateDBClusterInput {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *CreateDBClusterInput) SetEngineVersion(v string) *CreateDBClusterInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateDBClusterInput) SetKmsKeyId(v string) *CreateDBClusterInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *CreateDBClusterInput) SetMasterUserPassword(v string) *CreateDBClusterInput {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *CreateDBClusterInput) SetMasterUsername(v string) *CreateDBClusterInput {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *CreateDBClusterInput) SetOptionGroupName(v string) *CreateDBClusterInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateDBClusterInput) SetPort(v int64) *CreateDBClusterInput {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredBackupWindow sets the PreferredBackupWindow field's value.
+func (s *CreateDBClusterInput) SetPreferredBackupWindow(v string) *CreateDBClusterInput {
+	s.PreferredBackupWindow = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *CreateDBClusterInput) SetPreferredMaintenanceWindow(v string) *CreateDBClusterInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetReplicationSourceIdentifier sets the ReplicationSourceIdentifier field's value.
+func (s *CreateDBClusterInput) SetReplicationSourceIdentifier(v string) *CreateDBClusterInput {
+	s.ReplicationSourceIdentifier = &v
+	return s
+}
+
+// SetStorageEncrypted sets the StorageEncrypted field's value.
+func (s *CreateDBClusterInput) SetStorageEncrypted(v bool) *CreateDBClusterInput {
+	s.StorageEncrypted = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBClusterInput) SetTags(v []*Tag) *CreateDBClusterInput {
+	s.Tags = v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *CreateDBClusterInput) SetVpcSecurityGroupIds(v []*string) *CreateDBClusterInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type CreateDBClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8420,6 +8864,12 @@ func (s CreateDBClusterOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBCluster sets the DBCluster field's value.
+func (s *CreateDBClusterOutput) SetDBCluster(v *DBCluster) *CreateDBClusterOutput {
+	s.DBCluster = v
+	return s
 }
 
 type CreateDBClusterParameterGroupInput struct {
@@ -8486,6 +8936,30 @@ func (s *CreateDBClusterParameterGroupInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *CreateDBClusterParameterGroupInput) SetDBClusterParameterGroupName(v string) *CreateDBClusterParameterGroupInput {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *CreateDBClusterParameterGroupInput) SetDBParameterGroupFamily(v string) *CreateDBClusterParameterGroupInput {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateDBClusterParameterGroupInput) SetDescription(v string) *CreateDBClusterParameterGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBClusterParameterGroupInput) SetTags(v []*Tag) *CreateDBClusterParameterGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateDBClusterParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8506,6 +8980,12 @@ func (s CreateDBClusterParameterGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBClusterParameterGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterParameterGroup sets the DBClusterParameterGroup field's value.
+func (s *CreateDBClusterParameterGroupOutput) SetDBClusterParameterGroup(v *DBClusterParameterGroup) *CreateDBClusterParameterGroupOutput {
+	s.DBClusterParameterGroup = v
+	return s
 }
 
 type CreateDBClusterSnapshotInput struct {
@@ -8573,6 +9053,24 @@ func (s *CreateDBClusterSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *CreateDBClusterSnapshotInput) SetDBClusterIdentifier(v string) *CreateDBClusterSnapshotInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBClusterSnapshotIdentifier sets the DBClusterSnapshotIdentifier field's value.
+func (s *CreateDBClusterSnapshotInput) SetDBClusterSnapshotIdentifier(v string) *CreateDBClusterSnapshotInput {
+	s.DBClusterSnapshotIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBClusterSnapshotInput) SetTags(v []*Tag) *CreateDBClusterSnapshotInput {
+	s.Tags = v
+	return s
+}
+
 type CreateDBClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8595,6 +9093,12 @@ func (s CreateDBClusterSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBClusterSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterSnapshot sets the DBClusterSnapshot field's value.
+func (s *CreateDBClusterSnapshotOutput) SetDBClusterSnapshot(v *DBClusterSnapshot) *CreateDBClusterSnapshotOutput {
+	s.DBClusterSnapshot = v
+	return s
 }
 
 type CreateDBInstanceInput struct {
@@ -9320,6 +9824,234 @@ func (s *CreateDBInstanceInput) Validate() error {
 	return nil
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *CreateDBInstanceInput) SetAllocatedStorage(v int64) *CreateDBInstanceInput {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *CreateDBInstanceInput) SetAutoMinorVersionUpgrade(v bool) *CreateDBInstanceInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *CreateDBInstanceInput) SetAvailabilityZone(v string) *CreateDBInstanceInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *CreateDBInstanceInput) SetBackupRetentionPeriod(v int64) *CreateDBInstanceInput {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetCharacterSetName sets the CharacterSetName field's value.
+func (s *CreateDBInstanceInput) SetCharacterSetName(v string) *CreateDBInstanceInput {
+	s.CharacterSetName = &v
+	return s
+}
+
+// SetCopyTagsToSnapshot sets the CopyTagsToSnapshot field's value.
+func (s *CreateDBInstanceInput) SetCopyTagsToSnapshot(v bool) *CreateDBInstanceInput {
+	s.CopyTagsToSnapshot = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *CreateDBInstanceInput) SetDBClusterIdentifier(v string) *CreateDBInstanceInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *CreateDBInstanceInput) SetDBInstanceClass(v string) *CreateDBInstanceInput {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *CreateDBInstanceInput) SetDBInstanceIdentifier(v string) *CreateDBInstanceInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBName sets the DBName field's value.
+func (s *CreateDBInstanceInput) SetDBName(v string) *CreateDBInstanceInput {
+	s.DBName = &v
+	return s
+}
+
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *CreateDBInstanceInput) SetDBParameterGroupName(v string) *CreateDBInstanceInput {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetDBSecurityGroups sets the DBSecurityGroups field's value.
+func (s *CreateDBInstanceInput) SetDBSecurityGroups(v []*string) *CreateDBInstanceInput {
+	s.DBSecurityGroups = v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *CreateDBInstanceInput) SetDBSubnetGroupName(v string) *CreateDBInstanceInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *CreateDBInstanceInput) SetDomain(v string) *CreateDBInstanceInput {
+	s.Domain = &v
+	return s
+}
+
+// SetDomainIAMRoleName sets the DomainIAMRoleName field's value.
+func (s *CreateDBInstanceInput) SetDomainIAMRoleName(v string) *CreateDBInstanceInput {
+	s.DomainIAMRoleName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *CreateDBInstanceInput) SetEngine(v string) *CreateDBInstanceInput {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *CreateDBInstanceInput) SetEngineVersion(v string) *CreateDBInstanceInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *CreateDBInstanceInput) SetIops(v int64) *CreateDBInstanceInput {
+	s.Iops = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateDBInstanceInput) SetKmsKeyId(v string) *CreateDBInstanceInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *CreateDBInstanceInput) SetLicenseModel(v string) *CreateDBInstanceInput {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *CreateDBInstanceInput) SetMasterUserPassword(v string) *CreateDBInstanceInput {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *CreateDBInstanceInput) SetMasterUsername(v string) *CreateDBInstanceInput {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetMonitoringInterval sets the MonitoringInterval field's value.
+func (s *CreateDBInstanceInput) SetMonitoringInterval(v int64) *CreateDBInstanceInput {
+	s.MonitoringInterval = &v
+	return s
+}
+
+// SetMonitoringRoleArn sets the MonitoringRoleArn field's value.
+func (s *CreateDBInstanceInput) SetMonitoringRoleArn(v string) *CreateDBInstanceInput {
+	s.MonitoringRoleArn = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *CreateDBInstanceInput) SetMultiAZ(v bool) *CreateDBInstanceInput {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *CreateDBInstanceInput) SetOptionGroupName(v string) *CreateDBInstanceInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateDBInstanceInput) SetPort(v int64) *CreateDBInstanceInput {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredBackupWindow sets the PreferredBackupWindow field's value.
+func (s *CreateDBInstanceInput) SetPreferredBackupWindow(v string) *CreateDBInstanceInput {
+	s.PreferredBackupWindow = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *CreateDBInstanceInput) SetPreferredMaintenanceWindow(v string) *CreateDBInstanceInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPromotionTier sets the PromotionTier field's value.
+func (s *CreateDBInstanceInput) SetPromotionTier(v int64) *CreateDBInstanceInput {
+	s.PromotionTier = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *CreateDBInstanceInput) SetPubliclyAccessible(v bool) *CreateDBInstanceInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetStorageEncrypted sets the StorageEncrypted field's value.
+func (s *CreateDBInstanceInput) SetStorageEncrypted(v bool) *CreateDBInstanceInput {
+	s.StorageEncrypted = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *CreateDBInstanceInput) SetStorageType(v string) *CreateDBInstanceInput {
+	s.StorageType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBInstanceInput) SetTags(v []*Tag) *CreateDBInstanceInput {
+	s.Tags = v
+	return s
+}
+
+// SetTdeCredentialArn sets the TdeCredentialArn field's value.
+func (s *CreateDBInstanceInput) SetTdeCredentialArn(v string) *CreateDBInstanceInput {
+	s.TdeCredentialArn = &v
+	return s
+}
+
+// SetTdeCredentialPassword sets the TdeCredentialPassword field's value.
+func (s *CreateDBInstanceInput) SetTdeCredentialPassword(v string) *CreateDBInstanceInput {
+	s.TdeCredentialPassword = &v
+	return s
+}
+
+// SetTimezone sets the Timezone field's value.
+func (s *CreateDBInstanceInput) SetTimezone(v string) *CreateDBInstanceInput {
+	s.Timezone = &v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *CreateDBInstanceInput) SetVpcSecurityGroupIds(v []*string) *CreateDBInstanceInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type CreateDBInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9343,6 +10075,12 @@ func (s CreateDBInstanceOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBInstance sets the DBInstance field's value.
+func (s *CreateDBInstanceOutput) SetDBInstance(v *DBInstance) *CreateDBInstanceOutput {
+	s.DBInstance = v
+	return s
 }
 
 type CreateDBInstanceReadReplicaInput struct {
@@ -9528,6 +10266,96 @@ func (s *CreateDBInstanceReadReplicaInput) Validate() error {
 	return nil
 }
 
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetAutoMinorVersionUpgrade(v bool) *CreateDBInstanceReadReplicaInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetAvailabilityZone(v string) *CreateDBInstanceReadReplicaInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCopyTagsToSnapshot sets the CopyTagsToSnapshot field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetCopyTagsToSnapshot(v bool) *CreateDBInstanceReadReplicaInput {
+	s.CopyTagsToSnapshot = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetDBInstanceClass(v string) *CreateDBInstanceReadReplicaInput {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetDBInstanceIdentifier(v string) *CreateDBInstanceReadReplicaInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetDBSubnetGroupName(v string) *CreateDBInstanceReadReplicaInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetIops(v int64) *CreateDBInstanceReadReplicaInput {
+	s.Iops = &v
+	return s
+}
+
+// SetMonitoringInterval sets the MonitoringInterval field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetMonitoringInterval(v int64) *CreateDBInstanceReadReplicaInput {
+	s.MonitoringInterval = &v
+	return s
+}
+
+// SetMonitoringRoleArn sets the MonitoringRoleArn field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetMonitoringRoleArn(v string) *CreateDBInstanceReadReplicaInput {
+	s.MonitoringRoleArn = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetOptionGroupName(v string) *CreateDBInstanceReadReplicaInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetPort(v int64) *CreateDBInstanceReadReplicaInput {
+	s.Port = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetPubliclyAccessible(v bool) *CreateDBInstanceReadReplicaInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetSourceDBInstanceIdentifier sets the SourceDBInstanceIdentifier field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetSourceDBInstanceIdentifier(v string) *CreateDBInstanceReadReplicaInput {
+	s.SourceDBInstanceIdentifier = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetStorageType(v string) *CreateDBInstanceReadReplicaInput {
+	s.StorageType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetTags(v []*Tag) *CreateDBInstanceReadReplicaInput {
+	s.Tags = v
+	return s
+}
+
 type CreateDBInstanceReadReplicaOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9551,6 +10379,12 @@ func (s CreateDBInstanceReadReplicaOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBInstanceReadReplicaOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBInstance sets the DBInstance field's value.
+func (s *CreateDBInstanceReadReplicaOutput) SetDBInstance(v *DBInstance) *CreateDBInstanceReadReplicaOutput {
+	s.DBInstance = v
+	return s
 }
 
 type CreateDBParameterGroupInput struct {
@@ -9617,6 +10451,30 @@ func (s *CreateDBParameterGroupInput) Validate() error {
 	return nil
 }
 
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *CreateDBParameterGroupInput) SetDBParameterGroupFamily(v string) *CreateDBParameterGroupInput {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *CreateDBParameterGroupInput) SetDBParameterGroupName(v string) *CreateDBParameterGroupInput {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateDBParameterGroupInput) SetDescription(v string) *CreateDBParameterGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBParameterGroupInput) SetTags(v []*Tag) *CreateDBParameterGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateDBParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9636,6 +10494,12 @@ func (s CreateDBParameterGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBParameterGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBParameterGroup sets the DBParameterGroup field's value.
+func (s *CreateDBParameterGroupOutput) SetDBParameterGroup(v *DBParameterGroup) *CreateDBParameterGroupOutput {
+	s.DBParameterGroup = v
+	return s
 }
 
 type CreateDBSecurityGroupInput struct {
@@ -9693,6 +10557,24 @@ func (s *CreateDBSecurityGroupInput) Validate() error {
 	return nil
 }
 
+// SetDBSecurityGroupDescription sets the DBSecurityGroupDescription field's value.
+func (s *CreateDBSecurityGroupInput) SetDBSecurityGroupDescription(v string) *CreateDBSecurityGroupInput {
+	s.DBSecurityGroupDescription = &v
+	return s
+}
+
+// SetDBSecurityGroupName sets the DBSecurityGroupName field's value.
+func (s *CreateDBSecurityGroupInput) SetDBSecurityGroupName(v string) *CreateDBSecurityGroupInput {
+	s.DBSecurityGroupName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBSecurityGroupInput) SetTags(v []*Tag) *CreateDBSecurityGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateDBSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9719,6 +10601,12 @@ func (s CreateDBSecurityGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBSecurityGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSecurityGroup sets the DBSecurityGroup field's value.
+func (s *CreateDBSecurityGroupOutput) SetDBSecurityGroup(v *DBSecurityGroup) *CreateDBSecurityGroupOutput {
+	s.DBSecurityGroup = v
+	return s
 }
 
 type CreateDBSnapshotInput struct {
@@ -9784,6 +10672,24 @@ func (s *CreateDBSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *CreateDBSnapshotInput) SetDBInstanceIdentifier(v string) *CreateDBSnapshotInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBSnapshotIdentifier sets the DBSnapshotIdentifier field's value.
+func (s *CreateDBSnapshotInput) SetDBSnapshotIdentifier(v string) *CreateDBSnapshotInput {
+	s.DBSnapshotIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBSnapshotInput) SetTags(v []*Tag) *CreateDBSnapshotInput {
+	s.Tags = v
+	return s
+}
+
 type CreateDBSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9805,6 +10711,12 @@ func (s CreateDBSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSnapshot sets the DBSnapshot field's value.
+func (s *CreateDBSnapshotOutput) SetDBSnapshot(v *DBSnapshot) *CreateDBSnapshotOutput {
+	s.DBSnapshot = v
+	return s
 }
 
 type CreateDBSubnetGroupInput struct {
@@ -9863,6 +10775,30 @@ func (s *CreateDBSubnetGroupInput) Validate() error {
 	return nil
 }
 
+// SetDBSubnetGroupDescription sets the DBSubnetGroupDescription field's value.
+func (s *CreateDBSubnetGroupInput) SetDBSubnetGroupDescription(v string) *CreateDBSubnetGroupInput {
+	s.DBSubnetGroupDescription = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *CreateDBSubnetGroupInput) SetDBSubnetGroupName(v string) *CreateDBSubnetGroupInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *CreateDBSubnetGroupInput) SetSubnetIds(v []*string) *CreateDBSubnetGroupInput {
+	s.SubnetIds = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateDBSubnetGroupInput) SetTags(v []*Tag) *CreateDBSubnetGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateDBSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9889,6 +10825,12 @@ func (s CreateDBSubnetGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateDBSubnetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSubnetGroup sets the DBSubnetGroup field's value.
+func (s *CreateDBSubnetGroupOutput) SetDBSubnetGroup(v *DBSubnetGroup) *CreateDBSubnetGroupOutput {
+	s.DBSubnetGroup = v
+	return s
 }
 
 type CreateEventSubscriptionInput struct {
@@ -9980,6 +10922,48 @@ func (s *CreateEventSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *CreateEventSubscriptionInput) SetEnabled(v bool) *CreateEventSubscriptionInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *CreateEventSubscriptionInput) SetEventCategories(v []*string) *CreateEventSubscriptionInput {
+	s.EventCategories = v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *CreateEventSubscriptionInput) SetSnsTopicArn(v string) *CreateEventSubscriptionInput {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceIds sets the SourceIds field's value.
+func (s *CreateEventSubscriptionInput) SetSourceIds(v []*string) *CreateEventSubscriptionInput {
+	s.SourceIds = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *CreateEventSubscriptionInput) SetSourceType(v string) *CreateEventSubscriptionInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *CreateEventSubscriptionInput) SetSubscriptionName(v string) *CreateEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateEventSubscriptionInput) SetTags(v []*Tag) *CreateEventSubscriptionInput {
+	s.Tags = v
+	return s
+}
+
 type CreateEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9996,6 +10980,12 @@ func (s CreateEventSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s CreateEventSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *CreateEventSubscriptionOutput) SetEventSubscription(v *EventSubscription) *CreateEventSubscriptionOutput {
+	s.EventSubscription = v
+	return s
 }
 
 type CreateOptionGroupInput struct {
@@ -10069,6 +11059,36 @@ func (s *CreateOptionGroupInput) Validate() error {
 	return nil
 }
 
+// SetEngineName sets the EngineName field's value.
+func (s *CreateOptionGroupInput) SetEngineName(v string) *CreateOptionGroupInput {
+	s.EngineName = &v
+	return s
+}
+
+// SetMajorEngineVersion sets the MajorEngineVersion field's value.
+func (s *CreateOptionGroupInput) SetMajorEngineVersion(v string) *CreateOptionGroupInput {
+	s.MajorEngineVersion = &v
+	return s
+}
+
+// SetOptionGroupDescription sets the OptionGroupDescription field's value.
+func (s *CreateOptionGroupInput) SetOptionGroupDescription(v string) *CreateOptionGroupInput {
+	s.OptionGroupDescription = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *CreateOptionGroupInput) SetOptionGroupName(v string) *CreateOptionGroupInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateOptionGroupInput) SetTags(v []*Tag) *CreateOptionGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateOptionGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10083,6 +11103,12 @@ func (s CreateOptionGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateOptionGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetOptionGroup sets the OptionGroup field's value.
+func (s *CreateOptionGroupOutput) SetOptionGroup(v *OptionGroup) *CreateOptionGroupOutput {
+	s.OptionGroup = v
+	return s
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -10235,6 +11261,192 @@ func (s DBCluster) GoString() string {
 	return s.String()
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *DBCluster) SetAllocatedStorage(v int64) *DBCluster {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAssociatedRoles sets the AssociatedRoles field's value.
+func (s *DBCluster) SetAssociatedRoles(v []*DBClusterRole) *DBCluster {
+	s.AssociatedRoles = v
+	return s
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *DBCluster) SetAvailabilityZones(v []*string) *DBCluster {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *DBCluster) SetBackupRetentionPeriod(v int64) *DBCluster {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetCharacterSetName sets the CharacterSetName field's value.
+func (s *DBCluster) SetCharacterSetName(v string) *DBCluster {
+	s.CharacterSetName = &v
+	return s
+}
+
+// SetDBClusterArn sets the DBClusterArn field's value.
+func (s *DBCluster) SetDBClusterArn(v string) *DBCluster {
+	s.DBClusterArn = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *DBCluster) SetDBClusterIdentifier(v string) *DBCluster {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBClusterMembers sets the DBClusterMembers field's value.
+func (s *DBCluster) SetDBClusterMembers(v []*DBClusterMember) *DBCluster {
+	s.DBClusterMembers = v
+	return s
+}
+
+// SetDBClusterOptionGroupMemberships sets the DBClusterOptionGroupMemberships field's value.
+func (s *DBCluster) SetDBClusterOptionGroupMemberships(v []*DBClusterOptionGroupStatus) *DBCluster {
+	s.DBClusterOptionGroupMemberships = v
+	return s
+}
+
+// SetDBClusterParameterGroup sets the DBClusterParameterGroup field's value.
+func (s *DBCluster) SetDBClusterParameterGroup(v string) *DBCluster {
+	s.DBClusterParameterGroup = &v
+	return s
+}
+
+// SetDBSubnetGroup sets the DBSubnetGroup field's value.
+func (s *DBCluster) SetDBSubnetGroup(v string) *DBCluster {
+	s.DBSubnetGroup = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *DBCluster) SetDatabaseName(v string) *DBCluster {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetDbClusterResourceId sets the DbClusterResourceId field's value.
+func (s *DBCluster) SetDbClusterResourceId(v string) *DBCluster {
+	s.DbClusterResourceId = &v
+	return s
+}
+
+// SetEarliestRestorableTime sets the EarliestRestorableTime field's value.
+func (s *DBCluster) SetEarliestRestorableTime(v time.Time) *DBCluster {
+	s.EarliestRestorableTime = &v
+	return s
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *DBCluster) SetEndpoint(v string) *DBCluster {
+	s.Endpoint = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *DBCluster) SetEngine(v string) *DBCluster {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *DBCluster) SetEngineVersion(v string) *DBCluster {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *DBCluster) SetHostedZoneId(v string) *DBCluster {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *DBCluster) SetKmsKeyId(v string) *DBCluster {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLatestRestorableTime sets the LatestRestorableTime field's value.
+func (s *DBCluster) SetLatestRestorableTime(v time.Time) *DBCluster {
+	s.LatestRestorableTime = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *DBCluster) SetMasterUsername(v string) *DBCluster {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetPercentProgress sets the PercentProgress field's value.
+func (s *DBCluster) SetPercentProgress(v string) *DBCluster {
+	s.PercentProgress = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *DBCluster) SetPort(v int64) *DBCluster {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredBackupWindow sets the PreferredBackupWindow field's value.
+func (s *DBCluster) SetPreferredBackupWindow(v string) *DBCluster {
+	s.PreferredBackupWindow = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *DBCluster) SetPreferredMaintenanceWindow(v string) *DBCluster {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetReadReplicaIdentifiers sets the ReadReplicaIdentifiers field's value.
+func (s *DBCluster) SetReadReplicaIdentifiers(v []*string) *DBCluster {
+	s.ReadReplicaIdentifiers = v
+	return s
+}
+
+// SetReaderEndpoint sets the ReaderEndpoint field's value.
+func (s *DBCluster) SetReaderEndpoint(v string) *DBCluster {
+	s.ReaderEndpoint = &v
+	return s
+}
+
+// SetReplicationSourceIdentifier sets the ReplicationSourceIdentifier field's value.
+func (s *DBCluster) SetReplicationSourceIdentifier(v string) *DBCluster {
+	s.ReplicationSourceIdentifier = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DBCluster) SetStatus(v string) *DBCluster {
+	s.Status = &v
+	return s
+}
+
+// SetStorageEncrypted sets the StorageEncrypted field's value.
+func (s *DBCluster) SetStorageEncrypted(v bool) *DBCluster {
+	s.StorageEncrypted = &v
+	return s
+}
+
+// SetVpcSecurityGroups sets the VpcSecurityGroups field's value.
+func (s *DBCluster) SetVpcSecurityGroups(v []*VpcSecurityGroupMembership) *DBCluster {
+	s.VpcSecurityGroups = v
+	return s
+}
+
 // Contains information about an instance that is part of a DB cluster.
 type DBClusterMember struct {
 	_ struct{} `type:"structure"`
@@ -10266,6 +11478,30 @@ func (s DBClusterMember) GoString() string {
 	return s.String()
 }
 
+// SetDBClusterParameterGroupStatus sets the DBClusterParameterGroupStatus field's value.
+func (s *DBClusterMember) SetDBClusterParameterGroupStatus(v string) *DBClusterMember {
+	s.DBClusterParameterGroupStatus = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *DBClusterMember) SetDBInstanceIdentifier(v string) *DBClusterMember {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetIsClusterWriter sets the IsClusterWriter field's value.
+func (s *DBClusterMember) SetIsClusterWriter(v bool) *DBClusterMember {
+	s.IsClusterWriter = &v
+	return s
+}
+
+// SetPromotionTier sets the PromotionTier field's value.
+func (s *DBClusterMember) SetPromotionTier(v int64) *DBClusterMember {
+	s.PromotionTier = &v
+	return s
+}
+
 // Contains status information for a DB cluster option group.
 type DBClusterOptionGroupStatus struct {
 	_ struct{} `type:"structure"`
@@ -10285,6 +11521,18 @@ func (s DBClusterOptionGroupStatus) String() string {
 // GoString returns the string representation
 func (s DBClusterOptionGroupStatus) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterOptionGroupName sets the DBClusterOptionGroupName field's value.
+func (s *DBClusterOptionGroupStatus) SetDBClusterOptionGroupName(v string) *DBClusterOptionGroupStatus {
+	s.DBClusterOptionGroupName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DBClusterOptionGroupStatus) SetStatus(v string) *DBClusterOptionGroupStatus {
+	s.Status = &v
+	return s
 }
 
 // Contains the result of a successful invocation of the CreateDBClusterParameterGroup
@@ -10321,6 +11569,30 @@ func (s DBClusterParameterGroup) GoString() string {
 	return s.String()
 }
 
+// SetDBClusterParameterGroupArn sets the DBClusterParameterGroupArn field's value.
+func (s *DBClusterParameterGroup) SetDBClusterParameterGroupArn(v string) *DBClusterParameterGroup {
+	s.DBClusterParameterGroupArn = &v
+	return s
+}
+
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *DBClusterParameterGroup) SetDBClusterParameterGroupName(v string) *DBClusterParameterGroup {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *DBClusterParameterGroup) SetDBParameterGroupFamily(v string) *DBClusterParameterGroup {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DBClusterParameterGroup) SetDescription(v string) *DBClusterParameterGroup {
+	s.Description = &v
+	return s
+}
+
 type DBClusterParameterGroupNameMessage struct {
 	_ struct{} `type:"structure"`
 
@@ -10346,6 +11618,12 @@ func (s DBClusterParameterGroupNameMessage) String() string {
 // GoString returns the string representation
 func (s DBClusterParameterGroupNameMessage) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *DBClusterParameterGroupNameMessage) SetDBClusterParameterGroupName(v string) *DBClusterParameterGroupNameMessage {
+	s.DBClusterParameterGroupName = &v
+	return s
 }
 
 // Describes an AWS Identity and Access Management (IAM) role that is associated
@@ -10379,6 +11657,18 @@ func (s DBClusterRole) String() string {
 // GoString returns the string representation
 func (s DBClusterRole) GoString() string {
 	return s.String()
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *DBClusterRole) SetRoleArn(v string) *DBClusterRole {
+	s.RoleArn = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DBClusterRole) SetStatus(v string) *DBClusterRole {
+	s.Status = &v
+	return s
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -10463,6 +11753,114 @@ func (s DBClusterSnapshot) GoString() string {
 	return s.String()
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *DBClusterSnapshot) SetAllocatedStorage(v int64) *DBClusterSnapshot {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *DBClusterSnapshot) SetAvailabilityZones(v []*string) *DBClusterSnapshot {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetClusterCreateTime sets the ClusterCreateTime field's value.
+func (s *DBClusterSnapshot) SetClusterCreateTime(v time.Time) *DBClusterSnapshot {
+	s.ClusterCreateTime = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *DBClusterSnapshot) SetDBClusterIdentifier(v string) *DBClusterSnapshot {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBClusterSnapshotArn sets the DBClusterSnapshotArn field's value.
+func (s *DBClusterSnapshot) SetDBClusterSnapshotArn(v string) *DBClusterSnapshot {
+	s.DBClusterSnapshotArn = &v
+	return s
+}
+
+// SetDBClusterSnapshotIdentifier sets the DBClusterSnapshotIdentifier field's value.
+func (s *DBClusterSnapshot) SetDBClusterSnapshotIdentifier(v string) *DBClusterSnapshot {
+	s.DBClusterSnapshotIdentifier = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *DBClusterSnapshot) SetEngine(v string) *DBClusterSnapshot {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *DBClusterSnapshot) SetEngineVersion(v string) *DBClusterSnapshot {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *DBClusterSnapshot) SetKmsKeyId(v string) *DBClusterSnapshot {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *DBClusterSnapshot) SetLicenseModel(v string) *DBClusterSnapshot {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *DBClusterSnapshot) SetMasterUsername(v string) *DBClusterSnapshot {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetPercentProgress sets the PercentProgress field's value.
+func (s *DBClusterSnapshot) SetPercentProgress(v int64) *DBClusterSnapshot {
+	s.PercentProgress = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *DBClusterSnapshot) SetPort(v int64) *DBClusterSnapshot {
+	s.Port = &v
+	return s
+}
+
+// SetSnapshotCreateTime sets the SnapshotCreateTime field's value.
+func (s *DBClusterSnapshot) SetSnapshotCreateTime(v time.Time) *DBClusterSnapshot {
+	s.SnapshotCreateTime = &v
+	return s
+}
+
+// SetSnapshotType sets the SnapshotType field's value.
+func (s *DBClusterSnapshot) SetSnapshotType(v string) *DBClusterSnapshot {
+	s.SnapshotType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DBClusterSnapshot) SetStatus(v string) *DBClusterSnapshot {
+	s.Status = &v
+	return s
+}
+
+// SetStorageEncrypted sets the StorageEncrypted field's value.
+func (s *DBClusterSnapshot) SetStorageEncrypted(v bool) *DBClusterSnapshot {
+	s.StorageEncrypted = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DBClusterSnapshot) SetVpcId(v string) *DBClusterSnapshot {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the name and values of a manual DB cluster snapshot attribute.
 //
 // Manual DB cluster snapshot attributes are used to authorize other AWS accounts
@@ -10498,6 +11896,18 @@ func (s DBClusterSnapshotAttribute) GoString() string {
 	return s.String()
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *DBClusterSnapshotAttribute) SetAttributeName(v string) *DBClusterSnapshotAttribute {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValues sets the AttributeValues field's value.
+func (s *DBClusterSnapshotAttribute) SetAttributeValues(v []*string) *DBClusterSnapshotAttribute {
+	s.AttributeValues = v
+	return s
+}
+
 // Contains the results of a successful call to the DescribeDBClusterSnapshotAttributes
 // API action.
 //
@@ -10523,6 +11933,18 @@ func (s DBClusterSnapshotAttributesResult) String() string {
 // GoString returns the string representation
 func (s DBClusterSnapshotAttributesResult) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterSnapshotAttributes sets the DBClusterSnapshotAttributes field's value.
+func (s *DBClusterSnapshotAttributesResult) SetDBClusterSnapshotAttributes(v []*DBClusterSnapshotAttribute) *DBClusterSnapshotAttributesResult {
+	s.DBClusterSnapshotAttributes = v
+	return s
+}
+
+// SetDBClusterSnapshotIdentifier sets the DBClusterSnapshotIdentifier field's value.
+func (s *DBClusterSnapshotAttributesResult) SetDBClusterSnapshotIdentifier(v string) *DBClusterSnapshotAttributesResult {
+	s.DBClusterSnapshotIdentifier = &v
+	return s
 }
 
 // This data type is used as a response element in the action DescribeDBEngineVersions.
@@ -10569,6 +11991,60 @@ func (s DBEngineVersion) String() string {
 // GoString returns the string representation
 func (s DBEngineVersion) GoString() string {
 	return s.String()
+}
+
+// SetDBEngineDescription sets the DBEngineDescription field's value.
+func (s *DBEngineVersion) SetDBEngineDescription(v string) *DBEngineVersion {
+	s.DBEngineDescription = &v
+	return s
+}
+
+// SetDBEngineVersionDescription sets the DBEngineVersionDescription field's value.
+func (s *DBEngineVersion) SetDBEngineVersionDescription(v string) *DBEngineVersion {
+	s.DBEngineVersionDescription = &v
+	return s
+}
+
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *DBEngineVersion) SetDBParameterGroupFamily(v string) *DBEngineVersion {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetDefaultCharacterSet sets the DefaultCharacterSet field's value.
+func (s *DBEngineVersion) SetDefaultCharacterSet(v *CharacterSet) *DBEngineVersion {
+	s.DefaultCharacterSet = v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *DBEngineVersion) SetEngine(v string) *DBEngineVersion {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *DBEngineVersion) SetEngineVersion(v string) *DBEngineVersion {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetSupportedCharacterSets sets the SupportedCharacterSets field's value.
+func (s *DBEngineVersion) SetSupportedCharacterSets(v []*CharacterSet) *DBEngineVersion {
+	s.SupportedCharacterSets = v
+	return s
+}
+
+// SetSupportedTimezones sets the SupportedTimezones field's value.
+func (s *DBEngineVersion) SetSupportedTimezones(v []*Timezone) *DBEngineVersion {
+	s.SupportedTimezones = v
+	return s
+}
+
+// SetValidUpgradeTarget sets the ValidUpgradeTarget field's value.
+func (s *DBEngineVersion) SetValidUpgradeTarget(v []*UpgradeTarget) *DBEngineVersion {
+	s.ValidUpgradeTarget = v
+	return s
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -10793,6 +12269,288 @@ func (s DBInstance) GoString() string {
 	return s.String()
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *DBInstance) SetAllocatedStorage(v int64) *DBInstance {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *DBInstance) SetAutoMinorVersionUpgrade(v bool) *DBInstance {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *DBInstance) SetAvailabilityZone(v string) *DBInstance {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *DBInstance) SetBackupRetentionPeriod(v int64) *DBInstance {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetCACertificateIdentifier sets the CACertificateIdentifier field's value.
+func (s *DBInstance) SetCACertificateIdentifier(v string) *DBInstance {
+	s.CACertificateIdentifier = &v
+	return s
+}
+
+// SetCharacterSetName sets the CharacterSetName field's value.
+func (s *DBInstance) SetCharacterSetName(v string) *DBInstance {
+	s.CharacterSetName = &v
+	return s
+}
+
+// SetCopyTagsToSnapshot sets the CopyTagsToSnapshot field's value.
+func (s *DBInstance) SetCopyTagsToSnapshot(v bool) *DBInstance {
+	s.CopyTagsToSnapshot = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *DBInstance) SetDBClusterIdentifier(v string) *DBInstance {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBInstanceArn sets the DBInstanceArn field's value.
+func (s *DBInstance) SetDBInstanceArn(v string) *DBInstance {
+	s.DBInstanceArn = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *DBInstance) SetDBInstanceClass(v string) *DBInstance {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *DBInstance) SetDBInstanceIdentifier(v string) *DBInstance {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBInstanceStatus sets the DBInstanceStatus field's value.
+func (s *DBInstance) SetDBInstanceStatus(v string) *DBInstance {
+	s.DBInstanceStatus = &v
+	return s
+}
+
+// SetDBName sets the DBName field's value.
+func (s *DBInstance) SetDBName(v string) *DBInstance {
+	s.DBName = &v
+	return s
+}
+
+// SetDBParameterGroups sets the DBParameterGroups field's value.
+func (s *DBInstance) SetDBParameterGroups(v []*DBParameterGroupStatus) *DBInstance {
+	s.DBParameterGroups = v
+	return s
+}
+
+// SetDBSecurityGroups sets the DBSecurityGroups field's value.
+func (s *DBInstance) SetDBSecurityGroups(v []*DBSecurityGroupMembership) *DBInstance {
+	s.DBSecurityGroups = v
+	return s
+}
+
+// SetDBSubnetGroup sets the DBSubnetGroup field's value.
+func (s *DBInstance) SetDBSubnetGroup(v *DBSubnetGroup) *DBInstance {
+	s.DBSubnetGroup = v
+	return s
+}
+
+// SetDbInstancePort sets the DbInstancePort field's value.
+func (s *DBInstance) SetDbInstancePort(v int64) *DBInstance {
+	s.DbInstancePort = &v
+	return s
+}
+
+// SetDbiResourceId sets the DbiResourceId field's value.
+func (s *DBInstance) SetDbiResourceId(v string) *DBInstance {
+	s.DbiResourceId = &v
+	return s
+}
+
+// SetDomainMemberships sets the DomainMemberships field's value.
+func (s *DBInstance) SetDomainMemberships(v []*DomainMembership) *DBInstance {
+	s.DomainMemberships = v
+	return s
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *DBInstance) SetEndpoint(v *Endpoint) *DBInstance {
+	s.Endpoint = v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *DBInstance) SetEngine(v string) *DBInstance {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *DBInstance) SetEngineVersion(v string) *DBInstance {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetEnhancedMonitoringResourceArn sets the EnhancedMonitoringResourceArn field's value.
+func (s *DBInstance) SetEnhancedMonitoringResourceArn(v string) *DBInstance {
+	s.EnhancedMonitoringResourceArn = &v
+	return s
+}
+
+// SetInstanceCreateTime sets the InstanceCreateTime field's value.
+func (s *DBInstance) SetInstanceCreateTime(v time.Time) *DBInstance {
+	s.InstanceCreateTime = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *DBInstance) SetIops(v int64) *DBInstance {
+	s.Iops = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *DBInstance) SetKmsKeyId(v string) *DBInstance {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLatestRestorableTime sets the LatestRestorableTime field's value.
+func (s *DBInstance) SetLatestRestorableTime(v time.Time) *DBInstance {
+	s.LatestRestorableTime = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *DBInstance) SetLicenseModel(v string) *DBInstance {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *DBInstance) SetMasterUsername(v string) *DBInstance {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetMonitoringInterval sets the MonitoringInterval field's value.
+func (s *DBInstance) SetMonitoringInterval(v int64) *DBInstance {
+	s.MonitoringInterval = &v
+	return s
+}
+
+// SetMonitoringRoleArn sets the MonitoringRoleArn field's value.
+func (s *DBInstance) SetMonitoringRoleArn(v string) *DBInstance {
+	s.MonitoringRoleArn = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *DBInstance) SetMultiAZ(v bool) *DBInstance {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetOptionGroupMemberships sets the OptionGroupMemberships field's value.
+func (s *DBInstance) SetOptionGroupMemberships(v []*OptionGroupMembership) *DBInstance {
+	s.OptionGroupMemberships = v
+	return s
+}
+
+// SetPendingModifiedValues sets the PendingModifiedValues field's value.
+func (s *DBInstance) SetPendingModifiedValues(v *PendingModifiedValues) *DBInstance {
+	s.PendingModifiedValues = v
+	return s
+}
+
+// SetPreferredBackupWindow sets the PreferredBackupWindow field's value.
+func (s *DBInstance) SetPreferredBackupWindow(v string) *DBInstance {
+	s.PreferredBackupWindow = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *DBInstance) SetPreferredMaintenanceWindow(v string) *DBInstance {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPromotionTier sets the PromotionTier field's value.
+func (s *DBInstance) SetPromotionTier(v int64) *DBInstance {
+	s.PromotionTier = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *DBInstance) SetPubliclyAccessible(v bool) *DBInstance {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetReadReplicaDBInstanceIdentifiers sets the ReadReplicaDBInstanceIdentifiers field's value.
+func (s *DBInstance) SetReadReplicaDBInstanceIdentifiers(v []*string) *DBInstance {
+	s.ReadReplicaDBInstanceIdentifiers = v
+	return s
+}
+
+// SetReadReplicaSourceDBInstanceIdentifier sets the ReadReplicaSourceDBInstanceIdentifier field's value.
+func (s *DBInstance) SetReadReplicaSourceDBInstanceIdentifier(v string) *DBInstance {
+	s.ReadReplicaSourceDBInstanceIdentifier = &v
+	return s
+}
+
+// SetSecondaryAvailabilityZone sets the SecondaryAvailabilityZone field's value.
+func (s *DBInstance) SetSecondaryAvailabilityZone(v string) *DBInstance {
+	s.SecondaryAvailabilityZone = &v
+	return s
+}
+
+// SetStatusInfos sets the StatusInfos field's value.
+func (s *DBInstance) SetStatusInfos(v []*DBInstanceStatusInfo) *DBInstance {
+	s.StatusInfos = v
+	return s
+}
+
+// SetStorageEncrypted sets the StorageEncrypted field's value.
+func (s *DBInstance) SetStorageEncrypted(v bool) *DBInstance {
+	s.StorageEncrypted = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *DBInstance) SetStorageType(v string) *DBInstance {
+	s.StorageType = &v
+	return s
+}
+
+// SetTdeCredentialArn sets the TdeCredentialArn field's value.
+func (s *DBInstance) SetTdeCredentialArn(v string) *DBInstance {
+	s.TdeCredentialArn = &v
+	return s
+}
+
+// SetTimezone sets the Timezone field's value.
+func (s *DBInstance) SetTimezone(v string) *DBInstance {
+	s.Timezone = &v
+	return s
+}
+
+// SetVpcSecurityGroups sets the VpcSecurityGroups field's value.
+func (s *DBInstance) SetVpcSecurityGroups(v []*VpcSecurityGroupMembership) *DBInstance {
+	s.VpcSecurityGroups = v
+	return s
+}
+
 // Provides a list of status information for a DB instance.
 type DBInstanceStatusInfo struct {
 	_ struct{} `type:"structure"`
@@ -10821,6 +12579,30 @@ func (s DBInstanceStatusInfo) String() string {
 // GoString returns the string representation
 func (s DBInstanceStatusInfo) GoString() string {
 	return s.String()
+}
+
+// SetMessage sets the Message field's value.
+func (s *DBInstanceStatusInfo) SetMessage(v string) *DBInstanceStatusInfo {
+	s.Message = &v
+	return s
+}
+
+// SetNormal sets the Normal field's value.
+func (s *DBInstanceStatusInfo) SetNormal(v bool) *DBInstanceStatusInfo {
+	s.Normal = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DBInstanceStatusInfo) SetStatus(v string) *DBInstanceStatusInfo {
+	s.Status = &v
+	return s
+}
+
+// SetStatusType sets the StatusType field's value.
+func (s *DBInstanceStatusInfo) SetStatusType(v string) *DBInstanceStatusInfo {
+	s.StatusType = &v
+	return s
 }
 
 // Contains the result of a successful invocation of the CreateDBParameterGroup
@@ -10855,6 +12637,30 @@ func (s DBParameterGroup) GoString() string {
 	return s.String()
 }
 
+// SetDBParameterGroupArn sets the DBParameterGroupArn field's value.
+func (s *DBParameterGroup) SetDBParameterGroupArn(v string) *DBParameterGroup {
+	s.DBParameterGroupArn = &v
+	return s
+}
+
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *DBParameterGroup) SetDBParameterGroupFamily(v string) *DBParameterGroup {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *DBParameterGroup) SetDBParameterGroupName(v string) *DBParameterGroup {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DBParameterGroup) SetDescription(v string) *DBParameterGroup {
+	s.Description = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the ModifyDBParameterGroup
 // or ResetDBParameterGroup action.
 type DBParameterGroupNameMessage struct {
@@ -10872,6 +12678,12 @@ func (s DBParameterGroupNameMessage) String() string {
 // GoString returns the string representation
 func (s DBParameterGroupNameMessage) GoString() string {
 	return s.String()
+}
+
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *DBParameterGroupNameMessage) SetDBParameterGroupName(v string) *DBParameterGroupNameMessage {
+	s.DBParameterGroupName = &v
+	return s
 }
 
 // The status of the DB parameter group.
@@ -10907,6 +12719,18 @@ func (s DBParameterGroupStatus) String() string {
 // GoString returns the string representation
 func (s DBParameterGroupStatus) GoString() string {
 	return s.String()
+}
+
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *DBParameterGroupStatus) SetDBParameterGroupName(v string) *DBParameterGroupStatus {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetParameterApplyStatus sets the ParameterApplyStatus field's value.
+func (s *DBParameterGroupStatus) SetParameterApplyStatus(v string) *DBParameterGroupStatus {
+	s.ParameterApplyStatus = &v
+	return s
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -10956,6 +12780,48 @@ func (s DBSecurityGroup) GoString() string {
 	return s.String()
 }
 
+// SetDBSecurityGroupArn sets the DBSecurityGroupArn field's value.
+func (s *DBSecurityGroup) SetDBSecurityGroupArn(v string) *DBSecurityGroup {
+	s.DBSecurityGroupArn = &v
+	return s
+}
+
+// SetDBSecurityGroupDescription sets the DBSecurityGroupDescription field's value.
+func (s *DBSecurityGroup) SetDBSecurityGroupDescription(v string) *DBSecurityGroup {
+	s.DBSecurityGroupDescription = &v
+	return s
+}
+
+// SetDBSecurityGroupName sets the DBSecurityGroupName field's value.
+func (s *DBSecurityGroup) SetDBSecurityGroupName(v string) *DBSecurityGroup {
+	s.DBSecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroups sets the EC2SecurityGroups field's value.
+func (s *DBSecurityGroup) SetEC2SecurityGroups(v []*EC2SecurityGroup) *DBSecurityGroup {
+	s.EC2SecurityGroups = v
+	return s
+}
+
+// SetIPRanges sets the IPRanges field's value.
+func (s *DBSecurityGroup) SetIPRanges(v []*IPRange) *DBSecurityGroup {
+	s.IPRanges = v
+	return s
+}
+
+// SetOwnerId sets the OwnerId field's value.
+func (s *DBSecurityGroup) SetOwnerId(v string) *DBSecurityGroup {
+	s.OwnerId = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DBSecurityGroup) SetVpcId(v string) *DBSecurityGroup {
+	s.VpcId = &v
+	return s
+}
+
 // This data type is used as a response element in the following actions:
 //
 //    * ModifyDBInstance
@@ -10983,6 +12849,18 @@ func (s DBSecurityGroupMembership) String() string {
 // GoString returns the string representation
 func (s DBSecurityGroupMembership) GoString() string {
 	return s.String()
+}
+
+// SetDBSecurityGroupName sets the DBSecurityGroupName field's value.
+func (s *DBSecurityGroupMembership) SetDBSecurityGroupName(v string) *DBSecurityGroupMembership {
+	s.DBSecurityGroupName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DBSecurityGroupMembership) SetStatus(v string) *DBSecurityGroupMembership {
+	s.Status = &v
+	return s
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -11090,6 +12968,156 @@ func (s DBSnapshot) GoString() string {
 	return s.String()
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *DBSnapshot) SetAllocatedStorage(v int64) *DBSnapshot {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *DBSnapshot) SetAvailabilityZone(v string) *DBSnapshot {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *DBSnapshot) SetDBInstanceIdentifier(v string) *DBSnapshot {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBSnapshotArn sets the DBSnapshotArn field's value.
+func (s *DBSnapshot) SetDBSnapshotArn(v string) *DBSnapshot {
+	s.DBSnapshotArn = &v
+	return s
+}
+
+// SetDBSnapshotIdentifier sets the DBSnapshotIdentifier field's value.
+func (s *DBSnapshot) SetDBSnapshotIdentifier(v string) *DBSnapshot {
+	s.DBSnapshotIdentifier = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *DBSnapshot) SetEncrypted(v bool) *DBSnapshot {
+	s.Encrypted = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *DBSnapshot) SetEngine(v string) *DBSnapshot {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *DBSnapshot) SetEngineVersion(v string) *DBSnapshot {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetInstanceCreateTime sets the InstanceCreateTime field's value.
+func (s *DBSnapshot) SetInstanceCreateTime(v time.Time) *DBSnapshot {
+	s.InstanceCreateTime = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *DBSnapshot) SetIops(v int64) *DBSnapshot {
+	s.Iops = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *DBSnapshot) SetKmsKeyId(v string) *DBSnapshot {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *DBSnapshot) SetLicenseModel(v string) *DBSnapshot {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *DBSnapshot) SetMasterUsername(v string) *DBSnapshot {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *DBSnapshot) SetOptionGroupName(v string) *DBSnapshot {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPercentProgress sets the PercentProgress field's value.
+func (s *DBSnapshot) SetPercentProgress(v int64) *DBSnapshot {
+	s.PercentProgress = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *DBSnapshot) SetPort(v int64) *DBSnapshot {
+	s.Port = &v
+	return s
+}
+
+// SetSnapshotCreateTime sets the SnapshotCreateTime field's value.
+func (s *DBSnapshot) SetSnapshotCreateTime(v time.Time) *DBSnapshot {
+	s.SnapshotCreateTime = &v
+	return s
+}
+
+// SetSnapshotType sets the SnapshotType field's value.
+func (s *DBSnapshot) SetSnapshotType(v string) *DBSnapshot {
+	s.SnapshotType = &v
+	return s
+}
+
+// SetSourceDBSnapshotIdentifier sets the SourceDBSnapshotIdentifier field's value.
+func (s *DBSnapshot) SetSourceDBSnapshotIdentifier(v string) *DBSnapshot {
+	s.SourceDBSnapshotIdentifier = &v
+	return s
+}
+
+// SetSourceRegion sets the SourceRegion field's value.
+func (s *DBSnapshot) SetSourceRegion(v string) *DBSnapshot {
+	s.SourceRegion = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DBSnapshot) SetStatus(v string) *DBSnapshot {
+	s.Status = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *DBSnapshot) SetStorageType(v string) *DBSnapshot {
+	s.StorageType = &v
+	return s
+}
+
+// SetTdeCredentialArn sets the TdeCredentialArn field's value.
+func (s *DBSnapshot) SetTdeCredentialArn(v string) *DBSnapshot {
+	s.TdeCredentialArn = &v
+	return s
+}
+
+// SetTimezone sets the Timezone field's value.
+func (s *DBSnapshot) SetTimezone(v string) *DBSnapshot {
+	s.Timezone = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DBSnapshot) SetVpcId(v string) *DBSnapshot {
+	s.VpcId = &v
+	return s
+}
+
 // Contains the name and values of a manual DB snapshot attribute
 //
 // Manual DB snapshot attributes are used to authorize other AWS accounts to
@@ -11124,6 +13152,18 @@ func (s DBSnapshotAttribute) GoString() string {
 	return s.String()
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *DBSnapshotAttribute) SetAttributeName(v string) *DBSnapshotAttribute {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValues sets the AttributeValues field's value.
+func (s *DBSnapshotAttribute) SetAttributeValues(v []*string) *DBSnapshotAttribute {
+	s.AttributeValues = v
+	return s
+}
+
 // Contains the results of a successful call to the DescribeDBSnapshotAttributes
 // API action.
 //
@@ -11148,6 +13188,18 @@ func (s DBSnapshotAttributesResult) String() string {
 // GoString returns the string representation
 func (s DBSnapshotAttributesResult) GoString() string {
 	return s.String()
+}
+
+// SetDBSnapshotAttributes sets the DBSnapshotAttributes field's value.
+func (s *DBSnapshotAttributesResult) SetDBSnapshotAttributes(v []*DBSnapshotAttribute) *DBSnapshotAttributesResult {
+	s.DBSnapshotAttributes = v
+	return s
+}
+
+// SetDBSnapshotIdentifier sets the DBSnapshotIdentifier field's value.
+func (s *DBSnapshotAttributesResult) SetDBSnapshotIdentifier(v string) *DBSnapshotAttributesResult {
+	s.DBSnapshotIdentifier = &v
+	return s
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -11192,6 +13244,42 @@ func (s DBSubnetGroup) String() string {
 // GoString returns the string representation
 func (s DBSubnetGroup) GoString() string {
 	return s.String()
+}
+
+// SetDBSubnetGroupArn sets the DBSubnetGroupArn field's value.
+func (s *DBSubnetGroup) SetDBSubnetGroupArn(v string) *DBSubnetGroup {
+	s.DBSubnetGroupArn = &v
+	return s
+}
+
+// SetDBSubnetGroupDescription sets the DBSubnetGroupDescription field's value.
+func (s *DBSubnetGroup) SetDBSubnetGroupDescription(v string) *DBSubnetGroup {
+	s.DBSubnetGroupDescription = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *DBSubnetGroup) SetDBSubnetGroupName(v string) *DBSubnetGroup {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetSubnetGroupStatus sets the SubnetGroupStatus field's value.
+func (s *DBSubnetGroup) SetSubnetGroupStatus(v string) *DBSubnetGroup {
+	s.SubnetGroupStatus = &v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *DBSubnetGroup) SetSubnets(v []*Subnet) *DBSubnetGroup {
+	s.Subnets = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *DBSubnetGroup) SetVpcId(v string) *DBSubnetGroup {
+	s.VpcId = &v
+	return s
 }
 
 type DeleteDBClusterInput struct {
@@ -11260,6 +13348,24 @@ func (s *DeleteDBClusterInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *DeleteDBClusterInput) SetDBClusterIdentifier(v string) *DeleteDBClusterInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetFinalDBSnapshotIdentifier sets the FinalDBSnapshotIdentifier field's value.
+func (s *DeleteDBClusterInput) SetFinalDBSnapshotIdentifier(v string) *DeleteDBClusterInput {
+	s.FinalDBSnapshotIdentifier = &v
+	return s
+}
+
+// SetSkipFinalSnapshot sets the SkipFinalSnapshot field's value.
+func (s *DeleteDBClusterInput) SetSkipFinalSnapshot(v bool) *DeleteDBClusterInput {
+	s.SkipFinalSnapshot = &v
+	return s
+}
+
 type DeleteDBClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11289,6 +13395,12 @@ func (s DeleteDBClusterOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDBClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBCluster sets the DBCluster field's value.
+func (s *DeleteDBClusterOutput) SetDBCluster(v *DBCluster) *DeleteDBClusterOutput {
+	s.DBCluster = v
+	return s
 }
 
 type DeleteDBClusterParameterGroupInput struct {
@@ -11329,6 +13441,12 @@ func (s *DeleteDBClusterParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *DeleteDBClusterParameterGroupInput) SetDBClusterParameterGroupName(v string) *DeleteDBClusterParameterGroupInput {
+	s.DBClusterParameterGroupName = &v
+	return s
 }
 
 type DeleteDBClusterParameterGroupOutput struct {
@@ -11380,6 +13498,12 @@ func (s *DeleteDBClusterSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterSnapshotIdentifier sets the DBClusterSnapshotIdentifier field's value.
+func (s *DeleteDBClusterSnapshotInput) SetDBClusterSnapshotIdentifier(v string) *DeleteDBClusterSnapshotInput {
+	s.DBClusterSnapshotIdentifier = &v
+	return s
+}
+
 type DeleteDBClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11402,6 +13526,12 @@ func (s DeleteDBClusterSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDBClusterSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterSnapshot sets the DBClusterSnapshot field's value.
+func (s *DeleteDBClusterSnapshotOutput) SetDBClusterSnapshot(v *DBClusterSnapshot) *DeleteDBClusterSnapshotOutput {
+	s.DBClusterSnapshot = v
+	return s
 }
 
 type DeleteDBInstanceInput struct {
@@ -11478,6 +13608,24 @@ func (s *DeleteDBInstanceInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *DeleteDBInstanceInput) SetDBInstanceIdentifier(v string) *DeleteDBInstanceInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetFinalDBSnapshotIdentifier sets the FinalDBSnapshotIdentifier field's value.
+func (s *DeleteDBInstanceInput) SetFinalDBSnapshotIdentifier(v string) *DeleteDBInstanceInput {
+	s.FinalDBSnapshotIdentifier = &v
+	return s
+}
+
+// SetSkipFinalSnapshot sets the SkipFinalSnapshot field's value.
+func (s *DeleteDBInstanceInput) SetSkipFinalSnapshot(v bool) *DeleteDBInstanceInput {
+	s.SkipFinalSnapshot = &v
+	return s
+}
+
 type DeleteDBInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11501,6 +13649,12 @@ func (s DeleteDBInstanceOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDBInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBInstance sets the DBInstance field's value.
+func (s *DeleteDBInstanceOutput) SetDBInstance(v *DBInstance) *DeleteDBInstanceOutput {
+	s.DBInstance = v
+	return s
 }
 
 type DeleteDBParameterGroupInput struct {
@@ -11541,6 +13695,12 @@ func (s *DeleteDBParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *DeleteDBParameterGroupInput) SetDBParameterGroupName(v string) *DeleteDBParameterGroupInput {
+	s.DBParameterGroupName = &v
+	return s
 }
 
 type DeleteDBParameterGroupOutput struct {
@@ -11601,6 +13761,12 @@ func (s *DeleteDBSecurityGroupInput) Validate() error {
 	return nil
 }
 
+// SetDBSecurityGroupName sets the DBSecurityGroupName field's value.
+func (s *DeleteDBSecurityGroupInput) SetDBSecurityGroupName(v string) *DeleteDBSecurityGroupInput {
+	s.DBSecurityGroupName = &v
+	return s
+}
+
 type DeleteDBSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11650,6 +13816,12 @@ func (s *DeleteDBSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetDBSnapshotIdentifier sets the DBSnapshotIdentifier field's value.
+func (s *DeleteDBSnapshotInput) SetDBSnapshotIdentifier(v string) *DeleteDBSnapshotInput {
+	s.DBSnapshotIdentifier = &v
+	return s
+}
+
 type DeleteDBSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11671,6 +13843,12 @@ func (s DeleteDBSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDBSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSnapshot sets the DBSnapshot field's value.
+func (s *DeleteDBSnapshotOutput) SetDBSnapshot(v *DBSnapshot) *DeleteDBSnapshotOutput {
+	s.DBSnapshot = v
+	return s
 }
 
 type DeleteDBSubnetGroupInput struct {
@@ -11712,6 +13890,12 @@ func (s *DeleteDBSubnetGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *DeleteDBSubnetGroupInput) SetDBSubnetGroupName(v string) *DeleteDBSubnetGroupInput {
+	s.DBSubnetGroupName = &v
+	return s
 }
 
 type DeleteDBSubnetGroupOutput struct {
@@ -11760,6 +13944,12 @@ func (s *DeleteEventSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *DeleteEventSubscriptionInput) SetSubscriptionName(v string) *DeleteEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
 type DeleteEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11776,6 +13966,12 @@ func (s DeleteEventSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteEventSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *DeleteEventSubscriptionOutput) SetEventSubscription(v *EventSubscription) *DeleteEventSubscriptionOutput {
+	s.EventSubscription = v
+	return s
 }
 
 type DeleteOptionGroupInput struct {
@@ -11810,6 +14006,12 @@ func (s *DeleteOptionGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *DeleteOptionGroupInput) SetOptionGroupName(v string) *DeleteOptionGroupInput {
+	s.OptionGroupName = &v
+	return s
 }
 
 type DeleteOptionGroupOutput struct {
@@ -11857,6 +14059,12 @@ func (s DescribeAccountAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAccountAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccountQuotas sets the AccountQuotas field's value.
+func (s *DescribeAccountAttributesOutput) SetAccountQuotas(v []*AccountQuota) *DescribeAccountAttributesOutput {
+	s.AccountQuotas = v
+	return s
 }
 
 type DescribeCertificatesInput struct {
@@ -11923,6 +14131,30 @@ func (s *DescribeCertificatesInput) Validate() error {
 	return nil
 }
 
+// SetCertificateIdentifier sets the CertificateIdentifier field's value.
+func (s *DescribeCertificatesInput) SetCertificateIdentifier(v string) *DescribeCertificatesInput {
+	s.CertificateIdentifier = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeCertificatesInput) SetFilters(v []*Filter) *DescribeCertificatesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCertificatesInput) SetMarker(v string) *DescribeCertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeCertificatesInput) SetMaxRecords(v int64) *DescribeCertificatesInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Data returned by the DescribeCertificates action.
 type DescribeCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -11944,6 +14176,18 @@ func (s DescribeCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *DescribeCertificatesOutput) SetCertificates(v []*Certificate) *DescribeCertificatesOutput {
+	s.Certificates = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeCertificatesOutput) SetMarker(v string) *DescribeCertificatesOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBClusterParameterGroupsInput struct {
@@ -12008,6 +14252,30 @@ func (s *DescribeDBClusterParameterGroupsInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *DescribeDBClusterParameterGroupsInput) SetDBClusterParameterGroupName(v string) *DescribeDBClusterParameterGroupsInput {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBClusterParameterGroupsInput) SetFilters(v []*Filter) *DescribeDBClusterParameterGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBClusterParameterGroupsInput) SetMarker(v string) *DescribeDBClusterParameterGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBClusterParameterGroupsInput) SetMaxRecords(v int64) *DescribeDBClusterParameterGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeDBClusterParameterGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -12028,6 +14296,18 @@ func (s DescribeDBClusterParameterGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBClusterParameterGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterParameterGroups sets the DBClusterParameterGroups field's value.
+func (s *DescribeDBClusterParameterGroupsOutput) SetDBClusterParameterGroups(v []*DBClusterParameterGroup) *DescribeDBClusterParameterGroupsOutput {
+	s.DBClusterParameterGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBClusterParameterGroupsOutput) SetMarker(v string) *DescribeDBClusterParameterGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBClusterParametersInput struct {
@@ -12102,6 +14382,36 @@ func (s *DescribeDBClusterParametersInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *DescribeDBClusterParametersInput) SetDBClusterParameterGroupName(v string) *DescribeDBClusterParametersInput {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBClusterParametersInput) SetFilters(v []*Filter) *DescribeDBClusterParametersInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBClusterParametersInput) SetMarker(v string) *DescribeDBClusterParametersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBClusterParametersInput) SetMaxRecords(v int64) *DescribeDBClusterParametersInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *DescribeDBClusterParametersInput) SetSource(v string) *DescribeDBClusterParametersInput {
+	s.Source = &v
+	return s
+}
+
 // Provides details about a DB cluster parameter group including the parameters
 // in the DB cluster parameter group.
 type DescribeDBClusterParametersOutput struct {
@@ -12124,6 +14434,18 @@ func (s DescribeDBClusterParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBClusterParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBClusterParametersOutput) SetMarker(v string) *DescribeDBClusterParametersOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *DescribeDBClusterParametersOutput) SetParameters(v []*Parameter) *DescribeDBClusterParametersOutput {
+	s.Parameters = v
+	return s
 }
 
 type DescribeDBClusterSnapshotAttributesInput struct {
@@ -12158,6 +14480,12 @@ func (s *DescribeDBClusterSnapshotAttributesInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterSnapshotIdentifier sets the DBClusterSnapshotIdentifier field's value.
+func (s *DescribeDBClusterSnapshotAttributesInput) SetDBClusterSnapshotIdentifier(v string) *DescribeDBClusterSnapshotAttributesInput {
+	s.DBClusterSnapshotIdentifier = &v
+	return s
+}
+
 type DescribeDBClusterSnapshotAttributesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -12178,6 +14506,12 @@ func (s DescribeDBClusterSnapshotAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBClusterSnapshotAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterSnapshotAttributesResult sets the DBClusterSnapshotAttributesResult field's value.
+func (s *DescribeDBClusterSnapshotAttributesOutput) SetDBClusterSnapshotAttributesResult(v *DBClusterSnapshotAttributesResult) *DescribeDBClusterSnapshotAttributesOutput {
+	s.DBClusterSnapshotAttributesResult = v
+	return s
 }
 
 type DescribeDBClusterSnapshotsInput struct {
@@ -12302,6 +14636,54 @@ func (s *DescribeDBClusterSnapshotsInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *DescribeDBClusterSnapshotsInput) SetDBClusterIdentifier(v string) *DescribeDBClusterSnapshotsInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBClusterSnapshotIdentifier sets the DBClusterSnapshotIdentifier field's value.
+func (s *DescribeDBClusterSnapshotsInput) SetDBClusterSnapshotIdentifier(v string) *DescribeDBClusterSnapshotsInput {
+	s.DBClusterSnapshotIdentifier = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBClusterSnapshotsInput) SetFilters(v []*Filter) *DescribeDBClusterSnapshotsInput {
+	s.Filters = v
+	return s
+}
+
+// SetIncludePublic sets the IncludePublic field's value.
+func (s *DescribeDBClusterSnapshotsInput) SetIncludePublic(v bool) *DescribeDBClusterSnapshotsInput {
+	s.IncludePublic = &v
+	return s
+}
+
+// SetIncludeShared sets the IncludeShared field's value.
+func (s *DescribeDBClusterSnapshotsInput) SetIncludeShared(v bool) *DescribeDBClusterSnapshotsInput {
+	s.IncludeShared = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBClusterSnapshotsInput) SetMarker(v string) *DescribeDBClusterSnapshotsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBClusterSnapshotsInput) SetMaxRecords(v int64) *DescribeDBClusterSnapshotsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSnapshotType sets the SnapshotType field's value.
+func (s *DescribeDBClusterSnapshotsInput) SetSnapshotType(v string) *DescribeDBClusterSnapshotsInput {
+	s.SnapshotType = &v
+	return s
+}
+
 // Provides a list of DB cluster snapshots for the user as the result of a call
 // to the DescribeDBClusterSnapshots action.
 type DescribeDBClusterSnapshotsOutput struct {
@@ -12324,6 +14706,18 @@ func (s DescribeDBClusterSnapshotsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBClusterSnapshotsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterSnapshots sets the DBClusterSnapshots field's value.
+func (s *DescribeDBClusterSnapshotsOutput) SetDBClusterSnapshots(v []*DBClusterSnapshot) *DescribeDBClusterSnapshotsOutput {
+	s.DBClusterSnapshots = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBClusterSnapshotsOutput) SetMarker(v string) *DescribeDBClusterSnapshotsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBClustersInput struct {
@@ -12390,6 +14784,30 @@ func (s *DescribeDBClustersInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *DescribeDBClustersInput) SetDBClusterIdentifier(v string) *DescribeDBClustersInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBClustersInput) SetFilters(v []*Filter) *DescribeDBClustersInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBClustersInput) SetMarker(v string) *DescribeDBClustersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBClustersInput) SetMaxRecords(v int64) *DescribeDBClustersInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeDBClusters
 // action.
 type DescribeDBClustersOutput struct {
@@ -12410,6 +14828,18 @@ func (s DescribeDBClustersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBClustersOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusters sets the DBClusters field's value.
+func (s *DescribeDBClustersOutput) SetDBClusters(v []*DBCluster) *DescribeDBClustersOutput {
+	s.DBClusters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBClustersOutput) SetMarker(v string) *DescribeDBClustersOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBEngineVersionsInput struct {
@@ -12496,6 +14926,60 @@ func (s *DescribeDBEngineVersionsInput) Validate() error {
 	return nil
 }
 
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *DescribeDBEngineVersionsInput) SetDBParameterGroupFamily(v string) *DescribeDBEngineVersionsInput {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetDefaultOnly sets the DefaultOnly field's value.
+func (s *DescribeDBEngineVersionsInput) SetDefaultOnly(v bool) *DescribeDBEngineVersionsInput {
+	s.DefaultOnly = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *DescribeDBEngineVersionsInput) SetEngine(v string) *DescribeDBEngineVersionsInput {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *DescribeDBEngineVersionsInput) SetEngineVersion(v string) *DescribeDBEngineVersionsInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBEngineVersionsInput) SetFilters(v []*Filter) *DescribeDBEngineVersionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetListSupportedCharacterSets sets the ListSupportedCharacterSets field's value.
+func (s *DescribeDBEngineVersionsInput) SetListSupportedCharacterSets(v bool) *DescribeDBEngineVersionsInput {
+	s.ListSupportedCharacterSets = &v
+	return s
+}
+
+// SetListSupportedTimezones sets the ListSupportedTimezones field's value.
+func (s *DescribeDBEngineVersionsInput) SetListSupportedTimezones(v bool) *DescribeDBEngineVersionsInput {
+	s.ListSupportedTimezones = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBEngineVersionsInput) SetMarker(v string) *DescribeDBEngineVersionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBEngineVersionsInput) SetMaxRecords(v int64) *DescribeDBEngineVersionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeDBEngineVersions
 // action.
 type DescribeDBEngineVersionsOutput struct {
@@ -12518,6 +15002,18 @@ func (s DescribeDBEngineVersionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBEngineVersionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBEngineVersions sets the DBEngineVersions field's value.
+func (s *DescribeDBEngineVersionsOutput) SetDBEngineVersions(v []*DBEngineVersion) *DescribeDBEngineVersionsOutput {
+	s.DBEngineVersions = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBEngineVersionsOutput) SetMarker(v string) *DescribeDBEngineVersionsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBInstancesInput struct {
@@ -12583,6 +15079,30 @@ func (s *DescribeDBInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *DescribeDBInstancesInput) SetDBInstanceIdentifier(v string) *DescribeDBInstancesInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBInstancesInput) SetFilters(v []*Filter) *DescribeDBInstancesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBInstancesInput) SetMarker(v string) *DescribeDBInstancesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBInstancesInput) SetMaxRecords(v int64) *DescribeDBInstancesInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeDBInstances
 // action.
 type DescribeDBInstancesOutput struct {
@@ -12607,6 +15127,18 @@ func (s DescribeDBInstancesOutput) GoString() string {
 	return s.String()
 }
 
+// SetDBInstances sets the DBInstances field's value.
+func (s *DescribeDBInstancesOutput) SetDBInstances(v []*DBInstance) *DescribeDBInstancesOutput {
+	s.DBInstances = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBInstancesOutput) SetMarker(v string) *DescribeDBInstancesOutput {
+	s.Marker = &v
+	return s
+}
+
 // This data type is used as a response element to DescribeDBLogFiles.
 type DescribeDBLogFilesDetails struct {
 	_ struct{} `type:"structure"`
@@ -12629,6 +15161,24 @@ func (s DescribeDBLogFilesDetails) String() string {
 // GoString returns the string representation
 func (s DescribeDBLogFilesDetails) GoString() string {
 	return s.String()
+}
+
+// SetLastWritten sets the LastWritten field's value.
+func (s *DescribeDBLogFilesDetails) SetLastWritten(v int64) *DescribeDBLogFilesDetails {
+	s.LastWritten = &v
+	return s
+}
+
+// SetLogFileName sets the LogFileName field's value.
+func (s *DescribeDBLogFilesDetails) SetLogFileName(v string) *DescribeDBLogFilesDetails {
+	s.LogFileName = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *DescribeDBLogFilesDetails) SetSize(v int64) *DescribeDBLogFilesDetails {
+	s.Size = &v
+	return s
 }
 
 type DescribeDBLogFilesInput struct {
@@ -12706,6 +15256,48 @@ func (s *DescribeDBLogFilesInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *DescribeDBLogFilesInput) SetDBInstanceIdentifier(v string) *DescribeDBLogFilesInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetFileLastWritten sets the FileLastWritten field's value.
+func (s *DescribeDBLogFilesInput) SetFileLastWritten(v int64) *DescribeDBLogFilesInput {
+	s.FileLastWritten = &v
+	return s
+}
+
+// SetFileSize sets the FileSize field's value.
+func (s *DescribeDBLogFilesInput) SetFileSize(v int64) *DescribeDBLogFilesInput {
+	s.FileSize = &v
+	return s
+}
+
+// SetFilenameContains sets the FilenameContains field's value.
+func (s *DescribeDBLogFilesInput) SetFilenameContains(v string) *DescribeDBLogFilesInput {
+	s.FilenameContains = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBLogFilesInput) SetFilters(v []*Filter) *DescribeDBLogFilesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBLogFilesInput) SetMarker(v string) *DescribeDBLogFilesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBLogFilesInput) SetMaxRecords(v int64) *DescribeDBLogFilesInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // The response from a call to DescribeDBLogFiles.
 type DescribeDBLogFilesOutput struct {
 	_ struct{} `type:"structure"`
@@ -12725,6 +15317,18 @@ func (s DescribeDBLogFilesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBLogFilesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDescribeDBLogFiles sets the DescribeDBLogFiles field's value.
+func (s *DescribeDBLogFilesOutput) SetDescribeDBLogFiles(v []*DescribeDBLogFilesDetails) *DescribeDBLogFilesOutput {
+	s.DescribeDBLogFiles = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBLogFilesOutput) SetMarker(v string) *DescribeDBLogFilesOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBParameterGroupsInput struct {
@@ -12789,6 +15393,30 @@ func (s *DescribeDBParameterGroupsInput) Validate() error {
 	return nil
 }
 
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *DescribeDBParameterGroupsInput) SetDBParameterGroupName(v string) *DescribeDBParameterGroupsInput {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBParameterGroupsInput) SetFilters(v []*Filter) *DescribeDBParameterGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBParameterGroupsInput) SetMarker(v string) *DescribeDBParameterGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBParameterGroupsInput) SetMaxRecords(v int64) *DescribeDBParameterGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeDBParameterGroups
 // action.
 type DescribeDBParameterGroupsOutput struct {
@@ -12811,6 +15439,18 @@ func (s DescribeDBParameterGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBParameterGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBParameterGroups sets the DBParameterGroups field's value.
+func (s *DescribeDBParameterGroupsOutput) SetDBParameterGroups(v []*DBParameterGroup) *DescribeDBParameterGroupsOutput {
+	s.DBParameterGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBParameterGroupsOutput) SetMarker(v string) *DescribeDBParameterGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBParametersInput struct {
@@ -12887,6 +15527,36 @@ func (s *DescribeDBParametersInput) Validate() error {
 	return nil
 }
 
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *DescribeDBParametersInput) SetDBParameterGroupName(v string) *DescribeDBParametersInput {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBParametersInput) SetFilters(v []*Filter) *DescribeDBParametersInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBParametersInput) SetMarker(v string) *DescribeDBParametersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBParametersInput) SetMaxRecords(v int64) *DescribeDBParametersInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *DescribeDBParametersInput) SetSource(v string) *DescribeDBParametersInput {
+	s.Source = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeDBParameters
 // action.
 type DescribeDBParametersOutput struct {
@@ -12909,6 +15579,18 @@ func (s DescribeDBParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBParametersOutput) SetMarker(v string) *DescribeDBParametersOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *DescribeDBParametersOutput) SetParameters(v []*Parameter) *DescribeDBParametersOutput {
+	s.Parameters = v
+	return s
 }
 
 type DescribeDBSecurityGroupsInput struct {
@@ -12965,6 +15647,30 @@ func (s *DescribeDBSecurityGroupsInput) Validate() error {
 	return nil
 }
 
+// SetDBSecurityGroupName sets the DBSecurityGroupName field's value.
+func (s *DescribeDBSecurityGroupsInput) SetDBSecurityGroupName(v string) *DescribeDBSecurityGroupsInput {
+	s.DBSecurityGroupName = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBSecurityGroupsInput) SetFilters(v []*Filter) *DescribeDBSecurityGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBSecurityGroupsInput) SetMarker(v string) *DescribeDBSecurityGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBSecurityGroupsInput) SetMaxRecords(v int64) *DescribeDBSecurityGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeDBSecurityGroups
 // action.
 type DescribeDBSecurityGroupsOutput struct {
@@ -12987,6 +15693,18 @@ func (s DescribeDBSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSecurityGroups sets the DBSecurityGroups field's value.
+func (s *DescribeDBSecurityGroupsOutput) SetDBSecurityGroups(v []*DBSecurityGroup) *DescribeDBSecurityGroupsOutput {
+	s.DBSecurityGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBSecurityGroupsOutput) SetMarker(v string) *DescribeDBSecurityGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBSnapshotAttributesInput struct {
@@ -13021,6 +15739,12 @@ func (s *DescribeDBSnapshotAttributesInput) Validate() error {
 	return nil
 }
 
+// SetDBSnapshotIdentifier sets the DBSnapshotIdentifier field's value.
+func (s *DescribeDBSnapshotAttributesInput) SetDBSnapshotIdentifier(v string) *DescribeDBSnapshotAttributesInput {
+	s.DBSnapshotIdentifier = &v
+	return s
+}
+
 type DescribeDBSnapshotAttributesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -13041,6 +15765,12 @@ func (s DescribeDBSnapshotAttributesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBSnapshotAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSnapshotAttributesResult sets the DBSnapshotAttributesResult field's value.
+func (s *DescribeDBSnapshotAttributesOutput) SetDBSnapshotAttributesResult(v *DBSnapshotAttributesResult) *DescribeDBSnapshotAttributesOutput {
+	s.DBSnapshotAttributesResult = v
+	return s
 }
 
 type DescribeDBSnapshotsInput struct {
@@ -13164,6 +15894,54 @@ func (s *DescribeDBSnapshotsInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *DescribeDBSnapshotsInput) SetDBInstanceIdentifier(v string) *DescribeDBSnapshotsInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBSnapshotIdentifier sets the DBSnapshotIdentifier field's value.
+func (s *DescribeDBSnapshotsInput) SetDBSnapshotIdentifier(v string) *DescribeDBSnapshotsInput {
+	s.DBSnapshotIdentifier = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBSnapshotsInput) SetFilters(v []*Filter) *DescribeDBSnapshotsInput {
+	s.Filters = v
+	return s
+}
+
+// SetIncludePublic sets the IncludePublic field's value.
+func (s *DescribeDBSnapshotsInput) SetIncludePublic(v bool) *DescribeDBSnapshotsInput {
+	s.IncludePublic = &v
+	return s
+}
+
+// SetIncludeShared sets the IncludeShared field's value.
+func (s *DescribeDBSnapshotsInput) SetIncludeShared(v bool) *DescribeDBSnapshotsInput {
+	s.IncludeShared = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBSnapshotsInput) SetMarker(v string) *DescribeDBSnapshotsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBSnapshotsInput) SetMaxRecords(v int64) *DescribeDBSnapshotsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSnapshotType sets the SnapshotType field's value.
+func (s *DescribeDBSnapshotsInput) SetSnapshotType(v string) *DescribeDBSnapshotsInput {
+	s.SnapshotType = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeDBSnapshots
 // action.
 type DescribeDBSnapshotsOutput struct {
@@ -13186,6 +15964,18 @@ func (s DescribeDBSnapshotsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBSnapshotsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSnapshots sets the DBSnapshots field's value.
+func (s *DescribeDBSnapshotsOutput) SetDBSnapshots(v []*DBSnapshot) *DescribeDBSnapshotsOutput {
+	s.DBSnapshots = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBSnapshotsOutput) SetMarker(v string) *DescribeDBSnapshotsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDBSubnetGroupsInput struct {
@@ -13242,6 +16032,30 @@ func (s *DescribeDBSubnetGroupsInput) Validate() error {
 	return nil
 }
 
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *DescribeDBSubnetGroupsInput) SetDBSubnetGroupName(v string) *DescribeDBSubnetGroupsInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeDBSubnetGroupsInput) SetFilters(v []*Filter) *DescribeDBSubnetGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBSubnetGroupsInput) SetMarker(v string) *DescribeDBSubnetGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDBSubnetGroupsInput) SetMaxRecords(v int64) *DescribeDBSubnetGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeDBSubnetGroups
 // action.
 type DescribeDBSubnetGroupsOutput struct {
@@ -13264,6 +16078,18 @@ func (s DescribeDBSubnetGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDBSubnetGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSubnetGroups sets the DBSubnetGroups field's value.
+func (s *DescribeDBSubnetGroupsOutput) SetDBSubnetGroups(v []*DBSubnetGroup) *DescribeDBSubnetGroupsOutput {
+	s.DBSubnetGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeDBSubnetGroupsOutput) SetMarker(v string) *DescribeDBSubnetGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeEngineDefaultClusterParametersInput struct {
@@ -13326,6 +16152,30 @@ func (s *DescribeEngineDefaultClusterParametersInput) Validate() error {
 	return nil
 }
 
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *DescribeEngineDefaultClusterParametersInput) SetDBParameterGroupFamily(v string) *DescribeEngineDefaultClusterParametersInput {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeEngineDefaultClusterParametersInput) SetFilters(v []*Filter) *DescribeEngineDefaultClusterParametersInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEngineDefaultClusterParametersInput) SetMarker(v string) *DescribeEngineDefaultClusterParametersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEngineDefaultClusterParametersInput) SetMaxRecords(v int64) *DescribeEngineDefaultClusterParametersInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeEngineDefaultClusterParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -13342,6 +16192,12 @@ func (s DescribeEngineDefaultClusterParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEngineDefaultClusterParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetEngineDefaults sets the EngineDefaults field's value.
+func (s *DescribeEngineDefaultClusterParametersOutput) SetEngineDefaults(v *EngineDefaults) *DescribeEngineDefaultClusterParametersOutput {
+	s.EngineDefaults = v
+	return s
 }
 
 type DescribeEngineDefaultParametersInput struct {
@@ -13403,6 +16259,30 @@ func (s *DescribeEngineDefaultParametersInput) Validate() error {
 	return nil
 }
 
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *DescribeEngineDefaultParametersInput) SetDBParameterGroupFamily(v string) *DescribeEngineDefaultParametersInput {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeEngineDefaultParametersInput) SetFilters(v []*Filter) *DescribeEngineDefaultParametersInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEngineDefaultParametersInput) SetMarker(v string) *DescribeEngineDefaultParametersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEngineDefaultParametersInput) SetMaxRecords(v int64) *DescribeEngineDefaultParametersInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeEngineDefaultParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -13419,6 +16299,12 @@ func (s DescribeEngineDefaultParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEngineDefaultParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetEngineDefaults sets the EngineDefaults field's value.
+func (s *DescribeEngineDefaultParametersOutput) SetEngineDefaults(v *EngineDefaults) *DescribeEngineDefaultParametersOutput {
+	s.EngineDefaults = v
+	return s
 }
 
 type DescribeEventCategoriesInput struct {
@@ -13463,6 +16349,18 @@ func (s *DescribeEventCategoriesInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeEventCategoriesInput) SetFilters(v []*Filter) *DescribeEventCategoriesInput {
+	s.Filters = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *DescribeEventCategoriesInput) SetSourceType(v string) *DescribeEventCategoriesInput {
+	s.SourceType = &v
+	return s
+}
+
 // Data returned from the DescribeEventCategories action.
 type DescribeEventCategoriesOutput struct {
 	_ struct{} `type:"structure"`
@@ -13479,6 +16377,12 @@ func (s DescribeEventCategoriesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventCategoriesOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventCategoriesMapList sets the EventCategoriesMapList field's value.
+func (s *DescribeEventCategoriesOutput) SetEventCategoriesMapList(v []*EventCategoriesMap) *DescribeEventCategoriesOutput {
+	s.EventCategoriesMapList = v
+	return s
 }
 
 type DescribeEventSubscriptionsInput struct {
@@ -13535,6 +16439,30 @@ func (s *DescribeEventSubscriptionsInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeEventSubscriptionsInput) SetFilters(v []*Filter) *DescribeEventSubscriptionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventSubscriptionsInput) SetMarker(v string) *DescribeEventSubscriptionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEventSubscriptionsInput) SetMaxRecords(v int64) *DescribeEventSubscriptionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *DescribeEventSubscriptionsInput) SetSubscriptionName(v string) *DescribeEventSubscriptionsInput {
+	s.SubscriptionName = &v
+	return s
+}
+
 // Data returned by the DescribeEventSubscriptions action.
 type DescribeEventSubscriptionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13556,6 +16484,18 @@ func (s DescribeEventSubscriptionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventSubscriptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscriptionsList sets the EventSubscriptionsList field's value.
+func (s *DescribeEventSubscriptionsOutput) SetEventSubscriptionsList(v []*EventSubscription) *DescribeEventSubscriptionsOutput {
+	s.EventSubscriptionsList = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventSubscriptionsOutput) SetMarker(v string) *DescribeEventSubscriptionsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeEventsInput struct {
@@ -13657,6 +16597,60 @@ func (s *DescribeEventsInput) Validate() error {
 	return nil
 }
 
+// SetDuration sets the Duration field's value.
+func (s *DescribeEventsInput) SetDuration(v int64) *DescribeEventsInput {
+	s.Duration = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeEventsInput) SetEndTime(v time.Time) *DescribeEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *DescribeEventsInput) SetEventCategories(v []*string) *DescribeEventsInput {
+	s.EventCategories = v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeEventsInput) SetFilters(v []*Filter) *DescribeEventsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventsInput) SetMarker(v string) *DescribeEventsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEventsInput) SetMaxRecords(v int64) *DescribeEventsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *DescribeEventsInput) SetSourceIdentifier(v string) *DescribeEventsInput {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *DescribeEventsInput) SetSourceType(v string) *DescribeEventsInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeEventsInput) SetStartTime(v time.Time) *DescribeEventsInput {
+	s.StartTime = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeEvents action.
 type DescribeEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13678,6 +16672,18 @@ func (s DescribeEventsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *DescribeEventsOutput) SetEvents(v []*Event) *DescribeEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventsOutput) SetMarker(v string) *DescribeEventsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeOptionGroupOptionsInput struct {
@@ -13744,6 +16750,36 @@ func (s *DescribeOptionGroupOptionsInput) Validate() error {
 	return nil
 }
 
+// SetEngineName sets the EngineName field's value.
+func (s *DescribeOptionGroupOptionsInput) SetEngineName(v string) *DescribeOptionGroupOptionsInput {
+	s.EngineName = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeOptionGroupOptionsInput) SetFilters(v []*Filter) *DescribeOptionGroupOptionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMajorEngineVersion sets the MajorEngineVersion field's value.
+func (s *DescribeOptionGroupOptionsInput) SetMajorEngineVersion(v string) *DescribeOptionGroupOptionsInput {
+	s.MajorEngineVersion = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOptionGroupOptionsInput) SetMarker(v string) *DescribeOptionGroupOptionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeOptionGroupOptionsInput) SetMaxRecords(v int64) *DescribeOptionGroupOptionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 type DescribeOptionGroupOptionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -13764,6 +16800,18 @@ func (s DescribeOptionGroupOptionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeOptionGroupOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOptionGroupOptionsOutput) SetMarker(v string) *DescribeOptionGroupOptionsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetOptionGroupOptions sets the OptionGroupOptions field's value.
+func (s *DescribeOptionGroupOptionsOutput) SetOptionGroupOptions(v []*OptionGroupOption) *DescribeOptionGroupOptionsOutput {
+	s.OptionGroupOptions = v
+	return s
 }
 
 type DescribeOptionGroupsInput struct {
@@ -13830,6 +16878,42 @@ func (s *DescribeOptionGroupsInput) Validate() error {
 	return nil
 }
 
+// SetEngineName sets the EngineName field's value.
+func (s *DescribeOptionGroupsInput) SetEngineName(v string) *DescribeOptionGroupsInput {
+	s.EngineName = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeOptionGroupsInput) SetFilters(v []*Filter) *DescribeOptionGroupsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMajorEngineVersion sets the MajorEngineVersion field's value.
+func (s *DescribeOptionGroupsInput) SetMajorEngineVersion(v string) *DescribeOptionGroupsInput {
+	s.MajorEngineVersion = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOptionGroupsInput) SetMarker(v string) *DescribeOptionGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeOptionGroupsInput) SetMaxRecords(v int64) *DescribeOptionGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *DescribeOptionGroupsInput) SetOptionGroupName(v string) *DescribeOptionGroupsInput {
+	s.OptionGroupName = &v
+	return s
+}
+
 // List of option groups.
 type DescribeOptionGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13851,6 +16935,18 @@ func (s DescribeOptionGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeOptionGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOptionGroupsOutput) SetMarker(v string) *DescribeOptionGroupsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetOptionGroupsList sets the OptionGroupsList field's value.
+func (s *DescribeOptionGroupsOutput) SetOptionGroupsList(v []*OptionGroup) *DescribeOptionGroupsOutput {
+	s.OptionGroupsList = v
+	return s
 }
 
 type DescribeOrderableDBInstanceOptionsInput struct {
@@ -13928,6 +17024,54 @@ func (s *DescribeOrderableDBInstanceOptionsInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *DescribeOrderableDBInstanceOptionsInput) SetDBInstanceClass(v string) *DescribeOrderableDBInstanceOptionsInput {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *DescribeOrderableDBInstanceOptionsInput) SetEngine(v string) *DescribeOrderableDBInstanceOptionsInput {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *DescribeOrderableDBInstanceOptionsInput) SetEngineVersion(v string) *DescribeOrderableDBInstanceOptionsInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeOrderableDBInstanceOptionsInput) SetFilters(v []*Filter) *DescribeOrderableDBInstanceOptionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *DescribeOrderableDBInstanceOptionsInput) SetLicenseModel(v string) *DescribeOrderableDBInstanceOptionsInput {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOrderableDBInstanceOptionsInput) SetMarker(v string) *DescribeOrderableDBInstanceOptionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeOrderableDBInstanceOptionsInput) SetMaxRecords(v int64) *DescribeOrderableDBInstanceOptionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetVpc sets the Vpc field's value.
+func (s *DescribeOrderableDBInstanceOptionsInput) SetVpc(v bool) *DescribeOrderableDBInstanceOptionsInput {
+	s.Vpc = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeOrderableDBInstanceOptions
 // action.
 type DescribeOrderableDBInstanceOptionsOutput struct {
@@ -13951,6 +17095,18 @@ func (s DescribeOrderableDBInstanceOptionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeOrderableDBInstanceOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOrderableDBInstanceOptionsOutput) SetMarker(v string) *DescribeOrderableDBInstanceOptionsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetOrderableDBInstanceOptions sets the OrderableDBInstanceOptions field's value.
+func (s *DescribeOrderableDBInstanceOptionsOutput) SetOrderableDBInstanceOptions(v []*OrderableDBInstanceOption) *DescribeOrderableDBInstanceOptionsOutput {
+	s.OrderableDBInstanceOptions = v
+	return s
 }
 
 type DescribePendingMaintenanceActionsInput struct {
@@ -14014,6 +17170,30 @@ func (s *DescribePendingMaintenanceActionsInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribePendingMaintenanceActionsInput) SetFilters(v []*Filter) *DescribePendingMaintenanceActionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribePendingMaintenanceActionsInput) SetMarker(v string) *DescribePendingMaintenanceActionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribePendingMaintenanceActionsInput) SetMaxRecords(v int64) *DescribePendingMaintenanceActionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetResourceIdentifier sets the ResourceIdentifier field's value.
+func (s *DescribePendingMaintenanceActionsInput) SetResourceIdentifier(v string) *DescribePendingMaintenanceActionsInput {
+	s.ResourceIdentifier = &v
+	return s
+}
+
 // Data returned from the DescribePendingMaintenanceActions action.
 type DescribePendingMaintenanceActionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -14035,6 +17215,18 @@ func (s DescribePendingMaintenanceActionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribePendingMaintenanceActionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribePendingMaintenanceActionsOutput) SetMarker(v string) *DescribePendingMaintenanceActionsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetPendingMaintenanceActions sets the PendingMaintenanceActions field's value.
+func (s *DescribePendingMaintenanceActionsOutput) SetPendingMaintenanceActions(v []*ResourcePendingMaintenanceActions) *DescribePendingMaintenanceActionsOutput {
+	s.PendingMaintenanceActions = v
+	return s
 }
 
 type DescribeReservedDBInstancesInput struct {
@@ -14120,6 +17312,66 @@ func (s *DescribeReservedDBInstancesInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *DescribeReservedDBInstancesInput) SetDBInstanceClass(v string) *DescribeReservedDBInstancesInput {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *DescribeReservedDBInstancesInput) SetDuration(v string) *DescribeReservedDBInstancesInput {
+	s.Duration = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeReservedDBInstancesInput) SetFilters(v []*Filter) *DescribeReservedDBInstancesInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedDBInstancesInput) SetMarker(v string) *DescribeReservedDBInstancesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReservedDBInstancesInput) SetMaxRecords(v int64) *DescribeReservedDBInstancesInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *DescribeReservedDBInstancesInput) SetMultiAZ(v bool) *DescribeReservedDBInstancesInput {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DescribeReservedDBInstancesInput) SetOfferingType(v string) *DescribeReservedDBInstancesInput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *DescribeReservedDBInstancesInput) SetProductDescription(v string) *DescribeReservedDBInstancesInput {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetReservedDBInstanceId sets the ReservedDBInstanceId field's value.
+func (s *DescribeReservedDBInstancesInput) SetReservedDBInstanceId(v string) *DescribeReservedDBInstancesInput {
+	s.ReservedDBInstanceId = &v
+	return s
+}
+
+// SetReservedDBInstancesOfferingId sets the ReservedDBInstancesOfferingId field's value.
+func (s *DescribeReservedDBInstancesInput) SetReservedDBInstancesOfferingId(v string) *DescribeReservedDBInstancesInput {
+	s.ReservedDBInstancesOfferingId = &v
+	return s
+}
+
 type DescribeReservedDBInstancesOfferingsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -14201,6 +17453,60 @@ func (s *DescribeReservedDBInstancesOfferingsInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetDBInstanceClass(v string) *DescribeReservedDBInstancesOfferingsInput {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetDuration(v string) *DescribeReservedDBInstancesOfferingsInput {
+	s.Duration = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetFilters(v []*Filter) *DescribeReservedDBInstancesOfferingsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetMarker(v string) *DescribeReservedDBInstancesOfferingsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetMaxRecords(v int64) *DescribeReservedDBInstancesOfferingsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetMultiAZ(v bool) *DescribeReservedDBInstancesOfferingsInput {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetOfferingType(v string) *DescribeReservedDBInstancesOfferingsInput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetProductDescription(v string) *DescribeReservedDBInstancesOfferingsInput {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetReservedDBInstancesOfferingId sets the ReservedDBInstancesOfferingId field's value.
+func (s *DescribeReservedDBInstancesOfferingsInput) SetReservedDBInstancesOfferingId(v string) *DescribeReservedDBInstancesOfferingsInput {
+	s.ReservedDBInstancesOfferingId = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeReservedDBInstancesOfferings
 // action.
 type DescribeReservedDBInstancesOfferingsOutput struct {
@@ -14225,6 +17531,18 @@ func (s DescribeReservedDBInstancesOfferingsOutput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedDBInstancesOfferingsOutput) SetMarker(v string) *DescribeReservedDBInstancesOfferingsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReservedDBInstancesOfferings sets the ReservedDBInstancesOfferings field's value.
+func (s *DescribeReservedDBInstancesOfferingsOutput) SetReservedDBInstancesOfferings(v []*ReservedDBInstancesOffering) *DescribeReservedDBInstancesOfferingsOutput {
+	s.ReservedDBInstancesOfferings = v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeReservedDBInstances
 // action.
 type DescribeReservedDBInstancesOutput struct {
@@ -14247,6 +17565,18 @@ func (s DescribeReservedDBInstancesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReservedDBInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedDBInstancesOutput) SetMarker(v string) *DescribeReservedDBInstancesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReservedDBInstances sets the ReservedDBInstances field's value.
+func (s *DescribeReservedDBInstancesOutput) SetReservedDBInstances(v []*ReservedDBInstance) *DescribeReservedDBInstancesOutput {
+	s.ReservedDBInstances = v
+	return s
 }
 
 type DescribeSourceRegionsInput struct {
@@ -14307,6 +17637,30 @@ func (s *DescribeSourceRegionsInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeSourceRegionsInput) SetFilters(v []*Filter) *DescribeSourceRegionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeSourceRegionsInput) SetMarker(v string) *DescribeSourceRegionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeSourceRegionsInput) SetMaxRecords(v int64) *DescribeSourceRegionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *DescribeSourceRegionsInput) SetRegionName(v string) *DescribeSourceRegionsInput {
+	s.RegionName = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeSourceRegions
 // action.
 type DescribeSourceRegionsOutput struct {
@@ -14330,6 +17684,18 @@ func (s DescribeSourceRegionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSourceRegionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeSourceRegionsOutput) SetMarker(v string) *DescribeSourceRegionsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSourceRegions sets the SourceRegions field's value.
+func (s *DescribeSourceRegionsOutput) SetSourceRegions(v []*SourceRegion) *DescribeSourceRegionsOutput {
+	s.SourceRegions = v
+	return s
 }
 
 // An Active Directory Domain membership record associated with the DB instance.
@@ -14359,6 +17725,30 @@ func (s DomainMembership) String() string {
 // GoString returns the string representation
 func (s DomainMembership) GoString() string {
 	return s.String()
+}
+
+// SetDomain sets the Domain field's value.
+func (s *DomainMembership) SetDomain(v string) *DomainMembership {
+	s.Domain = &v
+	return s
+}
+
+// SetFQDN sets the FQDN field's value.
+func (s *DomainMembership) SetFQDN(v string) *DomainMembership {
+	s.FQDN = &v
+	return s
+}
+
+// SetIAMRoleName sets the IAMRoleName field's value.
+func (s *DomainMembership) SetIAMRoleName(v string) *DomainMembership {
+	s.IAMRoleName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DomainMembership) SetStatus(v string) *DomainMembership {
+	s.Status = &v
+	return s
 }
 
 type DownloadDBLogFilePortionInput struct {
@@ -14439,6 +17829,30 @@ func (s *DownloadDBLogFilePortionInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *DownloadDBLogFilePortionInput) SetDBInstanceIdentifier(v string) *DownloadDBLogFilePortionInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetLogFileName sets the LogFileName field's value.
+func (s *DownloadDBLogFilePortionInput) SetLogFileName(v string) *DownloadDBLogFilePortionInput {
+	s.LogFileName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DownloadDBLogFilePortionInput) SetMarker(v string) *DownloadDBLogFilePortionInput {
+	s.Marker = &v
+	return s
+}
+
+// SetNumberOfLines sets the NumberOfLines field's value.
+func (s *DownloadDBLogFilePortionInput) SetNumberOfLines(v int64) *DownloadDBLogFilePortionInput {
+	s.NumberOfLines = &v
+	return s
+}
+
 // This data type is used as a response element to DownloadDBLogFilePortion.
 type DownloadDBLogFilePortionOutput struct {
 	_ struct{} `type:"structure"`
@@ -14462,6 +17876,24 @@ func (s DownloadDBLogFilePortionOutput) String() string {
 // GoString returns the string representation
 func (s DownloadDBLogFilePortionOutput) GoString() string {
 	return s.String()
+}
+
+// SetAdditionalDataPending sets the AdditionalDataPending field's value.
+func (s *DownloadDBLogFilePortionOutput) SetAdditionalDataPending(v bool) *DownloadDBLogFilePortionOutput {
+	s.AdditionalDataPending = &v
+	return s
+}
+
+// SetLogFileData sets the LogFileData field's value.
+func (s *DownloadDBLogFilePortionOutput) SetLogFileData(v string) *DownloadDBLogFilePortionOutput {
+	s.LogFileData = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DownloadDBLogFilePortionOutput) SetMarker(v string) *DownloadDBLogFilePortionOutput {
+	s.Marker = &v
+	return s
 }
 
 // This data type is used as a response element in the following actions:
@@ -14499,6 +17931,30 @@ func (s EC2SecurityGroup) GoString() string {
 	return s.String()
 }
 
+// SetEC2SecurityGroupId sets the EC2SecurityGroupId field's value.
+func (s *EC2SecurityGroup) SetEC2SecurityGroupId(v string) *EC2SecurityGroup {
+	s.EC2SecurityGroupId = &v
+	return s
+}
+
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *EC2SecurityGroup) SetEC2SecurityGroupName(v string) *EC2SecurityGroup {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *EC2SecurityGroup) SetEC2SecurityGroupOwnerId(v string) *EC2SecurityGroup {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EC2SecurityGroup) SetStatus(v string) *EC2SecurityGroup {
+	s.Status = &v
+	return s
+}
+
 // This data type is used as a response element in the following actions:
 //
 //    * CreateDBInstance
@@ -14529,6 +17985,24 @@ func (s Endpoint) GoString() string {
 	return s.String()
 }
 
+// SetAddress sets the Address field's value.
+func (s *Endpoint) SetAddress(v string) *Endpoint {
+	s.Address = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *Endpoint) SetHostedZoneId(v string) *Endpoint {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *Endpoint) SetPort(v int64) *Endpoint {
+	s.Port = &v
+	return s
+}
+
 // Contains the result of a successful invocation of the DescribeEngineDefaultParameters
 // action.
 type EngineDefaults struct {
@@ -14555,6 +18029,24 @@ func (s EngineDefaults) String() string {
 // GoString returns the string representation
 func (s EngineDefaults) GoString() string {
 	return s.String()
+}
+
+// SetDBParameterGroupFamily sets the DBParameterGroupFamily field's value.
+func (s *EngineDefaults) SetDBParameterGroupFamily(v string) *EngineDefaults {
+	s.DBParameterGroupFamily = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *EngineDefaults) SetMarker(v string) *EngineDefaults {
+	s.Marker = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *EngineDefaults) SetParameters(v []*Parameter) *EngineDefaults {
+	s.Parameters = v
+	return s
 }
 
 // This data type is used as a response element in the DescribeEvents action.
@@ -14590,6 +18082,42 @@ func (s Event) GoString() string {
 	return s.String()
 }
 
+// SetDate sets the Date field's value.
+func (s *Event) SetDate(v time.Time) *Event {
+	s.Date = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *Event) SetEventCategories(v []*string) *Event {
+	s.EventCategories = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Event) SetMessage(v string) *Event {
+	s.Message = &v
+	return s
+}
+
+// SetSourceArn sets the SourceArn field's value.
+func (s *Event) SetSourceArn(v string) *Event {
+	s.SourceArn = &v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *Event) SetSourceIdentifier(v string) *Event {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *Event) SetSourceType(v string) *Event {
+	s.SourceType = &v
+	return s
+}
+
 // Contains the results of a successful invocation of the DescribeEventCategories
 // action.
 type EventCategoriesMap struct {
@@ -14610,6 +18138,18 @@ func (s EventCategoriesMap) String() string {
 // GoString returns the string representation
 func (s EventCategoriesMap) GoString() string {
 	return s.String()
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *EventCategoriesMap) SetEventCategories(v []*string) *EventCategoriesMap {
+	s.EventCategories = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *EventCategoriesMap) SetSourceType(v string) *EventCategoriesMap {
+	s.SourceType = &v
+	return s
 }
 
 // Contains the results of a successful invocation of the DescribeEventSubscriptions
@@ -14668,6 +18208,66 @@ func (s EventSubscription) GoString() string {
 	return s.String()
 }
 
+// SetCustSubscriptionId sets the CustSubscriptionId field's value.
+func (s *EventSubscription) SetCustSubscriptionId(v string) *EventSubscription {
+	s.CustSubscriptionId = &v
+	return s
+}
+
+// SetCustomerAwsId sets the CustomerAwsId field's value.
+func (s *EventSubscription) SetCustomerAwsId(v string) *EventSubscription {
+	s.CustomerAwsId = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *EventSubscription) SetEnabled(v bool) *EventSubscription {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategoriesList sets the EventCategoriesList field's value.
+func (s *EventSubscription) SetEventCategoriesList(v []*string) *EventSubscription {
+	s.EventCategoriesList = v
+	return s
+}
+
+// SetEventSubscriptionArn sets the EventSubscriptionArn field's value.
+func (s *EventSubscription) SetEventSubscriptionArn(v string) *EventSubscription {
+	s.EventSubscriptionArn = &v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *EventSubscription) SetSnsTopicArn(v string) *EventSubscription {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceIdsList sets the SourceIdsList field's value.
+func (s *EventSubscription) SetSourceIdsList(v []*string) *EventSubscription {
+	s.SourceIdsList = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *EventSubscription) SetSourceType(v string) *EventSubscription {
+	s.SourceType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EventSubscription) SetStatus(v string) *EventSubscription {
+	s.Status = &v
+	return s
+}
+
+// SetSubscriptionCreationTime sets the SubscriptionCreationTime field's value.
+func (s *EventSubscription) SetSubscriptionCreationTime(v string) *EventSubscription {
+	s.SubscriptionCreationTime = &v
+	return s
+}
+
 type FailoverDBClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -14699,6 +18299,18 @@ func (s FailoverDBClusterInput) GoString() string {
 	return s.String()
 }
 
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *FailoverDBClusterInput) SetDBClusterIdentifier(v string) *FailoverDBClusterInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetTargetDBInstanceIdentifier sets the TargetDBInstanceIdentifier field's value.
+func (s *FailoverDBClusterInput) SetTargetDBInstanceIdentifier(v string) *FailoverDBClusterInput {
+	s.TargetDBInstanceIdentifier = &v
+	return s
+}
+
 type FailoverDBClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -14728,6 +18340,12 @@ func (s FailoverDBClusterOutput) String() string {
 // GoString returns the string representation
 func (s FailoverDBClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBCluster sets the DBCluster field's value.
+func (s *FailoverDBClusterOutput) SetDBCluster(v *DBCluster) *FailoverDBClusterOutput {
+	s.DBCluster = v
+	return s
 }
 
 // This type is not currently supported.
@@ -14771,6 +18389,18 @@ func (s *Filter) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *Filter) SetName(v string) *Filter {
+	s.Name = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *Filter) SetValues(v []*string) *Filter {
+	s.Values = v
+	return s
+}
+
 // This data type is used as a response element in the DescribeDBSecurityGroups
 // action.
 type IPRange struct {
@@ -14792,6 +18422,18 @@ func (s IPRange) String() string {
 // GoString returns the string representation
 func (s IPRange) GoString() string {
 	return s.String()
+}
+
+// SetCIDRIP sets the CIDRIP field's value.
+func (s *IPRange) SetCIDRIP(v string) *IPRange {
+	s.CIDRIP = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *IPRange) SetStatus(v string) *IPRange {
+	s.Status = &v
+	return s
 }
 
 type ListTagsForResourceInput struct {
@@ -14841,6 +18483,18 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *ListTagsForResourceInput) SetFilters(v []*Filter) *ListTagsForResourceInput {
+	s.Filters = v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *ListTagsForResourceInput) SetResourceName(v string) *ListTagsForResourceInput {
+	s.ResourceName = &v
+	return s
+}
+
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -14856,6 +18510,12 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagList sets the TagList field's value.
+func (s *ListTagsForResourceOutput) SetTagList(v []*Tag) *ListTagsForResourceOutput {
+	s.TagList = v
+	return s
 }
 
 type ModifyDBClusterInput struct {
@@ -15006,6 +18666,72 @@ func (s *ModifyDBClusterInput) Validate() error {
 	return nil
 }
 
+// SetApplyImmediately sets the ApplyImmediately field's value.
+func (s *ModifyDBClusterInput) SetApplyImmediately(v bool) *ModifyDBClusterInput {
+	s.ApplyImmediately = &v
+	return s
+}
+
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *ModifyDBClusterInput) SetBackupRetentionPeriod(v int64) *ModifyDBClusterInput {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *ModifyDBClusterInput) SetDBClusterIdentifier(v string) *ModifyDBClusterInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *ModifyDBClusterInput) SetDBClusterParameterGroupName(v string) *ModifyDBClusterInput {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *ModifyDBClusterInput) SetMasterUserPassword(v string) *ModifyDBClusterInput {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetNewDBClusterIdentifier sets the NewDBClusterIdentifier field's value.
+func (s *ModifyDBClusterInput) SetNewDBClusterIdentifier(v string) *ModifyDBClusterInput {
+	s.NewDBClusterIdentifier = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *ModifyDBClusterInput) SetOptionGroupName(v string) *ModifyDBClusterInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *ModifyDBClusterInput) SetPort(v int64) *ModifyDBClusterInput {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredBackupWindow sets the PreferredBackupWindow field's value.
+func (s *ModifyDBClusterInput) SetPreferredBackupWindow(v string) *ModifyDBClusterInput {
+	s.PreferredBackupWindow = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *ModifyDBClusterInput) SetPreferredMaintenanceWindow(v string) *ModifyDBClusterInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *ModifyDBClusterInput) SetVpcSecurityGroupIds(v []*string) *ModifyDBClusterInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type ModifyDBClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -15035,6 +18761,12 @@ func (s ModifyDBClusterOutput) String() string {
 // GoString returns the string representation
 func (s ModifyDBClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBCluster sets the DBCluster field's value.
+func (s *ModifyDBClusterOutput) SetDBCluster(v *DBCluster) *ModifyDBClusterOutput {
+	s.DBCluster = v
+	return s
 }
 
 type ModifyDBClusterParameterGroupInput struct {
@@ -15075,6 +18807,18 @@ func (s *ModifyDBClusterParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *ModifyDBClusterParameterGroupInput) SetDBClusterParameterGroupName(v string) *ModifyDBClusterParameterGroupInput {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ModifyDBClusterParameterGroupInput) SetParameters(v []*Parameter) *ModifyDBClusterParameterGroupInput {
+	s.Parameters = v
+	return s
 }
 
 type ModifyDBClusterSnapshotAttributeInput struct {
@@ -15141,6 +18885,30 @@ func (s *ModifyDBClusterSnapshotAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *ModifyDBClusterSnapshotAttributeInput) SetAttributeName(v string) *ModifyDBClusterSnapshotAttributeInput {
+	s.AttributeName = &v
+	return s
+}
+
+// SetDBClusterSnapshotIdentifier sets the DBClusterSnapshotIdentifier field's value.
+func (s *ModifyDBClusterSnapshotAttributeInput) SetDBClusterSnapshotIdentifier(v string) *ModifyDBClusterSnapshotAttributeInput {
+	s.DBClusterSnapshotIdentifier = &v
+	return s
+}
+
+// SetValuesToAdd sets the ValuesToAdd field's value.
+func (s *ModifyDBClusterSnapshotAttributeInput) SetValuesToAdd(v []*string) *ModifyDBClusterSnapshotAttributeInput {
+	s.ValuesToAdd = v
+	return s
+}
+
+// SetValuesToRemove sets the ValuesToRemove field's value.
+func (s *ModifyDBClusterSnapshotAttributeInput) SetValuesToRemove(v []*string) *ModifyDBClusterSnapshotAttributeInput {
+	s.ValuesToRemove = v
+	return s
+}
+
 type ModifyDBClusterSnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -15161,6 +18929,12 @@ func (s ModifyDBClusterSnapshotAttributeOutput) String() string {
 // GoString returns the string representation
 func (s ModifyDBClusterSnapshotAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBClusterSnapshotAttributesResult sets the DBClusterSnapshotAttributesResult field's value.
+func (s *ModifyDBClusterSnapshotAttributeOutput) SetDBClusterSnapshotAttributesResult(v *DBClusterSnapshotAttributesResult) *ModifyDBClusterSnapshotAttributeOutput {
+	s.DBClusterSnapshotAttributesResult = v
+	return s
 }
 
 type ModifyDBInstanceInput struct {
@@ -15667,6 +19441,198 @@ func (s *ModifyDBInstanceInput) Validate() error {
 	return nil
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *ModifyDBInstanceInput) SetAllocatedStorage(v int64) *ModifyDBInstanceInput {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetAllowMajorVersionUpgrade sets the AllowMajorVersionUpgrade field's value.
+func (s *ModifyDBInstanceInput) SetAllowMajorVersionUpgrade(v bool) *ModifyDBInstanceInput {
+	s.AllowMajorVersionUpgrade = &v
+	return s
+}
+
+// SetApplyImmediately sets the ApplyImmediately field's value.
+func (s *ModifyDBInstanceInput) SetApplyImmediately(v bool) *ModifyDBInstanceInput {
+	s.ApplyImmediately = &v
+	return s
+}
+
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *ModifyDBInstanceInput) SetAutoMinorVersionUpgrade(v bool) *ModifyDBInstanceInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *ModifyDBInstanceInput) SetBackupRetentionPeriod(v int64) *ModifyDBInstanceInput {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetCACertificateIdentifier sets the CACertificateIdentifier field's value.
+func (s *ModifyDBInstanceInput) SetCACertificateIdentifier(v string) *ModifyDBInstanceInput {
+	s.CACertificateIdentifier = &v
+	return s
+}
+
+// SetCopyTagsToSnapshot sets the CopyTagsToSnapshot field's value.
+func (s *ModifyDBInstanceInput) SetCopyTagsToSnapshot(v bool) *ModifyDBInstanceInput {
+	s.CopyTagsToSnapshot = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *ModifyDBInstanceInput) SetDBInstanceClass(v string) *ModifyDBInstanceInput {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *ModifyDBInstanceInput) SetDBInstanceIdentifier(v string) *ModifyDBInstanceInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *ModifyDBInstanceInput) SetDBParameterGroupName(v string) *ModifyDBInstanceInput {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetDBPortNumber sets the DBPortNumber field's value.
+func (s *ModifyDBInstanceInput) SetDBPortNumber(v int64) *ModifyDBInstanceInput {
+	s.DBPortNumber = &v
+	return s
+}
+
+// SetDBSecurityGroups sets the DBSecurityGroups field's value.
+func (s *ModifyDBInstanceInput) SetDBSecurityGroups(v []*string) *ModifyDBInstanceInput {
+	s.DBSecurityGroups = v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *ModifyDBInstanceInput) SetDBSubnetGroupName(v string) *ModifyDBInstanceInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *ModifyDBInstanceInput) SetDomain(v string) *ModifyDBInstanceInput {
+	s.Domain = &v
+	return s
+}
+
+// SetDomainIAMRoleName sets the DomainIAMRoleName field's value.
+func (s *ModifyDBInstanceInput) SetDomainIAMRoleName(v string) *ModifyDBInstanceInput {
+	s.DomainIAMRoleName = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *ModifyDBInstanceInput) SetEngineVersion(v string) *ModifyDBInstanceInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *ModifyDBInstanceInput) SetIops(v int64) *ModifyDBInstanceInput {
+	s.Iops = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *ModifyDBInstanceInput) SetLicenseModel(v string) *ModifyDBInstanceInput {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *ModifyDBInstanceInput) SetMasterUserPassword(v string) *ModifyDBInstanceInput {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetMonitoringInterval sets the MonitoringInterval field's value.
+func (s *ModifyDBInstanceInput) SetMonitoringInterval(v int64) *ModifyDBInstanceInput {
+	s.MonitoringInterval = &v
+	return s
+}
+
+// SetMonitoringRoleArn sets the MonitoringRoleArn field's value.
+func (s *ModifyDBInstanceInput) SetMonitoringRoleArn(v string) *ModifyDBInstanceInput {
+	s.MonitoringRoleArn = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *ModifyDBInstanceInput) SetMultiAZ(v bool) *ModifyDBInstanceInput {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetNewDBInstanceIdentifier sets the NewDBInstanceIdentifier field's value.
+func (s *ModifyDBInstanceInput) SetNewDBInstanceIdentifier(v string) *ModifyDBInstanceInput {
+	s.NewDBInstanceIdentifier = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *ModifyDBInstanceInput) SetOptionGroupName(v string) *ModifyDBInstanceInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPreferredBackupWindow sets the PreferredBackupWindow field's value.
+func (s *ModifyDBInstanceInput) SetPreferredBackupWindow(v string) *ModifyDBInstanceInput {
+	s.PreferredBackupWindow = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *ModifyDBInstanceInput) SetPreferredMaintenanceWindow(v string) *ModifyDBInstanceInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPromotionTier sets the PromotionTier field's value.
+func (s *ModifyDBInstanceInput) SetPromotionTier(v int64) *ModifyDBInstanceInput {
+	s.PromotionTier = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *ModifyDBInstanceInput) SetPubliclyAccessible(v bool) *ModifyDBInstanceInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *ModifyDBInstanceInput) SetStorageType(v string) *ModifyDBInstanceInput {
+	s.StorageType = &v
+	return s
+}
+
+// SetTdeCredentialArn sets the TdeCredentialArn field's value.
+func (s *ModifyDBInstanceInput) SetTdeCredentialArn(v string) *ModifyDBInstanceInput {
+	s.TdeCredentialArn = &v
+	return s
+}
+
+// SetTdeCredentialPassword sets the TdeCredentialPassword field's value.
+func (s *ModifyDBInstanceInput) SetTdeCredentialPassword(v string) *ModifyDBInstanceInput {
+	s.TdeCredentialPassword = &v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *ModifyDBInstanceInput) SetVpcSecurityGroupIds(v []*string) *ModifyDBInstanceInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type ModifyDBInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -15690,6 +19656,12 @@ func (s ModifyDBInstanceOutput) String() string {
 // GoString returns the string representation
 func (s ModifyDBInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBInstance sets the DBInstance field's value.
+func (s *ModifyDBInstanceOutput) SetDBInstance(v *DBInstance) *ModifyDBInstanceOutput {
+	s.DBInstance = v
+	return s
 }
 
 type ModifyDBParameterGroupInput struct {
@@ -15749,6 +19721,18 @@ func (s *ModifyDBParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *ModifyDBParameterGroupInput) SetDBParameterGroupName(v string) *ModifyDBParameterGroupInput {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ModifyDBParameterGroupInput) SetParameters(v []*Parameter) *ModifyDBParameterGroupInput {
+	s.Parameters = v
+	return s
 }
 
 type ModifyDBSnapshotAttributeInput struct {
@@ -15813,6 +19797,30 @@ func (s *ModifyDBSnapshotAttributeInput) Validate() error {
 	return nil
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *ModifyDBSnapshotAttributeInput) SetAttributeName(v string) *ModifyDBSnapshotAttributeInput {
+	s.AttributeName = &v
+	return s
+}
+
+// SetDBSnapshotIdentifier sets the DBSnapshotIdentifier field's value.
+func (s *ModifyDBSnapshotAttributeInput) SetDBSnapshotIdentifier(v string) *ModifyDBSnapshotAttributeInput {
+	s.DBSnapshotIdentifier = &v
+	return s
+}
+
+// SetValuesToAdd sets the ValuesToAdd field's value.
+func (s *ModifyDBSnapshotAttributeInput) SetValuesToAdd(v []*string) *ModifyDBSnapshotAttributeInput {
+	s.ValuesToAdd = v
+	return s
+}
+
+// SetValuesToRemove sets the ValuesToRemove field's value.
+func (s *ModifyDBSnapshotAttributeInput) SetValuesToRemove(v []*string) *ModifyDBSnapshotAttributeInput {
+	s.ValuesToRemove = v
+	return s
+}
+
 type ModifyDBSnapshotAttributeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -15833,6 +19841,12 @@ func (s ModifyDBSnapshotAttributeOutput) String() string {
 // GoString returns the string representation
 func (s ModifyDBSnapshotAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSnapshotAttributesResult sets the DBSnapshotAttributesResult field's value.
+func (s *ModifyDBSnapshotAttributeOutput) SetDBSnapshotAttributesResult(v *DBSnapshotAttributesResult) *ModifyDBSnapshotAttributeOutput {
+	s.DBSnapshotAttributesResult = v
+	return s
 }
 
 type ModifyDBSubnetGroupInput struct {
@@ -15883,6 +19897,24 @@ func (s *ModifyDBSubnetGroupInput) Validate() error {
 	return nil
 }
 
+// SetDBSubnetGroupDescription sets the DBSubnetGroupDescription field's value.
+func (s *ModifyDBSubnetGroupInput) SetDBSubnetGroupDescription(v string) *ModifyDBSubnetGroupInput {
+	s.DBSubnetGroupDescription = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *ModifyDBSubnetGroupInput) SetDBSubnetGroupName(v string) *ModifyDBSubnetGroupInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *ModifyDBSubnetGroupInput) SetSubnetIds(v []*string) *ModifyDBSubnetGroupInput {
+	s.SubnetIds = v
+	return s
+}
+
 type ModifyDBSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -15909,6 +19941,12 @@ func (s ModifyDBSubnetGroupOutput) String() string {
 // GoString returns the string representation
 func (s ModifyDBSubnetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBSubnetGroup sets the DBSubnetGroup field's value.
+func (s *ModifyDBSubnetGroupOutput) SetDBSubnetGroup(v *DBSubnetGroup) *ModifyDBSubnetGroupOutput {
+	s.DBSubnetGroup = v
+	return s
 }
 
 type ModifyEventSubscriptionInput struct {
@@ -15966,6 +20004,36 @@ func (s *ModifyEventSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *ModifyEventSubscriptionInput) SetEnabled(v bool) *ModifyEventSubscriptionInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *ModifyEventSubscriptionInput) SetEventCategories(v []*string) *ModifyEventSubscriptionInput {
+	s.EventCategories = v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *ModifyEventSubscriptionInput) SetSnsTopicArn(v string) *ModifyEventSubscriptionInput {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *ModifyEventSubscriptionInput) SetSourceType(v string) *ModifyEventSubscriptionInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *ModifyEventSubscriptionInput) SetSubscriptionName(v string) *ModifyEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
 type ModifyEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -15982,6 +20050,12 @@ func (s ModifyEventSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s ModifyEventSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *ModifyEventSubscriptionOutput) SetEventSubscription(v *EventSubscription) *ModifyEventSubscriptionOutput {
+	s.EventSubscription = v
+	return s
 }
 
 type ModifyOptionGroupInput struct {
@@ -16041,6 +20115,30 @@ func (s *ModifyOptionGroupInput) Validate() error {
 	return nil
 }
 
+// SetApplyImmediately sets the ApplyImmediately field's value.
+func (s *ModifyOptionGroupInput) SetApplyImmediately(v bool) *ModifyOptionGroupInput {
+	s.ApplyImmediately = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *ModifyOptionGroupInput) SetOptionGroupName(v string) *ModifyOptionGroupInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetOptionsToInclude sets the OptionsToInclude field's value.
+func (s *ModifyOptionGroupInput) SetOptionsToInclude(v []*OptionConfiguration) *ModifyOptionGroupInput {
+	s.OptionsToInclude = v
+	return s
+}
+
+// SetOptionsToRemove sets the OptionsToRemove field's value.
+func (s *ModifyOptionGroupInput) SetOptionsToRemove(v []*string) *ModifyOptionGroupInput {
+	s.OptionsToRemove = v
+	return s
+}
+
 type ModifyOptionGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -16055,6 +20153,12 @@ func (s ModifyOptionGroupOutput) String() string {
 // GoString returns the string representation
 func (s ModifyOptionGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetOptionGroup sets the OptionGroup field's value.
+func (s *ModifyOptionGroupOutput) SetOptionGroup(v *OptionGroup) *ModifyOptionGroupOutput {
+	s.OptionGroup = v
+	return s
 }
 
 // Option details.
@@ -16099,6 +20203,60 @@ func (s Option) String() string {
 // GoString returns the string representation
 func (s Option) GoString() string {
 	return s.String()
+}
+
+// SetDBSecurityGroupMemberships sets the DBSecurityGroupMemberships field's value.
+func (s *Option) SetDBSecurityGroupMemberships(v []*DBSecurityGroupMembership) *Option {
+	s.DBSecurityGroupMemberships = v
+	return s
+}
+
+// SetOptionDescription sets the OptionDescription field's value.
+func (s *Option) SetOptionDescription(v string) *Option {
+	s.OptionDescription = &v
+	return s
+}
+
+// SetOptionName sets the OptionName field's value.
+func (s *Option) SetOptionName(v string) *Option {
+	s.OptionName = &v
+	return s
+}
+
+// SetOptionSettings sets the OptionSettings field's value.
+func (s *Option) SetOptionSettings(v []*OptionSetting) *Option {
+	s.OptionSettings = v
+	return s
+}
+
+// SetOptionVersion sets the OptionVersion field's value.
+func (s *Option) SetOptionVersion(v string) *Option {
+	s.OptionVersion = &v
+	return s
+}
+
+// SetPermanent sets the Permanent field's value.
+func (s *Option) SetPermanent(v bool) *Option {
+	s.Permanent = &v
+	return s
+}
+
+// SetPersistent sets the Persistent field's value.
+func (s *Option) SetPersistent(v bool) *Option {
+	s.Persistent = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *Option) SetPort(v int64) *Option {
+	s.Port = &v
+	return s
+}
+
+// SetVpcSecurityGroupMemberships sets the VpcSecurityGroupMemberships field's value.
+func (s *Option) SetVpcSecurityGroupMemberships(v []*VpcSecurityGroupMembership) *Option {
+	s.VpcSecurityGroupMemberships = v
+	return s
 }
 
 // A list of all available options
@@ -16149,6 +20307,42 @@ func (s *OptionConfiguration) Validate() error {
 	return nil
 }
 
+// SetDBSecurityGroupMemberships sets the DBSecurityGroupMemberships field's value.
+func (s *OptionConfiguration) SetDBSecurityGroupMemberships(v []*string) *OptionConfiguration {
+	s.DBSecurityGroupMemberships = v
+	return s
+}
+
+// SetOptionName sets the OptionName field's value.
+func (s *OptionConfiguration) SetOptionName(v string) *OptionConfiguration {
+	s.OptionName = &v
+	return s
+}
+
+// SetOptionSettings sets the OptionSettings field's value.
+func (s *OptionConfiguration) SetOptionSettings(v []*OptionSetting) *OptionConfiguration {
+	s.OptionSettings = v
+	return s
+}
+
+// SetOptionVersion sets the OptionVersion field's value.
+func (s *OptionConfiguration) SetOptionVersion(v string) *OptionConfiguration {
+	s.OptionVersion = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *OptionConfiguration) SetPort(v int64) *OptionConfiguration {
+	s.Port = &v
+	return s
+}
+
+// SetVpcSecurityGroupMemberships sets the VpcSecurityGroupMemberships field's value.
+func (s *OptionConfiguration) SetVpcSecurityGroupMemberships(v []*string) *OptionConfiguration {
+	s.VpcSecurityGroupMemberships = v
+	return s
+}
+
 type OptionGroup struct {
 	_ struct{} `type:"structure"`
 
@@ -16193,6 +20387,54 @@ func (s OptionGroup) GoString() string {
 	return s.String()
 }
 
+// SetAllowsVpcAndNonVpcInstanceMemberships sets the AllowsVpcAndNonVpcInstanceMemberships field's value.
+func (s *OptionGroup) SetAllowsVpcAndNonVpcInstanceMemberships(v bool) *OptionGroup {
+	s.AllowsVpcAndNonVpcInstanceMemberships = &v
+	return s
+}
+
+// SetEngineName sets the EngineName field's value.
+func (s *OptionGroup) SetEngineName(v string) *OptionGroup {
+	s.EngineName = &v
+	return s
+}
+
+// SetMajorEngineVersion sets the MajorEngineVersion field's value.
+func (s *OptionGroup) SetMajorEngineVersion(v string) *OptionGroup {
+	s.MajorEngineVersion = &v
+	return s
+}
+
+// SetOptionGroupArn sets the OptionGroupArn field's value.
+func (s *OptionGroup) SetOptionGroupArn(v string) *OptionGroup {
+	s.OptionGroupArn = &v
+	return s
+}
+
+// SetOptionGroupDescription sets the OptionGroupDescription field's value.
+func (s *OptionGroup) SetOptionGroupDescription(v string) *OptionGroup {
+	s.OptionGroupDescription = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *OptionGroup) SetOptionGroupName(v string) *OptionGroup {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetOptions sets the Options field's value.
+func (s *OptionGroup) SetOptions(v []*Option) *OptionGroup {
+	s.Options = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *OptionGroup) SetVpcId(v string) *OptionGroup {
+	s.VpcId = &v
+	return s
+}
+
 // Provides information on the option groups the DB instance is a member of.
 type OptionGroupMembership struct {
 	_ struct{} `type:"structure"`
@@ -16214,6 +20456,18 @@ func (s OptionGroupMembership) String() string {
 // GoString returns the string representation
 func (s OptionGroupMembership) GoString() string {
 	return s.String()
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *OptionGroupMembership) SetOptionGroupName(v string) *OptionGroupMembership {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *OptionGroupMembership) SetStatus(v string) *OptionGroupMembership {
+	s.Status = &v
+	return s
 }
 
 // Available option.
@@ -16275,6 +20529,84 @@ func (s OptionGroupOption) GoString() string {
 	return s.String()
 }
 
+// SetDefaultPort sets the DefaultPort field's value.
+func (s *OptionGroupOption) SetDefaultPort(v int64) *OptionGroupOption {
+	s.DefaultPort = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *OptionGroupOption) SetDescription(v string) *OptionGroupOption {
+	s.Description = &v
+	return s
+}
+
+// SetEngineName sets the EngineName field's value.
+func (s *OptionGroupOption) SetEngineName(v string) *OptionGroupOption {
+	s.EngineName = &v
+	return s
+}
+
+// SetMajorEngineVersion sets the MajorEngineVersion field's value.
+func (s *OptionGroupOption) SetMajorEngineVersion(v string) *OptionGroupOption {
+	s.MajorEngineVersion = &v
+	return s
+}
+
+// SetMinimumRequiredMinorEngineVersion sets the MinimumRequiredMinorEngineVersion field's value.
+func (s *OptionGroupOption) SetMinimumRequiredMinorEngineVersion(v string) *OptionGroupOption {
+	s.MinimumRequiredMinorEngineVersion = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *OptionGroupOption) SetName(v string) *OptionGroupOption {
+	s.Name = &v
+	return s
+}
+
+// SetOptionGroupOptionSettings sets the OptionGroupOptionSettings field's value.
+func (s *OptionGroupOption) SetOptionGroupOptionSettings(v []*OptionGroupOptionSetting) *OptionGroupOption {
+	s.OptionGroupOptionSettings = v
+	return s
+}
+
+// SetOptionGroupOptionVersions sets the OptionGroupOptionVersions field's value.
+func (s *OptionGroupOption) SetOptionGroupOptionVersions(v []*OptionVersion) *OptionGroupOption {
+	s.OptionGroupOptionVersions = v
+	return s
+}
+
+// SetOptionsConflictsWith sets the OptionsConflictsWith field's value.
+func (s *OptionGroupOption) SetOptionsConflictsWith(v []*string) *OptionGroupOption {
+	s.OptionsConflictsWith = v
+	return s
+}
+
+// SetOptionsDependedOn sets the OptionsDependedOn field's value.
+func (s *OptionGroupOption) SetOptionsDependedOn(v []*string) *OptionGroupOption {
+	s.OptionsDependedOn = v
+	return s
+}
+
+// SetPermanent sets the Permanent field's value.
+func (s *OptionGroupOption) SetPermanent(v bool) *OptionGroupOption {
+	s.Permanent = &v
+	return s
+}
+
+// SetPersistent sets the Persistent field's value.
+func (s *OptionGroupOption) SetPersistent(v bool) *OptionGroupOption {
+	s.Persistent = &v
+	return s
+}
+
+// SetPortRequired sets the PortRequired field's value.
+func (s *OptionGroupOption) SetPortRequired(v bool) *OptionGroupOption {
+	s.PortRequired = &v
+	return s
+}
+
 // Option group option settings are used to display settings available for each
 // option with their default values and other information. These values are
 // used with the DescribeOptionGroupOptions action.
@@ -16309,6 +20641,42 @@ func (s OptionGroupOptionSetting) String() string {
 // GoString returns the string representation
 func (s OptionGroupOptionSetting) GoString() string {
 	return s.String()
+}
+
+// SetAllowedValues sets the AllowedValues field's value.
+func (s *OptionGroupOptionSetting) SetAllowedValues(v string) *OptionGroupOptionSetting {
+	s.AllowedValues = &v
+	return s
+}
+
+// SetApplyType sets the ApplyType field's value.
+func (s *OptionGroupOptionSetting) SetApplyType(v string) *OptionGroupOptionSetting {
+	s.ApplyType = &v
+	return s
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *OptionGroupOptionSetting) SetDefaultValue(v string) *OptionGroupOptionSetting {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetIsModifiable sets the IsModifiable field's value.
+func (s *OptionGroupOptionSetting) SetIsModifiable(v bool) *OptionGroupOptionSetting {
+	s.IsModifiable = &v
+	return s
+}
+
+// SetSettingDescription sets the SettingDescription field's value.
+func (s *OptionGroupOptionSetting) SetSettingDescription(v string) *OptionGroupOptionSetting {
+	s.SettingDescription = &v
+	return s
+}
+
+// SetSettingName sets the SettingName field's value.
+func (s *OptionGroupOptionSetting) SetSettingName(v string) *OptionGroupOptionSetting {
+	s.SettingName = &v
+	return s
 }
 
 // Option settings are the actual settings being applied or configured for that
@@ -16357,6 +20725,60 @@ func (s OptionSetting) GoString() string {
 	return s.String()
 }
 
+// SetAllowedValues sets the AllowedValues field's value.
+func (s *OptionSetting) SetAllowedValues(v string) *OptionSetting {
+	s.AllowedValues = &v
+	return s
+}
+
+// SetApplyType sets the ApplyType field's value.
+func (s *OptionSetting) SetApplyType(v string) *OptionSetting {
+	s.ApplyType = &v
+	return s
+}
+
+// SetDataType sets the DataType field's value.
+func (s *OptionSetting) SetDataType(v string) *OptionSetting {
+	s.DataType = &v
+	return s
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *OptionSetting) SetDefaultValue(v string) *OptionSetting {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *OptionSetting) SetDescription(v string) *OptionSetting {
+	s.Description = &v
+	return s
+}
+
+// SetIsCollection sets the IsCollection field's value.
+func (s *OptionSetting) SetIsCollection(v bool) *OptionSetting {
+	s.IsCollection = &v
+	return s
+}
+
+// SetIsModifiable sets the IsModifiable field's value.
+func (s *OptionSetting) SetIsModifiable(v bool) *OptionSetting {
+	s.IsModifiable = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *OptionSetting) SetName(v string) *OptionSetting {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *OptionSetting) SetValue(v string) *OptionSetting {
+	s.Value = &v
+	return s
+}
+
 // The version for an option. Option group option versions are returned by the
 // DescribeOptionGroupOptions action.
 type OptionVersion struct {
@@ -16377,6 +20799,18 @@ func (s OptionVersion) String() string {
 // GoString returns the string representation
 func (s OptionVersion) GoString() string {
 	return s.String()
+}
+
+// SetIsDefault sets the IsDefault field's value.
+func (s *OptionVersion) SetIsDefault(v bool) *OptionVersion {
+	s.IsDefault = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *OptionVersion) SetVersion(v string) *OptionVersion {
+	s.Version = &v
+	return s
 }
 
 // Contains a list of available options for a DB instance
@@ -16434,6 +20868,78 @@ func (s OrderableDBInstanceOption) GoString() string {
 	return s.String()
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *OrderableDBInstanceOption) SetAvailabilityZones(v []*AvailabilityZone) *OrderableDBInstanceOption {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *OrderableDBInstanceOption) SetDBInstanceClass(v string) *OrderableDBInstanceOption {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *OrderableDBInstanceOption) SetEngine(v string) *OrderableDBInstanceOption {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *OrderableDBInstanceOption) SetEngineVersion(v string) *OrderableDBInstanceOption {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *OrderableDBInstanceOption) SetLicenseModel(v string) *OrderableDBInstanceOption {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMultiAZCapable sets the MultiAZCapable field's value.
+func (s *OrderableDBInstanceOption) SetMultiAZCapable(v bool) *OrderableDBInstanceOption {
+	s.MultiAZCapable = &v
+	return s
+}
+
+// SetReadReplicaCapable sets the ReadReplicaCapable field's value.
+func (s *OrderableDBInstanceOption) SetReadReplicaCapable(v bool) *OrderableDBInstanceOption {
+	s.ReadReplicaCapable = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *OrderableDBInstanceOption) SetStorageType(v string) *OrderableDBInstanceOption {
+	s.StorageType = &v
+	return s
+}
+
+// SetSupportsEnhancedMonitoring sets the SupportsEnhancedMonitoring field's value.
+func (s *OrderableDBInstanceOption) SetSupportsEnhancedMonitoring(v bool) *OrderableDBInstanceOption {
+	s.SupportsEnhancedMonitoring = &v
+	return s
+}
+
+// SetSupportsIops sets the SupportsIops field's value.
+func (s *OrderableDBInstanceOption) SetSupportsIops(v bool) *OrderableDBInstanceOption {
+	s.SupportsIops = &v
+	return s
+}
+
+// SetSupportsStorageEncryption sets the SupportsStorageEncryption field's value.
+func (s *OrderableDBInstanceOption) SetSupportsStorageEncryption(v bool) *OrderableDBInstanceOption {
+	s.SupportsStorageEncryption = &v
+	return s
+}
+
+// SetVpc sets the Vpc field's value.
+func (s *OrderableDBInstanceOption) SetVpc(v bool) *OrderableDBInstanceOption {
+	s.Vpc = &v
+	return s
+}
+
 // This data type is used as a request parameter in the ModifyDBParameterGroup
 // and ResetDBParameterGroup actions.
 //
@@ -16485,6 +20991,66 @@ func (s Parameter) GoString() string {
 	return s.String()
 }
 
+// SetAllowedValues sets the AllowedValues field's value.
+func (s *Parameter) SetAllowedValues(v string) *Parameter {
+	s.AllowedValues = &v
+	return s
+}
+
+// SetApplyMethod sets the ApplyMethod field's value.
+func (s *Parameter) SetApplyMethod(v string) *Parameter {
+	s.ApplyMethod = &v
+	return s
+}
+
+// SetApplyType sets the ApplyType field's value.
+func (s *Parameter) SetApplyType(v string) *Parameter {
+	s.ApplyType = &v
+	return s
+}
+
+// SetDataType sets the DataType field's value.
+func (s *Parameter) SetDataType(v string) *Parameter {
+	s.DataType = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Parameter) SetDescription(v string) *Parameter {
+	s.Description = &v
+	return s
+}
+
+// SetIsModifiable sets the IsModifiable field's value.
+func (s *Parameter) SetIsModifiable(v bool) *Parameter {
+	s.IsModifiable = &v
+	return s
+}
+
+// SetMinimumEngineVersion sets the MinimumEngineVersion field's value.
+func (s *Parameter) SetMinimumEngineVersion(v string) *Parameter {
+	s.MinimumEngineVersion = &v
+	return s
+}
+
+// SetParameterName sets the ParameterName field's value.
+func (s *Parameter) SetParameterName(v string) *Parameter {
+	s.ParameterName = &v
+	return s
+}
+
+// SetParameterValue sets the ParameterValue field's value.
+func (s *Parameter) SetParameterValue(v string) *Parameter {
+	s.ParameterValue = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *Parameter) SetSource(v string) *Parameter {
+	s.Source = &v
+	return s
+}
+
 // Provides information about a pending maintenance action for a resource.
 type PendingMaintenanceAction struct {
 	_ struct{} `type:"structure"`
@@ -16526,6 +21092,42 @@ func (s PendingMaintenanceAction) String() string {
 // GoString returns the string representation
 func (s PendingMaintenanceAction) GoString() string {
 	return s.String()
+}
+
+// SetAction sets the Action field's value.
+func (s *PendingMaintenanceAction) SetAction(v string) *PendingMaintenanceAction {
+	s.Action = &v
+	return s
+}
+
+// SetAutoAppliedAfterDate sets the AutoAppliedAfterDate field's value.
+func (s *PendingMaintenanceAction) SetAutoAppliedAfterDate(v time.Time) *PendingMaintenanceAction {
+	s.AutoAppliedAfterDate = &v
+	return s
+}
+
+// SetCurrentApplyDate sets the CurrentApplyDate field's value.
+func (s *PendingMaintenanceAction) SetCurrentApplyDate(v time.Time) *PendingMaintenanceAction {
+	s.CurrentApplyDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *PendingMaintenanceAction) SetDescription(v string) *PendingMaintenanceAction {
+	s.Description = &v
+	return s
+}
+
+// SetForcedApplyDate sets the ForcedApplyDate field's value.
+func (s *PendingMaintenanceAction) SetForcedApplyDate(v time.Time) *PendingMaintenanceAction {
+	s.ForcedApplyDate = &v
+	return s
+}
+
+// SetOptInStatus sets the OptInStatus field's value.
+func (s *PendingMaintenanceAction) SetOptInStatus(v string) *PendingMaintenanceAction {
+	s.OptInStatus = &v
+	return s
 }
 
 // This data type is used as a response element in the ModifyDBInstance action.
@@ -16589,6 +21191,84 @@ func (s PendingModifiedValues) GoString() string {
 	return s.String()
 }
 
+// SetAllocatedStorage sets the AllocatedStorage field's value.
+func (s *PendingModifiedValues) SetAllocatedStorage(v int64) *PendingModifiedValues {
+	s.AllocatedStorage = &v
+	return s
+}
+
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *PendingModifiedValues) SetBackupRetentionPeriod(v int64) *PendingModifiedValues {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetCACertificateIdentifier sets the CACertificateIdentifier field's value.
+func (s *PendingModifiedValues) SetCACertificateIdentifier(v string) *PendingModifiedValues {
+	s.CACertificateIdentifier = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *PendingModifiedValues) SetDBInstanceClass(v string) *PendingModifiedValues {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *PendingModifiedValues) SetDBInstanceIdentifier(v string) *PendingModifiedValues {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *PendingModifiedValues) SetDBSubnetGroupName(v string) *PendingModifiedValues {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *PendingModifiedValues) SetEngineVersion(v string) *PendingModifiedValues {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *PendingModifiedValues) SetIops(v int64) *PendingModifiedValues {
+	s.Iops = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *PendingModifiedValues) SetLicenseModel(v string) *PendingModifiedValues {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *PendingModifiedValues) SetMasterUserPassword(v string) *PendingModifiedValues {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *PendingModifiedValues) SetMultiAZ(v bool) *PendingModifiedValues {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *PendingModifiedValues) SetPort(v int64) *PendingModifiedValues {
+	s.Port = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *PendingModifiedValues) SetStorageType(v string) *PendingModifiedValues {
+	s.StorageType = &v
+	return s
+}
+
 type PromoteReadReplicaDBClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -16632,6 +21312,12 @@ func (s *PromoteReadReplicaDBClusterInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *PromoteReadReplicaDBClusterInput) SetDBClusterIdentifier(v string) *PromoteReadReplicaDBClusterInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
 type PromoteReadReplicaDBClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -16661,6 +21347,12 @@ func (s PromoteReadReplicaDBClusterOutput) String() string {
 // GoString returns the string representation
 func (s PromoteReadReplicaDBClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBCluster sets the DBCluster field's value.
+func (s *PromoteReadReplicaDBClusterOutput) SetDBCluster(v *DBCluster) *PromoteReadReplicaDBClusterOutput {
+	s.DBCluster = v
+	return s
 }
 
 type PromoteReadReplicaInput struct {
@@ -16737,6 +21429,24 @@ func (s *PromoteReadReplicaInput) Validate() error {
 	return nil
 }
 
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *PromoteReadReplicaInput) SetBackupRetentionPeriod(v int64) *PromoteReadReplicaInput {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *PromoteReadReplicaInput) SetDBInstanceIdentifier(v string) *PromoteReadReplicaInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetPreferredBackupWindow sets the PreferredBackupWindow field's value.
+func (s *PromoteReadReplicaInput) SetPreferredBackupWindow(v string) *PromoteReadReplicaInput {
+	s.PreferredBackupWindow = &v
+	return s
+}
+
 type PromoteReadReplicaOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -16760,6 +21470,12 @@ func (s PromoteReadReplicaOutput) String() string {
 // GoString returns the string representation
 func (s PromoteReadReplicaOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBInstance sets the DBInstance field's value.
+func (s *PromoteReadReplicaOutput) SetDBInstance(v *DBInstance) *PromoteReadReplicaOutput {
+	s.DBInstance = v
+	return s
 }
 
 type PurchaseReservedDBInstancesOfferingInput struct {
@@ -16809,6 +21525,30 @@ func (s *PurchaseReservedDBInstancesOfferingInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceCount sets the DBInstanceCount field's value.
+func (s *PurchaseReservedDBInstancesOfferingInput) SetDBInstanceCount(v int64) *PurchaseReservedDBInstancesOfferingInput {
+	s.DBInstanceCount = &v
+	return s
+}
+
+// SetReservedDBInstanceId sets the ReservedDBInstanceId field's value.
+func (s *PurchaseReservedDBInstancesOfferingInput) SetReservedDBInstanceId(v string) *PurchaseReservedDBInstancesOfferingInput {
+	s.ReservedDBInstanceId = &v
+	return s
+}
+
+// SetReservedDBInstancesOfferingId sets the ReservedDBInstancesOfferingId field's value.
+func (s *PurchaseReservedDBInstancesOfferingInput) SetReservedDBInstancesOfferingId(v string) *PurchaseReservedDBInstancesOfferingInput {
+	s.ReservedDBInstancesOfferingId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *PurchaseReservedDBInstancesOfferingInput) SetTags(v []*Tag) *PurchaseReservedDBInstancesOfferingInput {
+	s.Tags = v
+	return s
+}
+
 type PurchaseReservedDBInstancesOfferingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -16825,6 +21565,12 @@ func (s PurchaseReservedDBInstancesOfferingOutput) String() string {
 // GoString returns the string representation
 func (s PurchaseReservedDBInstancesOfferingOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedDBInstance sets the ReservedDBInstance field's value.
+func (s *PurchaseReservedDBInstancesOfferingOutput) SetReservedDBInstance(v *ReservedDBInstance) *PurchaseReservedDBInstancesOfferingOutput {
+	s.ReservedDBInstance = v
+	return s
 }
 
 type RebootDBInstanceInput struct {
@@ -16873,6 +21619,18 @@ func (s *RebootDBInstanceInput) Validate() error {
 	return nil
 }
 
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *RebootDBInstanceInput) SetDBInstanceIdentifier(v string) *RebootDBInstanceInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetForceFailover sets the ForceFailover field's value.
+func (s *RebootDBInstanceInput) SetForceFailover(v bool) *RebootDBInstanceInput {
+	s.ForceFailover = &v
+	return s
+}
+
 type RebootDBInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -16898,6 +21656,12 @@ func (s RebootDBInstanceOutput) GoString() string {
 	return s.String()
 }
 
+// SetDBInstance sets the DBInstance field's value.
+func (s *RebootDBInstanceOutput) SetDBInstance(v *DBInstance) *RebootDBInstanceOutput {
+	s.DBInstance = v
+	return s
+}
+
 // This data type is used as a response element in the DescribeReservedDBInstances
 // and DescribeReservedDBInstancesOfferings actions.
 type RecurringCharge struct {
@@ -16918,6 +21682,18 @@ func (s RecurringCharge) String() string {
 // GoString returns the string representation
 func (s RecurringCharge) GoString() string {
 	return s.String()
+}
+
+// SetRecurringChargeAmount sets the RecurringChargeAmount field's value.
+func (s *RecurringCharge) SetRecurringChargeAmount(v float64) *RecurringCharge {
+	s.RecurringChargeAmount = &v
+	return s
+}
+
+// SetRecurringChargeFrequency sets the RecurringChargeFrequency field's value.
+func (s *RecurringCharge) SetRecurringChargeFrequency(v string) *RecurringCharge {
+	s.RecurringChargeFrequency = &v
+	return s
 }
 
 type RemoveRoleFromDBClusterInput struct {
@@ -16959,6 +21735,18 @@ func (s *RemoveRoleFromDBClusterInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *RemoveRoleFromDBClusterInput) SetDBClusterIdentifier(v string) *RemoveRoleFromDBClusterInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *RemoveRoleFromDBClusterInput) SetRoleArn(v string) *RemoveRoleFromDBClusterInput {
+	s.RoleArn = &v
+	return s
 }
 
 type RemoveRoleFromDBClusterOutput struct {
@@ -17017,6 +21805,18 @@ func (s *RemoveSourceIdentifierFromSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *RemoveSourceIdentifierFromSubscriptionInput) SetSourceIdentifier(v string) *RemoveSourceIdentifierFromSubscriptionInput {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *RemoveSourceIdentifierFromSubscriptionInput) SetSubscriptionName(v string) *RemoveSourceIdentifierFromSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
 type RemoveSourceIdentifierFromSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -17033,6 +21833,12 @@ func (s RemoveSourceIdentifierFromSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s RemoveSourceIdentifierFromSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *RemoveSourceIdentifierFromSubscriptionOutput) SetEventSubscription(v *EventSubscription) *RemoveSourceIdentifierFromSubscriptionOutput {
+	s.EventSubscription = v
+	return s
 }
 
 type RemoveTagsFromResourceInput struct {
@@ -17075,6 +21881,18 @@ func (s *RemoveTagsFromResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *RemoveTagsFromResourceInput) SetResourceName(v string) *RemoveTagsFromResourceInput {
+	s.ResourceName = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsFromResourceInput) SetTagKeys(v []*string) *RemoveTagsFromResourceInput {
+	s.TagKeys = v
+	return s
 }
 
 type RemoveTagsFromResourceOutput struct {
@@ -17152,6 +21970,96 @@ func (s ReservedDBInstance) GoString() string {
 	return s.String()
 }
 
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedDBInstance) SetCurrencyCode(v string) *ReservedDBInstance {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *ReservedDBInstance) SetDBInstanceClass(v string) *ReservedDBInstance {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDBInstanceCount sets the DBInstanceCount field's value.
+func (s *ReservedDBInstance) SetDBInstanceCount(v int64) *ReservedDBInstance {
+	s.DBInstanceCount = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedDBInstance) SetDuration(v int64) *ReservedDBInstance {
+	s.Duration = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedDBInstance) SetFixedPrice(v float64) *ReservedDBInstance {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *ReservedDBInstance) SetMultiAZ(v bool) *ReservedDBInstance {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *ReservedDBInstance) SetOfferingType(v string) *ReservedDBInstance {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *ReservedDBInstance) SetProductDescription(v string) *ReservedDBInstance {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedDBInstance) SetRecurringCharges(v []*RecurringCharge) *ReservedDBInstance {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedDBInstanceArn sets the ReservedDBInstanceArn field's value.
+func (s *ReservedDBInstance) SetReservedDBInstanceArn(v string) *ReservedDBInstance {
+	s.ReservedDBInstanceArn = &v
+	return s
+}
+
+// SetReservedDBInstanceId sets the ReservedDBInstanceId field's value.
+func (s *ReservedDBInstance) SetReservedDBInstanceId(v string) *ReservedDBInstance {
+	s.ReservedDBInstanceId = &v
+	return s
+}
+
+// SetReservedDBInstancesOfferingId sets the ReservedDBInstancesOfferingId field's value.
+func (s *ReservedDBInstance) SetReservedDBInstancesOfferingId(v string) *ReservedDBInstance {
+	s.ReservedDBInstancesOfferingId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ReservedDBInstance) SetStartTime(v time.Time) *ReservedDBInstance {
+	s.StartTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ReservedDBInstance) SetState(v string) *ReservedDBInstance {
+	s.State = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedDBInstance) SetUsagePrice(v float64) *ReservedDBInstance {
+	s.UsagePrice = &v
+	return s
+}
+
 // This data type is used as a response element in the DescribeReservedDBInstancesOfferings
 // action.
 type ReservedDBInstancesOffering struct {
@@ -17198,6 +22106,66 @@ func (s ReservedDBInstancesOffering) GoString() string {
 	return s.String()
 }
 
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedDBInstancesOffering) SetCurrencyCode(v string) *ReservedDBInstancesOffering {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *ReservedDBInstancesOffering) SetDBInstanceClass(v string) *ReservedDBInstancesOffering {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedDBInstancesOffering) SetDuration(v int64) *ReservedDBInstancesOffering {
+	s.Duration = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedDBInstancesOffering) SetFixedPrice(v float64) *ReservedDBInstancesOffering {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *ReservedDBInstancesOffering) SetMultiAZ(v bool) *ReservedDBInstancesOffering {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *ReservedDBInstancesOffering) SetOfferingType(v string) *ReservedDBInstancesOffering {
+	s.OfferingType = &v
+	return s
+}
+
+// SetProductDescription sets the ProductDescription field's value.
+func (s *ReservedDBInstancesOffering) SetProductDescription(v string) *ReservedDBInstancesOffering {
+	s.ProductDescription = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedDBInstancesOffering) SetRecurringCharges(v []*RecurringCharge) *ReservedDBInstancesOffering {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedDBInstancesOfferingId sets the ReservedDBInstancesOfferingId field's value.
+func (s *ReservedDBInstancesOffering) SetReservedDBInstancesOfferingId(v string) *ReservedDBInstancesOffering {
+	s.ReservedDBInstancesOfferingId = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedDBInstancesOffering) SetUsagePrice(v float64) *ReservedDBInstancesOffering {
+	s.UsagePrice = &v
+	return s
+}
+
 type ResetDBClusterParameterGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -17238,6 +22206,24 @@ func (s *ResetDBClusterParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *ResetDBClusterParameterGroupInput) SetDBClusterParameterGroupName(v string) *ResetDBClusterParameterGroupInput {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ResetDBClusterParameterGroupInput) SetParameters(v []*Parameter) *ResetDBClusterParameterGroupInput {
+	s.Parameters = v
+	return s
+}
+
+// SetResetAllParameters sets the ResetAllParameters field's value.
+func (s *ResetDBClusterParameterGroupInput) SetResetAllParameters(v bool) *ResetDBClusterParameterGroupInput {
+	s.ResetAllParameters = &v
+	return s
 }
 
 type ResetDBParameterGroupInput struct {
@@ -17312,6 +22298,24 @@ func (s *ResetDBParameterGroupInput) Validate() error {
 	return nil
 }
 
+// SetDBParameterGroupName sets the DBParameterGroupName field's value.
+func (s *ResetDBParameterGroupInput) SetDBParameterGroupName(v string) *ResetDBParameterGroupInput {
+	s.DBParameterGroupName = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ResetDBParameterGroupInput) SetParameters(v []*Parameter) *ResetDBParameterGroupInput {
+	s.Parameters = v
+	return s
+}
+
+// SetResetAllParameters sets the ResetAllParameters field's value.
+func (s *ResetDBParameterGroupInput) SetResetAllParameters(v bool) *ResetDBParameterGroupInput {
+	s.ResetAllParameters = &v
+	return s
+}
+
 // Describes the pending maintenance actions for a resource.
 type ResourcePendingMaintenanceActions struct {
 	_ struct{} `type:"structure"`
@@ -17332,6 +22336,18 @@ func (s ResourcePendingMaintenanceActions) String() string {
 // GoString returns the string representation
 func (s ResourcePendingMaintenanceActions) GoString() string {
 	return s.String()
+}
+
+// SetPendingMaintenanceActionDetails sets the PendingMaintenanceActionDetails field's value.
+func (s *ResourcePendingMaintenanceActions) SetPendingMaintenanceActionDetails(v []*PendingMaintenanceAction) *ResourcePendingMaintenanceActions {
+	s.PendingMaintenanceActionDetails = v
+	return s
+}
+
+// SetResourceIdentifier sets the ResourceIdentifier field's value.
+func (s *ResourcePendingMaintenanceActions) SetResourceIdentifier(v string) *ResourcePendingMaintenanceActions {
+	s.ResourceIdentifier = &v
+	return s
 }
 
 type RestoreDBClusterFromS3Input struct {
@@ -17579,6 +22595,150 @@ func (s *RestoreDBClusterFromS3Input) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *RestoreDBClusterFromS3Input) SetAvailabilityZones(v []*string) *RestoreDBClusterFromS3Input {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
+func (s *RestoreDBClusterFromS3Input) SetBackupRetentionPeriod(v int64) *RestoreDBClusterFromS3Input {
+	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetCharacterSetName sets the CharacterSetName field's value.
+func (s *RestoreDBClusterFromS3Input) SetCharacterSetName(v string) *RestoreDBClusterFromS3Input {
+	s.CharacterSetName = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *RestoreDBClusterFromS3Input) SetDBClusterIdentifier(v string) *RestoreDBClusterFromS3Input {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBClusterParameterGroupName sets the DBClusterParameterGroupName field's value.
+func (s *RestoreDBClusterFromS3Input) SetDBClusterParameterGroupName(v string) *RestoreDBClusterFromS3Input {
+	s.DBClusterParameterGroupName = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *RestoreDBClusterFromS3Input) SetDBSubnetGroupName(v string) *RestoreDBClusterFromS3Input {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *RestoreDBClusterFromS3Input) SetDatabaseName(v string) *RestoreDBClusterFromS3Input {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *RestoreDBClusterFromS3Input) SetEngine(v string) *RestoreDBClusterFromS3Input {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *RestoreDBClusterFromS3Input) SetEngineVersion(v string) *RestoreDBClusterFromS3Input {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *RestoreDBClusterFromS3Input) SetKmsKeyId(v string) *RestoreDBClusterFromS3Input {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *RestoreDBClusterFromS3Input) SetMasterUserPassword(v string) *RestoreDBClusterFromS3Input {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *RestoreDBClusterFromS3Input) SetMasterUsername(v string) *RestoreDBClusterFromS3Input {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *RestoreDBClusterFromS3Input) SetOptionGroupName(v string) *RestoreDBClusterFromS3Input {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *RestoreDBClusterFromS3Input) SetPort(v int64) *RestoreDBClusterFromS3Input {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredBackupWindow sets the PreferredBackupWindow field's value.
+func (s *RestoreDBClusterFromS3Input) SetPreferredBackupWindow(v string) *RestoreDBClusterFromS3Input {
+	s.PreferredBackupWindow = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *RestoreDBClusterFromS3Input) SetPreferredMaintenanceWindow(v string) *RestoreDBClusterFromS3Input {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetS3BucketName sets the S3BucketName field's value.
+func (s *RestoreDBClusterFromS3Input) SetS3BucketName(v string) *RestoreDBClusterFromS3Input {
+	s.S3BucketName = &v
+	return s
+}
+
+// SetS3IngestionRoleArn sets the S3IngestionRoleArn field's value.
+func (s *RestoreDBClusterFromS3Input) SetS3IngestionRoleArn(v string) *RestoreDBClusterFromS3Input {
+	s.S3IngestionRoleArn = &v
+	return s
+}
+
+// SetS3Prefix sets the S3Prefix field's value.
+func (s *RestoreDBClusterFromS3Input) SetS3Prefix(v string) *RestoreDBClusterFromS3Input {
+	s.S3Prefix = &v
+	return s
+}
+
+// SetSourceEngine sets the SourceEngine field's value.
+func (s *RestoreDBClusterFromS3Input) SetSourceEngine(v string) *RestoreDBClusterFromS3Input {
+	s.SourceEngine = &v
+	return s
+}
+
+// SetSourceEngineVersion sets the SourceEngineVersion field's value.
+func (s *RestoreDBClusterFromS3Input) SetSourceEngineVersion(v string) *RestoreDBClusterFromS3Input {
+	s.SourceEngineVersion = &v
+	return s
+}
+
+// SetStorageEncrypted sets the StorageEncrypted field's value.
+func (s *RestoreDBClusterFromS3Input) SetStorageEncrypted(v bool) *RestoreDBClusterFromS3Input {
+	s.StorageEncrypted = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RestoreDBClusterFromS3Input) SetTags(v []*Tag) *RestoreDBClusterFromS3Input {
+	s.Tags = v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *RestoreDBClusterFromS3Input) SetVpcSecurityGroupIds(v []*string) *RestoreDBClusterFromS3Input {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type RestoreDBClusterFromS3Output struct {
 	_ struct{} `type:"structure"`
 
@@ -17608,6 +22768,12 @@ func (s RestoreDBClusterFromS3Output) String() string {
 // GoString returns the string representation
 func (s RestoreDBClusterFromS3Output) GoString() string {
 	return s.String()
+}
+
+// SetDBCluster sets the DBCluster field's value.
+func (s *RestoreDBClusterFromS3Output) SetDBCluster(v *DBCluster) *RestoreDBClusterFromS3Output {
+	s.DBCluster = v
+	return s
 }
 
 type RestoreDBClusterFromSnapshotInput struct {
@@ -17734,6 +22900,78 @@ func (s *RestoreDBClusterFromSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetAvailabilityZones(v []*string) *RestoreDBClusterFromSnapshotInput {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetDBClusterIdentifier(v string) *RestoreDBClusterFromSnapshotInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetDBSubnetGroupName(v string) *RestoreDBClusterFromSnapshotInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetDatabaseName(v string) *RestoreDBClusterFromSnapshotInput {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetEngine(v string) *RestoreDBClusterFromSnapshotInput {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetEngineVersion(v string) *RestoreDBClusterFromSnapshotInput {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetKmsKeyId(v string) *RestoreDBClusterFromSnapshotInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetOptionGroupName(v string) *RestoreDBClusterFromSnapshotInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetPort(v int64) *RestoreDBClusterFromSnapshotInput {
+	s.Port = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetSnapshotIdentifier(v string) *RestoreDBClusterFromSnapshotInput {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetTags(v []*Tag) *RestoreDBClusterFromSnapshotInput {
+	s.Tags = v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetVpcSecurityGroupIds(v []*string) *RestoreDBClusterFromSnapshotInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type RestoreDBClusterFromSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -17763,6 +23001,12 @@ func (s RestoreDBClusterFromSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s RestoreDBClusterFromSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBCluster sets the DBCluster field's value.
+func (s *RestoreDBClusterFromSnapshotOutput) SetDBCluster(v *DBCluster) *RestoreDBClusterFromSnapshotOutput {
+	s.DBCluster = v
+	return s
 }
 
 type RestoreDBClusterToPointInTimeInput struct {
@@ -17894,6 +23138,66 @@ func (s *RestoreDBClusterToPointInTimeInput) Validate() error {
 	return nil
 }
 
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetDBClusterIdentifier(v string) *RestoreDBClusterToPointInTimeInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetDBSubnetGroupName(v string) *RestoreDBClusterToPointInTimeInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetKmsKeyId(v string) *RestoreDBClusterToPointInTimeInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetOptionGroupName(v string) *RestoreDBClusterToPointInTimeInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetPort(v int64) *RestoreDBClusterToPointInTimeInput {
+	s.Port = &v
+	return s
+}
+
+// SetRestoreToTime sets the RestoreToTime field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetRestoreToTime(v time.Time) *RestoreDBClusterToPointInTimeInput {
+	s.RestoreToTime = &v
+	return s
+}
+
+// SetSourceDBClusterIdentifier sets the SourceDBClusterIdentifier field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetSourceDBClusterIdentifier(v string) *RestoreDBClusterToPointInTimeInput {
+	s.SourceDBClusterIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetTags(v []*Tag) *RestoreDBClusterToPointInTimeInput {
+	s.Tags = v
+	return s
+}
+
+// SetUseLatestRestorableTime sets the UseLatestRestorableTime field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetUseLatestRestorableTime(v bool) *RestoreDBClusterToPointInTimeInput {
+	s.UseLatestRestorableTime = &v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetVpcSecurityGroupIds(v []*string) *RestoreDBClusterToPointInTimeInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type RestoreDBClusterToPointInTimeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -17923,6 +23227,12 @@ func (s RestoreDBClusterToPointInTimeOutput) String() string {
 // GoString returns the string representation
 func (s RestoreDBClusterToPointInTimeOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBCluster sets the DBCluster field's value.
+func (s *RestoreDBClusterToPointInTimeOutput) SetDBCluster(v *DBCluster) *RestoreDBClusterToPointInTimeOutput {
+	s.DBCluster = v
+	return s
 }
 
 type RestoreDBInstanceFromDBSnapshotInput struct {
@@ -18123,6 +23433,132 @@ func (s *RestoreDBInstanceFromDBSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetAutoMinorVersionUpgrade(v bool) *RestoreDBInstanceFromDBSnapshotInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetAvailabilityZone(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCopyTagsToSnapshot sets the CopyTagsToSnapshot field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetCopyTagsToSnapshot(v bool) *RestoreDBInstanceFromDBSnapshotInput {
+	s.CopyTagsToSnapshot = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetDBInstanceClass(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDBInstanceIdentifier sets the DBInstanceIdentifier field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetDBInstanceIdentifier(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.DBInstanceIdentifier = &v
+	return s
+}
+
+// SetDBName sets the DBName field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetDBName(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.DBName = &v
+	return s
+}
+
+// SetDBSnapshotIdentifier sets the DBSnapshotIdentifier field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetDBSnapshotIdentifier(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.DBSnapshotIdentifier = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetDBSubnetGroupName(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetDomain(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.Domain = &v
+	return s
+}
+
+// SetDomainIAMRoleName sets the DomainIAMRoleName field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetDomainIAMRoleName(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.DomainIAMRoleName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetEngine(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.Engine = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetIops(v int64) *RestoreDBInstanceFromDBSnapshotInput {
+	s.Iops = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetLicenseModel(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetMultiAZ(v bool) *RestoreDBInstanceFromDBSnapshotInput {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetOptionGroupName(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetPort(v int64) *RestoreDBInstanceFromDBSnapshotInput {
+	s.Port = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetPubliclyAccessible(v bool) *RestoreDBInstanceFromDBSnapshotInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetStorageType(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.StorageType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetTags(v []*Tag) *RestoreDBInstanceFromDBSnapshotInput {
+	s.Tags = v
+	return s
+}
+
+// SetTdeCredentialArn sets the TdeCredentialArn field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetTdeCredentialArn(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.TdeCredentialArn = &v
+	return s
+}
+
+// SetTdeCredentialPassword sets the TdeCredentialPassword field's value.
+func (s *RestoreDBInstanceFromDBSnapshotInput) SetTdeCredentialPassword(v string) *RestoreDBInstanceFromDBSnapshotInput {
+	s.TdeCredentialPassword = &v
+	return s
+}
+
 type RestoreDBInstanceFromDBSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -18146,6 +23582,12 @@ func (s RestoreDBInstanceFromDBSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s RestoreDBInstanceFromDBSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBInstance sets the DBInstance field's value.
+func (s *RestoreDBInstanceFromDBSnapshotOutput) SetDBInstance(v *DBInstance) *RestoreDBInstanceFromDBSnapshotOutput {
+	s.DBInstance = v
+	return s
 }
 
 type RestoreDBInstanceToPointInTimeInput struct {
@@ -18360,6 +23802,144 @@ func (s *RestoreDBInstanceToPointInTimeInput) Validate() error {
 	return nil
 }
 
+// SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetAutoMinorVersionUpgrade(v bool) *RestoreDBInstanceToPointInTimeInput {
+	s.AutoMinorVersionUpgrade = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetAvailabilityZone(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetCopyTagsToSnapshot sets the CopyTagsToSnapshot field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetCopyTagsToSnapshot(v bool) *RestoreDBInstanceToPointInTimeInput {
+	s.CopyTagsToSnapshot = &v
+	return s
+}
+
+// SetDBInstanceClass sets the DBInstanceClass field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetDBInstanceClass(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.DBInstanceClass = &v
+	return s
+}
+
+// SetDBName sets the DBName field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetDBName(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.DBName = &v
+	return s
+}
+
+// SetDBSubnetGroupName sets the DBSubnetGroupName field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetDBSubnetGroupName(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.DBSubnetGroupName = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetDomain(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.Domain = &v
+	return s
+}
+
+// SetDomainIAMRoleName sets the DomainIAMRoleName field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetDomainIAMRoleName(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.DomainIAMRoleName = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetEngine(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.Engine = &v
+	return s
+}
+
+// SetIops sets the Iops field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetIops(v int64) *RestoreDBInstanceToPointInTimeInput {
+	s.Iops = &v
+	return s
+}
+
+// SetLicenseModel sets the LicenseModel field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetLicenseModel(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.LicenseModel = &v
+	return s
+}
+
+// SetMultiAZ sets the MultiAZ field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetMultiAZ(v bool) *RestoreDBInstanceToPointInTimeInput {
+	s.MultiAZ = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetOptionGroupName(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.OptionGroupName = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetPort(v int64) *RestoreDBInstanceToPointInTimeInput {
+	s.Port = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetPubliclyAccessible(v bool) *RestoreDBInstanceToPointInTimeInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetRestoreTime sets the RestoreTime field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetRestoreTime(v time.Time) *RestoreDBInstanceToPointInTimeInput {
+	s.RestoreTime = &v
+	return s
+}
+
+// SetSourceDBInstanceIdentifier sets the SourceDBInstanceIdentifier field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetSourceDBInstanceIdentifier(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.SourceDBInstanceIdentifier = &v
+	return s
+}
+
+// SetStorageType sets the StorageType field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetStorageType(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.StorageType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetTags(v []*Tag) *RestoreDBInstanceToPointInTimeInput {
+	s.Tags = v
+	return s
+}
+
+// SetTargetDBInstanceIdentifier sets the TargetDBInstanceIdentifier field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetTargetDBInstanceIdentifier(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.TargetDBInstanceIdentifier = &v
+	return s
+}
+
+// SetTdeCredentialArn sets the TdeCredentialArn field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetTdeCredentialArn(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.TdeCredentialArn = &v
+	return s
+}
+
+// SetTdeCredentialPassword sets the TdeCredentialPassword field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetTdeCredentialPassword(v string) *RestoreDBInstanceToPointInTimeInput {
+	s.TdeCredentialPassword = &v
+	return s
+}
+
+// SetUseLatestRestorableTime sets the UseLatestRestorableTime field's value.
+func (s *RestoreDBInstanceToPointInTimeInput) SetUseLatestRestorableTime(v bool) *RestoreDBInstanceToPointInTimeInput {
+	s.UseLatestRestorableTime = &v
+	return s
+}
+
 type RestoreDBInstanceToPointInTimeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -18383,6 +23963,12 @@ func (s RestoreDBInstanceToPointInTimeOutput) String() string {
 // GoString returns the string representation
 func (s RestoreDBInstanceToPointInTimeOutput) GoString() string {
 	return s.String()
+}
+
+// SetDBInstance sets the DBInstance field's value.
+func (s *RestoreDBInstanceToPointInTimeOutput) SetDBInstance(v *DBInstance) *RestoreDBInstanceToPointInTimeOutput {
+	s.DBInstance = v
+	return s
 }
 
 type RevokeDBSecurityGroupIngressInput struct {
@@ -18439,6 +24025,36 @@ func (s *RevokeDBSecurityGroupIngressInput) Validate() error {
 	return nil
 }
 
+// SetCIDRIP sets the CIDRIP field's value.
+func (s *RevokeDBSecurityGroupIngressInput) SetCIDRIP(v string) *RevokeDBSecurityGroupIngressInput {
+	s.CIDRIP = &v
+	return s
+}
+
+// SetDBSecurityGroupName sets the DBSecurityGroupName field's value.
+func (s *RevokeDBSecurityGroupIngressInput) SetDBSecurityGroupName(v string) *RevokeDBSecurityGroupIngressInput {
+	s.DBSecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupId sets the EC2SecurityGroupId field's value.
+func (s *RevokeDBSecurityGroupIngressInput) SetEC2SecurityGroupId(v string) *RevokeDBSecurityGroupIngressInput {
+	s.EC2SecurityGroupId = &v
+	return s
+}
+
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *RevokeDBSecurityGroupIngressInput) SetEC2SecurityGroupName(v string) *RevokeDBSecurityGroupIngressInput {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *RevokeDBSecurityGroupIngressInput) SetEC2SecurityGroupOwnerId(v string) *RevokeDBSecurityGroupIngressInput {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
 type RevokeDBSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -18467,6 +24083,12 @@ func (s RevokeDBSecurityGroupIngressOutput) GoString() string {
 	return s.String()
 }
 
+// SetDBSecurityGroup sets the DBSecurityGroup field's value.
+func (s *RevokeDBSecurityGroupIngressOutput) SetDBSecurityGroup(v *DBSecurityGroup) *RevokeDBSecurityGroupIngressOutput {
+	s.DBSecurityGroup = v
+	return s
+}
+
 // Contains an AWS Region name as the result of a successful call to the DescribeSourceRegions
 // action.
 type SourceRegion struct {
@@ -18490,6 +24112,24 @@ func (s SourceRegion) String() string {
 // GoString returns the string representation
 func (s SourceRegion) GoString() string {
 	return s.String()
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *SourceRegion) SetEndpoint(v string) *SourceRegion {
+	s.Endpoint = &v
+	return s
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *SourceRegion) SetRegionName(v string) *SourceRegion {
+	s.RegionName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *SourceRegion) SetStatus(v string) *SourceRegion {
+	s.Status = &v
+	return s
 }
 
 // This data type is used as a response element in the DescribeDBSubnetGroups
@@ -18521,6 +24161,24 @@ func (s Subnet) GoString() string {
 	return s.String()
 }
 
+// SetSubnetAvailabilityZone sets the SubnetAvailabilityZone field's value.
+func (s *Subnet) SetSubnetAvailabilityZone(v *AvailabilityZone) *Subnet {
+	s.SubnetAvailabilityZone = v
+	return s
+}
+
+// SetSubnetIdentifier sets the SubnetIdentifier field's value.
+func (s *Subnet) SetSubnetIdentifier(v string) *Subnet {
+	s.SubnetIdentifier = &v
+	return s
+}
+
+// SetSubnetStatus sets the SubnetStatus field's value.
+func (s *Subnet) SetSubnetStatus(v string) *Subnet {
+	s.SubnetStatus = &v
+	return s
+}
+
 // Metadata assigned to an Amazon RDS resource consisting of a key-value pair.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -18548,6 +24206,18 @@ func (s Tag) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // A time zone associated with a DBInstance or a DBSnapshot. This data type
 // is an element in the response to the DescribeDBInstances, the DescribeDBSnapshots,
 // and the DescribeDBEngineVersions actions.
@@ -18566,6 +24236,12 @@ func (s Timezone) String() string {
 // GoString returns the string representation
 func (s Timezone) GoString() string {
 	return s.String()
+}
+
+// SetTimezoneName sets the TimezoneName field's value.
+func (s *Timezone) SetTimezoneName(v string) *Timezone {
+	s.TimezoneName = &v
+	return s
 }
 
 // The version of the database engine that a DB instance can be upgraded to.
@@ -18600,6 +24276,36 @@ func (s UpgradeTarget) GoString() string {
 	return s.String()
 }
 
+// SetAutoUpgrade sets the AutoUpgrade field's value.
+func (s *UpgradeTarget) SetAutoUpgrade(v bool) *UpgradeTarget {
+	s.AutoUpgrade = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpgradeTarget) SetDescription(v string) *UpgradeTarget {
+	s.Description = &v
+	return s
+}
+
+// SetEngine sets the Engine field's value.
+func (s *UpgradeTarget) SetEngine(v string) *UpgradeTarget {
+	s.Engine = &v
+	return s
+}
+
+// SetEngineVersion sets the EngineVersion field's value.
+func (s *UpgradeTarget) SetEngineVersion(v string) *UpgradeTarget {
+	s.EngineVersion = &v
+	return s
+}
+
+// SetIsMajorVersionUpgrade sets the IsMajorVersionUpgrade field's value.
+func (s *UpgradeTarget) SetIsMajorVersionUpgrade(v bool) *UpgradeTarget {
+	s.IsMajorVersionUpgrade = &v
+	return s
+}
+
 // This data type is used as a response element for queries on VPC security
 // group membership.
 type VpcSecurityGroupMembership struct {
@@ -18620,6 +24326,18 @@ func (s VpcSecurityGroupMembership) String() string {
 // GoString returns the string representation
 func (s VpcSecurityGroupMembership) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *VpcSecurityGroupMembership) SetStatus(v string) *VpcSecurityGroupMembership {
+	s.Status = &v
+	return s
+}
+
+// SetVpcSecurityGroupId sets the VpcSecurityGroupId field's value.
+func (s *VpcSecurityGroupMembership) SetVpcSecurityGroupId(v string) *VpcSecurityGroupMembership {
+	s.VpcSecurityGroupId = &v
+	return s
 }
 
 const (

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -5526,6 +5526,12 @@ func (s AccountWithRestoreAccess) GoString() string {
 	return s.String()
 }
 
+// SetAccountId sets the AccountId field's value.
+func (s *AccountWithRestoreAccess) SetAccountId(v string) *AccountWithRestoreAccess {
+	s.AccountId = &v
+	return s
+}
+
 type AuthorizeClusterSecurityGroupIngressInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5571,6 +5577,30 @@ func (s *AuthorizeClusterSecurityGroupIngressInput) Validate() error {
 	return nil
 }
 
+// SetCIDRIP sets the CIDRIP field's value.
+func (s *AuthorizeClusterSecurityGroupIngressInput) SetCIDRIP(v string) *AuthorizeClusterSecurityGroupIngressInput {
+	s.CIDRIP = &v
+	return s
+}
+
+// SetClusterSecurityGroupName sets the ClusterSecurityGroupName field's value.
+func (s *AuthorizeClusterSecurityGroupIngressInput) SetClusterSecurityGroupName(v string) *AuthorizeClusterSecurityGroupIngressInput {
+	s.ClusterSecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *AuthorizeClusterSecurityGroupIngressInput) SetEC2SecurityGroupName(v string) *AuthorizeClusterSecurityGroupIngressInput {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *AuthorizeClusterSecurityGroupIngressInput) SetEC2SecurityGroupOwnerId(v string) *AuthorizeClusterSecurityGroupIngressInput {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
 type AuthorizeClusterSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5586,6 +5616,12 @@ func (s AuthorizeClusterSecurityGroupIngressOutput) String() string {
 // GoString returns the string representation
 func (s AuthorizeClusterSecurityGroupIngressOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterSecurityGroup sets the ClusterSecurityGroup field's value.
+func (s *AuthorizeClusterSecurityGroupIngressOutput) SetClusterSecurityGroup(v *ClusterSecurityGroup) *AuthorizeClusterSecurityGroupIngressOutput {
+	s.ClusterSecurityGroup = v
+	return s
 }
 
 type AuthorizeSnapshotAccessInput struct {
@@ -5634,6 +5670,24 @@ func (s *AuthorizeSnapshotAccessInput) Validate() error {
 	return nil
 }
 
+// SetAccountWithRestoreAccess sets the AccountWithRestoreAccess field's value.
+func (s *AuthorizeSnapshotAccessInput) SetAccountWithRestoreAccess(v string) *AuthorizeSnapshotAccessInput {
+	s.AccountWithRestoreAccess = &v
+	return s
+}
+
+// SetSnapshotClusterIdentifier sets the SnapshotClusterIdentifier field's value.
+func (s *AuthorizeSnapshotAccessInput) SetSnapshotClusterIdentifier(v string) *AuthorizeSnapshotAccessInput {
+	s.SnapshotClusterIdentifier = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *AuthorizeSnapshotAccessInput) SetSnapshotIdentifier(v string) *AuthorizeSnapshotAccessInput {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
 type AuthorizeSnapshotAccessOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5649,6 +5703,12 @@ func (s AuthorizeSnapshotAccessOutput) String() string {
 // GoString returns the string representation
 func (s AuthorizeSnapshotAccessOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshot sets the Snapshot field's value.
+func (s *AuthorizeSnapshotAccessOutput) SetSnapshot(v *Snapshot) *AuthorizeSnapshotAccessOutput {
+	s.Snapshot = v
+	return s
 }
 
 // Describes an availability zone.
@@ -5667,6 +5727,12 @@ func (s AvailabilityZone) String() string {
 // GoString returns the string representation
 func (s AvailabilityZone) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *AvailabilityZone) SetName(v string) *AvailabilityZone {
+	s.Name = &v
+	return s
 }
 
 // Describes a cluster.
@@ -5849,6 +5915,204 @@ func (s Cluster) GoString() string {
 	return s.String()
 }
 
+// SetAllowVersionUpgrade sets the AllowVersionUpgrade field's value.
+func (s *Cluster) SetAllowVersionUpgrade(v bool) *Cluster {
+	s.AllowVersionUpgrade = &v
+	return s
+}
+
+// SetAutomatedSnapshotRetentionPeriod sets the AutomatedSnapshotRetentionPeriod field's value.
+func (s *Cluster) SetAutomatedSnapshotRetentionPeriod(v int64) *Cluster {
+	s.AutomatedSnapshotRetentionPeriod = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Cluster) SetAvailabilityZone(v string) *Cluster {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetClusterCreateTime sets the ClusterCreateTime field's value.
+func (s *Cluster) SetClusterCreateTime(v time.Time) *Cluster {
+	s.ClusterCreateTime = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *Cluster) SetClusterIdentifier(v string) *Cluster {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetClusterNodes sets the ClusterNodes field's value.
+func (s *Cluster) SetClusterNodes(v []*ClusterNode) *Cluster {
+	s.ClusterNodes = v
+	return s
+}
+
+// SetClusterParameterGroups sets the ClusterParameterGroups field's value.
+func (s *Cluster) SetClusterParameterGroups(v []*ClusterParameterGroupStatus) *Cluster {
+	s.ClusterParameterGroups = v
+	return s
+}
+
+// SetClusterPublicKey sets the ClusterPublicKey field's value.
+func (s *Cluster) SetClusterPublicKey(v string) *Cluster {
+	s.ClusterPublicKey = &v
+	return s
+}
+
+// SetClusterRevisionNumber sets the ClusterRevisionNumber field's value.
+func (s *Cluster) SetClusterRevisionNumber(v string) *Cluster {
+	s.ClusterRevisionNumber = &v
+	return s
+}
+
+// SetClusterSecurityGroups sets the ClusterSecurityGroups field's value.
+func (s *Cluster) SetClusterSecurityGroups(v []*ClusterSecurityGroupMembership) *Cluster {
+	s.ClusterSecurityGroups = v
+	return s
+}
+
+// SetClusterSnapshotCopyStatus sets the ClusterSnapshotCopyStatus field's value.
+func (s *Cluster) SetClusterSnapshotCopyStatus(v *ClusterSnapshotCopyStatus) *Cluster {
+	s.ClusterSnapshotCopyStatus = v
+	return s
+}
+
+// SetClusterStatus sets the ClusterStatus field's value.
+func (s *Cluster) SetClusterStatus(v string) *Cluster {
+	s.ClusterStatus = &v
+	return s
+}
+
+// SetClusterSubnetGroupName sets the ClusterSubnetGroupName field's value.
+func (s *Cluster) SetClusterSubnetGroupName(v string) *Cluster {
+	s.ClusterSubnetGroupName = &v
+	return s
+}
+
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *Cluster) SetClusterVersion(v string) *Cluster {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetDBName sets the DBName field's value.
+func (s *Cluster) SetDBName(v string) *Cluster {
+	s.DBName = &v
+	return s
+}
+
+// SetElasticIpStatus sets the ElasticIpStatus field's value.
+func (s *Cluster) SetElasticIpStatus(v *ElasticIpStatus) *Cluster {
+	s.ElasticIpStatus = v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *Cluster) SetEncrypted(v bool) *Cluster {
+	s.Encrypted = &v
+	return s
+}
+
+// SetEndpoint sets the Endpoint field's value.
+func (s *Cluster) SetEndpoint(v *Endpoint) *Cluster {
+	s.Endpoint = v
+	return s
+}
+
+// SetEnhancedVpcRouting sets the EnhancedVpcRouting field's value.
+func (s *Cluster) SetEnhancedVpcRouting(v bool) *Cluster {
+	s.EnhancedVpcRouting = &v
+	return s
+}
+
+// SetHsmStatus sets the HsmStatus field's value.
+func (s *Cluster) SetHsmStatus(v *HsmStatus) *Cluster {
+	s.HsmStatus = v
+	return s
+}
+
+// SetIamRoles sets the IamRoles field's value.
+func (s *Cluster) SetIamRoles(v []*ClusterIamRole) *Cluster {
+	s.IamRoles = v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *Cluster) SetKmsKeyId(v string) *Cluster {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *Cluster) SetMasterUsername(v string) *Cluster {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetModifyStatus sets the ModifyStatus field's value.
+func (s *Cluster) SetModifyStatus(v string) *Cluster {
+	s.ModifyStatus = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *Cluster) SetNodeType(v string) *Cluster {
+	s.NodeType = &v
+	return s
+}
+
+// SetNumberOfNodes sets the NumberOfNodes field's value.
+func (s *Cluster) SetNumberOfNodes(v int64) *Cluster {
+	s.NumberOfNodes = &v
+	return s
+}
+
+// SetPendingModifiedValues sets the PendingModifiedValues field's value.
+func (s *Cluster) SetPendingModifiedValues(v *PendingModifiedValues) *Cluster {
+	s.PendingModifiedValues = v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *Cluster) SetPreferredMaintenanceWindow(v string) *Cluster {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *Cluster) SetPubliclyAccessible(v bool) *Cluster {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetRestoreStatus sets the RestoreStatus field's value.
+func (s *Cluster) SetRestoreStatus(v *RestoreStatus) *Cluster {
+	s.RestoreStatus = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Cluster) SetTags(v []*Tag) *Cluster {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *Cluster) SetVpcId(v string) *Cluster {
+	s.VpcId = &v
+	return s
+}
+
+// SetVpcSecurityGroups sets the VpcSecurityGroups field's value.
+func (s *Cluster) SetVpcSecurityGroups(v []*VpcSecurityGroupMembership) *Cluster {
+	s.VpcSecurityGroups = v
+	return s
+}
+
 // An AWS Identity and Access Management (IAM) role that can be used by the
 // associated Amazon Redshift cluster to access other AWS services.
 type ClusterIamRole struct {
@@ -5881,6 +6145,18 @@ func (s ClusterIamRole) GoString() string {
 	return s.String()
 }
 
+// SetApplyStatus sets the ApplyStatus field's value.
+func (s *ClusterIamRole) SetApplyStatus(v string) *ClusterIamRole {
+	s.ApplyStatus = &v
+	return s
+}
+
+// SetIamRoleArn sets the IamRoleArn field's value.
+func (s *ClusterIamRole) SetIamRoleArn(v string) *ClusterIamRole {
+	s.IamRoleArn = &v
+	return s
+}
+
 // The identifier of a node in a cluster.
 type ClusterNode struct {
 	_ struct{} `type:"structure"`
@@ -5903,6 +6179,24 @@ func (s ClusterNode) String() string {
 // GoString returns the string representation
 func (s ClusterNode) GoString() string {
 	return s.String()
+}
+
+// SetNodeRole sets the NodeRole field's value.
+func (s *ClusterNode) SetNodeRole(v string) *ClusterNode {
+	s.NodeRole = &v
+	return s
+}
+
+// SetPrivateIPAddress sets the PrivateIPAddress field's value.
+func (s *ClusterNode) SetPrivateIPAddress(v string) *ClusterNode {
+	s.PrivateIPAddress = &v
+	return s
+}
+
+// SetPublicIPAddress sets the PublicIPAddress field's value.
+func (s *ClusterNode) SetPublicIPAddress(v string) *ClusterNode {
+	s.PublicIPAddress = &v
+	return s
 }
 
 // Describes a parameter group.
@@ -5933,6 +6227,30 @@ func (s ClusterParameterGroup) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *ClusterParameterGroup) SetDescription(v string) *ClusterParameterGroup {
+	s.Description = &v
+	return s
+}
+
+// SetParameterGroupFamily sets the ParameterGroupFamily field's value.
+func (s *ClusterParameterGroup) SetParameterGroupFamily(v string) *ClusterParameterGroup {
+	s.ParameterGroupFamily = &v
+	return s
+}
+
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *ClusterParameterGroup) SetParameterGroupName(v string) *ClusterParameterGroup {
+	s.ParameterGroupName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ClusterParameterGroup) SetTags(v []*Tag) *ClusterParameterGroup {
+	s.Tags = v
+	return s
+}
+
 type ClusterParameterGroupNameMessage struct {
 	_ struct{} `type:"structure"`
 
@@ -5953,6 +6271,18 @@ func (s ClusterParameterGroupNameMessage) String() string {
 // GoString returns the string representation
 func (s ClusterParameterGroupNameMessage) GoString() string {
 	return s.String()
+}
+
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *ClusterParameterGroupNameMessage) SetParameterGroupName(v string) *ClusterParameterGroupNameMessage {
+	s.ParameterGroupName = &v
+	return s
+}
+
+// SetParameterGroupStatus sets the ParameterGroupStatus field's value.
+func (s *ClusterParameterGroupNameMessage) SetParameterGroupStatus(v string) *ClusterParameterGroupNameMessage {
+	s.ParameterGroupStatus = &v
+	return s
 }
 
 // Describes the status of a parameter group.
@@ -5981,6 +6311,24 @@ func (s ClusterParameterGroupStatus) String() string {
 // GoString returns the string representation
 func (s ClusterParameterGroupStatus) GoString() string {
 	return s.String()
+}
+
+// SetClusterParameterStatusList sets the ClusterParameterStatusList field's value.
+func (s *ClusterParameterGroupStatus) SetClusterParameterStatusList(v []*ClusterParameterStatus) *ClusterParameterGroupStatus {
+	s.ClusterParameterStatusList = v
+	return s
+}
+
+// SetParameterApplyStatus sets the ParameterApplyStatus field's value.
+func (s *ClusterParameterGroupStatus) SetParameterApplyStatus(v string) *ClusterParameterGroupStatus {
+	s.ParameterApplyStatus = &v
+	return s
+}
+
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *ClusterParameterGroupStatus) SetParameterGroupName(v string) *ClusterParameterGroupStatus {
+	s.ParameterGroupName = &v
+	return s
 }
 
 // Describes the status of a parameter group.
@@ -6030,6 +6378,24 @@ func (s ClusterParameterStatus) GoString() string {
 	return s.String()
 }
 
+// SetParameterApplyErrorDescription sets the ParameterApplyErrorDescription field's value.
+func (s *ClusterParameterStatus) SetParameterApplyErrorDescription(v string) *ClusterParameterStatus {
+	s.ParameterApplyErrorDescription = &v
+	return s
+}
+
+// SetParameterApplyStatus sets the ParameterApplyStatus field's value.
+func (s *ClusterParameterStatus) SetParameterApplyStatus(v string) *ClusterParameterStatus {
+	s.ParameterApplyStatus = &v
+	return s
+}
+
+// SetParameterName sets the ParameterName field's value.
+func (s *ClusterParameterStatus) SetParameterName(v string) *ClusterParameterStatus {
+	s.ParameterName = &v
+	return s
+}
+
 // Describes a security group.
 type ClusterSecurityGroup struct {
 	_ struct{} `type:"structure"`
@@ -6062,6 +6428,36 @@ func (s ClusterSecurityGroup) GoString() string {
 	return s.String()
 }
 
+// SetClusterSecurityGroupName sets the ClusterSecurityGroupName field's value.
+func (s *ClusterSecurityGroup) SetClusterSecurityGroupName(v string) *ClusterSecurityGroup {
+	s.ClusterSecurityGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ClusterSecurityGroup) SetDescription(v string) *ClusterSecurityGroup {
+	s.Description = &v
+	return s
+}
+
+// SetEC2SecurityGroups sets the EC2SecurityGroups field's value.
+func (s *ClusterSecurityGroup) SetEC2SecurityGroups(v []*EC2SecurityGroup) *ClusterSecurityGroup {
+	s.EC2SecurityGroups = v
+	return s
+}
+
+// SetIPRanges sets the IPRanges field's value.
+func (s *ClusterSecurityGroup) SetIPRanges(v []*IPRange) *ClusterSecurityGroup {
+	s.IPRanges = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ClusterSecurityGroup) SetTags(v []*Tag) *ClusterSecurityGroup {
+	s.Tags = v
+	return s
+}
+
 // Describes a cluster security group.
 type ClusterSecurityGroupMembership struct {
 	_ struct{} `type:"structure"`
@@ -6081,6 +6477,18 @@ func (s ClusterSecurityGroupMembership) String() string {
 // GoString returns the string representation
 func (s ClusterSecurityGroupMembership) GoString() string {
 	return s.String()
+}
+
+// SetClusterSecurityGroupName sets the ClusterSecurityGroupName field's value.
+func (s *ClusterSecurityGroupMembership) SetClusterSecurityGroupName(v string) *ClusterSecurityGroupMembership {
+	s.ClusterSecurityGroupName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ClusterSecurityGroupMembership) SetStatus(v string) *ClusterSecurityGroupMembership {
+	s.Status = &v
+	return s
 }
 
 // Returns the destination region and retention period that are configured for
@@ -6108,6 +6516,24 @@ func (s ClusterSnapshotCopyStatus) String() string {
 // GoString returns the string representation
 func (s ClusterSnapshotCopyStatus) GoString() string {
 	return s.String()
+}
+
+// SetDestinationRegion sets the DestinationRegion field's value.
+func (s *ClusterSnapshotCopyStatus) SetDestinationRegion(v string) *ClusterSnapshotCopyStatus {
+	s.DestinationRegion = &v
+	return s
+}
+
+// SetRetentionPeriod sets the RetentionPeriod field's value.
+func (s *ClusterSnapshotCopyStatus) SetRetentionPeriod(v int64) *ClusterSnapshotCopyStatus {
+	s.RetentionPeriod = &v
+	return s
+}
+
+// SetSnapshotCopyGrantName sets the SnapshotCopyGrantName field's value.
+func (s *ClusterSnapshotCopyStatus) SetSnapshotCopyGrantName(v string) *ClusterSnapshotCopyStatus {
+	s.SnapshotCopyGrantName = &v
+	return s
 }
 
 // Describes a subnet group.
@@ -6144,6 +6570,42 @@ func (s ClusterSubnetGroup) GoString() string {
 	return s.String()
 }
 
+// SetClusterSubnetGroupName sets the ClusterSubnetGroupName field's value.
+func (s *ClusterSubnetGroup) SetClusterSubnetGroupName(v string) *ClusterSubnetGroup {
+	s.ClusterSubnetGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ClusterSubnetGroup) SetDescription(v string) *ClusterSubnetGroup {
+	s.Description = &v
+	return s
+}
+
+// SetSubnetGroupStatus sets the SubnetGroupStatus field's value.
+func (s *ClusterSubnetGroup) SetSubnetGroupStatus(v string) *ClusterSubnetGroup {
+	s.SubnetGroupStatus = &v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *ClusterSubnetGroup) SetSubnets(v []*Subnet) *ClusterSubnetGroup {
+	s.Subnets = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ClusterSubnetGroup) SetTags(v []*Tag) *ClusterSubnetGroup {
+	s.Tags = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *ClusterSubnetGroup) SetVpcId(v string) *ClusterSubnetGroup {
+	s.VpcId = &v
+	return s
+}
+
 // Describes a cluster version, including the parameter group family and description
 // of the version.
 type ClusterVersion struct {
@@ -6167,6 +6629,24 @@ func (s ClusterVersion) String() string {
 // GoString returns the string representation
 func (s ClusterVersion) GoString() string {
 	return s.String()
+}
+
+// SetClusterParameterGroupFamily sets the ClusterParameterGroupFamily field's value.
+func (s *ClusterVersion) SetClusterParameterGroupFamily(v string) *ClusterVersion {
+	s.ClusterParameterGroupFamily = &v
+	return s
+}
+
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *ClusterVersion) SetClusterVersion(v string) *ClusterVersion {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ClusterVersion) SetDescription(v string) *ClusterVersion {
+	s.Description = &v
+	return s
 }
 
 type CopyClusterSnapshotInput struct {
@@ -6235,6 +6715,24 @@ func (s *CopyClusterSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetSourceSnapshotClusterIdentifier sets the SourceSnapshotClusterIdentifier field's value.
+func (s *CopyClusterSnapshotInput) SetSourceSnapshotClusterIdentifier(v string) *CopyClusterSnapshotInput {
+	s.SourceSnapshotClusterIdentifier = &v
+	return s
+}
+
+// SetSourceSnapshotIdentifier sets the SourceSnapshotIdentifier field's value.
+func (s *CopyClusterSnapshotInput) SetSourceSnapshotIdentifier(v string) *CopyClusterSnapshotInput {
+	s.SourceSnapshotIdentifier = &v
+	return s
+}
+
+// SetTargetSnapshotIdentifier sets the TargetSnapshotIdentifier field's value.
+func (s *CopyClusterSnapshotInput) SetTargetSnapshotIdentifier(v string) *CopyClusterSnapshotInput {
+	s.TargetSnapshotIdentifier = &v
+	return s
+}
+
 type CopyClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6250,6 +6748,12 @@ func (s CopyClusterSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CopyClusterSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshot sets the Snapshot field's value.
+func (s *CopyClusterSnapshotOutput) SetSnapshot(v *Snapshot) *CopyClusterSnapshotOutput {
+	s.Snapshot = v
+	return s
 }
 
 type CreateClusterInput struct {
@@ -6555,6 +7059,168 @@ func (s *CreateClusterInput) Validate() error {
 	return nil
 }
 
+// SetAdditionalInfo sets the AdditionalInfo field's value.
+func (s *CreateClusterInput) SetAdditionalInfo(v string) *CreateClusterInput {
+	s.AdditionalInfo = &v
+	return s
+}
+
+// SetAllowVersionUpgrade sets the AllowVersionUpgrade field's value.
+func (s *CreateClusterInput) SetAllowVersionUpgrade(v bool) *CreateClusterInput {
+	s.AllowVersionUpgrade = &v
+	return s
+}
+
+// SetAutomatedSnapshotRetentionPeriod sets the AutomatedSnapshotRetentionPeriod field's value.
+func (s *CreateClusterInput) SetAutomatedSnapshotRetentionPeriod(v int64) *CreateClusterInput {
+	s.AutomatedSnapshotRetentionPeriod = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *CreateClusterInput) SetAvailabilityZone(v string) *CreateClusterInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *CreateClusterInput) SetClusterIdentifier(v string) *CreateClusterInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetClusterParameterGroupName sets the ClusterParameterGroupName field's value.
+func (s *CreateClusterInput) SetClusterParameterGroupName(v string) *CreateClusterInput {
+	s.ClusterParameterGroupName = &v
+	return s
+}
+
+// SetClusterSecurityGroups sets the ClusterSecurityGroups field's value.
+func (s *CreateClusterInput) SetClusterSecurityGroups(v []*string) *CreateClusterInput {
+	s.ClusterSecurityGroups = v
+	return s
+}
+
+// SetClusterSubnetGroupName sets the ClusterSubnetGroupName field's value.
+func (s *CreateClusterInput) SetClusterSubnetGroupName(v string) *CreateClusterInput {
+	s.ClusterSubnetGroupName = &v
+	return s
+}
+
+// SetClusterType sets the ClusterType field's value.
+func (s *CreateClusterInput) SetClusterType(v string) *CreateClusterInput {
+	s.ClusterType = &v
+	return s
+}
+
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *CreateClusterInput) SetClusterVersion(v string) *CreateClusterInput {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetDBName sets the DBName field's value.
+func (s *CreateClusterInput) SetDBName(v string) *CreateClusterInput {
+	s.DBName = &v
+	return s
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *CreateClusterInput) SetElasticIp(v string) *CreateClusterInput {
+	s.ElasticIp = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *CreateClusterInput) SetEncrypted(v bool) *CreateClusterInput {
+	s.Encrypted = &v
+	return s
+}
+
+// SetEnhancedVpcRouting sets the EnhancedVpcRouting field's value.
+func (s *CreateClusterInput) SetEnhancedVpcRouting(v bool) *CreateClusterInput {
+	s.EnhancedVpcRouting = &v
+	return s
+}
+
+// SetHsmClientCertificateIdentifier sets the HsmClientCertificateIdentifier field's value.
+func (s *CreateClusterInput) SetHsmClientCertificateIdentifier(v string) *CreateClusterInput {
+	s.HsmClientCertificateIdentifier = &v
+	return s
+}
+
+// SetHsmConfigurationIdentifier sets the HsmConfigurationIdentifier field's value.
+func (s *CreateClusterInput) SetHsmConfigurationIdentifier(v string) *CreateClusterInput {
+	s.HsmConfigurationIdentifier = &v
+	return s
+}
+
+// SetIamRoles sets the IamRoles field's value.
+func (s *CreateClusterInput) SetIamRoles(v []*string) *CreateClusterInput {
+	s.IamRoles = v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateClusterInput) SetKmsKeyId(v string) *CreateClusterInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *CreateClusterInput) SetMasterUserPassword(v string) *CreateClusterInput {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *CreateClusterInput) SetMasterUsername(v string) *CreateClusterInput {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *CreateClusterInput) SetNodeType(v string) *CreateClusterInput {
+	s.NodeType = &v
+	return s
+}
+
+// SetNumberOfNodes sets the NumberOfNodes field's value.
+func (s *CreateClusterInput) SetNumberOfNodes(v int64) *CreateClusterInput {
+	s.NumberOfNodes = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *CreateClusterInput) SetPort(v int64) *CreateClusterInput {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *CreateClusterInput) SetPreferredMaintenanceWindow(v string) *CreateClusterInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *CreateClusterInput) SetPubliclyAccessible(v bool) *CreateClusterInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateClusterInput) SetTags(v []*Tag) *CreateClusterInput {
+	s.Tags = v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *CreateClusterInput) SetVpcSecurityGroupIds(v []*string) *CreateClusterInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type CreateClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6570,6 +7236,12 @@ func (s CreateClusterOutput) String() string {
 // GoString returns the string representation
 func (s CreateClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *CreateClusterOutput) SetCluster(v *Cluster) *CreateClusterOutput {
+	s.Cluster = v
+	return s
 }
 
 type CreateClusterParameterGroupInput struct {
@@ -6643,6 +7315,30 @@ func (s *CreateClusterParameterGroupInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateClusterParameterGroupInput) SetDescription(v string) *CreateClusterParameterGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetParameterGroupFamily sets the ParameterGroupFamily field's value.
+func (s *CreateClusterParameterGroupInput) SetParameterGroupFamily(v string) *CreateClusterParameterGroupInput {
+	s.ParameterGroupFamily = &v
+	return s
+}
+
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *CreateClusterParameterGroupInput) SetParameterGroupName(v string) *CreateClusterParameterGroupInput {
+	s.ParameterGroupName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateClusterParameterGroupInput) SetTags(v []*Tag) *CreateClusterParameterGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateClusterParameterGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6658,6 +7354,12 @@ func (s CreateClusterParameterGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateClusterParameterGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterParameterGroup sets the ClusterParameterGroup field's value.
+func (s *CreateClusterParameterGroupOutput) SetClusterParameterGroup(v *ClusterParameterGroup) *CreateClusterParameterGroupOutput {
+	s.ClusterParameterGroup = v
+	return s
 }
 
 type CreateClusterSecurityGroupInput struct {
@@ -6715,6 +7417,24 @@ func (s *CreateClusterSecurityGroupInput) Validate() error {
 	return nil
 }
 
+// SetClusterSecurityGroupName sets the ClusterSecurityGroupName field's value.
+func (s *CreateClusterSecurityGroupInput) SetClusterSecurityGroupName(v string) *CreateClusterSecurityGroupInput {
+	s.ClusterSecurityGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateClusterSecurityGroupInput) SetDescription(v string) *CreateClusterSecurityGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateClusterSecurityGroupInput) SetTags(v []*Tag) *CreateClusterSecurityGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateClusterSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6730,6 +7450,12 @@ func (s CreateClusterSecurityGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateClusterSecurityGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterSecurityGroup sets the ClusterSecurityGroup field's value.
+func (s *CreateClusterSecurityGroupOutput) SetClusterSecurityGroup(v *ClusterSecurityGroup) *CreateClusterSecurityGroupOutput {
+	s.ClusterSecurityGroup = v
+	return s
 }
 
 type CreateClusterSnapshotInput struct {
@@ -6788,6 +7514,24 @@ func (s *CreateClusterSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *CreateClusterSnapshotInput) SetClusterIdentifier(v string) *CreateClusterSnapshotInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *CreateClusterSnapshotInput) SetSnapshotIdentifier(v string) *CreateClusterSnapshotInput {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateClusterSnapshotInput) SetTags(v []*Tag) *CreateClusterSnapshotInput {
+	s.Tags = v
+	return s
+}
+
 type CreateClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6803,6 +7547,12 @@ func (s CreateClusterSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CreateClusterSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshot sets the Snapshot field's value.
+func (s *CreateClusterSnapshotOutput) SetSnapshot(v *Snapshot) *CreateClusterSnapshotOutput {
+	s.Snapshot = v
+	return s
 }
 
 type CreateClusterSubnetGroupInput struct {
@@ -6868,6 +7618,30 @@ func (s *CreateClusterSubnetGroupInput) Validate() error {
 	return nil
 }
 
+// SetClusterSubnetGroupName sets the ClusterSubnetGroupName field's value.
+func (s *CreateClusterSubnetGroupInput) SetClusterSubnetGroupName(v string) *CreateClusterSubnetGroupInput {
+	s.ClusterSubnetGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateClusterSubnetGroupInput) SetDescription(v string) *CreateClusterSubnetGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *CreateClusterSubnetGroupInput) SetSubnetIds(v []*string) *CreateClusterSubnetGroupInput {
+	s.SubnetIds = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateClusterSubnetGroupInput) SetTags(v []*Tag) *CreateClusterSubnetGroupInput {
+	s.Tags = v
+	return s
+}
+
 type CreateClusterSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6883,6 +7657,12 @@ func (s CreateClusterSubnetGroupOutput) String() string {
 // GoString returns the string representation
 func (s CreateClusterSubnetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterSubnetGroup sets the ClusterSubnetGroup field's value.
+func (s *CreateClusterSubnetGroupOutput) SetClusterSubnetGroup(v *ClusterSubnetGroup) *CreateClusterSubnetGroupOutput {
+	s.ClusterSubnetGroup = v
+	return s
 }
 
 type CreateEventSubscriptionInput struct {
@@ -6977,6 +7757,54 @@ func (s *CreateEventSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *CreateEventSubscriptionInput) SetEnabled(v bool) *CreateEventSubscriptionInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *CreateEventSubscriptionInput) SetEventCategories(v []*string) *CreateEventSubscriptionInput {
+	s.EventCategories = v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *CreateEventSubscriptionInput) SetSeverity(v string) *CreateEventSubscriptionInput {
+	s.Severity = &v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *CreateEventSubscriptionInput) SetSnsTopicArn(v string) *CreateEventSubscriptionInput {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceIds sets the SourceIds field's value.
+func (s *CreateEventSubscriptionInput) SetSourceIds(v []*string) *CreateEventSubscriptionInput {
+	s.SourceIds = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *CreateEventSubscriptionInput) SetSourceType(v string) *CreateEventSubscriptionInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *CreateEventSubscriptionInput) SetSubscriptionName(v string) *CreateEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateEventSubscriptionInput) SetTags(v []*Tag) *CreateEventSubscriptionInput {
+	s.Tags = v
+	return s
+}
+
 type CreateEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6992,6 +7820,12 @@ func (s CreateEventSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s CreateEventSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *CreateEventSubscriptionOutput) SetEventSubscription(v *EventSubscription) *CreateEventSubscriptionOutput {
+	s.EventSubscription = v
+	return s
 }
 
 type CreateHsmClientCertificateInput struct {
@@ -7030,6 +7864,18 @@ func (s *CreateHsmClientCertificateInput) Validate() error {
 	return nil
 }
 
+// SetHsmClientCertificateIdentifier sets the HsmClientCertificateIdentifier field's value.
+func (s *CreateHsmClientCertificateInput) SetHsmClientCertificateIdentifier(v string) *CreateHsmClientCertificateInput {
+	s.HsmClientCertificateIdentifier = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateHsmClientCertificateInput) SetTags(v []*Tag) *CreateHsmClientCertificateInput {
+	s.Tags = v
+	return s
+}
+
 type CreateHsmClientCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7047,6 +7893,12 @@ func (s CreateHsmClientCertificateOutput) String() string {
 // GoString returns the string representation
 func (s CreateHsmClientCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// SetHsmClientCertificate sets the HsmClientCertificate field's value.
+func (s *CreateHsmClientCertificateOutput) SetHsmClientCertificate(v *HsmClientCertificate) *CreateHsmClientCertificateOutput {
+	s.HsmClientCertificate = v
+	return s
 }
 
 type CreateHsmConfigurationInput struct {
@@ -7126,6 +7978,48 @@ func (s *CreateHsmConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateHsmConfigurationInput) SetDescription(v string) *CreateHsmConfigurationInput {
+	s.Description = &v
+	return s
+}
+
+// SetHsmConfigurationIdentifier sets the HsmConfigurationIdentifier field's value.
+func (s *CreateHsmConfigurationInput) SetHsmConfigurationIdentifier(v string) *CreateHsmConfigurationInput {
+	s.HsmConfigurationIdentifier = &v
+	return s
+}
+
+// SetHsmIpAddress sets the HsmIpAddress field's value.
+func (s *CreateHsmConfigurationInput) SetHsmIpAddress(v string) *CreateHsmConfigurationInput {
+	s.HsmIpAddress = &v
+	return s
+}
+
+// SetHsmPartitionName sets the HsmPartitionName field's value.
+func (s *CreateHsmConfigurationInput) SetHsmPartitionName(v string) *CreateHsmConfigurationInput {
+	s.HsmPartitionName = &v
+	return s
+}
+
+// SetHsmPartitionPassword sets the HsmPartitionPassword field's value.
+func (s *CreateHsmConfigurationInput) SetHsmPartitionPassword(v string) *CreateHsmConfigurationInput {
+	s.HsmPartitionPassword = &v
+	return s
+}
+
+// SetHsmServerPublicCertificate sets the HsmServerPublicCertificate field's value.
+func (s *CreateHsmConfigurationInput) SetHsmServerPublicCertificate(v string) *CreateHsmConfigurationInput {
+	s.HsmServerPublicCertificate = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateHsmConfigurationInput) SetTags(v []*Tag) *CreateHsmConfigurationInput {
+	s.Tags = v
+	return s
+}
+
 type CreateHsmConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7143,6 +8037,12 @@ func (s CreateHsmConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s CreateHsmConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetHsmConfiguration sets the HsmConfiguration field's value.
+func (s *CreateHsmConfigurationOutput) SetHsmConfiguration(v *HsmConfiguration) *CreateHsmConfigurationOutput {
+	s.HsmConfiguration = v
+	return s
 }
 
 // The result of the CreateSnapshotCopyGrant action.
@@ -7198,6 +8098,24 @@ func (s *CreateSnapshotCopyGrantInput) Validate() error {
 	return nil
 }
 
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateSnapshotCopyGrantInput) SetKmsKeyId(v string) *CreateSnapshotCopyGrantInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetSnapshotCopyGrantName sets the SnapshotCopyGrantName field's value.
+func (s *CreateSnapshotCopyGrantInput) SetSnapshotCopyGrantName(v string) *CreateSnapshotCopyGrantInput {
+	s.SnapshotCopyGrantName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateSnapshotCopyGrantInput) SetTags(v []*Tag) *CreateSnapshotCopyGrantInput {
+	s.Tags = v
+	return s
+}
+
 type CreateSnapshotCopyGrantOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7219,6 +8137,12 @@ func (s CreateSnapshotCopyGrantOutput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotCopyGrantOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshotCopyGrant sets the SnapshotCopyGrant field's value.
+func (s *CreateSnapshotCopyGrantOutput) SetSnapshotCopyGrant(v *SnapshotCopyGrant) *CreateSnapshotCopyGrantOutput {
+	s.SnapshotCopyGrant = v
+	return s
 }
 
 // Contains the output from the CreateTags action.
@@ -7267,6 +8191,18 @@ func (s *CreateTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceName sets the ResourceName field's value.
+func (s *CreateTagsInput) SetResourceName(v string) *CreateTagsInput {
+	s.ResourceName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateTagsInput) SetTags(v []*Tag) *CreateTagsInput {
+	s.Tags = v
+	return s
+}
+
 type CreateTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7308,6 +8244,24 @@ func (s DefaultClusterParameters) String() string {
 // GoString returns the string representation
 func (s DefaultClusterParameters) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DefaultClusterParameters) SetMarker(v string) *DefaultClusterParameters {
+	s.Marker = &v
+	return s
+}
+
+// SetParameterGroupFamily sets the ParameterGroupFamily field's value.
+func (s *DefaultClusterParameters) SetParameterGroupFamily(v string) *DefaultClusterParameters {
+	s.ParameterGroupFamily = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *DefaultClusterParameters) SetParameters(v []*Parameter) *DefaultClusterParameters {
+	s.Parameters = v
+	return s
 }
 
 type DeleteClusterInput struct {
@@ -7375,6 +8329,24 @@ func (s *DeleteClusterInput) Validate() error {
 	return nil
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *DeleteClusterInput) SetClusterIdentifier(v string) *DeleteClusterInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetFinalClusterSnapshotIdentifier sets the FinalClusterSnapshotIdentifier field's value.
+func (s *DeleteClusterInput) SetFinalClusterSnapshotIdentifier(v string) *DeleteClusterInput {
+	s.FinalClusterSnapshotIdentifier = &v
+	return s
+}
+
+// SetSkipFinalClusterSnapshot sets the SkipFinalClusterSnapshot field's value.
+func (s *DeleteClusterInput) SetSkipFinalClusterSnapshot(v bool) *DeleteClusterInput {
+	s.SkipFinalClusterSnapshot = &v
+	return s
+}
+
 type DeleteClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7390,6 +8362,12 @@ func (s DeleteClusterOutput) String() string {
 // GoString returns the string representation
 func (s DeleteClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *DeleteClusterOutput) SetCluster(v *Cluster) *DeleteClusterOutput {
+	s.Cluster = v
+	return s
 }
 
 type DeleteClusterParameterGroupInput struct {
@@ -7428,6 +8406,12 @@ func (s *DeleteClusterParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *DeleteClusterParameterGroupInput) SetParameterGroupName(v string) *DeleteClusterParameterGroupInput {
+	s.ParameterGroupName = &v
+	return s
 }
 
 type DeleteClusterParameterGroupOutput struct {
@@ -7474,6 +8458,12 @@ func (s *DeleteClusterSecurityGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClusterSecurityGroupName sets the ClusterSecurityGroupName field's value.
+func (s *DeleteClusterSecurityGroupInput) SetClusterSecurityGroupName(v string) *DeleteClusterSecurityGroupInput {
+	s.ClusterSecurityGroupName = &v
+	return s
 }
 
 type DeleteClusterSecurityGroupOutput struct {
@@ -7532,6 +8522,18 @@ func (s *DeleteClusterSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetSnapshotClusterIdentifier sets the SnapshotClusterIdentifier field's value.
+func (s *DeleteClusterSnapshotInput) SetSnapshotClusterIdentifier(v string) *DeleteClusterSnapshotInput {
+	s.SnapshotClusterIdentifier = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *DeleteClusterSnapshotInput) SetSnapshotIdentifier(v string) *DeleteClusterSnapshotInput {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
 type DeleteClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7547,6 +8549,12 @@ func (s DeleteClusterSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s DeleteClusterSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshot sets the Snapshot field's value.
+func (s *DeleteClusterSnapshotOutput) SetSnapshot(v *Snapshot) *DeleteClusterSnapshotOutput {
+	s.Snapshot = v
+	return s
 }
 
 type DeleteClusterSubnetGroupInput struct {
@@ -7579,6 +8587,12 @@ func (s *DeleteClusterSubnetGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClusterSubnetGroupName sets the ClusterSubnetGroupName field's value.
+func (s *DeleteClusterSubnetGroupInput) SetClusterSubnetGroupName(v string) *DeleteClusterSubnetGroupInput {
+	s.ClusterSubnetGroupName = &v
+	return s
 }
 
 type DeleteClusterSubnetGroupOutput struct {
@@ -7627,6 +8641,12 @@ func (s *DeleteEventSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *DeleteEventSubscriptionInput) SetSubscriptionName(v string) *DeleteEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
 type DeleteEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7671,6 +8691,12 @@ func (s *DeleteHsmClientCertificateInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHsmClientCertificateIdentifier sets the HsmClientCertificateIdentifier field's value.
+func (s *DeleteHsmClientCertificateInput) SetHsmClientCertificateIdentifier(v string) *DeleteHsmClientCertificateInput {
+	s.HsmClientCertificateIdentifier = &v
+	return s
 }
 
 type DeleteHsmClientCertificateOutput struct {
@@ -7719,6 +8745,12 @@ func (s *DeleteHsmConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetHsmConfigurationIdentifier sets the HsmConfigurationIdentifier field's value.
+func (s *DeleteHsmConfigurationInput) SetHsmConfigurationIdentifier(v string) *DeleteHsmConfigurationInput {
+	s.HsmConfigurationIdentifier = &v
+	return s
+}
+
 type DeleteHsmConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7764,6 +8796,12 @@ func (s *DeleteSnapshotCopyGrantInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetSnapshotCopyGrantName sets the SnapshotCopyGrantName field's value.
+func (s *DeleteSnapshotCopyGrantInput) SetSnapshotCopyGrantName(v string) *DeleteSnapshotCopyGrantInput {
+	s.SnapshotCopyGrantName = &v
+	return s
 }
 
 type DeleteSnapshotCopyGrantOutput struct {
@@ -7820,6 +8858,18 @@ func (s *DeleteTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *DeleteTagsInput) SetResourceName(v string) *DeleteTagsInput {
+	s.ResourceName = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DeleteTagsInput) SetTagKeys(v []*string) *DeleteTagsInput {
+	s.TagKeys = v
+	return s
 }
 
 type DeleteTagsOutput struct {
@@ -7888,6 +8938,36 @@ func (s DescribeClusterParameterGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterParameterGroupsInput) SetMarker(v string) *DescribeClusterParameterGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeClusterParameterGroupsInput) SetMaxRecords(v int64) *DescribeClusterParameterGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *DescribeClusterParameterGroupsInput) SetParameterGroupName(v string) *DescribeClusterParameterGroupsInput {
+	s.ParameterGroupName = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeClusterParameterGroupsInput) SetTagKeys(v []*string) *DescribeClusterParameterGroupsInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeClusterParameterGroupsInput) SetTagValues(v []*string) *DescribeClusterParameterGroupsInput {
+	s.TagValues = v
+	return s
+}
+
 // Contains the output from the DescribeClusterParameterGroups action.
 type DescribeClusterParameterGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7912,6 +8992,18 @@ func (s DescribeClusterParameterGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClusterParameterGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterParameterGroupsOutput) SetMarker(v string) *DescribeClusterParameterGroupsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetParameterGroups sets the ParameterGroups field's value.
+func (s *DescribeClusterParameterGroupsOutput) SetParameterGroups(v []*ClusterParameterGroup) *DescribeClusterParameterGroupsOutput {
+	s.ParameterGroups = v
+	return s
 }
 
 type DescribeClusterParametersInput struct {
@@ -7973,6 +9065,30 @@ func (s *DescribeClusterParametersInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterParametersInput) SetMarker(v string) *DescribeClusterParametersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeClusterParametersInput) SetMaxRecords(v int64) *DescribeClusterParametersInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *DescribeClusterParametersInput) SetParameterGroupName(v string) *DescribeClusterParametersInput {
+	s.ParameterGroupName = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *DescribeClusterParametersInput) SetSource(v string) *DescribeClusterParametersInput {
+	s.Source = &v
+	return s
+}
+
 // Contains the output from the DescribeClusterParameters action.
 type DescribeClusterParametersOutput struct {
 	_ struct{} `type:"structure"`
@@ -7997,6 +9113,18 @@ func (s DescribeClusterParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClusterParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterParametersOutput) SetMarker(v string) *DescribeClusterParametersOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *DescribeClusterParametersOutput) SetParameters(v []*Parameter) *DescribeClusterParametersOutput {
+	s.Parameters = v
+	return s
 }
 
 type DescribeClusterSecurityGroupsInput struct {
@@ -8057,6 +9185,36 @@ func (s DescribeClusterSecurityGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterSecurityGroupName sets the ClusterSecurityGroupName field's value.
+func (s *DescribeClusterSecurityGroupsInput) SetClusterSecurityGroupName(v string) *DescribeClusterSecurityGroupsInput {
+	s.ClusterSecurityGroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterSecurityGroupsInput) SetMarker(v string) *DescribeClusterSecurityGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeClusterSecurityGroupsInput) SetMaxRecords(v int64) *DescribeClusterSecurityGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeClusterSecurityGroupsInput) SetTagKeys(v []*string) *DescribeClusterSecurityGroupsInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeClusterSecurityGroupsInput) SetTagValues(v []*string) *DescribeClusterSecurityGroupsInput {
+	s.TagValues = v
+	return s
+}
+
 type DescribeClusterSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8079,6 +9237,18 @@ func (s DescribeClusterSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClusterSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterSecurityGroups sets the ClusterSecurityGroups field's value.
+func (s *DescribeClusterSecurityGroupsOutput) SetClusterSecurityGroups(v []*ClusterSecurityGroup) *DescribeClusterSecurityGroupsOutput {
+	s.ClusterSecurityGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterSecurityGroupsOutput) SetMarker(v string) *DescribeClusterSecurityGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeClusterSnapshotsInput struct {
@@ -8161,6 +9331,66 @@ func (s DescribeClusterSnapshotsInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *DescribeClusterSnapshotsInput) SetClusterIdentifier(v string) *DescribeClusterSnapshotsInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeClusterSnapshotsInput) SetEndTime(v time.Time) *DescribeClusterSnapshotsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterSnapshotsInput) SetMarker(v string) *DescribeClusterSnapshotsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeClusterSnapshotsInput) SetMaxRecords(v int64) *DescribeClusterSnapshotsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetOwnerAccount sets the OwnerAccount field's value.
+func (s *DescribeClusterSnapshotsInput) SetOwnerAccount(v string) *DescribeClusterSnapshotsInput {
+	s.OwnerAccount = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *DescribeClusterSnapshotsInput) SetSnapshotIdentifier(v string) *DescribeClusterSnapshotsInput {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
+// SetSnapshotType sets the SnapshotType field's value.
+func (s *DescribeClusterSnapshotsInput) SetSnapshotType(v string) *DescribeClusterSnapshotsInput {
+	s.SnapshotType = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeClusterSnapshotsInput) SetStartTime(v time.Time) *DescribeClusterSnapshotsInput {
+	s.StartTime = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeClusterSnapshotsInput) SetTagKeys(v []*string) *DescribeClusterSnapshotsInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeClusterSnapshotsInput) SetTagValues(v []*string) *DescribeClusterSnapshotsInput {
+	s.TagValues = v
+	return s
+}
+
 // Contains the output from the DescribeClusterSnapshots action.
 type DescribeClusterSnapshotsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8184,6 +9414,18 @@ func (s DescribeClusterSnapshotsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClusterSnapshotsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterSnapshotsOutput) SetMarker(v string) *DescribeClusterSnapshotsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSnapshots sets the Snapshots field's value.
+func (s *DescribeClusterSnapshotsOutput) SetSnapshots(v []*Snapshot) *DescribeClusterSnapshotsOutput {
+	s.Snapshots = v
+	return s
 }
 
 type DescribeClusterSubnetGroupsInput struct {
@@ -8237,6 +9479,36 @@ func (s DescribeClusterSubnetGroupsInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterSubnetGroupName sets the ClusterSubnetGroupName field's value.
+func (s *DescribeClusterSubnetGroupsInput) SetClusterSubnetGroupName(v string) *DescribeClusterSubnetGroupsInput {
+	s.ClusterSubnetGroupName = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterSubnetGroupsInput) SetMarker(v string) *DescribeClusterSubnetGroupsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeClusterSubnetGroupsInput) SetMaxRecords(v int64) *DescribeClusterSubnetGroupsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeClusterSubnetGroupsInput) SetTagKeys(v []*string) *DescribeClusterSubnetGroupsInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeClusterSubnetGroupsInput) SetTagValues(v []*string) *DescribeClusterSubnetGroupsInput {
+	s.TagValues = v
+	return s
+}
+
 // Contains the output from the DescribeClusterSubnetGroups action.
 type DescribeClusterSubnetGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8260,6 +9532,18 @@ func (s DescribeClusterSubnetGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClusterSubnetGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterSubnetGroups sets the ClusterSubnetGroups field's value.
+func (s *DescribeClusterSubnetGroupsOutput) SetClusterSubnetGroups(v []*ClusterSubnetGroup) *DescribeClusterSubnetGroupsOutput {
+	s.ClusterSubnetGroups = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterSubnetGroupsOutput) SetMarker(v string) *DescribeClusterSubnetGroupsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeClusterVersionsInput struct {
@@ -8309,6 +9593,30 @@ func (s DescribeClusterVersionsInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterParameterGroupFamily sets the ClusterParameterGroupFamily field's value.
+func (s *DescribeClusterVersionsInput) SetClusterParameterGroupFamily(v string) *DescribeClusterVersionsInput {
+	s.ClusterParameterGroupFamily = &v
+	return s
+}
+
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *DescribeClusterVersionsInput) SetClusterVersion(v string) *DescribeClusterVersionsInput {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterVersionsInput) SetMarker(v string) *DescribeClusterVersionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeClusterVersionsInput) SetMaxRecords(v int64) *DescribeClusterVersionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
 // Contains the output from the DescribeClusterVersions action.
 type DescribeClusterVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8332,6 +9640,18 @@ func (s DescribeClusterVersionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClusterVersionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterVersions sets the ClusterVersions field's value.
+func (s *DescribeClusterVersionsOutput) SetClusterVersions(v []*ClusterVersion) *DescribeClusterVersionsOutput {
+	s.ClusterVersions = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClusterVersionsOutput) SetMarker(v string) *DescribeClusterVersionsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeClustersInput struct {
@@ -8390,6 +9710,36 @@ func (s DescribeClustersInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *DescribeClustersInput) SetClusterIdentifier(v string) *DescribeClustersInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClustersInput) SetMarker(v string) *DescribeClustersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeClustersInput) SetMaxRecords(v int64) *DescribeClustersInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeClustersInput) SetTagKeys(v []*string) *DescribeClustersInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeClustersInput) SetTagValues(v []*string) *DescribeClustersInput {
+	s.TagValues = v
+	return s
+}
+
 // Contains the output from the DescribeClusters action.
 type DescribeClustersOutput struct {
 	_ struct{} `type:"structure"`
@@ -8413,6 +9763,18 @@ func (s DescribeClustersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeClustersOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusters sets the Clusters field's value.
+func (s *DescribeClustersOutput) SetClusters(v []*Cluster) *DescribeClustersOutput {
+	s.Clusters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeClustersOutput) SetMarker(v string) *DescribeClustersOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeDefaultClusterParametersInput struct {
@@ -8465,6 +9827,24 @@ func (s *DescribeDefaultClusterParametersInput) Validate() error {
 	return nil
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeDefaultClusterParametersInput) SetMarker(v string) *DescribeDefaultClusterParametersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeDefaultClusterParametersInput) SetMaxRecords(v int64) *DescribeDefaultClusterParametersInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetParameterGroupFamily sets the ParameterGroupFamily field's value.
+func (s *DescribeDefaultClusterParametersInput) SetParameterGroupFamily(v string) *DescribeDefaultClusterParametersInput {
+	s.ParameterGroupFamily = &v
+	return s
+}
+
 type DescribeDefaultClusterParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8480,6 +9860,12 @@ func (s DescribeDefaultClusterParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDefaultClusterParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetDefaultClusterParameters sets the DefaultClusterParameters field's value.
+func (s *DescribeDefaultClusterParametersOutput) SetDefaultClusterParameters(v *DefaultClusterParameters) *DescribeDefaultClusterParametersOutput {
+	s.DefaultClusterParameters = v
+	return s
 }
 
 type DescribeEventCategoriesInput struct {
@@ -8502,6 +9888,12 @@ func (s DescribeEventCategoriesInput) GoString() string {
 	return s.String()
 }
 
+// SetSourceType sets the SourceType field's value.
+func (s *DescribeEventCategoriesInput) SetSourceType(v string) *DescribeEventCategoriesInput {
+	s.SourceType = &v
+	return s
+}
+
 type DescribeEventCategoriesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8517,6 +9909,12 @@ func (s DescribeEventCategoriesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventCategoriesOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventCategoriesMapList sets the EventCategoriesMapList field's value.
+func (s *DescribeEventCategoriesOutput) SetEventCategoriesMapList(v []*EventCategoriesMap) *DescribeEventCategoriesOutput {
+	s.EventCategoriesMapList = v
+	return s
 }
 
 type DescribeEventSubscriptionsInput struct {
@@ -8554,6 +9952,24 @@ func (s DescribeEventSubscriptionsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventSubscriptionsInput) SetMarker(v string) *DescribeEventSubscriptionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEventSubscriptionsInput) SetMaxRecords(v int64) *DescribeEventSubscriptionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *DescribeEventSubscriptionsInput) SetSubscriptionName(v string) *DescribeEventSubscriptionsInput {
+	s.SubscriptionName = &v
+	return s
+}
+
 type DescribeEventSubscriptionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8576,6 +9992,18 @@ func (s DescribeEventSubscriptionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventSubscriptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscriptionsList sets the EventSubscriptionsList field's value.
+func (s *DescribeEventSubscriptionsOutput) SetEventSubscriptionsList(v []*EventSubscription) *DescribeEventSubscriptionsOutput {
+	s.EventSubscriptionsList = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventSubscriptionsOutput) SetMarker(v string) *DescribeEventSubscriptionsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeEventsInput struct {
@@ -8665,6 +10093,48 @@ func (s DescribeEventsInput) GoString() string {
 	return s.String()
 }
 
+// SetDuration sets the Duration field's value.
+func (s *DescribeEventsInput) SetDuration(v int64) *DescribeEventsInput {
+	s.Duration = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeEventsInput) SetEndTime(v time.Time) *DescribeEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventsInput) SetMarker(v string) *DescribeEventsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEventsInput) SetMaxRecords(v int64) *DescribeEventsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *DescribeEventsInput) SetSourceIdentifier(v string) *DescribeEventsInput {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *DescribeEventsInput) SetSourceType(v string) *DescribeEventsInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeEventsInput) SetStartTime(v time.Time) *DescribeEventsInput {
+	s.StartTime = &v
+	return s
+}
+
 type DescribeEventsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8687,6 +10157,18 @@ func (s DescribeEventsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeEventsOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *DescribeEventsOutput) SetEvents(v []*Event) *DescribeEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventsOutput) SetMarker(v string) *DescribeEventsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeHsmClientCertificatesInput struct {
@@ -8742,6 +10224,36 @@ func (s DescribeHsmClientCertificatesInput) GoString() string {
 	return s.String()
 }
 
+// SetHsmClientCertificateIdentifier sets the HsmClientCertificateIdentifier field's value.
+func (s *DescribeHsmClientCertificatesInput) SetHsmClientCertificateIdentifier(v string) *DescribeHsmClientCertificatesInput {
+	s.HsmClientCertificateIdentifier = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeHsmClientCertificatesInput) SetMarker(v string) *DescribeHsmClientCertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeHsmClientCertificatesInput) SetMaxRecords(v int64) *DescribeHsmClientCertificatesInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeHsmClientCertificatesInput) SetTagKeys(v []*string) *DescribeHsmClientCertificatesInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeHsmClientCertificatesInput) SetTagValues(v []*string) *DescribeHsmClientCertificatesInput {
+	s.TagValues = v
+	return s
+}
+
 type DescribeHsmClientCertificatesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8766,6 +10278,18 @@ func (s DescribeHsmClientCertificatesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeHsmClientCertificatesOutput) GoString() string {
 	return s.String()
+}
+
+// SetHsmClientCertificates sets the HsmClientCertificates field's value.
+func (s *DescribeHsmClientCertificatesOutput) SetHsmClientCertificates(v []*HsmClientCertificate) *DescribeHsmClientCertificatesOutput {
+	s.HsmClientCertificates = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeHsmClientCertificatesOutput) SetMarker(v string) *DescribeHsmClientCertificatesOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeHsmConfigurationsInput struct {
@@ -8821,6 +10345,36 @@ func (s DescribeHsmConfigurationsInput) GoString() string {
 	return s.String()
 }
 
+// SetHsmConfigurationIdentifier sets the HsmConfigurationIdentifier field's value.
+func (s *DescribeHsmConfigurationsInput) SetHsmConfigurationIdentifier(v string) *DescribeHsmConfigurationsInput {
+	s.HsmConfigurationIdentifier = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeHsmConfigurationsInput) SetMarker(v string) *DescribeHsmConfigurationsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeHsmConfigurationsInput) SetMaxRecords(v int64) *DescribeHsmConfigurationsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeHsmConfigurationsInput) SetTagKeys(v []*string) *DescribeHsmConfigurationsInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeHsmConfigurationsInput) SetTagValues(v []*string) *DescribeHsmConfigurationsInput {
+	s.TagValues = v
+	return s
+}
+
 type DescribeHsmConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8843,6 +10397,18 @@ func (s DescribeHsmConfigurationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeHsmConfigurationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetHsmConfigurations sets the HsmConfigurations field's value.
+func (s *DescribeHsmConfigurationsOutput) SetHsmConfigurations(v []*HsmConfiguration) *DescribeHsmConfigurationsOutput {
+	s.HsmConfigurations = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeHsmConfigurationsOutput) SetMarker(v string) *DescribeHsmConfigurationsOutput {
+	s.Marker = &v
+	return s
 }
 
 type DescribeLoggingStatusInput struct {
@@ -8877,6 +10443,12 @@ func (s *DescribeLoggingStatusInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *DescribeLoggingStatusInput) SetClusterIdentifier(v string) *DescribeLoggingStatusInput {
+	s.ClusterIdentifier = &v
+	return s
 }
 
 type DescribeOrderableClusterOptionsInput struct {
@@ -8923,6 +10495,30 @@ func (s DescribeOrderableClusterOptionsInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *DescribeOrderableClusterOptionsInput) SetClusterVersion(v string) *DescribeOrderableClusterOptionsInput {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOrderableClusterOptionsInput) SetMarker(v string) *DescribeOrderableClusterOptionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeOrderableClusterOptionsInput) SetMaxRecords(v int64) *DescribeOrderableClusterOptionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *DescribeOrderableClusterOptionsInput) SetNodeType(v string) *DescribeOrderableClusterOptionsInput {
+	s.NodeType = &v
+	return s
+}
+
 // Contains the output from the DescribeOrderableClusterOptions action.
 type DescribeOrderableClusterOptionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8947,6 +10543,18 @@ func (s DescribeOrderableClusterOptionsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeOrderableClusterOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeOrderableClusterOptionsOutput) SetMarker(v string) *DescribeOrderableClusterOptionsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetOrderableClusterOptions sets the OrderableClusterOptions field's value.
+func (s *DescribeOrderableClusterOptionsOutput) SetOrderableClusterOptions(v []*OrderableClusterOption) *DescribeOrderableClusterOptionsOutput {
+	s.OrderableClusterOptions = v
+	return s
 }
 
 type DescribeReservedNodeOfferingsInput struct {
@@ -8984,6 +10592,24 @@ func (s DescribeReservedNodeOfferingsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedNodeOfferingsInput) SetMarker(v string) *DescribeReservedNodeOfferingsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReservedNodeOfferingsInput) SetMaxRecords(v int64) *DescribeReservedNodeOfferingsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetReservedNodeOfferingId sets the ReservedNodeOfferingId field's value.
+func (s *DescribeReservedNodeOfferingsInput) SetReservedNodeOfferingId(v string) *DescribeReservedNodeOfferingsInput {
+	s.ReservedNodeOfferingId = &v
+	return s
+}
+
 type DescribeReservedNodeOfferingsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9006,6 +10632,18 @@ func (s DescribeReservedNodeOfferingsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReservedNodeOfferingsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedNodeOfferingsOutput) SetMarker(v string) *DescribeReservedNodeOfferingsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReservedNodeOfferings sets the ReservedNodeOfferings field's value.
+func (s *DescribeReservedNodeOfferingsOutput) SetReservedNodeOfferings(v []*ReservedNodeOffering) *DescribeReservedNodeOfferingsOutput {
+	s.ReservedNodeOfferings = v
+	return s
 }
 
 type DescribeReservedNodesInput struct {
@@ -9042,6 +10680,24 @@ func (s DescribeReservedNodesInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedNodesInput) SetMarker(v string) *DescribeReservedNodesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReservedNodesInput) SetMaxRecords(v int64) *DescribeReservedNodesInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetReservedNodeId sets the ReservedNodeId field's value.
+func (s *DescribeReservedNodesInput) SetReservedNodeId(v string) *DescribeReservedNodesInput {
+	s.ReservedNodeId = &v
+	return s
+}
+
 type DescribeReservedNodesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9064,6 +10720,18 @@ func (s DescribeReservedNodesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReservedNodesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReservedNodesOutput) SetMarker(v string) *DescribeReservedNodesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReservedNodes sets the ReservedNodes field's value.
+func (s *DescribeReservedNodesOutput) SetReservedNodes(v []*ReservedNode) *DescribeReservedNodesOutput {
+	s.ReservedNodes = v
+	return s
 }
 
 type DescribeResizeInput struct {
@@ -9100,6 +10768,12 @@ func (s *DescribeResizeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *DescribeResizeInput) SetClusterIdentifier(v string) *DescribeResizeInput {
+	s.ClusterIdentifier = &v
+	return s
 }
 
 // Describes the result of a cluster resize operation.
@@ -9176,6 +10850,78 @@ func (s DescribeResizeOutput) GoString() string {
 	return s.String()
 }
 
+// SetAvgResizeRateInMegaBytesPerSecond sets the AvgResizeRateInMegaBytesPerSecond field's value.
+func (s *DescribeResizeOutput) SetAvgResizeRateInMegaBytesPerSecond(v float64) *DescribeResizeOutput {
+	s.AvgResizeRateInMegaBytesPerSecond = &v
+	return s
+}
+
+// SetElapsedTimeInSeconds sets the ElapsedTimeInSeconds field's value.
+func (s *DescribeResizeOutput) SetElapsedTimeInSeconds(v int64) *DescribeResizeOutput {
+	s.ElapsedTimeInSeconds = &v
+	return s
+}
+
+// SetEstimatedTimeToCompletionInSeconds sets the EstimatedTimeToCompletionInSeconds field's value.
+func (s *DescribeResizeOutput) SetEstimatedTimeToCompletionInSeconds(v int64) *DescribeResizeOutput {
+	s.EstimatedTimeToCompletionInSeconds = &v
+	return s
+}
+
+// SetImportTablesCompleted sets the ImportTablesCompleted field's value.
+func (s *DescribeResizeOutput) SetImportTablesCompleted(v []*string) *DescribeResizeOutput {
+	s.ImportTablesCompleted = v
+	return s
+}
+
+// SetImportTablesInProgress sets the ImportTablesInProgress field's value.
+func (s *DescribeResizeOutput) SetImportTablesInProgress(v []*string) *DescribeResizeOutput {
+	s.ImportTablesInProgress = v
+	return s
+}
+
+// SetImportTablesNotStarted sets the ImportTablesNotStarted field's value.
+func (s *DescribeResizeOutput) SetImportTablesNotStarted(v []*string) *DescribeResizeOutput {
+	s.ImportTablesNotStarted = v
+	return s
+}
+
+// SetProgressInMegaBytes sets the ProgressInMegaBytes field's value.
+func (s *DescribeResizeOutput) SetProgressInMegaBytes(v int64) *DescribeResizeOutput {
+	s.ProgressInMegaBytes = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DescribeResizeOutput) SetStatus(v string) *DescribeResizeOutput {
+	s.Status = &v
+	return s
+}
+
+// SetTargetClusterType sets the TargetClusterType field's value.
+func (s *DescribeResizeOutput) SetTargetClusterType(v string) *DescribeResizeOutput {
+	s.TargetClusterType = &v
+	return s
+}
+
+// SetTargetNodeType sets the TargetNodeType field's value.
+func (s *DescribeResizeOutput) SetTargetNodeType(v string) *DescribeResizeOutput {
+	s.TargetNodeType = &v
+	return s
+}
+
+// SetTargetNumberOfNodes sets the TargetNumberOfNodes field's value.
+func (s *DescribeResizeOutput) SetTargetNumberOfNodes(v int64) *DescribeResizeOutput {
+	s.TargetNumberOfNodes = &v
+	return s
+}
+
+// SetTotalResizeDataInMegaBytes sets the TotalResizeDataInMegaBytes field's value.
+func (s *DescribeResizeOutput) SetTotalResizeDataInMegaBytes(v int64) *DescribeResizeOutput {
+	s.TotalResizeDataInMegaBytes = &v
+	return s
+}
+
 // The result of the DescribeSnapshotCopyGrants action.
 type DescribeSnapshotCopyGrantsInput struct {
 	_ struct{} `type:"structure"`
@@ -9231,6 +10977,36 @@ func (s DescribeSnapshotCopyGrantsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeSnapshotCopyGrantsInput) SetMarker(v string) *DescribeSnapshotCopyGrantsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeSnapshotCopyGrantsInput) SetMaxRecords(v int64) *DescribeSnapshotCopyGrantsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSnapshotCopyGrantName sets the SnapshotCopyGrantName field's value.
+func (s *DescribeSnapshotCopyGrantsInput) SetSnapshotCopyGrantName(v string) *DescribeSnapshotCopyGrantsInput {
+	s.SnapshotCopyGrantName = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeSnapshotCopyGrantsInput) SetTagKeys(v []*string) *DescribeSnapshotCopyGrantsInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeSnapshotCopyGrantsInput) SetTagValues(v []*string) *DescribeSnapshotCopyGrantsInput {
+	s.TagValues = v
+	return s
+}
+
 type DescribeSnapshotCopyGrantsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9257,6 +11033,18 @@ func (s DescribeSnapshotCopyGrantsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSnapshotCopyGrantsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeSnapshotCopyGrantsOutput) SetMarker(v string) *DescribeSnapshotCopyGrantsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetSnapshotCopyGrants sets the SnapshotCopyGrants field's value.
+func (s *DescribeSnapshotCopyGrantsOutput) SetSnapshotCopyGrants(v []*SnapshotCopyGrant) *DescribeSnapshotCopyGrantsOutput {
+	s.SnapshotCopyGrants = v
+	return s
 }
 
 type DescribeTableRestoreStatusInput struct {
@@ -9291,6 +11079,30 @@ func (s DescribeTableRestoreStatusInput) GoString() string {
 	return s.String()
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *DescribeTableRestoreStatusInput) SetClusterIdentifier(v string) *DescribeTableRestoreStatusInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTableRestoreStatusInput) SetMarker(v string) *DescribeTableRestoreStatusInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeTableRestoreStatusInput) SetMaxRecords(v int64) *DescribeTableRestoreStatusInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetTableRestoreRequestId sets the TableRestoreRequestId field's value.
+func (s *DescribeTableRestoreStatusInput) SetTableRestoreRequestId(v string) *DescribeTableRestoreStatusInput {
+	s.TableRestoreRequestId = &v
+	return s
+}
+
 type DescribeTableRestoreStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9310,6 +11122,18 @@ func (s DescribeTableRestoreStatusOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTableRestoreStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTableRestoreStatusOutput) SetMarker(v string) *DescribeTableRestoreStatusOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetTableRestoreStatusDetails sets the TableRestoreStatusDetails field's value.
+func (s *DescribeTableRestoreStatusOutput) SetTableRestoreStatusDetails(v []*TableRestoreStatus) *DescribeTableRestoreStatusOutput {
+	s.TableRestoreStatusDetails = v
+	return s
 }
 
 type DescribeTagsInput struct {
@@ -9387,6 +11211,42 @@ func (s DescribeTagsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *DescribeTagsInput) SetMarker(v string) *DescribeTagsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeTagsInput) SetMaxRecords(v int64) *DescribeTagsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *DescribeTagsInput) SetResourceName(v string) *DescribeTagsInput {
+	s.ResourceName = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *DescribeTagsInput) SetResourceType(v string) *DescribeTagsInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DescribeTagsInput) SetTagKeys(v []*string) *DescribeTagsInput {
+	s.TagKeys = v
+	return s
+}
+
+// SetTagValues sets the TagValues field's value.
+func (s *DescribeTagsInput) SetTagValues(v []*string) *DescribeTagsInput {
+	s.TagValues = v
+	return s
+}
+
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9409,6 +11269,18 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTagsOutput) SetMarker(v string) *DescribeTagsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetTaggedResources sets the TaggedResources field's value.
+func (s *DescribeTagsOutput) SetTaggedResources(v []*TaggedResource) *DescribeTagsOutput {
+	s.TaggedResources = v
+	return s
 }
 
 type DisableLoggingInput struct {
@@ -9443,6 +11315,12 @@ func (s *DisableLoggingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *DisableLoggingInput) SetClusterIdentifier(v string) *DisableLoggingInput {
+	s.ClusterIdentifier = &v
+	return s
 }
 
 type DisableSnapshotCopyInput struct {
@@ -9481,6 +11359,12 @@ func (s *DisableSnapshotCopyInput) Validate() error {
 	return nil
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *DisableSnapshotCopyInput) SetClusterIdentifier(v string) *DisableSnapshotCopyInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
 type DisableSnapshotCopyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9496,6 +11380,12 @@ func (s DisableSnapshotCopyOutput) String() string {
 // GoString returns the string representation
 func (s DisableSnapshotCopyOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *DisableSnapshotCopyOutput) SetCluster(v *Cluster) *DisableSnapshotCopyOutput {
+	s.Cluster = v
+	return s
 }
 
 // Describes an Amazon EC2 security group.
@@ -9526,6 +11416,30 @@ func (s EC2SecurityGroup) GoString() string {
 	return s.String()
 }
 
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *EC2SecurityGroup) SetEC2SecurityGroupName(v string) *EC2SecurityGroup {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *EC2SecurityGroup) SetEC2SecurityGroupOwnerId(v string) *EC2SecurityGroup {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EC2SecurityGroup) SetStatus(v string) *EC2SecurityGroup {
+	s.Status = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *EC2SecurityGroup) SetTags(v []*Tag) *EC2SecurityGroup {
+	s.Tags = v
+	return s
+}
+
 // Describes the status of the elastic IP (EIP) address.
 type ElasticIpStatus struct {
 	_ struct{} `type:"structure"`
@@ -9545,6 +11459,18 @@ func (s ElasticIpStatus) String() string {
 // GoString returns the string representation
 func (s ElasticIpStatus) GoString() string {
 	return s.String()
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *ElasticIpStatus) SetElasticIp(v string) *ElasticIpStatus {
+	s.ElasticIp = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ElasticIpStatus) SetStatus(v string) *ElasticIpStatus {
+	s.Status = &v
+	return s
 }
 
 type EnableLoggingInput struct {
@@ -9616,6 +11542,24 @@ func (s *EnableLoggingInput) Validate() error {
 	return nil
 }
 
+// SetBucketName sets the BucketName field's value.
+func (s *EnableLoggingInput) SetBucketName(v string) *EnableLoggingInput {
+	s.BucketName = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *EnableLoggingInput) SetClusterIdentifier(v string) *EnableLoggingInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *EnableLoggingInput) SetS3KeyPrefix(v string) *EnableLoggingInput {
+	s.S3KeyPrefix = &v
+	return s
+}
+
 type EnableSnapshotCopyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -9675,6 +11619,30 @@ func (s *EnableSnapshotCopyInput) Validate() error {
 	return nil
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *EnableSnapshotCopyInput) SetClusterIdentifier(v string) *EnableSnapshotCopyInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetDestinationRegion sets the DestinationRegion field's value.
+func (s *EnableSnapshotCopyInput) SetDestinationRegion(v string) *EnableSnapshotCopyInput {
+	s.DestinationRegion = &v
+	return s
+}
+
+// SetRetentionPeriod sets the RetentionPeriod field's value.
+func (s *EnableSnapshotCopyInput) SetRetentionPeriod(v int64) *EnableSnapshotCopyInput {
+	s.RetentionPeriod = &v
+	return s
+}
+
+// SetSnapshotCopyGrantName sets the SnapshotCopyGrantName field's value.
+func (s *EnableSnapshotCopyInput) SetSnapshotCopyGrantName(v string) *EnableSnapshotCopyInput {
+	s.SnapshotCopyGrantName = &v
+	return s
+}
+
 type EnableSnapshotCopyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9690,6 +11658,12 @@ func (s EnableSnapshotCopyOutput) String() string {
 // GoString returns the string representation
 func (s EnableSnapshotCopyOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *EnableSnapshotCopyOutput) SetCluster(v *Cluster) *EnableSnapshotCopyOutput {
+	s.Cluster = v
+	return s
 }
 
 // Describes a connection endpoint.
@@ -9711,6 +11685,18 @@ func (s Endpoint) String() string {
 // GoString returns the string representation
 func (s Endpoint) GoString() string {
 	return s.String()
+}
+
+// SetAddress sets the Address field's value.
+func (s *Endpoint) SetAddress(v string) *Endpoint {
+	s.Address = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *Endpoint) SetPort(v int64) *Endpoint {
+	s.Port = &v
+	return s
 }
 
 // Describes an event.
@@ -9753,6 +11739,48 @@ func (s Event) GoString() string {
 	return s.String()
 }
 
+// SetDate sets the Date field's value.
+func (s *Event) SetDate(v time.Time) *Event {
+	s.Date = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *Event) SetEventCategories(v []*string) *Event {
+	s.EventCategories = v
+	return s
+}
+
+// SetEventId sets the EventId field's value.
+func (s *Event) SetEventId(v string) *Event {
+	s.EventId = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Event) SetMessage(v string) *Event {
+	s.Message = &v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *Event) SetSeverity(v string) *Event {
+	s.Severity = &v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *Event) SetSourceIdentifier(v string) *Event {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *Event) SetSourceType(v string) *Event {
+	s.SourceType = &v
+	return s
+}
+
 // Describes event categories.
 type EventCategoriesMap struct {
 	_ struct{} `type:"structure"`
@@ -9773,6 +11801,18 @@ func (s EventCategoriesMap) String() string {
 // GoString returns the string representation
 func (s EventCategoriesMap) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *EventCategoriesMap) SetEvents(v []*EventInfoMap) *EventCategoriesMap {
+	s.Events = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *EventCategoriesMap) SetSourceType(v string) *EventCategoriesMap {
+	s.SourceType = &v
+	return s
 }
 
 // Describes event information.
@@ -9802,6 +11842,30 @@ func (s EventInfoMap) String() string {
 // GoString returns the string representation
 func (s EventInfoMap) GoString() string {
 	return s.String()
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *EventInfoMap) SetEventCategories(v []*string) *EventInfoMap {
+	s.EventCategories = v
+	return s
+}
+
+// SetEventDescription sets the EventDescription field's value.
+func (s *EventInfoMap) SetEventDescription(v string) *EventInfoMap {
+	s.EventDescription = &v
+	return s
+}
+
+// SetEventId sets the EventId field's value.
+func (s *EventInfoMap) SetEventId(v string) *EventInfoMap {
+	s.EventId = &v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *EventInfoMap) SetSeverity(v string) *EventInfoMap {
+	s.Severity = &v
+	return s
 }
 
 // Describes event subscriptions.
@@ -9871,6 +11935,72 @@ func (s EventSubscription) GoString() string {
 	return s.String()
 }
 
+// SetCustSubscriptionId sets the CustSubscriptionId field's value.
+func (s *EventSubscription) SetCustSubscriptionId(v string) *EventSubscription {
+	s.CustSubscriptionId = &v
+	return s
+}
+
+// SetCustomerAwsId sets the CustomerAwsId field's value.
+func (s *EventSubscription) SetCustomerAwsId(v string) *EventSubscription {
+	s.CustomerAwsId = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *EventSubscription) SetEnabled(v bool) *EventSubscription {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategoriesList sets the EventCategoriesList field's value.
+func (s *EventSubscription) SetEventCategoriesList(v []*string) *EventSubscription {
+	s.EventCategoriesList = v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *EventSubscription) SetSeverity(v string) *EventSubscription {
+	s.Severity = &v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *EventSubscription) SetSnsTopicArn(v string) *EventSubscription {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceIdsList sets the SourceIdsList field's value.
+func (s *EventSubscription) SetSourceIdsList(v []*string) *EventSubscription {
+	s.SourceIdsList = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *EventSubscription) SetSourceType(v string) *EventSubscription {
+	s.SourceType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EventSubscription) SetStatus(v string) *EventSubscription {
+	s.Status = &v
+	return s
+}
+
+// SetSubscriptionCreationTime sets the SubscriptionCreationTime field's value.
+func (s *EventSubscription) SetSubscriptionCreationTime(v time.Time) *EventSubscription {
+	s.SubscriptionCreationTime = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *EventSubscription) SetTags(v []*Tag) *EventSubscription {
+	s.Tags = v
+	return s
+}
+
 // Returns information about an HSM client certificate. The certificate is stored
 // in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift
 // cluster to encrypt data files.
@@ -9896,6 +12026,24 @@ func (s HsmClientCertificate) String() string {
 // GoString returns the string representation
 func (s HsmClientCertificate) GoString() string {
 	return s.String()
+}
+
+// SetHsmClientCertificateIdentifier sets the HsmClientCertificateIdentifier field's value.
+func (s *HsmClientCertificate) SetHsmClientCertificateIdentifier(v string) *HsmClientCertificate {
+	s.HsmClientCertificateIdentifier = &v
+	return s
+}
+
+// SetHsmClientCertificatePublicKey sets the HsmClientCertificatePublicKey field's value.
+func (s *HsmClientCertificate) SetHsmClientCertificatePublicKey(v string) *HsmClientCertificate {
+	s.HsmClientCertificatePublicKey = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *HsmClientCertificate) SetTags(v []*Tag) *HsmClientCertificate {
+	s.Tags = v
+	return s
 }
 
 // Returns information about an HSM configuration, which is an object that describes
@@ -9931,6 +12079,36 @@ func (s HsmConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *HsmConfiguration) SetDescription(v string) *HsmConfiguration {
+	s.Description = &v
+	return s
+}
+
+// SetHsmConfigurationIdentifier sets the HsmConfigurationIdentifier field's value.
+func (s *HsmConfiguration) SetHsmConfigurationIdentifier(v string) *HsmConfiguration {
+	s.HsmConfigurationIdentifier = &v
+	return s
+}
+
+// SetHsmIpAddress sets the HsmIpAddress field's value.
+func (s *HsmConfiguration) SetHsmIpAddress(v string) *HsmConfiguration {
+	s.HsmIpAddress = &v
+	return s
+}
+
+// SetHsmPartitionName sets the HsmPartitionName field's value.
+func (s *HsmConfiguration) SetHsmPartitionName(v string) *HsmConfiguration {
+	s.HsmPartitionName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *HsmConfiguration) SetTags(v []*Tag) *HsmConfiguration {
+	s.Tags = v
+	return s
+}
+
 // Describes the status of changes to HSM settings.
 type HsmStatus struct {
 	_ struct{} `type:"structure"`
@@ -9960,6 +12138,24 @@ func (s HsmStatus) GoString() string {
 	return s.String()
 }
 
+// SetHsmClientCertificateIdentifier sets the HsmClientCertificateIdentifier field's value.
+func (s *HsmStatus) SetHsmClientCertificateIdentifier(v string) *HsmStatus {
+	s.HsmClientCertificateIdentifier = &v
+	return s
+}
+
+// SetHsmConfigurationIdentifier sets the HsmConfigurationIdentifier field's value.
+func (s *HsmStatus) SetHsmConfigurationIdentifier(v string) *HsmStatus {
+	s.HsmConfigurationIdentifier = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *HsmStatus) SetStatus(v string) *HsmStatus {
+	s.Status = &v
+	return s
+}
+
 // Describes an IP range used in a security group.
 type IPRange struct {
 	_ struct{} `type:"structure"`
@@ -9982,6 +12178,24 @@ func (s IPRange) String() string {
 // GoString returns the string representation
 func (s IPRange) GoString() string {
 	return s.String()
+}
+
+// SetCIDRIP sets the CIDRIP field's value.
+func (s *IPRange) SetCIDRIP(v string) *IPRange {
+	s.CIDRIP = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *IPRange) SetStatus(v string) *IPRange {
+	s.Status = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *IPRange) SetTags(v []*Tag) *IPRange {
+	s.Tags = v
+	return s
 }
 
 // Describes the status of logging for a cluster.
@@ -10015,6 +12229,42 @@ func (s LoggingStatus) String() string {
 // GoString returns the string representation
 func (s LoggingStatus) GoString() string {
 	return s.String()
+}
+
+// SetBucketName sets the BucketName field's value.
+func (s *LoggingStatus) SetBucketName(v string) *LoggingStatus {
+	s.BucketName = &v
+	return s
+}
+
+// SetLastFailureMessage sets the LastFailureMessage field's value.
+func (s *LoggingStatus) SetLastFailureMessage(v string) *LoggingStatus {
+	s.LastFailureMessage = &v
+	return s
+}
+
+// SetLastFailureTime sets the LastFailureTime field's value.
+func (s *LoggingStatus) SetLastFailureTime(v time.Time) *LoggingStatus {
+	s.LastFailureTime = &v
+	return s
+}
+
+// SetLastSuccessfulDeliveryTime sets the LastSuccessfulDeliveryTime field's value.
+func (s *LoggingStatus) SetLastSuccessfulDeliveryTime(v time.Time) *LoggingStatus {
+	s.LastSuccessfulDeliveryTime = &v
+	return s
+}
+
+// SetLoggingEnabled sets the LoggingEnabled field's value.
+func (s *LoggingStatus) SetLoggingEnabled(v bool) *LoggingStatus {
+	s.LoggingEnabled = &v
+	return s
+}
+
+// SetS3KeyPrefix sets the S3KeyPrefix field's value.
+func (s *LoggingStatus) SetS3KeyPrefix(v string) *LoggingStatus {
+	s.S3KeyPrefix = &v
+	return s
 }
 
 type ModifyClusterIamRolesInput struct {
@@ -10059,6 +12309,24 @@ func (s *ModifyClusterIamRolesInput) Validate() error {
 	return nil
 }
 
+// SetAddIamRoles sets the AddIamRoles field's value.
+func (s *ModifyClusterIamRolesInput) SetAddIamRoles(v []*string) *ModifyClusterIamRolesInput {
+	s.AddIamRoles = v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *ModifyClusterIamRolesInput) SetClusterIdentifier(v string) *ModifyClusterIamRolesInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetRemoveIamRoles sets the RemoveIamRoles field's value.
+func (s *ModifyClusterIamRolesInput) SetRemoveIamRoles(v []*string) *ModifyClusterIamRolesInput {
+	s.RemoveIamRoles = v
+	return s
+}
+
 type ModifyClusterIamRolesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10074,6 +12342,12 @@ func (s ModifyClusterIamRolesOutput) String() string {
 // GoString returns the string representation
 func (s ModifyClusterIamRolesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *ModifyClusterIamRolesOutput) SetCluster(v *Cluster) *ModifyClusterIamRolesOutput {
+	s.Cluster = v
+	return s
 }
 
 type ModifyClusterInput struct {
@@ -10301,6 +12575,114 @@ func (s *ModifyClusterInput) Validate() error {
 	return nil
 }
 
+// SetAllowVersionUpgrade sets the AllowVersionUpgrade field's value.
+func (s *ModifyClusterInput) SetAllowVersionUpgrade(v bool) *ModifyClusterInput {
+	s.AllowVersionUpgrade = &v
+	return s
+}
+
+// SetAutomatedSnapshotRetentionPeriod sets the AutomatedSnapshotRetentionPeriod field's value.
+func (s *ModifyClusterInput) SetAutomatedSnapshotRetentionPeriod(v int64) *ModifyClusterInput {
+	s.AutomatedSnapshotRetentionPeriod = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *ModifyClusterInput) SetClusterIdentifier(v string) *ModifyClusterInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetClusterParameterGroupName sets the ClusterParameterGroupName field's value.
+func (s *ModifyClusterInput) SetClusterParameterGroupName(v string) *ModifyClusterInput {
+	s.ClusterParameterGroupName = &v
+	return s
+}
+
+// SetClusterSecurityGroups sets the ClusterSecurityGroups field's value.
+func (s *ModifyClusterInput) SetClusterSecurityGroups(v []*string) *ModifyClusterInput {
+	s.ClusterSecurityGroups = v
+	return s
+}
+
+// SetClusterType sets the ClusterType field's value.
+func (s *ModifyClusterInput) SetClusterType(v string) *ModifyClusterInput {
+	s.ClusterType = &v
+	return s
+}
+
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *ModifyClusterInput) SetClusterVersion(v string) *ModifyClusterInput {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *ModifyClusterInput) SetElasticIp(v string) *ModifyClusterInput {
+	s.ElasticIp = &v
+	return s
+}
+
+// SetEnhancedVpcRouting sets the EnhancedVpcRouting field's value.
+func (s *ModifyClusterInput) SetEnhancedVpcRouting(v bool) *ModifyClusterInput {
+	s.EnhancedVpcRouting = &v
+	return s
+}
+
+// SetHsmClientCertificateIdentifier sets the HsmClientCertificateIdentifier field's value.
+func (s *ModifyClusterInput) SetHsmClientCertificateIdentifier(v string) *ModifyClusterInput {
+	s.HsmClientCertificateIdentifier = &v
+	return s
+}
+
+// SetHsmConfigurationIdentifier sets the HsmConfigurationIdentifier field's value.
+func (s *ModifyClusterInput) SetHsmConfigurationIdentifier(v string) *ModifyClusterInput {
+	s.HsmConfigurationIdentifier = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *ModifyClusterInput) SetMasterUserPassword(v string) *ModifyClusterInput {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetNewClusterIdentifier sets the NewClusterIdentifier field's value.
+func (s *ModifyClusterInput) SetNewClusterIdentifier(v string) *ModifyClusterInput {
+	s.NewClusterIdentifier = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *ModifyClusterInput) SetNodeType(v string) *ModifyClusterInput {
+	s.NodeType = &v
+	return s
+}
+
+// SetNumberOfNodes sets the NumberOfNodes field's value.
+func (s *ModifyClusterInput) SetNumberOfNodes(v int64) *ModifyClusterInput {
+	s.NumberOfNodes = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *ModifyClusterInput) SetPreferredMaintenanceWindow(v string) *ModifyClusterInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *ModifyClusterInput) SetPubliclyAccessible(v bool) *ModifyClusterInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *ModifyClusterInput) SetVpcSecurityGroupIds(v []*string) *ModifyClusterInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type ModifyClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10316,6 +12698,12 @@ func (s ModifyClusterOutput) String() string {
 // GoString returns the string representation
 func (s ModifyClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *ModifyClusterOutput) SetCluster(v *Cluster) *ModifyClusterOutput {
+	s.Cluster = v
+	return s
 }
 
 type ModifyClusterParameterGroupInput struct {
@@ -10365,6 +12753,18 @@ func (s *ModifyClusterParameterGroupInput) Validate() error {
 	return nil
 }
 
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *ModifyClusterParameterGroupInput) SetParameterGroupName(v string) *ModifyClusterParameterGroupInput {
+	s.ParameterGroupName = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ModifyClusterParameterGroupInput) SetParameters(v []*Parameter) *ModifyClusterParameterGroupInput {
+	s.Parameters = v
+	return s
+}
+
 type ModifyClusterSubnetGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -10409,6 +12809,24 @@ func (s *ModifyClusterSubnetGroupInput) Validate() error {
 	return nil
 }
 
+// SetClusterSubnetGroupName sets the ClusterSubnetGroupName field's value.
+func (s *ModifyClusterSubnetGroupInput) SetClusterSubnetGroupName(v string) *ModifyClusterSubnetGroupInput {
+	s.ClusterSubnetGroupName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ModifyClusterSubnetGroupInput) SetDescription(v string) *ModifyClusterSubnetGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *ModifyClusterSubnetGroupInput) SetSubnetIds(v []*string) *ModifyClusterSubnetGroupInput {
+	s.SubnetIds = v
+	return s
+}
+
 type ModifyClusterSubnetGroupOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10424,6 +12842,12 @@ func (s ModifyClusterSubnetGroupOutput) String() string {
 // GoString returns the string representation
 func (s ModifyClusterSubnetGroupOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterSubnetGroup sets the ClusterSubnetGroup field's value.
+func (s *ModifyClusterSubnetGroupOutput) SetClusterSubnetGroup(v *ClusterSubnetGroup) *ModifyClusterSubnetGroupOutput {
+	s.ClusterSubnetGroup = v
+	return s
 }
 
 type ModifyEventSubscriptionInput struct {
@@ -10499,6 +12923,48 @@ func (s *ModifyEventSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *ModifyEventSubscriptionInput) SetEnabled(v bool) *ModifyEventSubscriptionInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *ModifyEventSubscriptionInput) SetEventCategories(v []*string) *ModifyEventSubscriptionInput {
+	s.EventCategories = v
+	return s
+}
+
+// SetSeverity sets the Severity field's value.
+func (s *ModifyEventSubscriptionInput) SetSeverity(v string) *ModifyEventSubscriptionInput {
+	s.Severity = &v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *ModifyEventSubscriptionInput) SetSnsTopicArn(v string) *ModifyEventSubscriptionInput {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceIds sets the SourceIds field's value.
+func (s *ModifyEventSubscriptionInput) SetSourceIds(v []*string) *ModifyEventSubscriptionInput {
+	s.SourceIds = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *ModifyEventSubscriptionInput) SetSourceType(v string) *ModifyEventSubscriptionInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *ModifyEventSubscriptionInput) SetSubscriptionName(v string) *ModifyEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
 type ModifyEventSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10514,6 +12980,12 @@ func (s ModifyEventSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s ModifyEventSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *ModifyEventSubscriptionOutput) SetEventSubscription(v *EventSubscription) *ModifyEventSubscriptionOutput {
+	s.EventSubscription = v
+	return s
 }
 
 type ModifySnapshotCopyRetentionPeriodInput struct {
@@ -10568,6 +13040,18 @@ func (s *ModifySnapshotCopyRetentionPeriodInput) Validate() error {
 	return nil
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *ModifySnapshotCopyRetentionPeriodInput) SetClusterIdentifier(v string) *ModifySnapshotCopyRetentionPeriodInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetRetentionPeriod sets the RetentionPeriod field's value.
+func (s *ModifySnapshotCopyRetentionPeriodInput) SetRetentionPeriod(v int64) *ModifySnapshotCopyRetentionPeriodInput {
+	s.RetentionPeriod = &v
+	return s
+}
+
 type ModifySnapshotCopyRetentionPeriodOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10583,6 +13067,12 @@ func (s ModifySnapshotCopyRetentionPeriodOutput) String() string {
 // GoString returns the string representation
 func (s ModifySnapshotCopyRetentionPeriodOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *ModifySnapshotCopyRetentionPeriodOutput) SetCluster(v *Cluster) *ModifySnapshotCopyRetentionPeriodOutput {
+	s.Cluster = v
+	return s
 }
 
 // Describes an orderable cluster option.
@@ -10610,6 +13100,30 @@ func (s OrderableClusterOption) String() string {
 // GoString returns the string representation
 func (s OrderableClusterOption) GoString() string {
 	return s.String()
+}
+
+// SetAvailabilityZones sets the AvailabilityZones field's value.
+func (s *OrderableClusterOption) SetAvailabilityZones(v []*AvailabilityZone) *OrderableClusterOption {
+	s.AvailabilityZones = v
+	return s
+}
+
+// SetClusterType sets the ClusterType field's value.
+func (s *OrderableClusterOption) SetClusterType(v string) *OrderableClusterOption {
+	s.ClusterType = &v
+	return s
+}
+
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *OrderableClusterOption) SetClusterVersion(v string) *OrderableClusterOption {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *OrderableClusterOption) SetNodeType(v string) *OrderableClusterOption {
+	s.NodeType = &v
+	return s
 }
 
 // Describes a parameter in a cluster parameter group.
@@ -10658,6 +13172,60 @@ func (s Parameter) String() string {
 // GoString returns the string representation
 func (s Parameter) GoString() string {
 	return s.String()
+}
+
+// SetAllowedValues sets the AllowedValues field's value.
+func (s *Parameter) SetAllowedValues(v string) *Parameter {
+	s.AllowedValues = &v
+	return s
+}
+
+// SetApplyType sets the ApplyType field's value.
+func (s *Parameter) SetApplyType(v string) *Parameter {
+	s.ApplyType = &v
+	return s
+}
+
+// SetDataType sets the DataType field's value.
+func (s *Parameter) SetDataType(v string) *Parameter {
+	s.DataType = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Parameter) SetDescription(v string) *Parameter {
+	s.Description = &v
+	return s
+}
+
+// SetIsModifiable sets the IsModifiable field's value.
+func (s *Parameter) SetIsModifiable(v bool) *Parameter {
+	s.IsModifiable = &v
+	return s
+}
+
+// SetMinimumEngineVersion sets the MinimumEngineVersion field's value.
+func (s *Parameter) SetMinimumEngineVersion(v string) *Parameter {
+	s.MinimumEngineVersion = &v
+	return s
+}
+
+// SetParameterName sets the ParameterName field's value.
+func (s *Parameter) SetParameterName(v string) *Parameter {
+	s.ParameterName = &v
+	return s
+}
+
+// SetParameterValue sets the ParameterValue field's value.
+func (s *Parameter) SetParameterValue(v string) *Parameter {
+	s.ParameterValue = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *Parameter) SetSource(v string) *Parameter {
+	s.Source = &v
+	return s
 }
 
 // Describes cluster attributes that are in a pending state. A change to one
@@ -10712,6 +13280,60 @@ func (s PendingModifiedValues) GoString() string {
 	return s.String()
 }
 
+// SetAutomatedSnapshotRetentionPeriod sets the AutomatedSnapshotRetentionPeriod field's value.
+func (s *PendingModifiedValues) SetAutomatedSnapshotRetentionPeriod(v int64) *PendingModifiedValues {
+	s.AutomatedSnapshotRetentionPeriod = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *PendingModifiedValues) SetClusterIdentifier(v string) *PendingModifiedValues {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetClusterType sets the ClusterType field's value.
+func (s *PendingModifiedValues) SetClusterType(v string) *PendingModifiedValues {
+	s.ClusterType = &v
+	return s
+}
+
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *PendingModifiedValues) SetClusterVersion(v string) *PendingModifiedValues {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetEnhancedVpcRouting sets the EnhancedVpcRouting field's value.
+func (s *PendingModifiedValues) SetEnhancedVpcRouting(v bool) *PendingModifiedValues {
+	s.EnhancedVpcRouting = &v
+	return s
+}
+
+// SetMasterUserPassword sets the MasterUserPassword field's value.
+func (s *PendingModifiedValues) SetMasterUserPassword(v string) *PendingModifiedValues {
+	s.MasterUserPassword = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *PendingModifiedValues) SetNodeType(v string) *PendingModifiedValues {
+	s.NodeType = &v
+	return s
+}
+
+// SetNumberOfNodes sets the NumberOfNodes field's value.
+func (s *PendingModifiedValues) SetNumberOfNodes(v int64) *PendingModifiedValues {
+	s.NumberOfNodes = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *PendingModifiedValues) SetPubliclyAccessible(v bool) *PendingModifiedValues {
+	s.PubliclyAccessible = &v
+	return s
+}
+
 type PurchaseReservedNodeOfferingInput struct {
 	_ struct{} `type:"structure"`
 
@@ -10749,6 +13371,18 @@ func (s *PurchaseReservedNodeOfferingInput) Validate() error {
 	return nil
 }
 
+// SetNodeCount sets the NodeCount field's value.
+func (s *PurchaseReservedNodeOfferingInput) SetNodeCount(v int64) *PurchaseReservedNodeOfferingInput {
+	s.NodeCount = &v
+	return s
+}
+
+// SetReservedNodeOfferingId sets the ReservedNodeOfferingId field's value.
+func (s *PurchaseReservedNodeOfferingInput) SetReservedNodeOfferingId(v string) *PurchaseReservedNodeOfferingInput {
+	s.ReservedNodeOfferingId = &v
+	return s
+}
+
 type PurchaseReservedNodeOfferingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10765,6 +13399,12 @@ func (s PurchaseReservedNodeOfferingOutput) String() string {
 // GoString returns the string representation
 func (s PurchaseReservedNodeOfferingOutput) GoString() string {
 	return s.String()
+}
+
+// SetReservedNode sets the ReservedNode field's value.
+func (s *PurchaseReservedNodeOfferingOutput) SetReservedNode(v *ReservedNode) *PurchaseReservedNodeOfferingOutput {
+	s.ReservedNode = v
+	return s
 }
 
 type RebootClusterInput struct {
@@ -10799,6 +13439,12 @@ func (s *RebootClusterInput) Validate() error {
 	return nil
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *RebootClusterInput) SetClusterIdentifier(v string) *RebootClusterInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
 type RebootClusterOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10814,6 +13460,12 @@ func (s RebootClusterOutput) String() string {
 // GoString returns the string representation
 func (s RebootClusterOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *RebootClusterOutput) SetCluster(v *Cluster) *RebootClusterOutput {
+	s.Cluster = v
+	return s
 }
 
 // Describes a recurring charge.
@@ -10836,6 +13488,18 @@ func (s RecurringCharge) String() string {
 // GoString returns the string representation
 func (s RecurringCharge) GoString() string {
 	return s.String()
+}
+
+// SetRecurringChargeAmount sets the RecurringChargeAmount field's value.
+func (s *RecurringCharge) SetRecurringChargeAmount(v float64) *RecurringCharge {
+	s.RecurringChargeAmount = &v
+	return s
+}
+
+// SetRecurringChargeFrequency sets the RecurringChargeFrequency field's value.
+func (s *RecurringCharge) SetRecurringChargeFrequency(v string) *RecurringCharge {
+	s.RecurringChargeFrequency = &v
+	return s
 }
 
 // Describes a reserved node. You can call the DescribeReservedNodeOfferings
@@ -10902,6 +13566,78 @@ func (s ReservedNode) GoString() string {
 	return s.String()
 }
 
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedNode) SetCurrencyCode(v string) *ReservedNode {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedNode) SetDuration(v int64) *ReservedNode {
+	s.Duration = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedNode) SetFixedPrice(v float64) *ReservedNode {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetNodeCount sets the NodeCount field's value.
+func (s *ReservedNode) SetNodeCount(v int64) *ReservedNode {
+	s.NodeCount = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *ReservedNode) SetNodeType(v string) *ReservedNode {
+	s.NodeType = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *ReservedNode) SetOfferingType(v string) *ReservedNode {
+	s.OfferingType = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedNode) SetRecurringCharges(v []*RecurringCharge) *ReservedNode {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedNodeId sets the ReservedNodeId field's value.
+func (s *ReservedNode) SetReservedNodeId(v string) *ReservedNode {
+	s.ReservedNodeId = &v
+	return s
+}
+
+// SetReservedNodeOfferingId sets the ReservedNodeOfferingId field's value.
+func (s *ReservedNode) SetReservedNodeOfferingId(v string) *ReservedNode {
+	s.ReservedNodeOfferingId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ReservedNode) SetStartTime(v time.Time) *ReservedNode {
+	s.StartTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ReservedNode) SetState(v string) *ReservedNode {
+	s.State = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedNode) SetUsagePrice(v float64) *ReservedNode {
+	s.UsagePrice = &v
+	return s
+}
+
 // Describes a reserved node offering.
 type ReservedNodeOffering struct {
 	_ struct{} `type:"structure"`
@@ -10946,6 +13682,54 @@ func (s ReservedNodeOffering) GoString() string {
 	return s.String()
 }
 
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedNodeOffering) SetCurrencyCode(v string) *ReservedNodeOffering {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedNodeOffering) SetDuration(v int64) *ReservedNodeOffering {
+	s.Duration = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedNodeOffering) SetFixedPrice(v float64) *ReservedNodeOffering {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *ReservedNodeOffering) SetNodeType(v string) *ReservedNodeOffering {
+	s.NodeType = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *ReservedNodeOffering) SetOfferingType(v string) *ReservedNodeOffering {
+	s.OfferingType = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedNodeOffering) SetRecurringCharges(v []*RecurringCharge) *ReservedNodeOffering {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedNodeOfferingId sets the ReservedNodeOfferingId field's value.
+func (s *ReservedNodeOffering) SetReservedNodeOfferingId(v string) *ReservedNodeOffering {
+	s.ReservedNodeOfferingId = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedNodeOffering) SetUsagePrice(v float64) *ReservedNodeOffering {
+	s.UsagePrice = &v
+	return s
+}
+
 type ResetClusterParameterGroupInput struct {
 	_ struct{} `type:"structure"`
 
@@ -10988,6 +13772,24 @@ func (s *ResetClusterParameterGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetParameterGroupName sets the ParameterGroupName field's value.
+func (s *ResetClusterParameterGroupInput) SetParameterGroupName(v string) *ResetClusterParameterGroupInput {
+	s.ParameterGroupName = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *ResetClusterParameterGroupInput) SetParameters(v []*Parameter) *ResetClusterParameterGroupInput {
+	s.Parameters = v
+	return s
+}
+
+// SetResetAllParameters sets the ResetAllParameters field's value.
+func (s *ResetClusterParameterGroupInput) SetResetAllParameters(v bool) *ResetClusterParameterGroupInput {
+	s.ResetAllParameters = &v
+	return s
 }
 
 type RestoreFromClusterSnapshotInput struct {
@@ -11188,6 +13990,138 @@ func (s *RestoreFromClusterSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetAdditionalInfo sets the AdditionalInfo field's value.
+func (s *RestoreFromClusterSnapshotInput) SetAdditionalInfo(v string) *RestoreFromClusterSnapshotInput {
+	s.AdditionalInfo = &v
+	return s
+}
+
+// SetAllowVersionUpgrade sets the AllowVersionUpgrade field's value.
+func (s *RestoreFromClusterSnapshotInput) SetAllowVersionUpgrade(v bool) *RestoreFromClusterSnapshotInput {
+	s.AllowVersionUpgrade = &v
+	return s
+}
+
+// SetAutomatedSnapshotRetentionPeriod sets the AutomatedSnapshotRetentionPeriod field's value.
+func (s *RestoreFromClusterSnapshotInput) SetAutomatedSnapshotRetentionPeriod(v int64) *RestoreFromClusterSnapshotInput {
+	s.AutomatedSnapshotRetentionPeriod = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *RestoreFromClusterSnapshotInput) SetAvailabilityZone(v string) *RestoreFromClusterSnapshotInput {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *RestoreFromClusterSnapshotInput) SetClusterIdentifier(v string) *RestoreFromClusterSnapshotInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetClusterParameterGroupName sets the ClusterParameterGroupName field's value.
+func (s *RestoreFromClusterSnapshotInput) SetClusterParameterGroupName(v string) *RestoreFromClusterSnapshotInput {
+	s.ClusterParameterGroupName = &v
+	return s
+}
+
+// SetClusterSecurityGroups sets the ClusterSecurityGroups field's value.
+func (s *RestoreFromClusterSnapshotInput) SetClusterSecurityGroups(v []*string) *RestoreFromClusterSnapshotInput {
+	s.ClusterSecurityGroups = v
+	return s
+}
+
+// SetClusterSubnetGroupName sets the ClusterSubnetGroupName field's value.
+func (s *RestoreFromClusterSnapshotInput) SetClusterSubnetGroupName(v string) *RestoreFromClusterSnapshotInput {
+	s.ClusterSubnetGroupName = &v
+	return s
+}
+
+// SetElasticIp sets the ElasticIp field's value.
+func (s *RestoreFromClusterSnapshotInput) SetElasticIp(v string) *RestoreFromClusterSnapshotInput {
+	s.ElasticIp = &v
+	return s
+}
+
+// SetEnhancedVpcRouting sets the EnhancedVpcRouting field's value.
+func (s *RestoreFromClusterSnapshotInput) SetEnhancedVpcRouting(v bool) *RestoreFromClusterSnapshotInput {
+	s.EnhancedVpcRouting = &v
+	return s
+}
+
+// SetHsmClientCertificateIdentifier sets the HsmClientCertificateIdentifier field's value.
+func (s *RestoreFromClusterSnapshotInput) SetHsmClientCertificateIdentifier(v string) *RestoreFromClusterSnapshotInput {
+	s.HsmClientCertificateIdentifier = &v
+	return s
+}
+
+// SetHsmConfigurationIdentifier sets the HsmConfigurationIdentifier field's value.
+func (s *RestoreFromClusterSnapshotInput) SetHsmConfigurationIdentifier(v string) *RestoreFromClusterSnapshotInput {
+	s.HsmConfigurationIdentifier = &v
+	return s
+}
+
+// SetIamRoles sets the IamRoles field's value.
+func (s *RestoreFromClusterSnapshotInput) SetIamRoles(v []*string) *RestoreFromClusterSnapshotInput {
+	s.IamRoles = v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *RestoreFromClusterSnapshotInput) SetKmsKeyId(v string) *RestoreFromClusterSnapshotInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *RestoreFromClusterSnapshotInput) SetNodeType(v string) *RestoreFromClusterSnapshotInput {
+	s.NodeType = &v
+	return s
+}
+
+// SetOwnerAccount sets the OwnerAccount field's value.
+func (s *RestoreFromClusterSnapshotInput) SetOwnerAccount(v string) *RestoreFromClusterSnapshotInput {
+	s.OwnerAccount = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *RestoreFromClusterSnapshotInput) SetPort(v int64) *RestoreFromClusterSnapshotInput {
+	s.Port = &v
+	return s
+}
+
+// SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
+func (s *RestoreFromClusterSnapshotInput) SetPreferredMaintenanceWindow(v string) *RestoreFromClusterSnapshotInput {
+	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetPubliclyAccessible sets the PubliclyAccessible field's value.
+func (s *RestoreFromClusterSnapshotInput) SetPubliclyAccessible(v bool) *RestoreFromClusterSnapshotInput {
+	s.PubliclyAccessible = &v
+	return s
+}
+
+// SetSnapshotClusterIdentifier sets the SnapshotClusterIdentifier field's value.
+func (s *RestoreFromClusterSnapshotInput) SetSnapshotClusterIdentifier(v string) *RestoreFromClusterSnapshotInput {
+	s.SnapshotClusterIdentifier = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *RestoreFromClusterSnapshotInput) SetSnapshotIdentifier(v string) *RestoreFromClusterSnapshotInput {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
+// SetVpcSecurityGroupIds sets the VpcSecurityGroupIds field's value.
+func (s *RestoreFromClusterSnapshotInput) SetVpcSecurityGroupIds(v []*string) *RestoreFromClusterSnapshotInput {
+	s.VpcSecurityGroupIds = v
+	return s
+}
+
 type RestoreFromClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11203,6 +14137,12 @@ func (s RestoreFromClusterSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s RestoreFromClusterSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *RestoreFromClusterSnapshotOutput) SetCluster(v *Cluster) *RestoreFromClusterSnapshotOutput {
+	s.Cluster = v
+	return s
 }
 
 // Describes the status of a cluster restore action. Returns null if the cluster
@@ -11241,6 +14181,42 @@ func (s RestoreStatus) String() string {
 // GoString returns the string representation
 func (s RestoreStatus) GoString() string {
 	return s.String()
+}
+
+// SetCurrentRestoreRateInMegaBytesPerSecond sets the CurrentRestoreRateInMegaBytesPerSecond field's value.
+func (s *RestoreStatus) SetCurrentRestoreRateInMegaBytesPerSecond(v float64) *RestoreStatus {
+	s.CurrentRestoreRateInMegaBytesPerSecond = &v
+	return s
+}
+
+// SetElapsedTimeInSeconds sets the ElapsedTimeInSeconds field's value.
+func (s *RestoreStatus) SetElapsedTimeInSeconds(v int64) *RestoreStatus {
+	s.ElapsedTimeInSeconds = &v
+	return s
+}
+
+// SetEstimatedTimeToCompletionInSeconds sets the EstimatedTimeToCompletionInSeconds field's value.
+func (s *RestoreStatus) SetEstimatedTimeToCompletionInSeconds(v int64) *RestoreStatus {
+	s.EstimatedTimeToCompletionInSeconds = &v
+	return s
+}
+
+// SetProgressInMegaBytes sets the ProgressInMegaBytes field's value.
+func (s *RestoreStatus) SetProgressInMegaBytes(v int64) *RestoreStatus {
+	s.ProgressInMegaBytes = &v
+	return s
+}
+
+// SetSnapshotSizeInMegaBytes sets the SnapshotSizeInMegaBytes field's value.
+func (s *RestoreStatus) SetSnapshotSizeInMegaBytes(v int64) *RestoreStatus {
+	s.SnapshotSizeInMegaBytes = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *RestoreStatus) SetStatus(v string) *RestoreStatus {
+	s.Status = &v
+	return s
 }
 
 type RestoreTableFromClusterSnapshotInput struct {
@@ -11319,6 +14295,54 @@ func (s *RestoreTableFromClusterSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *RestoreTableFromClusterSnapshotInput) SetClusterIdentifier(v string) *RestoreTableFromClusterSnapshotInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetNewTableName sets the NewTableName field's value.
+func (s *RestoreTableFromClusterSnapshotInput) SetNewTableName(v string) *RestoreTableFromClusterSnapshotInput {
+	s.NewTableName = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *RestoreTableFromClusterSnapshotInput) SetSnapshotIdentifier(v string) *RestoreTableFromClusterSnapshotInput {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
+// SetSourceDatabaseName sets the SourceDatabaseName field's value.
+func (s *RestoreTableFromClusterSnapshotInput) SetSourceDatabaseName(v string) *RestoreTableFromClusterSnapshotInput {
+	s.SourceDatabaseName = &v
+	return s
+}
+
+// SetSourceSchemaName sets the SourceSchemaName field's value.
+func (s *RestoreTableFromClusterSnapshotInput) SetSourceSchemaName(v string) *RestoreTableFromClusterSnapshotInput {
+	s.SourceSchemaName = &v
+	return s
+}
+
+// SetSourceTableName sets the SourceTableName field's value.
+func (s *RestoreTableFromClusterSnapshotInput) SetSourceTableName(v string) *RestoreTableFromClusterSnapshotInput {
+	s.SourceTableName = &v
+	return s
+}
+
+// SetTargetDatabaseName sets the TargetDatabaseName field's value.
+func (s *RestoreTableFromClusterSnapshotInput) SetTargetDatabaseName(v string) *RestoreTableFromClusterSnapshotInput {
+	s.TargetDatabaseName = &v
+	return s
+}
+
+// SetTargetSchemaName sets the TargetSchemaName field's value.
+func (s *RestoreTableFromClusterSnapshotInput) SetTargetSchemaName(v string) *RestoreTableFromClusterSnapshotInput {
+	s.TargetSchemaName = &v
+	return s
+}
+
 type RestoreTableFromClusterSnapshotOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11334,6 +14358,12 @@ func (s RestoreTableFromClusterSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s RestoreTableFromClusterSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetTableRestoreStatus sets the TableRestoreStatus field's value.
+func (s *RestoreTableFromClusterSnapshotOutput) SetTableRestoreStatus(v *TableRestoreStatus) *RestoreTableFromClusterSnapshotOutput {
+	s.TableRestoreStatus = v
+	return s
 }
 
 type RevokeClusterSecurityGroupIngressInput struct {
@@ -11386,6 +14416,30 @@ func (s *RevokeClusterSecurityGroupIngressInput) Validate() error {
 	return nil
 }
 
+// SetCIDRIP sets the CIDRIP field's value.
+func (s *RevokeClusterSecurityGroupIngressInput) SetCIDRIP(v string) *RevokeClusterSecurityGroupIngressInput {
+	s.CIDRIP = &v
+	return s
+}
+
+// SetClusterSecurityGroupName sets the ClusterSecurityGroupName field's value.
+func (s *RevokeClusterSecurityGroupIngressInput) SetClusterSecurityGroupName(v string) *RevokeClusterSecurityGroupIngressInput {
+	s.ClusterSecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupName sets the EC2SecurityGroupName field's value.
+func (s *RevokeClusterSecurityGroupIngressInput) SetEC2SecurityGroupName(v string) *RevokeClusterSecurityGroupIngressInput {
+	s.EC2SecurityGroupName = &v
+	return s
+}
+
+// SetEC2SecurityGroupOwnerId sets the EC2SecurityGroupOwnerId field's value.
+func (s *RevokeClusterSecurityGroupIngressInput) SetEC2SecurityGroupOwnerId(v string) *RevokeClusterSecurityGroupIngressInput {
+	s.EC2SecurityGroupOwnerId = &v
+	return s
+}
+
 type RevokeClusterSecurityGroupIngressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11401,6 +14455,12 @@ func (s RevokeClusterSecurityGroupIngressOutput) String() string {
 // GoString returns the string representation
 func (s RevokeClusterSecurityGroupIngressOutput) GoString() string {
 	return s.String()
+}
+
+// SetClusterSecurityGroup sets the ClusterSecurityGroup field's value.
+func (s *RevokeClusterSecurityGroupIngressOutput) SetClusterSecurityGroup(v *ClusterSecurityGroup) *RevokeClusterSecurityGroupIngressOutput {
+	s.ClusterSecurityGroup = v
+	return s
 }
 
 type RevokeSnapshotAccessInput struct {
@@ -11449,6 +14509,24 @@ func (s *RevokeSnapshotAccessInput) Validate() error {
 	return nil
 }
 
+// SetAccountWithRestoreAccess sets the AccountWithRestoreAccess field's value.
+func (s *RevokeSnapshotAccessInput) SetAccountWithRestoreAccess(v string) *RevokeSnapshotAccessInput {
+	s.AccountWithRestoreAccess = &v
+	return s
+}
+
+// SetSnapshotClusterIdentifier sets the SnapshotClusterIdentifier field's value.
+func (s *RevokeSnapshotAccessInput) SetSnapshotClusterIdentifier(v string) *RevokeSnapshotAccessInput {
+	s.SnapshotClusterIdentifier = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *RevokeSnapshotAccessInput) SetSnapshotIdentifier(v string) *RevokeSnapshotAccessInput {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
 type RevokeSnapshotAccessOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11464,6 +14542,12 @@ func (s RevokeSnapshotAccessOutput) String() string {
 // GoString returns the string representation
 func (s RevokeSnapshotAccessOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshot sets the Snapshot field's value.
+func (s *RevokeSnapshotAccessOutput) SetSnapshot(v *Snapshot) *RevokeSnapshotAccessOutput {
+	s.Snapshot = v
+	return s
 }
 
 type RotateEncryptionKeyInput struct {
@@ -11501,6 +14585,12 @@ func (s *RotateEncryptionKeyInput) Validate() error {
 	return nil
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *RotateEncryptionKeyInput) SetClusterIdentifier(v string) *RotateEncryptionKeyInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
 type RotateEncryptionKeyOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11516,6 +14606,12 @@ func (s RotateEncryptionKeyOutput) String() string {
 // GoString returns the string representation
 func (s RotateEncryptionKeyOutput) GoString() string {
 	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *RotateEncryptionKeyOutput) SetCluster(v *Cluster) *RotateEncryptionKeyOutput {
+	s.Cluster = v
+	return s
 }
 
 // Describes a snapshot.
@@ -11650,6 +14746,180 @@ func (s Snapshot) GoString() string {
 	return s.String()
 }
 
+// SetAccountsWithRestoreAccess sets the AccountsWithRestoreAccess field's value.
+func (s *Snapshot) SetAccountsWithRestoreAccess(v []*AccountWithRestoreAccess) *Snapshot {
+	s.AccountsWithRestoreAccess = v
+	return s
+}
+
+// SetActualIncrementalBackupSizeInMegaBytes sets the ActualIncrementalBackupSizeInMegaBytes field's value.
+func (s *Snapshot) SetActualIncrementalBackupSizeInMegaBytes(v float64) *Snapshot {
+	s.ActualIncrementalBackupSizeInMegaBytes = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *Snapshot) SetAvailabilityZone(v string) *Snapshot {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetBackupProgressInMegaBytes sets the BackupProgressInMegaBytes field's value.
+func (s *Snapshot) SetBackupProgressInMegaBytes(v float64) *Snapshot {
+	s.BackupProgressInMegaBytes = &v
+	return s
+}
+
+// SetClusterCreateTime sets the ClusterCreateTime field's value.
+func (s *Snapshot) SetClusterCreateTime(v time.Time) *Snapshot {
+	s.ClusterCreateTime = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *Snapshot) SetClusterIdentifier(v string) *Snapshot {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetClusterVersion sets the ClusterVersion field's value.
+func (s *Snapshot) SetClusterVersion(v string) *Snapshot {
+	s.ClusterVersion = &v
+	return s
+}
+
+// SetCurrentBackupRateInMegaBytesPerSecond sets the CurrentBackupRateInMegaBytesPerSecond field's value.
+func (s *Snapshot) SetCurrentBackupRateInMegaBytesPerSecond(v float64) *Snapshot {
+	s.CurrentBackupRateInMegaBytesPerSecond = &v
+	return s
+}
+
+// SetDBName sets the DBName field's value.
+func (s *Snapshot) SetDBName(v string) *Snapshot {
+	s.DBName = &v
+	return s
+}
+
+// SetElapsedTimeInSeconds sets the ElapsedTimeInSeconds field's value.
+func (s *Snapshot) SetElapsedTimeInSeconds(v int64) *Snapshot {
+	s.ElapsedTimeInSeconds = &v
+	return s
+}
+
+// SetEncrypted sets the Encrypted field's value.
+func (s *Snapshot) SetEncrypted(v bool) *Snapshot {
+	s.Encrypted = &v
+	return s
+}
+
+// SetEncryptedWithHSM sets the EncryptedWithHSM field's value.
+func (s *Snapshot) SetEncryptedWithHSM(v bool) *Snapshot {
+	s.EncryptedWithHSM = &v
+	return s
+}
+
+// SetEnhancedVpcRouting sets the EnhancedVpcRouting field's value.
+func (s *Snapshot) SetEnhancedVpcRouting(v bool) *Snapshot {
+	s.EnhancedVpcRouting = &v
+	return s
+}
+
+// SetEstimatedSecondsToCompletion sets the EstimatedSecondsToCompletion field's value.
+func (s *Snapshot) SetEstimatedSecondsToCompletion(v int64) *Snapshot {
+	s.EstimatedSecondsToCompletion = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *Snapshot) SetKmsKeyId(v string) *Snapshot {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetMasterUsername sets the MasterUsername field's value.
+func (s *Snapshot) SetMasterUsername(v string) *Snapshot {
+	s.MasterUsername = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *Snapshot) SetNodeType(v string) *Snapshot {
+	s.NodeType = &v
+	return s
+}
+
+// SetNumberOfNodes sets the NumberOfNodes field's value.
+func (s *Snapshot) SetNumberOfNodes(v int64) *Snapshot {
+	s.NumberOfNodes = &v
+	return s
+}
+
+// SetOwnerAccount sets the OwnerAccount field's value.
+func (s *Snapshot) SetOwnerAccount(v string) *Snapshot {
+	s.OwnerAccount = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *Snapshot) SetPort(v int64) *Snapshot {
+	s.Port = &v
+	return s
+}
+
+// SetRestorableNodeTypes sets the RestorableNodeTypes field's value.
+func (s *Snapshot) SetRestorableNodeTypes(v []*string) *Snapshot {
+	s.RestorableNodeTypes = v
+	return s
+}
+
+// SetSnapshotCreateTime sets the SnapshotCreateTime field's value.
+func (s *Snapshot) SetSnapshotCreateTime(v time.Time) *Snapshot {
+	s.SnapshotCreateTime = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *Snapshot) SetSnapshotIdentifier(v string) *Snapshot {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
+// SetSnapshotType sets the SnapshotType field's value.
+func (s *Snapshot) SetSnapshotType(v string) *Snapshot {
+	s.SnapshotType = &v
+	return s
+}
+
+// SetSourceRegion sets the SourceRegion field's value.
+func (s *Snapshot) SetSourceRegion(v string) *Snapshot {
+	s.SourceRegion = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Snapshot) SetStatus(v string) *Snapshot {
+	s.Status = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Snapshot) SetTags(v []*Tag) *Snapshot {
+	s.Tags = v
+	return s
+}
+
+// SetTotalBackupSizeInMegaBytes sets the TotalBackupSizeInMegaBytes field's value.
+func (s *Snapshot) SetTotalBackupSizeInMegaBytes(v float64) *Snapshot {
+	s.TotalBackupSizeInMegaBytes = &v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *Snapshot) SetVpcId(v string) *Snapshot {
+	s.VpcId = &v
+	return s
+}
+
 // The snapshot copy grant that grants Amazon Redshift permission to encrypt
 // copied snapshots with the specified customer master key (CMK) from AWS KMS
 // in the destination region.
@@ -11681,6 +14951,24 @@ func (s SnapshotCopyGrant) GoString() string {
 	return s.String()
 }
 
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *SnapshotCopyGrant) SetKmsKeyId(v string) *SnapshotCopyGrant {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetSnapshotCopyGrantName sets the SnapshotCopyGrantName field's value.
+func (s *SnapshotCopyGrant) SetSnapshotCopyGrantName(v string) *SnapshotCopyGrant {
+	s.SnapshotCopyGrantName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *SnapshotCopyGrant) SetTags(v []*Tag) *SnapshotCopyGrant {
+	s.Tags = v
+	return s
+}
+
 // Describes a subnet.
 type Subnet struct {
 	_ struct{} `type:"structure"`
@@ -11703,6 +14991,24 @@ func (s Subnet) String() string {
 // GoString returns the string representation
 func (s Subnet) GoString() string {
 	return s.String()
+}
+
+// SetSubnetAvailabilityZone sets the SubnetAvailabilityZone field's value.
+func (s *Subnet) SetSubnetAvailabilityZone(v *AvailabilityZone) *Subnet {
+	s.SubnetAvailabilityZone = v
+	return s
+}
+
+// SetSubnetIdentifier sets the SubnetIdentifier field's value.
+func (s *Subnet) SetSubnetIdentifier(v string) *Subnet {
+	s.SubnetIdentifier = &v
+	return s
+}
+
+// SetSubnetStatus sets the SubnetStatus field's value.
+func (s *Subnet) SetSubnetStatus(v string) *Subnet {
+	s.SubnetStatus = &v
+	return s
 }
 
 // Describes the status of a RestoreTableFromClusterSnapshot operation.
@@ -11767,6 +15073,90 @@ func (s TableRestoreStatus) GoString() string {
 	return s.String()
 }
 
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *TableRestoreStatus) SetClusterIdentifier(v string) *TableRestoreStatus {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *TableRestoreStatus) SetMessage(v string) *TableRestoreStatus {
+	s.Message = &v
+	return s
+}
+
+// SetNewTableName sets the NewTableName field's value.
+func (s *TableRestoreStatus) SetNewTableName(v string) *TableRestoreStatus {
+	s.NewTableName = &v
+	return s
+}
+
+// SetProgressInMegaBytes sets the ProgressInMegaBytes field's value.
+func (s *TableRestoreStatus) SetProgressInMegaBytes(v int64) *TableRestoreStatus {
+	s.ProgressInMegaBytes = &v
+	return s
+}
+
+// SetRequestTime sets the RequestTime field's value.
+func (s *TableRestoreStatus) SetRequestTime(v time.Time) *TableRestoreStatus {
+	s.RequestTime = &v
+	return s
+}
+
+// SetSnapshotIdentifier sets the SnapshotIdentifier field's value.
+func (s *TableRestoreStatus) SetSnapshotIdentifier(v string) *TableRestoreStatus {
+	s.SnapshotIdentifier = &v
+	return s
+}
+
+// SetSourceDatabaseName sets the SourceDatabaseName field's value.
+func (s *TableRestoreStatus) SetSourceDatabaseName(v string) *TableRestoreStatus {
+	s.SourceDatabaseName = &v
+	return s
+}
+
+// SetSourceSchemaName sets the SourceSchemaName field's value.
+func (s *TableRestoreStatus) SetSourceSchemaName(v string) *TableRestoreStatus {
+	s.SourceSchemaName = &v
+	return s
+}
+
+// SetSourceTableName sets the SourceTableName field's value.
+func (s *TableRestoreStatus) SetSourceTableName(v string) *TableRestoreStatus {
+	s.SourceTableName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *TableRestoreStatus) SetStatus(v string) *TableRestoreStatus {
+	s.Status = &v
+	return s
+}
+
+// SetTableRestoreRequestId sets the TableRestoreRequestId field's value.
+func (s *TableRestoreStatus) SetTableRestoreRequestId(v string) *TableRestoreStatus {
+	s.TableRestoreRequestId = &v
+	return s
+}
+
+// SetTargetDatabaseName sets the TargetDatabaseName field's value.
+func (s *TableRestoreStatus) SetTargetDatabaseName(v string) *TableRestoreStatus {
+	s.TargetDatabaseName = &v
+	return s
+}
+
+// SetTargetSchemaName sets the TargetSchemaName field's value.
+func (s *TableRestoreStatus) SetTargetSchemaName(v string) *TableRestoreStatus {
+	s.TargetSchemaName = &v
+	return s
+}
+
+// SetTotalDataInMegaBytes sets the TotalDataInMegaBytes field's value.
+func (s *TableRestoreStatus) SetTotalDataInMegaBytes(v int64) *TableRestoreStatus {
+	s.TotalDataInMegaBytes = &v
+	return s
+}
+
 // A tag consisting of a name/value pair for a resource.
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -11786,6 +15176,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // A tag and its associated resource.
@@ -11836,6 +15238,24 @@ func (s TaggedResource) GoString() string {
 	return s.String()
 }
 
+// SetResourceName sets the ResourceName field's value.
+func (s *TaggedResource) SetResourceName(v string) *TaggedResource {
+	s.ResourceName = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *TaggedResource) SetResourceType(v string) *TaggedResource {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTag sets the Tag field's value.
+func (s *TaggedResource) SetTag(v *Tag) *TaggedResource {
+	s.Tag = v
+	return s
+}
+
 // Describes the members of a VPC security group.
 type VpcSecurityGroupMembership struct {
 	_ struct{} `type:"structure"`
@@ -11855,6 +15275,18 @@ func (s VpcSecurityGroupMembership) String() string {
 // GoString returns the string representation
 func (s VpcSecurityGroupMembership) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *VpcSecurityGroupMembership) SetStatus(v string) *VpcSecurityGroupMembership {
+	s.Status = &v
+	return s
+}
+
+// SetVpcSecurityGroupId sets the VpcSecurityGroupId field's value.
+func (s *VpcSecurityGroupMembership) SetVpcSecurityGroupId(v string) *VpcSecurityGroupMembership {
+	s.VpcSecurityGroupId = &v
+	return s
 }
 
 const (

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -4326,6 +4326,18 @@ func (s *AlarmIdentifier) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *AlarmIdentifier) SetName(v string) *AlarmIdentifier {
+	s.Name = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *AlarmIdentifier) SetRegion(v string) *AlarmIdentifier {
+	s.Region = &v
+	return s
+}
+
 // Alias resource record sets only: Information about the CloudFront distribution,
 // Elastic Beanstalk environment, ELB load balancer, Amazon S3 bucket, or Amazon
 // Route 53 resource record set to which you are redirecting queries. The Elastic
@@ -4565,6 +4577,24 @@ func (s *AliasTarget) Validate() error {
 	return nil
 }
 
+// SetDNSName sets the DNSName field's value.
+func (s *AliasTarget) SetDNSName(v string) *AliasTarget {
+	s.DNSName = &v
+	return s
+}
+
+// SetEvaluateTargetHealth sets the EvaluateTargetHealth field's value.
+func (s *AliasTarget) SetEvaluateTargetHealth(v bool) *AliasTarget {
+	s.EvaluateTargetHealth = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *AliasTarget) SetHostedZoneId(v string) *AliasTarget {
+	s.HostedZoneId = &v
+	return s
+}
+
 // A complex type that contains information about the VPC and the hosted zone
 // that you want to associate.
 type AssociateVPCWithHostedZoneInput struct {
@@ -4619,6 +4649,24 @@ func (s *AssociateVPCWithHostedZoneInput) Validate() error {
 	return nil
 }
 
+// SetComment sets the Comment field's value.
+func (s *AssociateVPCWithHostedZoneInput) SetComment(v string) *AssociateVPCWithHostedZoneInput {
+	s.Comment = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *AssociateVPCWithHostedZoneInput) SetHostedZoneId(v string) *AssociateVPCWithHostedZoneInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetVPC sets the VPC field's value.
+func (s *AssociateVPCWithHostedZoneInput) SetVPC(v *VPC) *AssociateVPCWithHostedZoneInput {
+	s.VPC = v
+	return s
+}
+
 // A complex type that contains the response information for the hosted zone.
 type AssociateVPCWithHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -4637,6 +4685,12 @@ func (s AssociateVPCWithHostedZoneOutput) String() string {
 // GoString returns the string representation
 func (s AssociateVPCWithHostedZoneOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeInfo sets the ChangeInfo field's value.
+func (s *AssociateVPCWithHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *AssociateVPCWithHostedZoneOutput {
+	s.ChangeInfo = v
+	return s
 }
 
 // The information for each resource record set that you want to change.
@@ -4707,6 +4761,18 @@ func (s *Change) Validate() error {
 	return nil
 }
 
+// SetAction sets the Action field's value.
+func (s *Change) SetAction(v string) *Change {
+	s.Action = &v
+	return s
+}
+
+// SetResourceRecordSet sets the ResourceRecordSet field's value.
+func (s *Change) SetResourceRecordSet(v *ResourceRecordSet) *Change {
+	s.ResourceRecordSet = v
+	return s
+}
+
 // The information for a change request.
 type ChangeBatch struct {
 	_ struct{} `type:"structure"`
@@ -4754,6 +4820,18 @@ func (s *ChangeBatch) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetChanges sets the Changes field's value.
+func (s *ChangeBatch) SetChanges(v []*Change) *ChangeBatch {
+	s.Changes = v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *ChangeBatch) SetComment(v string) *ChangeBatch {
+	s.Comment = &v
+	return s
 }
 
 // A complex type that lists the changes and information for a ChangeBatch.
@@ -4804,6 +4882,42 @@ func (s ChangeBatchRecord) GoString() string {
 	return s.String()
 }
 
+// SetChanges sets the Changes field's value.
+func (s *ChangeBatchRecord) SetChanges(v []*Change) *ChangeBatchRecord {
+	s.Changes = v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *ChangeBatchRecord) SetComment(v string) *ChangeBatchRecord {
+	s.Comment = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ChangeBatchRecord) SetId(v string) *ChangeBatchRecord {
+	s.Id = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ChangeBatchRecord) SetStatus(v string) *ChangeBatchRecord {
+	s.Status = &v
+	return s
+}
+
+// SetSubmittedAt sets the SubmittedAt field's value.
+func (s *ChangeBatchRecord) SetSubmittedAt(v time.Time) *ChangeBatchRecord {
+	s.SubmittedAt = &v
+	return s
+}
+
+// SetSubmitter sets the Submitter field's value.
+func (s *ChangeBatchRecord) SetSubmitter(v string) *ChangeBatchRecord {
+	s.Submitter = &v
+	return s
+}
+
 // A complex type that describes change information about changes made to your
 // hosted zone.
 type ChangeInfo struct {
@@ -4843,6 +4957,30 @@ func (s ChangeInfo) String() string {
 // GoString returns the string representation
 func (s ChangeInfo) GoString() string {
 	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *ChangeInfo) SetComment(v string) *ChangeInfo {
+	s.Comment = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ChangeInfo) SetId(v string) *ChangeInfo {
+	s.Id = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ChangeInfo) SetStatus(v string) *ChangeInfo {
+	s.Status = &v
+	return s
+}
+
+// SetSubmittedAt sets the SubmittedAt field's value.
+func (s *ChangeInfo) SetSubmittedAt(v time.Time) *ChangeInfo {
+	s.SubmittedAt = &v
+	return s
 }
 
 // A complex type that contains change information for the resource record set.
@@ -4892,6 +5030,18 @@ func (s *ChangeResourceRecordSetsInput) Validate() error {
 	return nil
 }
 
+// SetChangeBatch sets the ChangeBatch field's value.
+func (s *ChangeResourceRecordSetsInput) SetChangeBatch(v *ChangeBatch) *ChangeResourceRecordSetsInput {
+	s.ChangeBatch = v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *ChangeResourceRecordSetsInput) SetHostedZoneId(v string) *ChangeResourceRecordSetsInput {
+	s.HostedZoneId = &v
+	return s
+}
+
 // A complex type containing the response for the request.
 type ChangeResourceRecordSetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4914,6 +5064,12 @@ func (s ChangeResourceRecordSetsOutput) String() string {
 // GoString returns the string representation
 func (s ChangeResourceRecordSetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeInfo sets the ChangeInfo field's value.
+func (s *ChangeResourceRecordSetsOutput) SetChangeInfo(v *ChangeInfo) *ChangeResourceRecordSetsOutput {
+	s.ChangeInfo = v
+	return s
 }
 
 // A complex type that contains information about the tags that you want to
@@ -4977,6 +5133,30 @@ func (s *ChangeTagsForResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAddTags sets the AddTags field's value.
+func (s *ChangeTagsForResourceInput) SetAddTags(v []*Tag) *ChangeTagsForResourceInput {
+	s.AddTags = v
+	return s
+}
+
+// SetRemoveTagKeys sets the RemoveTagKeys field's value.
+func (s *ChangeTagsForResourceInput) SetRemoveTagKeys(v []*string) *ChangeTagsForResourceInput {
+	s.RemoveTagKeys = v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ChangeTagsForResourceInput) SetResourceId(v string) *ChangeTagsForResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ChangeTagsForResourceInput) SetResourceType(v string) *ChangeTagsForResourceInput {
+	s.ResourceType = &v
+	return s
 }
 
 // Empty response for the request.
@@ -5058,6 +5238,54 @@ func (s CloudWatchAlarmConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *CloudWatchAlarmConfiguration) SetComparisonOperator(v string) *CloudWatchAlarmConfiguration {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetDimensions sets the Dimensions field's value.
+func (s *CloudWatchAlarmConfiguration) SetDimensions(v []*Dimension) *CloudWatchAlarmConfiguration {
+	s.Dimensions = v
+	return s
+}
+
+// SetEvaluationPeriods sets the EvaluationPeriods field's value.
+func (s *CloudWatchAlarmConfiguration) SetEvaluationPeriods(v int64) *CloudWatchAlarmConfiguration {
+	s.EvaluationPeriods = &v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *CloudWatchAlarmConfiguration) SetMetricName(v string) *CloudWatchAlarmConfiguration {
+	s.MetricName = &v
+	return s
+}
+
+// SetNamespace sets the Namespace field's value.
+func (s *CloudWatchAlarmConfiguration) SetNamespace(v string) *CloudWatchAlarmConfiguration {
+	s.Namespace = &v
+	return s
+}
+
+// SetPeriod sets the Period field's value.
+func (s *CloudWatchAlarmConfiguration) SetPeriod(v int64) *CloudWatchAlarmConfiguration {
+	s.Period = &v
+	return s
+}
+
+// SetStatistic sets the Statistic field's value.
+func (s *CloudWatchAlarmConfiguration) SetStatistic(v string) *CloudWatchAlarmConfiguration {
+	s.Statistic = &v
+	return s
+}
+
+// SetThreshold sets the Threshold field's value.
+func (s *CloudWatchAlarmConfiguration) SetThreshold(v float64) *CloudWatchAlarmConfiguration {
+	s.Threshold = &v
+	return s
+}
+
 // A complex type that contains the health check request information.
 type CreateHealthCheckInput struct {
 	_ struct{} `locationName:"CreateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
@@ -5110,6 +5338,18 @@ func (s *CreateHealthCheckInput) Validate() error {
 	return nil
 }
 
+// SetCallerReference sets the CallerReference field's value.
+func (s *CreateHealthCheckInput) SetCallerReference(v string) *CreateHealthCheckInput {
+	s.CallerReference = &v
+	return s
+}
+
+// SetHealthCheckConfig sets the HealthCheckConfig field's value.
+func (s *CreateHealthCheckInput) SetHealthCheckConfig(v *HealthCheckConfig) *CreateHealthCheckInput {
+	s.HealthCheckConfig = v
+	return s
+}
+
 // A complex type containing the response information for the new health check.
 type CreateHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
@@ -5133,6 +5373,18 @@ func (s CreateHealthCheckOutput) String() string {
 // GoString returns the string representation
 func (s CreateHealthCheckOutput) GoString() string {
 	return s.String()
+}
+
+// SetHealthCheck sets the HealthCheck field's value.
+func (s *CreateHealthCheckOutput) SetHealthCheck(v *HealthCheck) *CreateHealthCheckOutput {
+	s.HealthCheck = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateHealthCheckOutput) SetLocation(v string) *CreateHealthCheckOutput {
+	s.Location = &v
+	return s
 }
 
 // A complex type containing the hosted zone request information.
@@ -5219,6 +5471,36 @@ func (s *CreateHostedZoneInput) Validate() error {
 	return nil
 }
 
+// SetCallerReference sets the CallerReference field's value.
+func (s *CreateHostedZoneInput) SetCallerReference(v string) *CreateHostedZoneInput {
+	s.CallerReference = &v
+	return s
+}
+
+// SetDelegationSetId sets the DelegationSetId field's value.
+func (s *CreateHostedZoneInput) SetDelegationSetId(v string) *CreateHostedZoneInput {
+	s.DelegationSetId = &v
+	return s
+}
+
+// SetHostedZoneConfig sets the HostedZoneConfig field's value.
+func (s *CreateHostedZoneInput) SetHostedZoneConfig(v *HostedZoneConfig) *CreateHostedZoneInput {
+	s.HostedZoneConfig = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateHostedZoneInput) SetName(v string) *CreateHostedZoneInput {
+	s.Name = &v
+	return s
+}
+
+// SetVPC sets the VPC field's value.
+func (s *CreateHostedZoneInput) SetVPC(v *VPC) *CreateHostedZoneInput {
+	s.VPC = v
+	return s
+}
+
 // A complex type containing the response information for the hosted zone.
 type CreateHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -5256,6 +5538,36 @@ func (s CreateHostedZoneOutput) String() string {
 // GoString returns the string representation
 func (s CreateHostedZoneOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeInfo sets the ChangeInfo field's value.
+func (s *CreateHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *CreateHostedZoneOutput {
+	s.ChangeInfo = v
+	return s
+}
+
+// SetDelegationSet sets the DelegationSet field's value.
+func (s *CreateHostedZoneOutput) SetDelegationSet(v *DelegationSet) *CreateHostedZoneOutput {
+	s.DelegationSet = v
+	return s
+}
+
+// SetHostedZone sets the HostedZone field's value.
+func (s *CreateHostedZoneOutput) SetHostedZone(v *HostedZone) *CreateHostedZoneOutput {
+	s.HostedZone = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateHostedZoneOutput) SetLocation(v string) *CreateHostedZoneOutput {
+	s.Location = &v
+	return s
+}
+
+// SetVPC sets the VPC field's value.
+func (s *CreateHostedZoneOutput) SetVPC(v *VPC) *CreateHostedZoneOutput {
+	s.VPC = v
+	return s
 }
 
 type CreateReusableDelegationSetInput struct {
@@ -5301,6 +5613,18 @@ func (s *CreateReusableDelegationSetInput) Validate() error {
 	return nil
 }
 
+// SetCallerReference sets the CallerReference field's value.
+func (s *CreateReusableDelegationSetInput) SetCallerReference(v string) *CreateReusableDelegationSetInput {
+	s.CallerReference = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *CreateReusableDelegationSetInput) SetHostedZoneId(v string) *CreateReusableDelegationSetInput {
+	s.HostedZoneId = &v
+	return s
+}
+
 type CreateReusableDelegationSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5323,6 +5647,18 @@ func (s CreateReusableDelegationSetOutput) String() string {
 // GoString returns the string representation
 func (s CreateReusableDelegationSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetDelegationSet sets the DelegationSet field's value.
+func (s *CreateReusableDelegationSetOutput) SetDelegationSet(v *DelegationSet) *CreateReusableDelegationSetOutput {
+	s.DelegationSet = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateReusableDelegationSetOutput) SetLocation(v string) *CreateReusableDelegationSetOutput {
+	s.Location = &v
+	return s
 }
 
 // A complex type that contains information about the traffic policy that you
@@ -5370,6 +5706,24 @@ func (s *CreateTrafficPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetComment sets the Comment field's value.
+func (s *CreateTrafficPolicyInput) SetComment(v string) *CreateTrafficPolicyInput {
+	s.Comment = &v
+	return s
+}
+
+// SetDocument sets the Document field's value.
+func (s *CreateTrafficPolicyInput) SetDocument(v string) *CreateTrafficPolicyInput {
+	s.Document = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateTrafficPolicyInput) SetName(v string) *CreateTrafficPolicyInput {
+	s.Name = &v
+	return s
 }
 
 // A complex type that contains information about the resource record sets that
@@ -5447,6 +5801,36 @@ func (s *CreateTrafficPolicyInstanceInput) Validate() error {
 	return nil
 }
 
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *CreateTrafficPolicyInstanceInput) SetHostedZoneId(v string) *CreateTrafficPolicyInstanceInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateTrafficPolicyInstanceInput) SetName(v string) *CreateTrafficPolicyInstanceInput {
+	s.Name = &v
+	return s
+}
+
+// SetTTL sets the TTL field's value.
+func (s *CreateTrafficPolicyInstanceInput) SetTTL(v int64) *CreateTrafficPolicyInstanceInput {
+	s.TTL = &v
+	return s
+}
+
+// SetTrafficPolicyId sets the TrafficPolicyId field's value.
+func (s *CreateTrafficPolicyInstanceInput) SetTrafficPolicyId(v string) *CreateTrafficPolicyInstanceInput {
+	s.TrafficPolicyId = &v
+	return s
+}
+
+// SetTrafficPolicyVersion sets the TrafficPolicyVersion field's value.
+func (s *CreateTrafficPolicyInstanceInput) SetTrafficPolicyVersion(v int64) *CreateTrafficPolicyInstanceInput {
+	s.TrafficPolicyVersion = &v
+	return s
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicyInstance
 // request.
 type CreateTrafficPolicyInstanceOutput struct {
@@ -5473,6 +5857,18 @@ func (s CreateTrafficPolicyInstanceOutput) GoString() string {
 	return s.String()
 }
 
+// SetLocation sets the Location field's value.
+func (s *CreateTrafficPolicyInstanceOutput) SetLocation(v string) *CreateTrafficPolicyInstanceOutput {
+	s.Location = &v
+	return s
+}
+
+// SetTrafficPolicyInstance sets the TrafficPolicyInstance field's value.
+func (s *CreateTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficPolicyInstance) *CreateTrafficPolicyInstanceOutput {
+	s.TrafficPolicyInstance = v
+	return s
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicy
 // request.
 type CreateTrafficPolicyOutput struct {
@@ -5497,6 +5893,18 @@ func (s CreateTrafficPolicyOutput) String() string {
 // GoString returns the string representation
 func (s CreateTrafficPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateTrafficPolicyOutput) SetLocation(v string) *CreateTrafficPolicyOutput {
+	s.Location = &v
+	return s
+}
+
+// SetTrafficPolicy sets the TrafficPolicy field's value.
+func (s *CreateTrafficPolicyOutput) SetTrafficPolicy(v *TrafficPolicy) *CreateTrafficPolicyOutput {
+	s.TrafficPolicy = v
+	return s
 }
 
 // A complex type that contains information about the traffic policy for which
@@ -5547,6 +5955,24 @@ func (s *CreateTrafficPolicyVersionInput) Validate() error {
 	return nil
 }
 
+// SetComment sets the Comment field's value.
+func (s *CreateTrafficPolicyVersionInput) SetComment(v string) *CreateTrafficPolicyVersionInput {
+	s.Comment = &v
+	return s
+}
+
+// SetDocument sets the Document field's value.
+func (s *CreateTrafficPolicyVersionInput) SetDocument(v string) *CreateTrafficPolicyVersionInput {
+	s.Document = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *CreateTrafficPolicyVersionInput) SetId(v string) *CreateTrafficPolicyVersionInput {
+	s.Id = &v
+	return s
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicyVersion
 // request.
 type CreateTrafficPolicyVersionOutput struct {
@@ -5572,6 +5998,18 @@ func (s CreateTrafficPolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s CreateTrafficPolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateTrafficPolicyVersionOutput) SetLocation(v string) *CreateTrafficPolicyVersionOutput {
+	s.Location = &v
+	return s
+}
+
+// SetTrafficPolicy sets the TrafficPolicy field's value.
+func (s *CreateTrafficPolicyVersionOutput) SetTrafficPolicy(v *TrafficPolicy) *CreateTrafficPolicyVersionOutput {
+	s.TrafficPolicy = v
+	return s
 }
 
 // A complex type that describes the name servers for this hosted zone.
@@ -5603,6 +6041,24 @@ func (s DelegationSet) String() string {
 // GoString returns the string representation
 func (s DelegationSet) GoString() string {
 	return s.String()
+}
+
+// SetCallerReference sets the CallerReference field's value.
+func (s *DelegationSet) SetCallerReference(v string) *DelegationSet {
+	s.CallerReference = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *DelegationSet) SetId(v string) *DelegationSet {
+	s.Id = &v
+	return s
+}
+
+// SetNameServers sets the NameServers field's value.
+func (s *DelegationSet) SetNameServers(v []*string) *DelegationSet {
+	s.NameServers = v
+	return s
 }
 
 // This action deletes a health check. Send a DELETE request to the /2013-04-01/DeleteHealthCheckRequest
@@ -5637,6 +6093,12 @@ func (s *DeleteHealthCheckInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHealthCheckId sets the HealthCheckId field's value.
+func (s *DeleteHealthCheckInput) SetHealthCheckId(v string) *DeleteHealthCheckInput {
+	s.HealthCheckId = &v
+	return s
 }
 
 // An empty element.
@@ -5688,6 +6150,12 @@ func (s *DeleteHostedZoneInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *DeleteHostedZoneInput) SetId(v string) *DeleteHostedZoneInput {
+	s.Id = &v
+	return s
+}
+
 // A complex type containing the response information for the request.
 type DeleteHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -5707,6 +6175,12 @@ func (s DeleteHostedZoneOutput) String() string {
 // GoString returns the string representation
 func (s DeleteHostedZoneOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeInfo sets the ChangeInfo field's value.
+func (s *DeleteHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *DeleteHostedZoneOutput {
+	s.ChangeInfo = v
+	return s
 }
 
 // A complex type containing the information for the delete request.
@@ -5740,6 +6214,12 @@ func (s *DeleteReusableDelegationSetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *DeleteReusableDelegationSetInput) SetId(v string) *DeleteReusableDelegationSetInput {
+	s.Id = &v
+	return s
 }
 
 // An empty element.
@@ -5801,6 +6281,18 @@ func (s *DeleteTrafficPolicyInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *DeleteTrafficPolicyInput) SetId(v string) *DeleteTrafficPolicyInput {
+	s.Id = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *DeleteTrafficPolicyInput) SetVersion(v int64) *DeleteTrafficPolicyInput {
+	s.Version = &v
+	return s
+}
+
 // A complex type that contains information about the traffic policy instance
 // that you want to delete.
 type DeleteTrafficPolicyInstanceInput struct {
@@ -5837,6 +6329,12 @@ func (s *DeleteTrafficPolicyInstanceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *DeleteTrafficPolicyInstanceInput) SetId(v string) *DeleteTrafficPolicyInstanceInput {
+	s.Id = &v
+	return s
 }
 
 // An empty element.
@@ -5897,6 +6395,18 @@ func (s Dimension) GoString() string {
 	return s.String()
 }
 
+// SetName sets the Name field's value.
+func (s *Dimension) SetName(v string) *Dimension {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Dimension) SetValue(v string) *Dimension {
+	s.Value = &v
+	return s
+}
+
 // A complex type that contains information about the VPC and the hosted zone
 // that you want to disassociate.
 type DisassociateVPCFromHostedZoneInput struct {
@@ -5949,6 +6459,24 @@ func (s *DisassociateVPCFromHostedZoneInput) Validate() error {
 	return nil
 }
 
+// SetComment sets the Comment field's value.
+func (s *DisassociateVPCFromHostedZoneInput) SetComment(v string) *DisassociateVPCFromHostedZoneInput {
+	s.Comment = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *DisassociateVPCFromHostedZoneInput) SetHostedZoneId(v string) *DisassociateVPCFromHostedZoneInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetVPC sets the VPC field's value.
+func (s *DisassociateVPCFromHostedZoneInput) SetVPC(v *VPC) *DisassociateVPCFromHostedZoneInput {
+	s.VPC = v
+	return s
+}
+
 // A complex type that contains the response information for the disassociate
 // request.
 type DisassociateVPCFromHostedZoneOutput struct {
@@ -5968,6 +6496,12 @@ func (s DisassociateVPCFromHostedZoneOutput) String() string {
 // GoString returns the string representation
 func (s DisassociateVPCFromHostedZoneOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeInfo sets the ChangeInfo field's value.
+func (s *DisassociateVPCFromHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *DisassociateVPCFromHostedZoneOutput {
+	s.ChangeInfo = v
+	return s
 }
 
 // A complex type that contains information about a geo location.
@@ -6019,6 +6553,24 @@ func (s *GeoLocation) Validate() error {
 	return nil
 }
 
+// SetContinentCode sets the ContinentCode field's value.
+func (s *GeoLocation) SetContinentCode(v string) *GeoLocation {
+	s.ContinentCode = &v
+	return s
+}
+
+// SetCountryCode sets the CountryCode field's value.
+func (s *GeoLocation) SetCountryCode(v string) *GeoLocation {
+	s.CountryCode = &v
+	return s
+}
+
+// SetSubdivisionCode sets the SubdivisionCode field's value.
+func (s *GeoLocation) SetSubdivisionCode(v string) *GeoLocation {
+	s.SubdivisionCode = &v
+	return s
+}
+
 // A complex type that contains the codes and full continent, country, and subdivision
 // names for the specified geolocation code.
 type GeoLocationDetails struct {
@@ -6055,6 +6607,42 @@ func (s GeoLocationDetails) GoString() string {
 	return s.String()
 }
 
+// SetContinentCode sets the ContinentCode field's value.
+func (s *GeoLocationDetails) SetContinentCode(v string) *GeoLocationDetails {
+	s.ContinentCode = &v
+	return s
+}
+
+// SetContinentName sets the ContinentName field's value.
+func (s *GeoLocationDetails) SetContinentName(v string) *GeoLocationDetails {
+	s.ContinentName = &v
+	return s
+}
+
+// SetCountryCode sets the CountryCode field's value.
+func (s *GeoLocationDetails) SetCountryCode(v string) *GeoLocationDetails {
+	s.CountryCode = &v
+	return s
+}
+
+// SetCountryName sets the CountryName field's value.
+func (s *GeoLocationDetails) SetCountryName(v string) *GeoLocationDetails {
+	s.CountryName = &v
+	return s
+}
+
+// SetSubdivisionCode sets the SubdivisionCode field's value.
+func (s *GeoLocationDetails) SetSubdivisionCode(v string) *GeoLocationDetails {
+	s.SubdivisionCode = &v
+	return s
+}
+
+// SetSubdivisionName sets the SubdivisionName field's value.
+func (s *GeoLocationDetails) SetSubdivisionName(v string) *GeoLocationDetails {
+	s.SubdivisionName = &v
+	return s
+}
+
 // The input for a GetChangeDetails request.
 type GetChangeDetailsInput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -6089,6 +6677,12 @@ func (s *GetChangeDetailsInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetChangeDetailsInput) SetId(v string) *GetChangeDetailsInput {
+	s.Id = &v
+	return s
+}
+
 // A complex type that contains the ChangeBatchRecord element.
 type GetChangeDetailsOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -6109,6 +6703,12 @@ func (s GetChangeDetailsOutput) String() string {
 // GoString returns the string representation
 func (s GetChangeDetailsOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeBatchRecord sets the ChangeBatchRecord field's value.
+func (s *GetChangeDetailsOutput) SetChangeBatchRecord(v *ChangeBatchRecord) *GetChangeDetailsOutput {
+	s.ChangeBatchRecord = v
+	return s
 }
 
 // The input for a GetChange request.
@@ -6146,6 +6746,12 @@ func (s *GetChangeInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetChangeInput) SetId(v string) *GetChangeInput {
+	s.Id = &v
+	return s
+}
+
 // A complex type that contains the ChangeInfo element.
 type GetChangeOutput struct {
 	_ struct{} `type:"structure"`
@@ -6164,6 +6770,12 @@ func (s GetChangeOutput) String() string {
 // GoString returns the string representation
 func (s GetChangeOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeInfo sets the ChangeInfo field's value.
+func (s *GetChangeOutput) SetChangeInfo(v *ChangeInfo) *GetChangeOutput {
+	s.ChangeInfo = v
+	return s
 }
 
 // Empty request.
@@ -6200,6 +6812,12 @@ func (s GetCheckerIpRangesOutput) String() string {
 // GoString returns the string representation
 func (s GetCheckerIpRangesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCheckerIpRanges sets the CheckerIpRanges field's value.
+func (s *GetCheckerIpRangesOutput) SetCheckerIpRanges(v []*string) *GetCheckerIpRangesOutput {
+	s.CheckerIpRanges = v
+	return s
 }
 
 // A complex type that contains information about the request to get a geo location.
@@ -6263,6 +6881,24 @@ func (s *GetGeoLocationInput) Validate() error {
 	return nil
 }
 
+// SetContinentCode sets the ContinentCode field's value.
+func (s *GetGeoLocationInput) SetContinentCode(v string) *GetGeoLocationInput {
+	s.ContinentCode = &v
+	return s
+}
+
+// SetCountryCode sets the CountryCode field's value.
+func (s *GetGeoLocationInput) SetCountryCode(v string) *GetGeoLocationInput {
+	s.CountryCode = &v
+	return s
+}
+
+// SetSubdivisionCode sets the SubdivisionCode field's value.
+func (s *GetGeoLocationInput) SetSubdivisionCode(v string) *GetGeoLocationInput {
+	s.SubdivisionCode = &v
+	return s
+}
+
 // A complex type that contains the response information for the specified geolocation
 // code.
 type GetGeoLocationOutput struct {
@@ -6283,6 +6919,12 @@ func (s GetGeoLocationOutput) String() string {
 // GoString returns the string representation
 func (s GetGeoLocationOutput) GoString() string {
 	return s.String()
+}
+
+// SetGeoLocationDetails sets the GeoLocationDetails field's value.
+func (s *GetGeoLocationOutput) SetGeoLocationDetails(v *GeoLocationDetails) *GetGeoLocationOutput {
+	s.GeoLocationDetails = v
+	return s
 }
 
 // To retrieve a count of all your health checks, send a GET request to the
@@ -6319,6 +6961,12 @@ func (s GetHealthCheckCountOutput) String() string {
 // GoString returns the string representation
 func (s GetHealthCheckCountOutput) GoString() string {
 	return s.String()
+}
+
+// SetHealthCheckCount sets the HealthCheckCount field's value.
+func (s *GetHealthCheckCountOutput) SetHealthCheckCount(v int64) *GetHealthCheckCountOutput {
+	s.HealthCheckCount = &v
+	return s
 }
 
 // This action gets information about a specified health check.
@@ -6365,6 +7013,12 @@ func (s *GetHealthCheckInput) Validate() error {
 	return nil
 }
 
+// SetHealthCheckId sets the HealthCheckId field's value.
+func (s *GetHealthCheckInput) SetHealthCheckId(v string) *GetHealthCheckInput {
+	s.HealthCheckId = &v
+	return s
+}
+
 // This action gets the reason that a specified health check failed most recently.
 //
 // To get the reason for the last failure of a health check, send a GET request
@@ -6408,6 +7062,12 @@ func (s *GetHealthCheckLastFailureReasonInput) Validate() error {
 	return nil
 }
 
+// SetHealthCheckId sets the HealthCheckId field's value.
+func (s *GetHealthCheckLastFailureReasonInput) SetHealthCheckId(v string) *GetHealthCheckLastFailureReasonInput {
+	s.HealthCheckId = &v
+	return s
+}
+
 // A complex type that contains the response to a GetHealthCheckLastFailureReason
 // request.
 type GetHealthCheckLastFailureReasonOutput struct {
@@ -6430,6 +7090,12 @@ func (s GetHealthCheckLastFailureReasonOutput) GoString() string {
 	return s.String()
 }
 
+// SetHealthCheckObservations sets the HealthCheckObservations field's value.
+func (s *GetHealthCheckLastFailureReasonOutput) SetHealthCheckObservations(v []*HealthCheckObservation) *GetHealthCheckLastFailureReasonOutput {
+	s.HealthCheckObservations = v
+	return s
+}
+
 // A complex type that contains the response to a GetHealthCheck request.
 type GetHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
@@ -6449,6 +7115,12 @@ func (s GetHealthCheckOutput) String() string {
 // GoString returns the string representation
 func (s GetHealthCheckOutput) GoString() string {
 	return s.String()
+}
+
+// SetHealthCheck sets the HealthCheck field's value.
+func (s *GetHealthCheckOutput) SetHealthCheck(v *HealthCheck) *GetHealthCheckOutput {
+	s.HealthCheck = v
+	return s
 }
 
 // A complex type that contains information about the request to get health
@@ -6541,6 +7213,12 @@ func (s *GetHealthCheckStatusInput) Validate() error {
 	return nil
 }
 
+// SetHealthCheckId sets the HealthCheckId field's value.
+func (s *GetHealthCheckStatusInput) SetHealthCheckId(v string) *GetHealthCheckStatusInput {
+	s.HealthCheckId = &v
+	return s
+}
+
 // A complex type that contains the response to a GetHealthCheck request.
 type GetHealthCheckStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -6560,6 +7238,12 @@ func (s GetHealthCheckStatusOutput) String() string {
 // GoString returns the string representation
 func (s GetHealthCheckStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetHealthCheckObservations sets the HealthCheckObservations field's value.
+func (s *GetHealthCheckStatusOutput) SetHealthCheckObservations(v []*HealthCheckObservation) *GetHealthCheckStatusOutput {
+	s.HealthCheckObservations = v
+	return s
 }
 
 // To retrieve a count of all your hosted zones, send a GET request to the /2013-04-01/hostedzonecount
@@ -6599,6 +7283,12 @@ func (s GetHostedZoneCountOutput) GoString() string {
 	return s.String()
 }
 
+// SetHostedZoneCount sets the HostedZoneCount field's value.
+func (s *GetHostedZoneCountOutput) SetHostedZoneCount(v int64) *GetHostedZoneCountOutput {
+	s.HostedZoneCount = &v
+	return s
+}
+
 // The input for a GetHostedZone request.
 type GetHostedZoneInput struct {
 	_ struct{} `type:"structure"`
@@ -6633,6 +7323,12 @@ func (s *GetHostedZoneInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetHostedZoneInput) SetId(v string) *GetHostedZoneInput {
+	s.Id = &v
+	return s
+}
+
 // A complex type containing the response information for the hosted zone.
 type GetHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -6658,6 +7354,24 @@ func (s GetHostedZoneOutput) String() string {
 // GoString returns the string representation
 func (s GetHostedZoneOutput) GoString() string {
 	return s.String()
+}
+
+// SetDelegationSet sets the DelegationSet field's value.
+func (s *GetHostedZoneOutput) SetDelegationSet(v *DelegationSet) *GetHostedZoneOutput {
+	s.DelegationSet = v
+	return s
+}
+
+// SetHostedZone sets the HostedZone field's value.
+func (s *GetHostedZoneOutput) SetHostedZone(v *HostedZone) *GetHostedZoneOutput {
+	s.HostedZone = v
+	return s
+}
+
+// SetVPCs sets the VPCs field's value.
+func (s *GetHostedZoneOutput) SetVPCs(v []*VPC) *GetHostedZoneOutput {
+	s.VPCs = v
+	return s
 }
 
 // The input for a GetReusableDelegationSet request.
@@ -6694,6 +7408,12 @@ func (s *GetReusableDelegationSetInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetReusableDelegationSetInput) SetId(v string) *GetReusableDelegationSetInput {
+	s.Id = &v
+	return s
+}
+
 // A complex type that contains the response to the GetReusableDelegationSet
 // request.
 type GetReusableDelegationSetOutput struct {
@@ -6713,6 +7433,12 @@ func (s GetReusableDelegationSetOutput) String() string {
 // GoString returns the string representation
 func (s GetReusableDelegationSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetDelegationSet sets the DelegationSet field's value.
+func (s *GetReusableDelegationSetOutput) SetDelegationSet(v *DelegationSet) *GetReusableDelegationSetOutput {
+	s.DelegationSet = v
+	return s
 }
 
 // Gets information about a specific traffic policy version. To get the information,
@@ -6762,6 +7488,18 @@ func (s *GetTrafficPolicyInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetTrafficPolicyInput) SetId(v string) *GetTrafficPolicyInput {
+	s.Id = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *GetTrafficPolicyInput) SetVersion(v int64) *GetTrafficPolicyInput {
+	s.Version = &v
+	return s
+}
+
 // To retrieve a count of all your traffic policy instances, send a GET request
 // to the /2013-04-01/trafficpolicyinstancecount resource.
 type GetTrafficPolicyInstanceCountInput struct {
@@ -6800,6 +7538,12 @@ func (s GetTrafficPolicyInstanceCountOutput) GoString() string {
 	return s.String()
 }
 
+// SetTrafficPolicyInstanceCount sets the TrafficPolicyInstanceCount field's value.
+func (s *GetTrafficPolicyInstanceCountOutput) SetTrafficPolicyInstanceCount(v int64) *GetTrafficPolicyInstanceCountOutput {
+	s.TrafficPolicyInstanceCount = &v
+	return s
+}
+
 // Gets information about a specified traffic policy instance.
 //
 // To get information about a traffic policy instance, send a GET request to
@@ -6836,6 +7580,12 @@ func (s *GetTrafficPolicyInstanceInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *GetTrafficPolicyInstanceInput) SetId(v string) *GetTrafficPolicyInstanceInput {
+	s.Id = &v
+	return s
+}
+
 // A complex type that contains information about the resource record sets that
 // Amazon Route 53 created based on a specified traffic policy.
 type GetTrafficPolicyInstanceOutput struct {
@@ -6857,6 +7607,12 @@ func (s GetTrafficPolicyInstanceOutput) GoString() string {
 	return s.String()
 }
 
+// SetTrafficPolicyInstance sets the TrafficPolicyInstance field's value.
+func (s *GetTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficPolicyInstance) *GetTrafficPolicyInstanceOutput {
+	s.TrafficPolicyInstance = v
+	return s
+}
+
 // A complex type that contains the response information for the request.
 type GetTrafficPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -6875,6 +7631,12 @@ func (s GetTrafficPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetTrafficPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetTrafficPolicy sets the TrafficPolicy field's value.
+func (s *GetTrafficPolicyOutput) SetTrafficPolicy(v *TrafficPolicy) *GetTrafficPolicyOutput {
+	s.TrafficPolicy = v
+	return s
 }
 
 // A complex type that contains information about one health check that is associated
@@ -6920,6 +7682,36 @@ func (s HealthCheck) String() string {
 // GoString returns the string representation
 func (s HealthCheck) GoString() string {
 	return s.String()
+}
+
+// SetCallerReference sets the CallerReference field's value.
+func (s *HealthCheck) SetCallerReference(v string) *HealthCheck {
+	s.CallerReference = &v
+	return s
+}
+
+// SetCloudWatchAlarmConfiguration sets the CloudWatchAlarmConfiguration field's value.
+func (s *HealthCheck) SetCloudWatchAlarmConfiguration(v *CloudWatchAlarmConfiguration) *HealthCheck {
+	s.CloudWatchAlarmConfiguration = v
+	return s
+}
+
+// SetHealthCheckConfig sets the HealthCheckConfig field's value.
+func (s *HealthCheck) SetHealthCheckConfig(v *HealthCheckConfig) *HealthCheck {
+	s.HealthCheckConfig = v
+	return s
+}
+
+// SetHealthCheckVersion sets the HealthCheckVersion field's value.
+func (s *HealthCheck) SetHealthCheckVersion(v int64) *HealthCheck {
+	s.HealthCheckVersion = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *HealthCheck) SetId(v string) *HealthCheck {
+	s.Id = &v
+	return s
 }
 
 // A complex type that contains information about the health check.
@@ -7199,6 +7991,102 @@ func (s *HealthCheckConfig) Validate() error {
 	return nil
 }
 
+// SetAlarmIdentifier sets the AlarmIdentifier field's value.
+func (s *HealthCheckConfig) SetAlarmIdentifier(v *AlarmIdentifier) *HealthCheckConfig {
+	s.AlarmIdentifier = v
+	return s
+}
+
+// SetChildHealthChecks sets the ChildHealthChecks field's value.
+func (s *HealthCheckConfig) SetChildHealthChecks(v []*string) *HealthCheckConfig {
+	s.ChildHealthChecks = v
+	return s
+}
+
+// SetEnableSNI sets the EnableSNI field's value.
+func (s *HealthCheckConfig) SetEnableSNI(v bool) *HealthCheckConfig {
+	s.EnableSNI = &v
+	return s
+}
+
+// SetFailureThreshold sets the FailureThreshold field's value.
+func (s *HealthCheckConfig) SetFailureThreshold(v int64) *HealthCheckConfig {
+	s.FailureThreshold = &v
+	return s
+}
+
+// SetFullyQualifiedDomainName sets the FullyQualifiedDomainName field's value.
+func (s *HealthCheckConfig) SetFullyQualifiedDomainName(v string) *HealthCheckConfig {
+	s.FullyQualifiedDomainName = &v
+	return s
+}
+
+// SetHealthThreshold sets the HealthThreshold field's value.
+func (s *HealthCheckConfig) SetHealthThreshold(v int64) *HealthCheckConfig {
+	s.HealthThreshold = &v
+	return s
+}
+
+// SetIPAddress sets the IPAddress field's value.
+func (s *HealthCheckConfig) SetIPAddress(v string) *HealthCheckConfig {
+	s.IPAddress = &v
+	return s
+}
+
+// SetInsufficientDataHealthStatus sets the InsufficientDataHealthStatus field's value.
+func (s *HealthCheckConfig) SetInsufficientDataHealthStatus(v string) *HealthCheckConfig {
+	s.InsufficientDataHealthStatus = &v
+	return s
+}
+
+// SetInverted sets the Inverted field's value.
+func (s *HealthCheckConfig) SetInverted(v bool) *HealthCheckConfig {
+	s.Inverted = &v
+	return s
+}
+
+// SetMeasureLatency sets the MeasureLatency field's value.
+func (s *HealthCheckConfig) SetMeasureLatency(v bool) *HealthCheckConfig {
+	s.MeasureLatency = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *HealthCheckConfig) SetPort(v int64) *HealthCheckConfig {
+	s.Port = &v
+	return s
+}
+
+// SetRegions sets the Regions field's value.
+func (s *HealthCheckConfig) SetRegions(v []*string) *HealthCheckConfig {
+	s.Regions = v
+	return s
+}
+
+// SetRequestInterval sets the RequestInterval field's value.
+func (s *HealthCheckConfig) SetRequestInterval(v int64) *HealthCheckConfig {
+	s.RequestInterval = &v
+	return s
+}
+
+// SetResourcePath sets the ResourcePath field's value.
+func (s *HealthCheckConfig) SetResourcePath(v string) *HealthCheckConfig {
+	s.ResourcePath = &v
+	return s
+}
+
+// SetSearchString sets the SearchString field's value.
+func (s *HealthCheckConfig) SetSearchString(v string) *HealthCheckConfig {
+	s.SearchString = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *HealthCheckConfig) SetType(v string) *HealthCheckConfig {
+	s.Type = &v
+	return s
+}
+
 // A complex type that contains the last failure reason as reported by one Amazon
 // Route 53 health checker.
 type HealthCheckObservation struct {
@@ -7225,6 +8113,24 @@ func (s HealthCheckObservation) String() string {
 // GoString returns the string representation
 func (s HealthCheckObservation) GoString() string {
 	return s.String()
+}
+
+// SetIPAddress sets the IPAddress field's value.
+func (s *HealthCheckObservation) SetIPAddress(v string) *HealthCheckObservation {
+	s.IPAddress = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *HealthCheckObservation) SetRegion(v string) *HealthCheckObservation {
+	s.Region = &v
+	return s
+}
+
+// SetStatusReport sets the StatusReport field's value.
+func (s *HealthCheckObservation) SetStatusReport(v *StatusReport) *HealthCheckObservation {
+	s.StatusReport = v
+	return s
 }
 
 // A complex type that contains general information about the hosted zone.
@@ -7271,6 +8177,36 @@ func (s HostedZone) GoString() string {
 	return s.String()
 }
 
+// SetCallerReference sets the CallerReference field's value.
+func (s *HostedZone) SetCallerReference(v string) *HostedZone {
+	s.CallerReference = &v
+	return s
+}
+
+// SetConfig sets the Config field's value.
+func (s *HostedZone) SetConfig(v *HostedZoneConfig) *HostedZone {
+	s.Config = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *HostedZone) SetId(v string) *HostedZone {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *HostedZone) SetName(v string) *HostedZone {
+	s.Name = &v
+	return s
+}
+
+// SetResourceRecordSetCount sets the ResourceRecordSetCount field's value.
+func (s *HostedZone) SetResourceRecordSetCount(v int64) *HostedZone {
+	s.ResourceRecordSetCount = &v
+	return s
+}
+
 // A complex type that contains an optional comment about your hosted zone.
 // If you don't want to specify a comment, omit both the HostedZoneConfig and
 // Comment elements.
@@ -7292,6 +8228,18 @@ func (s HostedZoneConfig) String() string {
 // GoString returns the string representation
 func (s HostedZoneConfig) GoString() string {
 	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *HostedZoneConfig) SetComment(v string) *HostedZoneConfig {
+	s.Comment = &v
+	return s
+}
+
+// SetPrivateZone sets the PrivateZone field's value.
+func (s *HostedZoneConfig) SetPrivateZone(v bool) *HostedZoneConfig {
+	s.PrivateZone = &v
+	return s
 }
 
 // The input for a ListChangeBatchesByHostedZone request.
@@ -7349,6 +8297,36 @@ func (s *ListChangeBatchesByHostedZoneInput) Validate() error {
 	return nil
 }
 
+// SetEndDate sets the EndDate field's value.
+func (s *ListChangeBatchesByHostedZoneInput) SetEndDate(v string) *ListChangeBatchesByHostedZoneInput {
+	s.EndDate = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *ListChangeBatchesByHostedZoneInput) SetHostedZoneId(v string) *ListChangeBatchesByHostedZoneInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListChangeBatchesByHostedZoneInput) SetMarker(v string) *ListChangeBatchesByHostedZoneInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListChangeBatchesByHostedZoneInput) SetMaxItems(v string) *ListChangeBatchesByHostedZoneInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *ListChangeBatchesByHostedZoneInput) SetStartDate(v string) *ListChangeBatchesByHostedZoneInput {
+	s.StartDate = &v
+	return s
+}
+
 // A complex type containing the response information for the request.
 type ListChangeBatchesByHostedZoneOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -7386,6 +8364,36 @@ func (s ListChangeBatchesByHostedZoneOutput) String() string {
 // GoString returns the string representation
 func (s ListChangeBatchesByHostedZoneOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeBatchRecords sets the ChangeBatchRecords field's value.
+func (s *ListChangeBatchesByHostedZoneOutput) SetChangeBatchRecords(v []*ChangeBatchRecord) *ListChangeBatchesByHostedZoneOutput {
+	s.ChangeBatchRecords = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListChangeBatchesByHostedZoneOutput) SetIsTruncated(v bool) *ListChangeBatchesByHostedZoneOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListChangeBatchesByHostedZoneOutput) SetMarker(v string) *ListChangeBatchesByHostedZoneOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListChangeBatchesByHostedZoneOutput) SetMaxItems(v string) *ListChangeBatchesByHostedZoneOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListChangeBatchesByHostedZoneOutput) SetNextMarker(v string) *ListChangeBatchesByHostedZoneOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // The input for a ListChangeBatchesByRRSet request.
@@ -7465,6 +8473,54 @@ func (s *ListChangeBatchesByRRSetInput) Validate() error {
 	return nil
 }
 
+// SetEndDate sets the EndDate field's value.
+func (s *ListChangeBatchesByRRSetInput) SetEndDate(v string) *ListChangeBatchesByRRSetInput {
+	s.EndDate = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *ListChangeBatchesByRRSetInput) SetHostedZoneId(v string) *ListChangeBatchesByRRSetInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListChangeBatchesByRRSetInput) SetMarker(v string) *ListChangeBatchesByRRSetInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListChangeBatchesByRRSetInput) SetMaxItems(v string) *ListChangeBatchesByRRSetInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ListChangeBatchesByRRSetInput) SetName(v string) *ListChangeBatchesByRRSetInput {
+	s.Name = &v
+	return s
+}
+
+// SetSetIdentifier sets the SetIdentifier field's value.
+func (s *ListChangeBatchesByRRSetInput) SetSetIdentifier(v string) *ListChangeBatchesByRRSetInput {
+	s.SetIdentifier = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *ListChangeBatchesByRRSetInput) SetStartDate(v string) *ListChangeBatchesByRRSetInput {
+	s.StartDate = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ListChangeBatchesByRRSetInput) SetType(v string) *ListChangeBatchesByRRSetInput {
+	s.Type = &v
+	return s
+}
+
 // The input for a ListChangeBatchesByRRSet request.
 type ListChangeBatchesByRRSetOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -7499,6 +8555,36 @@ func (s ListChangeBatchesByRRSetOutput) String() string {
 // GoString returns the string representation
 func (s ListChangeBatchesByRRSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeBatchRecords sets the ChangeBatchRecords field's value.
+func (s *ListChangeBatchesByRRSetOutput) SetChangeBatchRecords(v []*ChangeBatchRecord) *ListChangeBatchesByRRSetOutput {
+	s.ChangeBatchRecords = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListChangeBatchesByRRSetOutput) SetIsTruncated(v bool) *ListChangeBatchesByRRSetOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListChangeBatchesByRRSetOutput) SetMarker(v string) *ListChangeBatchesByRRSetOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListChangeBatchesByRRSetOutput) SetMaxItems(v string) *ListChangeBatchesByRRSetOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListChangeBatchesByRRSetOutput) SetNextMarker(v string) *ListChangeBatchesByRRSetOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // To get a list of geographic locations that Amazon Route 53 supports for geolocation,
@@ -7579,6 +8665,30 @@ func (s *ListGeoLocationsInput) Validate() error {
 	return nil
 }
 
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListGeoLocationsInput) SetMaxItems(v string) *ListGeoLocationsInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetStartContinentCode sets the StartContinentCode field's value.
+func (s *ListGeoLocationsInput) SetStartContinentCode(v string) *ListGeoLocationsInput {
+	s.StartContinentCode = &v
+	return s
+}
+
+// SetStartCountryCode sets the StartCountryCode field's value.
+func (s *ListGeoLocationsInput) SetStartCountryCode(v string) *ListGeoLocationsInput {
+	s.StartCountryCode = &v
+	return s
+}
+
+// SetStartSubdivisionCode sets the StartSubdivisionCode field's value.
+func (s *ListGeoLocationsInput) SetStartSubdivisionCode(v string) *ListGeoLocationsInput {
+	s.StartSubdivisionCode = &v
+	return s
+}
+
 // A complex type containing the response information for the request.
 type ListGeoLocationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7629,6 +8739,42 @@ func (s ListGeoLocationsOutput) GoString() string {
 	return s.String()
 }
 
+// SetGeoLocationDetailsList sets the GeoLocationDetailsList field's value.
+func (s *ListGeoLocationsOutput) SetGeoLocationDetailsList(v []*GeoLocationDetails) *ListGeoLocationsOutput {
+	s.GeoLocationDetailsList = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListGeoLocationsOutput) SetIsTruncated(v bool) *ListGeoLocationsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListGeoLocationsOutput) SetMaxItems(v string) *ListGeoLocationsOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextContinentCode sets the NextContinentCode field's value.
+func (s *ListGeoLocationsOutput) SetNextContinentCode(v string) *ListGeoLocationsOutput {
+	s.NextContinentCode = &v
+	return s
+}
+
+// SetNextCountryCode sets the NextCountryCode field's value.
+func (s *ListGeoLocationsOutput) SetNextCountryCode(v string) *ListGeoLocationsOutput {
+	s.NextCountryCode = &v
+	return s
+}
+
+// SetNextSubdivisionCode sets the NextSubdivisionCode field's value.
+func (s *ListGeoLocationsOutput) SetNextSubdivisionCode(v string) *ListGeoLocationsOutput {
+	s.NextSubdivisionCode = &v
+	return s
+}
+
 // To retrieve a list of your health checks, send a GET request to the /2013-04-01/healthcheck
 // resource. The response to this request includes a HealthChecks element with
 // zero or more HealthCheck child elements. By default, the list of health checks
@@ -7674,6 +8820,18 @@ func (s ListHealthChecksInput) String() string {
 // GoString returns the string representation
 func (s ListHealthChecksInput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListHealthChecksInput) SetMarker(v string) *ListHealthChecksInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListHealthChecksInput) SetMaxItems(v string) *ListHealthChecksInput {
+	s.MaxItems = &v
+	return s
 }
 
 // A complex type that contains the response to a ListHealthChecks request.
@@ -7722,6 +8880,36 @@ func (s ListHealthChecksOutput) String() string {
 // GoString returns the string representation
 func (s ListHealthChecksOutput) GoString() string {
 	return s.String()
+}
+
+// SetHealthChecks sets the HealthChecks field's value.
+func (s *ListHealthChecksOutput) SetHealthChecks(v []*HealthCheck) *ListHealthChecksOutput {
+	s.HealthChecks = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListHealthChecksOutput) SetIsTruncated(v bool) *ListHealthChecksOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListHealthChecksOutput) SetMarker(v string) *ListHealthChecksOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListHealthChecksOutput) SetMaxItems(v string) *ListHealthChecksOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListHealthChecksOutput) SetNextMarker(v string) *ListHealthChecksOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // To retrieve a list of your public and private hosted zones in ASCII order
@@ -7810,6 +8998,24 @@ func (s ListHostedZonesByNameInput) GoString() string {
 	return s.String()
 }
 
+// SetDNSName sets the DNSName field's value.
+func (s *ListHostedZonesByNameInput) SetDNSName(v string) *ListHostedZonesByNameInput {
+	s.DNSName = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *ListHostedZonesByNameInput) SetHostedZoneId(v string) *ListHostedZonesByNameInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListHostedZonesByNameInput) SetMaxItems(v string) *ListHostedZonesByNameInput {
+	s.MaxItems = &v
+	return s
+}
+
 // A complex type that contains the response information for the request.
 type ListHostedZonesByNameOutput struct {
 	_ struct{} `type:"structure"`
@@ -7868,6 +9074,48 @@ func (s ListHostedZonesByNameOutput) String() string {
 // GoString returns the string representation
 func (s ListHostedZonesByNameOutput) GoString() string {
 	return s.String()
+}
+
+// SetDNSName sets the DNSName field's value.
+func (s *ListHostedZonesByNameOutput) SetDNSName(v string) *ListHostedZonesByNameOutput {
+	s.DNSName = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *ListHostedZonesByNameOutput) SetHostedZoneId(v string) *ListHostedZonesByNameOutput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetHostedZones sets the HostedZones field's value.
+func (s *ListHostedZonesByNameOutput) SetHostedZones(v []*HostedZone) *ListHostedZonesByNameOutput {
+	s.HostedZones = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListHostedZonesByNameOutput) SetIsTruncated(v bool) *ListHostedZonesByNameOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListHostedZonesByNameOutput) SetMaxItems(v string) *ListHostedZonesByNameOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextDNSName sets the NextDNSName field's value.
+func (s *ListHostedZonesByNameOutput) SetNextDNSName(v string) *ListHostedZonesByNameOutput {
+	s.NextDNSName = &v
+	return s
+}
+
+// SetNextHostedZoneId sets the NextHostedZoneId field's value.
+func (s *ListHostedZonesByNameOutput) SetNextHostedZoneId(v string) *ListHostedZonesByNameOutput {
+	s.NextHostedZoneId = &v
+	return s
 }
 
 // To retrieve a list of your public and private hosted zones, send a GET request
@@ -7934,6 +9182,24 @@ func (s ListHostedZonesInput) GoString() string {
 	return s.String()
 }
 
+// SetDelegationSetId sets the DelegationSetId field's value.
+func (s *ListHostedZonesInput) SetDelegationSetId(v string) *ListHostedZonesInput {
+	s.DelegationSetId = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListHostedZonesInput) SetMarker(v string) *ListHostedZonesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListHostedZonesInput) SetMaxItems(v string) *ListHostedZonesInput {
+	s.MaxItems = &v
+	return s
+}
+
 type ListHostedZonesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7979,6 +9245,36 @@ func (s ListHostedZonesOutput) String() string {
 // GoString returns the string representation
 func (s ListHostedZonesOutput) GoString() string {
 	return s.String()
+}
+
+// SetHostedZones sets the HostedZones field's value.
+func (s *ListHostedZonesOutput) SetHostedZones(v []*HostedZone) *ListHostedZonesOutput {
+	s.HostedZones = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListHostedZonesOutput) SetIsTruncated(v bool) *ListHostedZonesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListHostedZonesOutput) SetMarker(v string) *ListHostedZonesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListHostedZonesOutput) SetMaxItems(v string) *ListHostedZonesOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListHostedZonesOutput) SetNextMarker(v string) *ListHostedZonesOutput {
+	s.NextMarker = &v
+	return s
 }
 
 // The input for a ListResourceRecordSets request.
@@ -8058,6 +9354,36 @@ func (s *ListResourceRecordSetsInput) Validate() error {
 	return nil
 }
 
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *ListResourceRecordSetsInput) SetHostedZoneId(v string) *ListResourceRecordSetsInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListResourceRecordSetsInput) SetMaxItems(v string) *ListResourceRecordSetsInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetStartRecordIdentifier sets the StartRecordIdentifier field's value.
+func (s *ListResourceRecordSetsInput) SetStartRecordIdentifier(v string) *ListResourceRecordSetsInput {
+	s.StartRecordIdentifier = &v
+	return s
+}
+
+// SetStartRecordName sets the StartRecordName field's value.
+func (s *ListResourceRecordSetsInput) SetStartRecordName(v string) *ListResourceRecordSetsInput {
+	s.StartRecordName = &v
+	return s
+}
+
+// SetStartRecordType sets the StartRecordType field's value.
+func (s *ListResourceRecordSetsInput) SetStartRecordType(v string) *ListResourceRecordSetsInput {
+	s.StartRecordType = &v
+	return s
+}
+
 // A complex type that contains list information for the resource record set.
 type ListResourceRecordSetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8105,6 +9431,42 @@ func (s ListResourceRecordSetsOutput) GoString() string {
 	return s.String()
 }
 
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListResourceRecordSetsOutput) SetIsTruncated(v bool) *ListResourceRecordSetsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListResourceRecordSetsOutput) SetMaxItems(v string) *ListResourceRecordSetsOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextRecordIdentifier sets the NextRecordIdentifier field's value.
+func (s *ListResourceRecordSetsOutput) SetNextRecordIdentifier(v string) *ListResourceRecordSetsOutput {
+	s.NextRecordIdentifier = &v
+	return s
+}
+
+// SetNextRecordName sets the NextRecordName field's value.
+func (s *ListResourceRecordSetsOutput) SetNextRecordName(v string) *ListResourceRecordSetsOutput {
+	s.NextRecordName = &v
+	return s
+}
+
+// SetNextRecordType sets the NextRecordType field's value.
+func (s *ListResourceRecordSetsOutput) SetNextRecordType(v string) *ListResourceRecordSetsOutput {
+	s.NextRecordType = &v
+	return s
+}
+
+// SetResourceRecordSets sets the ResourceRecordSets field's value.
+func (s *ListResourceRecordSetsOutput) SetResourceRecordSets(v []*ResourceRecordSet) *ListResourceRecordSetsOutput {
+	s.ResourceRecordSets = v
+	return s
+}
+
 // To retrieve a list of your reusable delegation sets, send a GET request to
 // the /2013-04-01/delegationset resource. The response to this request includes
 // a DelegationSets element with zero or more DelegationSet child elements.
@@ -8136,6 +9498,18 @@ func (s ListReusableDelegationSetsInput) String() string {
 // GoString returns the string representation
 func (s ListReusableDelegationSetsInput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListReusableDelegationSetsInput) SetMarker(v string) *ListReusableDelegationSetsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListReusableDelegationSetsInput) SetMaxItems(v string) *ListReusableDelegationSetsInput {
+	s.MaxItems = &v
+	return s
 }
 
 // A complex type that contains information about the reusable delegation sets
@@ -8187,6 +9561,36 @@ func (s ListReusableDelegationSetsOutput) GoString() string {
 	return s.String()
 }
 
+// SetDelegationSets sets the DelegationSets field's value.
+func (s *ListReusableDelegationSetsOutput) SetDelegationSets(v []*DelegationSet) *ListReusableDelegationSetsOutput {
+	s.DelegationSets = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListReusableDelegationSetsOutput) SetIsTruncated(v bool) *ListReusableDelegationSetsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListReusableDelegationSetsOutput) SetMarker(v string) *ListReusableDelegationSetsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListReusableDelegationSetsOutput) SetMaxItems(v string) *ListReusableDelegationSetsOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListReusableDelegationSetsOutput) SetNextMarker(v string) *ListReusableDelegationSetsOutput {
+	s.NextMarker = &v
+	return s
+}
+
 // A complex type containing information about a request for a list of the tags
 // that are associated with an individual resource.
 type ListTagsForResourceInput struct {
@@ -8233,6 +9637,18 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *ListTagsForResourceInput) SetResourceId(v string) *ListTagsForResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ListTagsForResourceInput) SetResourceType(v string) *ListTagsForResourceInput {
+	s.ResourceType = &v
+	return s
+}
+
 // A complex type that contains information about the health checks or hosted
 // zones for which you want to list tags.
 type ListTagsForResourceOutput struct {
@@ -8252,6 +9668,12 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourceTagSet sets the ResourceTagSet field's value.
+func (s *ListTagsForResourceOutput) SetResourceTagSet(v *ResourceTagSet) *ListTagsForResourceOutput {
+	s.ResourceTagSet = v
+	return s
 }
 
 // A complex type that contains information about the health checks or hosted
@@ -8304,6 +9726,18 @@ func (s *ListTagsForResourcesInput) Validate() error {
 	return nil
 }
 
+// SetResourceIds sets the ResourceIds field's value.
+func (s *ListTagsForResourcesInput) SetResourceIds(v []*string) *ListTagsForResourcesInput {
+	s.ResourceIds = v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ListTagsForResourcesInput) SetResourceType(v string) *ListTagsForResourcesInput {
+	s.ResourceType = &v
+	return s
+}
+
 // A complex type containing tags for the specified resources.
 type ListTagsForResourcesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8322,6 +9756,12 @@ func (s ListTagsForResourcesOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourcesOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourceTagSets sets the ResourceTagSets field's value.
+func (s *ListTagsForResourcesOutput) SetResourceTagSets(v []*ResourceTagSet) *ListTagsForResourcesOutput {
+	s.ResourceTagSets = v
+	return s
 }
 
 // A complex type that contains the information about the request to list the
@@ -8357,6 +9797,18 @@ func (s ListTrafficPoliciesInput) String() string {
 // GoString returns the string representation
 func (s ListTrafficPoliciesInput) GoString() string {
 	return s.String()
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPoliciesInput) SetMaxItems(v string) *ListTrafficPoliciesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyIdMarker sets the TrafficPolicyIdMarker field's value.
+func (s *ListTrafficPoliciesInput) SetTrafficPolicyIdMarker(v string) *ListTrafficPoliciesInput {
+	s.TrafficPolicyIdMarker = &v
+	return s
 }
 
 // A complex type that contains the response information for the request.
@@ -8400,6 +9852,30 @@ func (s ListTrafficPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListTrafficPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListTrafficPoliciesOutput) SetIsTruncated(v bool) *ListTrafficPoliciesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPoliciesOutput) SetMaxItems(v string) *ListTrafficPoliciesOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyIdMarker sets the TrafficPolicyIdMarker field's value.
+func (s *ListTrafficPoliciesOutput) SetTrafficPolicyIdMarker(v string) *ListTrafficPoliciesOutput {
+	s.TrafficPolicyIdMarker = &v
+	return s
+}
+
+// SetTrafficPolicySummaries sets the TrafficPolicySummaries field's value.
+func (s *ListTrafficPoliciesOutput) SetTrafficPolicySummaries(v []*TrafficPolicySummary) *ListTrafficPoliciesOutput {
+	s.TrafficPolicySummaries = v
+	return s
 }
 
 // A request for the traffic policy instances that you created in a specified
@@ -8469,6 +9945,30 @@ func (s *ListTrafficPolicyInstancesByHostedZoneInput) Validate() error {
 	return nil
 }
 
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneInput) SetHostedZoneId(v string) *ListTrafficPolicyInstancesByHostedZoneInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneInput) SetMaxItems(v string) *ListTrafficPolicyInstancesByHostedZoneInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceNameMarker sets the TrafficPolicyInstanceNameMarker field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneInput) SetTrafficPolicyInstanceNameMarker(v string) *ListTrafficPolicyInstancesByHostedZoneInput {
+	s.TrafficPolicyInstanceNameMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceTypeMarker sets the TrafficPolicyInstanceTypeMarker field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneInput) SetTrafficPolicyInstanceTypeMarker(v string) *ListTrafficPolicyInstancesByHostedZoneInput {
+	s.TrafficPolicyInstanceTypeMarker = &v
+	return s
+}
+
 // A complex type that contains the response information for the request.
 type ListTrafficPolicyInstancesByHostedZoneOutput struct {
 	_ struct{} `type:"structure"`
@@ -8514,6 +10014,36 @@ func (s ListTrafficPolicyInstancesByHostedZoneOutput) String() string {
 // GoString returns the string representation
 func (s ListTrafficPolicyInstancesByHostedZoneOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetIsTruncated(v bool) *ListTrafficPolicyInstancesByHostedZoneOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetMaxItems(v string) *ListTrafficPolicyInstancesByHostedZoneOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceNameMarker sets the TrafficPolicyInstanceNameMarker field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstanceNameMarker(v string) *ListTrafficPolicyInstancesByHostedZoneOutput {
+	s.TrafficPolicyInstanceNameMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceTypeMarker sets the TrafficPolicyInstanceTypeMarker field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstanceTypeMarker(v string) *ListTrafficPolicyInstancesByHostedZoneOutput {
+	s.TrafficPolicyInstanceTypeMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstances sets the TrafficPolicyInstances field's value.
+func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstances(v []*TrafficPolicyInstance) *ListTrafficPolicyInstancesByHostedZoneOutput {
+	s.TrafficPolicyInstances = v
+	return s
 }
 
 // A complex type that contains the information about the request to list your
@@ -8607,6 +10137,42 @@ func (s *ListTrafficPolicyInstancesByPolicyInput) Validate() error {
 	return nil
 }
 
+// SetHostedZoneIdMarker sets the HostedZoneIdMarker field's value.
+func (s *ListTrafficPolicyInstancesByPolicyInput) SetHostedZoneIdMarker(v string) *ListTrafficPolicyInstancesByPolicyInput {
+	s.HostedZoneIdMarker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPolicyInstancesByPolicyInput) SetMaxItems(v string) *ListTrafficPolicyInstancesByPolicyInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyId sets the TrafficPolicyId field's value.
+func (s *ListTrafficPolicyInstancesByPolicyInput) SetTrafficPolicyId(v string) *ListTrafficPolicyInstancesByPolicyInput {
+	s.TrafficPolicyId = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceNameMarker sets the TrafficPolicyInstanceNameMarker field's value.
+func (s *ListTrafficPolicyInstancesByPolicyInput) SetTrafficPolicyInstanceNameMarker(v string) *ListTrafficPolicyInstancesByPolicyInput {
+	s.TrafficPolicyInstanceNameMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceTypeMarker sets the TrafficPolicyInstanceTypeMarker field's value.
+func (s *ListTrafficPolicyInstancesByPolicyInput) SetTrafficPolicyInstanceTypeMarker(v string) *ListTrafficPolicyInstancesByPolicyInput {
+	s.TrafficPolicyInstanceTypeMarker = &v
+	return s
+}
+
+// SetTrafficPolicyVersion sets the TrafficPolicyVersion field's value.
+func (s *ListTrafficPolicyInstancesByPolicyInput) SetTrafficPolicyVersion(v int64) *ListTrafficPolicyInstancesByPolicyInput {
+	s.TrafficPolicyVersion = &v
+	return s
+}
+
 // A complex type that contains the response information for the request.
 type ListTrafficPolicyInstancesByPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -8657,6 +10223,42 @@ func (s ListTrafficPolicyInstancesByPolicyOutput) String() string {
 // GoString returns the string representation
 func (s ListTrafficPolicyInstancesByPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetHostedZoneIdMarker sets the HostedZoneIdMarker field's value.
+func (s *ListTrafficPolicyInstancesByPolicyOutput) SetHostedZoneIdMarker(v string) *ListTrafficPolicyInstancesByPolicyOutput {
+	s.HostedZoneIdMarker = &v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListTrafficPolicyInstancesByPolicyOutput) SetIsTruncated(v bool) *ListTrafficPolicyInstancesByPolicyOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPolicyInstancesByPolicyOutput) SetMaxItems(v string) *ListTrafficPolicyInstancesByPolicyOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceNameMarker sets the TrafficPolicyInstanceNameMarker field's value.
+func (s *ListTrafficPolicyInstancesByPolicyOutput) SetTrafficPolicyInstanceNameMarker(v string) *ListTrafficPolicyInstancesByPolicyOutput {
+	s.TrafficPolicyInstanceNameMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceTypeMarker sets the TrafficPolicyInstanceTypeMarker field's value.
+func (s *ListTrafficPolicyInstancesByPolicyOutput) SetTrafficPolicyInstanceTypeMarker(v string) *ListTrafficPolicyInstancesByPolicyOutput {
+	s.TrafficPolicyInstanceTypeMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstances sets the TrafficPolicyInstances field's value.
+func (s *ListTrafficPolicyInstancesByPolicyOutput) SetTrafficPolicyInstances(v []*TrafficPolicyInstance) *ListTrafficPolicyInstancesByPolicyOutput {
+	s.TrafficPolicyInstances = v
+	return s
 }
 
 // A complex type that contains the information about the request to list your
@@ -8716,6 +10318,30 @@ func (s ListTrafficPolicyInstancesInput) GoString() string {
 	return s.String()
 }
 
+// SetHostedZoneIdMarker sets the HostedZoneIdMarker field's value.
+func (s *ListTrafficPolicyInstancesInput) SetHostedZoneIdMarker(v string) *ListTrafficPolicyInstancesInput {
+	s.HostedZoneIdMarker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPolicyInstancesInput) SetMaxItems(v string) *ListTrafficPolicyInstancesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceNameMarker sets the TrafficPolicyInstanceNameMarker field's value.
+func (s *ListTrafficPolicyInstancesInput) SetTrafficPolicyInstanceNameMarker(v string) *ListTrafficPolicyInstancesInput {
+	s.TrafficPolicyInstanceNameMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceTypeMarker sets the TrafficPolicyInstanceTypeMarker field's value.
+func (s *ListTrafficPolicyInstancesInput) SetTrafficPolicyInstanceTypeMarker(v string) *ListTrafficPolicyInstancesInput {
+	s.TrafficPolicyInstanceTypeMarker = &v
+	return s
+}
+
 // A complex type that contains the response information for the request.
 type ListTrafficPolicyInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8766,6 +10392,42 @@ func (s ListTrafficPolicyInstancesOutput) String() string {
 // GoString returns the string representation
 func (s ListTrafficPolicyInstancesOutput) GoString() string {
 	return s.String()
+}
+
+// SetHostedZoneIdMarker sets the HostedZoneIdMarker field's value.
+func (s *ListTrafficPolicyInstancesOutput) SetHostedZoneIdMarker(v string) *ListTrafficPolicyInstancesOutput {
+	s.HostedZoneIdMarker = &v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListTrafficPolicyInstancesOutput) SetIsTruncated(v bool) *ListTrafficPolicyInstancesOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPolicyInstancesOutput) SetMaxItems(v string) *ListTrafficPolicyInstancesOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceNameMarker sets the TrafficPolicyInstanceNameMarker field's value.
+func (s *ListTrafficPolicyInstancesOutput) SetTrafficPolicyInstanceNameMarker(v string) *ListTrafficPolicyInstancesOutput {
+	s.TrafficPolicyInstanceNameMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceTypeMarker sets the TrafficPolicyInstanceTypeMarker field's value.
+func (s *ListTrafficPolicyInstancesOutput) SetTrafficPolicyInstanceTypeMarker(v string) *ListTrafficPolicyInstancesOutput {
+	s.TrafficPolicyInstanceTypeMarker = &v
+	return s
+}
+
+// SetTrafficPolicyInstances sets the TrafficPolicyInstances field's value.
+func (s *ListTrafficPolicyInstancesOutput) SetTrafficPolicyInstances(v []*TrafficPolicyInstance) *ListTrafficPolicyInstancesOutput {
+	s.TrafficPolicyInstances = v
+	return s
 }
 
 // A complex type that contains the information about the request to list your
@@ -8823,6 +10485,24 @@ func (s *ListTrafficPolicyVersionsInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *ListTrafficPolicyVersionsInput) SetId(v string) *ListTrafficPolicyVersionsInput {
+	s.Id = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPolicyVersionsInput) SetMaxItems(v string) *ListTrafficPolicyVersionsInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicyVersionMarker sets the TrafficPolicyVersionMarker field's value.
+func (s *ListTrafficPolicyVersionsInput) SetTrafficPolicyVersionMarker(v string) *ListTrafficPolicyVersionsInput {
+	s.TrafficPolicyVersionMarker = &v
+	return s
+}
+
 // A complex type that contains the response information for the request.
 type ListTrafficPolicyVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8868,6 +10548,30 @@ func (s ListTrafficPolicyVersionsOutput) GoString() string {
 	return s.String()
 }
 
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListTrafficPolicyVersionsOutput) SetIsTruncated(v bool) *ListTrafficPolicyVersionsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListTrafficPolicyVersionsOutput) SetMaxItems(v string) *ListTrafficPolicyVersionsOutput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetTrafficPolicies sets the TrafficPolicies field's value.
+func (s *ListTrafficPolicyVersionsOutput) SetTrafficPolicies(v []*TrafficPolicy) *ListTrafficPolicyVersionsOutput {
+	s.TrafficPolicies = v
+	return s
+}
+
+// SetTrafficPolicyVersionMarker sets the TrafficPolicyVersionMarker field's value.
+func (s *ListTrafficPolicyVersionsOutput) SetTrafficPolicyVersionMarker(v string) *ListTrafficPolicyVersionsOutput {
+	s.TrafficPolicyVersionMarker = &v
+	return s
+}
+
 // Information specific to the resource record.
 //
 // If you are creating an alias resource record set, omit ResourceRecord.
@@ -8910,6 +10614,12 @@ func (s *ResourceRecord) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetValue sets the Value field's value.
+func (s *ResourceRecord) SetValue(v string) *ResourceRecord {
+	s.Value = &v
+	return s
 }
 
 // Information about the resource record set to create or delete.
@@ -9329,6 +11039,78 @@ func (s *ResourceRecordSet) Validate() error {
 	return nil
 }
 
+// SetAliasTarget sets the AliasTarget field's value.
+func (s *ResourceRecordSet) SetAliasTarget(v *AliasTarget) *ResourceRecordSet {
+	s.AliasTarget = v
+	return s
+}
+
+// SetFailover sets the Failover field's value.
+func (s *ResourceRecordSet) SetFailover(v string) *ResourceRecordSet {
+	s.Failover = &v
+	return s
+}
+
+// SetGeoLocation sets the GeoLocation field's value.
+func (s *ResourceRecordSet) SetGeoLocation(v *GeoLocation) *ResourceRecordSet {
+	s.GeoLocation = v
+	return s
+}
+
+// SetHealthCheckId sets the HealthCheckId field's value.
+func (s *ResourceRecordSet) SetHealthCheckId(v string) *ResourceRecordSet {
+	s.HealthCheckId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ResourceRecordSet) SetName(v string) *ResourceRecordSet {
+	s.Name = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *ResourceRecordSet) SetRegion(v string) *ResourceRecordSet {
+	s.Region = &v
+	return s
+}
+
+// SetResourceRecords sets the ResourceRecords field's value.
+func (s *ResourceRecordSet) SetResourceRecords(v []*ResourceRecord) *ResourceRecordSet {
+	s.ResourceRecords = v
+	return s
+}
+
+// SetSetIdentifier sets the SetIdentifier field's value.
+func (s *ResourceRecordSet) SetSetIdentifier(v string) *ResourceRecordSet {
+	s.SetIdentifier = &v
+	return s
+}
+
+// SetTTL sets the TTL field's value.
+func (s *ResourceRecordSet) SetTTL(v int64) *ResourceRecordSet {
+	s.TTL = &v
+	return s
+}
+
+// SetTrafficPolicyInstanceId sets the TrafficPolicyInstanceId field's value.
+func (s *ResourceRecordSet) SetTrafficPolicyInstanceId(v string) *ResourceRecordSet {
+	s.TrafficPolicyInstanceId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ResourceRecordSet) SetType(v string) *ResourceRecordSet {
+	s.Type = &v
+	return s
+}
+
+// SetWeight sets the Weight field's value.
+func (s *ResourceRecordSet) SetWeight(v int64) *ResourceRecordSet {
+	s.Weight = &v
+	return s
+}
+
 // A complex type containing a resource and its associated tags.
 type ResourceTagSet struct {
 	_ struct{} `type:"structure"`
@@ -9357,6 +11139,24 @@ func (s ResourceTagSet) GoString() string {
 	return s.String()
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *ResourceTagSet) SetResourceId(v string) *ResourceTagSet {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ResourceTagSet) SetResourceType(v string) *ResourceTagSet {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ResourceTagSet) SetTags(v []*Tag) *ResourceTagSet {
+	s.Tags = v
+	return s
+}
+
 // A complex type that contains the status that one Amazon Route 53 health checker
 // reports and the time of the health check.
 type StatusReport struct {
@@ -9381,6 +11181,18 @@ func (s StatusReport) String() string {
 // GoString returns the string representation
 func (s StatusReport) GoString() string {
 	return s.String()
+}
+
+// SetCheckedTime sets the CheckedTime field's value.
+func (s *StatusReport) SetCheckedTime(v time.Time) *StatusReport {
+	s.CheckedTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *StatusReport) SetStatus(v string) *StatusReport {
+	s.Status = &v
+	return s
 }
 
 // A complex type that contains information about a tag that you want to add
@@ -9420,6 +11232,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // Gets the value that Amazon Route 53 returns in response to a DNS request
@@ -9515,6 +11339,42 @@ func (s *TestDNSAnswerInput) Validate() error {
 	return nil
 }
 
+// SetEDNS0ClientSubnetIP sets the EDNS0ClientSubnetIP field's value.
+func (s *TestDNSAnswerInput) SetEDNS0ClientSubnetIP(v string) *TestDNSAnswerInput {
+	s.EDNS0ClientSubnetIP = &v
+	return s
+}
+
+// SetEDNS0ClientSubnetMask sets the EDNS0ClientSubnetMask field's value.
+func (s *TestDNSAnswerInput) SetEDNS0ClientSubnetMask(v string) *TestDNSAnswerInput {
+	s.EDNS0ClientSubnetMask = &v
+	return s
+}
+
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *TestDNSAnswerInput) SetHostedZoneId(v string) *TestDNSAnswerInput {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetRecordName sets the RecordName field's value.
+func (s *TestDNSAnswerInput) SetRecordName(v string) *TestDNSAnswerInput {
+	s.RecordName = &v
+	return s
+}
+
+// SetRecordType sets the RecordType field's value.
+func (s *TestDNSAnswerInput) SetRecordType(v string) *TestDNSAnswerInput {
+	s.RecordType = &v
+	return s
+}
+
+// SetResolverIP sets the ResolverIP field's value.
+func (s *TestDNSAnswerInput) SetResolverIP(v string) *TestDNSAnswerInput {
+	s.ResolverIP = &v
+	return s
+}
+
 // A complex type that contains the response to a TestDNSAnswer request.
 type TestDNSAnswerOutput struct {
 	_ struct{} `type:"structure"`
@@ -9566,6 +11426,42 @@ func (s TestDNSAnswerOutput) GoString() string {
 	return s.String()
 }
 
+// SetNameserver sets the Nameserver field's value.
+func (s *TestDNSAnswerOutput) SetNameserver(v string) *TestDNSAnswerOutput {
+	s.Nameserver = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *TestDNSAnswerOutput) SetProtocol(v string) *TestDNSAnswerOutput {
+	s.Protocol = &v
+	return s
+}
+
+// SetRecordData sets the RecordData field's value.
+func (s *TestDNSAnswerOutput) SetRecordData(v []*string) *TestDNSAnswerOutput {
+	s.RecordData = v
+	return s
+}
+
+// SetRecordName sets the RecordName field's value.
+func (s *TestDNSAnswerOutput) SetRecordName(v string) *TestDNSAnswerOutput {
+	s.RecordName = &v
+	return s
+}
+
+// SetRecordType sets the RecordType field's value.
+func (s *TestDNSAnswerOutput) SetRecordType(v string) *TestDNSAnswerOutput {
+	s.RecordType = &v
+	return s
+}
+
+// SetResponseCode sets the ResponseCode field's value.
+func (s *TestDNSAnswerOutput) SetResponseCode(v string) *TestDNSAnswerOutput {
+	s.ResponseCode = &v
+	return s
+}
+
 // A complex type that contains settings for a traffic policy.
 type TrafficPolicy struct {
 	_ struct{} `type:"structure"`
@@ -9612,6 +11508,42 @@ func (s TrafficPolicy) String() string {
 // GoString returns the string representation
 func (s TrafficPolicy) GoString() string {
 	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *TrafficPolicy) SetComment(v string) *TrafficPolicy {
+	s.Comment = &v
+	return s
+}
+
+// SetDocument sets the Document field's value.
+func (s *TrafficPolicy) SetDocument(v string) *TrafficPolicy {
+	s.Document = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *TrafficPolicy) SetId(v string) *TrafficPolicy {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *TrafficPolicy) SetName(v string) *TrafficPolicy {
+	s.Name = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *TrafficPolicy) SetType(v string) *TrafficPolicy {
+	s.Type = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *TrafficPolicy) SetVersion(v int64) *TrafficPolicy {
+	s.Version = &v
+	return s
 }
 
 // A complex type that contains settings for the new traffic policy instance.
@@ -9692,6 +11624,60 @@ func (s TrafficPolicyInstance) GoString() string {
 	return s.String()
 }
 
+// SetHostedZoneId sets the HostedZoneId field's value.
+func (s *TrafficPolicyInstance) SetHostedZoneId(v string) *TrafficPolicyInstance {
+	s.HostedZoneId = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *TrafficPolicyInstance) SetId(v string) *TrafficPolicyInstance {
+	s.Id = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *TrafficPolicyInstance) SetMessage(v string) *TrafficPolicyInstance {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *TrafficPolicyInstance) SetName(v string) *TrafficPolicyInstance {
+	s.Name = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *TrafficPolicyInstance) SetState(v string) *TrafficPolicyInstance {
+	s.State = &v
+	return s
+}
+
+// SetTTL sets the TTL field's value.
+func (s *TrafficPolicyInstance) SetTTL(v int64) *TrafficPolicyInstance {
+	s.TTL = &v
+	return s
+}
+
+// SetTrafficPolicyId sets the TrafficPolicyId field's value.
+func (s *TrafficPolicyInstance) SetTrafficPolicyId(v string) *TrafficPolicyInstance {
+	s.TrafficPolicyId = &v
+	return s
+}
+
+// SetTrafficPolicyType sets the TrafficPolicyType field's value.
+func (s *TrafficPolicyInstance) SetTrafficPolicyType(v string) *TrafficPolicyInstance {
+	s.TrafficPolicyType = &v
+	return s
+}
+
+// SetTrafficPolicyVersion sets the TrafficPolicyVersion field's value.
+func (s *TrafficPolicyInstance) SetTrafficPolicyVersion(v int64) *TrafficPolicyInstance {
+	s.TrafficPolicyVersion = &v
+	return s
+}
+
 // A complex type that contains information about the latest version of one
 // traffic policy that is associated with the current AWS account.
 type TrafficPolicySummary struct {
@@ -9733,6 +11719,36 @@ func (s TrafficPolicySummary) String() string {
 // GoString returns the string representation
 func (s TrafficPolicySummary) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *TrafficPolicySummary) SetId(v string) *TrafficPolicySummary {
+	s.Id = &v
+	return s
+}
+
+// SetLatestVersion sets the LatestVersion field's value.
+func (s *TrafficPolicySummary) SetLatestVersion(v int64) *TrafficPolicySummary {
+	s.LatestVersion = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *TrafficPolicySummary) SetName(v string) *TrafficPolicySummary {
+	s.Name = &v
+	return s
+}
+
+// SetTrafficPolicyCount sets the TrafficPolicyCount field's value.
+func (s *TrafficPolicySummary) SetTrafficPolicyCount(v int64) *TrafficPolicySummary {
+	s.TrafficPolicyCount = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *TrafficPolicySummary) SetType(v string) *TrafficPolicySummary {
+	s.Type = &v
+	return s
 }
 
 // A complex type that contains the health check request information.
@@ -9975,6 +11991,96 @@ func (s *UpdateHealthCheckInput) Validate() error {
 	return nil
 }
 
+// SetAlarmIdentifier sets the AlarmIdentifier field's value.
+func (s *UpdateHealthCheckInput) SetAlarmIdentifier(v *AlarmIdentifier) *UpdateHealthCheckInput {
+	s.AlarmIdentifier = v
+	return s
+}
+
+// SetChildHealthChecks sets the ChildHealthChecks field's value.
+func (s *UpdateHealthCheckInput) SetChildHealthChecks(v []*string) *UpdateHealthCheckInput {
+	s.ChildHealthChecks = v
+	return s
+}
+
+// SetEnableSNI sets the EnableSNI field's value.
+func (s *UpdateHealthCheckInput) SetEnableSNI(v bool) *UpdateHealthCheckInput {
+	s.EnableSNI = &v
+	return s
+}
+
+// SetFailureThreshold sets the FailureThreshold field's value.
+func (s *UpdateHealthCheckInput) SetFailureThreshold(v int64) *UpdateHealthCheckInput {
+	s.FailureThreshold = &v
+	return s
+}
+
+// SetFullyQualifiedDomainName sets the FullyQualifiedDomainName field's value.
+func (s *UpdateHealthCheckInput) SetFullyQualifiedDomainName(v string) *UpdateHealthCheckInput {
+	s.FullyQualifiedDomainName = &v
+	return s
+}
+
+// SetHealthCheckId sets the HealthCheckId field's value.
+func (s *UpdateHealthCheckInput) SetHealthCheckId(v string) *UpdateHealthCheckInput {
+	s.HealthCheckId = &v
+	return s
+}
+
+// SetHealthCheckVersion sets the HealthCheckVersion field's value.
+func (s *UpdateHealthCheckInput) SetHealthCheckVersion(v int64) *UpdateHealthCheckInput {
+	s.HealthCheckVersion = &v
+	return s
+}
+
+// SetHealthThreshold sets the HealthThreshold field's value.
+func (s *UpdateHealthCheckInput) SetHealthThreshold(v int64) *UpdateHealthCheckInput {
+	s.HealthThreshold = &v
+	return s
+}
+
+// SetIPAddress sets the IPAddress field's value.
+func (s *UpdateHealthCheckInput) SetIPAddress(v string) *UpdateHealthCheckInput {
+	s.IPAddress = &v
+	return s
+}
+
+// SetInsufficientDataHealthStatus sets the InsufficientDataHealthStatus field's value.
+func (s *UpdateHealthCheckInput) SetInsufficientDataHealthStatus(v string) *UpdateHealthCheckInput {
+	s.InsufficientDataHealthStatus = &v
+	return s
+}
+
+// SetInverted sets the Inverted field's value.
+func (s *UpdateHealthCheckInput) SetInverted(v bool) *UpdateHealthCheckInput {
+	s.Inverted = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *UpdateHealthCheckInput) SetPort(v int64) *UpdateHealthCheckInput {
+	s.Port = &v
+	return s
+}
+
+// SetRegions sets the Regions field's value.
+func (s *UpdateHealthCheckInput) SetRegions(v []*string) *UpdateHealthCheckInput {
+	s.Regions = v
+	return s
+}
+
+// SetResourcePath sets the ResourcePath field's value.
+func (s *UpdateHealthCheckInput) SetResourcePath(v string) *UpdateHealthCheckInput {
+	s.ResourcePath = &v
+	return s
+}
+
+// SetSearchString sets the SearchString field's value.
+func (s *UpdateHealthCheckInput) SetSearchString(v string) *UpdateHealthCheckInput {
+	s.SearchString = &v
+	return s
+}
+
 type UpdateHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9993,6 +12099,12 @@ func (s UpdateHealthCheckOutput) String() string {
 // GoString returns the string representation
 func (s UpdateHealthCheckOutput) GoString() string {
 	return s.String()
+}
+
+// SetHealthCheck sets the HealthCheck field's value.
+func (s *UpdateHealthCheckOutput) SetHealthCheck(v *HealthCheck) *UpdateHealthCheckOutput {
+	s.HealthCheck = v
+	return s
 }
 
 // A complex type that contains the hosted zone request information.
@@ -10032,6 +12144,18 @@ func (s *UpdateHostedZoneCommentInput) Validate() error {
 	return nil
 }
 
+// SetComment sets the Comment field's value.
+func (s *UpdateHostedZoneCommentInput) SetComment(v string) *UpdateHostedZoneCommentInput {
+	s.Comment = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UpdateHostedZoneCommentInput) SetId(v string) *UpdateHostedZoneCommentInput {
+	s.Id = &v
+	return s
+}
+
 // A complex type that contains the response to the UpdateHostedZoneCommentRequest.
 type UpdateHostedZoneCommentOutput struct {
 	_ struct{} `type:"structure"`
@@ -10050,6 +12174,12 @@ func (s UpdateHostedZoneCommentOutput) String() string {
 // GoString returns the string representation
 func (s UpdateHostedZoneCommentOutput) GoString() string {
 	return s.String()
+}
+
+// SetHostedZone sets the HostedZone field's value.
+func (s *UpdateHostedZoneCommentOutput) SetHostedZone(v *HostedZone) *UpdateHostedZoneCommentOutput {
+	s.HostedZone = v
+	return s
 }
 
 // A complex type that contains information about the traffic policy for which
@@ -10106,6 +12236,24 @@ func (s *UpdateTrafficPolicyCommentInput) Validate() error {
 	return nil
 }
 
+// SetComment sets the Comment field's value.
+func (s *UpdateTrafficPolicyCommentInput) SetComment(v string) *UpdateTrafficPolicyCommentInput {
+	s.Comment = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UpdateTrafficPolicyCommentInput) SetId(v string) *UpdateTrafficPolicyCommentInput {
+	s.Id = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *UpdateTrafficPolicyCommentInput) SetVersion(v int64) *UpdateTrafficPolicyCommentInput {
+	s.Version = &v
+	return s
+}
+
 // A complex type that contains the response information for the traffic policy.
 type UpdateTrafficPolicyCommentOutput struct {
 	_ struct{} `type:"structure"`
@@ -10124,6 +12272,12 @@ func (s UpdateTrafficPolicyCommentOutput) String() string {
 // GoString returns the string representation
 func (s UpdateTrafficPolicyCommentOutput) GoString() string {
 	return s.String()
+}
+
+// SetTrafficPolicy sets the TrafficPolicy field's value.
+func (s *UpdateTrafficPolicyCommentOutput) SetTrafficPolicy(v *TrafficPolicy) *UpdateTrafficPolicyCommentOutput {
+	s.TrafficPolicy = v
+	return s
 }
 
 // A complex type that contains information about the resource record sets that
@@ -10190,6 +12344,30 @@ func (s *UpdateTrafficPolicyInstanceInput) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *UpdateTrafficPolicyInstanceInput) SetId(v string) *UpdateTrafficPolicyInstanceInput {
+	s.Id = &v
+	return s
+}
+
+// SetTTL sets the TTL field's value.
+func (s *UpdateTrafficPolicyInstanceInput) SetTTL(v int64) *UpdateTrafficPolicyInstanceInput {
+	s.TTL = &v
+	return s
+}
+
+// SetTrafficPolicyId sets the TrafficPolicyId field's value.
+func (s *UpdateTrafficPolicyInstanceInput) SetTrafficPolicyId(v string) *UpdateTrafficPolicyInstanceInput {
+	s.TrafficPolicyId = &v
+	return s
+}
+
+// SetTrafficPolicyVersion sets the TrafficPolicyVersion field's value.
+func (s *UpdateTrafficPolicyInstanceInput) SetTrafficPolicyVersion(v int64) *UpdateTrafficPolicyInstanceInput {
+	s.TrafficPolicyVersion = &v
+	return s
+}
+
 // A complex type that contains information about the resource record sets that
 // Amazon Route 53 created based on a specified traffic policy.
 type UpdateTrafficPolicyInstanceOutput struct {
@@ -10209,6 +12387,12 @@ func (s UpdateTrafficPolicyInstanceOutput) String() string {
 // GoString returns the string representation
 func (s UpdateTrafficPolicyInstanceOutput) GoString() string {
 	return s.String()
+}
+
+// SetTrafficPolicyInstance sets the TrafficPolicyInstance field's value.
+func (s *UpdateTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficPolicyInstance) *UpdateTrafficPolicyInstanceOutput {
+	s.TrafficPolicyInstance = v
+	return s
 }
 
 // A complex type that contains information about the Amazon VPC that you're
@@ -10245,6 +12429,18 @@ func (s *VPC) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetVPCId sets the VPCId field's value.
+func (s *VPC) SetVPCId(v string) *VPC {
+	s.VPCId = &v
+	return s
+}
+
+// SetVPCRegion sets the VPCRegion field's value.
+func (s *VPC) SetVPCRegion(v string) *VPC {
+	s.VPCRegion = &v
+	return s
 }
 
 const (

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -1933,6 +1933,36 @@ func (s BillingRecord) GoString() string {
 	return s.String()
 }
 
+// SetBillDate sets the BillDate field's value.
+func (s *BillingRecord) SetBillDate(v time.Time) *BillingRecord {
+	s.BillDate = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *BillingRecord) SetDomainName(v string) *BillingRecord {
+	s.DomainName = &v
+	return s
+}
+
+// SetInvoiceId sets the InvoiceId field's value.
+func (s *BillingRecord) SetInvoiceId(v string) *BillingRecord {
+	s.InvoiceId = &v
+	return s
+}
+
+// SetOperation sets the Operation field's value.
+func (s *BillingRecord) SetOperation(v string) *BillingRecord {
+	s.Operation = &v
+	return s
+}
+
+// SetPrice sets the Price field's value.
+func (s *BillingRecord) SetPrice(v float64) *BillingRecord {
+	s.Price = &v
+	return s
+}
+
 // The CheckDomainAvailability request contains the following elements.
 type CheckDomainAvailabilityInput struct {
 	_ struct{} `type:"structure"`
@@ -1979,6 +2009,18 @@ func (s *CheckDomainAvailabilityInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *CheckDomainAvailabilityInput) SetDomainName(v string) *CheckDomainAvailabilityInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetIdnLangCode sets the IdnLangCode field's value.
+func (s *CheckDomainAvailabilityInput) SetIdnLangCode(v string) *CheckDomainAvailabilityInput {
+	s.IdnLangCode = &v
+	return s
+}
+
 // The CheckDomainAvailability response includes the following elements.
 type CheckDomainAvailabilityOutput struct {
 	_ struct{} `type:"structure"`
@@ -2018,6 +2060,12 @@ func (s CheckDomainAvailabilityOutput) String() string {
 // GoString returns the string representation
 func (s CheckDomainAvailabilityOutput) GoString() string {
 	return s.String()
+}
+
+// SetAvailability sets the Availability field's value.
+func (s *CheckDomainAvailabilityOutput) SetAvailability(v string) *CheckDomainAvailabilityOutput {
+	s.Availability = &v
+	return s
 }
 
 // ContactDetail includes the following elements.
@@ -2245,6 +2293,90 @@ func (s *ContactDetail) Validate() error {
 	return nil
 }
 
+// SetAddressLine1 sets the AddressLine1 field's value.
+func (s *ContactDetail) SetAddressLine1(v string) *ContactDetail {
+	s.AddressLine1 = &v
+	return s
+}
+
+// SetAddressLine2 sets the AddressLine2 field's value.
+func (s *ContactDetail) SetAddressLine2(v string) *ContactDetail {
+	s.AddressLine2 = &v
+	return s
+}
+
+// SetCity sets the City field's value.
+func (s *ContactDetail) SetCity(v string) *ContactDetail {
+	s.City = &v
+	return s
+}
+
+// SetContactType sets the ContactType field's value.
+func (s *ContactDetail) SetContactType(v string) *ContactDetail {
+	s.ContactType = &v
+	return s
+}
+
+// SetCountryCode sets the CountryCode field's value.
+func (s *ContactDetail) SetCountryCode(v string) *ContactDetail {
+	s.CountryCode = &v
+	return s
+}
+
+// SetEmail sets the Email field's value.
+func (s *ContactDetail) SetEmail(v string) *ContactDetail {
+	s.Email = &v
+	return s
+}
+
+// SetExtraParams sets the ExtraParams field's value.
+func (s *ContactDetail) SetExtraParams(v []*ExtraParam) *ContactDetail {
+	s.ExtraParams = v
+	return s
+}
+
+// SetFax sets the Fax field's value.
+func (s *ContactDetail) SetFax(v string) *ContactDetail {
+	s.Fax = &v
+	return s
+}
+
+// SetFirstName sets the FirstName field's value.
+func (s *ContactDetail) SetFirstName(v string) *ContactDetail {
+	s.FirstName = &v
+	return s
+}
+
+// SetLastName sets the LastName field's value.
+func (s *ContactDetail) SetLastName(v string) *ContactDetail {
+	s.LastName = &v
+	return s
+}
+
+// SetOrganizationName sets the OrganizationName field's value.
+func (s *ContactDetail) SetOrganizationName(v string) *ContactDetail {
+	s.OrganizationName = &v
+	return s
+}
+
+// SetPhoneNumber sets the PhoneNumber field's value.
+func (s *ContactDetail) SetPhoneNumber(v string) *ContactDetail {
+	s.PhoneNumber = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ContactDetail) SetState(v string) *ContactDetail {
+	s.State = &v
+	return s
+}
+
+// SetZipCode sets the ZipCode field's value.
+func (s *ContactDetail) SetZipCode(v string) *ContactDetail {
+	s.ZipCode = &v
+	return s
+}
+
 // The DeleteTagsForDomainRequest includes the following elements.
 type DeleteTagsForDomainInput struct {
 	_ struct{} `type:"structure"`
@@ -2306,6 +2438,18 @@ func (s *DeleteTagsForDomainInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteTagsForDomainInput) SetDomainName(v string) *DeleteTagsForDomainInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetTagsToDelete sets the TagsToDelete field's value.
+func (s *DeleteTagsForDomainInput) SetTagsToDelete(v []*string) *DeleteTagsForDomainInput {
+	s.TagsToDelete = v
+	return s
+}
+
 type DeleteTagsForDomainOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2348,6 +2492,12 @@ func (s *DisableDomainAutoRenewInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DisableDomainAutoRenewInput) SetDomainName(v string) *DisableDomainAutoRenewInput {
+	s.DomainName = &v
+	return s
 }
 
 type DisableDomainAutoRenewOutput struct {
@@ -2407,6 +2557,12 @@ func (s *DisableDomainTransferLockInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DisableDomainTransferLockInput) SetDomainName(v string) *DisableDomainTransferLockInput {
+	s.DomainName = &v
+	return s
+}
+
 // The DisableDomainTransferLock response includes the following element.
 type DisableDomainTransferLockOutput struct {
 	_ struct{} `type:"structure"`
@@ -2434,6 +2590,12 @@ func (s DisableDomainTransferLockOutput) GoString() string {
 	return s.String()
 }
 
+// SetOperationId sets the OperationId field's value.
+func (s *DisableDomainTransferLockOutput) SetOperationId(v string) *DisableDomainTransferLockOutput {
+	s.OperationId = &v
+	return s
+}
+
 type DomainSuggestion struct {
 	_ struct{} `type:"structure"`
 
@@ -2450,6 +2612,18 @@ func (s DomainSuggestion) String() string {
 // GoString returns the string representation
 func (s DomainSuggestion) GoString() string {
 	return s.String()
+}
+
+// SetAvailability sets the Availability field's value.
+func (s *DomainSuggestion) SetAvailability(v string) *DomainSuggestion {
+	s.Availability = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DomainSuggestion) SetDomainName(v string) *DomainSuggestion {
+	s.DomainName = &v
+	return s
 }
 
 type DomainSummary struct {
@@ -2493,6 +2667,30 @@ func (s DomainSummary) GoString() string {
 	return s.String()
 }
 
+// SetAutoRenew sets the AutoRenew field's value.
+func (s *DomainSummary) SetAutoRenew(v bool) *DomainSummary {
+	s.AutoRenew = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DomainSummary) SetDomainName(v string) *DomainSummary {
+	s.DomainName = &v
+	return s
+}
+
+// SetExpiry sets the Expiry field's value.
+func (s *DomainSummary) SetExpiry(v time.Time) *DomainSummary {
+	s.Expiry = &v
+	return s
+}
+
+// SetTransferLock sets the TransferLock field's value.
+func (s *DomainSummary) SetTransferLock(v bool) *DomainSummary {
+	s.TransferLock = &v
+	return s
+}
+
 type EnableDomainAutoRenewInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2521,6 +2719,12 @@ func (s *EnableDomainAutoRenewInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *EnableDomainAutoRenewInput) SetDomainName(v string) *EnableDomainAutoRenewInput {
+	s.DomainName = &v
+	return s
 }
 
 type EnableDomainAutoRenewOutput struct {
@@ -2580,6 +2784,12 @@ func (s *EnableDomainTransferLockInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *EnableDomainTransferLockInput) SetDomainName(v string) *EnableDomainTransferLockInput {
+	s.DomainName = &v
+	return s
+}
+
 // The EnableDomainTransferLock response includes the following elements.
 type EnableDomainTransferLockOutput struct {
 	_ struct{} `type:"structure"`
@@ -2605,6 +2815,12 @@ func (s EnableDomainTransferLockOutput) String() string {
 // GoString returns the string representation
 func (s EnableDomainTransferLockOutput) GoString() string {
 	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *EnableDomainTransferLockOutput) SetOperationId(v string) *EnableDomainTransferLockOutput {
+	s.OperationId = &v
+	return s
 }
 
 // ExtraParam includes the following elements.
@@ -2673,6 +2889,18 @@ func (s *ExtraParam) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *ExtraParam) SetName(v string) *ExtraParam {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ExtraParam) SetValue(v string) *ExtraParam {
+	s.Value = &v
+	return s
+}
+
 type GetContactReachabilityStatusInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2695,6 +2923,12 @@ func (s GetContactReachabilityStatusInput) String() string {
 // GoString returns the string representation
 func (s GetContactReachabilityStatusInput) GoString() string {
 	return s.String()
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetContactReachabilityStatusInput) SetDomainName(v string) *GetContactReachabilityStatusInput {
+	s.DomainName = &v
+	return s
 }
 
 type GetContactReachabilityStatusOutput struct {
@@ -2723,6 +2957,18 @@ func (s GetContactReachabilityStatusOutput) String() string {
 // GoString returns the string representation
 func (s GetContactReachabilityStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetContactReachabilityStatusOutput) SetDomainName(v string) *GetContactReachabilityStatusOutput {
+	s.DomainName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetContactReachabilityStatusOutput) SetStatus(v string) *GetContactReachabilityStatusOutput {
+	s.Status = &v
+	return s
 }
 
 // The GetDomainDetail request includes the following element.
@@ -2766,6 +3012,12 @@ func (s *GetDomainDetailInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetDomainDetailInput) SetDomainName(v string) *GetDomainDetailInput {
+	s.DomainName = &v
+	return s
 }
 
 // The GetDomainDetail response includes the following elements.
@@ -2930,6 +3182,132 @@ func (s GetDomainDetailOutput) GoString() string {
 	return s.String()
 }
 
+// SetAbuseContactEmail sets the AbuseContactEmail field's value.
+func (s *GetDomainDetailOutput) SetAbuseContactEmail(v string) *GetDomainDetailOutput {
+	s.AbuseContactEmail = &v
+	return s
+}
+
+// SetAbuseContactPhone sets the AbuseContactPhone field's value.
+func (s *GetDomainDetailOutput) SetAbuseContactPhone(v string) *GetDomainDetailOutput {
+	s.AbuseContactPhone = &v
+	return s
+}
+
+// SetAdminContact sets the AdminContact field's value.
+func (s *GetDomainDetailOutput) SetAdminContact(v *ContactDetail) *GetDomainDetailOutput {
+	s.AdminContact = v
+	return s
+}
+
+// SetAdminPrivacy sets the AdminPrivacy field's value.
+func (s *GetDomainDetailOutput) SetAdminPrivacy(v bool) *GetDomainDetailOutput {
+	s.AdminPrivacy = &v
+	return s
+}
+
+// SetAutoRenew sets the AutoRenew field's value.
+func (s *GetDomainDetailOutput) SetAutoRenew(v bool) *GetDomainDetailOutput {
+	s.AutoRenew = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *GetDomainDetailOutput) SetCreationDate(v time.Time) *GetDomainDetailOutput {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDnsSec sets the DnsSec field's value.
+func (s *GetDomainDetailOutput) SetDnsSec(v string) *GetDomainDetailOutput {
+	s.DnsSec = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetDomainDetailOutput) SetDomainName(v string) *GetDomainDetailOutput {
+	s.DomainName = &v
+	return s
+}
+
+// SetExpirationDate sets the ExpirationDate field's value.
+func (s *GetDomainDetailOutput) SetExpirationDate(v time.Time) *GetDomainDetailOutput {
+	s.ExpirationDate = &v
+	return s
+}
+
+// SetNameservers sets the Nameservers field's value.
+func (s *GetDomainDetailOutput) SetNameservers(v []*Nameserver) *GetDomainDetailOutput {
+	s.Nameservers = v
+	return s
+}
+
+// SetRegistrantContact sets the RegistrantContact field's value.
+func (s *GetDomainDetailOutput) SetRegistrantContact(v *ContactDetail) *GetDomainDetailOutput {
+	s.RegistrantContact = v
+	return s
+}
+
+// SetRegistrantPrivacy sets the RegistrantPrivacy field's value.
+func (s *GetDomainDetailOutput) SetRegistrantPrivacy(v bool) *GetDomainDetailOutput {
+	s.RegistrantPrivacy = &v
+	return s
+}
+
+// SetRegistrarName sets the RegistrarName field's value.
+func (s *GetDomainDetailOutput) SetRegistrarName(v string) *GetDomainDetailOutput {
+	s.RegistrarName = &v
+	return s
+}
+
+// SetRegistrarUrl sets the RegistrarUrl field's value.
+func (s *GetDomainDetailOutput) SetRegistrarUrl(v string) *GetDomainDetailOutput {
+	s.RegistrarUrl = &v
+	return s
+}
+
+// SetRegistryDomainId sets the RegistryDomainId field's value.
+func (s *GetDomainDetailOutput) SetRegistryDomainId(v string) *GetDomainDetailOutput {
+	s.RegistryDomainId = &v
+	return s
+}
+
+// SetReseller sets the Reseller field's value.
+func (s *GetDomainDetailOutput) SetReseller(v string) *GetDomainDetailOutput {
+	s.Reseller = &v
+	return s
+}
+
+// SetStatusList sets the StatusList field's value.
+func (s *GetDomainDetailOutput) SetStatusList(v []*string) *GetDomainDetailOutput {
+	s.StatusList = v
+	return s
+}
+
+// SetTechContact sets the TechContact field's value.
+func (s *GetDomainDetailOutput) SetTechContact(v *ContactDetail) *GetDomainDetailOutput {
+	s.TechContact = v
+	return s
+}
+
+// SetTechPrivacy sets the TechPrivacy field's value.
+func (s *GetDomainDetailOutput) SetTechPrivacy(v bool) *GetDomainDetailOutput {
+	s.TechPrivacy = &v
+	return s
+}
+
+// SetUpdatedDate sets the UpdatedDate field's value.
+func (s *GetDomainDetailOutput) SetUpdatedDate(v time.Time) *GetDomainDetailOutput {
+	s.UpdatedDate = &v
+	return s
+}
+
+// SetWhoIsServer sets the WhoIsServer field's value.
+func (s *GetDomainDetailOutput) SetWhoIsServer(v string) *GetDomainDetailOutput {
+	s.WhoIsServer = &v
+	return s
+}
+
 type GetDomainSuggestionsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2972,6 +3350,24 @@ func (s *GetDomainSuggestionsInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *GetDomainSuggestionsInput) SetDomainName(v string) *GetDomainSuggestionsInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetOnlyAvailable sets the OnlyAvailable field's value.
+func (s *GetDomainSuggestionsInput) SetOnlyAvailable(v bool) *GetDomainSuggestionsInput {
+	s.OnlyAvailable = &v
+	return s
+}
+
+// SetSuggestionCount sets the SuggestionCount field's value.
+func (s *GetDomainSuggestionsInput) SetSuggestionCount(v int64) *GetDomainSuggestionsInput {
+	s.SuggestionCount = &v
+	return s
+}
+
 type GetDomainSuggestionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2986,6 +3382,12 @@ func (s GetDomainSuggestionsOutput) String() string {
 // GoString returns the string representation
 func (s GetDomainSuggestionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSuggestionsList sets the SuggestionsList field's value.
+func (s *GetDomainSuggestionsOutput) SetSuggestionsList(v []*DomainSuggestion) *GetDomainSuggestionsOutput {
+	s.SuggestionsList = v
+	return s
 }
 
 // The GetOperationDetail request includes the following element.
@@ -3026,6 +3428,12 @@ func (s *GetOperationDetailInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *GetOperationDetailInput) SetOperationId(v string) *GetOperationDetailInput {
+	s.OperationId = &v
+	return s
 }
 
 // The GetOperationDetail response includes the following elements.
@@ -3071,6 +3479,42 @@ func (s GetOperationDetailOutput) GoString() string {
 	return s.String()
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *GetOperationDetailOutput) SetDomainName(v string) *GetOperationDetailOutput {
+	s.DomainName = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *GetOperationDetailOutput) SetMessage(v string) *GetOperationDetailOutput {
+	s.Message = &v
+	return s
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *GetOperationDetailOutput) SetOperationId(v string) *GetOperationDetailOutput {
+	s.OperationId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetOperationDetailOutput) SetStatus(v string) *GetOperationDetailOutput {
+	s.Status = &v
+	return s
+}
+
+// SetSubmittedDate sets the SubmittedDate field's value.
+func (s *GetOperationDetailOutput) SetSubmittedDate(v time.Time) *GetOperationDetailOutput {
+	s.SubmittedDate = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *GetOperationDetailOutput) SetType(v string) *GetOperationDetailOutput {
+	s.Type = &v
+	return s
+}
+
 // The ListDomains request includes the following elements.
 type ListDomainsInput struct {
 	_ struct{} `type:"structure"`
@@ -3113,6 +3557,18 @@ func (s ListDomainsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListDomainsInput) SetMarker(v string) *ListDomainsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListDomainsInput) SetMaxItems(v int64) *ListDomainsInput {
+	s.MaxItems = &v
+	return s
+}
+
 // The ListDomains response includes the following elements.
 type ListDomainsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3144,6 +3600,18 @@ func (s ListDomainsOutput) String() string {
 // GoString returns the string representation
 func (s ListDomainsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomains sets the Domains field's value.
+func (s *ListDomainsOutput) SetDomains(v []*DomainSummary) *ListDomainsOutput {
+	s.Domains = v
+	return s
+}
+
+// SetNextPageMarker sets the NextPageMarker field's value.
+func (s *ListDomainsOutput) SetNextPageMarker(v string) *ListDomainsOutput {
+	s.NextPageMarker = &v
+	return s
 }
 
 // The ListOperations request includes the following elements.
@@ -3186,6 +3654,18 @@ func (s ListOperationsInput) GoString() string {
 	return s.String()
 }
 
+// SetMarker sets the Marker field's value.
+func (s *ListOperationsInput) SetMarker(v string) *ListOperationsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListOperationsInput) SetMaxItems(v int64) *ListOperationsInput {
+	s.MaxItems = &v
+	return s
+}
+
 // The ListOperations response includes the following elements.
 type ListOperationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3219,6 +3699,18 @@ func (s ListOperationsOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextPageMarker sets the NextPageMarker field's value.
+func (s *ListOperationsOutput) SetNextPageMarker(v string) *ListOperationsOutput {
+	s.NextPageMarker = &v
+	return s
+}
+
+// SetOperations sets the Operations field's value.
+func (s *ListOperationsOutput) SetOperations(v []*OperationSummary) *ListOperationsOutput {
+	s.Operations = v
+	return s
+}
+
 // The ListTagsForDomainRequest includes the following elements.
 type ListTagsForDomainInput struct {
 	_ struct{} `type:"structure"`
@@ -3250,6 +3742,12 @@ func (s *ListTagsForDomainInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *ListTagsForDomainInput) SetDomainName(v string) *ListTagsForDomainInput {
+	s.DomainName = &v
+	return s
 }
 
 // The ListTagsForDomain response includes the following elements.
@@ -3286,6 +3784,12 @@ func (s ListTagsForDomainOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagList sets the TagList field's value.
+func (s *ListTagsForDomainOutput) SetTagList(v []*Tag) *ListTagsForDomainOutput {
+	s.TagList = v
+	return s
 }
 
 // Nameserver includes the following elements.
@@ -3339,6 +3843,18 @@ func (s *Nameserver) Validate() error {
 	return nil
 }
 
+// SetGlueIps sets the GlueIps field's value.
+func (s *Nameserver) SetGlueIps(v []*string) *Nameserver {
+	s.GlueIps = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Nameserver) SetName(v string) *Nameserver {
+	s.Name = &v
+	return s
+}
+
 // OperationSummary includes the following elements.
 type OperationSummary struct {
 	_ struct{} `type:"structure"`
@@ -3381,6 +3897,30 @@ func (s OperationSummary) String() string {
 // GoString returns the string representation
 func (s OperationSummary) GoString() string {
 	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *OperationSummary) SetOperationId(v string) *OperationSummary {
+	s.OperationId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *OperationSummary) SetStatus(v string) *OperationSummary {
+	s.Status = &v
+	return s
+}
+
+// SetSubmittedDate sets the SubmittedDate field's value.
+func (s *OperationSummary) SetSubmittedDate(v time.Time) *OperationSummary {
+	s.SubmittedDate = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *OperationSummary) SetType(v string) *OperationSummary {
+	s.Type = &v
+	return s
 }
 
 // The RegisterDomain request includes the following elements.
@@ -3566,6 +4106,66 @@ func (s *RegisterDomainInput) Validate() error {
 	return nil
 }
 
+// SetAdminContact sets the AdminContact field's value.
+func (s *RegisterDomainInput) SetAdminContact(v *ContactDetail) *RegisterDomainInput {
+	s.AdminContact = v
+	return s
+}
+
+// SetAutoRenew sets the AutoRenew field's value.
+func (s *RegisterDomainInput) SetAutoRenew(v bool) *RegisterDomainInput {
+	s.AutoRenew = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *RegisterDomainInput) SetDomainName(v string) *RegisterDomainInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetDurationInYears sets the DurationInYears field's value.
+func (s *RegisterDomainInput) SetDurationInYears(v int64) *RegisterDomainInput {
+	s.DurationInYears = &v
+	return s
+}
+
+// SetIdnLangCode sets the IdnLangCode field's value.
+func (s *RegisterDomainInput) SetIdnLangCode(v string) *RegisterDomainInput {
+	s.IdnLangCode = &v
+	return s
+}
+
+// SetPrivacyProtectAdminContact sets the PrivacyProtectAdminContact field's value.
+func (s *RegisterDomainInput) SetPrivacyProtectAdminContact(v bool) *RegisterDomainInput {
+	s.PrivacyProtectAdminContact = &v
+	return s
+}
+
+// SetPrivacyProtectRegistrantContact sets the PrivacyProtectRegistrantContact field's value.
+func (s *RegisterDomainInput) SetPrivacyProtectRegistrantContact(v bool) *RegisterDomainInput {
+	s.PrivacyProtectRegistrantContact = &v
+	return s
+}
+
+// SetPrivacyProtectTechContact sets the PrivacyProtectTechContact field's value.
+func (s *RegisterDomainInput) SetPrivacyProtectTechContact(v bool) *RegisterDomainInput {
+	s.PrivacyProtectTechContact = &v
+	return s
+}
+
+// SetRegistrantContact sets the RegistrantContact field's value.
+func (s *RegisterDomainInput) SetRegistrantContact(v *ContactDetail) *RegisterDomainInput {
+	s.RegistrantContact = v
+	return s
+}
+
+// SetTechContact sets the TechContact field's value.
+func (s *RegisterDomainInput) SetTechContact(v *ContactDetail) *RegisterDomainInput {
+	s.TechContact = v
+	return s
+}
+
 // The RegisterDomain response includes the following element.
 type RegisterDomainOutput struct {
 	_ struct{} `type:"structure"`
@@ -3591,6 +4191,12 @@ func (s RegisterDomainOutput) String() string {
 // GoString returns the string representation
 func (s RegisterDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *RegisterDomainOutput) SetOperationId(v string) *RegisterDomainOutput {
+	s.OperationId = &v
+	return s
 }
 
 // A RenewDomain request includes the number of years that you want to renew
@@ -3659,6 +4265,24 @@ func (s *RenewDomainInput) Validate() error {
 	return nil
 }
 
+// SetCurrentExpiryYear sets the CurrentExpiryYear field's value.
+func (s *RenewDomainInput) SetCurrentExpiryYear(v int64) *RenewDomainInput {
+	s.CurrentExpiryYear = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *RenewDomainInput) SetDomainName(v string) *RenewDomainInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetDurationInYears sets the DurationInYears field's value.
+func (s *RenewDomainInput) SetDurationInYears(v int64) *RenewDomainInput {
+	s.DurationInYears = &v
+	return s
+}
+
 type RenewDomainOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3674,6 +4298,12 @@ func (s RenewDomainOutput) String() string {
 // GoString returns the string representation
 func (s RenewDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *RenewDomainOutput) SetOperationId(v string) *RenewDomainOutput {
+	s.OperationId = &v
+	return s
 }
 
 type ResendContactReachabilityEmailInput struct {
@@ -3700,6 +4330,12 @@ func (s ResendContactReachabilityEmailInput) GoString() string {
 	return s.String()
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *ResendContactReachabilityEmailInput) SetDomainName(v string) *ResendContactReachabilityEmailInput {
+	s.DomainName = &v
+	return s
+}
+
 type ResendContactReachabilityEmailOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3724,6 +4360,24 @@ func (s ResendContactReachabilityEmailOutput) String() string {
 // GoString returns the string representation
 func (s ResendContactReachabilityEmailOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *ResendContactReachabilityEmailOutput) SetDomainName(v string) *ResendContactReachabilityEmailOutput {
+	s.DomainName = &v
+	return s
+}
+
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *ResendContactReachabilityEmailOutput) SetEmailAddress(v string) *ResendContactReachabilityEmailOutput {
+	s.EmailAddress = &v
+	return s
+}
+
+// SetIsAlreadyVerified sets the IsAlreadyVerified field's value.
+func (s *ResendContactReachabilityEmailOutput) SetIsAlreadyVerified(v bool) *ResendContactReachabilityEmailOutput {
+	s.IsAlreadyVerified = &v
+	return s
 }
 
 // The RetrieveDomainAuthCode request includes the following element.
@@ -3769,6 +4423,12 @@ func (s *RetrieveDomainAuthCodeInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *RetrieveDomainAuthCodeInput) SetDomainName(v string) *RetrieveDomainAuthCodeInput {
+	s.DomainName = &v
+	return s
+}
+
 // The RetrieveDomainAuthCode response includes the following element.
 type RetrieveDomainAuthCodeOutput struct {
 	_ struct{} `type:"structure"`
@@ -3789,6 +4449,12 @@ func (s RetrieveDomainAuthCodeOutput) String() string {
 // GoString returns the string representation
 func (s RetrieveDomainAuthCodeOutput) GoString() string {
 	return s.String()
+}
+
+// SetAuthCode sets the AuthCode field's value.
+func (s *RetrieveDomainAuthCodeOutput) SetAuthCode(v string) *RetrieveDomainAuthCodeOutput {
+	s.AuthCode = &v
+	return s
 }
 
 // Each tag includes the following elements.
@@ -3830,6 +4496,18 @@ func (s Tag) String() string {
 // GoString returns the string representation
 func (s Tag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 // The TransferDomain request includes the following elements.
@@ -4042,6 +4720,78 @@ func (s *TransferDomainInput) Validate() error {
 	return nil
 }
 
+// SetAdminContact sets the AdminContact field's value.
+func (s *TransferDomainInput) SetAdminContact(v *ContactDetail) *TransferDomainInput {
+	s.AdminContact = v
+	return s
+}
+
+// SetAuthCode sets the AuthCode field's value.
+func (s *TransferDomainInput) SetAuthCode(v string) *TransferDomainInput {
+	s.AuthCode = &v
+	return s
+}
+
+// SetAutoRenew sets the AutoRenew field's value.
+func (s *TransferDomainInput) SetAutoRenew(v bool) *TransferDomainInput {
+	s.AutoRenew = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *TransferDomainInput) SetDomainName(v string) *TransferDomainInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetDurationInYears sets the DurationInYears field's value.
+func (s *TransferDomainInput) SetDurationInYears(v int64) *TransferDomainInput {
+	s.DurationInYears = &v
+	return s
+}
+
+// SetIdnLangCode sets the IdnLangCode field's value.
+func (s *TransferDomainInput) SetIdnLangCode(v string) *TransferDomainInput {
+	s.IdnLangCode = &v
+	return s
+}
+
+// SetNameservers sets the Nameservers field's value.
+func (s *TransferDomainInput) SetNameservers(v []*Nameserver) *TransferDomainInput {
+	s.Nameservers = v
+	return s
+}
+
+// SetPrivacyProtectAdminContact sets the PrivacyProtectAdminContact field's value.
+func (s *TransferDomainInput) SetPrivacyProtectAdminContact(v bool) *TransferDomainInput {
+	s.PrivacyProtectAdminContact = &v
+	return s
+}
+
+// SetPrivacyProtectRegistrantContact sets the PrivacyProtectRegistrantContact field's value.
+func (s *TransferDomainInput) SetPrivacyProtectRegistrantContact(v bool) *TransferDomainInput {
+	s.PrivacyProtectRegistrantContact = &v
+	return s
+}
+
+// SetPrivacyProtectTechContact sets the PrivacyProtectTechContact field's value.
+func (s *TransferDomainInput) SetPrivacyProtectTechContact(v bool) *TransferDomainInput {
+	s.PrivacyProtectTechContact = &v
+	return s
+}
+
+// SetRegistrantContact sets the RegistrantContact field's value.
+func (s *TransferDomainInput) SetRegistrantContact(v *ContactDetail) *TransferDomainInput {
+	s.RegistrantContact = v
+	return s
+}
+
+// SetTechContact sets the TechContact field's value.
+func (s *TransferDomainInput) SetTechContact(v *ContactDetail) *TransferDomainInput {
+	s.TechContact = v
+	return s
+}
+
 // The TranserDomain response includes the following element.
 type TransferDomainOutput struct {
 	_ struct{} `type:"structure"`
@@ -4067,6 +4817,12 @@ func (s TransferDomainOutput) String() string {
 // GoString returns the string representation
 func (s TransferDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *TransferDomainOutput) SetOperationId(v string) *TransferDomainOutput {
+	s.OperationId = &v
+	return s
 }
 
 // The UpdateDomainContact request includes the following elements.
@@ -4160,6 +4916,30 @@ func (s *UpdateDomainContactInput) Validate() error {
 	return nil
 }
 
+// SetAdminContact sets the AdminContact field's value.
+func (s *UpdateDomainContactInput) SetAdminContact(v *ContactDetail) *UpdateDomainContactInput {
+	s.AdminContact = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateDomainContactInput) SetDomainName(v string) *UpdateDomainContactInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetRegistrantContact sets the RegistrantContact field's value.
+func (s *UpdateDomainContactInput) SetRegistrantContact(v *ContactDetail) *UpdateDomainContactInput {
+	s.RegistrantContact = v
+	return s
+}
+
+// SetTechContact sets the TechContact field's value.
+func (s *UpdateDomainContactInput) SetTechContact(v *ContactDetail) *UpdateDomainContactInput {
+	s.TechContact = v
+	return s
+}
+
 // The UpdateDomainContact response includes the following element.
 type UpdateDomainContactOutput struct {
 	_ struct{} `type:"structure"`
@@ -4185,6 +4965,12 @@ func (s UpdateDomainContactOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDomainContactOutput) GoString() string {
 	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *UpdateDomainContactOutput) SetOperationId(v string) *UpdateDomainContactOutput {
+	s.OperationId = &v
+	return s
 }
 
 // The UpdateDomainContactPrivacy request includes the following elements.
@@ -4272,6 +5058,30 @@ func (s *UpdateDomainContactPrivacyInput) Validate() error {
 	return nil
 }
 
+// SetAdminPrivacy sets the AdminPrivacy field's value.
+func (s *UpdateDomainContactPrivacyInput) SetAdminPrivacy(v bool) *UpdateDomainContactPrivacyInput {
+	s.AdminPrivacy = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateDomainContactPrivacyInput) SetDomainName(v string) *UpdateDomainContactPrivacyInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetRegistrantPrivacy sets the RegistrantPrivacy field's value.
+func (s *UpdateDomainContactPrivacyInput) SetRegistrantPrivacy(v bool) *UpdateDomainContactPrivacyInput {
+	s.RegistrantPrivacy = &v
+	return s
+}
+
+// SetTechPrivacy sets the TechPrivacy field's value.
+func (s *UpdateDomainContactPrivacyInput) SetTechPrivacy(v bool) *UpdateDomainContactPrivacyInput {
+	s.TechPrivacy = &v
+	return s
+}
+
 // The UpdateDomainContactPrivacy response includes the following element.
 type UpdateDomainContactPrivacyOutput struct {
 	_ struct{} `type:"structure"`
@@ -4297,6 +5107,12 @@ func (s UpdateDomainContactPrivacyOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDomainContactPrivacyOutput) GoString() string {
 	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *UpdateDomainContactPrivacyOutput) SetOperationId(v string) *UpdateDomainContactPrivacyOutput {
+	s.OperationId = &v
+	return s
 }
 
 // The UpdateDomainNameserver request includes the following elements.
@@ -4369,6 +5185,24 @@ func (s *UpdateDomainNameserversInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateDomainNameserversInput) SetDomainName(v string) *UpdateDomainNameserversInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetFIAuthKey sets the FIAuthKey field's value.
+func (s *UpdateDomainNameserversInput) SetFIAuthKey(v string) *UpdateDomainNameserversInput {
+	s.FIAuthKey = &v
+	return s
+}
+
+// SetNameservers sets the Nameservers field's value.
+func (s *UpdateDomainNameserversInput) SetNameservers(v []*Nameserver) *UpdateDomainNameserversInput {
+	s.Nameservers = v
+	return s
+}
+
 // The UpdateDomainNameservers response includes the following element.
 type UpdateDomainNameserversOutput struct {
 	_ struct{} `type:"structure"`
@@ -4394,6 +5228,12 @@ func (s UpdateDomainNameserversOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDomainNameserversOutput) GoString() string {
 	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *UpdateDomainNameserversOutput) SetOperationId(v string) *UpdateDomainNameserversOutput {
+	s.OperationId = &v
+	return s
 }
 
 // The UpdateTagsForDomainRequest includes the following elements.
@@ -4483,6 +5323,18 @@ func (s *UpdateTagsForDomainInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *UpdateTagsForDomainInput) SetDomainName(v string) *UpdateTagsForDomainInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetTagsToUpdate sets the TagsToUpdate field's value.
+func (s *UpdateTagsForDomainInput) SetTagsToUpdate(v []*Tag) *UpdateTagsForDomainInput {
+	s.TagsToUpdate = v
+	return s
+}
+
 type UpdateTagsForDomainOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4560,6 +5412,30 @@ func (s ViewBillingInput) GoString() string {
 	return s.String()
 }
 
+// SetEnd sets the End field's value.
+func (s *ViewBillingInput) SetEnd(v time.Time) *ViewBillingInput {
+	s.End = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ViewBillingInput) SetMarker(v string) *ViewBillingInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ViewBillingInput) SetMaxItems(v int64) *ViewBillingInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *ViewBillingInput) SetStart(v time.Time) *ViewBillingInput {
+	s.Start = &v
+	return s
+}
+
 // The ViewBilling response includes the following elements.
 type ViewBillingOutput struct {
 	_ struct{} `type:"structure"`
@@ -4589,6 +5465,18 @@ func (s ViewBillingOutput) String() string {
 // GoString returns the string representation
 func (s ViewBillingOutput) GoString() string {
 	return s.String()
+}
+
+// SetBillingRecords sets the BillingRecords field's value.
+func (s *ViewBillingOutput) SetBillingRecords(v []*BillingRecord) *ViewBillingOutput {
+	s.BillingRecords = v
+	return s
+}
+
+// SetNextPageMarker sets the NextPageMarker field's value.
+func (s *ViewBillingOutput) SetNextPageMarker(v string) *ViewBillingOutput {
+	s.NextPageMarker = &v
+	return s
 }
 
 const (

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -3826,6 +3826,12 @@ func (s AbortIncompleteMultipartUpload) GoString() string {
 	return s.String()
 }
 
+// SetDaysAfterInitiation sets the DaysAfterInitiation field's value.
+func (s *AbortIncompleteMultipartUpload) SetDaysAfterInitiation(v int64) *AbortIncompleteMultipartUpload {
+	s.DaysAfterInitiation = &v
+	return s
+}
+
 type AbortMultipartUploadInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3877,6 +3883,30 @@ func (s *AbortMultipartUploadInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *AbortMultipartUploadInput) SetBucket(v string) *AbortMultipartUploadInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *AbortMultipartUploadInput) SetKey(v string) *AbortMultipartUploadInput {
+	s.Key = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *AbortMultipartUploadInput) SetRequestPayer(v string) *AbortMultipartUploadInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *AbortMultipartUploadInput) SetUploadId(v string) *AbortMultipartUploadInput {
+	s.UploadId = &v
+	return s
+}
+
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3895,6 +3925,12 @@ func (s AbortMultipartUploadOutput) GoString() string {
 	return s.String()
 }
 
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *AbortMultipartUploadOutput) SetRequestCharged(v string) *AbortMultipartUploadOutput {
+	s.RequestCharged = &v
+	return s
+}
+
 type AccelerateConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -3910,6 +3946,12 @@ func (s AccelerateConfiguration) String() string {
 // GoString returns the string representation
 func (s AccelerateConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *AccelerateConfiguration) SetStatus(v string) *AccelerateConfiguration {
+	s.Status = &v
+	return s
 }
 
 type AccessControlPolicy struct {
@@ -3951,6 +3993,18 @@ func (s *AccessControlPolicy) Validate() error {
 	return nil
 }
 
+// SetGrants sets the Grants field's value.
+func (s *AccessControlPolicy) SetGrants(v []*Grant) *AccessControlPolicy {
+	s.Grants = v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *AccessControlPolicy) SetOwner(v *Owner) *AccessControlPolicy {
+	s.Owner = v
+	return s
+}
+
 type Bucket struct {
 	_ struct{} `type:"structure"`
 
@@ -3969,6 +4023,18 @@ func (s Bucket) String() string {
 // GoString returns the string representation
 func (s Bucket) GoString() string {
 	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *Bucket) SetCreationDate(v time.Time) *Bucket {
+	s.CreationDate = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Bucket) SetName(v string) *Bucket {
+	s.Name = &v
+	return s
 }
 
 type BucketLifecycleConfiguration struct {
@@ -4011,6 +4077,12 @@ func (s *BucketLifecycleConfiguration) Validate() error {
 	return nil
 }
 
+// SetRules sets the Rules field's value.
+func (s *BucketLifecycleConfiguration) SetRules(v []*LifecycleRule) *BucketLifecycleConfiguration {
+	s.Rules = v
+	return s
+}
+
 type BucketLoggingStatus struct {
 	_ struct{} `type:"structure"`
 
@@ -4040,6 +4112,12 @@ func (s *BucketLoggingStatus) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLoggingEnabled sets the LoggingEnabled field's value.
+func (s *BucketLoggingStatus) SetLoggingEnabled(v *LoggingEnabled) *BucketLoggingStatus {
+	s.LoggingEnabled = v
+	return s
 }
 
 type CORSConfiguration struct {
@@ -4080,6 +4158,12 @@ func (s *CORSConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCORSRules sets the CORSRules field's value.
+func (s *CORSConfiguration) SetCORSRules(v []*CORSRule) *CORSConfiguration {
+	s.CORSRules = v
+	return s
 }
 
 type CORSRule struct {
@@ -4135,6 +4219,36 @@ func (s *CORSRule) Validate() error {
 	return nil
 }
 
+// SetAllowedHeaders sets the AllowedHeaders field's value.
+func (s *CORSRule) SetAllowedHeaders(v []*string) *CORSRule {
+	s.AllowedHeaders = v
+	return s
+}
+
+// SetAllowedMethods sets the AllowedMethods field's value.
+func (s *CORSRule) SetAllowedMethods(v []*string) *CORSRule {
+	s.AllowedMethods = v
+	return s
+}
+
+// SetAllowedOrigins sets the AllowedOrigins field's value.
+func (s *CORSRule) SetAllowedOrigins(v []*string) *CORSRule {
+	s.AllowedOrigins = v
+	return s
+}
+
+// SetExposeHeaders sets the ExposeHeaders field's value.
+func (s *CORSRule) SetExposeHeaders(v []*string) *CORSRule {
+	s.ExposeHeaders = v
+	return s
+}
+
+// SetMaxAgeSeconds sets the MaxAgeSeconds field's value.
+func (s *CORSRule) SetMaxAgeSeconds(v int64) *CORSRule {
+	s.MaxAgeSeconds = &v
+	return s
+}
+
 type CloudFunctionConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -4162,6 +4276,36 @@ func (s CloudFunctionConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetCloudFunction sets the CloudFunction field's value.
+func (s *CloudFunctionConfiguration) SetCloudFunction(v string) *CloudFunctionConfiguration {
+	s.CloudFunction = &v
+	return s
+}
+
+// SetEvent sets the Event field's value.
+func (s *CloudFunctionConfiguration) SetEvent(v string) *CloudFunctionConfiguration {
+	s.Event = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *CloudFunctionConfiguration) SetEvents(v []*string) *CloudFunctionConfiguration {
+	s.Events = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *CloudFunctionConfiguration) SetId(v string) *CloudFunctionConfiguration {
+	s.Id = &v
+	return s
+}
+
+// SetInvocationRole sets the InvocationRole field's value.
+func (s *CloudFunctionConfiguration) SetInvocationRole(v string) *CloudFunctionConfiguration {
+	s.InvocationRole = &v
+	return s
+}
+
 type CommonPrefix struct {
 	_ struct{} `type:"structure"`
 
@@ -4176,6 +4320,12 @@ func (s CommonPrefix) String() string {
 // GoString returns the string representation
 func (s CommonPrefix) GoString() string {
 	return s.String()
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *CommonPrefix) SetPrefix(v string) *CommonPrefix {
+	s.Prefix = &v
+	return s
 }
 
 type CompleteMultipartUploadInput struct {
@@ -4231,6 +4381,36 @@ func (s *CompleteMultipartUploadInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *CompleteMultipartUploadInput) SetBucket(v string) *CompleteMultipartUploadInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *CompleteMultipartUploadInput) SetKey(v string) *CompleteMultipartUploadInput {
+	s.Key = &v
+	return s
+}
+
+// SetMultipartUpload sets the MultipartUpload field's value.
+func (s *CompleteMultipartUploadInput) SetMultipartUpload(v *CompletedMultipartUpload) *CompleteMultipartUploadInput {
+	s.MultipartUpload = v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *CompleteMultipartUploadInput) SetRequestPayer(v string) *CompleteMultipartUploadInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *CompleteMultipartUploadInput) SetUploadId(v string) *CompleteMultipartUploadInput {
+	s.UploadId = &v
+	return s
+}
+
 type CompleteMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4273,6 +4453,60 @@ func (s CompleteMultipartUploadOutput) GoString() string {
 	return s.String()
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *CompleteMultipartUploadOutput) SetBucket(v string) *CompleteMultipartUploadOutput {
+	s.Bucket = &v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *CompleteMultipartUploadOutput) SetETag(v string) *CompleteMultipartUploadOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *CompleteMultipartUploadOutput) SetExpiration(v string) *CompleteMultipartUploadOutput {
+	s.Expiration = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *CompleteMultipartUploadOutput) SetKey(v string) *CompleteMultipartUploadOutput {
+	s.Key = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CompleteMultipartUploadOutput) SetLocation(v string) *CompleteMultipartUploadOutput {
+	s.Location = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *CompleteMultipartUploadOutput) SetRequestCharged(v string) *CompleteMultipartUploadOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *CompleteMultipartUploadOutput) SetSSEKMSKeyId(v string) *CompleteMultipartUploadOutput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *CompleteMultipartUploadOutput) SetServerSideEncryption(v string) *CompleteMultipartUploadOutput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *CompleteMultipartUploadOutput) SetVersionId(v string) *CompleteMultipartUploadOutput {
+	s.VersionId = &v
+	return s
+}
+
 type CompletedMultipartUpload struct {
 	_ struct{} `type:"structure"`
 
@@ -4287,6 +4521,12 @@ func (s CompletedMultipartUpload) String() string {
 // GoString returns the string representation
 func (s CompletedMultipartUpload) GoString() string {
 	return s.String()
+}
+
+// SetParts sets the Parts field's value.
+func (s *CompletedMultipartUpload) SetParts(v []*CompletedPart) *CompletedMultipartUpload {
+	s.Parts = v
+	return s
 }
 
 type CompletedPart struct {
@@ -4308,6 +4548,18 @@ func (s CompletedPart) String() string {
 // GoString returns the string representation
 func (s CompletedPart) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *CompletedPart) SetETag(v string) *CompletedPart {
+	s.ETag = &v
+	return s
+}
+
+// SetPartNumber sets the PartNumber field's value.
+func (s *CompletedPart) SetPartNumber(v int64) *CompletedPart {
+	s.PartNumber = &v
+	return s
 }
 
 type Condition struct {
@@ -4338,6 +4590,18 @@ func (s Condition) String() string {
 // GoString returns the string representation
 func (s Condition) GoString() string {
 	return s.String()
+}
+
+// SetHttpErrorCodeReturnedEquals sets the HttpErrorCodeReturnedEquals field's value.
+func (s *Condition) SetHttpErrorCodeReturnedEquals(v string) *Condition {
+	s.HttpErrorCodeReturnedEquals = &v
+	return s
+}
+
+// SetKeyPrefixEquals sets the KeyPrefixEquals field's value.
+func (s *Condition) SetKeyPrefixEquals(v string) *Condition {
+	s.KeyPrefixEquals = &v
+	return s
 }
 
 type CopyObjectInput struct {
@@ -4495,6 +4759,192 @@ func (s *CopyObjectInput) Validate() error {
 	return nil
 }
 
+// SetACL sets the ACL field's value.
+func (s *CopyObjectInput) SetACL(v string) *CopyObjectInput {
+	s.ACL = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *CopyObjectInput) SetBucket(v string) *CopyObjectInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetCacheControl sets the CacheControl field's value.
+func (s *CopyObjectInput) SetCacheControl(v string) *CopyObjectInput {
+	s.CacheControl = &v
+	return s
+}
+
+// SetContentDisposition sets the ContentDisposition field's value.
+func (s *CopyObjectInput) SetContentDisposition(v string) *CopyObjectInput {
+	s.ContentDisposition = &v
+	return s
+}
+
+// SetContentEncoding sets the ContentEncoding field's value.
+func (s *CopyObjectInput) SetContentEncoding(v string) *CopyObjectInput {
+	s.ContentEncoding = &v
+	return s
+}
+
+// SetContentLanguage sets the ContentLanguage field's value.
+func (s *CopyObjectInput) SetContentLanguage(v string) *CopyObjectInput {
+	s.ContentLanguage = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *CopyObjectInput) SetContentType(v string) *CopyObjectInput {
+	s.ContentType = &v
+	return s
+}
+
+// SetCopySource sets the CopySource field's value.
+func (s *CopyObjectInput) SetCopySource(v string) *CopyObjectInput {
+	s.CopySource = &v
+	return s
+}
+
+// SetCopySourceIfMatch sets the CopySourceIfMatch field's value.
+func (s *CopyObjectInput) SetCopySourceIfMatch(v string) *CopyObjectInput {
+	s.CopySourceIfMatch = &v
+	return s
+}
+
+// SetCopySourceIfModifiedSince sets the CopySourceIfModifiedSince field's value.
+func (s *CopyObjectInput) SetCopySourceIfModifiedSince(v time.Time) *CopyObjectInput {
+	s.CopySourceIfModifiedSince = &v
+	return s
+}
+
+// SetCopySourceIfNoneMatch sets the CopySourceIfNoneMatch field's value.
+func (s *CopyObjectInput) SetCopySourceIfNoneMatch(v string) *CopyObjectInput {
+	s.CopySourceIfNoneMatch = &v
+	return s
+}
+
+// SetCopySourceIfUnmodifiedSince sets the CopySourceIfUnmodifiedSince field's value.
+func (s *CopyObjectInput) SetCopySourceIfUnmodifiedSince(v time.Time) *CopyObjectInput {
+	s.CopySourceIfUnmodifiedSince = &v
+	return s
+}
+
+// SetCopySourceSSECustomerAlgorithm sets the CopySourceSSECustomerAlgorithm field's value.
+func (s *CopyObjectInput) SetCopySourceSSECustomerAlgorithm(v string) *CopyObjectInput {
+	s.CopySourceSSECustomerAlgorithm = &v
+	return s
+}
+
+// SetCopySourceSSECustomerKey sets the CopySourceSSECustomerKey field's value.
+func (s *CopyObjectInput) SetCopySourceSSECustomerKey(v string) *CopyObjectInput {
+	s.CopySourceSSECustomerKey = &v
+	return s
+}
+
+// SetCopySourceSSECustomerKeyMD5 sets the CopySourceSSECustomerKeyMD5 field's value.
+func (s *CopyObjectInput) SetCopySourceSSECustomerKeyMD5(v string) *CopyObjectInput {
+	s.CopySourceSSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetExpires sets the Expires field's value.
+func (s *CopyObjectInput) SetExpires(v time.Time) *CopyObjectInput {
+	s.Expires = &v
+	return s
+}
+
+// SetGrantFullControl sets the GrantFullControl field's value.
+func (s *CopyObjectInput) SetGrantFullControl(v string) *CopyObjectInput {
+	s.GrantFullControl = &v
+	return s
+}
+
+// SetGrantRead sets the GrantRead field's value.
+func (s *CopyObjectInput) SetGrantRead(v string) *CopyObjectInput {
+	s.GrantRead = &v
+	return s
+}
+
+// SetGrantReadACP sets the GrantReadACP field's value.
+func (s *CopyObjectInput) SetGrantReadACP(v string) *CopyObjectInput {
+	s.GrantReadACP = &v
+	return s
+}
+
+// SetGrantWriteACP sets the GrantWriteACP field's value.
+func (s *CopyObjectInput) SetGrantWriteACP(v string) *CopyObjectInput {
+	s.GrantWriteACP = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *CopyObjectInput) SetKey(v string) *CopyObjectInput {
+	s.Key = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *CopyObjectInput) SetMetadata(v map[string]*string) *CopyObjectInput {
+	s.Metadata = v
+	return s
+}
+
+// SetMetadataDirective sets the MetadataDirective field's value.
+func (s *CopyObjectInput) SetMetadataDirective(v string) *CopyObjectInput {
+	s.MetadataDirective = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *CopyObjectInput) SetRequestPayer(v string) *CopyObjectInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *CopyObjectInput) SetSSECustomerAlgorithm(v string) *CopyObjectInput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKey sets the SSECustomerKey field's value.
+func (s *CopyObjectInput) SetSSECustomerKey(v string) *CopyObjectInput {
+	s.SSECustomerKey = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *CopyObjectInput) SetSSECustomerKeyMD5(v string) *CopyObjectInput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *CopyObjectInput) SetSSEKMSKeyId(v string) *CopyObjectInput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *CopyObjectInput) SetServerSideEncryption(v string) *CopyObjectInput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *CopyObjectInput) SetStorageClass(v string) *CopyObjectInput {
+	s.StorageClass = &v
+	return s
+}
+
+// SetWebsiteRedirectLocation sets the WebsiteRedirectLocation field's value.
+func (s *CopyObjectInput) SetWebsiteRedirectLocation(v string) *CopyObjectInput {
+	s.WebsiteRedirectLocation = &v
+	return s
+}
+
 type CopyObjectOutput struct {
 	_ struct{} `type:"structure" payload:"CopyObjectResult"`
 
@@ -4541,6 +4991,60 @@ func (s CopyObjectOutput) GoString() string {
 	return s.String()
 }
 
+// SetCopyObjectResult sets the CopyObjectResult field's value.
+func (s *CopyObjectOutput) SetCopyObjectResult(v *CopyObjectResult) *CopyObjectOutput {
+	s.CopyObjectResult = v
+	return s
+}
+
+// SetCopySourceVersionId sets the CopySourceVersionId field's value.
+func (s *CopyObjectOutput) SetCopySourceVersionId(v string) *CopyObjectOutput {
+	s.CopySourceVersionId = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *CopyObjectOutput) SetExpiration(v string) *CopyObjectOutput {
+	s.Expiration = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *CopyObjectOutput) SetRequestCharged(v string) *CopyObjectOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *CopyObjectOutput) SetSSECustomerAlgorithm(v string) *CopyObjectOutput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *CopyObjectOutput) SetSSECustomerKeyMD5(v string) *CopyObjectOutput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *CopyObjectOutput) SetSSEKMSKeyId(v string) *CopyObjectOutput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *CopyObjectOutput) SetServerSideEncryption(v string) *CopyObjectOutput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *CopyObjectOutput) SetVersionId(v string) *CopyObjectOutput {
+	s.VersionId = &v
+	return s
+}
+
 type CopyObjectResult struct {
 	_ struct{} `type:"structure"`
 
@@ -4557,6 +5061,18 @@ func (s CopyObjectResult) String() string {
 // GoString returns the string representation
 func (s CopyObjectResult) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *CopyObjectResult) SetETag(v string) *CopyObjectResult {
+	s.ETag = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *CopyObjectResult) SetLastModified(v time.Time) *CopyObjectResult {
+	s.LastModified = &v
+	return s
 }
 
 type CopyPartResult struct {
@@ -4579,6 +5095,18 @@ func (s CopyPartResult) GoString() string {
 	return s.String()
 }
 
+// SetETag sets the ETag field's value.
+func (s *CopyPartResult) SetETag(v string) *CopyPartResult {
+	s.ETag = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *CopyPartResult) SetLastModified(v time.Time) *CopyPartResult {
+	s.LastModified = &v
+	return s
+}
+
 type CreateBucketConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -4595,6 +5123,12 @@ func (s CreateBucketConfiguration) String() string {
 // GoString returns the string representation
 func (s CreateBucketConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetLocationConstraint sets the LocationConstraint field's value.
+func (s *CreateBucketConfiguration) SetLocationConstraint(v string) *CreateBucketConfiguration {
+	s.LocationConstraint = &v
+	return s
 }
 
 type CreateBucketInput struct {
@@ -4648,6 +5182,54 @@ func (s *CreateBucketInput) Validate() error {
 	return nil
 }
 
+// SetACL sets the ACL field's value.
+func (s *CreateBucketInput) SetACL(v string) *CreateBucketInput {
+	s.ACL = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *CreateBucketInput) SetBucket(v string) *CreateBucketInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetCreateBucketConfiguration sets the CreateBucketConfiguration field's value.
+func (s *CreateBucketInput) SetCreateBucketConfiguration(v *CreateBucketConfiguration) *CreateBucketInput {
+	s.CreateBucketConfiguration = v
+	return s
+}
+
+// SetGrantFullControl sets the GrantFullControl field's value.
+func (s *CreateBucketInput) SetGrantFullControl(v string) *CreateBucketInput {
+	s.GrantFullControl = &v
+	return s
+}
+
+// SetGrantRead sets the GrantRead field's value.
+func (s *CreateBucketInput) SetGrantRead(v string) *CreateBucketInput {
+	s.GrantRead = &v
+	return s
+}
+
+// SetGrantReadACP sets the GrantReadACP field's value.
+func (s *CreateBucketInput) SetGrantReadACP(v string) *CreateBucketInput {
+	s.GrantReadACP = &v
+	return s
+}
+
+// SetGrantWrite sets the GrantWrite field's value.
+func (s *CreateBucketInput) SetGrantWrite(v string) *CreateBucketInput {
+	s.GrantWrite = &v
+	return s
+}
+
+// SetGrantWriteACP sets the GrantWriteACP field's value.
+func (s *CreateBucketInput) SetGrantWriteACP(v string) *CreateBucketInput {
+	s.GrantWriteACP = &v
+	return s
+}
+
 type CreateBucketOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4662,6 +5244,12 @@ func (s CreateBucketOutput) String() string {
 // GoString returns the string representation
 func (s CreateBucketOutput) GoString() string {
 	return s.String()
+}
+
+// SetLocation sets the Location field's value.
+func (s *CreateBucketOutput) SetLocation(v string) *CreateBucketOutput {
+	s.Location = &v
+	return s
 }
 
 type CreateMultipartUploadInput struct {
@@ -4780,6 +5368,138 @@ func (s *CreateMultipartUploadInput) Validate() error {
 	return nil
 }
 
+// SetACL sets the ACL field's value.
+func (s *CreateMultipartUploadInput) SetACL(v string) *CreateMultipartUploadInput {
+	s.ACL = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *CreateMultipartUploadInput) SetBucket(v string) *CreateMultipartUploadInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetCacheControl sets the CacheControl field's value.
+func (s *CreateMultipartUploadInput) SetCacheControl(v string) *CreateMultipartUploadInput {
+	s.CacheControl = &v
+	return s
+}
+
+// SetContentDisposition sets the ContentDisposition field's value.
+func (s *CreateMultipartUploadInput) SetContentDisposition(v string) *CreateMultipartUploadInput {
+	s.ContentDisposition = &v
+	return s
+}
+
+// SetContentEncoding sets the ContentEncoding field's value.
+func (s *CreateMultipartUploadInput) SetContentEncoding(v string) *CreateMultipartUploadInput {
+	s.ContentEncoding = &v
+	return s
+}
+
+// SetContentLanguage sets the ContentLanguage field's value.
+func (s *CreateMultipartUploadInput) SetContentLanguage(v string) *CreateMultipartUploadInput {
+	s.ContentLanguage = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *CreateMultipartUploadInput) SetContentType(v string) *CreateMultipartUploadInput {
+	s.ContentType = &v
+	return s
+}
+
+// SetExpires sets the Expires field's value.
+func (s *CreateMultipartUploadInput) SetExpires(v time.Time) *CreateMultipartUploadInput {
+	s.Expires = &v
+	return s
+}
+
+// SetGrantFullControl sets the GrantFullControl field's value.
+func (s *CreateMultipartUploadInput) SetGrantFullControl(v string) *CreateMultipartUploadInput {
+	s.GrantFullControl = &v
+	return s
+}
+
+// SetGrantRead sets the GrantRead field's value.
+func (s *CreateMultipartUploadInput) SetGrantRead(v string) *CreateMultipartUploadInput {
+	s.GrantRead = &v
+	return s
+}
+
+// SetGrantReadACP sets the GrantReadACP field's value.
+func (s *CreateMultipartUploadInput) SetGrantReadACP(v string) *CreateMultipartUploadInput {
+	s.GrantReadACP = &v
+	return s
+}
+
+// SetGrantWriteACP sets the GrantWriteACP field's value.
+func (s *CreateMultipartUploadInput) SetGrantWriteACP(v string) *CreateMultipartUploadInput {
+	s.GrantWriteACP = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *CreateMultipartUploadInput) SetKey(v string) *CreateMultipartUploadInput {
+	s.Key = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *CreateMultipartUploadInput) SetMetadata(v map[string]*string) *CreateMultipartUploadInput {
+	s.Metadata = v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *CreateMultipartUploadInput) SetRequestPayer(v string) *CreateMultipartUploadInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *CreateMultipartUploadInput) SetSSECustomerAlgorithm(v string) *CreateMultipartUploadInput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKey sets the SSECustomerKey field's value.
+func (s *CreateMultipartUploadInput) SetSSECustomerKey(v string) *CreateMultipartUploadInput {
+	s.SSECustomerKey = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *CreateMultipartUploadInput) SetSSECustomerKeyMD5(v string) *CreateMultipartUploadInput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *CreateMultipartUploadInput) SetSSEKMSKeyId(v string) *CreateMultipartUploadInput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *CreateMultipartUploadInput) SetServerSideEncryption(v string) *CreateMultipartUploadInput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *CreateMultipartUploadInput) SetStorageClass(v string) *CreateMultipartUploadInput {
+	s.StorageClass = &v
+	return s
+}
+
+// SetWebsiteRedirectLocation sets the WebsiteRedirectLocation field's value.
+func (s *CreateMultipartUploadInput) SetWebsiteRedirectLocation(v string) *CreateMultipartUploadInput {
+	s.WebsiteRedirectLocation = &v
+	return s
+}
+
 type CreateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4832,6 +5552,66 @@ func (s CreateMultipartUploadOutput) GoString() string {
 	return s.String()
 }
 
+// SetAbortDate sets the AbortDate field's value.
+func (s *CreateMultipartUploadOutput) SetAbortDate(v time.Time) *CreateMultipartUploadOutput {
+	s.AbortDate = &v
+	return s
+}
+
+// SetAbortRuleId sets the AbortRuleId field's value.
+func (s *CreateMultipartUploadOutput) SetAbortRuleId(v string) *CreateMultipartUploadOutput {
+	s.AbortRuleId = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *CreateMultipartUploadOutput) SetBucket(v string) *CreateMultipartUploadOutput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *CreateMultipartUploadOutput) SetKey(v string) *CreateMultipartUploadOutput {
+	s.Key = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *CreateMultipartUploadOutput) SetRequestCharged(v string) *CreateMultipartUploadOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *CreateMultipartUploadOutput) SetSSECustomerAlgorithm(v string) *CreateMultipartUploadOutput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *CreateMultipartUploadOutput) SetSSECustomerKeyMD5(v string) *CreateMultipartUploadOutput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *CreateMultipartUploadOutput) SetSSEKMSKeyId(v string) *CreateMultipartUploadOutput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *CreateMultipartUploadOutput) SetServerSideEncryption(v string) *CreateMultipartUploadOutput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *CreateMultipartUploadOutput) SetUploadId(v string) *CreateMultipartUploadOutput {
+	s.UploadId = &v
+	return s
+}
+
 type Delete struct {
 	_ struct{} `type:"structure"`
 
@@ -4876,6 +5656,18 @@ func (s *Delete) Validate() error {
 	return nil
 }
 
+// SetObjects sets the Objects field's value.
+func (s *Delete) SetObjects(v []*ObjectIdentifier) *Delete {
+	s.Objects = v
+	return s
+}
+
+// SetQuiet sets the Quiet field's value.
+func (s *Delete) SetQuiet(v bool) *Delete {
+	s.Quiet = &v
+	return s
+}
+
 type DeleteBucketCorsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4904,6 +5696,12 @@ func (s *DeleteBucketCorsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketCorsInput) SetBucket(v string) *DeleteBucketCorsInput {
+	s.Bucket = &v
+	return s
 }
 
 type DeleteBucketCorsOutput struct {
@@ -4950,6 +5748,12 @@ func (s *DeleteBucketInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketInput) SetBucket(v string) *DeleteBucketInput {
+	s.Bucket = &v
+	return s
+}
+
 type DeleteBucketLifecycleInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4978,6 +5782,12 @@ func (s *DeleteBucketLifecycleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketLifecycleInput) SetBucket(v string) *DeleteBucketLifecycleInput {
+	s.Bucket = &v
+	return s
 }
 
 type DeleteBucketLifecycleOutput struct {
@@ -5038,6 +5848,12 @@ func (s *DeleteBucketPolicyInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketPolicyInput) SetBucket(v string) *DeleteBucketPolicyInput {
+	s.Bucket = &v
+	return s
+}
+
 type DeleteBucketPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5080,6 +5896,12 @@ func (s *DeleteBucketReplicationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketReplicationInput) SetBucket(v string) *DeleteBucketReplicationInput {
+	s.Bucket = &v
+	return s
 }
 
 type DeleteBucketReplicationOutput struct {
@@ -5126,6 +5948,12 @@ func (s *DeleteBucketTaggingInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketTaggingInput) SetBucket(v string) *DeleteBucketTaggingInput {
+	s.Bucket = &v
+	return s
+}
+
 type DeleteBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5170,6 +5998,12 @@ func (s *DeleteBucketWebsiteInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketWebsiteInput) SetBucket(v string) *DeleteBucketWebsiteInput {
+	s.Bucket = &v
+	return s
+}
+
 type DeleteBucketWebsiteOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5211,6 +6045,36 @@ func (s DeleteMarkerEntry) String() string {
 // GoString returns the string representation
 func (s DeleteMarkerEntry) GoString() string {
 	return s.String()
+}
+
+// SetIsLatest sets the IsLatest field's value.
+func (s *DeleteMarkerEntry) SetIsLatest(v bool) *DeleteMarkerEntry {
+	s.IsLatest = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *DeleteMarkerEntry) SetKey(v string) *DeleteMarkerEntry {
+	s.Key = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *DeleteMarkerEntry) SetLastModified(v time.Time) *DeleteMarkerEntry {
+	s.LastModified = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *DeleteMarkerEntry) SetOwner(v *Owner) *DeleteMarkerEntry {
+	s.Owner = v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *DeleteMarkerEntry) SetVersionId(v string) *DeleteMarkerEntry {
+	s.VersionId = &v
+	return s
 }
 
 type DeleteObjectInput struct {
@@ -5265,6 +6129,36 @@ func (s *DeleteObjectInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *DeleteObjectInput) SetBucket(v string) *DeleteObjectInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *DeleteObjectInput) SetKey(v string) *DeleteObjectInput {
+	s.Key = &v
+	return s
+}
+
+// SetMFA sets the MFA field's value.
+func (s *DeleteObjectInput) SetMFA(v string) *DeleteObjectInput {
+	s.MFA = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *DeleteObjectInput) SetRequestPayer(v string) *DeleteObjectInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *DeleteObjectInput) SetVersionId(v string) *DeleteObjectInput {
+	s.VersionId = &v
+	return s
+}
+
 type DeleteObjectOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5289,6 +6183,24 @@ func (s DeleteObjectOutput) String() string {
 // GoString returns the string representation
 func (s DeleteObjectOutput) GoString() string {
 	return s.String()
+}
+
+// SetDeleteMarker sets the DeleteMarker field's value.
+func (s *DeleteObjectOutput) SetDeleteMarker(v bool) *DeleteObjectOutput {
+	s.DeleteMarker = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *DeleteObjectOutput) SetRequestCharged(v string) *DeleteObjectOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *DeleteObjectOutput) SetVersionId(v string) *DeleteObjectOutput {
+	s.VersionId = &v
+	return s
 }
 
 type DeleteObjectsInput struct {
@@ -5342,6 +6254,30 @@ func (s *DeleteObjectsInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *DeleteObjectsInput) SetBucket(v string) *DeleteObjectsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetDelete sets the Delete field's value.
+func (s *DeleteObjectsInput) SetDelete(v *Delete) *DeleteObjectsInput {
+	s.Delete = v
+	return s
+}
+
+// SetMFA sets the MFA field's value.
+func (s *DeleteObjectsInput) SetMFA(v string) *DeleteObjectsInput {
+	s.MFA = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *DeleteObjectsInput) SetRequestPayer(v string) *DeleteObjectsInput {
+	s.RequestPayer = &v
+	return s
+}
+
 type DeleteObjectsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5364,6 +6300,24 @@ func (s DeleteObjectsOutput) GoString() string {
 	return s.String()
 }
 
+// SetDeleted sets the Deleted field's value.
+func (s *DeleteObjectsOutput) SetDeleted(v []*DeletedObject) *DeleteObjectsOutput {
+	s.Deleted = v
+	return s
+}
+
+// SetErrors sets the Errors field's value.
+func (s *DeleteObjectsOutput) SetErrors(v []*Error) *DeleteObjectsOutput {
+	s.Errors = v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *DeleteObjectsOutput) SetRequestCharged(v string) *DeleteObjectsOutput {
+	s.RequestCharged = &v
+	return s
+}
+
 type DeletedObject struct {
 	_ struct{} `type:"structure"`
 
@@ -5384,6 +6338,30 @@ func (s DeletedObject) String() string {
 // GoString returns the string representation
 func (s DeletedObject) GoString() string {
 	return s.String()
+}
+
+// SetDeleteMarker sets the DeleteMarker field's value.
+func (s *DeletedObject) SetDeleteMarker(v bool) *DeletedObject {
+	s.DeleteMarker = &v
+	return s
+}
+
+// SetDeleteMarkerVersionId sets the DeleteMarkerVersionId field's value.
+func (s *DeletedObject) SetDeleteMarkerVersionId(v string) *DeletedObject {
+	s.DeleteMarkerVersionId = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *DeletedObject) SetKey(v string) *DeletedObject {
+	s.Key = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *DeletedObject) SetVersionId(v string) *DeletedObject {
+	s.VersionId = &v
+	return s
 }
 
 type Destination struct {
@@ -5422,6 +6400,18 @@ func (s *Destination) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *Destination) SetBucket(v string) *Destination {
+	s.Bucket = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *Destination) SetStorageClass(v string) *Destination {
+	s.StorageClass = &v
+	return s
+}
+
 type Error struct {
 	_ struct{} `type:"structure"`
 
@@ -5442,6 +6432,30 @@ func (s Error) String() string {
 // GoString returns the string representation
 func (s Error) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *Error) SetCode(v string) *Error {
+	s.Code = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *Error) SetKey(v string) *Error {
+	s.Key = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Error) SetMessage(v string) *Error {
+	s.Message = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *Error) SetVersionId(v string) *Error {
+	s.VersionId = &v
+	return s
 }
 
 type ErrorDocument struct {
@@ -5479,6 +6493,12 @@ func (s *ErrorDocument) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *ErrorDocument) SetKey(v string) *ErrorDocument {
+	s.Key = &v
+	return s
+}
+
 // Container for key value pair that defines the criteria for the filter rule.
 type FilterRule struct {
 	_ struct{} `type:"structure"`
@@ -5500,6 +6520,18 @@ func (s FilterRule) String() string {
 // GoString returns the string representation
 func (s FilterRule) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *FilterRule) SetName(v string) *FilterRule {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *FilterRule) SetValue(v string) *FilterRule {
+	s.Value = &v
+	return s
 }
 
 type GetBucketAccelerateConfigurationInput struct {
@@ -5534,6 +6566,12 @@ func (s *GetBucketAccelerateConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketAccelerateConfigurationInput) SetBucket(v string) *GetBucketAccelerateConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5549,6 +6587,12 @@ func (s GetBucketAccelerateConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketAccelerateConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetBucketAccelerateConfigurationOutput) SetStatus(v string) *GetBucketAccelerateConfigurationOutput {
+	s.Status = &v
+	return s
 }
 
 type GetBucketAclInput struct {
@@ -5581,6 +6625,12 @@ func (s *GetBucketAclInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketAclInput) SetBucket(v string) *GetBucketAclInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketAclOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5598,6 +6648,18 @@ func (s GetBucketAclOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketAclOutput) GoString() string {
 	return s.String()
+}
+
+// SetGrants sets the Grants field's value.
+func (s *GetBucketAclOutput) SetGrants(v []*Grant) *GetBucketAclOutput {
+	s.Grants = v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *GetBucketAclOutput) SetOwner(v *Owner) *GetBucketAclOutput {
+	s.Owner = v
+	return s
 }
 
 type GetBucketCorsInput struct {
@@ -5630,6 +6692,12 @@ func (s *GetBucketCorsInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketCorsInput) SetBucket(v string) *GetBucketCorsInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5644,6 +6712,12 @@ func (s GetBucketCorsOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketCorsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCORSRules sets the CORSRules field's value.
+func (s *GetBucketCorsOutput) SetCORSRules(v []*CORSRule) *GetBucketCorsOutput {
+	s.CORSRules = v
+	return s
 }
 
 type GetBucketLifecycleConfigurationInput struct {
@@ -5676,6 +6750,12 @@ func (s *GetBucketLifecycleConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketLifecycleConfigurationInput) SetBucket(v string) *GetBucketLifecycleConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketLifecycleConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5690,6 +6770,12 @@ func (s GetBucketLifecycleConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketLifecycleConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// SetRules sets the Rules field's value.
+func (s *GetBucketLifecycleConfigurationOutput) SetRules(v []*LifecycleRule) *GetBucketLifecycleConfigurationOutput {
+	s.Rules = v
+	return s
 }
 
 type GetBucketLifecycleInput struct {
@@ -5722,6 +6808,12 @@ func (s *GetBucketLifecycleInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketLifecycleInput) SetBucket(v string) *GetBucketLifecycleInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5736,6 +6828,12 @@ func (s GetBucketLifecycleOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketLifecycleOutput) GoString() string {
 	return s.String()
+}
+
+// SetRules sets the Rules field's value.
+func (s *GetBucketLifecycleOutput) SetRules(v []*Rule) *GetBucketLifecycleOutput {
+	s.Rules = v
+	return s
 }
 
 type GetBucketLocationInput struct {
@@ -5768,6 +6866,12 @@ func (s *GetBucketLocationInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketLocationInput) SetBucket(v string) *GetBucketLocationInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketLocationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5782,6 +6886,12 @@ func (s GetBucketLocationOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketLocationOutput) GoString() string {
 	return s.String()
+}
+
+// SetLocationConstraint sets the LocationConstraint field's value.
+func (s *GetBucketLocationOutput) SetLocationConstraint(v string) *GetBucketLocationOutput {
+	s.LocationConstraint = &v
+	return s
 }
 
 type GetBucketLoggingInput struct {
@@ -5814,6 +6924,12 @@ func (s *GetBucketLoggingInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketLoggingInput) SetBucket(v string) *GetBucketLoggingInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketLoggingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5828,6 +6944,12 @@ func (s GetBucketLoggingOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketLoggingOutput) GoString() string {
 	return s.String()
+}
+
+// SetLoggingEnabled sets the LoggingEnabled field's value.
+func (s *GetBucketLoggingOutput) SetLoggingEnabled(v *LoggingEnabled) *GetBucketLoggingOutput {
+	s.LoggingEnabled = v
+	return s
 }
 
 type GetBucketNotificationConfigurationRequest struct {
@@ -5862,6 +6984,12 @@ func (s *GetBucketNotificationConfigurationRequest) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketNotificationConfigurationRequest) SetBucket(v string) *GetBucketNotificationConfigurationRequest {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketPolicyInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5892,6 +7020,12 @@ func (s *GetBucketPolicyInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketPolicyInput) SetBucket(v string) *GetBucketPolicyInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketPolicyOutput struct {
 	_ struct{} `type:"structure" payload:"Policy"`
 
@@ -5907,6 +7041,12 @@ func (s GetBucketPolicyOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetBucketPolicyOutput) SetPolicy(v string) *GetBucketPolicyOutput {
+	s.Policy = &v
+	return s
 }
 
 type GetBucketReplicationInput struct {
@@ -5939,6 +7079,12 @@ func (s *GetBucketReplicationInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketReplicationInput) SetBucket(v string) *GetBucketReplicationInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketReplicationOutput struct {
 	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
 
@@ -5955,6 +7101,12 @@ func (s GetBucketReplicationOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketReplicationOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationConfiguration sets the ReplicationConfiguration field's value.
+func (s *GetBucketReplicationOutput) SetReplicationConfiguration(v *ReplicationConfiguration) *GetBucketReplicationOutput {
+	s.ReplicationConfiguration = v
+	return s
 }
 
 type GetBucketRequestPaymentInput struct {
@@ -5987,6 +7139,12 @@ func (s *GetBucketRequestPaymentInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketRequestPaymentInput) SetBucket(v string) *GetBucketRequestPaymentInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6002,6 +7160,12 @@ func (s GetBucketRequestPaymentOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketRequestPaymentOutput) GoString() string {
 	return s.String()
+}
+
+// SetPayer sets the Payer field's value.
+func (s *GetBucketRequestPaymentOutput) SetPayer(v string) *GetBucketRequestPaymentOutput {
+	s.Payer = &v
+	return s
 }
 
 type GetBucketTaggingInput struct {
@@ -6034,6 +7198,12 @@ func (s *GetBucketTaggingInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketTaggingInput) SetBucket(v string) *GetBucketTaggingInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6049,6 +7219,12 @@ func (s GetBucketTaggingOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketTaggingOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagSet sets the TagSet field's value.
+func (s *GetBucketTaggingOutput) SetTagSet(v []*Tag) *GetBucketTaggingOutput {
+	s.TagSet = v
+	return s
 }
 
 type GetBucketVersioningInput struct {
@@ -6081,6 +7257,12 @@ func (s *GetBucketVersioningInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketVersioningInput) SetBucket(v string) *GetBucketVersioningInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketVersioningOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6101,6 +7283,18 @@ func (s GetBucketVersioningOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketVersioningOutput) GoString() string {
 	return s.String()
+}
+
+// SetMFADelete sets the MFADelete field's value.
+func (s *GetBucketVersioningOutput) SetMFADelete(v string) *GetBucketVersioningOutput {
+	s.MFADelete = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetBucketVersioningOutput) SetStatus(v string) *GetBucketVersioningOutput {
+	s.Status = &v
+	return s
 }
 
 type GetBucketWebsiteInput struct {
@@ -6133,6 +7327,12 @@ func (s *GetBucketWebsiteInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketWebsiteInput) SetBucket(v string) *GetBucketWebsiteInput {
+	s.Bucket = &v
+	return s
+}
+
 type GetBucketWebsiteOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6153,6 +7353,30 @@ func (s GetBucketWebsiteOutput) String() string {
 // GoString returns the string representation
 func (s GetBucketWebsiteOutput) GoString() string {
 	return s.String()
+}
+
+// SetErrorDocument sets the ErrorDocument field's value.
+func (s *GetBucketWebsiteOutput) SetErrorDocument(v *ErrorDocument) *GetBucketWebsiteOutput {
+	s.ErrorDocument = v
+	return s
+}
+
+// SetIndexDocument sets the IndexDocument field's value.
+func (s *GetBucketWebsiteOutput) SetIndexDocument(v *IndexDocument) *GetBucketWebsiteOutput {
+	s.IndexDocument = v
+	return s
+}
+
+// SetRedirectAllRequestsTo sets the RedirectAllRequestsTo field's value.
+func (s *GetBucketWebsiteOutput) SetRedirectAllRequestsTo(v *RedirectAllRequestsTo) *GetBucketWebsiteOutput {
+	s.RedirectAllRequestsTo = v
+	return s
+}
+
+// SetRoutingRules sets the RoutingRules field's value.
+func (s *GetBucketWebsiteOutput) SetRoutingRules(v []*RoutingRule) *GetBucketWebsiteOutput {
+	s.RoutingRules = v
+	return s
 }
 
 type GetObjectAclInput struct {
@@ -6203,6 +7427,30 @@ func (s *GetObjectAclInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetObjectAclInput) SetBucket(v string) *GetObjectAclInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *GetObjectAclInput) SetKey(v string) *GetObjectAclInput {
+	s.Key = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *GetObjectAclInput) SetRequestPayer(v string) *GetObjectAclInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *GetObjectAclInput) SetVersionId(v string) *GetObjectAclInput {
+	s.VersionId = &v
+	return s
+}
+
 type GetObjectAclOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6224,6 +7472,24 @@ func (s GetObjectAclOutput) String() string {
 // GoString returns the string representation
 func (s GetObjectAclOutput) GoString() string {
 	return s.String()
+}
+
+// SetGrants sets the Grants field's value.
+func (s *GetObjectAclOutput) SetGrants(v []*Grant) *GetObjectAclOutput {
+	s.Grants = v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *GetObjectAclOutput) SetOwner(v *Owner) *GetObjectAclOutput {
+	s.Owner = v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *GetObjectAclOutput) SetRequestCharged(v string) *GetObjectAclOutput {
+	s.RequestCharged = &v
+	return s
 }
 
 type GetObjectInput struct {
@@ -6330,6 +7596,120 @@ func (s *GetObjectInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *GetObjectInput) SetBucket(v string) *GetObjectInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetIfMatch sets the IfMatch field's value.
+func (s *GetObjectInput) SetIfMatch(v string) *GetObjectInput {
+	s.IfMatch = &v
+	return s
+}
+
+// SetIfModifiedSince sets the IfModifiedSince field's value.
+func (s *GetObjectInput) SetIfModifiedSince(v time.Time) *GetObjectInput {
+	s.IfModifiedSince = &v
+	return s
+}
+
+// SetIfNoneMatch sets the IfNoneMatch field's value.
+func (s *GetObjectInput) SetIfNoneMatch(v string) *GetObjectInput {
+	s.IfNoneMatch = &v
+	return s
+}
+
+// SetIfUnmodifiedSince sets the IfUnmodifiedSince field's value.
+func (s *GetObjectInput) SetIfUnmodifiedSince(v time.Time) *GetObjectInput {
+	s.IfUnmodifiedSince = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *GetObjectInput) SetKey(v string) *GetObjectInput {
+	s.Key = &v
+	return s
+}
+
+// SetPartNumber sets the PartNumber field's value.
+func (s *GetObjectInput) SetPartNumber(v int64) *GetObjectInput {
+	s.PartNumber = &v
+	return s
+}
+
+// SetRange sets the Range field's value.
+func (s *GetObjectInput) SetRange(v string) *GetObjectInput {
+	s.Range = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *GetObjectInput) SetRequestPayer(v string) *GetObjectInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetResponseCacheControl sets the ResponseCacheControl field's value.
+func (s *GetObjectInput) SetResponseCacheControl(v string) *GetObjectInput {
+	s.ResponseCacheControl = &v
+	return s
+}
+
+// SetResponseContentDisposition sets the ResponseContentDisposition field's value.
+func (s *GetObjectInput) SetResponseContentDisposition(v string) *GetObjectInput {
+	s.ResponseContentDisposition = &v
+	return s
+}
+
+// SetResponseContentEncoding sets the ResponseContentEncoding field's value.
+func (s *GetObjectInput) SetResponseContentEncoding(v string) *GetObjectInput {
+	s.ResponseContentEncoding = &v
+	return s
+}
+
+// SetResponseContentLanguage sets the ResponseContentLanguage field's value.
+func (s *GetObjectInput) SetResponseContentLanguage(v string) *GetObjectInput {
+	s.ResponseContentLanguage = &v
+	return s
+}
+
+// SetResponseContentType sets the ResponseContentType field's value.
+func (s *GetObjectInput) SetResponseContentType(v string) *GetObjectInput {
+	s.ResponseContentType = &v
+	return s
+}
+
+// SetResponseExpires sets the ResponseExpires field's value.
+func (s *GetObjectInput) SetResponseExpires(v time.Time) *GetObjectInput {
+	s.ResponseExpires = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *GetObjectInput) SetSSECustomerAlgorithm(v string) *GetObjectInput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKey sets the SSECustomerKey field's value.
+func (s *GetObjectInput) SetSSECustomerKey(v string) *GetObjectInput {
+	s.SSECustomerKey = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *GetObjectInput) SetSSECustomerKeyMD5(v string) *GetObjectInput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *GetObjectInput) SetVersionId(v string) *GetObjectInput {
+	s.VersionId = &v
+	return s
 }
 
 type GetObjectOutput struct {
@@ -6444,6 +7824,168 @@ func (s GetObjectOutput) GoString() string {
 	return s.String()
 }
 
+// SetAcceptRanges sets the AcceptRanges field's value.
+func (s *GetObjectOutput) SetAcceptRanges(v string) *GetObjectOutput {
+	s.AcceptRanges = &v
+	return s
+}
+
+// SetBody sets the Body field's value.
+func (s *GetObjectOutput) SetBody(v io.ReadCloser) *GetObjectOutput {
+	s.Body = v
+	return s
+}
+
+// SetCacheControl sets the CacheControl field's value.
+func (s *GetObjectOutput) SetCacheControl(v string) *GetObjectOutput {
+	s.CacheControl = &v
+	return s
+}
+
+// SetContentDisposition sets the ContentDisposition field's value.
+func (s *GetObjectOutput) SetContentDisposition(v string) *GetObjectOutput {
+	s.ContentDisposition = &v
+	return s
+}
+
+// SetContentEncoding sets the ContentEncoding field's value.
+func (s *GetObjectOutput) SetContentEncoding(v string) *GetObjectOutput {
+	s.ContentEncoding = &v
+	return s
+}
+
+// SetContentLanguage sets the ContentLanguage field's value.
+func (s *GetObjectOutput) SetContentLanguage(v string) *GetObjectOutput {
+	s.ContentLanguage = &v
+	return s
+}
+
+// SetContentLength sets the ContentLength field's value.
+func (s *GetObjectOutput) SetContentLength(v int64) *GetObjectOutput {
+	s.ContentLength = &v
+	return s
+}
+
+// SetContentRange sets the ContentRange field's value.
+func (s *GetObjectOutput) SetContentRange(v string) *GetObjectOutput {
+	s.ContentRange = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *GetObjectOutput) SetContentType(v string) *GetObjectOutput {
+	s.ContentType = &v
+	return s
+}
+
+// SetDeleteMarker sets the DeleteMarker field's value.
+func (s *GetObjectOutput) SetDeleteMarker(v bool) *GetObjectOutput {
+	s.DeleteMarker = &v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *GetObjectOutput) SetETag(v string) *GetObjectOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *GetObjectOutput) SetExpiration(v string) *GetObjectOutput {
+	s.Expiration = &v
+	return s
+}
+
+// SetExpires sets the Expires field's value.
+func (s *GetObjectOutput) SetExpires(v string) *GetObjectOutput {
+	s.Expires = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *GetObjectOutput) SetLastModified(v time.Time) *GetObjectOutput {
+	s.LastModified = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *GetObjectOutput) SetMetadata(v map[string]*string) *GetObjectOutput {
+	s.Metadata = v
+	return s
+}
+
+// SetMissingMeta sets the MissingMeta field's value.
+func (s *GetObjectOutput) SetMissingMeta(v int64) *GetObjectOutput {
+	s.MissingMeta = &v
+	return s
+}
+
+// SetPartsCount sets the PartsCount field's value.
+func (s *GetObjectOutput) SetPartsCount(v int64) *GetObjectOutput {
+	s.PartsCount = &v
+	return s
+}
+
+// SetReplicationStatus sets the ReplicationStatus field's value.
+func (s *GetObjectOutput) SetReplicationStatus(v string) *GetObjectOutput {
+	s.ReplicationStatus = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *GetObjectOutput) SetRequestCharged(v string) *GetObjectOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetRestore sets the Restore field's value.
+func (s *GetObjectOutput) SetRestore(v string) *GetObjectOutput {
+	s.Restore = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *GetObjectOutput) SetSSECustomerAlgorithm(v string) *GetObjectOutput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *GetObjectOutput) SetSSECustomerKeyMD5(v string) *GetObjectOutput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *GetObjectOutput) SetSSEKMSKeyId(v string) *GetObjectOutput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *GetObjectOutput) SetServerSideEncryption(v string) *GetObjectOutput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *GetObjectOutput) SetStorageClass(v string) *GetObjectOutput {
+	s.StorageClass = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *GetObjectOutput) SetVersionId(v string) *GetObjectOutput {
+	s.VersionId = &v
+	return s
+}
+
+// SetWebsiteRedirectLocation sets the WebsiteRedirectLocation field's value.
+func (s *GetObjectOutput) SetWebsiteRedirectLocation(v string) *GetObjectOutput {
+	s.WebsiteRedirectLocation = &v
+	return s
+}
+
 type GetObjectTorrentInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6489,6 +8031,24 @@ func (s *GetObjectTorrentInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *GetObjectTorrentInput) SetBucket(v string) *GetObjectTorrentInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *GetObjectTorrentInput) SetKey(v string) *GetObjectTorrentInput {
+	s.Key = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *GetObjectTorrentInput) SetRequestPayer(v string) *GetObjectTorrentInput {
+	s.RequestPayer = &v
+	return s
+}
+
 type GetObjectTorrentOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
 
@@ -6507,6 +8067,18 @@ func (s GetObjectTorrentOutput) String() string {
 // GoString returns the string representation
 func (s GetObjectTorrentOutput) GoString() string {
 	return s.String()
+}
+
+// SetBody sets the Body field's value.
+func (s *GetObjectTorrentOutput) SetBody(v io.ReadCloser) *GetObjectTorrentOutput {
+	s.Body = v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *GetObjectTorrentOutput) SetRequestCharged(v string) *GetObjectTorrentOutput {
+	s.RequestCharged = &v
+	return s
 }
 
 type Grant struct {
@@ -6541,6 +8113,18 @@ func (s *Grant) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGrantee sets the Grantee field's value.
+func (s *Grant) SetGrantee(v *Grantee) *Grant {
+	s.Grantee = v
+	return s
+}
+
+// SetPermission sets the Permission field's value.
+func (s *Grant) SetPermission(v string) *Grant {
+	s.Permission = &v
+	return s
 }
 
 type Grantee struct {
@@ -6587,6 +8171,36 @@ func (s *Grantee) Validate() error {
 	return nil
 }
 
+// SetDisplayName sets the DisplayName field's value.
+func (s *Grantee) SetDisplayName(v string) *Grantee {
+	s.DisplayName = &v
+	return s
+}
+
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *Grantee) SetEmailAddress(v string) *Grantee {
+	s.EmailAddress = &v
+	return s
+}
+
+// SetID sets the ID field's value.
+func (s *Grantee) SetID(v string) *Grantee {
+	s.ID = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Grantee) SetType(v string) *Grantee {
+	s.Type = &v
+	return s
+}
+
+// SetURI sets the URI field's value.
+func (s *Grantee) SetURI(v string) *Grantee {
+	s.URI = &v
+	return s
+}
+
 type HeadBucketInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6615,6 +8229,12 @@ func (s *HeadBucketInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *HeadBucketInput) SetBucket(v string) *HeadBucketInput {
+	s.Bucket = &v
+	return s
 }
 
 type HeadBucketOutput struct {
@@ -6718,6 +8338,84 @@ func (s *HeadObjectInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *HeadObjectInput) SetBucket(v string) *HeadObjectInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetIfMatch sets the IfMatch field's value.
+func (s *HeadObjectInput) SetIfMatch(v string) *HeadObjectInput {
+	s.IfMatch = &v
+	return s
+}
+
+// SetIfModifiedSince sets the IfModifiedSince field's value.
+func (s *HeadObjectInput) SetIfModifiedSince(v time.Time) *HeadObjectInput {
+	s.IfModifiedSince = &v
+	return s
+}
+
+// SetIfNoneMatch sets the IfNoneMatch field's value.
+func (s *HeadObjectInput) SetIfNoneMatch(v string) *HeadObjectInput {
+	s.IfNoneMatch = &v
+	return s
+}
+
+// SetIfUnmodifiedSince sets the IfUnmodifiedSince field's value.
+func (s *HeadObjectInput) SetIfUnmodifiedSince(v time.Time) *HeadObjectInput {
+	s.IfUnmodifiedSince = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *HeadObjectInput) SetKey(v string) *HeadObjectInput {
+	s.Key = &v
+	return s
+}
+
+// SetPartNumber sets the PartNumber field's value.
+func (s *HeadObjectInput) SetPartNumber(v int64) *HeadObjectInput {
+	s.PartNumber = &v
+	return s
+}
+
+// SetRange sets the Range field's value.
+func (s *HeadObjectInput) SetRange(v string) *HeadObjectInput {
+	s.Range = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *HeadObjectInput) SetRequestPayer(v string) *HeadObjectInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *HeadObjectInput) SetSSECustomerAlgorithm(v string) *HeadObjectInput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKey sets the SSECustomerKey field's value.
+func (s *HeadObjectInput) SetSSECustomerKey(v string) *HeadObjectInput {
+	s.SSECustomerKey = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *HeadObjectInput) SetSSECustomerKeyMD5(v string) *HeadObjectInput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *HeadObjectInput) SetVersionId(v string) *HeadObjectInput {
+	s.VersionId = &v
+	return s
 }
 
 type HeadObjectOutput struct {
@@ -6826,6 +8524,156 @@ func (s HeadObjectOutput) GoString() string {
 	return s.String()
 }
 
+// SetAcceptRanges sets the AcceptRanges field's value.
+func (s *HeadObjectOutput) SetAcceptRanges(v string) *HeadObjectOutput {
+	s.AcceptRanges = &v
+	return s
+}
+
+// SetCacheControl sets the CacheControl field's value.
+func (s *HeadObjectOutput) SetCacheControl(v string) *HeadObjectOutput {
+	s.CacheControl = &v
+	return s
+}
+
+// SetContentDisposition sets the ContentDisposition field's value.
+func (s *HeadObjectOutput) SetContentDisposition(v string) *HeadObjectOutput {
+	s.ContentDisposition = &v
+	return s
+}
+
+// SetContentEncoding sets the ContentEncoding field's value.
+func (s *HeadObjectOutput) SetContentEncoding(v string) *HeadObjectOutput {
+	s.ContentEncoding = &v
+	return s
+}
+
+// SetContentLanguage sets the ContentLanguage field's value.
+func (s *HeadObjectOutput) SetContentLanguage(v string) *HeadObjectOutput {
+	s.ContentLanguage = &v
+	return s
+}
+
+// SetContentLength sets the ContentLength field's value.
+func (s *HeadObjectOutput) SetContentLength(v int64) *HeadObjectOutput {
+	s.ContentLength = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *HeadObjectOutput) SetContentType(v string) *HeadObjectOutput {
+	s.ContentType = &v
+	return s
+}
+
+// SetDeleteMarker sets the DeleteMarker field's value.
+func (s *HeadObjectOutput) SetDeleteMarker(v bool) *HeadObjectOutput {
+	s.DeleteMarker = &v
+	return s
+}
+
+// SetETag sets the ETag field's value.
+func (s *HeadObjectOutput) SetETag(v string) *HeadObjectOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *HeadObjectOutput) SetExpiration(v string) *HeadObjectOutput {
+	s.Expiration = &v
+	return s
+}
+
+// SetExpires sets the Expires field's value.
+func (s *HeadObjectOutput) SetExpires(v string) *HeadObjectOutput {
+	s.Expires = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *HeadObjectOutput) SetLastModified(v time.Time) *HeadObjectOutput {
+	s.LastModified = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *HeadObjectOutput) SetMetadata(v map[string]*string) *HeadObjectOutput {
+	s.Metadata = v
+	return s
+}
+
+// SetMissingMeta sets the MissingMeta field's value.
+func (s *HeadObjectOutput) SetMissingMeta(v int64) *HeadObjectOutput {
+	s.MissingMeta = &v
+	return s
+}
+
+// SetPartsCount sets the PartsCount field's value.
+func (s *HeadObjectOutput) SetPartsCount(v int64) *HeadObjectOutput {
+	s.PartsCount = &v
+	return s
+}
+
+// SetReplicationStatus sets the ReplicationStatus field's value.
+func (s *HeadObjectOutput) SetReplicationStatus(v string) *HeadObjectOutput {
+	s.ReplicationStatus = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *HeadObjectOutput) SetRequestCharged(v string) *HeadObjectOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetRestore sets the Restore field's value.
+func (s *HeadObjectOutput) SetRestore(v string) *HeadObjectOutput {
+	s.Restore = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *HeadObjectOutput) SetSSECustomerAlgorithm(v string) *HeadObjectOutput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *HeadObjectOutput) SetSSECustomerKeyMD5(v string) *HeadObjectOutput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *HeadObjectOutput) SetSSEKMSKeyId(v string) *HeadObjectOutput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *HeadObjectOutput) SetServerSideEncryption(v string) *HeadObjectOutput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *HeadObjectOutput) SetStorageClass(v string) *HeadObjectOutput {
+	s.StorageClass = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *HeadObjectOutput) SetVersionId(v string) *HeadObjectOutput {
+	s.VersionId = &v
+	return s
+}
+
+// SetWebsiteRedirectLocation sets the WebsiteRedirectLocation field's value.
+func (s *HeadObjectOutput) SetWebsiteRedirectLocation(v string) *HeadObjectOutput {
+	s.WebsiteRedirectLocation = &v
+	return s
+}
+
 type IndexDocument struct {
 	_ struct{} `type:"structure"`
 
@@ -6861,6 +8709,12 @@ func (s *IndexDocument) Validate() error {
 	return nil
 }
 
+// SetSuffix sets the Suffix field's value.
+func (s *IndexDocument) SetSuffix(v string) *IndexDocument {
+	s.Suffix = &v
+	return s
+}
+
 type Initiator struct {
 	_ struct{} `type:"structure"`
 
@@ -6882,6 +8736,18 @@ func (s Initiator) GoString() string {
 	return s.String()
 }
 
+// SetDisplayName sets the DisplayName field's value.
+func (s *Initiator) SetDisplayName(v string) *Initiator {
+	s.DisplayName = &v
+	return s
+}
+
+// SetID sets the ID field's value.
+func (s *Initiator) SetID(v string) *Initiator {
+	s.ID = &v
+	return s
+}
+
 // Container for object key name prefix and suffix filtering rules.
 type KeyFilter struct {
 	_ struct{} `type:"structure"`
@@ -6899,6 +8765,12 @@ func (s KeyFilter) String() string {
 // GoString returns the string representation
 func (s KeyFilter) GoString() string {
 	return s.String()
+}
+
+// SetFilterRules sets the FilterRules field's value.
+func (s *KeyFilter) SetFilterRules(v []*FilterRule) *KeyFilter {
+	s.FilterRules = v
+	return s
 }
 
 // Container for specifying the AWS Lambda notification configuration.
@@ -6949,6 +8821,30 @@ func (s *LambdaFunctionConfiguration) Validate() error {
 	return nil
 }
 
+// SetEvents sets the Events field's value.
+func (s *LambdaFunctionConfiguration) SetEvents(v []*string) *LambdaFunctionConfiguration {
+	s.Events = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *LambdaFunctionConfiguration) SetFilter(v *NotificationConfigurationFilter) *LambdaFunctionConfiguration {
+	s.Filter = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *LambdaFunctionConfiguration) SetId(v string) *LambdaFunctionConfiguration {
+	s.Id = &v
+	return s
+}
+
+// SetLambdaFunctionArn sets the LambdaFunctionArn field's value.
+func (s *LambdaFunctionConfiguration) SetLambdaFunctionArn(v string) *LambdaFunctionConfiguration {
+	s.LambdaFunctionArn = &v
+	return s
+}
+
 type LifecycleConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -6989,6 +8885,12 @@ func (s *LifecycleConfiguration) Validate() error {
 	return nil
 }
 
+// SetRules sets the Rules field's value.
+func (s *LifecycleConfiguration) SetRules(v []*Rule) *LifecycleConfiguration {
+	s.Rules = v
+	return s
+}
+
 type LifecycleExpiration struct {
 	_ struct{} `type:"structure"`
 
@@ -7015,6 +8917,24 @@ func (s LifecycleExpiration) String() string {
 // GoString returns the string representation
 func (s LifecycleExpiration) GoString() string {
 	return s.String()
+}
+
+// SetDate sets the Date field's value.
+func (s *LifecycleExpiration) SetDate(v time.Time) *LifecycleExpiration {
+	s.Date = &v
+	return s
+}
+
+// SetDays sets the Days field's value.
+func (s *LifecycleExpiration) SetDays(v int64) *LifecycleExpiration {
+	s.Days = &v
+	return s
+}
+
+// SetExpiredObjectDeleteMarker sets the ExpiredObjectDeleteMarker field's value.
+func (s *LifecycleExpiration) SetExpiredObjectDeleteMarker(v bool) *LifecycleExpiration {
+	s.ExpiredObjectDeleteMarker = &v
+	return s
 }
 
 type LifecycleRule struct {
@@ -7078,6 +8998,54 @@ func (s *LifecycleRule) Validate() error {
 	return nil
 }
 
+// SetAbortIncompleteMultipartUpload sets the AbortIncompleteMultipartUpload field's value.
+func (s *LifecycleRule) SetAbortIncompleteMultipartUpload(v *AbortIncompleteMultipartUpload) *LifecycleRule {
+	s.AbortIncompleteMultipartUpload = v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *LifecycleRule) SetExpiration(v *LifecycleExpiration) *LifecycleRule {
+	s.Expiration = v
+	return s
+}
+
+// SetID sets the ID field's value.
+func (s *LifecycleRule) SetID(v string) *LifecycleRule {
+	s.ID = &v
+	return s
+}
+
+// SetNoncurrentVersionExpiration sets the NoncurrentVersionExpiration field's value.
+func (s *LifecycleRule) SetNoncurrentVersionExpiration(v *NoncurrentVersionExpiration) *LifecycleRule {
+	s.NoncurrentVersionExpiration = v
+	return s
+}
+
+// SetNoncurrentVersionTransitions sets the NoncurrentVersionTransitions field's value.
+func (s *LifecycleRule) SetNoncurrentVersionTransitions(v []*NoncurrentVersionTransition) *LifecycleRule {
+	s.NoncurrentVersionTransitions = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *LifecycleRule) SetPrefix(v string) *LifecycleRule {
+	s.Prefix = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *LifecycleRule) SetStatus(v string) *LifecycleRule {
+	s.Status = &v
+	return s
+}
+
+// SetTransitions sets the Transitions field's value.
+func (s *LifecycleRule) SetTransitions(v []*Transition) *LifecycleRule {
+	s.Transitions = v
+	return s
+}
+
 type ListBucketsInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7108,6 +9076,18 @@ func (s ListBucketsOutput) String() string {
 // GoString returns the string representation
 func (s ListBucketsOutput) GoString() string {
 	return s.String()
+}
+
+// SetBuckets sets the Buckets field's value.
+func (s *ListBucketsOutput) SetBuckets(v []*Bucket) *ListBucketsOutput {
+	s.Buckets = v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *ListBucketsOutput) SetOwner(v *Owner) *ListBucketsOutput {
+	s.Owner = v
+	return s
 }
 
 type ListMultipartUploadsInput struct {
@@ -7169,6 +9149,48 @@ func (s *ListMultipartUploadsInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *ListMultipartUploadsInput) SetBucket(v string) *ListMultipartUploadsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetDelimiter sets the Delimiter field's value.
+func (s *ListMultipartUploadsInput) SetDelimiter(v string) *ListMultipartUploadsInput {
+	s.Delimiter = &v
+	return s
+}
+
+// SetEncodingType sets the EncodingType field's value.
+func (s *ListMultipartUploadsInput) SetEncodingType(v string) *ListMultipartUploadsInput {
+	s.EncodingType = &v
+	return s
+}
+
+// SetKeyMarker sets the KeyMarker field's value.
+func (s *ListMultipartUploadsInput) SetKeyMarker(v string) *ListMultipartUploadsInput {
+	s.KeyMarker = &v
+	return s
+}
+
+// SetMaxUploads sets the MaxUploads field's value.
+func (s *ListMultipartUploadsInput) SetMaxUploads(v int64) *ListMultipartUploadsInput {
+	s.MaxUploads = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ListMultipartUploadsInput) SetPrefix(v string) *ListMultipartUploadsInput {
+	s.Prefix = &v
+	return s
+}
+
+// SetUploadIdMarker sets the UploadIdMarker field's value.
+func (s *ListMultipartUploadsInput) SetUploadIdMarker(v string) *ListMultipartUploadsInput {
+	s.UploadIdMarker = &v
+	return s
+}
+
 type ListMultipartUploadsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7221,6 +9243,78 @@ func (s ListMultipartUploadsOutput) String() string {
 // GoString returns the string representation
 func (s ListMultipartUploadsOutput) GoString() string {
 	return s.String()
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *ListMultipartUploadsOutput) SetBucket(v string) *ListMultipartUploadsOutput {
+	s.Bucket = &v
+	return s
+}
+
+// SetCommonPrefixes sets the CommonPrefixes field's value.
+func (s *ListMultipartUploadsOutput) SetCommonPrefixes(v []*CommonPrefix) *ListMultipartUploadsOutput {
+	s.CommonPrefixes = v
+	return s
+}
+
+// SetDelimiter sets the Delimiter field's value.
+func (s *ListMultipartUploadsOutput) SetDelimiter(v string) *ListMultipartUploadsOutput {
+	s.Delimiter = &v
+	return s
+}
+
+// SetEncodingType sets the EncodingType field's value.
+func (s *ListMultipartUploadsOutput) SetEncodingType(v string) *ListMultipartUploadsOutput {
+	s.EncodingType = &v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListMultipartUploadsOutput) SetIsTruncated(v bool) *ListMultipartUploadsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetKeyMarker sets the KeyMarker field's value.
+func (s *ListMultipartUploadsOutput) SetKeyMarker(v string) *ListMultipartUploadsOutput {
+	s.KeyMarker = &v
+	return s
+}
+
+// SetMaxUploads sets the MaxUploads field's value.
+func (s *ListMultipartUploadsOutput) SetMaxUploads(v int64) *ListMultipartUploadsOutput {
+	s.MaxUploads = &v
+	return s
+}
+
+// SetNextKeyMarker sets the NextKeyMarker field's value.
+func (s *ListMultipartUploadsOutput) SetNextKeyMarker(v string) *ListMultipartUploadsOutput {
+	s.NextKeyMarker = &v
+	return s
+}
+
+// SetNextUploadIdMarker sets the NextUploadIdMarker field's value.
+func (s *ListMultipartUploadsOutput) SetNextUploadIdMarker(v string) *ListMultipartUploadsOutput {
+	s.NextUploadIdMarker = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ListMultipartUploadsOutput) SetPrefix(v string) *ListMultipartUploadsOutput {
+	s.Prefix = &v
+	return s
+}
+
+// SetUploadIdMarker sets the UploadIdMarker field's value.
+func (s *ListMultipartUploadsOutput) SetUploadIdMarker(v string) *ListMultipartUploadsOutput {
+	s.UploadIdMarker = &v
+	return s
+}
+
+// SetUploads sets the Uploads field's value.
+func (s *ListMultipartUploadsOutput) SetUploads(v []*MultipartUpload) *ListMultipartUploadsOutput {
+	s.Uploads = v
+	return s
 }
 
 type ListObjectVersionsInput struct {
@@ -7277,6 +9371,48 @@ func (s *ListObjectVersionsInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *ListObjectVersionsInput) SetBucket(v string) *ListObjectVersionsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetDelimiter sets the Delimiter field's value.
+func (s *ListObjectVersionsInput) SetDelimiter(v string) *ListObjectVersionsInput {
+	s.Delimiter = &v
+	return s
+}
+
+// SetEncodingType sets the EncodingType field's value.
+func (s *ListObjectVersionsInput) SetEncodingType(v string) *ListObjectVersionsInput {
+	s.EncodingType = &v
+	return s
+}
+
+// SetKeyMarker sets the KeyMarker field's value.
+func (s *ListObjectVersionsInput) SetKeyMarker(v string) *ListObjectVersionsInput {
+	s.KeyMarker = &v
+	return s
+}
+
+// SetMaxKeys sets the MaxKeys field's value.
+func (s *ListObjectVersionsInput) SetMaxKeys(v int64) *ListObjectVersionsInput {
+	s.MaxKeys = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ListObjectVersionsInput) SetPrefix(v string) *ListObjectVersionsInput {
+	s.Prefix = &v
+	return s
+}
+
+// SetVersionIdMarker sets the VersionIdMarker field's value.
+func (s *ListObjectVersionsInput) SetVersionIdMarker(v string) *ListObjectVersionsInput {
+	s.VersionIdMarker = &v
+	return s
+}
+
 type ListObjectVersionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7324,6 +9460,84 @@ func (s ListObjectVersionsOutput) String() string {
 // GoString returns the string representation
 func (s ListObjectVersionsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCommonPrefixes sets the CommonPrefixes field's value.
+func (s *ListObjectVersionsOutput) SetCommonPrefixes(v []*CommonPrefix) *ListObjectVersionsOutput {
+	s.CommonPrefixes = v
+	return s
+}
+
+// SetDeleteMarkers sets the DeleteMarkers field's value.
+func (s *ListObjectVersionsOutput) SetDeleteMarkers(v []*DeleteMarkerEntry) *ListObjectVersionsOutput {
+	s.DeleteMarkers = v
+	return s
+}
+
+// SetDelimiter sets the Delimiter field's value.
+func (s *ListObjectVersionsOutput) SetDelimiter(v string) *ListObjectVersionsOutput {
+	s.Delimiter = &v
+	return s
+}
+
+// SetEncodingType sets the EncodingType field's value.
+func (s *ListObjectVersionsOutput) SetEncodingType(v string) *ListObjectVersionsOutput {
+	s.EncodingType = &v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListObjectVersionsOutput) SetIsTruncated(v bool) *ListObjectVersionsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetKeyMarker sets the KeyMarker field's value.
+func (s *ListObjectVersionsOutput) SetKeyMarker(v string) *ListObjectVersionsOutput {
+	s.KeyMarker = &v
+	return s
+}
+
+// SetMaxKeys sets the MaxKeys field's value.
+func (s *ListObjectVersionsOutput) SetMaxKeys(v int64) *ListObjectVersionsOutput {
+	s.MaxKeys = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ListObjectVersionsOutput) SetName(v string) *ListObjectVersionsOutput {
+	s.Name = &v
+	return s
+}
+
+// SetNextKeyMarker sets the NextKeyMarker field's value.
+func (s *ListObjectVersionsOutput) SetNextKeyMarker(v string) *ListObjectVersionsOutput {
+	s.NextKeyMarker = &v
+	return s
+}
+
+// SetNextVersionIdMarker sets the NextVersionIdMarker field's value.
+func (s *ListObjectVersionsOutput) SetNextVersionIdMarker(v string) *ListObjectVersionsOutput {
+	s.NextVersionIdMarker = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ListObjectVersionsOutput) SetPrefix(v string) *ListObjectVersionsOutput {
+	s.Prefix = &v
+	return s
+}
+
+// SetVersionIdMarker sets the VersionIdMarker field's value.
+func (s *ListObjectVersionsOutput) SetVersionIdMarker(v string) *ListObjectVersionsOutput {
+	s.VersionIdMarker = &v
+	return s
+}
+
+// SetVersions sets the Versions field's value.
+func (s *ListObjectVersionsOutput) SetVersions(v []*ObjectVersion) *ListObjectVersionsOutput {
+	s.Versions = v
+	return s
 }
 
 type ListObjectsInput struct {
@@ -7382,6 +9596,48 @@ func (s *ListObjectsInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *ListObjectsInput) SetBucket(v string) *ListObjectsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetDelimiter sets the Delimiter field's value.
+func (s *ListObjectsInput) SetDelimiter(v string) *ListObjectsInput {
+	s.Delimiter = &v
+	return s
+}
+
+// SetEncodingType sets the EncodingType field's value.
+func (s *ListObjectsInput) SetEncodingType(v string) *ListObjectsInput {
+	s.EncodingType = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListObjectsInput) SetMarker(v string) *ListObjectsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxKeys sets the MaxKeys field's value.
+func (s *ListObjectsInput) SetMaxKeys(v int64) *ListObjectsInput {
+	s.MaxKeys = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ListObjectsInput) SetPrefix(v string) *ListObjectsInput {
+	s.Prefix = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *ListObjectsInput) SetRequestPayer(v string) *ListObjectsInput {
+	s.RequestPayer = &v
+	return s
+}
+
 type ListObjectsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7424,6 +9680,66 @@ func (s ListObjectsOutput) String() string {
 // GoString returns the string representation
 func (s ListObjectsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCommonPrefixes sets the CommonPrefixes field's value.
+func (s *ListObjectsOutput) SetCommonPrefixes(v []*CommonPrefix) *ListObjectsOutput {
+	s.CommonPrefixes = v
+	return s
+}
+
+// SetContents sets the Contents field's value.
+func (s *ListObjectsOutput) SetContents(v []*Object) *ListObjectsOutput {
+	s.Contents = v
+	return s
+}
+
+// SetDelimiter sets the Delimiter field's value.
+func (s *ListObjectsOutput) SetDelimiter(v string) *ListObjectsOutput {
+	s.Delimiter = &v
+	return s
+}
+
+// SetEncodingType sets the EncodingType field's value.
+func (s *ListObjectsOutput) SetEncodingType(v string) *ListObjectsOutput {
+	s.EncodingType = &v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListObjectsOutput) SetIsTruncated(v bool) *ListObjectsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListObjectsOutput) SetMarker(v string) *ListObjectsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxKeys sets the MaxKeys field's value.
+func (s *ListObjectsOutput) SetMaxKeys(v int64) *ListObjectsOutput {
+	s.MaxKeys = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ListObjectsOutput) SetName(v string) *ListObjectsOutput {
+	s.Name = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListObjectsOutput) SetNextMarker(v string) *ListObjectsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ListObjectsOutput) SetPrefix(v string) *ListObjectsOutput {
+	s.Prefix = &v
+	return s
 }
 
 type ListObjectsV2Input struct {
@@ -7490,6 +9806,60 @@ func (s *ListObjectsV2Input) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *ListObjectsV2Input) SetBucket(v string) *ListObjectsV2Input {
+	s.Bucket = &v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ListObjectsV2Input) SetContinuationToken(v string) *ListObjectsV2Input {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetDelimiter sets the Delimiter field's value.
+func (s *ListObjectsV2Input) SetDelimiter(v string) *ListObjectsV2Input {
+	s.Delimiter = &v
+	return s
+}
+
+// SetEncodingType sets the EncodingType field's value.
+func (s *ListObjectsV2Input) SetEncodingType(v string) *ListObjectsV2Input {
+	s.EncodingType = &v
+	return s
+}
+
+// SetFetchOwner sets the FetchOwner field's value.
+func (s *ListObjectsV2Input) SetFetchOwner(v bool) *ListObjectsV2Input {
+	s.FetchOwner = &v
+	return s
+}
+
+// SetMaxKeys sets the MaxKeys field's value.
+func (s *ListObjectsV2Input) SetMaxKeys(v int64) *ListObjectsV2Input {
+	s.MaxKeys = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ListObjectsV2Input) SetPrefix(v string) *ListObjectsV2Input {
+	s.Prefix = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *ListObjectsV2Input) SetRequestPayer(v string) *ListObjectsV2Input {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetStartAfter sets the StartAfter field's value.
+func (s *ListObjectsV2Input) SetStartAfter(v string) *ListObjectsV2Input {
+	s.StartAfter = &v
+	return s
+}
+
 type ListObjectsV2Output struct {
 	_ struct{} `type:"structure"`
 
@@ -7549,6 +9919,78 @@ func (s ListObjectsV2Output) String() string {
 // GoString returns the string representation
 func (s ListObjectsV2Output) GoString() string {
 	return s.String()
+}
+
+// SetCommonPrefixes sets the CommonPrefixes field's value.
+func (s *ListObjectsV2Output) SetCommonPrefixes(v []*CommonPrefix) *ListObjectsV2Output {
+	s.CommonPrefixes = v
+	return s
+}
+
+// SetContents sets the Contents field's value.
+func (s *ListObjectsV2Output) SetContents(v []*Object) *ListObjectsV2Output {
+	s.Contents = v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ListObjectsV2Output) SetContinuationToken(v string) *ListObjectsV2Output {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetDelimiter sets the Delimiter field's value.
+func (s *ListObjectsV2Output) SetDelimiter(v string) *ListObjectsV2Output {
+	s.Delimiter = &v
+	return s
+}
+
+// SetEncodingType sets the EncodingType field's value.
+func (s *ListObjectsV2Output) SetEncodingType(v string) *ListObjectsV2Output {
+	s.EncodingType = &v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListObjectsV2Output) SetIsTruncated(v bool) *ListObjectsV2Output {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetKeyCount sets the KeyCount field's value.
+func (s *ListObjectsV2Output) SetKeyCount(v int64) *ListObjectsV2Output {
+	s.KeyCount = &v
+	return s
+}
+
+// SetMaxKeys sets the MaxKeys field's value.
+func (s *ListObjectsV2Output) SetMaxKeys(v int64) *ListObjectsV2Output {
+	s.MaxKeys = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ListObjectsV2Output) SetName(v string) *ListObjectsV2Output {
+	s.Name = &v
+	return s
+}
+
+// SetNextContinuationToken sets the NextContinuationToken field's value.
+func (s *ListObjectsV2Output) SetNextContinuationToken(v string) *ListObjectsV2Output {
+	s.NextContinuationToken = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ListObjectsV2Output) SetPrefix(v string) *ListObjectsV2Output {
+	s.Prefix = &v
+	return s
+}
+
+// SetStartAfter sets the StartAfter field's value.
+func (s *ListObjectsV2Output) SetStartAfter(v string) *ListObjectsV2Output {
+	s.StartAfter = &v
+	return s
 }
 
 type ListPartsInput struct {
@@ -7611,6 +10053,42 @@ func (s *ListPartsInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *ListPartsInput) SetBucket(v string) *ListPartsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *ListPartsInput) SetKey(v string) *ListPartsInput {
+	s.Key = &v
+	return s
+}
+
+// SetMaxParts sets the MaxParts field's value.
+func (s *ListPartsInput) SetMaxParts(v int64) *ListPartsInput {
+	s.MaxParts = &v
+	return s
+}
+
+// SetPartNumberMarker sets the PartNumberMarker field's value.
+func (s *ListPartsInput) SetPartNumberMarker(v int64) *ListPartsInput {
+	s.PartNumberMarker = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *ListPartsInput) SetRequestPayer(v string) *ListPartsInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *ListPartsInput) SetUploadId(v string) *ListPartsInput {
+	s.UploadId = &v
+	return s
+}
+
 type ListPartsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7669,6 +10147,90 @@ func (s ListPartsOutput) GoString() string {
 	return s.String()
 }
 
+// SetAbortDate sets the AbortDate field's value.
+func (s *ListPartsOutput) SetAbortDate(v time.Time) *ListPartsOutput {
+	s.AbortDate = &v
+	return s
+}
+
+// SetAbortRuleId sets the AbortRuleId field's value.
+func (s *ListPartsOutput) SetAbortRuleId(v string) *ListPartsOutput {
+	s.AbortRuleId = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *ListPartsOutput) SetBucket(v string) *ListPartsOutput {
+	s.Bucket = &v
+	return s
+}
+
+// SetInitiator sets the Initiator field's value.
+func (s *ListPartsOutput) SetInitiator(v *Initiator) *ListPartsOutput {
+	s.Initiator = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListPartsOutput) SetIsTruncated(v bool) *ListPartsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *ListPartsOutput) SetKey(v string) *ListPartsOutput {
+	s.Key = &v
+	return s
+}
+
+// SetMaxParts sets the MaxParts field's value.
+func (s *ListPartsOutput) SetMaxParts(v int64) *ListPartsOutput {
+	s.MaxParts = &v
+	return s
+}
+
+// SetNextPartNumberMarker sets the NextPartNumberMarker field's value.
+func (s *ListPartsOutput) SetNextPartNumberMarker(v int64) *ListPartsOutput {
+	s.NextPartNumberMarker = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *ListPartsOutput) SetOwner(v *Owner) *ListPartsOutput {
+	s.Owner = v
+	return s
+}
+
+// SetPartNumberMarker sets the PartNumberMarker field's value.
+func (s *ListPartsOutput) SetPartNumberMarker(v int64) *ListPartsOutput {
+	s.PartNumberMarker = &v
+	return s
+}
+
+// SetParts sets the Parts field's value.
+func (s *ListPartsOutput) SetParts(v []*Part) *ListPartsOutput {
+	s.Parts = v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *ListPartsOutput) SetRequestCharged(v string) *ListPartsOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *ListPartsOutput) SetStorageClass(v string) *ListPartsOutput {
+	s.StorageClass = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *ListPartsOutput) SetUploadId(v string) *ListPartsOutput {
+	s.UploadId = &v
+	return s
+}
+
 type LoggingEnabled struct {
 	_ struct{} `type:"structure"`
 
@@ -7717,6 +10279,24 @@ func (s *LoggingEnabled) Validate() error {
 	return nil
 }
 
+// SetTargetBucket sets the TargetBucket field's value.
+func (s *LoggingEnabled) SetTargetBucket(v string) *LoggingEnabled {
+	s.TargetBucket = &v
+	return s
+}
+
+// SetTargetGrants sets the TargetGrants field's value.
+func (s *LoggingEnabled) SetTargetGrants(v []*TargetGrant) *LoggingEnabled {
+	s.TargetGrants = v
+	return s
+}
+
+// SetTargetPrefix sets the TargetPrefix field's value.
+func (s *LoggingEnabled) SetTargetPrefix(v string) *LoggingEnabled {
+	s.TargetPrefix = &v
+	return s
+}
+
 type MultipartUpload struct {
 	_ struct{} `type:"structure"`
 
@@ -7748,6 +10328,42 @@ func (s MultipartUpload) GoString() string {
 	return s.String()
 }
 
+// SetInitiated sets the Initiated field's value.
+func (s *MultipartUpload) SetInitiated(v time.Time) *MultipartUpload {
+	s.Initiated = &v
+	return s
+}
+
+// SetInitiator sets the Initiator field's value.
+func (s *MultipartUpload) SetInitiator(v *Initiator) *MultipartUpload {
+	s.Initiator = v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *MultipartUpload) SetKey(v string) *MultipartUpload {
+	s.Key = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *MultipartUpload) SetOwner(v *Owner) *MultipartUpload {
+	s.Owner = v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *MultipartUpload) SetStorageClass(v string) *MultipartUpload {
+	s.StorageClass = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *MultipartUpload) SetUploadId(v string) *MultipartUpload {
+	s.UploadId = &v
+	return s
+}
+
 // Specifies when noncurrent object versions expire. Upon expiration, Amazon
 // S3 permanently deletes the noncurrent object versions. You set this lifecycle
 // configuration action on a bucket that has versioning enabled (or suspended)
@@ -7771,6 +10387,12 @@ func (s NoncurrentVersionExpiration) String() string {
 // GoString returns the string representation
 func (s NoncurrentVersionExpiration) GoString() string {
 	return s.String()
+}
+
+// SetNoncurrentDays sets the NoncurrentDays field's value.
+func (s *NoncurrentVersionExpiration) SetNoncurrentDays(v int64) *NoncurrentVersionExpiration {
+	s.NoncurrentDays = &v
+	return s
 }
 
 // Container for the transition rule that describes when noncurrent objects
@@ -7799,6 +10421,18 @@ func (s NoncurrentVersionTransition) String() string {
 // GoString returns the string representation
 func (s NoncurrentVersionTransition) GoString() string {
 	return s.String()
+}
+
+// SetNoncurrentDays sets the NoncurrentDays field's value.
+func (s *NoncurrentVersionTransition) SetNoncurrentDays(v int64) *NoncurrentVersionTransition {
+	s.NoncurrentDays = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *NoncurrentVersionTransition) SetStorageClass(v string) *NoncurrentVersionTransition {
+	s.StorageClass = &v
+	return s
 }
 
 // Container for specifying the notification configuration of the bucket. If
@@ -7863,6 +10497,24 @@ func (s *NotificationConfiguration) Validate() error {
 	return nil
 }
 
+// SetLambdaFunctionConfigurations sets the LambdaFunctionConfigurations field's value.
+func (s *NotificationConfiguration) SetLambdaFunctionConfigurations(v []*LambdaFunctionConfiguration) *NotificationConfiguration {
+	s.LambdaFunctionConfigurations = v
+	return s
+}
+
+// SetQueueConfigurations sets the QueueConfigurations field's value.
+func (s *NotificationConfiguration) SetQueueConfigurations(v []*QueueConfiguration) *NotificationConfiguration {
+	s.QueueConfigurations = v
+	return s
+}
+
+// SetTopicConfigurations sets the TopicConfigurations field's value.
+func (s *NotificationConfiguration) SetTopicConfigurations(v []*TopicConfiguration) *NotificationConfiguration {
+	s.TopicConfigurations = v
+	return s
+}
+
 type NotificationConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
 
@@ -7883,6 +10535,24 @@ func (s NotificationConfigurationDeprecated) GoString() string {
 	return s.String()
 }
 
+// SetCloudFunctionConfiguration sets the CloudFunctionConfiguration field's value.
+func (s *NotificationConfigurationDeprecated) SetCloudFunctionConfiguration(v *CloudFunctionConfiguration) *NotificationConfigurationDeprecated {
+	s.CloudFunctionConfiguration = v
+	return s
+}
+
+// SetQueueConfiguration sets the QueueConfiguration field's value.
+func (s *NotificationConfigurationDeprecated) SetQueueConfiguration(v *QueueConfigurationDeprecated) *NotificationConfigurationDeprecated {
+	s.QueueConfiguration = v
+	return s
+}
+
+// SetTopicConfiguration sets the TopicConfiguration field's value.
+func (s *NotificationConfigurationDeprecated) SetTopicConfiguration(v *TopicConfigurationDeprecated) *NotificationConfigurationDeprecated {
+	s.TopicConfiguration = v
+	return s
+}
+
 // Container for object key name filtering rules. For information about key
 // name filtering, go to Configuring Event Notifications (http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 type NotificationConfigurationFilter struct {
@@ -7900,6 +10570,12 @@ func (s NotificationConfigurationFilter) String() string {
 // GoString returns the string representation
 func (s NotificationConfigurationFilter) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *NotificationConfigurationFilter) SetKey(v *KeyFilter) *NotificationConfigurationFilter {
+	s.Key = v
+	return s
 }
 
 type Object struct {
@@ -7927,6 +10603,42 @@ func (s Object) String() string {
 // GoString returns the string representation
 func (s Object) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *Object) SetETag(v string) *Object {
+	s.ETag = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *Object) SetKey(v string) *Object {
+	s.Key = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *Object) SetLastModified(v time.Time) *Object {
+	s.LastModified = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *Object) SetOwner(v *Owner) *Object {
+	s.Owner = v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *Object) SetSize(v int64) *Object {
+	s.Size = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *Object) SetStorageClass(v string) *Object {
+	s.StorageClass = &v
+	return s
 }
 
 type ObjectIdentifier struct {
@@ -7967,6 +10679,18 @@ func (s *ObjectIdentifier) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *ObjectIdentifier) SetKey(v string) *ObjectIdentifier {
+	s.Key = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *ObjectIdentifier) SetVersionId(v string) *ObjectIdentifier {
+	s.VersionId = &v
+	return s
+}
+
 type ObjectVersion struct {
 	_ struct{} `type:"structure"`
 
@@ -8004,6 +10728,54 @@ func (s ObjectVersion) GoString() string {
 	return s.String()
 }
 
+// SetETag sets the ETag field's value.
+func (s *ObjectVersion) SetETag(v string) *ObjectVersion {
+	s.ETag = &v
+	return s
+}
+
+// SetIsLatest sets the IsLatest field's value.
+func (s *ObjectVersion) SetIsLatest(v bool) *ObjectVersion {
+	s.IsLatest = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *ObjectVersion) SetKey(v string) *ObjectVersion {
+	s.Key = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *ObjectVersion) SetLastModified(v time.Time) *ObjectVersion {
+	s.LastModified = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *ObjectVersion) SetOwner(v *Owner) *ObjectVersion {
+	s.Owner = v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *ObjectVersion) SetSize(v int64) *ObjectVersion {
+	s.Size = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *ObjectVersion) SetStorageClass(v string) *ObjectVersion {
+	s.StorageClass = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *ObjectVersion) SetVersionId(v string) *ObjectVersion {
+	s.VersionId = &v
+	return s
+}
+
 type Owner struct {
 	_ struct{} `type:"structure"`
 
@@ -8020,6 +10792,18 @@ func (s Owner) String() string {
 // GoString returns the string representation
 func (s Owner) GoString() string {
 	return s.String()
+}
+
+// SetDisplayName sets the DisplayName field's value.
+func (s *Owner) SetDisplayName(v string) *Owner {
+	s.DisplayName = &v
+	return s
+}
+
+// SetID sets the ID field's value.
+func (s *Owner) SetID(v string) *Owner {
+	s.ID = &v
+	return s
 }
 
 type Part struct {
@@ -8047,6 +10831,30 @@ func (s Part) String() string {
 // GoString returns the string representation
 func (s Part) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *Part) SetETag(v string) *Part {
+	s.ETag = &v
+	return s
+}
+
+// SetLastModified sets the LastModified field's value.
+func (s *Part) SetLastModified(v time.Time) *Part {
+	s.LastModified = &v
+	return s
+}
+
+// SetPartNumber sets the PartNumber field's value.
+func (s *Part) SetPartNumber(v int64) *Part {
+	s.PartNumber = &v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *Part) SetSize(v int64) *Part {
+	s.Size = &v
+	return s
 }
 
 type PutBucketAccelerateConfigurationInput struct {
@@ -8087,6 +10895,18 @@ func (s *PutBucketAccelerateConfigurationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccelerateConfiguration sets the AccelerateConfiguration field's value.
+func (s *PutBucketAccelerateConfigurationInput) SetAccelerateConfiguration(v *AccelerateConfiguration) *PutBucketAccelerateConfigurationInput {
+	s.AccelerateConfiguration = v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketAccelerateConfigurationInput) SetBucket(v string) *PutBucketAccelerateConfigurationInput {
+	s.Bucket = &v
+	return s
 }
 
 type PutBucketAccelerateConfigurationOutput struct {
@@ -8159,6 +10979,54 @@ func (s *PutBucketAclInput) Validate() error {
 	return nil
 }
 
+// SetACL sets the ACL field's value.
+func (s *PutBucketAclInput) SetACL(v string) *PutBucketAclInput {
+	s.ACL = &v
+	return s
+}
+
+// SetAccessControlPolicy sets the AccessControlPolicy field's value.
+func (s *PutBucketAclInput) SetAccessControlPolicy(v *AccessControlPolicy) *PutBucketAclInput {
+	s.AccessControlPolicy = v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketAclInput) SetBucket(v string) *PutBucketAclInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetGrantFullControl sets the GrantFullControl field's value.
+func (s *PutBucketAclInput) SetGrantFullControl(v string) *PutBucketAclInput {
+	s.GrantFullControl = &v
+	return s
+}
+
+// SetGrantRead sets the GrantRead field's value.
+func (s *PutBucketAclInput) SetGrantRead(v string) *PutBucketAclInput {
+	s.GrantRead = &v
+	return s
+}
+
+// SetGrantReadACP sets the GrantReadACP field's value.
+func (s *PutBucketAclInput) SetGrantReadACP(v string) *PutBucketAclInput {
+	s.GrantReadACP = &v
+	return s
+}
+
+// SetGrantWrite sets the GrantWrite field's value.
+func (s *PutBucketAclInput) SetGrantWrite(v string) *PutBucketAclInput {
+	s.GrantWrite = &v
+	return s
+}
+
+// SetGrantWriteACP sets the GrantWriteACP field's value.
+func (s *PutBucketAclInput) SetGrantWriteACP(v string) *PutBucketAclInput {
+	s.GrantWriteACP = &v
+	return s
+}
+
 type PutBucketAclOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8214,6 +11082,18 @@ func (s *PutBucketCorsInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketCorsInput) SetBucket(v string) *PutBucketCorsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetCORSConfiguration sets the CORSConfiguration field's value.
+func (s *PutBucketCorsInput) SetCORSConfiguration(v *CORSConfiguration) *PutBucketCorsInput {
+	s.CORSConfiguration = v
+	return s
+}
+
 type PutBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8265,6 +11145,18 @@ func (s *PutBucketLifecycleConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketLifecycleConfigurationInput) SetBucket(v string) *PutBucketLifecycleConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetLifecycleConfiguration sets the LifecycleConfiguration field's value.
+func (s *PutBucketLifecycleConfigurationInput) SetLifecycleConfiguration(v *BucketLifecycleConfiguration) *PutBucketLifecycleConfigurationInput {
+	s.LifecycleConfiguration = v
+	return s
+}
+
 type PutBucketLifecycleConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8314,6 +11206,18 @@ func (s *PutBucketLifecycleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketLifecycleInput) SetBucket(v string) *PutBucketLifecycleInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetLifecycleConfiguration sets the LifecycleConfiguration field's value.
+func (s *PutBucketLifecycleInput) SetLifecycleConfiguration(v *LifecycleConfiguration) *PutBucketLifecycleInput {
+	s.LifecycleConfiguration = v
+	return s
 }
 
 type PutBucketLifecycleOutput struct {
@@ -8369,6 +11273,18 @@ func (s *PutBucketLoggingInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketLoggingInput) SetBucket(v string) *PutBucketLoggingInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetBucketLoggingStatus sets the BucketLoggingStatus field's value.
+func (s *PutBucketLoggingInput) SetBucketLoggingStatus(v *BucketLoggingStatus) *PutBucketLoggingInput {
+	s.BucketLoggingStatus = v
+	return s
 }
 
 type PutBucketLoggingOutput struct {
@@ -8429,6 +11345,18 @@ func (s *PutBucketNotificationConfigurationInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketNotificationConfigurationInput) SetBucket(v string) *PutBucketNotificationConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetNotificationConfiguration sets the NotificationConfiguration field's value.
+func (s *PutBucketNotificationConfigurationInput) SetNotificationConfiguration(v *NotificationConfiguration) *PutBucketNotificationConfigurationInput {
+	s.NotificationConfiguration = v
+	return s
+}
+
 type PutBucketNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8477,6 +11405,18 @@ func (s *PutBucketNotificationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketNotificationInput) SetBucket(v string) *PutBucketNotificationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetNotificationConfiguration sets the NotificationConfiguration field's value.
+func (s *PutBucketNotificationInput) SetNotificationConfiguration(v *NotificationConfigurationDeprecated) *PutBucketNotificationInput {
+	s.NotificationConfiguration = v
+	return s
 }
 
 type PutBucketNotificationOutput struct {
@@ -8529,6 +11469,18 @@ func (s *PutBucketPolicyInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketPolicyInput) SetBucket(v string) *PutBucketPolicyInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *PutBucketPolicyInput) SetPolicy(v string) *PutBucketPolicyInput {
+	s.Policy = &v
+	return s
 }
 
 type PutBucketPolicyOutput struct {
@@ -8589,6 +11541,18 @@ func (s *PutBucketReplicationInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketReplicationInput) SetBucket(v string) *PutBucketReplicationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetReplicationConfiguration sets the ReplicationConfiguration field's value.
+func (s *PutBucketReplicationInput) SetReplicationConfiguration(v *ReplicationConfiguration) *PutBucketReplicationInput {
+	s.ReplicationConfiguration = v
+	return s
+}
+
 type PutBucketReplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8642,6 +11606,18 @@ func (s *PutBucketRequestPaymentInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketRequestPaymentInput) SetBucket(v string) *PutBucketRequestPaymentInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetRequestPaymentConfiguration sets the RequestPaymentConfiguration field's value.
+func (s *PutBucketRequestPaymentInput) SetRequestPaymentConfiguration(v *RequestPaymentConfiguration) *PutBucketRequestPaymentInput {
+	s.RequestPaymentConfiguration = v
+	return s
 }
 
 type PutBucketRequestPaymentOutput struct {
@@ -8699,6 +11675,18 @@ func (s *PutBucketTaggingInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketTaggingInput) SetBucket(v string) *PutBucketTaggingInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetTagging sets the Tagging field's value.
+func (s *PutBucketTaggingInput) SetTagging(v *Tagging) *PutBucketTaggingInput {
+	s.Tagging = v
+	return s
+}
+
 type PutBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8751,6 +11739,24 @@ func (s *PutBucketVersioningInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketVersioningInput) SetBucket(v string) *PutBucketVersioningInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetMFA sets the MFA field's value.
+func (s *PutBucketVersioningInput) SetMFA(v string) *PutBucketVersioningInput {
+	s.MFA = &v
+	return s
+}
+
+// SetVersioningConfiguration sets the VersioningConfiguration field's value.
+func (s *PutBucketVersioningInput) SetVersioningConfiguration(v *VersioningConfiguration) *PutBucketVersioningInput {
+	s.VersioningConfiguration = v
+	return s
 }
 
 type PutBucketVersioningOutput struct {
@@ -8806,6 +11812,18 @@ func (s *PutBucketWebsiteInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketWebsiteInput) SetBucket(v string) *PutBucketWebsiteInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetWebsiteConfiguration sets the WebsiteConfiguration field's value.
+func (s *PutBucketWebsiteInput) SetWebsiteConfiguration(v *WebsiteConfiguration) *PutBucketWebsiteInput {
+	s.WebsiteConfiguration = v
+	return s
 }
 
 type PutBucketWebsiteOutput struct {
@@ -8896,6 +11914,72 @@ func (s *PutObjectAclInput) Validate() error {
 	return nil
 }
 
+// SetACL sets the ACL field's value.
+func (s *PutObjectAclInput) SetACL(v string) *PutObjectAclInput {
+	s.ACL = &v
+	return s
+}
+
+// SetAccessControlPolicy sets the AccessControlPolicy field's value.
+func (s *PutObjectAclInput) SetAccessControlPolicy(v *AccessControlPolicy) *PutObjectAclInput {
+	s.AccessControlPolicy = v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutObjectAclInput) SetBucket(v string) *PutObjectAclInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetGrantFullControl sets the GrantFullControl field's value.
+func (s *PutObjectAclInput) SetGrantFullControl(v string) *PutObjectAclInput {
+	s.GrantFullControl = &v
+	return s
+}
+
+// SetGrantRead sets the GrantRead field's value.
+func (s *PutObjectAclInput) SetGrantRead(v string) *PutObjectAclInput {
+	s.GrantRead = &v
+	return s
+}
+
+// SetGrantReadACP sets the GrantReadACP field's value.
+func (s *PutObjectAclInput) SetGrantReadACP(v string) *PutObjectAclInput {
+	s.GrantReadACP = &v
+	return s
+}
+
+// SetGrantWrite sets the GrantWrite field's value.
+func (s *PutObjectAclInput) SetGrantWrite(v string) *PutObjectAclInput {
+	s.GrantWrite = &v
+	return s
+}
+
+// SetGrantWriteACP sets the GrantWriteACP field's value.
+func (s *PutObjectAclInput) SetGrantWriteACP(v string) *PutObjectAclInput {
+	s.GrantWriteACP = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *PutObjectAclInput) SetKey(v string) *PutObjectAclInput {
+	s.Key = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *PutObjectAclInput) SetRequestPayer(v string) *PutObjectAclInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *PutObjectAclInput) SetVersionId(v string) *PutObjectAclInput {
+	s.VersionId = &v
+	return s
+}
+
 type PutObjectAclOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8912,6 +11996,12 @@ func (s PutObjectAclOutput) String() string {
 // GoString returns the string representation
 func (s PutObjectAclOutput) GoString() string {
 	return s.String()
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *PutObjectAclOutput) SetRequestCharged(v string) *PutObjectAclOutput {
+	s.RequestCharged = &v
+	return s
 }
 
 type PutObjectInput struct {
@@ -9041,6 +12131,150 @@ func (s *PutObjectInput) Validate() error {
 	return nil
 }
 
+// SetACL sets the ACL field's value.
+func (s *PutObjectInput) SetACL(v string) *PutObjectInput {
+	s.ACL = &v
+	return s
+}
+
+// SetBody sets the Body field's value.
+func (s *PutObjectInput) SetBody(v io.ReadSeeker) *PutObjectInput {
+	s.Body = v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutObjectInput) SetBucket(v string) *PutObjectInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetCacheControl sets the CacheControl field's value.
+func (s *PutObjectInput) SetCacheControl(v string) *PutObjectInput {
+	s.CacheControl = &v
+	return s
+}
+
+// SetContentDisposition sets the ContentDisposition field's value.
+func (s *PutObjectInput) SetContentDisposition(v string) *PutObjectInput {
+	s.ContentDisposition = &v
+	return s
+}
+
+// SetContentEncoding sets the ContentEncoding field's value.
+func (s *PutObjectInput) SetContentEncoding(v string) *PutObjectInput {
+	s.ContentEncoding = &v
+	return s
+}
+
+// SetContentLanguage sets the ContentLanguage field's value.
+func (s *PutObjectInput) SetContentLanguage(v string) *PutObjectInput {
+	s.ContentLanguage = &v
+	return s
+}
+
+// SetContentLength sets the ContentLength field's value.
+func (s *PutObjectInput) SetContentLength(v int64) *PutObjectInput {
+	s.ContentLength = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *PutObjectInput) SetContentType(v string) *PutObjectInput {
+	s.ContentType = &v
+	return s
+}
+
+// SetExpires sets the Expires field's value.
+func (s *PutObjectInput) SetExpires(v time.Time) *PutObjectInput {
+	s.Expires = &v
+	return s
+}
+
+// SetGrantFullControl sets the GrantFullControl field's value.
+func (s *PutObjectInput) SetGrantFullControl(v string) *PutObjectInput {
+	s.GrantFullControl = &v
+	return s
+}
+
+// SetGrantRead sets the GrantRead field's value.
+func (s *PutObjectInput) SetGrantRead(v string) *PutObjectInput {
+	s.GrantRead = &v
+	return s
+}
+
+// SetGrantReadACP sets the GrantReadACP field's value.
+func (s *PutObjectInput) SetGrantReadACP(v string) *PutObjectInput {
+	s.GrantReadACP = &v
+	return s
+}
+
+// SetGrantWriteACP sets the GrantWriteACP field's value.
+func (s *PutObjectInput) SetGrantWriteACP(v string) *PutObjectInput {
+	s.GrantWriteACP = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *PutObjectInput) SetKey(v string) *PutObjectInput {
+	s.Key = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *PutObjectInput) SetMetadata(v map[string]*string) *PutObjectInput {
+	s.Metadata = v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *PutObjectInput) SetRequestPayer(v string) *PutObjectInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *PutObjectInput) SetSSECustomerAlgorithm(v string) *PutObjectInput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKey sets the SSECustomerKey field's value.
+func (s *PutObjectInput) SetSSECustomerKey(v string) *PutObjectInput {
+	s.SSECustomerKey = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *PutObjectInput) SetSSECustomerKeyMD5(v string) *PutObjectInput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *PutObjectInput) SetSSEKMSKeyId(v string) *PutObjectInput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *PutObjectInput) SetServerSideEncryption(v string) *PutObjectInput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *PutObjectInput) SetStorageClass(v string) *PutObjectInput {
+	s.StorageClass = &v
+	return s
+}
+
+// SetWebsiteRedirectLocation sets the WebsiteRedirectLocation field's value.
+func (s *PutObjectInput) SetWebsiteRedirectLocation(v string) *PutObjectInput {
+	s.WebsiteRedirectLocation = &v
+	return s
+}
+
 type PutObjectOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9085,6 +12319,54 @@ func (s PutObjectOutput) String() string {
 // GoString returns the string representation
 func (s PutObjectOutput) GoString() string {
 	return s.String()
+}
+
+// SetETag sets the ETag field's value.
+func (s *PutObjectOutput) SetETag(v string) *PutObjectOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *PutObjectOutput) SetExpiration(v string) *PutObjectOutput {
+	s.Expiration = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *PutObjectOutput) SetRequestCharged(v string) *PutObjectOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *PutObjectOutput) SetSSECustomerAlgorithm(v string) *PutObjectOutput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *PutObjectOutput) SetSSECustomerKeyMD5(v string) *PutObjectOutput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *PutObjectOutput) SetSSEKMSKeyId(v string) *PutObjectOutput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *PutObjectOutput) SetServerSideEncryption(v string) *PutObjectOutput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *PutObjectOutput) SetVersionId(v string) *PutObjectOutput {
+	s.VersionId = &v
+	return s
 }
 
 // Container for specifying an configuration when you want Amazon S3 to publish
@@ -9136,6 +12418,30 @@ func (s *QueueConfiguration) Validate() error {
 	return nil
 }
 
+// SetEvents sets the Events field's value.
+func (s *QueueConfiguration) SetEvents(v []*string) *QueueConfiguration {
+	s.Events = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *QueueConfiguration) SetFilter(v *NotificationConfigurationFilter) *QueueConfiguration {
+	s.Filter = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *QueueConfiguration) SetId(v string) *QueueConfiguration {
+	s.Id = &v
+	return s
+}
+
+// SetQueueArn sets the QueueArn field's value.
+func (s *QueueConfiguration) SetQueueArn(v string) *QueueConfiguration {
+	s.QueueArn = &v
+	return s
+}
+
 type QueueConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
 
@@ -9159,6 +12465,30 @@ func (s QueueConfigurationDeprecated) String() string {
 // GoString returns the string representation
 func (s QueueConfigurationDeprecated) GoString() string {
 	return s.String()
+}
+
+// SetEvent sets the Event field's value.
+func (s *QueueConfigurationDeprecated) SetEvent(v string) *QueueConfigurationDeprecated {
+	s.Event = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *QueueConfigurationDeprecated) SetEvents(v []*string) *QueueConfigurationDeprecated {
+	s.Events = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *QueueConfigurationDeprecated) SetId(v string) *QueueConfigurationDeprecated {
+	s.Id = &v
+	return s
+}
+
+// SetQueue sets the Queue field's value.
+func (s *QueueConfigurationDeprecated) SetQueue(v string) *QueueConfigurationDeprecated {
+	s.Queue = &v
+	return s
 }
 
 type Redirect struct {
@@ -9199,6 +12529,36 @@ func (s Redirect) GoString() string {
 	return s.String()
 }
 
+// SetHostName sets the HostName field's value.
+func (s *Redirect) SetHostName(v string) *Redirect {
+	s.HostName = &v
+	return s
+}
+
+// SetHttpRedirectCode sets the HttpRedirectCode field's value.
+func (s *Redirect) SetHttpRedirectCode(v string) *Redirect {
+	s.HttpRedirectCode = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *Redirect) SetProtocol(v string) *Redirect {
+	s.Protocol = &v
+	return s
+}
+
+// SetReplaceKeyPrefixWith sets the ReplaceKeyPrefixWith field's value.
+func (s *Redirect) SetReplaceKeyPrefixWith(v string) *Redirect {
+	s.ReplaceKeyPrefixWith = &v
+	return s
+}
+
+// SetReplaceKeyWith sets the ReplaceKeyWith field's value.
+func (s *Redirect) SetReplaceKeyWith(v string) *Redirect {
+	s.ReplaceKeyWith = &v
+	return s
+}
+
 type RedirectAllRequestsTo struct {
 	_ struct{} `type:"structure"`
 
@@ -9233,6 +12593,18 @@ func (s *RedirectAllRequestsTo) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHostName sets the HostName field's value.
+func (s *RedirectAllRequestsTo) SetHostName(v string) *RedirectAllRequestsTo {
+	s.HostName = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *RedirectAllRequestsTo) SetProtocol(v string) *RedirectAllRequestsTo {
+	s.Protocol = &v
+	return s
 }
 
 // Container for replication rules. You can add as many as 1,000 rules. Total
@@ -9287,6 +12659,18 @@ func (s *ReplicationConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRole sets the Role field's value.
+func (s *ReplicationConfiguration) SetRole(v string) *ReplicationConfiguration {
+	s.Role = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *ReplicationConfiguration) SetRules(v []*ReplicationRule) *ReplicationConfiguration {
+	s.Rules = v
+	return s
 }
 
 type ReplicationRule struct {
@@ -9345,6 +12729,30 @@ func (s *ReplicationRule) Validate() error {
 	return nil
 }
 
+// SetDestination sets the Destination field's value.
+func (s *ReplicationRule) SetDestination(v *Destination) *ReplicationRule {
+	s.Destination = v
+	return s
+}
+
+// SetID sets the ID field's value.
+func (s *ReplicationRule) SetID(v string) *ReplicationRule {
+	s.ID = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *ReplicationRule) SetPrefix(v string) *ReplicationRule {
+	s.Prefix = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ReplicationRule) SetStatus(v string) *ReplicationRule {
+	s.Status = &v
+	return s
+}
+
 type RequestPaymentConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -9375,6 +12783,12 @@ func (s *RequestPaymentConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPayer sets the Payer field's value.
+func (s *RequestPaymentConfiguration) SetPayer(v string) *RequestPaymentConfiguration {
+	s.Payer = &v
+	return s
 }
 
 type RestoreObjectInput struct {
@@ -9431,6 +12845,36 @@ func (s *RestoreObjectInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *RestoreObjectInput) SetBucket(v string) *RestoreObjectInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *RestoreObjectInput) SetKey(v string) *RestoreObjectInput {
+	s.Key = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *RestoreObjectInput) SetRequestPayer(v string) *RestoreObjectInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetRestoreRequest sets the RestoreRequest field's value.
+func (s *RestoreObjectInput) SetRestoreRequest(v *RestoreRequest) *RestoreObjectInput {
+	s.RestoreRequest = v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *RestoreObjectInput) SetVersionId(v string) *RestoreObjectInput {
+	s.VersionId = &v
+	return s
+}
+
 type RestoreObjectOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -9447,6 +12891,12 @@ func (s RestoreObjectOutput) String() string {
 // GoString returns the string representation
 func (s RestoreObjectOutput) GoString() string {
 	return s.String()
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *RestoreObjectOutput) SetRequestCharged(v string) *RestoreObjectOutput {
+	s.RequestCharged = &v
+	return s
 }
 
 type RestoreRequest struct {
@@ -9479,6 +12929,12 @@ func (s *RestoreRequest) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDays sets the Days field's value.
+func (s *RestoreRequest) SetDays(v int64) *RestoreRequest {
+	s.Days = &v
+	return s
 }
 
 type RoutingRule struct {
@@ -9519,6 +12975,18 @@ func (s *RoutingRule) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCondition sets the Condition field's value.
+func (s *RoutingRule) SetCondition(v *Condition) *RoutingRule {
+	s.Condition = v
+	return s
+}
+
+// SetRedirect sets the Redirect field's value.
+func (s *RoutingRule) SetRedirect(v *Redirect) *RoutingRule {
+	s.Redirect = v
+	return s
 }
 
 type Rule struct {
@@ -9587,6 +13055,54 @@ func (s *Rule) Validate() error {
 	return nil
 }
 
+// SetAbortIncompleteMultipartUpload sets the AbortIncompleteMultipartUpload field's value.
+func (s *Rule) SetAbortIncompleteMultipartUpload(v *AbortIncompleteMultipartUpload) *Rule {
+	s.AbortIncompleteMultipartUpload = v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *Rule) SetExpiration(v *LifecycleExpiration) *Rule {
+	s.Expiration = v
+	return s
+}
+
+// SetID sets the ID field's value.
+func (s *Rule) SetID(v string) *Rule {
+	s.ID = &v
+	return s
+}
+
+// SetNoncurrentVersionExpiration sets the NoncurrentVersionExpiration field's value.
+func (s *Rule) SetNoncurrentVersionExpiration(v *NoncurrentVersionExpiration) *Rule {
+	s.NoncurrentVersionExpiration = v
+	return s
+}
+
+// SetNoncurrentVersionTransition sets the NoncurrentVersionTransition field's value.
+func (s *Rule) SetNoncurrentVersionTransition(v *NoncurrentVersionTransition) *Rule {
+	s.NoncurrentVersionTransition = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *Rule) SetPrefix(v string) *Rule {
+	s.Prefix = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Rule) SetStatus(v string) *Rule {
+	s.Status = &v
+	return s
+}
+
+// SetTransition sets the Transition field's value.
+func (s *Rule) SetTransition(v *Transition) *Rule {
+	s.Transition = v
+	return s
+}
+
 type Tag struct {
 	_ struct{} `type:"structure"`
 
@@ -9630,6 +13146,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 type Tagging struct {
 	_ struct{} `type:"structure"`
 
@@ -9670,6 +13198,12 @@ func (s *Tagging) Validate() error {
 	return nil
 }
 
+// SetTagSet sets the TagSet field's value.
+func (s *Tagging) SetTagSet(v []*Tag) *Tagging {
+	s.TagSet = v
+	return s
+}
+
 type TargetGrant struct {
 	_ struct{} `type:"structure"`
 
@@ -9702,6 +13236,18 @@ func (s *TargetGrant) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGrantee sets the Grantee field's value.
+func (s *TargetGrant) SetGrantee(v *Grantee) *TargetGrant {
+	s.Grantee = v
+	return s
+}
+
+// SetPermission sets the Permission field's value.
+func (s *TargetGrant) SetPermission(v string) *TargetGrant {
+	s.Permission = &v
+	return s
 }
 
 // Container for specifying the configuration when you want Amazon S3 to publish
@@ -9753,6 +13299,30 @@ func (s *TopicConfiguration) Validate() error {
 	return nil
 }
 
+// SetEvents sets the Events field's value.
+func (s *TopicConfiguration) SetEvents(v []*string) *TopicConfiguration {
+	s.Events = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *TopicConfiguration) SetFilter(v *NotificationConfigurationFilter) *TopicConfiguration {
+	s.Filter = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *TopicConfiguration) SetId(v string) *TopicConfiguration {
+	s.Id = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *TopicConfiguration) SetTopicArn(v string) *TopicConfiguration {
+	s.TopicArn = &v
+	return s
+}
+
 type TopicConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
 
@@ -9780,6 +13350,30 @@ func (s TopicConfigurationDeprecated) GoString() string {
 	return s.String()
 }
 
+// SetEvent sets the Event field's value.
+func (s *TopicConfigurationDeprecated) SetEvent(v string) *TopicConfigurationDeprecated {
+	s.Event = &v
+	return s
+}
+
+// SetEvents sets the Events field's value.
+func (s *TopicConfigurationDeprecated) SetEvents(v []*string) *TopicConfigurationDeprecated {
+	s.Events = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *TopicConfigurationDeprecated) SetId(v string) *TopicConfigurationDeprecated {
+	s.Id = &v
+	return s
+}
+
+// SetTopic sets the Topic field's value.
+func (s *TopicConfigurationDeprecated) SetTopic(v string) *TopicConfigurationDeprecated {
+	s.Topic = &v
+	return s
+}
+
 type Transition struct {
 	_ struct{} `type:"structure"`
 
@@ -9803,6 +13397,24 @@ func (s Transition) String() string {
 // GoString returns the string representation
 func (s Transition) GoString() string {
 	return s.String()
+}
+
+// SetDate sets the Date field's value.
+func (s *Transition) SetDate(v time.Time) *Transition {
+	s.Date = &v
+	return s
+}
+
+// SetDays sets the Days field's value.
+func (s *Transition) SetDays(v int64) *Transition {
+	s.Days = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *Transition) SetStorageClass(v string) *Transition {
+	s.StorageClass = &v
+	return s
 }
 
 type UploadPartCopyInput struct {
@@ -9925,6 +13537,108 @@ func (s *UploadPartCopyInput) Validate() error {
 	return nil
 }
 
+// SetBucket sets the Bucket field's value.
+func (s *UploadPartCopyInput) SetBucket(v string) *UploadPartCopyInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetCopySource sets the CopySource field's value.
+func (s *UploadPartCopyInput) SetCopySource(v string) *UploadPartCopyInput {
+	s.CopySource = &v
+	return s
+}
+
+// SetCopySourceIfMatch sets the CopySourceIfMatch field's value.
+func (s *UploadPartCopyInput) SetCopySourceIfMatch(v string) *UploadPartCopyInput {
+	s.CopySourceIfMatch = &v
+	return s
+}
+
+// SetCopySourceIfModifiedSince sets the CopySourceIfModifiedSince field's value.
+func (s *UploadPartCopyInput) SetCopySourceIfModifiedSince(v time.Time) *UploadPartCopyInput {
+	s.CopySourceIfModifiedSince = &v
+	return s
+}
+
+// SetCopySourceIfNoneMatch sets the CopySourceIfNoneMatch field's value.
+func (s *UploadPartCopyInput) SetCopySourceIfNoneMatch(v string) *UploadPartCopyInput {
+	s.CopySourceIfNoneMatch = &v
+	return s
+}
+
+// SetCopySourceIfUnmodifiedSince sets the CopySourceIfUnmodifiedSince field's value.
+func (s *UploadPartCopyInput) SetCopySourceIfUnmodifiedSince(v time.Time) *UploadPartCopyInput {
+	s.CopySourceIfUnmodifiedSince = &v
+	return s
+}
+
+// SetCopySourceRange sets the CopySourceRange field's value.
+func (s *UploadPartCopyInput) SetCopySourceRange(v string) *UploadPartCopyInput {
+	s.CopySourceRange = &v
+	return s
+}
+
+// SetCopySourceSSECustomerAlgorithm sets the CopySourceSSECustomerAlgorithm field's value.
+func (s *UploadPartCopyInput) SetCopySourceSSECustomerAlgorithm(v string) *UploadPartCopyInput {
+	s.CopySourceSSECustomerAlgorithm = &v
+	return s
+}
+
+// SetCopySourceSSECustomerKey sets the CopySourceSSECustomerKey field's value.
+func (s *UploadPartCopyInput) SetCopySourceSSECustomerKey(v string) *UploadPartCopyInput {
+	s.CopySourceSSECustomerKey = &v
+	return s
+}
+
+// SetCopySourceSSECustomerKeyMD5 sets the CopySourceSSECustomerKeyMD5 field's value.
+func (s *UploadPartCopyInput) SetCopySourceSSECustomerKeyMD5(v string) *UploadPartCopyInput {
+	s.CopySourceSSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *UploadPartCopyInput) SetKey(v string) *UploadPartCopyInput {
+	s.Key = &v
+	return s
+}
+
+// SetPartNumber sets the PartNumber field's value.
+func (s *UploadPartCopyInput) SetPartNumber(v int64) *UploadPartCopyInput {
+	s.PartNumber = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *UploadPartCopyInput) SetRequestPayer(v string) *UploadPartCopyInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *UploadPartCopyInput) SetSSECustomerAlgorithm(v string) *UploadPartCopyInput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKey sets the SSECustomerKey field's value.
+func (s *UploadPartCopyInput) SetSSECustomerKey(v string) *UploadPartCopyInput {
+	s.SSECustomerKey = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *UploadPartCopyInput) SetSSECustomerKeyMD5(v string) *UploadPartCopyInput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *UploadPartCopyInput) SetUploadId(v string) *UploadPartCopyInput {
+	s.UploadId = &v
+	return s
+}
+
 type UploadPartCopyOutput struct {
 	_ struct{} `type:"structure" payload:"CopyPartResult"`
 
@@ -9965,6 +13679,48 @@ func (s UploadPartCopyOutput) String() string {
 // GoString returns the string representation
 func (s UploadPartCopyOutput) GoString() string {
 	return s.String()
+}
+
+// SetCopyPartResult sets the CopyPartResult field's value.
+func (s *UploadPartCopyOutput) SetCopyPartResult(v *CopyPartResult) *UploadPartCopyOutput {
+	s.CopyPartResult = v
+	return s
+}
+
+// SetCopySourceVersionId sets the CopySourceVersionId field's value.
+func (s *UploadPartCopyOutput) SetCopySourceVersionId(v string) *UploadPartCopyOutput {
+	s.CopySourceVersionId = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *UploadPartCopyOutput) SetRequestCharged(v string) *UploadPartCopyOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *UploadPartCopyOutput) SetSSECustomerAlgorithm(v string) *UploadPartCopyOutput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *UploadPartCopyOutput) SetSSECustomerKeyMD5(v string) *UploadPartCopyOutput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *UploadPartCopyOutput) SetSSEKMSKeyId(v string) *UploadPartCopyOutput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *UploadPartCopyOutput) SetServerSideEncryption(v string) *UploadPartCopyOutput {
+	s.ServerSideEncryption = &v
+	return s
 }
 
 type UploadPartInput struct {
@@ -10056,6 +13812,66 @@ func (s *UploadPartInput) Validate() error {
 	return nil
 }
 
+// SetBody sets the Body field's value.
+func (s *UploadPartInput) SetBody(v io.ReadSeeker) *UploadPartInput {
+	s.Body = v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *UploadPartInput) SetBucket(v string) *UploadPartInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetContentLength sets the ContentLength field's value.
+func (s *UploadPartInput) SetContentLength(v int64) *UploadPartInput {
+	s.ContentLength = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *UploadPartInput) SetKey(v string) *UploadPartInput {
+	s.Key = &v
+	return s
+}
+
+// SetPartNumber sets the PartNumber field's value.
+func (s *UploadPartInput) SetPartNumber(v int64) *UploadPartInput {
+	s.PartNumber = &v
+	return s
+}
+
+// SetRequestPayer sets the RequestPayer field's value.
+func (s *UploadPartInput) SetRequestPayer(v string) *UploadPartInput {
+	s.RequestPayer = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *UploadPartInput) SetSSECustomerAlgorithm(v string) *UploadPartInput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKey sets the SSECustomerKey field's value.
+func (s *UploadPartInput) SetSSECustomerKey(v string) *UploadPartInput {
+	s.SSECustomerKey = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *UploadPartInput) SetSSECustomerKeyMD5(v string) *UploadPartInput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetUploadId sets the UploadId field's value.
+func (s *UploadPartInput) SetUploadId(v string) *UploadPartInput {
+	s.UploadId = &v
+	return s
+}
+
 type UploadPartOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10095,6 +13911,42 @@ func (s UploadPartOutput) GoString() string {
 	return s.String()
 }
 
+// SetETag sets the ETag field's value.
+func (s *UploadPartOutput) SetETag(v string) *UploadPartOutput {
+	s.ETag = &v
+	return s
+}
+
+// SetRequestCharged sets the RequestCharged field's value.
+func (s *UploadPartOutput) SetRequestCharged(v string) *UploadPartOutput {
+	s.RequestCharged = &v
+	return s
+}
+
+// SetSSECustomerAlgorithm sets the SSECustomerAlgorithm field's value.
+func (s *UploadPartOutput) SetSSECustomerAlgorithm(v string) *UploadPartOutput {
+	s.SSECustomerAlgorithm = &v
+	return s
+}
+
+// SetSSECustomerKeyMD5 sets the SSECustomerKeyMD5 field's value.
+func (s *UploadPartOutput) SetSSECustomerKeyMD5(v string) *UploadPartOutput {
+	s.SSECustomerKeyMD5 = &v
+	return s
+}
+
+// SetSSEKMSKeyId sets the SSEKMSKeyId field's value.
+func (s *UploadPartOutput) SetSSEKMSKeyId(v string) *UploadPartOutput {
+	s.SSEKMSKeyId = &v
+	return s
+}
+
+// SetServerSideEncryption sets the ServerSideEncryption field's value.
+func (s *UploadPartOutput) SetServerSideEncryption(v string) *UploadPartOutput {
+	s.ServerSideEncryption = &v
+	return s
+}
+
 type VersioningConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -10115,6 +13967,18 @@ func (s VersioningConfiguration) String() string {
 // GoString returns the string representation
 func (s VersioningConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetMFADelete sets the MFADelete field's value.
+func (s *VersioningConfiguration) SetMFADelete(v string) *VersioningConfiguration {
+	s.MFADelete = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *VersioningConfiguration) SetStatus(v string) *VersioningConfiguration {
+	s.Status = &v
+	return s
 }
 
 type WebsiteConfiguration struct {
@@ -10172,6 +14036,30 @@ func (s *WebsiteConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetErrorDocument sets the ErrorDocument field's value.
+func (s *WebsiteConfiguration) SetErrorDocument(v *ErrorDocument) *WebsiteConfiguration {
+	s.ErrorDocument = v
+	return s
+}
+
+// SetIndexDocument sets the IndexDocument field's value.
+func (s *WebsiteConfiguration) SetIndexDocument(v *IndexDocument) *WebsiteConfiguration {
+	s.IndexDocument = v
+	return s
+}
+
+// SetRedirectAllRequestsTo sets the RedirectAllRequestsTo field's value.
+func (s *WebsiteConfiguration) SetRedirectAllRequestsTo(v *RedirectAllRequestsTo) *WebsiteConfiguration {
+	s.RedirectAllRequestsTo = v
+	return s
+}
+
+// SetRoutingRules sets the RoutingRules field's value.
+func (s *WebsiteConfiguration) SetRoutingRules(v []*RoutingRule) *WebsiteConfiguration {
+	s.RoutingRules = v
+	return s
 }
 
 const (

--- a/service/servicecatalog/api.go
+++ b/service/servicecatalog/api.go
@@ -801,6 +801,18 @@ func (s AccessLevelFilter) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *AccessLevelFilter) SetKey(v string) *AccessLevelFilter {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *AccessLevelFilter) SetValue(v string) *AccessLevelFilter {
+	s.Value = &v
+	return s
+}
+
 // An administrator-specified constraint to apply when provisioning a product.
 type ConstraintSummary struct {
 	_ struct{} `type:"structure"`
@@ -820,6 +832,18 @@ func (s ConstraintSummary) String() string {
 // GoString returns the string representation
 func (s ConstraintSummary) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *ConstraintSummary) SetDescription(v string) *ConstraintSummary {
+	s.Description = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ConstraintSummary) SetType(v string) *ConstraintSummary {
+	s.Type = &v
+	return s
 }
 
 type DescribeProductInput struct {
@@ -869,6 +893,18 @@ func (s *DescribeProductInput) Validate() error {
 	return nil
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *DescribeProductInput) SetAcceptLanguage(v string) *DescribeProductInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *DescribeProductInput) SetId(v string) *DescribeProductInput {
+	s.Id = &v
+	return s
+}
+
 type DescribeProductOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -888,6 +924,18 @@ func (s DescribeProductOutput) String() string {
 // GoString returns the string representation
 func (s DescribeProductOutput) GoString() string {
 	return s.String()
+}
+
+// SetProductViewSummary sets the ProductViewSummary field's value.
+func (s *DescribeProductOutput) SetProductViewSummary(v *ProductViewSummary) *DescribeProductOutput {
+	s.ProductViewSummary = v
+	return s
+}
+
+// SetProvisioningArtifacts sets the ProvisioningArtifacts field's value.
+func (s *DescribeProductOutput) SetProvisioningArtifacts(v []*ProvisioningArtifact) *DescribeProductOutput {
+	s.ProvisioningArtifacts = v
+	return s
 }
 
 type DescribeProductViewInput struct {
@@ -937,6 +985,18 @@ func (s *DescribeProductViewInput) Validate() error {
 	return nil
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *DescribeProductViewInput) SetAcceptLanguage(v string) *DescribeProductViewInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *DescribeProductViewInput) SetId(v string) *DescribeProductViewInput {
+	s.Id = &v
+	return s
+}
+
 type DescribeProductViewOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -956,6 +1016,18 @@ func (s DescribeProductViewOutput) String() string {
 // GoString returns the string representation
 func (s DescribeProductViewOutput) GoString() string {
 	return s.String()
+}
+
+// SetProductViewSummary sets the ProductViewSummary field's value.
+func (s *DescribeProductViewOutput) SetProductViewSummary(v *ProductViewSummary) *DescribeProductViewOutput {
+	s.ProductViewSummary = v
+	return s
+}
+
+// SetProvisioningArtifacts sets the ProvisioningArtifacts field's value.
+func (s *DescribeProductViewOutput) SetProvisioningArtifacts(v []*ProvisioningArtifact) *DescribeProductViewOutput {
+	s.ProvisioningArtifacts = v
+	return s
 }
 
 type DescribeProvisioningParametersInput struct {
@@ -1024,6 +1096,30 @@ func (s *DescribeProvisioningParametersInput) Validate() error {
 	return nil
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *DescribeProvisioningParametersInput) SetAcceptLanguage(v string) *DescribeProvisioningParametersInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetPathId sets the PathId field's value.
+func (s *DescribeProvisioningParametersInput) SetPathId(v string) *DescribeProvisioningParametersInput {
+	s.PathId = &v
+	return s
+}
+
+// SetProductId sets the ProductId field's value.
+func (s *DescribeProvisioningParametersInput) SetProductId(v string) *DescribeProvisioningParametersInput {
+	s.ProductId = &v
+	return s
+}
+
+// SetProvisioningArtifactId sets the ProvisioningArtifactId field's value.
+func (s *DescribeProvisioningParametersInput) SetProvisioningArtifactId(v string) *DescribeProvisioningParametersInput {
+	s.ProvisioningArtifactId = &v
+	return s
+}
+
 type DescribeProvisioningParametersOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1047,6 +1143,24 @@ func (s DescribeProvisioningParametersOutput) String() string {
 // GoString returns the string representation
 func (s DescribeProvisioningParametersOutput) GoString() string {
 	return s.String()
+}
+
+// SetConstraintSummaries sets the ConstraintSummaries field's value.
+func (s *DescribeProvisioningParametersOutput) SetConstraintSummaries(v []*ConstraintSummary) *DescribeProvisioningParametersOutput {
+	s.ConstraintSummaries = v
+	return s
+}
+
+// SetProvisioningArtifactParameters sets the ProvisioningArtifactParameters field's value.
+func (s *DescribeProvisioningParametersOutput) SetProvisioningArtifactParameters(v []*ProvisioningArtifactParameter) *DescribeProvisioningParametersOutput {
+	s.ProvisioningArtifactParameters = v
+	return s
+}
+
+// SetUsageInstructions sets the UsageInstructions field's value.
+func (s *DescribeProvisioningParametersOutput) SetUsageInstructions(v []*UsageInstruction) *DescribeProvisioningParametersOutput {
+	s.UsageInstructions = v
+	return s
 }
 
 type DescribeRecordInput struct {
@@ -1107,6 +1221,30 @@ func (s *DescribeRecordInput) Validate() error {
 	return nil
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *DescribeRecordInput) SetAcceptLanguage(v string) *DescribeRecordInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *DescribeRecordInput) SetId(v string) *DescribeRecordInput {
+	s.Id = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeRecordInput) SetPageSize(v int64) *DescribeRecordInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *DescribeRecordInput) SetPageToken(v string) *DescribeRecordInput {
+	s.PageToken = &v
+	return s
+}
+
 type DescribeRecordOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1131,6 +1269,24 @@ func (s DescribeRecordOutput) String() string {
 // GoString returns the string representation
 func (s DescribeRecordOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *DescribeRecordOutput) SetNextPageToken(v string) *DescribeRecordOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetRecordDetail sets the RecordDetail field's value.
+func (s *DescribeRecordOutput) SetRecordDetail(v *RecordDetail) *DescribeRecordOutput {
+	s.RecordDetail = v
+	return s
+}
+
+// SetRecordOutputs sets the RecordOutputs field's value.
+func (s *DescribeRecordOutput) SetRecordOutputs(v []*RecordOutput) *DescribeRecordOutput {
+	s.RecordOutputs = v
+	return s
 }
 
 // Summary information about a path for a user to have access to a specified
@@ -1159,6 +1315,30 @@ func (s LaunchPathSummary) String() string {
 // GoString returns the string representation
 func (s LaunchPathSummary) GoString() string {
 	return s.String()
+}
+
+// SetConstraintSummaries sets the ConstraintSummaries field's value.
+func (s *LaunchPathSummary) SetConstraintSummaries(v []*ConstraintSummary) *LaunchPathSummary {
+	s.ConstraintSummaries = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *LaunchPathSummary) SetId(v string) *LaunchPathSummary {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *LaunchPathSummary) SetName(v string) *LaunchPathSummary {
+	s.Name = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *LaunchPathSummary) SetTags(v []*Tag) *LaunchPathSummary {
+	s.Tags = v
+	return s
 }
 
 type ListLaunchPathsInput struct {
@@ -1217,6 +1397,30 @@ func (s *ListLaunchPathsInput) Validate() error {
 	return nil
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *ListLaunchPathsInput) SetAcceptLanguage(v string) *ListLaunchPathsInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListLaunchPathsInput) SetPageSize(v int64) *ListLaunchPathsInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListLaunchPathsInput) SetPageToken(v string) *ListLaunchPathsInput {
+	s.PageToken = &v
+	return s
+}
+
+// SetProductId sets the ProductId field's value.
+func (s *ListLaunchPathsInput) SetProductId(v string) *ListLaunchPathsInput {
+	s.ProductId = &v
+	return s
+}
+
 type ListLaunchPathsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1236,6 +1440,18 @@ func (s ListLaunchPathsOutput) String() string {
 // GoString returns the string representation
 func (s ListLaunchPathsOutput) GoString() string {
 	return s.String()
+}
+
+// SetLaunchPathSummaries sets the LaunchPathSummaries field's value.
+func (s *ListLaunchPathsOutput) SetLaunchPathSummaries(v []*LaunchPathSummary) *ListLaunchPathsOutput {
+	s.LaunchPathSummaries = v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListLaunchPathsOutput) SetNextPageToken(v string) *ListLaunchPathsOutput {
+	s.NextPageToken = &v
+	return s
 }
 
 type ListRecordHistoryInput struct {
@@ -1280,6 +1496,36 @@ func (s ListRecordHistoryInput) GoString() string {
 	return s.String()
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *ListRecordHistoryInput) SetAcceptLanguage(v string) *ListRecordHistoryInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetAccessLevelFilter sets the AccessLevelFilter field's value.
+func (s *ListRecordHistoryInput) SetAccessLevelFilter(v *AccessLevelFilter) *ListRecordHistoryInput {
+	s.AccessLevelFilter = v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListRecordHistoryInput) SetPageSize(v int64) *ListRecordHistoryInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListRecordHistoryInput) SetPageToken(v string) *ListRecordHistoryInput {
+	s.PageToken = &v
+	return s
+}
+
+// SetSearchFilter sets the SearchFilter field's value.
+func (s *ListRecordHistoryInput) SetSearchFilter(v *ListRecordHistorySearchFilter) *ListRecordHistoryInput {
+	s.SearchFilter = v
+	return s
+}
+
 type ListRecordHistoryOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1299,6 +1545,18 @@ func (s ListRecordHistoryOutput) String() string {
 // GoString returns the string representation
 func (s ListRecordHistoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListRecordHistoryOutput) SetNextPageToken(v string) *ListRecordHistoryOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetRecordDetails sets the RecordDetails field's value.
+func (s *ListRecordHistoryOutput) SetRecordDetails(v []*RecordDetail) *ListRecordHistoryOutput {
+	s.RecordDetails = v
+	return s
 }
 
 // The search filter to limit results when listing request history records.
@@ -1322,6 +1580,18 @@ func (s ListRecordHistorySearchFilter) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *ListRecordHistorySearchFilter) SetKey(v string) *ListRecordHistorySearchFilter {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ListRecordHistorySearchFilter) SetValue(v string) *ListRecordHistorySearchFilter {
+	s.Value = &v
+	return s
+}
+
 // The constraints that the administrator has put on the parameter.
 type ParameterConstraints struct {
 	_ struct{} `type:"structure"`
@@ -1338,6 +1608,12 @@ func (s ParameterConstraints) String() string {
 // GoString returns the string representation
 func (s ParameterConstraints) GoString() string {
 	return s.String()
+}
+
+// SetAllowedValues sets the AllowedValues field's value.
+func (s *ParameterConstraints) SetAllowedValues(v []*string) *ParameterConstraints {
+	s.AllowedValues = v
+	return s
 }
 
 // A single product view aggregation value/count pair, containing metadata about
@@ -1360,6 +1636,18 @@ func (s ProductViewAggregationValue) String() string {
 // GoString returns the string representation
 func (s ProductViewAggregationValue) GoString() string {
 	return s.String()
+}
+
+// SetApproximateCount sets the ApproximateCount field's value.
+func (s *ProductViewAggregationValue) SetApproximateCount(v int64) *ProductViewAggregationValue {
+	s.ApproximateCount = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ProductViewAggregationValue) SetValue(v string) *ProductViewAggregationValue {
+	s.Value = &v
+	return s
 }
 
 // The summary metadata about the specified product.
@@ -1415,6 +1703,72 @@ func (s ProductViewSummary) String() string {
 // GoString returns the string representation
 func (s ProductViewSummary) GoString() string {
 	return s.String()
+}
+
+// SetDistributor sets the Distributor field's value.
+func (s *ProductViewSummary) SetDistributor(v string) *ProductViewSummary {
+	s.Distributor = &v
+	return s
+}
+
+// SetHasDefaultPath sets the HasDefaultPath field's value.
+func (s *ProductViewSummary) SetHasDefaultPath(v bool) *ProductViewSummary {
+	s.HasDefaultPath = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ProductViewSummary) SetId(v string) *ProductViewSummary {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ProductViewSummary) SetName(v string) *ProductViewSummary {
+	s.Name = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *ProductViewSummary) SetOwner(v string) *ProductViewSummary {
+	s.Owner = &v
+	return s
+}
+
+// SetProductId sets the ProductId field's value.
+func (s *ProductViewSummary) SetProductId(v string) *ProductViewSummary {
+	s.ProductId = &v
+	return s
+}
+
+// SetShortDescription sets the ShortDescription field's value.
+func (s *ProductViewSummary) SetShortDescription(v string) *ProductViewSummary {
+	s.ShortDescription = &v
+	return s
+}
+
+// SetSupportDescription sets the SupportDescription field's value.
+func (s *ProductViewSummary) SetSupportDescription(v string) *ProductViewSummary {
+	s.SupportDescription = &v
+	return s
+}
+
+// SetSupportEmail sets the SupportEmail field's value.
+func (s *ProductViewSummary) SetSupportEmail(v string) *ProductViewSummary {
+	s.SupportEmail = &v
+	return s
+}
+
+// SetSupportUrl sets the SupportUrl field's value.
+func (s *ProductViewSummary) SetSupportUrl(v string) *ProductViewSummary {
+	s.SupportUrl = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ProductViewSummary) SetType(v string) *ProductViewSummary {
+	s.Type = &v
+	return s
 }
 
 type ProvisionProductInput struct {
@@ -1525,6 +1879,60 @@ func (s *ProvisionProductInput) Validate() error {
 	return nil
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *ProvisionProductInput) SetAcceptLanguage(v string) *ProvisionProductInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetNotificationArns sets the NotificationArns field's value.
+func (s *ProvisionProductInput) SetNotificationArns(v []*string) *ProvisionProductInput {
+	s.NotificationArns = v
+	return s
+}
+
+// SetPathId sets the PathId field's value.
+func (s *ProvisionProductInput) SetPathId(v string) *ProvisionProductInput {
+	s.PathId = &v
+	return s
+}
+
+// SetProductId sets the ProductId field's value.
+func (s *ProvisionProductInput) SetProductId(v string) *ProvisionProductInput {
+	s.ProductId = &v
+	return s
+}
+
+// SetProvisionToken sets the ProvisionToken field's value.
+func (s *ProvisionProductInput) SetProvisionToken(v string) *ProvisionProductInput {
+	s.ProvisionToken = &v
+	return s
+}
+
+// SetProvisionedProductName sets the ProvisionedProductName field's value.
+func (s *ProvisionProductInput) SetProvisionedProductName(v string) *ProvisionProductInput {
+	s.ProvisionedProductName = &v
+	return s
+}
+
+// SetProvisioningArtifactId sets the ProvisioningArtifactId field's value.
+func (s *ProvisionProductInput) SetProvisioningArtifactId(v string) *ProvisionProductInput {
+	s.ProvisioningArtifactId = &v
+	return s
+}
+
+// SetProvisioningParameters sets the ProvisioningParameters field's value.
+func (s *ProvisionProductInput) SetProvisioningParameters(v []*ProvisioningParameter) *ProvisionProductInput {
+	s.ProvisioningParameters = v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ProvisionProductInput) SetTags(v []*Tag) *ProvisionProductInput {
+	s.Tags = v
+	return s
+}
+
 type ProvisionProductOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1543,6 +1951,12 @@ func (s ProvisionProductOutput) String() string {
 // GoString returns the string representation
 func (s ProvisionProductOutput) GoString() string {
 	return s.String()
+}
+
+// SetRecordDetail sets the RecordDetail field's value.
+func (s *ProvisionProductOutput) SetRecordDetail(v *RecordDetail) *ProvisionProductOutput {
+	s.RecordDetail = v
+	return s
 }
 
 // Detailed information about a ProvisionedProduct object.
@@ -1588,6 +2002,60 @@ func (s ProvisionedProductDetail) GoString() string {
 	return s.String()
 }
 
+// SetArn sets the Arn field's value.
+func (s *ProvisionedProductDetail) SetArn(v string) *ProvisionedProductDetail {
+	s.Arn = &v
+	return s
+}
+
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *ProvisionedProductDetail) SetCreatedTime(v time.Time) *ProvisionedProductDetail {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ProvisionedProductDetail) SetId(v string) *ProvisionedProductDetail {
+	s.Id = &v
+	return s
+}
+
+// SetIdempotencyToken sets the IdempotencyToken field's value.
+func (s *ProvisionedProductDetail) SetIdempotencyToken(v string) *ProvisionedProductDetail {
+	s.IdempotencyToken = &v
+	return s
+}
+
+// SetLastRecordId sets the LastRecordId field's value.
+func (s *ProvisionedProductDetail) SetLastRecordId(v string) *ProvisionedProductDetail {
+	s.LastRecordId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ProvisionedProductDetail) SetName(v string) *ProvisionedProductDetail {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ProvisionedProductDetail) SetStatus(v string) *ProvisionedProductDetail {
+	s.Status = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ProvisionedProductDetail) SetStatusMessage(v string) *ProvisionedProductDetail {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ProvisionedProductDetail) SetType(v string) *ProvisionedProductDetail {
+	s.Type = &v
+	return s
+}
+
 // Contains information indicating the ways in which a product can be provisioned.
 type ProvisioningArtifact struct {
 	_ struct{} `type:"structure"`
@@ -1613,6 +2081,30 @@ func (s ProvisioningArtifact) String() string {
 // GoString returns the string representation
 func (s ProvisioningArtifact) GoString() string {
 	return s.String()
+}
+
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *ProvisioningArtifact) SetCreatedTime(v time.Time) *ProvisioningArtifact {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ProvisioningArtifact) SetDescription(v string) *ProvisioningArtifact {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ProvisioningArtifact) SetId(v string) *ProvisioningArtifact {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ProvisioningArtifact) SetName(v string) *ProvisioningArtifact {
+	s.Name = &v
+	return s
 }
 
 // A parameter used to successfully provision the product. This value includes
@@ -1651,6 +2143,42 @@ func (s ProvisioningArtifactParameter) GoString() string {
 	return s.String()
 }
 
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *ProvisioningArtifactParameter) SetDefaultValue(v string) *ProvisioningArtifactParameter {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ProvisioningArtifactParameter) SetDescription(v string) *ProvisioningArtifactParameter {
+	s.Description = &v
+	return s
+}
+
+// SetIsNoEcho sets the IsNoEcho field's value.
+func (s *ProvisioningArtifactParameter) SetIsNoEcho(v bool) *ProvisioningArtifactParameter {
+	s.IsNoEcho = &v
+	return s
+}
+
+// SetParameterConstraints sets the ParameterConstraints field's value.
+func (s *ProvisioningArtifactParameter) SetParameterConstraints(v *ParameterConstraints) *ProvisioningArtifactParameter {
+	s.ParameterConstraints = v
+	return s
+}
+
+// SetParameterKey sets the ParameterKey field's value.
+func (s *ProvisioningArtifactParameter) SetParameterKey(v string) *ProvisioningArtifactParameter {
+	s.ParameterKey = &v
+	return s
+}
+
+// SetParameterType sets the ParameterType field's value.
+func (s *ProvisioningArtifactParameter) SetParameterType(v string) *ProvisioningArtifactParameter {
+	s.ParameterType = &v
+	return s
+}
+
 // The arameter key/value pairs used to provision a product.
 type ProvisioningParameter struct {
 	_ struct{} `type:"structure"`
@@ -1671,6 +2199,18 @@ func (s ProvisioningParameter) String() string {
 // GoString returns the string representation
 func (s ProvisioningParameter) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *ProvisioningParameter) SetKey(v string) *ProvisioningParameter {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ProvisioningParameter) SetValue(v string) *ProvisioningParameter {
+	s.Value = &v
+	return s
 }
 
 // The full details of a specific ProvisionedProduct object.
@@ -1727,6 +2267,84 @@ func (s RecordDetail) GoString() string {
 	return s.String()
 }
 
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *RecordDetail) SetCreatedTime(v time.Time) *RecordDetail {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetPathId sets the PathId field's value.
+func (s *RecordDetail) SetPathId(v string) *RecordDetail {
+	s.PathId = &v
+	return s
+}
+
+// SetProductId sets the ProductId field's value.
+func (s *RecordDetail) SetProductId(v string) *RecordDetail {
+	s.ProductId = &v
+	return s
+}
+
+// SetProvisionedProductId sets the ProvisionedProductId field's value.
+func (s *RecordDetail) SetProvisionedProductId(v string) *RecordDetail {
+	s.ProvisionedProductId = &v
+	return s
+}
+
+// SetProvisionedProductName sets the ProvisionedProductName field's value.
+func (s *RecordDetail) SetProvisionedProductName(v string) *RecordDetail {
+	s.ProvisionedProductName = &v
+	return s
+}
+
+// SetProvisionedProductType sets the ProvisionedProductType field's value.
+func (s *RecordDetail) SetProvisionedProductType(v string) *RecordDetail {
+	s.ProvisionedProductType = &v
+	return s
+}
+
+// SetProvisioningArtifactId sets the ProvisioningArtifactId field's value.
+func (s *RecordDetail) SetProvisioningArtifactId(v string) *RecordDetail {
+	s.ProvisioningArtifactId = &v
+	return s
+}
+
+// SetRecordErrors sets the RecordErrors field's value.
+func (s *RecordDetail) SetRecordErrors(v []*RecordError) *RecordDetail {
+	s.RecordErrors = v
+	return s
+}
+
+// SetRecordId sets the RecordId field's value.
+func (s *RecordDetail) SetRecordId(v string) *RecordDetail {
+	s.RecordId = &v
+	return s
+}
+
+// SetRecordTags sets the RecordTags field's value.
+func (s *RecordDetail) SetRecordTags(v []*RecordTag) *RecordDetail {
+	s.RecordTags = v
+	return s
+}
+
+// SetRecordType sets the RecordType field's value.
+func (s *RecordDetail) SetRecordType(v string) *RecordDetail {
+	s.RecordType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *RecordDetail) SetStatus(v string) *RecordDetail {
+	s.Status = &v
+	return s
+}
+
+// SetUpdatedTime sets the UpdatedTime field's value.
+func (s *RecordDetail) SetUpdatedTime(v time.Time) *RecordDetail {
+	s.UpdatedTime = &v
+	return s
+}
+
 // The error code and description resulting from an operation.
 type RecordError struct {
 	_ struct{} `type:"structure"`
@@ -1746,6 +2364,18 @@ func (s RecordError) String() string {
 // GoString returns the string representation
 func (s RecordError) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *RecordError) SetCode(v string) *RecordError {
+	s.Code = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *RecordError) SetDescription(v string) *RecordError {
+	s.Description = &v
+	return s
 }
 
 // An output for the specified Product object created as the result of a request.
@@ -1774,6 +2404,24 @@ func (s RecordOutput) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *RecordOutput) SetDescription(v string) *RecordOutput {
+	s.Description = &v
+	return s
+}
+
+// SetOutputKey sets the OutputKey field's value.
+func (s *RecordOutput) SetOutputKey(v string) *RecordOutput {
+	s.OutputKey = &v
+	return s
+}
+
+// SetOutputValue sets the OutputValue field's value.
+func (s *RecordOutput) SetOutputValue(v string) *RecordOutput {
+	s.OutputValue = &v
+	return s
+}
+
 // A tag associated with the record, stored as a key-value pair.
 type RecordTag struct {
 	_ struct{} `type:"structure"`
@@ -1793,6 +2441,18 @@ func (s RecordTag) String() string {
 // GoString returns the string representation
 func (s RecordTag) GoString() string {
 	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *RecordTag) SetKey(v string) *RecordTag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *RecordTag) SetValue(v string) *RecordTag {
+	s.Value = &v
+	return s
 }
 
 type ScanProvisionedProductsInput struct {
@@ -1834,6 +2494,30 @@ func (s ScanProvisionedProductsInput) GoString() string {
 	return s.String()
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *ScanProvisionedProductsInput) SetAcceptLanguage(v string) *ScanProvisionedProductsInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetAccessLevelFilter sets the AccessLevelFilter field's value.
+func (s *ScanProvisionedProductsInput) SetAccessLevelFilter(v *AccessLevelFilter) *ScanProvisionedProductsInput {
+	s.AccessLevelFilter = v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ScanProvisionedProductsInput) SetPageSize(v int64) *ScanProvisionedProductsInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ScanProvisionedProductsInput) SetPageToken(v string) *ScanProvisionedProductsInput {
+	s.PageToken = &v
+	return s
+}
+
 type ScanProvisionedProductsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1853,6 +2537,18 @@ func (s ScanProvisionedProductsOutput) String() string {
 // GoString returns the string representation
 func (s ScanProvisionedProductsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ScanProvisionedProductsOutput) SetNextPageToken(v string) *ScanProvisionedProductsOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetProvisionedProducts sets the ProvisionedProducts field's value.
+func (s *ScanProvisionedProductsOutput) SetProvisionedProducts(v []*ProvisionedProductDetail) *ScanProvisionedProductsOutput {
+	s.ProvisionedProducts = v
+	return s
 }
 
 type SearchProductsInput struct {
@@ -1901,6 +2597,42 @@ func (s SearchProductsInput) GoString() string {
 	return s.String()
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *SearchProductsInput) SetAcceptLanguage(v string) *SearchProductsInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *SearchProductsInput) SetFilters(v map[string][]*string) *SearchProductsInput {
+	s.Filters = v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *SearchProductsInput) SetPageSize(v int64) *SearchProductsInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *SearchProductsInput) SetPageToken(v string) *SearchProductsInput {
+	s.PageToken = &v
+	return s
+}
+
+// SetSortBy sets the SortBy field's value.
+func (s *SearchProductsInput) SetSortBy(v string) *SearchProductsInput {
+	s.SortBy = &v
+	return s
+}
+
+// SetSortOrder sets the SortOrder field's value.
+func (s *SearchProductsInput) SetSortOrder(v string) *SearchProductsInput {
+	s.SortOrder = &v
+	return s
+}
+
 type SearchProductsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1923,6 +2655,24 @@ func (s SearchProductsOutput) String() string {
 // GoString returns the string representation
 func (s SearchProductsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *SearchProductsOutput) SetNextPageToken(v string) *SearchProductsOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetProductViewAggregations sets the ProductViewAggregations field's value.
+func (s *SearchProductsOutput) SetProductViewAggregations(v map[string][]*ProductViewAggregationValue) *SearchProductsOutput {
+	s.ProductViewAggregations = v
+	return s
+}
+
+// SetProductViewSummaries sets the ProductViewSummaries field's value.
+func (s *SearchProductsOutput) SetProductViewSummaries(v []*ProductViewSummary) *SearchProductsOutput {
+	s.ProductViewSummaries = v
+	return s
 }
 
 // Key/value pairs to associate with this provisioning. These tags are entirely
@@ -1961,6 +2711,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 type TerminateProvisionedProductInput struct {
@@ -2031,6 +2793,36 @@ func (s *TerminateProvisionedProductInput) Validate() error {
 	return nil
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *TerminateProvisionedProductInput) SetAcceptLanguage(v string) *TerminateProvisionedProductInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetIgnoreErrors sets the IgnoreErrors field's value.
+func (s *TerminateProvisionedProductInput) SetIgnoreErrors(v bool) *TerminateProvisionedProductInput {
+	s.IgnoreErrors = &v
+	return s
+}
+
+// SetProvisionedProductId sets the ProvisionedProductId field's value.
+func (s *TerminateProvisionedProductInput) SetProvisionedProductId(v string) *TerminateProvisionedProductInput {
+	s.ProvisionedProductId = &v
+	return s
+}
+
+// SetProvisionedProductName sets the ProvisionedProductName field's value.
+func (s *TerminateProvisionedProductInput) SetProvisionedProductName(v string) *TerminateProvisionedProductInput {
+	s.ProvisionedProductName = &v
+	return s
+}
+
+// SetTerminateToken sets the TerminateToken field's value.
+func (s *TerminateProvisionedProductInput) SetTerminateToken(v string) *TerminateProvisionedProductInput {
+	s.TerminateToken = &v
+	return s
+}
+
 type TerminateProvisionedProductOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2049,6 +2841,12 @@ func (s TerminateProvisionedProductOutput) String() string {
 // GoString returns the string representation
 func (s TerminateProvisionedProductOutput) GoString() string {
 	return s.String()
+}
+
+// SetRecordDetail sets the RecordDetail field's value.
+func (s *TerminateProvisionedProductOutput) SetRecordDetail(v *RecordDetail) *TerminateProvisionedProductOutput {
+	s.RecordDetail = v
+	return s
 }
 
 type UpdateProvisionedProductInput struct {
@@ -2136,6 +2934,54 @@ func (s *UpdateProvisionedProductInput) Validate() error {
 	return nil
 }
 
+// SetAcceptLanguage sets the AcceptLanguage field's value.
+func (s *UpdateProvisionedProductInput) SetAcceptLanguage(v string) *UpdateProvisionedProductInput {
+	s.AcceptLanguage = &v
+	return s
+}
+
+// SetPathId sets the PathId field's value.
+func (s *UpdateProvisionedProductInput) SetPathId(v string) *UpdateProvisionedProductInput {
+	s.PathId = &v
+	return s
+}
+
+// SetProductId sets the ProductId field's value.
+func (s *UpdateProvisionedProductInput) SetProductId(v string) *UpdateProvisionedProductInput {
+	s.ProductId = &v
+	return s
+}
+
+// SetProvisionedProductId sets the ProvisionedProductId field's value.
+func (s *UpdateProvisionedProductInput) SetProvisionedProductId(v string) *UpdateProvisionedProductInput {
+	s.ProvisionedProductId = &v
+	return s
+}
+
+// SetProvisionedProductName sets the ProvisionedProductName field's value.
+func (s *UpdateProvisionedProductInput) SetProvisionedProductName(v string) *UpdateProvisionedProductInput {
+	s.ProvisionedProductName = &v
+	return s
+}
+
+// SetProvisioningArtifactId sets the ProvisioningArtifactId field's value.
+func (s *UpdateProvisionedProductInput) SetProvisioningArtifactId(v string) *UpdateProvisionedProductInput {
+	s.ProvisioningArtifactId = &v
+	return s
+}
+
+// SetProvisioningParameters sets the ProvisioningParameters field's value.
+func (s *UpdateProvisionedProductInput) SetProvisioningParameters(v []*UpdateProvisioningParameter) *UpdateProvisionedProductInput {
+	s.ProvisioningParameters = v
+	return s
+}
+
+// SetUpdateToken sets the UpdateToken field's value.
+func (s *UpdateProvisionedProductInput) SetUpdateToken(v string) *UpdateProvisionedProductInput {
+	s.UpdateToken = &v
+	return s
+}
+
 type UpdateProvisionedProductOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2154,6 +3000,12 @@ func (s UpdateProvisionedProductOutput) String() string {
 // GoString returns the string representation
 func (s UpdateProvisionedProductOutput) GoString() string {
 	return s.String()
+}
+
+// SetRecordDetail sets the RecordDetail field's value.
+func (s *UpdateProvisionedProductOutput) SetRecordDetail(v *RecordDetail) *UpdateProvisionedProductOutput {
+	s.RecordDetail = v
+	return s
 }
 
 // The parameter key/value pair used to update a ProvisionedProduct object.
@@ -2184,6 +3036,24 @@ func (s UpdateProvisioningParameter) GoString() string {
 	return s.String()
 }
 
+// SetKey sets the Key field's value.
+func (s *UpdateProvisioningParameter) SetKey(v string) *UpdateProvisioningParameter {
+	s.Key = &v
+	return s
+}
+
+// SetUsePreviousValue sets the UsePreviousValue field's value.
+func (s *UpdateProvisioningParameter) SetUsePreviousValue(v bool) *UpdateProvisioningParameter {
+	s.UsePreviousValue = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *UpdateProvisioningParameter) SetValue(v string) *UpdateProvisioningParameter {
+	s.Value = &v
+	return s
+}
+
 // Additional information provided by the administrator.
 type UsageInstruction struct {
 	_ struct{} `type:"structure"`
@@ -2203,6 +3073,18 @@ func (s UsageInstruction) String() string {
 // GoString returns the string representation
 func (s UsageInstruction) GoString() string {
 	return s.String()
+}
+
+// SetType sets the Type field's value.
+func (s *UsageInstruction) SetType(v string) *UsageInstruction {
+	s.Type = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *UsageInstruction) SetValue(v string) *UsageInstruction {
+	s.Value = &v
+	return s
 }
 
 const (

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -3111,6 +3111,18 @@ func (s *AddHeaderAction) Validate() error {
 	return nil
 }
 
+// SetHeaderName sets the HeaderName field's value.
+func (s *AddHeaderAction) SetHeaderName(v string) *AddHeaderAction {
+	s.HeaderName = &v
+	return s
+}
+
+// SetHeaderValue sets the HeaderValue field's value.
+func (s *AddHeaderAction) SetHeaderValue(v string) *AddHeaderAction {
+	s.HeaderValue = &v
+	return s
+}
+
 // Represents the body of the message. You can specify text, HTML, or both.
 // If you use both, then the message should display correctly in the widest
 // variety of email clients.
@@ -3155,6 +3167,18 @@ func (s *Body) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetHtml sets the Html field's value.
+func (s *Body) SetHtml(v *Content) *Body {
+	s.Html = v
+	return s
+}
+
+// SetText sets the Text field's value.
+func (s *Body) SetText(v *Content) *Body {
+	s.Text = v
+	return s
 }
 
 // When included in a receipt rule, this action rejects the received email by
@@ -3221,6 +3245,36 @@ func (s *BounceAction) Validate() error {
 	return nil
 }
 
+// SetMessage sets the Message field's value.
+func (s *BounceAction) SetMessage(v string) *BounceAction {
+	s.Message = &v
+	return s
+}
+
+// SetSender sets the Sender field's value.
+func (s *BounceAction) SetSender(v string) *BounceAction {
+	s.Sender = &v
+	return s
+}
+
+// SetSmtpReplyCode sets the SmtpReplyCode field's value.
+func (s *BounceAction) SetSmtpReplyCode(v string) *BounceAction {
+	s.SmtpReplyCode = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *BounceAction) SetStatusCode(v string) *BounceAction {
+	s.StatusCode = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *BounceAction) SetTopicArn(v string) *BounceAction {
+	s.TopicArn = &v
+	return s
+}
+
 // Recipient-related information to include in the Delivery Status Notification
 // (DSN) when an email that Amazon SES receives on your behalf bounces.
 //
@@ -3277,6 +3331,30 @@ func (s *BouncedRecipientInfo) Validate() error {
 	return nil
 }
 
+// SetBounceType sets the BounceType field's value.
+func (s *BouncedRecipientInfo) SetBounceType(v string) *BouncedRecipientInfo {
+	s.BounceType = &v
+	return s
+}
+
+// SetRecipient sets the Recipient field's value.
+func (s *BouncedRecipientInfo) SetRecipient(v string) *BouncedRecipientInfo {
+	s.Recipient = &v
+	return s
+}
+
+// SetRecipientArn sets the RecipientArn field's value.
+func (s *BouncedRecipientInfo) SetRecipientArn(v string) *BouncedRecipientInfo {
+	s.RecipientArn = &v
+	return s
+}
+
+// SetRecipientDsnFields sets the RecipientDsnFields field's value.
+func (s *BouncedRecipientInfo) SetRecipientDsnFields(v *RecipientDsnFields) *BouncedRecipientInfo {
+	s.RecipientDsnFields = v
+	return s
+}
+
 // Represents a request to create a receipt rule set by cloning an existing
 // one. You use receipt rule sets to receive email with Amazon SES. For more
 // information, see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html).
@@ -3325,6 +3403,18 @@ func (s *CloneReceiptRuleSetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetOriginalRuleSetName sets the OriginalRuleSetName field's value.
+func (s *CloneReceiptRuleSetInput) SetOriginalRuleSetName(v string) *CloneReceiptRuleSetInput {
+	s.OriginalRuleSetName = &v
+	return s
+}
+
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *CloneReceiptRuleSetInput) SetRuleSetName(v string) *CloneReceiptRuleSetInput {
+	s.RuleSetName = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -3382,6 +3472,18 @@ func (s *Content) Validate() error {
 	return nil
 }
 
+// SetCharset sets the Charset field's value.
+func (s *Content) SetCharset(v string) *Content {
+	s.Charset = &v
+	return s
+}
+
+// SetData sets the Data field's value.
+func (s *Content) SetData(v string) *Content {
+	s.Data = &v
+	return s
+}
+
 // Represents a request to create a new IP address filter. You use IP address
 // filters when you receive email with Amazon SES. For more information, see
 // the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html).
@@ -3421,6 +3523,12 @@ func (s *CreateReceiptFilterInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFilter sets the Filter field's value.
+func (s *CreateReceiptFilterInput) SetFilter(v *ReceiptFilter) *CreateReceiptFilterInput {
+	s.Filter = v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -3492,6 +3600,24 @@ func (s *CreateReceiptRuleInput) Validate() error {
 	return nil
 }
 
+// SetAfter sets the After field's value.
+func (s *CreateReceiptRuleInput) SetAfter(v string) *CreateReceiptRuleInput {
+	s.After = &v
+	return s
+}
+
+// SetRule sets the Rule field's value.
+func (s *CreateReceiptRuleInput) SetRule(v *ReceiptRule) *CreateReceiptRuleInput {
+	s.Rule = v
+	return s
+}
+
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *CreateReceiptRuleInput) SetRuleSetName(v string) *CreateReceiptRuleInput {
+	s.RuleSetName = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type CreateReceiptRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -3549,6 +3675,12 @@ func (s *CreateReceiptRuleSetInput) Validate() error {
 	return nil
 }
 
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *CreateReceiptRuleSetInput) SetRuleSetName(v string) *CreateReceiptRuleSetInput {
+	s.RuleSetName = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type CreateReceiptRuleSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -3596,6 +3728,12 @@ func (s *DeleteIdentityInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *DeleteIdentityInput) SetIdentity(v string) *DeleteIdentityInput {
+	s.Identity = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -3664,6 +3802,18 @@ func (s *DeleteIdentityPolicyInput) Validate() error {
 	return nil
 }
 
+// SetIdentity sets the Identity field's value.
+func (s *DeleteIdentityPolicyInput) SetIdentity(v string) *DeleteIdentityPolicyInput {
+	s.Identity = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DeleteIdentityPolicyInput) SetPolicyName(v string) *DeleteIdentityPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type DeleteIdentityPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -3712,6 +3862,12 @@ func (s *DeleteReceiptFilterInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFilterName sets the FilterName field's value.
+func (s *DeleteReceiptFilterInput) SetFilterName(v string) *DeleteReceiptFilterInput {
+	s.FilterName = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -3772,6 +3928,18 @@ func (s *DeleteReceiptRuleInput) Validate() error {
 	return nil
 }
 
+// SetRuleName sets the RuleName field's value.
+func (s *DeleteReceiptRuleInput) SetRuleName(v string) *DeleteReceiptRuleInput {
+	s.RuleName = &v
+	return s
+}
+
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *DeleteReceiptRuleInput) SetRuleSetName(v string) *DeleteReceiptRuleInput {
+	s.RuleSetName = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type DeleteReceiptRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -3822,6 +3990,12 @@ func (s *DeleteReceiptRuleSetInput) Validate() error {
 	return nil
 }
 
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *DeleteReceiptRuleSetInput) SetRuleSetName(v string) *DeleteReceiptRuleSetInput {
+	s.RuleSetName = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type DeleteReceiptRuleSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -3869,6 +4043,12 @@ func (s *DeleteVerifiedEmailAddressInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *DeleteVerifiedEmailAddressInput) SetEmailAddress(v string) *DeleteVerifiedEmailAddressInput {
+	s.EmailAddress = &v
+	return s
 }
 
 type DeleteVerifiedEmailAddressOutput struct {
@@ -3926,6 +4106,18 @@ func (s DescribeActiveReceiptRuleSetOutput) GoString() string {
 	return s.String()
 }
 
+// SetMetadata sets the Metadata field's value.
+func (s *DescribeActiveReceiptRuleSetOutput) SetMetadata(v *ReceiptRuleSetMetadata) *DescribeActiveReceiptRuleSetOutput {
+	s.Metadata = v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *DescribeActiveReceiptRuleSetOutput) SetRules(v []*ReceiptRule) *DescribeActiveReceiptRuleSetOutput {
+	s.Rules = v
+	return s
+}
+
 // Represents a request to return the details of a receipt rule. You use receipt
 // rules to receive email with Amazon SES. For more information, see the Amazon
 // SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html).
@@ -3969,6 +4161,18 @@ func (s *DescribeReceiptRuleInput) Validate() error {
 	return nil
 }
 
+// SetRuleName sets the RuleName field's value.
+func (s *DescribeReceiptRuleInput) SetRuleName(v string) *DescribeReceiptRuleInput {
+	s.RuleName = &v
+	return s
+}
+
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *DescribeReceiptRuleInput) SetRuleSetName(v string) *DescribeReceiptRuleInput {
+	s.RuleSetName = &v
+	return s
+}
+
 // Represents the details of a receipt rule.
 type DescribeReceiptRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -3987,6 +4191,12 @@ func (s DescribeReceiptRuleOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReceiptRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetRule sets the Rule field's value.
+func (s *DescribeReceiptRuleOutput) SetRule(v *ReceiptRule) *DescribeReceiptRuleOutput {
+	s.Rule = v
+	return s
 }
 
 // Represents a request to return the details of a receipt rule set. You use
@@ -4024,6 +4234,12 @@ func (s *DescribeReceiptRuleSetInput) Validate() error {
 	return nil
 }
 
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *DescribeReceiptRuleSetInput) SetRuleSetName(v string) *DescribeReceiptRuleSetInput {
+	s.RuleSetName = &v
+	return s
+}
+
 // Represents the details of the specified receipt rule set.
 type DescribeReceiptRuleSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -4044,6 +4260,18 @@ func (s DescribeReceiptRuleSetOutput) String() string {
 // GoString returns the string representation
 func (s DescribeReceiptRuleSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *DescribeReceiptRuleSetOutput) SetMetadata(v *ReceiptRuleSetMetadata) *DescribeReceiptRuleSetOutput {
+	s.Metadata = v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *DescribeReceiptRuleSetOutput) SetRules(v []*ReceiptRule) *DescribeReceiptRuleSetOutput {
+	s.Rules = v
+	return s
 }
 
 // Represents the destination of the message, consisting of To:, CC:, and BCC:
@@ -4074,6 +4302,24 @@ func (s Destination) String() string {
 // GoString returns the string representation
 func (s Destination) GoString() string {
 	return s.String()
+}
+
+// SetBccAddresses sets the BccAddresses field's value.
+func (s *Destination) SetBccAddresses(v []*string) *Destination {
+	s.BccAddresses = v
+	return s
+}
+
+// SetCcAddresses sets the CcAddresses field's value.
+func (s *Destination) SetCcAddresses(v []*string) *Destination {
+	s.CcAddresses = v
+	return s
+}
+
+// SetToAddresses sets the ToAddresses field's value.
+func (s *Destination) SetToAddresses(v []*string) *Destination {
+	s.ToAddresses = v
+	return s
 }
 
 // Additional X-headers to include in the Delivery Status Notification (DSN)
@@ -4123,6 +4369,18 @@ func (s *ExtensionField) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *ExtensionField) SetName(v string) *ExtensionField {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ExtensionField) SetValue(v string) *ExtensionField {
+	s.Value = &v
+	return s
+}
+
 // Represents a request for the status of Amazon SES Easy DKIM signing for an
 // identity. For domain identities, this request also returns the DKIM tokens
 // that are required for Easy DKIM signing, and whether Amazon SES successfully
@@ -4161,6 +4419,12 @@ func (s *GetIdentityDkimAttributesInput) Validate() error {
 	return nil
 }
 
+// SetIdentities sets the Identities field's value.
+func (s *GetIdentityDkimAttributesInput) SetIdentities(v []*string) *GetIdentityDkimAttributesInput {
+	s.Identities = v
+	return s
+}
+
 // Represents the status of Amazon SES Easy DKIM signing for an identity. For
 // domain identities, this response also contains the DKIM tokens that are required
 // for Easy DKIM signing, and whether Amazon SES successfully verified that
@@ -4182,6 +4446,12 @@ func (s GetIdentityDkimAttributesOutput) String() string {
 // GoString returns the string representation
 func (s GetIdentityDkimAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDkimAttributes sets the DkimAttributes field's value.
+func (s *GetIdentityDkimAttributesOutput) SetDkimAttributes(v map[string]*IdentityDkimAttributes) *GetIdentityDkimAttributesOutput {
+	s.DkimAttributes = v
+	return s
 }
 
 // Represents a request to return the Amazon SES custom MAIL FROM attributes
@@ -4219,6 +4489,12 @@ func (s *GetIdentityMailFromDomainAttributesInput) Validate() error {
 	return nil
 }
 
+// SetIdentities sets the Identities field's value.
+func (s *GetIdentityMailFromDomainAttributesInput) SetIdentities(v []*string) *GetIdentityMailFromDomainAttributesInput {
+	s.Identities = v
+	return s
+}
+
 // Represents the custom MAIL FROM attributes for a list of identities.
 type GetIdentityMailFromDomainAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4237,6 +4513,12 @@ func (s GetIdentityMailFromDomainAttributesOutput) String() string {
 // GoString returns the string representation
 func (s GetIdentityMailFromDomainAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMailFromDomainAttributes sets the MailFromDomainAttributes field's value.
+func (s *GetIdentityMailFromDomainAttributesOutput) SetMailFromDomainAttributes(v map[string]*IdentityMailFromDomainAttributes) *GetIdentityMailFromDomainAttributesOutput {
+	s.MailFromDomainAttributes = v
+	return s
 }
 
 // Represents a request to return the notification attributes for a list of
@@ -4276,6 +4558,12 @@ func (s *GetIdentityNotificationAttributesInput) Validate() error {
 	return nil
 }
 
+// SetIdentities sets the Identities field's value.
+func (s *GetIdentityNotificationAttributesInput) SetIdentities(v []*string) *GetIdentityNotificationAttributesInput {
+	s.Identities = v
+	return s
+}
+
 // Represents the notification attributes for a list of identities.
 type GetIdentityNotificationAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4294,6 +4582,12 @@ func (s GetIdentityNotificationAttributesOutput) String() string {
 // GoString returns the string representation
 func (s GetIdentityNotificationAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNotificationAttributes sets the NotificationAttributes field's value.
+func (s *GetIdentityNotificationAttributesOutput) SetNotificationAttributes(v map[string]*IdentityNotificationAttributes) *GetIdentityNotificationAttributesOutput {
+	s.NotificationAttributes = v
+	return s
 }
 
 // Represents a request to return the requested sending authorization policies
@@ -4346,6 +4640,18 @@ func (s *GetIdentityPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetIdentity sets the Identity field's value.
+func (s *GetIdentityPoliciesInput) SetIdentity(v string) *GetIdentityPoliciesInput {
+	s.Identity = &v
+	return s
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *GetIdentityPoliciesInput) SetPolicyNames(v []*string) *GetIdentityPoliciesInput {
+	s.PolicyNames = v
+	return s
+}
+
 // Represents the requested sending authorization policies.
 type GetIdentityPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4364,6 +4670,12 @@ func (s GetIdentityPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s GetIdentityPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *GetIdentityPoliciesOutput) SetPolicies(v map[string]*string) *GetIdentityPoliciesOutput {
+	s.Policies = v
+	return s
 }
 
 // Represents a request to return the Amazon SES verification status of a list
@@ -4402,6 +4714,12 @@ func (s *GetIdentityVerificationAttributesInput) Validate() error {
 	return nil
 }
 
+// SetIdentities sets the Identities field's value.
+func (s *GetIdentityVerificationAttributesInput) SetIdentities(v []*string) *GetIdentityVerificationAttributesInput {
+	s.Identities = v
+	return s
+}
+
 // The Amazon SES verification status of a list of identities. For domain identities,
 // this response also contains the verification token.
 type GetIdentityVerificationAttributesOutput struct {
@@ -4421,6 +4739,12 @@ func (s GetIdentityVerificationAttributesOutput) String() string {
 // GoString returns the string representation
 func (s GetIdentityVerificationAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetVerificationAttributes sets the VerificationAttributes field's value.
+func (s *GetIdentityVerificationAttributesOutput) SetVerificationAttributes(v map[string]*IdentityVerificationAttributes) *GetIdentityVerificationAttributesOutput {
+	s.VerificationAttributes = v
+	return s
 }
 
 type GetSendQuotaInput struct {
@@ -4467,6 +4791,24 @@ func (s GetSendQuotaOutput) GoString() string {
 	return s.String()
 }
 
+// SetMax24HourSend sets the Max24HourSend field's value.
+func (s *GetSendQuotaOutput) SetMax24HourSend(v float64) *GetSendQuotaOutput {
+	s.Max24HourSend = &v
+	return s
+}
+
+// SetMaxSendRate sets the MaxSendRate field's value.
+func (s *GetSendQuotaOutput) SetMaxSendRate(v float64) *GetSendQuotaOutput {
+	s.MaxSendRate = &v
+	return s
+}
+
+// SetSentLast24Hours sets the SentLast24Hours field's value.
+func (s *GetSendQuotaOutput) SetSentLast24Hours(v float64) *GetSendQuotaOutput {
+	s.SentLast24Hours = &v
+	return s
+}
+
 type GetSendStatisticsInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4498,6 +4840,12 @@ func (s GetSendStatisticsOutput) String() string {
 // GoString returns the string representation
 func (s GetSendStatisticsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSendDataPoints sets the SendDataPoints field's value.
+func (s *GetSendStatisticsOutput) SetSendDataPoints(v []*SendDataPoint) *GetSendStatisticsOutput {
+	s.SendDataPoints = v
+	return s
 }
 
 // Represents the DKIM attributes of a verified email address or a domain.
@@ -4537,6 +4885,24 @@ func (s IdentityDkimAttributes) String() string {
 // GoString returns the string representation
 func (s IdentityDkimAttributes) GoString() string {
 	return s.String()
+}
+
+// SetDkimEnabled sets the DkimEnabled field's value.
+func (s *IdentityDkimAttributes) SetDkimEnabled(v bool) *IdentityDkimAttributes {
+	s.DkimEnabled = &v
+	return s
+}
+
+// SetDkimTokens sets the DkimTokens field's value.
+func (s *IdentityDkimAttributes) SetDkimTokens(v []*string) *IdentityDkimAttributes {
+	s.DkimTokens = v
+	return s
+}
+
+// SetDkimVerificationStatus sets the DkimVerificationStatus field's value.
+func (s *IdentityDkimAttributes) SetDkimVerificationStatus(v string) *IdentityDkimAttributes {
+	s.DkimVerificationStatus = &v
+	return s
 }
 
 // Represents the custom MAIL FROM domain attributes of a verified identity
@@ -4580,6 +4946,24 @@ func (s IdentityMailFromDomainAttributes) String() string {
 // GoString returns the string representation
 func (s IdentityMailFromDomainAttributes) GoString() string {
 	return s.String()
+}
+
+// SetBehaviorOnMXFailure sets the BehaviorOnMXFailure field's value.
+func (s *IdentityMailFromDomainAttributes) SetBehaviorOnMXFailure(v string) *IdentityMailFromDomainAttributes {
+	s.BehaviorOnMXFailure = &v
+	return s
+}
+
+// SetMailFromDomain sets the MailFromDomain field's value.
+func (s *IdentityMailFromDomainAttributes) SetMailFromDomain(v string) *IdentityMailFromDomainAttributes {
+	s.MailFromDomain = &v
+	return s
+}
+
+// SetMailFromDomainStatus sets the MailFromDomainStatus field's value.
+func (s *IdentityMailFromDomainAttributes) SetMailFromDomainStatus(v string) *IdentityMailFromDomainAttributes {
+	s.MailFromDomainStatus = &v
+	return s
 }
 
 // Represents the notification attributes of an identity, including whether
@@ -4644,6 +5028,48 @@ func (s IdentityNotificationAttributes) GoString() string {
 	return s.String()
 }
 
+// SetBounceTopic sets the BounceTopic field's value.
+func (s *IdentityNotificationAttributes) SetBounceTopic(v string) *IdentityNotificationAttributes {
+	s.BounceTopic = &v
+	return s
+}
+
+// SetComplaintTopic sets the ComplaintTopic field's value.
+func (s *IdentityNotificationAttributes) SetComplaintTopic(v string) *IdentityNotificationAttributes {
+	s.ComplaintTopic = &v
+	return s
+}
+
+// SetDeliveryTopic sets the DeliveryTopic field's value.
+func (s *IdentityNotificationAttributes) SetDeliveryTopic(v string) *IdentityNotificationAttributes {
+	s.DeliveryTopic = &v
+	return s
+}
+
+// SetForwardingEnabled sets the ForwardingEnabled field's value.
+func (s *IdentityNotificationAttributes) SetForwardingEnabled(v bool) *IdentityNotificationAttributes {
+	s.ForwardingEnabled = &v
+	return s
+}
+
+// SetHeadersInBounceNotificationsEnabled sets the HeadersInBounceNotificationsEnabled field's value.
+func (s *IdentityNotificationAttributes) SetHeadersInBounceNotificationsEnabled(v bool) *IdentityNotificationAttributes {
+	s.HeadersInBounceNotificationsEnabled = &v
+	return s
+}
+
+// SetHeadersInComplaintNotificationsEnabled sets the HeadersInComplaintNotificationsEnabled field's value.
+func (s *IdentityNotificationAttributes) SetHeadersInComplaintNotificationsEnabled(v bool) *IdentityNotificationAttributes {
+	s.HeadersInComplaintNotificationsEnabled = &v
+	return s
+}
+
+// SetHeadersInDeliveryNotificationsEnabled sets the HeadersInDeliveryNotificationsEnabled field's value.
+func (s *IdentityNotificationAttributes) SetHeadersInDeliveryNotificationsEnabled(v bool) *IdentityNotificationAttributes {
+	s.HeadersInDeliveryNotificationsEnabled = &v
+	return s
+}
+
 // Represents the verification attributes of a single identity.
 type IdentityVerificationAttributes struct {
 	_ struct{} `type:"structure"`
@@ -4666,6 +5092,18 @@ func (s IdentityVerificationAttributes) String() string {
 // GoString returns the string representation
 func (s IdentityVerificationAttributes) GoString() string {
 	return s.String()
+}
+
+// SetVerificationStatus sets the VerificationStatus field's value.
+func (s *IdentityVerificationAttributes) SetVerificationStatus(v string) *IdentityVerificationAttributes {
+	s.VerificationStatus = &v
+	return s
+}
+
+// SetVerificationToken sets the VerificationToken field's value.
+func (s *IdentityVerificationAttributes) SetVerificationToken(v string) *IdentityVerificationAttributes {
+	s.VerificationToken = &v
+	return s
 }
 
 // When included in a receipt rule, this action calls an AWS Lambda function
@@ -4732,6 +5170,24 @@ func (s *LambdaAction) Validate() error {
 	return nil
 }
 
+// SetFunctionArn sets the FunctionArn field's value.
+func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
+	s.FunctionArn = &v
+	return s
+}
+
+// SetInvocationType sets the InvocationType field's value.
+func (s *LambdaAction) SetInvocationType(v string) *LambdaAction {
+	s.InvocationType = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *LambdaAction) SetTopicArn(v string) *LambdaAction {
+	s.TopicArn = &v
+	return s
+}
+
 // Represents a request to return a list of all identities (email addresses
 // and domains) that you have attempted to verify under your AWS account, regardless
 // of verification status.
@@ -4759,6 +5215,24 @@ func (s ListIdentitiesInput) GoString() string {
 	return s.String()
 }
 
+// SetIdentityType sets the IdentityType field's value.
+func (s *ListIdentitiesInput) SetIdentityType(v string) *ListIdentitiesInput {
+	s.IdentityType = &v
+	return s
+}
+
+// SetMaxItems sets the MaxItems field's value.
+func (s *ListIdentitiesInput) SetMaxItems(v int64) *ListIdentitiesInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIdentitiesInput) SetNextToken(v string) *ListIdentitiesInput {
+	s.NextToken = &v
+	return s
+}
+
 // A list of all identities that you have attempted to verify under your AWS
 // account, regardless of verification status.
 type ListIdentitiesOutput struct {
@@ -4781,6 +5255,18 @@ func (s ListIdentitiesOutput) String() string {
 // GoString returns the string representation
 func (s ListIdentitiesOutput) GoString() string {
 	return s.String()
+}
+
+// SetIdentities sets the Identities field's value.
+func (s *ListIdentitiesOutput) SetIdentities(v []*string) *ListIdentitiesOutput {
+	s.Identities = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIdentitiesOutput) SetNextToken(v string) *ListIdentitiesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Represents a request to return a list of sending authorization policies that
@@ -4823,6 +5309,12 @@ func (s *ListIdentityPoliciesInput) Validate() error {
 	return nil
 }
 
+// SetIdentity sets the Identity field's value.
+func (s *ListIdentityPoliciesInput) SetIdentity(v string) *ListIdentityPoliciesInput {
+	s.Identity = &v
+	return s
+}
+
 // A list of names of sending authorization policies that apply to an identity.
 type ListIdentityPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4841,6 +5333,12 @@ func (s ListIdentityPoliciesOutput) String() string {
 // GoString returns the string representation
 func (s ListIdentityPoliciesOutput) GoString() string {
 	return s.String()
+}
+
+// SetPolicyNames sets the PolicyNames field's value.
+func (s *ListIdentityPoliciesOutput) SetPolicyNames(v []*string) *ListIdentityPoliciesOutput {
+	s.PolicyNames = v
+	return s
 }
 
 // : Represents a request to list the IP address filters that exist under your
@@ -4879,6 +5377,12 @@ func (s ListReceiptFiltersOutput) GoString() string {
 	return s.String()
 }
 
+// SetFilters sets the Filters field's value.
+func (s *ListReceiptFiltersOutput) SetFilters(v []*ReceiptFilter) *ListReceiptFiltersOutput {
+	s.Filters = v
+	return s
+}
+
 // Represents a request to list the receipt rule sets that exist under your
 // AWS account. You use receipt rule sets to receive email with Amazon SES.
 // For more information, see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html).
@@ -4898,6 +5402,12 @@ func (s ListReceiptRuleSetsInput) String() string {
 // GoString returns the string representation
 func (s ListReceiptRuleSetsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListReceiptRuleSetsInput) SetNextToken(v string) *ListReceiptRuleSetsInput {
+	s.NextToken = &v
+	return s
 }
 
 // A list of receipt rule sets that exist under your AWS account.
@@ -4922,6 +5432,18 @@ func (s ListReceiptRuleSetsOutput) String() string {
 // GoString returns the string representation
 func (s ListReceiptRuleSetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListReceiptRuleSetsOutput) SetNextToken(v string) *ListReceiptRuleSetsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRuleSets sets the RuleSets field's value.
+func (s *ListReceiptRuleSetsOutput) SetRuleSets(v []*ReceiptRuleSetMetadata) *ListReceiptRuleSetsOutput {
+	s.RuleSets = v
+	return s
 }
 
 type ListVerifiedEmailAddressesInput struct {
@@ -4955,6 +5477,12 @@ func (s ListVerifiedEmailAddressesOutput) String() string {
 // GoString returns the string representation
 func (s ListVerifiedEmailAddressesOutput) GoString() string {
 	return s.String()
+}
+
+// SetVerifiedEmailAddresses sets the VerifiedEmailAddresses field's value.
+func (s *ListVerifiedEmailAddressesOutput) SetVerifiedEmailAddresses(v []*string) *ListVerifiedEmailAddressesOutput {
+	s.VerifiedEmailAddresses = v
+	return s
 }
 
 // Represents the message to be sent, composed of a subject and a body.
@@ -5007,6 +5535,18 @@ func (s *Message) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBody sets the Body field's value.
+func (s *Message) SetBody(v *Body) *Message {
+	s.Body = v
+	return s
+}
+
+// SetSubject sets the Subject field's value.
+func (s *Message) SetSubject(v *Content) *Message {
+	s.Subject = v
+	return s
 }
 
 // Message-related information to include in the Delivery Status Notification
@@ -5063,6 +5603,24 @@ func (s *MessageDsn) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetArrivalDate sets the ArrivalDate field's value.
+func (s *MessageDsn) SetArrivalDate(v time.Time) *MessageDsn {
+	s.ArrivalDate = &v
+	return s
+}
+
+// SetExtensionFields sets the ExtensionFields field's value.
+func (s *MessageDsn) SetExtensionFields(v []*ExtensionField) *MessageDsn {
+	s.ExtensionFields = v
+	return s
+}
+
+// SetReportingMta sets the ReportingMta field's value.
+func (s *MessageDsn) SetReportingMta(v string) *MessageDsn {
+	s.ReportingMta = &v
+	return s
 }
 
 // Represents a request to add or update a sending authorization policy for
@@ -5133,6 +5691,24 @@ func (s *PutIdentityPolicyInput) Validate() error {
 	return nil
 }
 
+// SetIdentity sets the Identity field's value.
+func (s *PutIdentityPolicyInput) SetIdentity(v string) *PutIdentityPolicyInput {
+	s.Identity = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *PutIdentityPolicyInput) SetPolicy(v string) *PutIdentityPolicyInput {
+	s.Policy = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *PutIdentityPolicyInput) SetPolicyName(v string) *PutIdentityPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type PutIdentityPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -5194,6 +5770,12 @@ func (s *RawMessage) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetData sets the Data field's value.
+func (s *RawMessage) SetData(v []byte) *RawMessage {
+	s.Data = v
+	return s
 }
 
 // An action that Amazon SES can take when it receives an email on behalf of
@@ -5288,6 +5870,48 @@ func (s *ReceiptAction) Validate() error {
 	return nil
 }
 
+// SetAddHeaderAction sets the AddHeaderAction field's value.
+func (s *ReceiptAction) SetAddHeaderAction(v *AddHeaderAction) *ReceiptAction {
+	s.AddHeaderAction = v
+	return s
+}
+
+// SetBounceAction sets the BounceAction field's value.
+func (s *ReceiptAction) SetBounceAction(v *BounceAction) *ReceiptAction {
+	s.BounceAction = v
+	return s
+}
+
+// SetLambdaAction sets the LambdaAction field's value.
+func (s *ReceiptAction) SetLambdaAction(v *LambdaAction) *ReceiptAction {
+	s.LambdaAction = v
+	return s
+}
+
+// SetS3Action sets the S3Action field's value.
+func (s *ReceiptAction) SetS3Action(v *S3Action) *ReceiptAction {
+	s.S3Action = v
+	return s
+}
+
+// SetSNSAction sets the SNSAction field's value.
+func (s *ReceiptAction) SetSNSAction(v *SNSAction) *ReceiptAction {
+	s.SNSAction = v
+	return s
+}
+
+// SetStopAction sets the StopAction field's value.
+func (s *ReceiptAction) SetStopAction(v *StopAction) *ReceiptAction {
+	s.StopAction = v
+	return s
+}
+
+// SetWorkmailAction sets the WorkmailAction field's value.
+func (s *ReceiptAction) SetWorkmailAction(v *WorkmailAction) *ReceiptAction {
+	s.WorkmailAction = v
+	return s
+}
+
 // A receipt IP address filter enables you to specify whether to accept or reject
 // mail originating from an IP address or range of IP addresses.
 //
@@ -5346,6 +5970,18 @@ func (s *ReceiptFilter) Validate() error {
 	return nil
 }
 
+// SetIpFilter sets the IpFilter field's value.
+func (s *ReceiptFilter) SetIpFilter(v *ReceiptIpFilter) *ReceiptFilter {
+	s.IpFilter = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ReceiptFilter) SetName(v string) *ReceiptFilter {
+	s.Name = &v
+	return s
+}
+
 // A receipt IP address filter enables you to specify whether to accept or reject
 // mail originating from an IP address or range of IP addresses.
 //
@@ -5392,6 +6028,18 @@ func (s *ReceiptIpFilter) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCidr sets the Cidr field's value.
+func (s *ReceiptIpFilter) SetCidr(v string) *ReceiptIpFilter {
+	s.Cidr = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *ReceiptIpFilter) SetPolicy(v string) *ReceiptIpFilter {
+	s.Policy = &v
+	return s
 }
 
 // Receipt rules enable you to specify which actions Amazon SES should take
@@ -5476,6 +6124,42 @@ func (s *ReceiptRule) Validate() error {
 	return nil
 }
 
+// SetActions sets the Actions field's value.
+func (s *ReceiptRule) SetActions(v []*ReceiptAction) *ReceiptRule {
+	s.Actions = v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *ReceiptRule) SetEnabled(v bool) *ReceiptRule {
+	s.Enabled = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ReceiptRule) SetName(v string) *ReceiptRule {
+	s.Name = &v
+	return s
+}
+
+// SetRecipients sets the Recipients field's value.
+func (s *ReceiptRule) SetRecipients(v []*string) *ReceiptRule {
+	s.Recipients = v
+	return s
+}
+
+// SetScanEnabled sets the ScanEnabled field's value.
+func (s *ReceiptRule) SetScanEnabled(v bool) *ReceiptRule {
+	s.ScanEnabled = &v
+	return s
+}
+
+// SetTlsPolicy sets the TlsPolicy field's value.
+func (s *ReceiptRule) SetTlsPolicy(v string) *ReceiptRule {
+	s.TlsPolicy = &v
+	return s
+}
+
 // Information about a receipt rule set.
 //
 // A receipt rule set is a collection of rules that specify what Amazon SES
@@ -5508,6 +6192,18 @@ func (s ReceiptRuleSetMetadata) String() string {
 // GoString returns the string representation
 func (s ReceiptRuleSetMetadata) GoString() string {
 	return s.String()
+}
+
+// SetCreatedTimestamp sets the CreatedTimestamp field's value.
+func (s *ReceiptRuleSetMetadata) SetCreatedTimestamp(v time.Time) *ReceiptRuleSetMetadata {
+	s.CreatedTimestamp = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ReceiptRuleSetMetadata) SetName(v string) *ReceiptRuleSetMetadata {
+	s.Name = &v
+	return s
 }
 
 // Recipient-related information to include in the Delivery Status Notification
@@ -5596,6 +6292,48 @@ func (s *RecipientDsnFields) Validate() error {
 	return nil
 }
 
+// SetAction sets the Action field's value.
+func (s *RecipientDsnFields) SetAction(v string) *RecipientDsnFields {
+	s.Action = &v
+	return s
+}
+
+// SetDiagnosticCode sets the DiagnosticCode field's value.
+func (s *RecipientDsnFields) SetDiagnosticCode(v string) *RecipientDsnFields {
+	s.DiagnosticCode = &v
+	return s
+}
+
+// SetExtensionFields sets the ExtensionFields field's value.
+func (s *RecipientDsnFields) SetExtensionFields(v []*ExtensionField) *RecipientDsnFields {
+	s.ExtensionFields = v
+	return s
+}
+
+// SetFinalRecipient sets the FinalRecipient field's value.
+func (s *RecipientDsnFields) SetFinalRecipient(v string) *RecipientDsnFields {
+	s.FinalRecipient = &v
+	return s
+}
+
+// SetLastAttemptDate sets the LastAttemptDate field's value.
+func (s *RecipientDsnFields) SetLastAttemptDate(v time.Time) *RecipientDsnFields {
+	s.LastAttemptDate = &v
+	return s
+}
+
+// SetRemoteMta sets the RemoteMta field's value.
+func (s *RecipientDsnFields) SetRemoteMta(v string) *RecipientDsnFields {
+	s.RemoteMta = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *RecipientDsnFields) SetStatus(v string) *RecipientDsnFields {
+	s.Status = &v
+	return s
+}
+
 // Represents a request to reorder the receipt rules within a receipt rule set.
 // You use receipt rule sets to receive email with Amazon SES. For more information,
 // see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html).
@@ -5638,6 +6376,18 @@ func (s *ReorderReceiptRuleSetInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRuleNames sets the RuleNames field's value.
+func (s *ReorderReceiptRuleSetInput) SetRuleNames(v []*string) *ReorderReceiptRuleSetInput {
+	s.RuleNames = v
+	return s
+}
+
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *ReorderReceiptRuleSetInput) SetRuleSetName(v string) *ReorderReceiptRuleSetInput {
+	s.RuleSetName = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -5743,6 +6493,30 @@ func (s *S3Action) Validate() error {
 	return nil
 }
 
+// SetBucketName sets the BucketName field's value.
+func (s *S3Action) SetBucketName(v string) *S3Action {
+	s.BucketName = &v
+	return s
+}
+
+// SetKmsKeyArn sets the KmsKeyArn field's value.
+func (s *S3Action) SetKmsKeyArn(v string) *S3Action {
+	s.KmsKeyArn = &v
+	return s
+}
+
+// SetObjectKeyPrefix sets the ObjectKeyPrefix field's value.
+func (s *S3Action) SetObjectKeyPrefix(v string) *S3Action {
+	s.ObjectKeyPrefix = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *S3Action) SetTopicArn(v string) *S3Action {
+	s.TopicArn = &v
+	return s
+}
+
 // When included in a receipt rule, this action publishes a notification to
 // Amazon Simple Notification Service (Amazon SNS). This action includes a complete
 // copy of the email content in the Amazon SNS notifications. Amazon SNS notifications
@@ -5800,6 +6574,18 @@ func (s *SNSAction) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEncoding sets the Encoding field's value.
+func (s *SNSAction) SetEncoding(v string) *SNSAction {
+	s.Encoding = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *SNSAction) SetTopicArn(v string) *SNSAction {
+	s.TopicArn = &v
+	return s
 }
 
 // Represents a request to send a bounce message to the sender of an email you
@@ -5885,6 +6671,42 @@ func (s *SendBounceInput) Validate() error {
 	return nil
 }
 
+// SetBounceSender sets the BounceSender field's value.
+func (s *SendBounceInput) SetBounceSender(v string) *SendBounceInput {
+	s.BounceSender = &v
+	return s
+}
+
+// SetBounceSenderArn sets the BounceSenderArn field's value.
+func (s *SendBounceInput) SetBounceSenderArn(v string) *SendBounceInput {
+	s.BounceSenderArn = &v
+	return s
+}
+
+// SetBouncedRecipientInfoList sets the BouncedRecipientInfoList field's value.
+func (s *SendBounceInput) SetBouncedRecipientInfoList(v []*BouncedRecipientInfo) *SendBounceInput {
+	s.BouncedRecipientInfoList = v
+	return s
+}
+
+// SetExplanation sets the Explanation field's value.
+func (s *SendBounceInput) SetExplanation(v string) *SendBounceInput {
+	s.Explanation = &v
+	return s
+}
+
+// SetMessageDsn sets the MessageDsn field's value.
+func (s *SendBounceInput) SetMessageDsn(v *MessageDsn) *SendBounceInput {
+	s.MessageDsn = v
+	return s
+}
+
+// SetOriginalMessageId sets the OriginalMessageId field's value.
+func (s *SendBounceInput) SetOriginalMessageId(v string) *SendBounceInput {
+	s.OriginalMessageId = &v
+	return s
+}
+
 // Represents a unique message ID.
 type SendBounceOutput struct {
 	_ struct{} `type:"structure"`
@@ -5901,6 +6723,12 @@ func (s SendBounceOutput) String() string {
 // GoString returns the string representation
 func (s SendBounceOutput) GoString() string {
 	return s.String()
+}
+
+// SetMessageId sets the MessageId field's value.
+func (s *SendBounceOutput) SetMessageId(v string) *SendBounceOutput {
+	s.MessageId = &v
+	return s
 }
 
 // Represents sending statistics data. Each SendDataPoint contains statistics
@@ -5932,6 +6760,36 @@ func (s SendDataPoint) String() string {
 // GoString returns the string representation
 func (s SendDataPoint) GoString() string {
 	return s.String()
+}
+
+// SetBounces sets the Bounces field's value.
+func (s *SendDataPoint) SetBounces(v int64) *SendDataPoint {
+	s.Bounces = &v
+	return s
+}
+
+// SetComplaints sets the Complaints field's value.
+func (s *SendDataPoint) SetComplaints(v int64) *SendDataPoint {
+	s.Complaints = &v
+	return s
+}
+
+// SetDeliveryAttempts sets the DeliveryAttempts field's value.
+func (s *SendDataPoint) SetDeliveryAttempts(v int64) *SendDataPoint {
+	s.DeliveryAttempts = &v
+	return s
+}
+
+// SetRejects sets the Rejects field's value.
+func (s *SendDataPoint) SetRejects(v int64) *SendDataPoint {
+	s.Rejects = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *SendDataPoint) SetTimestamp(v time.Time) *SendDataPoint {
+	s.Timestamp = &v
+	return s
 }
 
 // Represents a request to send a single formatted email using Amazon SES. For
@@ -6042,6 +6900,48 @@ func (s *SendEmailInput) Validate() error {
 	return nil
 }
 
+// SetDestination sets the Destination field's value.
+func (s *SendEmailInput) SetDestination(v *Destination) *SendEmailInput {
+	s.Destination = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *SendEmailInput) SetMessage(v *Message) *SendEmailInput {
+	s.Message = v
+	return s
+}
+
+// SetReplyToAddresses sets the ReplyToAddresses field's value.
+func (s *SendEmailInput) SetReplyToAddresses(v []*string) *SendEmailInput {
+	s.ReplyToAddresses = v
+	return s
+}
+
+// SetReturnPath sets the ReturnPath field's value.
+func (s *SendEmailInput) SetReturnPath(v string) *SendEmailInput {
+	s.ReturnPath = &v
+	return s
+}
+
+// SetReturnPathArn sets the ReturnPathArn field's value.
+func (s *SendEmailInput) SetReturnPathArn(v string) *SendEmailInput {
+	s.ReturnPathArn = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *SendEmailInput) SetSource(v string) *SendEmailInput {
+	s.Source = &v
+	return s
+}
+
+// SetSourceArn sets the SourceArn field's value.
+func (s *SendEmailInput) SetSourceArn(v string) *SendEmailInput {
+	s.SourceArn = &v
+	return s
+}
+
 // Represents a unique message ID.
 type SendEmailOutput struct {
 	_ struct{} `type:"structure"`
@@ -6060,6 +6960,12 @@ func (s SendEmailOutput) String() string {
 // GoString returns the string representation
 func (s SendEmailOutput) GoString() string {
 	return s.String()
+}
+
+// SetMessageId sets the MessageId field's value.
+func (s *SendEmailOutput) SetMessageId(v string) *SendEmailOutput {
+	s.MessageId = &v
+	return s
 }
 
 // Represents a request to send a single raw email using Amazon SES. For more
@@ -6179,6 +7085,42 @@ func (s *SendRawEmailInput) Validate() error {
 	return nil
 }
 
+// SetDestinations sets the Destinations field's value.
+func (s *SendRawEmailInput) SetDestinations(v []*string) *SendRawEmailInput {
+	s.Destinations = v
+	return s
+}
+
+// SetFromArn sets the FromArn field's value.
+func (s *SendRawEmailInput) SetFromArn(v string) *SendRawEmailInput {
+	s.FromArn = &v
+	return s
+}
+
+// SetRawMessage sets the RawMessage field's value.
+func (s *SendRawEmailInput) SetRawMessage(v *RawMessage) *SendRawEmailInput {
+	s.RawMessage = v
+	return s
+}
+
+// SetReturnPathArn sets the ReturnPathArn field's value.
+func (s *SendRawEmailInput) SetReturnPathArn(v string) *SendRawEmailInput {
+	s.ReturnPathArn = &v
+	return s
+}
+
+// SetSource sets the Source field's value.
+func (s *SendRawEmailInput) SetSource(v string) *SendRawEmailInput {
+	s.Source = &v
+	return s
+}
+
+// SetSourceArn sets the SourceArn field's value.
+func (s *SendRawEmailInput) SetSourceArn(v string) *SendRawEmailInput {
+	s.SourceArn = &v
+	return s
+}
+
 // Represents a unique message ID.
 type SendRawEmailOutput struct {
 	_ struct{} `type:"structure"`
@@ -6197,6 +7139,12 @@ func (s SendRawEmailOutput) String() string {
 // GoString returns the string representation
 func (s SendRawEmailOutput) GoString() string {
 	return s.String()
+}
+
+// SetMessageId sets the MessageId field's value.
+func (s *SendRawEmailOutput) SetMessageId(v string) *SendRawEmailOutput {
+	s.MessageId = &v
+	return s
 }
 
 // Represents a request to set a receipt rule set as the active receipt rule
@@ -6218,6 +7166,12 @@ func (s SetActiveReceiptRuleSetInput) String() string {
 // GoString returns the string representation
 func (s SetActiveReceiptRuleSetInput) GoString() string {
 	return s.String()
+}
+
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *SetActiveReceiptRuleSetInput) SetRuleSetName(v string) *SetActiveReceiptRuleSetInput {
+	s.RuleSetName = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -6277,6 +7231,18 @@ func (s *SetIdentityDkimEnabledInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDkimEnabled sets the DkimEnabled field's value.
+func (s *SetIdentityDkimEnabledInput) SetDkimEnabled(v bool) *SetIdentityDkimEnabledInput {
+	s.DkimEnabled = &v
+	return s
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *SetIdentityDkimEnabledInput) SetIdentity(v string) *SetIdentityDkimEnabledInput {
+	s.Identity = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -6341,6 +7307,18 @@ func (s *SetIdentityFeedbackForwardingEnabledInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetForwardingEnabled sets the ForwardingEnabled field's value.
+func (s *SetIdentityFeedbackForwardingEnabledInput) SetForwardingEnabled(v bool) *SetIdentityFeedbackForwardingEnabledInput {
+	s.ForwardingEnabled = &v
+	return s
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *SetIdentityFeedbackForwardingEnabledInput) SetIdentity(v string) *SetIdentityFeedbackForwardingEnabledInput {
+	s.Identity = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -6416,6 +7394,24 @@ func (s *SetIdentityHeadersInNotificationsEnabledInput) Validate() error {
 	return nil
 }
 
+// SetEnabled sets the Enabled field's value.
+func (s *SetIdentityHeadersInNotificationsEnabledInput) SetEnabled(v bool) *SetIdentityHeadersInNotificationsEnabledInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *SetIdentityHeadersInNotificationsEnabledInput) SetIdentity(v string) *SetIdentityHeadersInNotificationsEnabledInput {
+	s.Identity = &v
+	return s
+}
+
+// SetNotificationType sets the NotificationType field's value.
+func (s *SetIdentityHeadersInNotificationsEnabledInput) SetNotificationType(v string) *SetIdentityHeadersInNotificationsEnabledInput {
+	s.NotificationType = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type SetIdentityHeadersInNotificationsEnabledOutput struct {
 	_ struct{} `type:"structure"`
@@ -6486,6 +7482,24 @@ func (s *SetIdentityMailFromDomainInput) Validate() error {
 	return nil
 }
 
+// SetBehaviorOnMXFailure sets the BehaviorOnMXFailure field's value.
+func (s *SetIdentityMailFromDomainInput) SetBehaviorOnMXFailure(v string) *SetIdentityMailFromDomainInput {
+	s.BehaviorOnMXFailure = &v
+	return s
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *SetIdentityMailFromDomainInput) SetIdentity(v string) *SetIdentityMailFromDomainInput {
+	s.Identity = &v
+	return s
+}
+
+// SetMailFromDomain sets the MailFromDomain field's value.
+func (s *SetIdentityMailFromDomainInput) SetMailFromDomain(v string) *SetIdentityMailFromDomainInput {
+	s.MailFromDomain = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type SetIdentityMailFromDomainOutput struct {
 	_ struct{} `type:"structure"`
@@ -6553,6 +7567,24 @@ func (s *SetIdentityNotificationTopicInput) Validate() error {
 	return nil
 }
 
+// SetIdentity sets the Identity field's value.
+func (s *SetIdentityNotificationTopicInput) SetIdentity(v string) *SetIdentityNotificationTopicInput {
+	s.Identity = &v
+	return s
+}
+
+// SetNotificationType sets the NotificationType field's value.
+func (s *SetIdentityNotificationTopicInput) SetNotificationType(v string) *SetIdentityNotificationTopicInput {
+	s.NotificationType = &v
+	return s
+}
+
+// SetSnsTopic sets the SnsTopic field's value.
+func (s *SetIdentityNotificationTopicInput) SetSnsTopic(v string) *SetIdentityNotificationTopicInput {
+	s.SnsTopic = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type SetIdentityNotificationTopicOutput struct {
 	_ struct{} `type:"structure"`
@@ -6614,6 +7646,24 @@ func (s *SetReceiptRulePositionInput) Validate() error {
 	return nil
 }
 
+// SetAfter sets the After field's value.
+func (s *SetReceiptRulePositionInput) SetAfter(v string) *SetReceiptRulePositionInput {
+	s.After = &v
+	return s
+}
+
+// SetRuleName sets the RuleName field's value.
+func (s *SetReceiptRulePositionInput) SetRuleName(v string) *SetReceiptRulePositionInput {
+	s.RuleName = &v
+	return s
+}
+
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *SetReceiptRulePositionInput) SetRuleSetName(v string) *SetReceiptRulePositionInput {
+	s.RuleSetName = &v
+	return s
+}
+
 // An empty element returned on a successful request.
 type SetReceiptRulePositionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6673,6 +7723,18 @@ func (s *StopAction) Validate() error {
 	return nil
 }
 
+// SetScope sets the Scope field's value.
+func (s *StopAction) SetScope(v string) *StopAction {
+	s.Scope = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *StopAction) SetTopicArn(v string) *StopAction {
+	s.TopicArn = &v
+	return s
+}
+
 // Represents a request to update a receipt rule. You use receipt rules to receive
 // email with Amazon SES. For more information, see the Amazon SES Developer
 // Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html).
@@ -6719,6 +7781,18 @@ func (s *UpdateReceiptRuleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetRule sets the Rule field's value.
+func (s *UpdateReceiptRuleInput) SetRule(v *ReceiptRule) *UpdateReceiptRuleInput {
+	s.Rule = v
+	return s
+}
+
+// SetRuleSetName sets the RuleSetName field's value.
+func (s *UpdateReceiptRuleInput) SetRuleSetName(v string) *UpdateReceiptRuleInput {
+	s.RuleSetName = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -6771,6 +7845,12 @@ func (s *VerifyDomainDkimInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *VerifyDomainDkimInput) SetDomain(v string) *VerifyDomainDkimInput {
+	s.Domain = &v
+	return s
+}
+
 // Returns CNAME records that you must publish to the DNS server of your domain
 // to set up Easy DKIM with Amazon SES.
 type VerifyDomainDkimOutput struct {
@@ -6800,6 +7880,12 @@ func (s VerifyDomainDkimOutput) String() string {
 // GoString returns the string representation
 func (s VerifyDomainDkimOutput) GoString() string {
 	return s.String()
+}
+
+// SetDkimTokens sets the DkimTokens field's value.
+func (s *VerifyDomainDkimOutput) SetDkimTokens(v []*string) *VerifyDomainDkimOutput {
+	s.DkimTokens = v
+	return s
 }
 
 // Represents a request to begin Amazon SES domain verification and to generate
@@ -6838,6 +7924,12 @@ func (s *VerifyDomainIdentityInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *VerifyDomainIdentityInput) SetDomain(v string) *VerifyDomainIdentityInput {
+	s.Domain = &v
+	return s
+}
+
 // Returns a TXT record that you must publish to the DNS server of your domain
 // to complete domain verification with Amazon SES.
 type VerifyDomainIdentityOutput struct {
@@ -6858,6 +7950,12 @@ func (s VerifyDomainIdentityOutput) String() string {
 // GoString returns the string representation
 func (s VerifyDomainIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// SetVerificationToken sets the VerificationToken field's value.
+func (s *VerifyDomainIdentityOutput) SetVerificationToken(v string) *VerifyDomainIdentityOutput {
+	s.VerificationToken = &v
+	return s
 }
 
 // Represents a request to begin email address verification with Amazon SES.
@@ -6893,6 +7991,12 @@ func (s *VerifyEmailAddressInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *VerifyEmailAddressInput) SetEmailAddress(v string) *VerifyEmailAddressInput {
+	s.EmailAddress = &v
+	return s
 }
 
 type VerifyEmailAddressOutput struct {
@@ -6942,6 +8046,12 @@ func (s *VerifyEmailIdentityInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *VerifyEmailIdentityInput) SetEmailAddress(v string) *VerifyEmailIdentityInput {
+	s.EmailAddress = &v
+	return s
 }
 
 // An empty element returned on a successful request.
@@ -7005,6 +8115,18 @@ func (s *WorkmailAction) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetOrganizationArn sets the OrganizationArn field's value.
+func (s *WorkmailAction) SetOrganizationArn(v string) *WorkmailAction {
+	s.OrganizationArn = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *WorkmailAction) SetTopicArn(v string) *WorkmailAction {
+	s.TopicArn = &v
+	return s
 }
 
 const (

--- a/service/simpledb/api.go
+++ b/service/simpledb/api.go
@@ -987,6 +987,30 @@ func (s Attribute) GoString() string {
 	return s.String()
 }
 
+// SetAlternateNameEncoding sets the AlternateNameEncoding field's value.
+func (s *Attribute) SetAlternateNameEncoding(v string) *Attribute {
+	s.AlternateNameEncoding = &v
+	return s
+}
+
+// SetAlternateValueEncoding sets the AlternateValueEncoding field's value.
+func (s *Attribute) SetAlternateValueEncoding(v string) *Attribute {
+	s.AlternateValueEncoding = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Attribute) SetName(v string) *Attribute {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Attribute) SetValue(v string) *Attribute {
+	s.Value = &v
+	return s
+}
+
 type BatchDeleteAttributesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1035,6 +1059,18 @@ func (s *BatchDeleteAttributesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *BatchDeleteAttributesInput) SetDomainName(v string) *BatchDeleteAttributesInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *BatchDeleteAttributesInput) SetItems(v []*DeletableItem) *BatchDeleteAttributesInput {
+	s.Items = v
+	return s
 }
 
 type BatchDeleteAttributesOutput struct {
@@ -1101,6 +1137,18 @@ func (s *BatchPutAttributesInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *BatchPutAttributesInput) SetDomainName(v string) *BatchPutAttributesInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetItems sets the Items field's value.
+func (s *BatchPutAttributesInput) SetItems(v []*ReplaceableItem) *BatchPutAttributesInput {
+	s.Items = v
+	return s
+}
+
 type BatchPutAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1146,6 +1194,12 @@ func (s *CreateDomainInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *CreateDomainInput) SetDomainName(v string) *CreateDomainInput {
+	s.DomainName = &v
+	return s
 }
 
 type CreateDomainOutput struct {
@@ -1197,6 +1251,18 @@ func (s *DeletableAttribute) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *DeletableAttribute) SetName(v string) *DeletableAttribute {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *DeletableAttribute) SetValue(v string) *DeletableAttribute {
+	s.Value = &v
+	return s
+}
+
 type DeletableItem struct {
 	_ struct{} `type:"structure"`
 
@@ -1237,6 +1303,18 @@ func (s *DeletableItem) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *DeletableItem) SetAttributes(v []*DeletableAttribute) *DeletableItem {
+	s.Attributes = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeletableItem) SetName(v string) *DeletableItem {
+	s.Name = &v
+	return s
 }
 
 type DeleteAttributesInput struct {
@@ -1299,6 +1377,30 @@ func (s *DeleteAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *DeleteAttributesInput) SetAttributes(v []*DeletableAttribute) *DeleteAttributesInput {
+	s.Attributes = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteAttributesInput) SetDomainName(v string) *DeleteAttributesInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetExpected sets the Expected field's value.
+func (s *DeleteAttributesInput) SetExpected(v *UpdateCondition) *DeleteAttributesInput {
+	s.Expected = v
+	return s
+}
+
+// SetItemName sets the ItemName field's value.
+func (s *DeleteAttributesInput) SetItemName(v string) *DeleteAttributesInput {
+	s.ItemName = &v
+	return s
+}
+
 type DeleteAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1343,6 +1445,12 @@ func (s *DeleteDomainInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DeleteDomainInput) SetDomainName(v string) *DeleteDomainInput {
+	s.DomainName = &v
+	return s
 }
 
 type DeleteDomainOutput struct {
@@ -1391,6 +1499,12 @@ func (s *DomainMetadataInput) Validate() error {
 	return nil
 }
 
+// SetDomainName sets the DomainName field's value.
+func (s *DomainMetadataInput) SetDomainName(v string) *DomainMetadataInput {
+	s.DomainName = &v
+	return s
+}
+
 type DomainMetadataOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1424,6 +1538,48 @@ func (s DomainMetadataOutput) String() string {
 // GoString returns the string representation
 func (s DomainMetadataOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributeNameCount sets the AttributeNameCount field's value.
+func (s *DomainMetadataOutput) SetAttributeNameCount(v int64) *DomainMetadataOutput {
+	s.AttributeNameCount = &v
+	return s
+}
+
+// SetAttributeNamesSizeBytes sets the AttributeNamesSizeBytes field's value.
+func (s *DomainMetadataOutput) SetAttributeNamesSizeBytes(v int64) *DomainMetadataOutput {
+	s.AttributeNamesSizeBytes = &v
+	return s
+}
+
+// SetAttributeValueCount sets the AttributeValueCount field's value.
+func (s *DomainMetadataOutput) SetAttributeValueCount(v int64) *DomainMetadataOutput {
+	s.AttributeValueCount = &v
+	return s
+}
+
+// SetAttributeValuesSizeBytes sets the AttributeValuesSizeBytes field's value.
+func (s *DomainMetadataOutput) SetAttributeValuesSizeBytes(v int64) *DomainMetadataOutput {
+	s.AttributeValuesSizeBytes = &v
+	return s
+}
+
+// SetItemCount sets the ItemCount field's value.
+func (s *DomainMetadataOutput) SetItemCount(v int64) *DomainMetadataOutput {
+	s.ItemCount = &v
+	return s
+}
+
+// SetItemNamesSizeBytes sets the ItemNamesSizeBytes field's value.
+func (s *DomainMetadataOutput) SetItemNamesSizeBytes(v int64) *DomainMetadataOutput {
+	s.ItemNamesSizeBytes = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *DomainMetadataOutput) SetTimestamp(v int64) *DomainMetadataOutput {
+	s.Timestamp = &v
+	return s
 }
 
 type GetAttributesInput struct {
@@ -1473,6 +1629,30 @@ func (s *GetAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAttributeNames sets the AttributeNames field's value.
+func (s *GetAttributesInput) SetAttributeNames(v []*string) *GetAttributesInput {
+	s.AttributeNames = v
+	return s
+}
+
+// SetConsistentRead sets the ConsistentRead field's value.
+func (s *GetAttributesInput) SetConsistentRead(v bool) *GetAttributesInput {
+	s.ConsistentRead = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetAttributesInput) SetDomainName(v string) *GetAttributesInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetItemName sets the ItemName field's value.
+func (s *GetAttributesInput) SetItemName(v string) *GetAttributesInput {
+	s.ItemName = &v
+	return s
+}
+
 type GetAttributesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1488,6 +1668,12 @@ func (s GetAttributesOutput) String() string {
 // GoString returns the string representation
 func (s GetAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *GetAttributesOutput) SetAttributes(v []*Attribute) *GetAttributesOutput {
+	s.Attributes = v
+	return s
 }
 
 type Item struct {
@@ -1516,6 +1702,24 @@ func (s Item) GoString() string {
 	return s.String()
 }
 
+// SetAlternateNameEncoding sets the AlternateNameEncoding field's value.
+func (s *Item) SetAlternateNameEncoding(v string) *Item {
+	s.AlternateNameEncoding = &v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *Item) SetAttributes(v []*Attribute) *Item {
+	s.Attributes = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Item) SetName(v string) *Item {
+	s.Name = &v
+	return s
+}
+
 type ListDomainsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1538,6 +1742,18 @@ func (s ListDomainsInput) GoString() string {
 	return s.String()
 }
 
+// SetMaxNumberOfDomains sets the MaxNumberOfDomains field's value.
+func (s *ListDomainsInput) SetMaxNumberOfDomains(v int64) *ListDomainsInput {
+	s.MaxNumberOfDomains = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDomainsInput) SetNextToken(v string) *ListDomainsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListDomainsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1557,6 +1773,18 @@ func (s ListDomainsOutput) String() string {
 // GoString returns the string representation
 func (s ListDomainsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainNames sets the DomainNames field's value.
+func (s *ListDomainsOutput) SetDomainNames(v []*string) *ListDomainsOutput {
+	s.DomainNames = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDomainsOutput) SetNextToken(v string) *ListDomainsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type PutAttributesInput struct {
@@ -1622,6 +1850,30 @@ func (s *PutAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *PutAttributesInput) SetAttributes(v []*ReplaceableAttribute) *PutAttributesInput {
+	s.Attributes = v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *PutAttributesInput) SetDomainName(v string) *PutAttributesInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetExpected sets the Expected field's value.
+func (s *PutAttributesInput) SetExpected(v *UpdateCondition) *PutAttributesInput {
+	s.Expected = v
+	return s
+}
+
+// SetItemName sets the ItemName field's value.
+func (s *PutAttributesInput) SetItemName(v string) *PutAttributesInput {
+	s.ItemName = &v
+	return s
+}
+
 type PutAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1680,6 +1932,24 @@ func (s *ReplaceableAttribute) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *ReplaceableAttribute) SetName(v string) *ReplaceableAttribute {
+	s.Name = &v
+	return s
+}
+
+// SetReplace sets the Replace field's value.
+func (s *ReplaceableAttribute) SetReplace(v bool) *ReplaceableAttribute {
+	s.Replace = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ReplaceableAttribute) SetValue(v string) *ReplaceableAttribute {
+	s.Value = &v
+	return s
+}
+
 type ReplaceableItem struct {
 	_ struct{} `type:"structure"`
 
@@ -1730,6 +2000,18 @@ func (s *ReplaceableItem) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *ReplaceableItem) SetAttributes(v []*ReplaceableAttribute) *ReplaceableItem {
+	s.Attributes = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ReplaceableItem) SetName(v string) *ReplaceableItem {
+	s.Name = &v
+	return s
+}
+
 type SelectInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1769,6 +2051,24 @@ func (s *SelectInput) Validate() error {
 	return nil
 }
 
+// SetConsistentRead sets the ConsistentRead field's value.
+func (s *SelectInput) SetConsistentRead(v bool) *SelectInput {
+	s.ConsistentRead = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SelectInput) SetNextToken(v string) *SelectInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSelectExpression sets the SelectExpression field's value.
+func (s *SelectInput) SetSelectExpression(v string) *SelectInput {
+	s.SelectExpression = &v
+	return s
+}
+
 type SelectOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1787,6 +2087,18 @@ func (s SelectOutput) String() string {
 // GoString returns the string representation
 func (s SelectOutput) GoString() string {
 	return s.String()
+}
+
+// SetItems sets the Items field's value.
+func (s *SelectOutput) SetItems(v []*Item) *SelectOutput {
+	s.Items = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SelectOutput) SetNextToken(v string) *SelectOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Specifies the conditions under which data should be updated. If an update
@@ -1819,4 +2131,22 @@ func (s UpdateCondition) String() string {
 // GoString returns the string representation
 func (s UpdateCondition) GoString() string {
 	return s.String()
+}
+
+// SetExists sets the Exists field's value.
+func (s *UpdateCondition) SetExists(v bool) *UpdateCondition {
+	s.Exists = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateCondition) SetName(v string) *UpdateCondition {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *UpdateCondition) SetValue(v string) *UpdateCondition {
+	s.Value = &v
+	return s
 }

--- a/service/sms/api.go
+++ b/service/sms/api.go
@@ -1046,6 +1046,66 @@ func (s Connector) GoString() string {
 	return s.String()
 }
 
+// SetAssociatedOn sets the AssociatedOn field's value.
+func (s *Connector) SetAssociatedOn(v time.Time) *Connector {
+	s.AssociatedOn = &v
+	return s
+}
+
+// SetCapabilityList sets the CapabilityList field's value.
+func (s *Connector) SetCapabilityList(v []*string) *Connector {
+	s.CapabilityList = v
+	return s
+}
+
+// SetConnectorId sets the ConnectorId field's value.
+func (s *Connector) SetConnectorId(v string) *Connector {
+	s.ConnectorId = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *Connector) SetIpAddress(v string) *Connector {
+	s.IpAddress = &v
+	return s
+}
+
+// SetMacAddress sets the MacAddress field's value.
+func (s *Connector) SetMacAddress(v string) *Connector {
+	s.MacAddress = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Connector) SetStatus(v string) *Connector {
+	s.Status = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *Connector) SetVersion(v string) *Connector {
+	s.Version = &v
+	return s
+}
+
+// SetVmManagerId sets the VmManagerId field's value.
+func (s *Connector) SetVmManagerId(v string) *Connector {
+	s.VmManagerId = &v
+	return s
+}
+
+// SetVmManagerName sets the VmManagerName field's value.
+func (s *Connector) SetVmManagerName(v string) *Connector {
+	s.VmManagerName = &v
+	return s
+}
+
+// SetVmManagerType sets the VmManagerType field's value.
+func (s *Connector) SetVmManagerType(v string) *Connector {
+	s.VmManagerType = &v
+	return s
+}
+
 type CreateReplicationJobInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1105,6 +1165,42 @@ func (s *CreateReplicationJobInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *CreateReplicationJobInput) SetDescription(v string) *CreateReplicationJobInput {
+	s.Description = &v
+	return s
+}
+
+// SetFrequency sets the Frequency field's value.
+func (s *CreateReplicationJobInput) SetFrequency(v int64) *CreateReplicationJobInput {
+	s.Frequency = &v
+	return s
+}
+
+// SetLicenseType sets the LicenseType field's value.
+func (s *CreateReplicationJobInput) SetLicenseType(v string) *CreateReplicationJobInput {
+	s.LicenseType = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *CreateReplicationJobInput) SetRoleName(v string) *CreateReplicationJobInput {
+	s.RoleName = &v
+	return s
+}
+
+// SetSeedReplicationTime sets the SeedReplicationTime field's value.
+func (s *CreateReplicationJobInput) SetSeedReplicationTime(v time.Time) *CreateReplicationJobInput {
+	s.SeedReplicationTime = &v
+	return s
+}
+
+// SetServerId sets the ServerId field's value.
+func (s *CreateReplicationJobInput) SetServerId(v string) *CreateReplicationJobInput {
+	s.ServerId = &v
+	return s
+}
+
 type CreateReplicationJobOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1120,6 +1216,12 @@ func (s CreateReplicationJobOutput) String() string {
 // GoString returns the string representation
 func (s CreateReplicationJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationJobId sets the ReplicationJobId field's value.
+func (s *CreateReplicationJobOutput) SetReplicationJobId(v string) *CreateReplicationJobOutput {
+	s.ReplicationJobId = &v
+	return s
 }
 
 type DeleteReplicationJobInput struct {
@@ -1152,6 +1254,12 @@ func (s *DeleteReplicationJobInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetReplicationJobId sets the ReplicationJobId field's value.
+func (s *DeleteReplicationJobInput) SetReplicationJobId(v string) *DeleteReplicationJobInput {
+	s.ReplicationJobId = &v
+	return s
 }
 
 type DeleteReplicationJobOutput struct {
@@ -1228,6 +1336,12 @@ func (s *DisassociateConnectorInput) Validate() error {
 	return nil
 }
 
+// SetConnectorId sets the ConnectorId field's value.
+func (s *DisassociateConnectorInput) SetConnectorId(v string) *DisassociateConnectorInput {
+	s.ConnectorId = &v
+	return s
+}
+
 type DisassociateConnectorOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1263,6 +1377,18 @@ func (s GetConnectorsInput) GoString() string {
 	return s.String()
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetConnectorsInput) SetMaxResults(v int64) *GetConnectorsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetConnectorsInput) SetNextToken(v string) *GetConnectorsInput {
+	s.NextToken = &v
+	return s
+}
+
 type GetConnectorsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1281,6 +1407,18 @@ func (s GetConnectorsOutput) String() string {
 // GoString returns the string representation
 func (s GetConnectorsOutput) GoString() string {
 	return s.String()
+}
+
+// SetConnectorList sets the ConnectorList field's value.
+func (s *GetConnectorsOutput) SetConnectorList(v []*Connector) *GetConnectorsOutput {
+	s.ConnectorList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetConnectorsOutput) SetNextToken(v string) *GetConnectorsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type GetReplicationJobsInput struct {
@@ -1307,6 +1445,24 @@ func (s GetReplicationJobsInput) GoString() string {
 	return s.String()
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetReplicationJobsInput) SetMaxResults(v int64) *GetReplicationJobsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetReplicationJobsInput) SetNextToken(v string) *GetReplicationJobsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReplicationJobId sets the ReplicationJobId field's value.
+func (s *GetReplicationJobsInput) SetReplicationJobId(v string) *GetReplicationJobsInput {
+	s.ReplicationJobId = &v
+	return s
+}
+
 type GetReplicationJobsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1325,6 +1481,18 @@ func (s GetReplicationJobsOutput) String() string {
 // GoString returns the string representation
 func (s GetReplicationJobsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetReplicationJobsOutput) SetNextToken(v string) *GetReplicationJobsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReplicationJobList sets the ReplicationJobList field's value.
+func (s *GetReplicationJobsOutput) SetReplicationJobList(v []*ReplicationJob) *GetReplicationJobsOutput {
+	s.ReplicationJobList = v
+	return s
 }
 
 type GetReplicationRunsInput struct {
@@ -1366,6 +1534,24 @@ func (s *GetReplicationRunsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetReplicationRunsInput) SetMaxResults(v int64) *GetReplicationRunsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetReplicationRunsInput) SetNextToken(v string) *GetReplicationRunsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReplicationJobId sets the ReplicationJobId field's value.
+func (s *GetReplicationRunsInput) SetReplicationJobId(v string) *GetReplicationRunsInput {
+	s.ReplicationJobId = &v
+	return s
+}
+
 type GetReplicationRunsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1389,6 +1575,24 @@ func (s GetReplicationRunsOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *GetReplicationRunsOutput) SetNextToken(v string) *GetReplicationRunsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReplicationJob sets the ReplicationJob field's value.
+func (s *GetReplicationRunsOutput) SetReplicationJob(v *ReplicationJob) *GetReplicationRunsOutput {
+	s.ReplicationJob = v
+	return s
+}
+
+// SetReplicationRunList sets the ReplicationRunList field's value.
+func (s *GetReplicationRunsOutput) SetReplicationRunList(v []*ReplicationRun) *GetReplicationRunsOutput {
+	s.ReplicationRunList = v
+	return s
+}
+
 type GetServersInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1408,6 +1612,18 @@ func (s GetServersInput) String() string {
 // GoString returns the string representation
 func (s GetServersInput) GoString() string {
 	return s.String()
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetServersInput) SetMaxResults(v int64) *GetServersInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetServersInput) SetNextToken(v string) *GetServersInput {
+	s.NextToken = &v
+	return s
 }
 
 type GetServersOutput struct {
@@ -1434,6 +1650,30 @@ func (s GetServersOutput) String() string {
 // GoString returns the string representation
 func (s GetServersOutput) GoString() string {
 	return s.String()
+}
+
+// SetLastModifiedOn sets the LastModifiedOn field's value.
+func (s *GetServersOutput) SetLastModifiedOn(v time.Time) *GetServersOutput {
+	s.LastModifiedOn = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetServersOutput) SetNextToken(v string) *GetServersOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetServerCatalogStatus sets the ServerCatalogStatus field's value.
+func (s *GetServersOutput) SetServerCatalogStatus(v string) *GetServersOutput {
+	s.ServerCatalogStatus = &v
+	return s
+}
+
+// SetServerList sets the ServerList field's value.
+func (s *GetServersOutput) SetServerList(v []*Server) *GetServersOutput {
+	s.ServerList = v
+	return s
 }
 
 type ImportServerCatalogInput struct {
@@ -1523,6 +1763,90 @@ func (s ReplicationJob) GoString() string {
 	return s.String()
 }
 
+// SetDescription sets the Description field's value.
+func (s *ReplicationJob) SetDescription(v string) *ReplicationJob {
+	s.Description = &v
+	return s
+}
+
+// SetFrequency sets the Frequency field's value.
+func (s *ReplicationJob) SetFrequency(v int64) *ReplicationJob {
+	s.Frequency = &v
+	return s
+}
+
+// SetLatestAmiId sets the LatestAmiId field's value.
+func (s *ReplicationJob) SetLatestAmiId(v string) *ReplicationJob {
+	s.LatestAmiId = &v
+	return s
+}
+
+// SetLicenseType sets the LicenseType field's value.
+func (s *ReplicationJob) SetLicenseType(v string) *ReplicationJob {
+	s.LicenseType = &v
+	return s
+}
+
+// SetNextReplicationRunStartTime sets the NextReplicationRunStartTime field's value.
+func (s *ReplicationJob) SetNextReplicationRunStartTime(v time.Time) *ReplicationJob {
+	s.NextReplicationRunStartTime = &v
+	return s
+}
+
+// SetReplicationJobId sets the ReplicationJobId field's value.
+func (s *ReplicationJob) SetReplicationJobId(v string) *ReplicationJob {
+	s.ReplicationJobId = &v
+	return s
+}
+
+// SetReplicationRunList sets the ReplicationRunList field's value.
+func (s *ReplicationJob) SetReplicationRunList(v []*ReplicationRun) *ReplicationJob {
+	s.ReplicationRunList = v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *ReplicationJob) SetRoleName(v string) *ReplicationJob {
+	s.RoleName = &v
+	return s
+}
+
+// SetSeedReplicationTime sets the SeedReplicationTime field's value.
+func (s *ReplicationJob) SetSeedReplicationTime(v time.Time) *ReplicationJob {
+	s.SeedReplicationTime = &v
+	return s
+}
+
+// SetServerId sets the ServerId field's value.
+func (s *ReplicationJob) SetServerId(v string) *ReplicationJob {
+	s.ServerId = &v
+	return s
+}
+
+// SetServerType sets the ServerType field's value.
+func (s *ReplicationJob) SetServerType(v string) *ReplicationJob {
+	s.ServerType = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ReplicationJob) SetState(v string) *ReplicationJob {
+	s.State = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ReplicationJob) SetStatusMessage(v string) *ReplicationJob {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetVmServer sets the VmServer field's value.
+func (s *ReplicationJob) SetVmServer(v *VmServer) *ReplicationJob {
+	s.VmServer = v
+	return s
+}
+
 // Object representing a Replication Run
 type ReplicationRun struct {
 	_ struct{} `type:"structure"`
@@ -1562,6 +1886,54 @@ func (s ReplicationRun) GoString() string {
 	return s.String()
 }
 
+// SetAmiId sets the AmiId field's value.
+func (s *ReplicationRun) SetAmiId(v string) *ReplicationRun {
+	s.AmiId = &v
+	return s
+}
+
+// SetCompletedTime sets the CompletedTime field's value.
+func (s *ReplicationRun) SetCompletedTime(v time.Time) *ReplicationRun {
+	s.CompletedTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ReplicationRun) SetDescription(v string) *ReplicationRun {
+	s.Description = &v
+	return s
+}
+
+// SetReplicationRunId sets the ReplicationRunId field's value.
+func (s *ReplicationRun) SetReplicationRunId(v string) *ReplicationRun {
+	s.ReplicationRunId = &v
+	return s
+}
+
+// SetScheduledStartTime sets the ScheduledStartTime field's value.
+func (s *ReplicationRun) SetScheduledStartTime(v time.Time) *ReplicationRun {
+	s.ScheduledStartTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ReplicationRun) SetState(v string) *ReplicationRun {
+	s.State = &v
+	return s
+}
+
+// SetStatusMessage sets the StatusMessage field's value.
+func (s *ReplicationRun) SetStatusMessage(v string) *ReplicationRun {
+	s.StatusMessage = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ReplicationRun) SetType(v string) *ReplicationRun {
+	s.Type = &v
+	return s
+}
+
 // Object representing a server
 type Server struct {
 	_ struct{} `type:"structure"`
@@ -1590,6 +1962,36 @@ func (s Server) String() string {
 // GoString returns the string representation
 func (s Server) GoString() string {
 	return s.String()
+}
+
+// SetReplicationJobId sets the ReplicationJobId field's value.
+func (s *Server) SetReplicationJobId(v string) *Server {
+	s.ReplicationJobId = &v
+	return s
+}
+
+// SetReplicationJobTerminated sets the ReplicationJobTerminated field's value.
+func (s *Server) SetReplicationJobTerminated(v bool) *Server {
+	s.ReplicationJobTerminated = &v
+	return s
+}
+
+// SetServerId sets the ServerId field's value.
+func (s *Server) SetServerId(v string) *Server {
+	s.ServerId = &v
+	return s
+}
+
+// SetServerType sets the ServerType field's value.
+func (s *Server) SetServerType(v string) *Server {
+	s.ServerType = &v
+	return s
+}
+
+// SetVmServer sets the VmServer field's value.
+func (s *Server) SetVmServer(v *VmServer) *Server {
+	s.VmServer = v
+	return s
 }
 
 type StartOnDemandReplicationRunInput struct {
@@ -1627,6 +2029,18 @@ func (s *StartOnDemandReplicationRunInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *StartOnDemandReplicationRunInput) SetDescription(v string) *StartOnDemandReplicationRunInput {
+	s.Description = &v
+	return s
+}
+
+// SetReplicationJobId sets the ReplicationJobId field's value.
+func (s *StartOnDemandReplicationRunInput) SetReplicationJobId(v string) *StartOnDemandReplicationRunInput {
+	s.ReplicationJobId = &v
+	return s
+}
+
 type StartOnDemandReplicationRunOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1642,6 +2056,12 @@ func (s StartOnDemandReplicationRunOutput) String() string {
 // GoString returns the string representation
 func (s StartOnDemandReplicationRunOutput) GoString() string {
 	return s.String()
+}
+
+// SetReplicationRunId sets the ReplicationRunId field's value.
+func (s *StartOnDemandReplicationRunOutput) SetReplicationRunId(v string) *StartOnDemandReplicationRunOutput {
+	s.ReplicationRunId = &v
+	return s
 }
 
 type UpdateReplicationJobInput struct {
@@ -1693,6 +2113,42 @@ func (s *UpdateReplicationJobInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *UpdateReplicationJobInput) SetDescription(v string) *UpdateReplicationJobInput {
+	s.Description = &v
+	return s
+}
+
+// SetFrequency sets the Frequency field's value.
+func (s *UpdateReplicationJobInput) SetFrequency(v int64) *UpdateReplicationJobInput {
+	s.Frequency = &v
+	return s
+}
+
+// SetLicenseType sets the LicenseType field's value.
+func (s *UpdateReplicationJobInput) SetLicenseType(v string) *UpdateReplicationJobInput {
+	s.LicenseType = &v
+	return s
+}
+
+// SetNextReplicationRunStartTime sets the NextReplicationRunStartTime field's value.
+func (s *UpdateReplicationJobInput) SetNextReplicationRunStartTime(v time.Time) *UpdateReplicationJobInput {
+	s.NextReplicationRunStartTime = &v
+	return s
+}
+
+// SetReplicationJobId sets the ReplicationJobId field's value.
+func (s *UpdateReplicationJobInput) SetReplicationJobId(v string) *UpdateReplicationJobInput {
+	s.ReplicationJobId = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *UpdateReplicationJobInput) SetRoleName(v string) *UpdateReplicationJobInput {
+	s.RoleName = &v
+	return s
+}
+
 type UpdateReplicationJobOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1737,6 +2193,36 @@ func (s VmServer) GoString() string {
 	return s.String()
 }
 
+// SetVmManagerName sets the VmManagerName field's value.
+func (s *VmServer) SetVmManagerName(v string) *VmServer {
+	s.VmManagerName = &v
+	return s
+}
+
+// SetVmManagerType sets the VmManagerType field's value.
+func (s *VmServer) SetVmManagerType(v string) *VmServer {
+	s.VmManagerType = &v
+	return s
+}
+
+// SetVmName sets the VmName field's value.
+func (s *VmServer) SetVmName(v string) *VmServer {
+	s.VmName = &v
+	return s
+}
+
+// SetVmPath sets the VmPath field's value.
+func (s *VmServer) SetVmPath(v string) *VmServer {
+	s.VmPath = &v
+	return s
+}
+
+// SetVmServerAddress sets the VmServerAddress field's value.
+func (s *VmServer) SetVmServerAddress(v *VmServerAddress) *VmServer {
+	s.VmServerAddress = v
+	return s
+}
+
 // Object representing a server's location
 type VmServerAddress struct {
 	_ struct{} `type:"structure"`
@@ -1756,6 +2242,18 @@ func (s VmServerAddress) String() string {
 // GoString returns the string representation
 func (s VmServerAddress) GoString() string {
 	return s.String()
+}
+
+// SetVmId sets the VmId field's value.
+func (s *VmServerAddress) SetVmId(v string) *VmServerAddress {
+	s.VmId = &v
+	return s
+}
+
+// SetVmManagerId sets the VmManagerId field's value.
+func (s *VmServerAddress) SetVmManagerId(v string) *VmServerAddress {
+	s.VmManagerId = &v
+	return s
 }
 
 // Capabilities for a Connector

--- a/service/snowball/api.go
+++ b/service/snowball/api.go
@@ -972,6 +972,84 @@ func (s *Address) Validate() error {
 	return nil
 }
 
+// SetAddressId sets the AddressId field's value.
+func (s *Address) SetAddressId(v string) *Address {
+	s.AddressId = &v
+	return s
+}
+
+// SetCity sets the City field's value.
+func (s *Address) SetCity(v string) *Address {
+	s.City = &v
+	return s
+}
+
+// SetCompany sets the Company field's value.
+func (s *Address) SetCompany(v string) *Address {
+	s.Company = &v
+	return s
+}
+
+// SetCountry sets the Country field's value.
+func (s *Address) SetCountry(v string) *Address {
+	s.Country = &v
+	return s
+}
+
+// SetLandmark sets the Landmark field's value.
+func (s *Address) SetLandmark(v string) *Address {
+	s.Landmark = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Address) SetName(v string) *Address {
+	s.Name = &v
+	return s
+}
+
+// SetPhoneNumber sets the PhoneNumber field's value.
+func (s *Address) SetPhoneNumber(v string) *Address {
+	s.PhoneNumber = &v
+	return s
+}
+
+// SetPostalCode sets the PostalCode field's value.
+func (s *Address) SetPostalCode(v string) *Address {
+	s.PostalCode = &v
+	return s
+}
+
+// SetPrefectureOrDistrict sets the PrefectureOrDistrict field's value.
+func (s *Address) SetPrefectureOrDistrict(v string) *Address {
+	s.PrefectureOrDistrict = &v
+	return s
+}
+
+// SetStateOrProvince sets the StateOrProvince field's value.
+func (s *Address) SetStateOrProvince(v string) *Address {
+	s.StateOrProvince = &v
+	return s
+}
+
+// SetStreet1 sets the Street1 field's value.
+func (s *Address) SetStreet1(v string) *Address {
+	s.Street1 = &v
+	return s
+}
+
+// SetStreet2 sets the Street2 field's value.
+func (s *Address) SetStreet2(v string) *Address {
+	s.Street2 = &v
+	return s
+}
+
+// SetStreet3 sets the Street3 field's value.
+func (s *Address) SetStreet3(v string) *Address {
+	s.Street3 = &v
+	return s
+}
+
 type CancelJobInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1006,6 +1084,12 @@ func (s *CancelJobInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetJobId sets the JobId field's value.
+func (s *CancelJobInput) SetJobId(v string) *CancelJobInput {
+	s.JobId = &v
+	return s
 }
 
 type CancelJobOutput struct {
@@ -1059,6 +1143,12 @@ func (s *CreateAddressInput) Validate() error {
 	return nil
 }
 
+// SetAddress sets the Address field's value.
+func (s *CreateAddressInput) SetAddress(v *Address) *CreateAddressInput {
+	s.Address = v
+	return s
+}
+
 type CreateAddressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1076,6 +1166,12 @@ func (s CreateAddressOutput) String() string {
 // GoString returns the string representation
 func (s CreateAddressOutput) GoString() string {
 	return s.String()
+}
+
+// SetAddressId sets the AddressId field's value.
+func (s *CreateAddressOutput) SetAddressId(v string) *CreateAddressOutput {
+	s.AddressId = &v
+	return s
 }
 
 type CreateJobInput struct {
@@ -1197,6 +1293,60 @@ func (s *CreateJobInput) Validate() error {
 	return nil
 }
 
+// SetAddressId sets the AddressId field's value.
+func (s *CreateJobInput) SetAddressId(v string) *CreateJobInput {
+	s.AddressId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateJobInput) SetDescription(v string) *CreateJobInput {
+	s.Description = &v
+	return s
+}
+
+// SetJobType sets the JobType field's value.
+func (s *CreateJobInput) SetJobType(v string) *CreateJobInput {
+	s.JobType = &v
+	return s
+}
+
+// SetKmsKeyARN sets the KmsKeyARN field's value.
+func (s *CreateJobInput) SetKmsKeyARN(v string) *CreateJobInput {
+	s.KmsKeyARN = &v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *CreateJobInput) SetNotification(v *Notification) *CreateJobInput {
+	s.Notification = v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *CreateJobInput) SetResources(v *JobResource) *CreateJobInput {
+	s.Resources = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *CreateJobInput) SetRoleARN(v string) *CreateJobInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetShippingOption sets the ShippingOption field's value.
+func (s *CreateJobInput) SetShippingOption(v string) *CreateJobInput {
+	s.ShippingOption = &v
+	return s
+}
+
+// SetSnowballCapacityPreference sets the SnowballCapacityPreference field's value.
+func (s *CreateJobInput) SetSnowballCapacityPreference(v string) *CreateJobInput {
+	s.SnowballCapacityPreference = &v
+	return s
+}
+
 type CreateJobOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1212,6 +1362,12 @@ func (s CreateJobOutput) String() string {
 // GoString returns the string representation
 func (s CreateJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobId sets the JobId field's value.
+func (s *CreateJobOutput) SetJobId(v string) *CreateJobOutput {
+	s.JobId = &v
+	return s
 }
 
 // Defines the real-time status of a Snowball's data transfer while the appliance
@@ -1245,6 +1401,30 @@ func (s DataTransfer) String() string {
 // GoString returns the string representation
 func (s DataTransfer) GoString() string {
 	return s.String()
+}
+
+// SetBytesTransferred sets the BytesTransferred field's value.
+func (s *DataTransfer) SetBytesTransferred(v int64) *DataTransfer {
+	s.BytesTransferred = &v
+	return s
+}
+
+// SetObjectsTransferred sets the ObjectsTransferred field's value.
+func (s *DataTransfer) SetObjectsTransferred(v int64) *DataTransfer {
+	s.ObjectsTransferred = &v
+	return s
+}
+
+// SetTotalBytes sets the TotalBytes field's value.
+func (s *DataTransfer) SetTotalBytes(v int64) *DataTransfer {
+	s.TotalBytes = &v
+	return s
+}
+
+// SetTotalObjects sets the TotalObjects field's value.
+func (s *DataTransfer) SetTotalObjects(v int64) *DataTransfer {
+	s.TotalObjects = &v
+	return s
 }
 
 type DescribeAddressInput struct {
@@ -1282,6 +1462,12 @@ func (s *DescribeAddressInput) Validate() error {
 	return nil
 }
 
+// SetAddressId sets the AddressId field's value.
+func (s *DescribeAddressInput) SetAddressId(v string) *DescribeAddressInput {
+	s.AddressId = &v
+	return s
+}
+
 type DescribeAddressOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1298,6 +1484,12 @@ func (s DescribeAddressOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAddressOutput) GoString() string {
 	return s.String()
+}
+
+// SetAddress sets the Address field's value.
+func (s *DescribeAddressOutput) SetAddress(v *Address) *DescribeAddressOutput {
+	s.Address = v
+	return s
 }
 
 type DescribeAddressesInput struct {
@@ -1335,6 +1527,18 @@ func (s *DescribeAddressesInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeAddressesInput) SetMaxResults(v int64) *DescribeAddressesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAddressesInput) SetNextToken(v string) *DescribeAddressesInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeAddressesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1355,6 +1559,18 @@ func (s DescribeAddressesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAddressesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAddresses sets the Addresses field's value.
+func (s *DescribeAddressesOutput) SetAddresses(v []*Address) *DescribeAddressesOutput {
+	s.Addresses = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAddressesOutput) SetNextToken(v string) *DescribeAddressesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeJobInput struct {
@@ -1392,6 +1608,12 @@ func (s *DescribeJobInput) Validate() error {
 	return nil
 }
 
+// SetJobId sets the JobId field's value.
+func (s *DescribeJobInput) SetJobId(v string) *DescribeJobInput {
+	s.JobId = &v
+	return s
+}
+
 type DescribeJobOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1412,6 +1634,18 @@ func (s DescribeJobOutput) String() string {
 // GoString returns the string representation
 func (s DescribeJobOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobMetadata sets the JobMetadata field's value.
+func (s *DescribeJobOutput) SetJobMetadata(v *JobMetadata) *DescribeJobOutput {
+	s.JobMetadata = v
+	return s
+}
+
+// SetSubJobMetadata sets the SubJobMetadata field's value.
+func (s *DescribeJobOutput) SetSubJobMetadata(v []*JobMetadata) *DescribeJobOutput {
+	s.SubJobMetadata = v
+	return s
 }
 
 type GetJobManifestInput struct {
@@ -1450,6 +1684,12 @@ func (s *GetJobManifestInput) Validate() error {
 	return nil
 }
 
+// SetJobId sets the JobId field's value.
+func (s *GetJobManifestInput) SetJobId(v string) *GetJobManifestInput {
+	s.JobId = &v
+	return s
+}
+
 type GetJobManifestOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1466,6 +1706,12 @@ func (s GetJobManifestOutput) String() string {
 // GoString returns the string representation
 func (s GetJobManifestOutput) GoString() string {
 	return s.String()
+}
+
+// SetManifestURI sets the ManifestURI field's value.
+func (s *GetJobManifestOutput) SetManifestURI(v string) *GetJobManifestOutput {
+	s.ManifestURI = &v
+	return s
 }
 
 type GetJobUnlockCodeInput struct {
@@ -1504,6 +1750,12 @@ func (s *GetJobUnlockCodeInput) Validate() error {
 	return nil
 }
 
+// SetJobId sets the JobId field's value.
+func (s *GetJobUnlockCodeInput) SetJobId(v string) *GetJobUnlockCodeInput {
+	s.JobId = &v
+	return s
+}
+
 type GetJobUnlockCodeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1520,6 +1772,12 @@ func (s GetJobUnlockCodeOutput) String() string {
 // GoString returns the string representation
 func (s GetJobUnlockCodeOutput) GoString() string {
 	return s.String()
+}
+
+// SetUnlockCode sets the UnlockCode field's value.
+func (s *GetJobUnlockCodeOutput) SetUnlockCode(v string) *GetJobUnlockCodeOutput {
+	s.UnlockCode = &v
+	return s
 }
 
 type GetSnowballUsageInput struct {
@@ -1557,6 +1815,18 @@ func (s GetSnowballUsageOutput) GoString() string {
 	return s.String()
 }
 
+// SetSnowballLimit sets the SnowballLimit field's value.
+func (s *GetSnowballUsageOutput) SetSnowballLimit(v int64) *GetSnowballUsageOutput {
+	s.SnowballLimit = &v
+	return s
+}
+
+// SetSnowballsInUse sets the SnowballsInUse field's value.
+func (s *GetSnowballUsageOutput) SetSnowballsInUse(v int64) *GetSnowballUsageOutput {
+	s.SnowballsInUse = &v
+	return s
+}
+
 // Each JobListEntry object contains a job's state, a job's ID, and a value
 // that indicates whether the job is a job part, in the case of an export job.
 type JobListEntry struct {
@@ -1585,6 +1855,24 @@ func (s JobListEntry) String() string {
 // GoString returns the string representation
 func (s JobListEntry) GoString() string {
 	return s.String()
+}
+
+// SetIsMaster sets the IsMaster field's value.
+func (s *JobListEntry) SetIsMaster(v bool) *JobListEntry {
+	s.IsMaster = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *JobListEntry) SetJobId(v string) *JobListEntry {
+	s.JobId = &v
+	return s
+}
+
+// SetJobState sets the JobState field's value.
+func (s *JobListEntry) SetJobState(v string) *JobListEntry {
+	s.JobState = &v
+	return s
 }
 
 // Contains job logs. Whenever Snowball is used to import data into or export
@@ -1628,6 +1916,24 @@ func (s JobLogs) String() string {
 // GoString returns the string representation
 func (s JobLogs) GoString() string {
 	return s.String()
+}
+
+// SetJobCompletionReportURI sets the JobCompletionReportURI field's value.
+func (s *JobLogs) SetJobCompletionReportURI(v string) *JobLogs {
+	s.JobCompletionReportURI = &v
+	return s
+}
+
+// SetJobFailureLogURI sets the JobFailureLogURI field's value.
+func (s *JobLogs) SetJobFailureLogURI(v string) *JobLogs {
+	s.JobFailureLogURI = &v
+	return s
+}
+
+// SetJobSuccessLogURI sets the JobSuccessLogURI field's value.
+func (s *JobLogs) SetJobSuccessLogURI(v string) *JobLogs {
+	s.JobSuccessLogURI = &v
+	return s
 }
 
 // Contains information about a specific job including shipping information,
@@ -1704,6 +2010,90 @@ func (s JobMetadata) GoString() string {
 	return s.String()
 }
 
+// SetAddressId sets the AddressId field's value.
+func (s *JobMetadata) SetAddressId(v string) *JobMetadata {
+	s.AddressId = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *JobMetadata) SetCreationDate(v time.Time) *JobMetadata {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDataTransferProgress sets the DataTransferProgress field's value.
+func (s *JobMetadata) SetDataTransferProgress(v *DataTransfer) *JobMetadata {
+	s.DataTransferProgress = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *JobMetadata) SetDescription(v string) *JobMetadata {
+	s.Description = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *JobMetadata) SetJobId(v string) *JobMetadata {
+	s.JobId = &v
+	return s
+}
+
+// SetJobLogInfo sets the JobLogInfo field's value.
+func (s *JobMetadata) SetJobLogInfo(v *JobLogs) *JobMetadata {
+	s.JobLogInfo = v
+	return s
+}
+
+// SetJobState sets the JobState field's value.
+func (s *JobMetadata) SetJobState(v string) *JobMetadata {
+	s.JobState = &v
+	return s
+}
+
+// SetJobType sets the JobType field's value.
+func (s *JobMetadata) SetJobType(v string) *JobMetadata {
+	s.JobType = &v
+	return s
+}
+
+// SetKmsKeyARN sets the KmsKeyARN field's value.
+func (s *JobMetadata) SetKmsKeyARN(v string) *JobMetadata {
+	s.KmsKeyARN = &v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *JobMetadata) SetNotification(v *Notification) *JobMetadata {
+	s.Notification = v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *JobMetadata) SetResources(v *JobResource) *JobMetadata {
+	s.Resources = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *JobMetadata) SetRoleARN(v string) *JobMetadata {
+	s.RoleARN = &v
+	return s
+}
+
+// SetShippingDetails sets the ShippingDetails field's value.
+func (s *JobMetadata) SetShippingDetails(v *ShippingDetails) *JobMetadata {
+	s.ShippingDetails = v
+	return s
+}
+
+// SetSnowballCapacityPreference sets the SnowballCapacityPreference field's value.
+func (s *JobMetadata) SetSnowballCapacityPreference(v string) *JobMetadata {
+	s.SnowballCapacityPreference = &v
+	return s
+}
+
 // Contains an array of S3Resource objects. Each S3Resource object represents
 // an Amazon S3 bucket that your transferred data will be exported from or imported
 // into.
@@ -1742,6 +2132,12 @@ func (s *JobResource) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetS3Resources sets the S3Resources field's value.
+func (s *JobResource) SetS3Resources(v []*S3Resource) *JobResource {
+	s.S3Resources = v
+	return s
 }
 
 // Contains a key range. For export jobs, a S3Resource object can have an optional
@@ -1786,6 +2182,18 @@ func (s *KeyRange) Validate() error {
 	return nil
 }
 
+// SetBeginMarker sets the BeginMarker field's value.
+func (s *KeyRange) SetBeginMarker(v string) *KeyRange {
+	s.BeginMarker = &v
+	return s
+}
+
+// SetEndMarker sets the EndMarker field's value.
+func (s *KeyRange) SetEndMarker(v string) *KeyRange {
+	s.EndMarker = &v
+	return s
+}
+
 type ListJobsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1821,6 +2229,18 @@ func (s *ListJobsInput) Validate() error {
 	return nil
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListJobsInput) SetMaxResults(v int64) *ListJobsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobsInput) SetNextToken(v string) *ListJobsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1842,6 +2262,18 @@ func (s ListJobsOutput) String() string {
 // GoString returns the string representation
 func (s ListJobsOutput) GoString() string {
 	return s.String()
+}
+
+// SetJobListEntries sets the JobListEntries field's value.
+func (s *ListJobsOutput) SetJobListEntries(v []*JobListEntry) *ListJobsOutput {
+	s.JobListEntries = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobsOutput) SetNextToken(v string) *ListJobsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // The Amazon Simple Notification Service (Amazon SNS) notification settings
@@ -1880,6 +2312,24 @@ func (s Notification) String() string {
 // GoString returns the string representation
 func (s Notification) GoString() string {
 	return s.String()
+}
+
+// SetJobStatesToNotify sets the JobStatesToNotify field's value.
+func (s *Notification) SetJobStatesToNotify(v []*string) *Notification {
+	s.JobStatesToNotify = v
+	return s
+}
+
+// SetNotifyAll sets the NotifyAll field's value.
+func (s *Notification) SetNotifyAll(v bool) *Notification {
+	s.NotifyAll = &v
+	return s
+}
+
+// SetSnsTopicARN sets the SnsTopicARN field's value.
+func (s *Notification) SetSnsTopicARN(v string) *Notification {
+	s.SnsTopicARN = &v
+	return s
 }
 
 // Each S3Resource object represents an Amazon S3 bucket that your transferred
@@ -1925,6 +2375,18 @@ func (s *S3Resource) Validate() error {
 	return nil
 }
 
+// SetBucketArn sets the BucketArn field's value.
+func (s *S3Resource) SetBucketArn(v string) *S3Resource {
+	s.BucketArn = &v
+	return s
+}
+
+// SetKeyRange sets the KeyRange field's value.
+func (s *S3Resource) SetKeyRange(v *KeyRange) *S3Resource {
+	s.KeyRange = v
+	return s
+}
+
 // The Status and TrackingNumber information for an inbound or outbound shipment.
 type Shipment struct {
 	_ struct{} `type:"structure"`
@@ -1949,6 +2411,18 @@ func (s Shipment) String() string {
 // GoString returns the string representation
 func (s Shipment) GoString() string {
 	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *Shipment) SetStatus(v string) *Shipment {
+	s.Status = &v
+	return s
+}
+
+// SetTrackingNumber sets the TrackingNumber field's value.
+func (s *Shipment) SetTrackingNumber(v string) *Shipment {
+	s.TrackingNumber = &v
+	return s
 }
 
 // A job's shipping information, including inbound and outbound tracking numbers
@@ -1992,6 +2466,24 @@ func (s ShippingDetails) String() string {
 // GoString returns the string representation
 func (s ShippingDetails) GoString() string {
 	return s.String()
+}
+
+// SetInboundShipment sets the InboundShipment field's value.
+func (s *ShippingDetails) SetInboundShipment(v *Shipment) *ShippingDetails {
+	s.InboundShipment = v
+	return s
+}
+
+// SetOutboundShipment sets the OutboundShipment field's value.
+func (s *ShippingDetails) SetOutboundShipment(v *Shipment) *ShippingDetails {
+	s.OutboundShipment = v
+	return s
+}
+
+// SetShippingOption sets the ShippingOption field's value.
+func (s *ShippingDetails) SetShippingOption(v string) *ShippingDetails {
+	s.ShippingOption = &v
+	return s
 }
 
 type UpdateJobInput struct {
@@ -2063,6 +2555,54 @@ func (s *UpdateJobInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAddressId sets the AddressId field's value.
+func (s *UpdateJobInput) SetAddressId(v string) *UpdateJobInput {
+	s.AddressId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateJobInput) SetDescription(v string) *UpdateJobInput {
+	s.Description = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *UpdateJobInput) SetJobId(v string) *UpdateJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetNotification sets the Notification field's value.
+func (s *UpdateJobInput) SetNotification(v *Notification) *UpdateJobInput {
+	s.Notification = v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *UpdateJobInput) SetResources(v *JobResource) *UpdateJobInput {
+	s.Resources = v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *UpdateJobInput) SetRoleARN(v string) *UpdateJobInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetShippingOption sets the ShippingOption field's value.
+func (s *UpdateJobInput) SetShippingOption(v string) *UpdateJobInput {
+	s.ShippingOption = &v
+	return s
+}
+
+// SetSnowballCapacityPreference sets the SnowballCapacityPreference field's value.
+func (s *UpdateJobInput) SetSnowballCapacityPreference(v string) *UpdateJobInput {
+	s.SnowballCapacityPreference = &v
+	return s
 }
 
 type UpdateJobOutput struct {

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -2572,6 +2572,30 @@ func (s *AddPermissionInput) Validate() error {
 	return nil
 }
 
+// SetAWSAccountId sets the AWSAccountId field's value.
+func (s *AddPermissionInput) SetAWSAccountId(v []*string) *AddPermissionInput {
+	s.AWSAccountId = v
+	return s
+}
+
+// SetActionName sets the ActionName field's value.
+func (s *AddPermissionInput) SetActionName(v []*string) *AddPermissionInput {
+	s.ActionName = v
+	return s
+}
+
+// SetLabel sets the Label field's value.
+func (s *AddPermissionInput) SetLabel(v string) *AddPermissionInput {
+	s.Label = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *AddPermissionInput) SetTopicArn(v string) *AddPermissionInput {
+	s.TopicArn = &v
+	return s
+}
+
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2619,6 +2643,12 @@ func (s *CheckIfPhoneNumberIsOptedOutInput) Validate() error {
 	return nil
 }
 
+// SetPhoneNumber sets the PhoneNumber field's value.
+func (s *CheckIfPhoneNumberIsOptedOutInput) SetPhoneNumber(v string) *CheckIfPhoneNumberIsOptedOutInput {
+	s.PhoneNumber = &v
+	return s
+}
+
 // The response from the CheckIfPhoneNumberIsOptedOut action.
 type CheckIfPhoneNumberIsOptedOutOutput struct {
 	_ struct{} `type:"structure"`
@@ -2641,6 +2671,12 @@ func (s CheckIfPhoneNumberIsOptedOutOutput) String() string {
 // GoString returns the string representation
 func (s CheckIfPhoneNumberIsOptedOutOutput) GoString() string {
 	return s.String()
+}
+
+// SetIsOptedOut sets the IsOptedOut field's value.
+func (s *CheckIfPhoneNumberIsOptedOutOutput) SetIsOptedOut(v bool) *CheckIfPhoneNumberIsOptedOutOutput {
+	s.IsOptedOut = &v
+	return s
 }
 
 // Input for ConfirmSubscription action.
@@ -2690,6 +2726,24 @@ func (s *ConfirmSubscriptionInput) Validate() error {
 	return nil
 }
 
+// SetAuthenticateOnUnsubscribe sets the AuthenticateOnUnsubscribe field's value.
+func (s *ConfirmSubscriptionInput) SetAuthenticateOnUnsubscribe(v string) *ConfirmSubscriptionInput {
+	s.AuthenticateOnUnsubscribe = &v
+	return s
+}
+
+// SetToken sets the Token field's value.
+func (s *ConfirmSubscriptionInput) SetToken(v string) *ConfirmSubscriptionInput {
+	s.Token = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *ConfirmSubscriptionInput) SetTopicArn(v string) *ConfirmSubscriptionInput {
+	s.TopicArn = &v
+	return s
+}
+
 // Response for ConfirmSubscriptions action.
 type ConfirmSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2706,6 +2760,12 @@ func (s ConfirmSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s ConfirmSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// SetSubscriptionArn sets the SubscriptionArn field's value.
+func (s *ConfirmSubscriptionOutput) SetSubscriptionArn(v string) *ConfirmSubscriptionOutput {
+	s.SubscriptionArn = &v
+	return s
 }
 
 // Input for CreatePlatformApplication action.
@@ -2760,6 +2820,24 @@ func (s *CreatePlatformApplicationInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *CreatePlatformApplicationInput) SetAttributes(v map[string]*string) *CreatePlatformApplicationInput {
+	s.Attributes = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreatePlatformApplicationInput) SetName(v string) *CreatePlatformApplicationInput {
+	s.Name = &v
+	return s
+}
+
+// SetPlatform sets the Platform field's value.
+func (s *CreatePlatformApplicationInput) SetPlatform(v string) *CreatePlatformApplicationInput {
+	s.Platform = &v
+	return s
+}
+
 // Response from CreatePlatformApplication action.
 type CreatePlatformApplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -2776,6 +2854,12 @@ func (s CreatePlatformApplicationOutput) String() string {
 // GoString returns the string representation
 func (s CreatePlatformApplicationOutput) GoString() string {
 	return s.String()
+}
+
+// SetPlatformApplicationArn sets the PlatformApplicationArn field's value.
+func (s *CreatePlatformApplicationOutput) SetPlatformApplicationArn(v string) *CreatePlatformApplicationOutput {
+	s.PlatformApplicationArn = &v
+	return s
 }
 
 // Input for CreatePlatformEndpoint action.
@@ -2831,6 +2915,30 @@ func (s *CreatePlatformEndpointInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *CreatePlatformEndpointInput) SetAttributes(v map[string]*string) *CreatePlatformEndpointInput {
+	s.Attributes = v
+	return s
+}
+
+// SetCustomUserData sets the CustomUserData field's value.
+func (s *CreatePlatformEndpointInput) SetCustomUserData(v string) *CreatePlatformEndpointInput {
+	s.CustomUserData = &v
+	return s
+}
+
+// SetPlatformApplicationArn sets the PlatformApplicationArn field's value.
+func (s *CreatePlatformEndpointInput) SetPlatformApplicationArn(v string) *CreatePlatformEndpointInput {
+	s.PlatformApplicationArn = &v
+	return s
+}
+
+// SetToken sets the Token field's value.
+func (s *CreatePlatformEndpointInput) SetToken(v string) *CreatePlatformEndpointInput {
+	s.Token = &v
+	return s
+}
+
 // Response from CreateEndpoint action.
 type CreatePlatformEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -2847,6 +2955,12 @@ func (s CreatePlatformEndpointOutput) String() string {
 // GoString returns the string representation
 func (s CreatePlatformEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *CreatePlatformEndpointOutput) SetEndpointArn(v string) *CreatePlatformEndpointOutput {
+	s.EndpointArn = &v
+	return s
 }
 
 // Input for CreateTopic action.
@@ -2886,6 +3000,12 @@ func (s *CreateTopicInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *CreateTopicInput) SetName(v string) *CreateTopicInput {
+	s.Name = &v
+	return s
+}
+
 // Response from CreateTopic action.
 type CreateTopicOutput struct {
 	_ struct{} `type:"structure"`
@@ -2902,6 +3022,12 @@ func (s CreateTopicOutput) String() string {
 // GoString returns the string representation
 func (s CreateTopicOutput) GoString() string {
 	return s.String()
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *CreateTopicOutput) SetTopicArn(v string) *CreateTopicOutput {
+	s.TopicArn = &v
+	return s
 }
 
 // Input for DeleteEndpoint action.
@@ -2935,6 +3061,12 @@ func (s *DeleteEndpointInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *DeleteEndpointInput) SetEndpointArn(v string) *DeleteEndpointInput {
+	s.EndpointArn = &v
+	return s
 }
 
 type DeleteEndpointOutput struct {
@@ -2984,6 +3116,12 @@ func (s *DeletePlatformApplicationInput) Validate() error {
 	return nil
 }
 
+// SetPlatformApplicationArn sets the PlatformApplicationArn field's value.
+func (s *DeletePlatformApplicationInput) SetPlatformApplicationArn(v string) *DeletePlatformApplicationInput {
+	s.PlatformApplicationArn = &v
+	return s
+}
+
 type DeletePlatformApplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3030,6 +3168,12 @@ func (s *DeleteTopicInput) Validate() error {
 	return nil
 }
 
+// SetTopicArn sets the TopicArn field's value.
+func (s *DeleteTopicInput) SetTopicArn(v string) *DeleteTopicInput {
+	s.TopicArn = &v
+	return s
+}
+
 type DeleteTopicOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3065,6 +3209,18 @@ func (s Endpoint) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *Endpoint) SetAttributes(v map[string]*string) *Endpoint {
+	s.Attributes = v
+	return s
+}
+
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *Endpoint) SetEndpointArn(v string) *Endpoint {
+	s.EndpointArn = &v
+	return s
+}
+
 // Input for GetEndpointAttributes action.
 type GetEndpointAttributesInput struct {
 	_ struct{} `type:"structure"`
@@ -3098,6 +3254,12 @@ func (s *GetEndpointAttributesInput) Validate() error {
 	return nil
 }
 
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *GetEndpointAttributesInput) SetEndpointArn(v string) *GetEndpointAttributesInput {
+	s.EndpointArn = &v
+	return s
+}
+
 // Response from GetEndpointAttributes of the EndpointArn.
 type GetEndpointAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3127,6 +3289,12 @@ func (s GetEndpointAttributesOutput) String() string {
 // GoString returns the string representation
 func (s GetEndpointAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *GetEndpointAttributesOutput) SetAttributes(v map[string]*string) *GetEndpointAttributesOutput {
+	s.Attributes = v
+	return s
 }
 
 // Input for GetPlatformApplicationAttributes action.
@@ -3162,6 +3330,12 @@ func (s *GetPlatformApplicationAttributesInput) Validate() error {
 	return nil
 }
 
+// SetPlatformApplicationArn sets the PlatformApplicationArn field's value.
+func (s *GetPlatformApplicationAttributesInput) SetPlatformApplicationArn(v string) *GetPlatformApplicationAttributesInput {
+	s.PlatformApplicationArn = &v
+	return s
+}
+
 // Response for GetPlatformApplicationAttributes action.
 type GetPlatformApplicationAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3193,6 +3367,12 @@ func (s GetPlatformApplicationAttributesOutput) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *GetPlatformApplicationAttributesOutput) SetAttributes(v map[string]*string) *GetPlatformApplicationAttributesOutput {
+	s.Attributes = v
+	return s
+}
+
 // The input for the GetSMSAttributes request.
 type GetSMSAttributesInput struct {
 	_ struct{} `type:"structure"`
@@ -3216,6 +3396,12 @@ func (s GetSMSAttributesInput) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *GetSMSAttributesInput) SetAttributes(v []*string) *GetSMSAttributesInput {
+	s.Attributes = v
+	return s
+}
+
 // The response from the GetSMSAttributes request.
 type GetSMSAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3232,6 +3418,12 @@ func (s GetSMSAttributesOutput) String() string {
 // GoString returns the string representation
 func (s GetSMSAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *GetSMSAttributesOutput) SetAttributes(v map[string]*string) *GetSMSAttributesOutput {
+	s.Attributes = v
+	return s
 }
 
 // Input for GetSubscriptionAttributes.
@@ -3265,6 +3457,12 @@ func (s *GetSubscriptionAttributesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetSubscriptionArn sets the SubscriptionArn field's value.
+func (s *GetSubscriptionAttributesInput) SetSubscriptionArn(v string) *GetSubscriptionAttributesInput {
+	s.SubscriptionArn = &v
+	return s
 }
 
 // Response for GetSubscriptionAttributes action.
@@ -3302,6 +3500,12 @@ func (s GetSubscriptionAttributesOutput) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *GetSubscriptionAttributesOutput) SetAttributes(v map[string]*string) *GetSubscriptionAttributesOutput {
+	s.Attributes = v
+	return s
+}
+
 // Input for GetTopicAttributes action.
 type GetTopicAttributesInput struct {
 	_ struct{} `type:"structure"`
@@ -3333,6 +3537,12 @@ func (s *GetTopicAttributesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *GetTopicAttributesInput) SetTopicArn(v string) *GetTopicAttributesInput {
+	s.TopicArn = &v
+	return s
 }
 
 // Response for GetTopicAttributes action.
@@ -3376,6 +3586,12 @@ func (s GetTopicAttributesOutput) GoString() string {
 	return s.String()
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *GetTopicAttributesOutput) SetAttributes(v map[string]*string) *GetTopicAttributesOutput {
+	s.Attributes = v
+	return s
+}
+
 // Input for ListEndpointsByPlatformApplication action.
 type ListEndpointsByPlatformApplicationInput struct {
 	_ struct{} `type:"structure"`
@@ -3414,6 +3630,18 @@ func (s *ListEndpointsByPlatformApplicationInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListEndpointsByPlatformApplicationInput) SetNextToken(v string) *ListEndpointsByPlatformApplicationInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPlatformApplicationArn sets the PlatformApplicationArn field's value.
+func (s *ListEndpointsByPlatformApplicationInput) SetPlatformApplicationArn(v string) *ListEndpointsByPlatformApplicationInput {
+	s.PlatformApplicationArn = &v
+	return s
+}
+
 // Response for ListEndpointsByPlatformApplication action.
 type ListEndpointsByPlatformApplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -3436,6 +3664,18 @@ func (s ListEndpointsByPlatformApplicationOutput) GoString() string {
 	return s.String()
 }
 
+// SetEndpoints sets the Endpoints field's value.
+func (s *ListEndpointsByPlatformApplicationOutput) SetEndpoints(v []*Endpoint) *ListEndpointsByPlatformApplicationOutput {
+	s.Endpoints = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListEndpointsByPlatformApplicationOutput) SetNextToken(v string) *ListEndpointsByPlatformApplicationOutput {
+	s.NextToken = &v
+	return s
+}
+
 // The input for the ListPhoneNumbersOptedOut action.
 type ListPhoneNumbersOptedOutInput struct {
 	_ struct{} `type:"structure"`
@@ -3454,6 +3694,12 @@ func (s ListPhoneNumbersOptedOutInput) String() string {
 // GoString returns the string representation
 func (s ListPhoneNumbersOptedOutInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPhoneNumbersOptedOutInput) SetNextToken(v string) *ListPhoneNumbersOptedOutInput {
+	s.NextToken = &v
+	return s
 }
 
 // The response from the ListPhoneNumbersOptedOut action.
@@ -3479,6 +3725,18 @@ func (s ListPhoneNumbersOptedOutOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListPhoneNumbersOptedOutOutput) SetNextToken(v string) *ListPhoneNumbersOptedOutOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPhoneNumbers sets the PhoneNumbers field's value.
+func (s *ListPhoneNumbersOptedOutOutput) SetPhoneNumbers(v []*string) *ListPhoneNumbersOptedOutOutput {
+	s.PhoneNumbers = v
+	return s
+}
+
 // Input for ListPlatformApplications action.
 type ListPlatformApplicationsInput struct {
 	_ struct{} `type:"structure"`
@@ -3496,6 +3754,12 @@ func (s ListPlatformApplicationsInput) String() string {
 // GoString returns the string representation
 func (s ListPlatformApplicationsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPlatformApplicationsInput) SetNextToken(v string) *ListPlatformApplicationsInput {
+	s.NextToken = &v
+	return s
 }
 
 // Response for ListPlatformApplications action.
@@ -3518,6 +3782,18 @@ func (s ListPlatformApplicationsOutput) String() string {
 // GoString returns the string representation
 func (s ListPlatformApplicationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPlatformApplicationsOutput) SetNextToken(v string) *ListPlatformApplicationsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPlatformApplications sets the PlatformApplications field's value.
+func (s *ListPlatformApplicationsOutput) SetPlatformApplications(v []*PlatformApplication) *ListPlatformApplicationsOutput {
+	s.PlatformApplications = v
+	return s
 }
 
 // Input for ListSubscriptionsByTopic action.
@@ -3556,6 +3832,18 @@ func (s *ListSubscriptionsByTopicInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListSubscriptionsByTopicInput) SetNextToken(v string) *ListSubscriptionsByTopicInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *ListSubscriptionsByTopicInput) SetTopicArn(v string) *ListSubscriptionsByTopicInput {
+	s.TopicArn = &v
+	return s
+}
+
 // Response for ListSubscriptionsByTopic action.
 type ListSubscriptionsByTopicOutput struct {
 	_ struct{} `type:"structure"`
@@ -3578,6 +3866,18 @@ func (s ListSubscriptionsByTopicOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListSubscriptionsByTopicOutput) SetNextToken(v string) *ListSubscriptionsByTopicOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSubscriptions sets the Subscriptions field's value.
+func (s *ListSubscriptionsByTopicOutput) SetSubscriptions(v []*Subscription) *ListSubscriptionsByTopicOutput {
+	s.Subscriptions = v
+	return s
+}
+
 // Input for ListSubscriptions action.
 type ListSubscriptionsInput struct {
 	_ struct{} `type:"structure"`
@@ -3594,6 +3894,12 @@ func (s ListSubscriptionsInput) String() string {
 // GoString returns the string representation
 func (s ListSubscriptionsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListSubscriptionsInput) SetNextToken(v string) *ListSubscriptionsInput {
+	s.NextToken = &v
+	return s
 }
 
 // Response for ListSubscriptions action
@@ -3618,6 +3924,18 @@ func (s ListSubscriptionsOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *ListSubscriptionsOutput) SetNextToken(v string) *ListSubscriptionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSubscriptions sets the Subscriptions field's value.
+func (s *ListSubscriptionsOutput) SetSubscriptions(v []*Subscription) *ListSubscriptionsOutput {
+	s.Subscriptions = v
+	return s
+}
+
 type ListTopicsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -3633,6 +3951,12 @@ func (s ListTopicsInput) String() string {
 // GoString returns the string representation
 func (s ListTopicsInput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTopicsInput) SetNextToken(v string) *ListTopicsInput {
+	s.NextToken = &v
+	return s
 }
 
 // Response for ListTopics action.
@@ -3655,6 +3979,18 @@ func (s ListTopicsOutput) String() string {
 // GoString returns the string representation
 func (s ListTopicsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTopicsOutput) SetNextToken(v string) *ListTopicsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTopics sets the Topics field's value.
+func (s *ListTopicsOutput) SetTopics(v []*Topic) *ListTopicsOutput {
+	s.Topics = v
+	return s
 }
 
 // The user-specified message attribute value. For string data types, the value
@@ -3709,6 +4045,24 @@ func (s *MessageAttributeValue) Validate() error {
 	return nil
 }
 
+// SetBinaryValue sets the BinaryValue field's value.
+func (s *MessageAttributeValue) SetBinaryValue(v []byte) *MessageAttributeValue {
+	s.BinaryValue = v
+	return s
+}
+
+// SetDataType sets the DataType field's value.
+func (s *MessageAttributeValue) SetDataType(v string) *MessageAttributeValue {
+	s.DataType = &v
+	return s
+}
+
+// SetStringValue sets the StringValue field's value.
+func (s *MessageAttributeValue) SetStringValue(v string) *MessageAttributeValue {
+	s.StringValue = &v
+	return s
+}
+
 // Input for the OptInPhoneNumber action.
 type OptInPhoneNumberInput struct {
 	_ struct{} `type:"structure"`
@@ -3740,6 +4094,12 @@ func (s *OptInPhoneNumberInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetPhoneNumber sets the PhoneNumber field's value.
+func (s *OptInPhoneNumberInput) SetPhoneNumber(v string) *OptInPhoneNumberInput {
+	s.PhoneNumber = &v
+	return s
 }
 
 // The response for the OptInPhoneNumber action.
@@ -3776,6 +4136,18 @@ func (s PlatformApplication) String() string {
 // GoString returns the string representation
 func (s PlatformApplication) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *PlatformApplication) SetAttributes(v map[string]*string) *PlatformApplication {
+	s.Attributes = v
+	return s
+}
+
+// SetPlatformApplicationArn sets the PlatformApplicationArn field's value.
+func (s *PlatformApplication) SetPlatformApplicationArn(v string) *PlatformApplication {
+	s.PlatformApplicationArn = &v
+	return s
 }
 
 // Input for Publish action.
@@ -3907,6 +4279,48 @@ func (s *PublishInput) Validate() error {
 	return nil
 }
 
+// SetMessage sets the Message field's value.
+func (s *PublishInput) SetMessage(v string) *PublishInput {
+	s.Message = &v
+	return s
+}
+
+// SetMessageAttributes sets the MessageAttributes field's value.
+func (s *PublishInput) SetMessageAttributes(v map[string]*MessageAttributeValue) *PublishInput {
+	s.MessageAttributes = v
+	return s
+}
+
+// SetMessageStructure sets the MessageStructure field's value.
+func (s *PublishInput) SetMessageStructure(v string) *PublishInput {
+	s.MessageStructure = &v
+	return s
+}
+
+// SetPhoneNumber sets the PhoneNumber field's value.
+func (s *PublishInput) SetPhoneNumber(v string) *PublishInput {
+	s.PhoneNumber = &v
+	return s
+}
+
+// SetSubject sets the Subject field's value.
+func (s *PublishInput) SetSubject(v string) *PublishInput {
+	s.Subject = &v
+	return s
+}
+
+// SetTargetArn sets the TargetArn field's value.
+func (s *PublishInput) SetTargetArn(v string) *PublishInput {
+	s.TargetArn = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *PublishInput) SetTopicArn(v string) *PublishInput {
+	s.TopicArn = &v
+	return s
+}
+
 // Response for Publish action.
 type PublishOutput struct {
 	_ struct{} `type:"structure"`
@@ -3925,6 +4339,12 @@ func (s PublishOutput) String() string {
 // GoString returns the string representation
 func (s PublishOutput) GoString() string {
 	return s.String()
+}
+
+// SetMessageId sets the MessageId field's value.
+func (s *PublishOutput) SetMessageId(v string) *PublishOutput {
+	s.MessageId = &v
+	return s
 }
 
 // Input for RemovePermission action.
@@ -3966,6 +4386,18 @@ func (s *RemovePermissionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLabel sets the Label field's value.
+func (s *RemovePermissionInput) SetLabel(v string) *RemovePermissionInput {
+	s.Label = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *RemovePermissionInput) SetTopicArn(v string) *RemovePermissionInput {
+	s.TopicArn = &v
+	return s
 }
 
 type RemovePermissionOutput struct {
@@ -4034,6 +4466,18 @@ func (s *SetEndpointAttributesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *SetEndpointAttributesInput) SetAttributes(v map[string]*string) *SetEndpointAttributesInput {
+	s.Attributes = v
+	return s
+}
+
+// SetEndpointArn sets the EndpointArn field's value.
+func (s *SetEndpointAttributesInput) SetEndpointArn(v string) *SetEndpointAttributesInput {
+	s.EndpointArn = &v
+	return s
 }
 
 type SetEndpointAttributesOutput struct {
@@ -4122,6 +4566,18 @@ func (s *SetPlatformApplicationAttributesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *SetPlatformApplicationAttributesInput) SetAttributes(v map[string]*string) *SetPlatformApplicationAttributesInput {
+	s.Attributes = v
+	return s
+}
+
+// SetPlatformApplicationArn sets the PlatformApplicationArn field's value.
+func (s *SetPlatformApplicationAttributesInput) SetPlatformApplicationArn(v string) *SetPlatformApplicationAttributesInput {
+	s.PlatformApplicationArn = &v
+	return s
 }
 
 type SetPlatformApplicationAttributesOutput struct {
@@ -4242,6 +4698,12 @@ func (s *SetSMSAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *SetSMSAttributesInput) SetAttributes(v map[string]*string) *SetSMSAttributesInput {
+	s.Attributes = v
+	return s
+}
+
 // The response for the SetSMSAttributes action.
 type SetSMSAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -4304,6 +4766,24 @@ func (s *SetSubscriptionAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAttributeName sets the AttributeName field's value.
+func (s *SetSubscriptionAttributesInput) SetAttributeName(v string) *SetSubscriptionAttributesInput {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValue sets the AttributeValue field's value.
+func (s *SetSubscriptionAttributesInput) SetAttributeValue(v string) *SetSubscriptionAttributesInput {
+	s.AttributeValue = &v
+	return s
+}
+
+// SetSubscriptionArn sets the SubscriptionArn field's value.
+func (s *SetSubscriptionAttributesInput) SetSubscriptionArn(v string) *SetSubscriptionAttributesInput {
+	s.SubscriptionArn = &v
+	return s
+}
+
 type SetSubscriptionAttributesOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4363,6 +4843,24 @@ func (s *SetTopicAttributesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *SetTopicAttributesInput) SetAttributeName(v string) *SetTopicAttributesInput {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValue sets the AttributeValue field's value.
+func (s *SetTopicAttributesInput) SetAttributeValue(v string) *SetTopicAttributesInput {
+	s.AttributeValue = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *SetTopicAttributesInput) SetTopicArn(v string) *SetTopicAttributesInput {
+	s.TopicArn = &v
+	return s
 }
 
 type SetTopicAttributesOutput struct {
@@ -4458,6 +4956,24 @@ func (s *SubscribeInput) Validate() error {
 	return nil
 }
 
+// SetEndpoint sets the Endpoint field's value.
+func (s *SubscribeInput) SetEndpoint(v string) *SubscribeInput {
+	s.Endpoint = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *SubscribeInput) SetProtocol(v string) *SubscribeInput {
+	s.Protocol = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *SubscribeInput) SetTopicArn(v string) *SubscribeInput {
+	s.TopicArn = &v
+	return s
+}
+
 // Response for Subscribe action.
 type SubscribeOutput struct {
 	_ struct{} `type:"structure"`
@@ -4475,6 +4991,12 @@ func (s SubscribeOutput) String() string {
 // GoString returns the string representation
 func (s SubscribeOutput) GoString() string {
 	return s.String()
+}
+
+// SetSubscriptionArn sets the SubscriptionArn field's value.
+func (s *SubscribeOutput) SetSubscriptionArn(v string) *SubscribeOutput {
+	s.SubscriptionArn = &v
+	return s
 }
 
 // A wrapper type for the attributes of an Amazon SNS subscription.
@@ -4507,6 +5029,36 @@ func (s Subscription) GoString() string {
 	return s.String()
 }
 
+// SetEndpoint sets the Endpoint field's value.
+func (s *Subscription) SetEndpoint(v string) *Subscription {
+	s.Endpoint = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *Subscription) SetOwner(v string) *Subscription {
+	s.Owner = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *Subscription) SetProtocol(v string) *Subscription {
+	s.Protocol = &v
+	return s
+}
+
+// SetSubscriptionArn sets the SubscriptionArn field's value.
+func (s *Subscription) SetSubscriptionArn(v string) *Subscription {
+	s.SubscriptionArn = &v
+	return s
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *Subscription) SetTopicArn(v string) *Subscription {
+	s.TopicArn = &v
+	return s
+}
+
 // A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a
 // topic's attributes, use GetTopicAttributes.
 type Topic struct {
@@ -4524,6 +5076,12 @@ func (s Topic) String() string {
 // GoString returns the string representation
 func (s Topic) GoString() string {
 	return s.String()
+}
+
+// SetTopicArn sets the TopicArn field's value.
+func (s *Topic) SetTopicArn(v string) *Topic {
+	s.TopicArn = &v
+	return s
 }
 
 // Input for Unsubscribe action.
@@ -4557,6 +5115,12 @@ func (s *UnsubscribeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetSubscriptionArn sets the SubscriptionArn field's value.
+func (s *UnsubscribeInput) SetSubscriptionArn(v string) *UnsubscribeInput {
+	s.SubscriptionArn = &v
+	return s
 }
 
 type UnsubscribeOutput struct {

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -1464,6 +1464,30 @@ func (s *AddPermissionInput) Validate() error {
 	return nil
 }
 
+// SetAWSAccountIds sets the AWSAccountIds field's value.
+func (s *AddPermissionInput) SetAWSAccountIds(v []*string) *AddPermissionInput {
+	s.AWSAccountIds = v
+	return s
+}
+
+// SetActions sets the Actions field's value.
+func (s *AddPermissionInput) SetActions(v []*string) *AddPermissionInput {
+	s.Actions = v
+	return s
+}
+
+// SetLabel sets the Label field's value.
+func (s *AddPermissionInput) SetLabel(v string) *AddPermissionInput {
+	s.Label = &v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *AddPermissionInput) SetQueueUrl(v string) *AddPermissionInput {
+	s.QueueUrl = &v
+	return s
+}
+
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1510,6 +1534,30 @@ func (s BatchResultErrorEntry) String() string {
 // GoString returns the string representation
 func (s BatchResultErrorEntry) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *BatchResultErrorEntry) SetCode(v string) *BatchResultErrorEntry {
+	s.Code = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *BatchResultErrorEntry) SetId(v string) *BatchResultErrorEntry {
+	s.Id = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *BatchResultErrorEntry) SetMessage(v string) *BatchResultErrorEntry {
+	s.Message = &v
+	return s
+}
+
+// SetSenderFault sets the SenderFault field's value.
+func (s *BatchResultErrorEntry) SetSenderFault(v bool) *BatchResultErrorEntry {
+	s.SenderFault = &v
+	return s
 }
 
 type ChangeMessageVisibilityBatchInput struct {
@@ -1565,6 +1613,18 @@ func (s *ChangeMessageVisibilityBatchInput) Validate() error {
 	return nil
 }
 
+// SetEntries sets the Entries field's value.
+func (s *ChangeMessageVisibilityBatchInput) SetEntries(v []*ChangeMessageVisibilityBatchRequestEntry) *ChangeMessageVisibilityBatchInput {
+	s.Entries = v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *ChangeMessageVisibilityBatchInput) SetQueueUrl(v string) *ChangeMessageVisibilityBatchInput {
+	s.QueueUrl = &v
+	return s
+}
+
 // For each message in the batch, the response contains a ChangeMessageVisibilityBatchResultEntry
 // tag if the message succeeds or a BatchResultErrorEntry tag if the message
 // fails.
@@ -1590,6 +1650,18 @@ func (s ChangeMessageVisibilityBatchOutput) String() string {
 // GoString returns the string representation
 func (s ChangeMessageVisibilityBatchOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailed sets the Failed field's value.
+func (s *ChangeMessageVisibilityBatchOutput) SetFailed(v []*BatchResultErrorEntry) *ChangeMessageVisibilityBatchOutput {
+	s.Failed = v
+	return s
+}
+
+// SetSuccessful sets the Successful field's value.
+func (s *ChangeMessageVisibilityBatchOutput) SetSuccessful(v []*ChangeMessageVisibilityBatchResultEntry) *ChangeMessageVisibilityBatchOutput {
+	s.Successful = v
+	return s
 }
 
 // Encloses a receipt handle and an entry id for each message in ChangeMessageVisibilityBatch.
@@ -1645,6 +1717,24 @@ func (s *ChangeMessageVisibilityBatchRequestEntry) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *ChangeMessageVisibilityBatchRequestEntry) SetId(v string) *ChangeMessageVisibilityBatchRequestEntry {
+	s.Id = &v
+	return s
+}
+
+// SetReceiptHandle sets the ReceiptHandle field's value.
+func (s *ChangeMessageVisibilityBatchRequestEntry) SetReceiptHandle(v string) *ChangeMessageVisibilityBatchRequestEntry {
+	s.ReceiptHandle = &v
+	return s
+}
+
+// SetVisibilityTimeout sets the VisibilityTimeout field's value.
+func (s *ChangeMessageVisibilityBatchRequestEntry) SetVisibilityTimeout(v int64) *ChangeMessageVisibilityBatchRequestEntry {
+	s.VisibilityTimeout = &v
+	return s
+}
+
 // Encloses the id of an entry in ChangeMessageVisibilityBatch.
 type ChangeMessageVisibilityBatchResultEntry struct {
 	_ struct{} `type:"structure"`
@@ -1663,6 +1753,12 @@ func (s ChangeMessageVisibilityBatchResultEntry) String() string {
 // GoString returns the string representation
 func (s ChangeMessageVisibilityBatchResultEntry) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *ChangeMessageVisibilityBatchResultEntry) SetId(v string) *ChangeMessageVisibilityBatchResultEntry {
+	s.Id = &v
+	return s
 }
 
 type ChangeMessageVisibilityInput struct {
@@ -1715,6 +1811,24 @@ func (s *ChangeMessageVisibilityInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *ChangeMessageVisibilityInput) SetQueueUrl(v string) *ChangeMessageVisibilityInput {
+	s.QueueUrl = &v
+	return s
+}
+
+// SetReceiptHandle sets the ReceiptHandle field's value.
+func (s *ChangeMessageVisibilityInput) SetReceiptHandle(v string) *ChangeMessageVisibilityInput {
+	s.ReceiptHandle = &v
+	return s
+}
+
+// SetVisibilityTimeout sets the VisibilityTimeout field's value.
+func (s *ChangeMessageVisibilityInput) SetVisibilityTimeout(v int64) *ChangeMessageVisibilityInput {
+	s.VisibilityTimeout = &v
+	return s
 }
 
 type ChangeMessageVisibilityOutput struct {
@@ -1806,6 +1920,18 @@ func (s *CreateQueueInput) Validate() error {
 	return nil
 }
 
+// SetAttributes sets the Attributes field's value.
+func (s *CreateQueueInput) SetAttributes(v map[string]*string) *CreateQueueInput {
+	s.Attributes = v
+	return s
+}
+
+// SetQueueName sets the QueueName field's value.
+func (s *CreateQueueInput) SetQueueName(v string) *CreateQueueInput {
+	s.QueueName = &v
+	return s
+}
+
 // Returns the QueueUrl element of the created queue.
 type CreateQueueOutput struct {
 	_ struct{} `type:"structure"`
@@ -1822,6 +1948,12 @@ func (s CreateQueueOutput) String() string {
 // GoString returns the string representation
 func (s CreateQueueOutput) GoString() string {
 	return s.String()
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *CreateQueueOutput) SetQueueUrl(v string) *CreateQueueOutput {
+	s.QueueUrl = &v
+	return s
 }
 
 type DeleteMessageBatchInput struct {
@@ -1876,6 +2008,18 @@ func (s *DeleteMessageBatchInput) Validate() error {
 	return nil
 }
 
+// SetEntries sets the Entries field's value.
+func (s *DeleteMessageBatchInput) SetEntries(v []*DeleteMessageBatchRequestEntry) *DeleteMessageBatchInput {
+	s.Entries = v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *DeleteMessageBatchInput) SetQueueUrl(v string) *DeleteMessageBatchInput {
+	s.QueueUrl = &v
+	return s
+}
+
 // For each message in the batch, the response contains a DeleteMessageBatchResultEntry
 // tag if the message is deleted or a BatchResultErrorEntry tag if the message
 // cannot be deleted.
@@ -1901,6 +2045,18 @@ func (s DeleteMessageBatchOutput) String() string {
 // GoString returns the string representation
 func (s DeleteMessageBatchOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailed sets the Failed field's value.
+func (s *DeleteMessageBatchOutput) SetFailed(v []*BatchResultErrorEntry) *DeleteMessageBatchOutput {
+	s.Failed = v
+	return s
+}
+
+// SetSuccessful sets the Successful field's value.
+func (s *DeleteMessageBatchOutput) SetSuccessful(v []*DeleteMessageBatchResultEntry) *DeleteMessageBatchOutput {
+	s.Successful = v
+	return s
 }
 
 // Encloses a receipt handle and an identifier for it.
@@ -1946,6 +2102,18 @@ func (s *DeleteMessageBatchRequestEntry) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *DeleteMessageBatchRequestEntry) SetId(v string) *DeleteMessageBatchRequestEntry {
+	s.Id = &v
+	return s
+}
+
+// SetReceiptHandle sets the ReceiptHandle field's value.
+func (s *DeleteMessageBatchRequestEntry) SetReceiptHandle(v string) *DeleteMessageBatchRequestEntry {
+	s.ReceiptHandle = &v
+	return s
+}
+
 // Encloses the id an entry in DeleteMessageBatch.
 type DeleteMessageBatchResultEntry struct {
 	_ struct{} `type:"structure"`
@@ -1964,6 +2132,12 @@ func (s DeleteMessageBatchResultEntry) String() string {
 // GoString returns the string representation
 func (s DeleteMessageBatchResultEntry) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *DeleteMessageBatchResultEntry) SetId(v string) *DeleteMessageBatchResultEntry {
+	s.Id = &v
+	return s
 }
 
 type DeleteMessageInput struct {
@@ -2006,6 +2180,18 @@ func (s *DeleteMessageInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *DeleteMessageInput) SetQueueUrl(v string) *DeleteMessageInput {
+	s.QueueUrl = &v
+	return s
+}
+
+// SetReceiptHandle sets the ReceiptHandle field's value.
+func (s *DeleteMessageInput) SetReceiptHandle(v string) *DeleteMessageInput {
+	s.ReceiptHandle = &v
+	return s
 }
 
 type DeleteMessageOutput struct {
@@ -2054,6 +2240,12 @@ func (s *DeleteQueueInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *DeleteQueueInput) SetQueueUrl(v string) *DeleteQueueInput {
+	s.QueueUrl = &v
+	return s
 }
 
 type DeleteQueueOutput struct {
@@ -2157,6 +2349,18 @@ func (s *GetQueueAttributesInput) Validate() error {
 	return nil
 }
 
+// SetAttributeNames sets the AttributeNames field's value.
+func (s *GetQueueAttributesInput) SetAttributeNames(v []*string) *GetQueueAttributesInput {
+	s.AttributeNames = v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *GetQueueAttributesInput) SetQueueUrl(v string) *GetQueueAttributesInput {
+	s.QueueUrl = &v
+	return s
+}
+
 // A list of returned queue attributes.
 type GetQueueAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2173,6 +2377,12 @@ func (s GetQueueAttributesOutput) String() string {
 // GoString returns the string representation
 func (s GetQueueAttributesOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *GetQueueAttributesOutput) SetAttributes(v map[string]*string) *GetQueueAttributesOutput {
+	s.Attributes = v
+	return s
 }
 
 type GetQueueUrlInput struct {
@@ -2213,6 +2423,18 @@ func (s *GetQueueUrlInput) Validate() error {
 	return nil
 }
 
+// SetQueueName sets the QueueName field's value.
+func (s *GetQueueUrlInput) SetQueueName(v string) *GetQueueUrlInput {
+	s.QueueName = &v
+	return s
+}
+
+// SetQueueOwnerAWSAccountId sets the QueueOwnerAWSAccountId field's value.
+func (s *GetQueueUrlInput) SetQueueOwnerAWSAccountId(v string) *GetQueueUrlInput {
+	s.QueueOwnerAWSAccountId = &v
+	return s
+}
+
 // For more information, see Responses (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html)
 // in the Amazon SQS Developer Guide.
 type GetQueueUrlOutput struct {
@@ -2230,6 +2452,12 @@ func (s GetQueueUrlOutput) String() string {
 // GoString returns the string representation
 func (s GetQueueUrlOutput) GoString() string {
 	return s.String()
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *GetQueueUrlOutput) SetQueueUrl(v string) *GetQueueUrlOutput {
+	s.QueueUrl = &v
+	return s
 }
 
 type ListDeadLetterSourceQueuesInput struct {
@@ -2266,6 +2494,12 @@ func (s *ListDeadLetterSourceQueuesInput) Validate() error {
 	return nil
 }
 
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *ListDeadLetterSourceQueuesInput) SetQueueUrl(v string) *ListDeadLetterSourceQueuesInput {
+	s.QueueUrl = &v
+	return s
+}
+
 // A list of your dead letter source queues.
 type ListDeadLetterSourceQueuesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2285,6 +2519,12 @@ func (s ListDeadLetterSourceQueuesOutput) String() string {
 // GoString returns the string representation
 func (s ListDeadLetterSourceQueuesOutput) GoString() string {
 	return s.String()
+}
+
+// SetQueueUrls sets the QueueUrls field's value.
+func (s *ListDeadLetterSourceQueuesOutput) SetQueueUrls(v []*string) *ListDeadLetterSourceQueuesOutput {
+	s.QueueUrls = v
+	return s
 }
 
 type ListQueuesInput struct {
@@ -2307,6 +2547,12 @@ func (s ListQueuesInput) GoString() string {
 	return s.String()
 }
 
+// SetQueueNamePrefix sets the QueueNamePrefix field's value.
+func (s *ListQueuesInput) SetQueueNamePrefix(v string) *ListQueuesInput {
+	s.QueueNamePrefix = &v
+	return s
+}
+
 // A list of your queues.
 type ListQueuesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2323,6 +2569,12 @@ func (s ListQueuesOutput) String() string {
 // GoString returns the string representation
 func (s ListQueuesOutput) GoString() string {
 	return s.String()
+}
+
+// SetQueueUrls sets the QueueUrls field's value.
+func (s *ListQueuesOutput) SetQueueUrls(v []*string) *ListQueuesOutput {
+	s.QueueUrls = v
+	return s
 }
 
 // An Amazon SQS message.
@@ -2369,6 +2621,48 @@ func (s Message) String() string {
 // GoString returns the string representation
 func (s Message) GoString() string {
 	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *Message) SetAttributes(v map[string]*string) *Message {
+	s.Attributes = v
+	return s
+}
+
+// SetBody sets the Body field's value.
+func (s *Message) SetBody(v string) *Message {
+	s.Body = &v
+	return s
+}
+
+// SetMD5OfBody sets the MD5OfBody field's value.
+func (s *Message) SetMD5OfBody(v string) *Message {
+	s.MD5OfBody = &v
+	return s
+}
+
+// SetMD5OfMessageAttributes sets the MD5OfMessageAttributes field's value.
+func (s *Message) SetMD5OfMessageAttributes(v string) *Message {
+	s.MD5OfMessageAttributes = &v
+	return s
+}
+
+// SetMessageAttributes sets the MessageAttributes field's value.
+func (s *Message) SetMessageAttributes(v map[string]*MessageAttributeValue) *Message {
+	s.MessageAttributes = v
+	return s
+}
+
+// SetMessageId sets the MessageId field's value.
+func (s *Message) SetMessageId(v string) *Message {
+	s.MessageId = &v
+	return s
+}
+
+// SetReceiptHandle sets the ReceiptHandle field's value.
+func (s *Message) SetReceiptHandle(v string) *Message {
+	s.ReceiptHandle = &v
+	return s
 }
 
 // The user-specified message attribute value. For string data types, the value
@@ -2431,6 +2725,36 @@ func (s *MessageAttributeValue) Validate() error {
 	return nil
 }
 
+// SetBinaryListValues sets the BinaryListValues field's value.
+func (s *MessageAttributeValue) SetBinaryListValues(v [][]byte) *MessageAttributeValue {
+	s.BinaryListValues = v
+	return s
+}
+
+// SetBinaryValue sets the BinaryValue field's value.
+func (s *MessageAttributeValue) SetBinaryValue(v []byte) *MessageAttributeValue {
+	s.BinaryValue = v
+	return s
+}
+
+// SetDataType sets the DataType field's value.
+func (s *MessageAttributeValue) SetDataType(v string) *MessageAttributeValue {
+	s.DataType = &v
+	return s
+}
+
+// SetStringListValues sets the StringListValues field's value.
+func (s *MessageAttributeValue) SetStringListValues(v []*string) *MessageAttributeValue {
+	s.StringListValues = v
+	return s
+}
+
+// SetStringValue sets the StringValue field's value.
+func (s *MessageAttributeValue) SetStringValue(v string) *MessageAttributeValue {
+	s.StringValue = &v
+	return s
+}
+
 type PurgeQueueInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2464,6 +2788,12 @@ func (s *PurgeQueueInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *PurgeQueueInput) SetQueueUrl(v string) *PurgeQueueInput {
+	s.QueueUrl = &v
+	return s
 }
 
 type PurgeQueueOutput struct {
@@ -2569,6 +2899,42 @@ func (s *ReceiveMessageInput) Validate() error {
 	return nil
 }
 
+// SetAttributeNames sets the AttributeNames field's value.
+func (s *ReceiveMessageInput) SetAttributeNames(v []*string) *ReceiveMessageInput {
+	s.AttributeNames = v
+	return s
+}
+
+// SetMaxNumberOfMessages sets the MaxNumberOfMessages field's value.
+func (s *ReceiveMessageInput) SetMaxNumberOfMessages(v int64) *ReceiveMessageInput {
+	s.MaxNumberOfMessages = &v
+	return s
+}
+
+// SetMessageAttributeNames sets the MessageAttributeNames field's value.
+func (s *ReceiveMessageInput) SetMessageAttributeNames(v []*string) *ReceiveMessageInput {
+	s.MessageAttributeNames = v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *ReceiveMessageInput) SetQueueUrl(v string) *ReceiveMessageInput {
+	s.QueueUrl = &v
+	return s
+}
+
+// SetVisibilityTimeout sets the VisibilityTimeout field's value.
+func (s *ReceiveMessageInput) SetVisibilityTimeout(v int64) *ReceiveMessageInput {
+	s.VisibilityTimeout = &v
+	return s
+}
+
+// SetWaitTimeSeconds sets the WaitTimeSeconds field's value.
+func (s *ReceiveMessageInput) SetWaitTimeSeconds(v int64) *ReceiveMessageInput {
+	s.WaitTimeSeconds = &v
+	return s
+}
+
 // A list of received messages.
 type ReceiveMessageOutput struct {
 	_ struct{} `type:"structure"`
@@ -2585,6 +2951,12 @@ func (s ReceiveMessageOutput) String() string {
 // GoString returns the string representation
 func (s ReceiveMessageOutput) GoString() string {
 	return s.String()
+}
+
+// SetMessages sets the Messages field's value.
+func (s *ReceiveMessageOutput) SetMessages(v []*Message) *ReceiveMessageOutput {
+	s.Messages = v
+	return s
 }
 
 type RemovePermissionInput struct {
@@ -2628,6 +3000,18 @@ func (s *RemovePermissionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetLabel sets the Label field's value.
+func (s *RemovePermissionInput) SetLabel(v string) *RemovePermissionInput {
+	s.Label = &v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *RemovePermissionInput) SetQueueUrl(v string) *RemovePermissionInput {
+	s.QueueUrl = &v
+	return s
 }
 
 type RemovePermissionOutput struct {
@@ -2696,6 +3080,18 @@ func (s *SendMessageBatchInput) Validate() error {
 	return nil
 }
 
+// SetEntries sets the Entries field's value.
+func (s *SendMessageBatchInput) SetEntries(v []*SendMessageBatchRequestEntry) *SendMessageBatchInput {
+	s.Entries = v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *SendMessageBatchInput) SetQueueUrl(v string) *SendMessageBatchInput {
+	s.QueueUrl = &v
+	return s
+}
+
 // For each message in the batch, the response contains a SendMessageBatchResultEntry
 // tag if the message succeeds or a BatchResultErrorEntry tag if the message
 // fails.
@@ -2722,6 +3118,18 @@ func (s SendMessageBatchOutput) String() string {
 // GoString returns the string representation
 func (s SendMessageBatchOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailed sets the Failed field's value.
+func (s *SendMessageBatchOutput) SetFailed(v []*BatchResultErrorEntry) *SendMessageBatchOutput {
+	s.Failed = v
+	return s
+}
+
+// SetSuccessful sets the Successful field's value.
+func (s *SendMessageBatchOutput) SetSuccessful(v []*SendMessageBatchResultEntry) *SendMessageBatchOutput {
+	s.Successful = v
+	return s
 }
 
 // Contains the details of a single Amazon SQS message along with a Id.
@@ -2784,6 +3192,30 @@ func (s *SendMessageBatchRequestEntry) Validate() error {
 	return nil
 }
 
+// SetDelaySeconds sets the DelaySeconds field's value.
+func (s *SendMessageBatchRequestEntry) SetDelaySeconds(v int64) *SendMessageBatchRequestEntry {
+	s.DelaySeconds = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *SendMessageBatchRequestEntry) SetId(v string) *SendMessageBatchRequestEntry {
+	s.Id = &v
+	return s
+}
+
+// SetMessageAttributes sets the MessageAttributes field's value.
+func (s *SendMessageBatchRequestEntry) SetMessageAttributes(v map[string]*MessageAttributeValue) *SendMessageBatchRequestEntry {
+	s.MessageAttributes = v
+	return s
+}
+
+// SetMessageBody sets the MessageBody field's value.
+func (s *SendMessageBatchRequestEntry) SetMessageBody(v string) *SendMessageBatchRequestEntry {
+	s.MessageBody = &v
+	return s
+}
+
 // Encloses a message ID for successfully enqueued message of a SendMessageBatch.
 type SendMessageBatchResultEntry struct {
 	_ struct{} `type:"structure"`
@@ -2821,6 +3253,30 @@ func (s SendMessageBatchResultEntry) String() string {
 // GoString returns the string representation
 func (s SendMessageBatchResultEntry) GoString() string {
 	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *SendMessageBatchResultEntry) SetId(v string) *SendMessageBatchResultEntry {
+	s.Id = &v
+	return s
+}
+
+// SetMD5OfMessageAttributes sets the MD5OfMessageAttributes field's value.
+func (s *SendMessageBatchResultEntry) SetMD5OfMessageAttributes(v string) *SendMessageBatchResultEntry {
+	s.MD5OfMessageAttributes = &v
+	return s
+}
+
+// SetMD5OfMessageBody sets the MD5OfMessageBody field's value.
+func (s *SendMessageBatchResultEntry) SetMD5OfMessageBody(v string) *SendMessageBatchResultEntry {
+	s.MD5OfMessageBody = &v
+	return s
+}
+
+// SetMessageId sets the MessageId field's value.
+func (s *SendMessageBatchResultEntry) SetMessageId(v string) *SendMessageBatchResultEntry {
+	s.MessageId = &v
+	return s
 }
 
 type SendMessageInput struct {
@@ -2886,6 +3342,30 @@ func (s *SendMessageInput) Validate() error {
 	return nil
 }
 
+// SetDelaySeconds sets the DelaySeconds field's value.
+func (s *SendMessageInput) SetDelaySeconds(v int64) *SendMessageInput {
+	s.DelaySeconds = &v
+	return s
+}
+
+// SetMessageAttributes sets the MessageAttributes field's value.
+func (s *SendMessageInput) SetMessageAttributes(v map[string]*MessageAttributeValue) *SendMessageInput {
+	s.MessageAttributes = v
+	return s
+}
+
+// SetMessageBody sets the MessageBody field's value.
+func (s *SendMessageInput) SetMessageBody(v string) *SendMessageInput {
+	s.MessageBody = &v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *SendMessageInput) SetQueueUrl(v string) *SendMessageInput {
+	s.QueueUrl = &v
+	return s
+}
+
 // The MD5OfMessageBody and MessageId elements.
 type SendMessageOutput struct {
 	_ struct{} `type:"structure"`
@@ -2916,6 +3396,24 @@ func (s SendMessageOutput) String() string {
 // GoString returns the string representation
 func (s SendMessageOutput) GoString() string {
 	return s.String()
+}
+
+// SetMD5OfMessageAttributes sets the MD5OfMessageAttributes field's value.
+func (s *SendMessageOutput) SetMD5OfMessageAttributes(v string) *SendMessageOutput {
+	s.MD5OfMessageAttributes = &v
+	return s
+}
+
+// SetMD5OfMessageBody sets the MD5OfMessageBody field's value.
+func (s *SendMessageOutput) SetMD5OfMessageBody(v string) *SendMessageOutput {
+	s.MD5OfMessageBody = &v
+	return s
+}
+
+// SetMessageId sets the MessageId field's value.
+func (s *SendMessageOutput) SetMessageId(v string) *SendMessageOutput {
+	s.MessageId = &v
+	return s
 }
 
 type SetQueueAttributesInput struct {
@@ -2996,6 +3494,18 @@ func (s *SetQueueAttributesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *SetQueueAttributesInput) SetAttributes(v map[string]*string) *SetQueueAttributesInput {
+	s.Attributes = v
+	return s
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *SetQueueAttributesInput) SetQueueUrl(v string) *SetQueueAttributesInput {
+	s.QueueUrl = &v
+	return s
 }
 
 type SetQueueAttributesOutput struct {

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -2252,6 +2252,60 @@ func (s Activation) GoString() string {
 	return s.String()
 }
 
+// SetActivationId sets the ActivationId field's value.
+func (s *Activation) SetActivationId(v string) *Activation {
+	s.ActivationId = &v
+	return s
+}
+
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *Activation) SetCreatedDate(v time.Time) *Activation {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetDefaultInstanceName sets the DefaultInstanceName field's value.
+func (s *Activation) SetDefaultInstanceName(v string) *Activation {
+	s.DefaultInstanceName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Activation) SetDescription(v string) *Activation {
+	s.Description = &v
+	return s
+}
+
+// SetExpirationDate sets the ExpirationDate field's value.
+func (s *Activation) SetExpirationDate(v time.Time) *Activation {
+	s.ExpirationDate = &v
+	return s
+}
+
+// SetExpired sets the Expired field's value.
+func (s *Activation) SetExpired(v bool) *Activation {
+	s.Expired = &v
+	return s
+}
+
+// SetIamRole sets the IamRole field's value.
+func (s *Activation) SetIamRole(v string) *Activation {
+	s.IamRole = &v
+	return s
+}
+
+// SetRegistrationLimit sets the RegistrationLimit field's value.
+func (s *Activation) SetRegistrationLimit(v int64) *Activation {
+	s.RegistrationLimit = &v
+	return s
+}
+
+// SetRegistrationsCount sets the RegistrationsCount field's value.
+func (s *Activation) SetRegistrationsCount(v int64) *Activation {
+	s.RegistrationsCount = &v
+	return s
+}
+
 type AddTagsToResourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2312,6 +2366,24 @@ func (s *AddTagsToResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *AddTagsToResourceInput) SetResourceId(v string) *AddTagsToResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *AddTagsToResourceInput) SetResourceType(v string) *AddTagsToResourceInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToResourceInput) SetTags(v []*Tag) *AddTagsToResourceInput {
+	s.Tags = v
+	return s
+}
+
 type AddTagsToResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2347,6 +2419,18 @@ func (s Association) GoString() string {
 	return s.String()
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *Association) SetInstanceId(v string) *Association {
+	s.InstanceId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Association) SetName(v string) *Association {
+	s.Name = &v
+	return s
+}
+
 // Describes the parameters for a document.
 type AssociationDescription struct {
 	_ struct{} `type:"structure"`
@@ -2375,6 +2459,36 @@ func (s AssociationDescription) String() string {
 // GoString returns the string representation
 func (s AssociationDescription) GoString() string {
 	return s.String()
+}
+
+// SetDate sets the Date field's value.
+func (s *AssociationDescription) SetDate(v time.Time) *AssociationDescription {
+	s.Date = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *AssociationDescription) SetInstanceId(v string) *AssociationDescription {
+	s.InstanceId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AssociationDescription) SetName(v string) *AssociationDescription {
+	s.Name = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *AssociationDescription) SetParameters(v map[string][]*string) *AssociationDescription {
+	s.Parameters = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AssociationDescription) SetStatus(v *AssociationStatus) *AssociationDescription {
+	s.Status = v
+	return s
 }
 
 // Describes a filter.
@@ -2419,6 +2533,18 @@ func (s *AssociationFilter) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *AssociationFilter) SetKey(v string) *AssociationFilter {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *AssociationFilter) SetValue(v string) *AssociationFilter {
+	s.Value = &v
+	return s
 }
 
 // Describes an association status.
@@ -2473,6 +2599,30 @@ func (s *AssociationStatus) Validate() error {
 	return nil
 }
 
+// SetAdditionalInfo sets the AdditionalInfo field's value.
+func (s *AssociationStatus) SetAdditionalInfo(v string) *AssociationStatus {
+	s.AdditionalInfo = &v
+	return s
+}
+
+// SetDate sets the Date field's value.
+func (s *AssociationStatus) SetDate(v time.Time) *AssociationStatus {
+	s.Date = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *AssociationStatus) SetMessage(v string) *AssociationStatus {
+	s.Message = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AssociationStatus) SetName(v string) *AssociationStatus {
+	s.Name = &v
+	return s
+}
+
 type CancelCommandInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2514,6 +2664,18 @@ func (s *CancelCommandInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetCommandId sets the CommandId field's value.
+func (s *CancelCommandInput) SetCommandId(v string) *CancelCommandInput {
+	s.CommandId = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *CancelCommandInput) SetInstanceIds(v []*string) *CancelCommandInput {
+	s.InstanceIds = v
+	return s
 }
 
 // Whether or not the command was successfully canceled. There is no guarantee
@@ -2590,6 +2752,78 @@ func (s Command) GoString() string {
 	return s.String()
 }
 
+// SetCommandId sets the CommandId field's value.
+func (s *Command) SetCommandId(v string) *Command {
+	s.CommandId = &v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *Command) SetComment(v string) *Command {
+	s.Comment = &v
+	return s
+}
+
+// SetDocumentName sets the DocumentName field's value.
+func (s *Command) SetDocumentName(v string) *Command {
+	s.DocumentName = &v
+	return s
+}
+
+// SetExpiresAfter sets the ExpiresAfter field's value.
+func (s *Command) SetExpiresAfter(v time.Time) *Command {
+	s.ExpiresAfter = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *Command) SetInstanceIds(v []*string) *Command {
+	s.InstanceIds = v
+	return s
+}
+
+// SetNotificationConfig sets the NotificationConfig field's value.
+func (s *Command) SetNotificationConfig(v *NotificationConfig) *Command {
+	s.NotificationConfig = v
+	return s
+}
+
+// SetOutputS3BucketName sets the OutputS3BucketName field's value.
+func (s *Command) SetOutputS3BucketName(v string) *Command {
+	s.OutputS3BucketName = &v
+	return s
+}
+
+// SetOutputS3KeyPrefix sets the OutputS3KeyPrefix field's value.
+func (s *Command) SetOutputS3KeyPrefix(v string) *Command {
+	s.OutputS3KeyPrefix = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *Command) SetParameters(v map[string][]*string) *Command {
+	s.Parameters = v
+	return s
+}
+
+// SetRequestedDateTime sets the RequestedDateTime field's value.
+func (s *Command) SetRequestedDateTime(v time.Time) *Command {
+	s.RequestedDateTime = &v
+	return s
+}
+
+// SetServiceRole sets the ServiceRole field's value.
+func (s *Command) SetServiceRole(v string) *Command {
+	s.ServiceRole = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Command) SetStatus(v string) *Command {
+	s.Status = &v
+	return s
+}
+
 // Describes a command filter.
 type CommandFilter struct {
 	_ struct{} `type:"structure"`
@@ -2632,6 +2866,18 @@ func (s *CommandFilter) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *CommandFilter) SetKey(v string) *CommandFilter {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *CommandFilter) SetValue(v string) *CommandFilter {
+	s.Value = &v
+	return s
 }
 
 // An invocation is copy of a command sent to a specific instance. A command
@@ -2685,6 +2931,66 @@ func (s CommandInvocation) GoString() string {
 	return s.String()
 }
 
+// SetCommandId sets the CommandId field's value.
+func (s *CommandInvocation) SetCommandId(v string) *CommandInvocation {
+	s.CommandId = &v
+	return s
+}
+
+// SetCommandPlugins sets the CommandPlugins field's value.
+func (s *CommandInvocation) SetCommandPlugins(v []*CommandPlugin) *CommandInvocation {
+	s.CommandPlugins = v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *CommandInvocation) SetComment(v string) *CommandInvocation {
+	s.Comment = &v
+	return s
+}
+
+// SetDocumentName sets the DocumentName field's value.
+func (s *CommandInvocation) SetDocumentName(v string) *CommandInvocation {
+	s.DocumentName = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CommandInvocation) SetInstanceId(v string) *CommandInvocation {
+	s.InstanceId = &v
+	return s
+}
+
+// SetNotificationConfig sets the NotificationConfig field's value.
+func (s *CommandInvocation) SetNotificationConfig(v *NotificationConfig) *CommandInvocation {
+	s.NotificationConfig = v
+	return s
+}
+
+// SetRequestedDateTime sets the RequestedDateTime field's value.
+func (s *CommandInvocation) SetRequestedDateTime(v time.Time) *CommandInvocation {
+	s.RequestedDateTime = &v
+	return s
+}
+
+// SetServiceRole sets the ServiceRole field's value.
+func (s *CommandInvocation) SetServiceRole(v string) *CommandInvocation {
+	s.ServiceRole = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CommandInvocation) SetStatus(v string) *CommandInvocation {
+	s.Status = &v
+	return s
+}
+
+// SetTraceOutput sets the TraceOutput field's value.
+func (s *CommandInvocation) SetTraceOutput(v string) *CommandInvocation {
+	s.TraceOutput = &v
+	return s
+}
+
 // Describes plugin details.
 type CommandPlugin struct {
 	_ struct{} `type:"structure"`
@@ -2727,6 +3033,54 @@ func (s CommandPlugin) String() string {
 // GoString returns the string representation
 func (s CommandPlugin) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *CommandPlugin) SetName(v string) *CommandPlugin {
+	s.Name = &v
+	return s
+}
+
+// SetOutput sets the Output field's value.
+func (s *CommandPlugin) SetOutput(v string) *CommandPlugin {
+	s.Output = &v
+	return s
+}
+
+// SetOutputS3BucketName sets the OutputS3BucketName field's value.
+func (s *CommandPlugin) SetOutputS3BucketName(v string) *CommandPlugin {
+	s.OutputS3BucketName = &v
+	return s
+}
+
+// SetOutputS3KeyPrefix sets the OutputS3KeyPrefix field's value.
+func (s *CommandPlugin) SetOutputS3KeyPrefix(v string) *CommandPlugin {
+	s.OutputS3KeyPrefix = &v
+	return s
+}
+
+// SetResponseCode sets the ResponseCode field's value.
+func (s *CommandPlugin) SetResponseCode(v int64) *CommandPlugin {
+	s.ResponseCode = &v
+	return s
+}
+
+// SetResponseFinishDateTime sets the ResponseFinishDateTime field's value.
+func (s *CommandPlugin) SetResponseFinishDateTime(v time.Time) *CommandPlugin {
+	s.ResponseFinishDateTime = &v
+	return s
+}
+
+// SetResponseStartDateTime sets the ResponseStartDateTime field's value.
+func (s *CommandPlugin) SetResponseStartDateTime(v time.Time) *CommandPlugin {
+	s.ResponseStartDateTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CommandPlugin) SetStatus(v string) *CommandPlugin {
+	s.Status = &v
+	return s
 }
 
 type CreateActivationInput struct {
@@ -2781,6 +3135,36 @@ func (s *CreateActivationInput) Validate() error {
 	return nil
 }
 
+// SetDefaultInstanceName sets the DefaultInstanceName field's value.
+func (s *CreateActivationInput) SetDefaultInstanceName(v string) *CreateActivationInput {
+	s.DefaultInstanceName = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateActivationInput) SetDescription(v string) *CreateActivationInput {
+	s.Description = &v
+	return s
+}
+
+// SetExpirationDate sets the ExpirationDate field's value.
+func (s *CreateActivationInput) SetExpirationDate(v time.Time) *CreateActivationInput {
+	s.ExpirationDate = &v
+	return s
+}
+
+// SetIamRole sets the IamRole field's value.
+func (s *CreateActivationInput) SetIamRole(v string) *CreateActivationInput {
+	s.IamRole = &v
+	return s
+}
+
+// SetRegistrationLimit sets the RegistrationLimit field's value.
+func (s *CreateActivationInput) SetRegistrationLimit(v int64) *CreateActivationInput {
+	s.RegistrationLimit = &v
+	return s
+}
+
 type CreateActivationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2801,6 +3185,18 @@ func (s CreateActivationOutput) String() string {
 // GoString returns the string representation
 func (s CreateActivationOutput) GoString() string {
 	return s.String()
+}
+
+// SetActivationCode sets the ActivationCode field's value.
+func (s *CreateActivationOutput) SetActivationCode(v string) *CreateActivationOutput {
+	s.ActivationCode = &v
+	return s
+}
+
+// SetActivationId sets the ActivationId field's value.
+func (s *CreateActivationOutput) SetActivationId(v string) *CreateActivationOutput {
+	s.ActivationId = &v
+	return s
 }
 
 type CreateAssociationBatchInput struct {
@@ -2835,6 +3231,12 @@ func (s *CreateAssociationBatchInput) Validate() error {
 	return nil
 }
 
+// SetEntries sets the Entries field's value.
+func (s *CreateAssociationBatchInput) SetEntries(v []*CreateAssociationBatchRequestEntry) *CreateAssociationBatchInput {
+	s.Entries = v
+	return s
+}
+
 type CreateAssociationBatchOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2853,6 +3255,18 @@ func (s CreateAssociationBatchOutput) String() string {
 // GoString returns the string representation
 func (s CreateAssociationBatchOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailed sets the Failed field's value.
+func (s *CreateAssociationBatchOutput) SetFailed(v []*FailedCreateAssociation) *CreateAssociationBatchOutput {
+	s.Failed = v
+	return s
+}
+
+// SetSuccessful sets the Successful field's value.
+func (s *CreateAssociationBatchOutput) SetSuccessful(v []*AssociationDescription) *CreateAssociationBatchOutput {
+	s.Successful = v
+	return s
 }
 
 // Describes the association of an SSM document and an instance.
@@ -2877,6 +3291,24 @@ func (s CreateAssociationBatchRequestEntry) String() string {
 // GoString returns the string representation
 func (s CreateAssociationBatchRequestEntry) GoString() string {
 	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *CreateAssociationBatchRequestEntry) SetInstanceId(v string) *CreateAssociationBatchRequestEntry {
+	s.InstanceId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateAssociationBatchRequestEntry) SetName(v string) *CreateAssociationBatchRequestEntry {
+	s.Name = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *CreateAssociationBatchRequestEntry) SetParameters(v map[string][]*string) *CreateAssociationBatchRequestEntry {
+	s.Parameters = v
+	return s
 }
 
 type CreateAssociationInput struct {
@@ -2922,6 +3354,24 @@ func (s *CreateAssociationInput) Validate() error {
 	return nil
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *CreateAssociationInput) SetInstanceId(v string) *CreateAssociationInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateAssociationInput) SetName(v string) *CreateAssociationInput {
+	s.Name = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *CreateAssociationInput) SetParameters(v map[string][]*string) *CreateAssociationInput {
+	s.Parameters = v
+	return s
+}
+
 type CreateAssociationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2937,6 +3387,12 @@ func (s CreateAssociationOutput) String() string {
 // GoString returns the string representation
 func (s CreateAssociationOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssociationDescription sets the AssociationDescription field's value.
+func (s *CreateAssociationOutput) SetAssociationDescription(v *AssociationDescription) *CreateAssociationOutput {
+	s.AssociationDescription = v
+	return s
 }
 
 type CreateDocumentInput struct {
@@ -2982,6 +3438,18 @@ func (s *CreateDocumentInput) Validate() error {
 	return nil
 }
 
+// SetContent sets the Content field's value.
+func (s *CreateDocumentInput) SetContent(v string) *CreateDocumentInput {
+	s.Content = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateDocumentInput) SetName(v string) *CreateDocumentInput {
+	s.Name = &v
+	return s
+}
+
 type CreateDocumentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2997,6 +3465,12 @@ func (s CreateDocumentOutput) String() string {
 // GoString returns the string representation
 func (s CreateDocumentOutput) GoString() string {
 	return s.String()
+}
+
+// SetDocumentDescription sets the DocumentDescription field's value.
+func (s *CreateDocumentOutput) SetDocumentDescription(v *DocumentDescription) *CreateDocumentOutput {
+	s.DocumentDescription = v
+	return s
 }
 
 type DeleteActivationInput struct {
@@ -3029,6 +3503,12 @@ func (s *DeleteActivationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetActivationId sets the ActivationId field's value.
+func (s *DeleteActivationInput) SetActivationId(v string) *DeleteActivationInput {
+	s.ActivationId = &v
+	return s
 }
 
 type DeleteActivationOutput struct {
@@ -3085,6 +3565,18 @@ func (s *DeleteAssociationInput) Validate() error {
 	return nil
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *DeleteAssociationInput) SetInstanceId(v string) *DeleteAssociationInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteAssociationInput) SetName(v string) *DeleteAssociationInput {
+	s.Name = &v
+	return s
+}
+
 type DeleteAssociationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3129,6 +3621,12 @@ func (s *DeleteDocumentInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteDocumentInput) SetName(v string) *DeleteDocumentInput {
+	s.Name = &v
+	return s
 }
 
 type DeleteDocumentOutput struct {
@@ -3178,6 +3676,12 @@ func (s *DeregisterManagedInstanceInput) Validate() error {
 	return nil
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *DeregisterManagedInstanceInput) SetInstanceId(v string) *DeregisterManagedInstanceInput {
+	s.InstanceId = &v
+	return s
+}
+
 type DeregisterManagedInstanceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3211,6 +3715,18 @@ func (s DescribeActivationsFilter) String() string {
 // GoString returns the string representation
 func (s DescribeActivationsFilter) GoString() string {
 	return s.String()
+}
+
+// SetFilterKey sets the FilterKey field's value.
+func (s *DescribeActivationsFilter) SetFilterKey(v string) *DescribeActivationsFilter {
+	s.FilterKey = &v
+	return s
+}
+
+// SetFilterValues sets the FilterValues field's value.
+func (s *DescribeActivationsFilter) SetFilterValues(v []*string) *DescribeActivationsFilter {
+	s.FilterValues = v
+	return s
 }
 
 type DescribeActivationsInput struct {
@@ -3251,6 +3767,24 @@ func (s *DescribeActivationsInput) Validate() error {
 	return nil
 }
 
+// SetFilters sets the Filters field's value.
+func (s *DescribeActivationsInput) SetFilters(v []*DescribeActivationsFilter) *DescribeActivationsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeActivationsInput) SetMaxResults(v int64) *DescribeActivationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeActivationsInput) SetNextToken(v string) *DescribeActivationsInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeActivationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3270,6 +3804,18 @@ func (s DescribeActivationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeActivationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetActivationList sets the ActivationList field's value.
+func (s *DescribeActivationsOutput) SetActivationList(v []*Activation) *DescribeActivationsOutput {
+	s.ActivationList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeActivationsOutput) SetNextToken(v string) *DescribeActivationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeAssociationInput struct {
@@ -3312,6 +3858,18 @@ func (s *DescribeAssociationInput) Validate() error {
 	return nil
 }
 
+// SetInstanceId sets the InstanceId field's value.
+func (s *DescribeAssociationInput) SetInstanceId(v string) *DescribeAssociationInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DescribeAssociationInput) SetName(v string) *DescribeAssociationInput {
+	s.Name = &v
+	return s
+}
+
 type DescribeAssociationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3327,6 +3885,12 @@ func (s DescribeAssociationOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAssociationOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssociationDescription sets the AssociationDescription field's value.
+func (s *DescribeAssociationOutput) SetAssociationDescription(v *AssociationDescription) *DescribeAssociationOutput {
+	s.AssociationDescription = v
+	return s
 }
 
 type DescribeDocumentInput struct {
@@ -3361,6 +3925,12 @@ func (s *DescribeDocumentInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *DescribeDocumentInput) SetName(v string) *DescribeDocumentInput {
+	s.Name = &v
+	return s
+}
+
 type DescribeDocumentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3376,6 +3946,12 @@ func (s DescribeDocumentOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDocumentOutput) GoString() string {
 	return s.String()
+}
+
+// SetDocument sets the Document field's value.
+func (s *DescribeDocumentOutput) SetDocument(v *DocumentDescription) *DescribeDocumentOutput {
+	s.Document = v
+	return s
 }
 
 type DescribeDocumentPermissionInput struct {
@@ -3418,6 +3994,18 @@ func (s *DescribeDocumentPermissionInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *DescribeDocumentPermissionInput) SetName(v string) *DescribeDocumentPermissionInput {
+	s.Name = &v
+	return s
+}
+
+// SetPermissionType sets the PermissionType field's value.
+func (s *DescribeDocumentPermissionInput) SetPermissionType(v string) *DescribeDocumentPermissionInput {
+	s.PermissionType = &v
+	return s
+}
+
 type DescribeDocumentPermissionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3434,6 +4022,12 @@ func (s DescribeDocumentPermissionOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDocumentPermissionOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccountIds sets the AccountIds field's value.
+func (s *DescribeDocumentPermissionOutput) SetAccountIds(v []*string) *DescribeDocumentPermissionOutput {
+	s.AccountIds = v
+	return s
 }
 
 type DescribeInstanceInformationInput struct {
@@ -3488,6 +4082,24 @@ func (s *DescribeInstanceInformationInput) Validate() error {
 	return nil
 }
 
+// SetInstanceInformationFilterList sets the InstanceInformationFilterList field's value.
+func (s *DescribeInstanceInformationInput) SetInstanceInformationFilterList(v []*InstanceInformationFilter) *DescribeInstanceInformationInput {
+	s.InstanceInformationFilterList = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeInstanceInformationInput) SetMaxResults(v int64) *DescribeInstanceInformationInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceInformationInput) SetNextToken(v string) *DescribeInstanceInformationInput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeInstanceInformationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3507,6 +4119,18 @@ func (s DescribeInstanceInformationOutput) String() string {
 // GoString returns the string representation
 func (s DescribeInstanceInformationOutput) GoString() string {
 	return s.String()
+}
+
+// SetInstanceInformationList sets the InstanceInformationList field's value.
+func (s *DescribeInstanceInformationOutput) SetInstanceInformationList(v []*InstanceInformation) *DescribeInstanceInformationOutput {
+	s.InstanceInformationList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceInformationOutput) SetNextToken(v string) *DescribeInstanceInformationOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Describes an SSM document.
@@ -3558,6 +4182,66 @@ func (s DocumentDescription) GoString() string {
 	return s.String()
 }
 
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *DocumentDescription) SetCreatedDate(v time.Time) *DocumentDescription {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DocumentDescription) SetDescription(v string) *DocumentDescription {
+	s.Description = &v
+	return s
+}
+
+// SetHash sets the Hash field's value.
+func (s *DocumentDescription) SetHash(v string) *DocumentDescription {
+	s.Hash = &v
+	return s
+}
+
+// SetHashType sets the HashType field's value.
+func (s *DocumentDescription) SetHashType(v string) *DocumentDescription {
+	s.HashType = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DocumentDescription) SetName(v string) *DocumentDescription {
+	s.Name = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *DocumentDescription) SetOwner(v string) *DocumentDescription {
+	s.Owner = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *DocumentDescription) SetParameters(v []*DocumentParameter) *DocumentDescription {
+	s.Parameters = v
+	return s
+}
+
+// SetPlatformTypes sets the PlatformTypes field's value.
+func (s *DocumentDescription) SetPlatformTypes(v []*string) *DocumentDescription {
+	s.PlatformTypes = v
+	return s
+}
+
+// SetSha1 sets the Sha1 field's value.
+func (s *DocumentDescription) SetSha1(v string) *DocumentDescription {
+	s.Sha1 = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DocumentDescription) SetStatus(v string) *DocumentDescription {
+	s.Status = &v
+	return s
+}
+
 // Describes a filter.
 type DocumentFilter struct {
 	_ struct{} `type:"structure"`
@@ -3602,6 +4286,18 @@ func (s *DocumentFilter) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *DocumentFilter) SetKey(v string) *DocumentFilter {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *DocumentFilter) SetValue(v string) *DocumentFilter {
+	s.Value = &v
+	return s
+}
+
 // Describes the name of an SSM document.
 type DocumentIdentifier struct {
 	_ struct{} `type:"structure"`
@@ -3624,6 +4320,24 @@ func (s DocumentIdentifier) String() string {
 // GoString returns the string representation
 func (s DocumentIdentifier) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *DocumentIdentifier) SetName(v string) *DocumentIdentifier {
+	s.Name = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *DocumentIdentifier) SetOwner(v string) *DocumentIdentifier {
+	s.Owner = &v
+	return s
+}
+
+// SetPlatformTypes sets the PlatformTypes field's value.
+func (s *DocumentIdentifier) SetPlatformTypes(v []*string) *DocumentIdentifier {
+	s.PlatformTypes = v
+	return s
 }
 
 // Parameters specified in the SSM document that execute on the server when
@@ -3656,6 +4370,30 @@ func (s DocumentParameter) GoString() string {
 	return s.String()
 }
 
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *DocumentParameter) SetDefaultValue(v string) *DocumentParameter {
+	s.DefaultValue = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DocumentParameter) SetDescription(v string) *DocumentParameter {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DocumentParameter) SetName(v string) *DocumentParameter {
+	s.Name = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *DocumentParameter) SetType(v string) *DocumentParameter {
+	s.Type = &v
+	return s
+}
+
 // Describes a failed association.
 type FailedCreateAssociation struct {
 	_ struct{} `type:"structure"`
@@ -3678,6 +4416,24 @@ func (s FailedCreateAssociation) String() string {
 // GoString returns the string representation
 func (s FailedCreateAssociation) GoString() string {
 	return s.String()
+}
+
+// SetEntry sets the Entry field's value.
+func (s *FailedCreateAssociation) SetEntry(v *CreateAssociationBatchRequestEntry) *FailedCreateAssociation {
+	s.Entry = v
+	return s
+}
+
+// SetFault sets the Fault field's value.
+func (s *FailedCreateAssociation) SetFault(v string) *FailedCreateAssociation {
+	s.Fault = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *FailedCreateAssociation) SetMessage(v string) *FailedCreateAssociation {
+	s.Message = &v
+	return s
 }
 
 type GetDocumentInput struct {
@@ -3712,6 +4468,12 @@ func (s *GetDocumentInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *GetDocumentInput) SetName(v string) *GetDocumentInput {
+	s.Name = &v
+	return s
+}
+
 type GetDocumentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3730,6 +4492,18 @@ func (s GetDocumentOutput) String() string {
 // GoString returns the string representation
 func (s GetDocumentOutput) GoString() string {
 	return s.String()
+}
+
+// SetContent sets the Content field's value.
+func (s *GetDocumentOutput) SetContent(v string) *GetDocumentOutput {
+	s.Content = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetDocumentOutput) SetName(v string) *GetDocumentOutput {
+	s.Name = &v
+	return s
 }
 
 // Describes a filter for a specific list of instances.
@@ -3793,6 +4567,96 @@ func (s InstanceInformation) GoString() string {
 	return s.String()
 }
 
+// SetActivationId sets the ActivationId field's value.
+func (s *InstanceInformation) SetActivationId(v string) *InstanceInformation {
+	s.ActivationId = &v
+	return s
+}
+
+// SetAgentVersion sets the AgentVersion field's value.
+func (s *InstanceInformation) SetAgentVersion(v string) *InstanceInformation {
+	s.AgentVersion = &v
+	return s
+}
+
+// SetComputerName sets the ComputerName field's value.
+func (s *InstanceInformation) SetComputerName(v string) *InstanceInformation {
+	s.ComputerName = &v
+	return s
+}
+
+// SetIPAddress sets the IPAddress field's value.
+func (s *InstanceInformation) SetIPAddress(v string) *InstanceInformation {
+	s.IPAddress = &v
+	return s
+}
+
+// SetIamRole sets the IamRole field's value.
+func (s *InstanceInformation) SetIamRole(v string) *InstanceInformation {
+	s.IamRole = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceInformation) SetInstanceId(v string) *InstanceInformation {
+	s.InstanceId = &v
+	return s
+}
+
+// SetIsLatestVersion sets the IsLatestVersion field's value.
+func (s *InstanceInformation) SetIsLatestVersion(v bool) *InstanceInformation {
+	s.IsLatestVersion = &v
+	return s
+}
+
+// SetLastPingDateTime sets the LastPingDateTime field's value.
+func (s *InstanceInformation) SetLastPingDateTime(v time.Time) *InstanceInformation {
+	s.LastPingDateTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InstanceInformation) SetName(v string) *InstanceInformation {
+	s.Name = &v
+	return s
+}
+
+// SetPingStatus sets the PingStatus field's value.
+func (s *InstanceInformation) SetPingStatus(v string) *InstanceInformation {
+	s.PingStatus = &v
+	return s
+}
+
+// SetPlatformName sets the PlatformName field's value.
+func (s *InstanceInformation) SetPlatformName(v string) *InstanceInformation {
+	s.PlatformName = &v
+	return s
+}
+
+// SetPlatformType sets the PlatformType field's value.
+func (s *InstanceInformation) SetPlatformType(v string) *InstanceInformation {
+	s.PlatformType = &v
+	return s
+}
+
+// SetPlatformVersion sets the PlatformVersion field's value.
+func (s *InstanceInformation) SetPlatformVersion(v string) *InstanceInformation {
+	s.PlatformVersion = &v
+	return s
+}
+
+// SetRegistrationDate sets the RegistrationDate field's value.
+func (s *InstanceInformation) SetRegistrationDate(v time.Time) *InstanceInformation {
+	s.RegistrationDate = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *InstanceInformation) SetResourceType(v string) *InstanceInformation {
+	s.ResourceType = &v
+	return s
+}
+
 // Describes a filter for a specific list of instances.
 type InstanceInformationFilter struct {
 	_ struct{} `type:"structure"`
@@ -3835,6 +4699,18 @@ func (s *InstanceInformationFilter) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *InstanceInformationFilter) SetKey(v string) *InstanceInformationFilter {
+	s.Key = &v
+	return s
+}
+
+// SetValueSet sets the ValueSet field's value.
+func (s *InstanceInformationFilter) SetValueSet(v []*string) *InstanceInformationFilter {
+	s.ValueSet = v
+	return s
 }
 
 type ListAssociationsInput struct {
@@ -3894,6 +4770,24 @@ func (s *ListAssociationsInput) Validate() error {
 	return nil
 }
 
+// SetAssociationFilterList sets the AssociationFilterList field's value.
+func (s *ListAssociationsInput) SetAssociationFilterList(v []*AssociationFilter) *ListAssociationsInput {
+	s.AssociationFilterList = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListAssociationsInput) SetMaxResults(v int64) *ListAssociationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssociationsInput) SetNextToken(v string) *ListAssociationsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListAssociationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3913,6 +4807,18 @@ func (s ListAssociationsOutput) String() string {
 // GoString returns the string representation
 func (s ListAssociationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssociations sets the Associations field's value.
+func (s *ListAssociationsOutput) SetAssociations(v []*Association) *ListAssociationsOutput {
+	s.Associations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssociationsOutput) SetNextToken(v string) *ListAssociationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListCommandInvocationsInput struct {
@@ -3981,6 +4887,42 @@ func (s *ListCommandInvocationsInput) Validate() error {
 	return nil
 }
 
+// SetCommandId sets the CommandId field's value.
+func (s *ListCommandInvocationsInput) SetCommandId(v string) *ListCommandInvocationsInput {
+	s.CommandId = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *ListCommandInvocationsInput) SetDetails(v bool) *ListCommandInvocationsInput {
+	s.Details = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *ListCommandInvocationsInput) SetFilters(v []*CommandFilter) *ListCommandInvocationsInput {
+	s.Filters = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ListCommandInvocationsInput) SetInstanceId(v string) *ListCommandInvocationsInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListCommandInvocationsInput) SetMaxResults(v int64) *ListCommandInvocationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListCommandInvocationsInput) SetNextToken(v string) *ListCommandInvocationsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListCommandInvocationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4000,6 +4942,18 @@ func (s ListCommandInvocationsOutput) String() string {
 // GoString returns the string representation
 func (s ListCommandInvocationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCommandInvocations sets the CommandInvocations field's value.
+func (s *ListCommandInvocationsOutput) SetCommandInvocations(v []*CommandInvocation) *ListCommandInvocationsOutput {
+	s.CommandInvocations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListCommandInvocationsOutput) SetNextToken(v string) *ListCommandInvocationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListCommandsInput struct {
@@ -4064,6 +5018,36 @@ func (s *ListCommandsInput) Validate() error {
 	return nil
 }
 
+// SetCommandId sets the CommandId field's value.
+func (s *ListCommandsInput) SetCommandId(v string) *ListCommandsInput {
+	s.CommandId = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *ListCommandsInput) SetFilters(v []*CommandFilter) *ListCommandsInput {
+	s.Filters = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *ListCommandsInput) SetInstanceId(v string) *ListCommandsInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListCommandsInput) SetMaxResults(v int64) *ListCommandsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListCommandsInput) SetNextToken(v string) *ListCommandsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListCommandsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4083,6 +5067,18 @@ func (s ListCommandsOutput) String() string {
 // GoString returns the string representation
 func (s ListCommandsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCommands sets the Commands field's value.
+func (s *ListCommandsOutput) SetCommands(v []*Command) *ListCommandsOutput {
+	s.Commands = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListCommandsOutput) SetNextToken(v string) *ListCommandsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListDocumentsInput struct {
@@ -4137,6 +5133,24 @@ func (s *ListDocumentsInput) Validate() error {
 	return nil
 }
 
+// SetDocumentFilterList sets the DocumentFilterList field's value.
+func (s *ListDocumentsInput) SetDocumentFilterList(v []*DocumentFilter) *ListDocumentsInput {
+	s.DocumentFilterList = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListDocumentsInput) SetMaxResults(v int64) *ListDocumentsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDocumentsInput) SetNextToken(v string) *ListDocumentsInput {
+	s.NextToken = &v
+	return s
+}
+
 type ListDocumentsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4156,6 +5170,18 @@ func (s ListDocumentsOutput) String() string {
 // GoString returns the string representation
 func (s ListDocumentsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDocumentIdentifiers sets the DocumentIdentifiers field's value.
+func (s *ListDocumentsOutput) SetDocumentIdentifiers(v []*DocumentIdentifier) *ListDocumentsOutput {
+	s.DocumentIdentifiers = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListDocumentsOutput) SetNextToken(v string) *ListDocumentsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type ListTagsForResourceInput struct {
@@ -4198,6 +5224,18 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *ListTagsForResourceInput) SetResourceId(v string) *ListTagsForResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ListTagsForResourceInput) SetResourceType(v string) *ListTagsForResourceInput {
+	s.ResourceType = &v
+	return s
+}
+
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4213,6 +5251,12 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagList sets the TagList field's value.
+func (s *ListTagsForResourceOutput) SetTagList(v []*Tag) *ListTagsForResourceOutput {
+	s.TagList = v
+	return s
 }
 
 type ModifyDocumentPermissionInput struct {
@@ -4265,6 +5309,30 @@ func (s *ModifyDocumentPermissionInput) Validate() error {
 	return nil
 }
 
+// SetAccountIdsToAdd sets the AccountIdsToAdd field's value.
+func (s *ModifyDocumentPermissionInput) SetAccountIdsToAdd(v []*string) *ModifyDocumentPermissionInput {
+	s.AccountIdsToAdd = v
+	return s
+}
+
+// SetAccountIdsToRemove sets the AccountIdsToRemove field's value.
+func (s *ModifyDocumentPermissionInput) SetAccountIdsToRemove(v []*string) *ModifyDocumentPermissionInput {
+	s.AccountIdsToRemove = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ModifyDocumentPermissionInput) SetName(v string) *ModifyDocumentPermissionInput {
+	s.Name = &v
+	return s
+}
+
+// SetPermissionType sets the PermissionType field's value.
+func (s *ModifyDocumentPermissionInput) SetPermissionType(v string) *ModifyDocumentPermissionInput {
+	s.PermissionType = &v
+	return s
+}
+
 type ModifyDocumentPermissionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4307,6 +5375,24 @@ func (s NotificationConfig) String() string {
 // GoString returns the string representation
 func (s NotificationConfig) GoString() string {
 	return s.String()
+}
+
+// SetNotificationArn sets the NotificationArn field's value.
+func (s *NotificationConfig) SetNotificationArn(v string) *NotificationConfig {
+	s.NotificationArn = &v
+	return s
+}
+
+// SetNotificationEvents sets the NotificationEvents field's value.
+func (s *NotificationConfig) SetNotificationEvents(v []*string) *NotificationConfig {
+	s.NotificationEvents = v
+	return s
+}
+
+// SetNotificationType sets the NotificationType field's value.
+func (s *NotificationConfig) SetNotificationType(v string) *NotificationConfig {
+	s.NotificationType = &v
+	return s
 }
 
 type RemoveTagsFromResourceInput struct {
@@ -4355,6 +5441,24 @@ func (s *RemoveTagsFromResourceInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *RemoveTagsFromResourceInput) SetResourceId(v string) *RemoveTagsFromResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *RemoveTagsFromResourceInput) SetResourceType(v string) *RemoveTagsFromResourceInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsFromResourceInput) SetTagKeys(v []*string) *RemoveTagsFromResourceInput {
+	s.TagKeys = v
+	return s
 }
 
 type RemoveTagsFromResourceOutput struct {
@@ -4457,6 +5561,72 @@ func (s *SendCommandInput) Validate() error {
 	return nil
 }
 
+// SetComment sets the Comment field's value.
+func (s *SendCommandInput) SetComment(v string) *SendCommandInput {
+	s.Comment = &v
+	return s
+}
+
+// SetDocumentHash sets the DocumentHash field's value.
+func (s *SendCommandInput) SetDocumentHash(v string) *SendCommandInput {
+	s.DocumentHash = &v
+	return s
+}
+
+// SetDocumentHashType sets the DocumentHashType field's value.
+func (s *SendCommandInput) SetDocumentHashType(v string) *SendCommandInput {
+	s.DocumentHashType = &v
+	return s
+}
+
+// SetDocumentName sets the DocumentName field's value.
+func (s *SendCommandInput) SetDocumentName(v string) *SendCommandInput {
+	s.DocumentName = &v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *SendCommandInput) SetInstanceIds(v []*string) *SendCommandInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetNotificationConfig sets the NotificationConfig field's value.
+func (s *SendCommandInput) SetNotificationConfig(v *NotificationConfig) *SendCommandInput {
+	s.NotificationConfig = v
+	return s
+}
+
+// SetOutputS3BucketName sets the OutputS3BucketName field's value.
+func (s *SendCommandInput) SetOutputS3BucketName(v string) *SendCommandInput {
+	s.OutputS3BucketName = &v
+	return s
+}
+
+// SetOutputS3KeyPrefix sets the OutputS3KeyPrefix field's value.
+func (s *SendCommandInput) SetOutputS3KeyPrefix(v string) *SendCommandInput {
+	s.OutputS3KeyPrefix = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *SendCommandInput) SetParameters(v map[string][]*string) *SendCommandInput {
+	s.Parameters = v
+	return s
+}
+
+// SetServiceRoleArn sets the ServiceRoleArn field's value.
+func (s *SendCommandInput) SetServiceRoleArn(v string) *SendCommandInput {
+	s.ServiceRoleArn = &v
+	return s
+}
+
+// SetTimeoutSeconds sets the TimeoutSeconds field's value.
+func (s *SendCommandInput) SetTimeoutSeconds(v int64) *SendCommandInput {
+	s.TimeoutSeconds = &v
+	return s
+}
+
 type SendCommandOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4473,6 +5643,12 @@ func (s SendCommandOutput) String() string {
 // GoString returns the string representation
 func (s SendCommandOutput) GoString() string {
 	return s.String()
+}
+
+// SetCommand sets the Command field's value.
+func (s *SendCommandOutput) SetCommand(v *Command) *SendCommandOutput {
+	s.Command = v
+	return s
 }
 
 // Metadata that you assign to your managed instances. Tags enable you to categorize
@@ -4522,6 +5698,18 @@ func (s *Tag) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
 }
 
 type UpdateAssociationStatusInput struct {
@@ -4577,6 +5765,24 @@ func (s *UpdateAssociationStatusInput) Validate() error {
 	return nil
 }
 
+// SetAssociationStatus sets the AssociationStatus field's value.
+func (s *UpdateAssociationStatusInput) SetAssociationStatus(v *AssociationStatus) *UpdateAssociationStatusInput {
+	s.AssociationStatus = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *UpdateAssociationStatusInput) SetInstanceId(v string) *UpdateAssociationStatusInput {
+	s.InstanceId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateAssociationStatusInput) SetName(v string) *UpdateAssociationStatusInput {
+	s.Name = &v
+	return s
+}
+
 type UpdateAssociationStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4592,6 +5798,12 @@ func (s UpdateAssociationStatusOutput) String() string {
 // GoString returns the string representation
 func (s UpdateAssociationStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssociationDescription sets the AssociationDescription field's value.
+func (s *UpdateAssociationStatusOutput) SetAssociationDescription(v *AssociationDescription) *UpdateAssociationStatusOutput {
+	s.AssociationDescription = v
+	return s
 }
 
 type UpdateManagedInstanceRoleInput struct {
@@ -4632,6 +5844,18 @@ func (s *UpdateManagedInstanceRoleInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetIamRole sets the IamRole field's value.
+func (s *UpdateManagedInstanceRoleInput) SetIamRole(v string) *UpdateManagedInstanceRoleInput {
+	s.IamRole = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *UpdateManagedInstanceRoleInput) SetInstanceId(v string) *UpdateManagedInstanceRoleInput {
+	s.InstanceId = &v
+	return s
 }
 
 type UpdateManagedInstanceRoleOutput struct {

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -4551,6 +4551,48 @@ func (s *ActivateGatewayInput) Validate() error {
 	return nil
 }
 
+// SetActivationKey sets the ActivationKey field's value.
+func (s *ActivateGatewayInput) SetActivationKey(v string) *ActivateGatewayInput {
+	s.ActivationKey = &v
+	return s
+}
+
+// SetGatewayName sets the GatewayName field's value.
+func (s *ActivateGatewayInput) SetGatewayName(v string) *ActivateGatewayInput {
+	s.GatewayName = &v
+	return s
+}
+
+// SetGatewayRegion sets the GatewayRegion field's value.
+func (s *ActivateGatewayInput) SetGatewayRegion(v string) *ActivateGatewayInput {
+	s.GatewayRegion = &v
+	return s
+}
+
+// SetGatewayTimezone sets the GatewayTimezone field's value.
+func (s *ActivateGatewayInput) SetGatewayTimezone(v string) *ActivateGatewayInput {
+	s.GatewayTimezone = &v
+	return s
+}
+
+// SetGatewayType sets the GatewayType field's value.
+func (s *ActivateGatewayInput) SetGatewayType(v string) *ActivateGatewayInput {
+	s.GatewayType = &v
+	return s
+}
+
+// SetMediumChangerType sets the MediumChangerType field's value.
+func (s *ActivateGatewayInput) SetMediumChangerType(v string) *ActivateGatewayInput {
+	s.MediumChangerType = &v
+	return s
+}
+
+// SetTapeDriveType sets the TapeDriveType field's value.
+func (s *ActivateGatewayInput) SetTapeDriveType(v string) *ActivateGatewayInput {
+	s.TapeDriveType = &v
+	return s
+}
+
 // AWS Storage Gateway returns the Amazon Resource Name (ARN) of the activated
 // gateway. It is a string made of information such as your account, gateway
 // name, and region. This ARN is used to reference the gateway in other API
@@ -4575,6 +4617,12 @@ func (s ActivateGatewayOutput) String() string {
 // GoString returns the string representation
 func (s ActivateGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ActivateGatewayOutput) SetGatewayARN(v string) *ActivateGatewayOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 type AddCacheInput struct {
@@ -4619,6 +4667,18 @@ func (s *AddCacheInput) Validate() error {
 	return nil
 }
 
+// SetDiskIds sets the DiskIds field's value.
+func (s *AddCacheInput) SetDiskIds(v []*string) *AddCacheInput {
+	s.DiskIds = v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *AddCacheInput) SetGatewayARN(v string) *AddCacheInput {
+	s.GatewayARN = &v
+	return s
+}
+
 type AddCacheOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4635,6 +4695,12 @@ func (s AddCacheOutput) String() string {
 // GoString returns the string representation
 func (s AddCacheOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *AddCacheOutput) SetGatewayARN(v string) *AddCacheOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // AddTagsToResourceInput
@@ -4695,6 +4761,18 @@ func (s *AddTagsToResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceARN sets the ResourceARN field's value.
+func (s *AddTagsToResourceInput) SetResourceARN(v string) *AddTagsToResourceInput {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AddTagsToResourceInput) SetTags(v []*Tag) *AddTagsToResourceInput {
+	s.Tags = v
+	return s
+}
+
 // AddTagsToResourceOutput
 type AddTagsToResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -4711,6 +4789,12 @@ func (s AddTagsToResourceOutput) String() string {
 // GoString returns the string representation
 func (s AddTagsToResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *AddTagsToResourceOutput) SetResourceARN(v string) *AddTagsToResourceOutput {
+	s.ResourceARN = &v
+	return s
 }
 
 type AddUploadBufferInput struct {
@@ -4755,6 +4839,18 @@ func (s *AddUploadBufferInput) Validate() error {
 	return nil
 }
 
+// SetDiskIds sets the DiskIds field's value.
+func (s *AddUploadBufferInput) SetDiskIds(v []*string) *AddUploadBufferInput {
+	s.DiskIds = v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *AddUploadBufferInput) SetGatewayARN(v string) *AddUploadBufferInput {
+	s.GatewayARN = &v
+	return s
+}
+
 type AddUploadBufferOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4771,6 +4867,12 @@ func (s AddUploadBufferOutput) String() string {
 // GoString returns the string representation
 func (s AddUploadBufferOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *AddUploadBufferOutput) SetGatewayARN(v string) *AddUploadBufferOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // A JSON object containing one or more of the following fields:
@@ -4822,6 +4924,18 @@ func (s *AddWorkingStorageInput) Validate() error {
 	return nil
 }
 
+// SetDiskIds sets the DiskIds field's value.
+func (s *AddWorkingStorageInput) SetDiskIds(v []*string) *AddWorkingStorageInput {
+	s.DiskIds = v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *AddWorkingStorageInput) SetGatewayARN(v string) *AddWorkingStorageInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the of the gateway for which working storage was
 // configured.
 type AddWorkingStorageOutput struct {
@@ -4840,6 +4954,12 @@ func (s AddWorkingStorageOutput) String() string {
 // GoString returns the string representation
 func (s AddWorkingStorageOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *AddWorkingStorageOutput) SetGatewayARN(v string) *AddWorkingStorageOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 type CachediSCSIVolume struct {
@@ -4871,6 +4991,54 @@ func (s CachediSCSIVolume) String() string {
 // GoString returns the string representation
 func (s CachediSCSIVolume) GoString() string {
 	return s.String()
+}
+
+// SetSourceSnapshotId sets the SourceSnapshotId field's value.
+func (s *CachediSCSIVolume) SetSourceSnapshotId(v string) *CachediSCSIVolume {
+	s.SourceSnapshotId = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *CachediSCSIVolume) SetVolumeARN(v string) *CachediSCSIVolume {
+	s.VolumeARN = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *CachediSCSIVolume) SetVolumeId(v string) *CachediSCSIVolume {
+	s.VolumeId = &v
+	return s
+}
+
+// SetVolumeProgress sets the VolumeProgress field's value.
+func (s *CachediSCSIVolume) SetVolumeProgress(v float64) *CachediSCSIVolume {
+	s.VolumeProgress = &v
+	return s
+}
+
+// SetVolumeSizeInBytes sets the VolumeSizeInBytes field's value.
+func (s *CachediSCSIVolume) SetVolumeSizeInBytes(v int64) *CachediSCSIVolume {
+	s.VolumeSizeInBytes = &v
+	return s
+}
+
+// SetVolumeStatus sets the VolumeStatus field's value.
+func (s *CachediSCSIVolume) SetVolumeStatus(v string) *CachediSCSIVolume {
+	s.VolumeStatus = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *CachediSCSIVolume) SetVolumeType(v string) *CachediSCSIVolume {
+	s.VolumeType = &v
+	return s
+}
+
+// SetVolumeiSCSIAttributes sets the VolumeiSCSIAttributes field's value.
+func (s *CachediSCSIVolume) SetVolumeiSCSIAttributes(v *VolumeiSCSIAttributes) *CachediSCSIVolume {
+	s.VolumeiSCSIAttributes = v
+	return s
 }
 
 // CancelArchivalInput
@@ -4922,6 +5090,18 @@ func (s *CancelArchivalInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *CancelArchivalInput) SetGatewayARN(v string) *CancelArchivalInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *CancelArchivalInput) SetTapeARN(v string) *CancelArchivalInput {
+	s.TapeARN = &v
+	return s
+}
+
 // CancelArchivalOutput
 type CancelArchivalOutput struct {
 	_ struct{} `type:"structure"`
@@ -4939,6 +5119,12 @@ func (s CancelArchivalOutput) String() string {
 // GoString returns the string representation
 func (s CancelArchivalOutput) GoString() string {
 	return s.String()
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *CancelArchivalOutput) SetTapeARN(v string) *CancelArchivalOutput {
+	s.TapeARN = &v
+	return s
 }
 
 // CancelRetrievalInput
@@ -4990,6 +5176,18 @@ func (s *CancelRetrievalInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *CancelRetrievalInput) SetGatewayARN(v string) *CancelRetrievalInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *CancelRetrievalInput) SetTapeARN(v string) *CancelRetrievalInput {
+	s.TapeARN = &v
+	return s
+}
+
 // CancelRetrievalOutput
 type CancelRetrievalOutput struct {
 	_ struct{} `type:"structure"`
@@ -5007,6 +5205,12 @@ func (s CancelRetrievalOutput) String() string {
 // GoString returns the string representation
 func (s CancelRetrievalOutput) GoString() string {
 	return s.String()
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *CancelRetrievalOutput) SetTapeARN(v string) *CancelRetrievalOutput {
+	s.TapeARN = &v
+	return s
 }
 
 // Describes Challenge-Handshake Authentication Protocol (CHAP) information
@@ -5040,6 +5244,30 @@ func (s ChapInfo) String() string {
 // GoString returns the string representation
 func (s ChapInfo) GoString() string {
 	return s.String()
+}
+
+// SetInitiatorName sets the InitiatorName field's value.
+func (s *ChapInfo) SetInitiatorName(v string) *ChapInfo {
+	s.InitiatorName = &v
+	return s
+}
+
+// SetSecretToAuthenticateInitiator sets the SecretToAuthenticateInitiator field's value.
+func (s *ChapInfo) SetSecretToAuthenticateInitiator(v string) *ChapInfo {
+	s.SecretToAuthenticateInitiator = &v
+	return s
+}
+
+// SetSecretToAuthenticateTarget sets the SecretToAuthenticateTarget field's value.
+func (s *ChapInfo) SetSecretToAuthenticateTarget(v string) *ChapInfo {
+	s.SecretToAuthenticateTarget = &v
+	return s
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *ChapInfo) SetTargetARN(v string) *ChapInfo {
+	s.TargetARN = &v
+	return s
 }
 
 type CreateCachediSCSIVolumeInput struct {
@@ -5110,6 +5338,42 @@ func (s *CreateCachediSCSIVolumeInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateCachediSCSIVolumeInput) SetClientToken(v string) *CreateCachediSCSIVolumeInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *CreateCachediSCSIVolumeInput) SetGatewayARN(v string) *CreateCachediSCSIVolumeInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *CreateCachediSCSIVolumeInput) SetNetworkInterfaceId(v string) *CreateCachediSCSIVolumeInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *CreateCachediSCSIVolumeInput) SetSnapshotId(v string) *CreateCachediSCSIVolumeInput {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetTargetName sets the TargetName field's value.
+func (s *CreateCachediSCSIVolumeInput) SetTargetName(v string) *CreateCachediSCSIVolumeInput {
+	s.TargetName = &v
+	return s
+}
+
+// SetVolumeSizeInBytes sets the VolumeSizeInBytes field's value.
+func (s *CreateCachediSCSIVolumeInput) SetVolumeSizeInBytes(v int64) *CreateCachediSCSIVolumeInput {
+	s.VolumeSizeInBytes = &v
+	return s
+}
+
 type CreateCachediSCSIVolumeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5126,6 +5390,18 @@ func (s CreateCachediSCSIVolumeOutput) String() string {
 // GoString returns the string representation
 func (s CreateCachediSCSIVolumeOutput) GoString() string {
 	return s.String()
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *CreateCachediSCSIVolumeOutput) SetTargetARN(v string) *CreateCachediSCSIVolumeOutput {
+	s.TargetARN = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *CreateCachediSCSIVolumeOutput) SetVolumeARN(v string) *CreateCachediSCSIVolumeOutput {
+	s.VolumeARN = &v
+	return s
 }
 
 type CreateSnapshotFromVolumeRecoveryPointInput struct {
@@ -5170,6 +5446,18 @@ func (s *CreateSnapshotFromVolumeRecoveryPointInput) Validate() error {
 	return nil
 }
 
+// SetSnapshotDescription sets the SnapshotDescription field's value.
+func (s *CreateSnapshotFromVolumeRecoveryPointInput) SetSnapshotDescription(v string) *CreateSnapshotFromVolumeRecoveryPointInput {
+	s.SnapshotDescription = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *CreateSnapshotFromVolumeRecoveryPointInput) SetVolumeARN(v string) *CreateSnapshotFromVolumeRecoveryPointInput {
+	s.VolumeARN = &v
+	return s
+}
+
 type CreateSnapshotFromVolumeRecoveryPointOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5188,6 +5476,24 @@ func (s CreateSnapshotFromVolumeRecoveryPointOutput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotFromVolumeRecoveryPointOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *CreateSnapshotFromVolumeRecoveryPointOutput) SetSnapshotId(v string) *CreateSnapshotFromVolumeRecoveryPointOutput {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *CreateSnapshotFromVolumeRecoveryPointOutput) SetVolumeARN(v string) *CreateSnapshotFromVolumeRecoveryPointOutput {
+	s.VolumeARN = &v
+	return s
+}
+
+// SetVolumeRecoveryPointTime sets the VolumeRecoveryPointTime field's value.
+func (s *CreateSnapshotFromVolumeRecoveryPointOutput) SetVolumeRecoveryPointTime(v string) *CreateSnapshotFromVolumeRecoveryPointOutput {
+	s.VolumeRecoveryPointTime = &v
+	return s
 }
 
 // A JSON object containing one or more of the following fields:
@@ -5244,6 +5550,18 @@ func (s *CreateSnapshotInput) Validate() error {
 	return nil
 }
 
+// SetSnapshotDescription sets the SnapshotDescription field's value.
+func (s *CreateSnapshotInput) SetSnapshotDescription(v string) *CreateSnapshotInput {
+	s.SnapshotDescription = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *CreateSnapshotInput) SetVolumeARN(v string) *CreateSnapshotInput {
+	s.VolumeARN = &v
+	return s
+}
+
 // A JSON object containing the following fields:
 type CreateSnapshotOutput struct {
 	_ struct{} `type:"structure"`
@@ -5265,6 +5583,18 @@ func (s CreateSnapshotOutput) String() string {
 // GoString returns the string representation
 func (s CreateSnapshotOutput) GoString() string {
 	return s.String()
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *CreateSnapshotOutput) SetSnapshotId(v string) *CreateSnapshotOutput {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *CreateSnapshotOutput) SetVolumeARN(v string) *CreateSnapshotOutput {
+	s.VolumeARN = &v
+	return s
 }
 
 // A JSON object containing one or more of the following fields:
@@ -5371,6 +5701,42 @@ func (s *CreateStorediSCSIVolumeInput) Validate() error {
 	return nil
 }
 
+// SetDiskId sets the DiskId field's value.
+func (s *CreateStorediSCSIVolumeInput) SetDiskId(v string) *CreateStorediSCSIVolumeInput {
+	s.DiskId = &v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *CreateStorediSCSIVolumeInput) SetGatewayARN(v string) *CreateStorediSCSIVolumeInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *CreateStorediSCSIVolumeInput) SetNetworkInterfaceId(v string) *CreateStorediSCSIVolumeInput {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetPreserveExistingData sets the PreserveExistingData field's value.
+func (s *CreateStorediSCSIVolumeInput) SetPreserveExistingData(v bool) *CreateStorediSCSIVolumeInput {
+	s.PreserveExistingData = &v
+	return s
+}
+
+// SetSnapshotId sets the SnapshotId field's value.
+func (s *CreateStorediSCSIVolumeInput) SetSnapshotId(v string) *CreateStorediSCSIVolumeInput {
+	s.SnapshotId = &v
+	return s
+}
+
+// SetTargetName sets the TargetName field's value.
+func (s *CreateStorediSCSIVolumeInput) SetTargetName(v string) *CreateStorediSCSIVolumeInput {
+	s.TargetName = &v
+	return s
+}
+
 // A JSON object containing the following fields:
 type CreateStorediSCSIVolumeOutput struct {
 	_ struct{} `type:"structure"`
@@ -5394,6 +5760,24 @@ func (s CreateStorediSCSIVolumeOutput) String() string {
 // GoString returns the string representation
 func (s CreateStorediSCSIVolumeOutput) GoString() string {
 	return s.String()
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *CreateStorediSCSIVolumeOutput) SetTargetARN(v string) *CreateStorediSCSIVolumeOutput {
+	s.TargetARN = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *CreateStorediSCSIVolumeOutput) SetVolumeARN(v string) *CreateStorediSCSIVolumeOutput {
+	s.VolumeARN = &v
+	return s
+}
+
+// SetVolumeSizeInBytes sets the VolumeSizeInBytes field's value.
+func (s *CreateStorediSCSIVolumeOutput) SetVolumeSizeInBytes(v int64) *CreateStorediSCSIVolumeOutput {
+	s.VolumeSizeInBytes = &v
+	return s
 }
 
 // CreateTapeWithBarcodeInput
@@ -5455,6 +5839,24 @@ func (s *CreateTapeWithBarcodeInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *CreateTapeWithBarcodeInput) SetGatewayARN(v string) *CreateTapeWithBarcodeInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetTapeBarcode sets the TapeBarcode field's value.
+func (s *CreateTapeWithBarcodeInput) SetTapeBarcode(v string) *CreateTapeWithBarcodeInput {
+	s.TapeBarcode = &v
+	return s
+}
+
+// SetTapeSizeInBytes sets the TapeSizeInBytes field's value.
+func (s *CreateTapeWithBarcodeInput) SetTapeSizeInBytes(v int64) *CreateTapeWithBarcodeInput {
+	s.TapeSizeInBytes = &v
+	return s
+}
+
 // CreateTapeOutput
 type CreateTapeWithBarcodeOutput struct {
 	_ struct{} `type:"structure"`
@@ -5472,6 +5874,12 @@ func (s CreateTapeWithBarcodeOutput) String() string {
 // GoString returns the string representation
 func (s CreateTapeWithBarcodeOutput) GoString() string {
 	return s.String()
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *CreateTapeWithBarcodeOutput) SetTapeARN(v string) *CreateTapeWithBarcodeOutput {
+	s.TapeARN = &v
+	return s
 }
 
 // CreateTapesInput
@@ -5562,6 +5970,36 @@ func (s *CreateTapesInput) Validate() error {
 	return nil
 }
 
+// SetClientToken sets the ClientToken field's value.
+func (s *CreateTapesInput) SetClientToken(v string) *CreateTapesInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *CreateTapesInput) SetGatewayARN(v string) *CreateTapesInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetNumTapesToCreate sets the NumTapesToCreate field's value.
+func (s *CreateTapesInput) SetNumTapesToCreate(v int64) *CreateTapesInput {
+	s.NumTapesToCreate = &v
+	return s
+}
+
+// SetTapeBarcodePrefix sets the TapeBarcodePrefix field's value.
+func (s *CreateTapesInput) SetTapeBarcodePrefix(v string) *CreateTapesInput {
+	s.TapeBarcodePrefix = &v
+	return s
+}
+
+// SetTapeSizeInBytes sets the TapeSizeInBytes field's value.
+func (s *CreateTapesInput) SetTapeSizeInBytes(v int64) *CreateTapesInput {
+	s.TapeSizeInBytes = &v
+	return s
+}
+
 // CreateTapeOutput
 type CreateTapesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5579,6 +6017,12 @@ func (s CreateTapesOutput) String() string {
 // GoString returns the string representation
 func (s CreateTapesOutput) GoString() string {
 	return s.String()
+}
+
+// SetTapeARNs sets the TapeARNs field's value.
+func (s *CreateTapesOutput) SetTapeARNs(v []*string) *CreateTapesOutput {
+	s.TapeARNs = v
+	return s
 }
 
 type DeleteBandwidthRateLimitInput struct {
@@ -5626,6 +6070,18 @@ func (s *DeleteBandwidthRateLimitInput) Validate() error {
 	return nil
 }
 
+// SetBandwidthType sets the BandwidthType field's value.
+func (s *DeleteBandwidthRateLimitInput) SetBandwidthType(v string) *DeleteBandwidthRateLimitInput {
+	s.BandwidthType = &v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DeleteBandwidthRateLimitInput) SetGatewayARN(v string) *DeleteBandwidthRateLimitInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the of the gateway whose bandwidth rate information
 // was deleted.
 type DeleteBandwidthRateLimitOutput struct {
@@ -5644,6 +6100,12 @@ func (s DeleteBandwidthRateLimitOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBandwidthRateLimitOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DeleteBandwidthRateLimitOutput) SetGatewayARN(v string) *DeleteBandwidthRateLimitOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // A JSON object containing one or more of the following fields:
@@ -5698,6 +6160,18 @@ func (s *DeleteChapCredentialsInput) Validate() error {
 	return nil
 }
 
+// SetInitiatorName sets the InitiatorName field's value.
+func (s *DeleteChapCredentialsInput) SetInitiatorName(v string) *DeleteChapCredentialsInput {
+	s.InitiatorName = &v
+	return s
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *DeleteChapCredentialsInput) SetTargetARN(v string) *DeleteChapCredentialsInput {
+	s.TargetARN = &v
+	return s
+}
+
 // A JSON object containing the following fields:
 type DeleteChapCredentialsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5717,6 +6191,18 @@ func (s DeleteChapCredentialsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteChapCredentialsOutput) GoString() string {
 	return s.String()
+}
+
+// SetInitiatorName sets the InitiatorName field's value.
+func (s *DeleteChapCredentialsOutput) SetInitiatorName(v string) *DeleteChapCredentialsOutput {
+	s.InitiatorName = &v
+	return s
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *DeleteChapCredentialsOutput) SetTargetARN(v string) *DeleteChapCredentialsOutput {
+	s.TargetARN = &v
+	return s
 }
 
 // A JSON object containing the id of the gateway to delete.
@@ -5756,6 +6242,12 @@ func (s *DeleteGatewayInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DeleteGatewayInput) SetGatewayARN(v string) *DeleteGatewayInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the id of the deleted gateway.
 type DeleteGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -5773,6 +6265,12 @@ func (s DeleteGatewayOutput) String() string {
 // GoString returns the string representation
 func (s DeleteGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DeleteGatewayOutput) SetGatewayARN(v string) *DeleteGatewayOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 type DeleteSnapshotScheduleInput struct {
@@ -5808,6 +6306,12 @@ func (s *DeleteSnapshotScheduleInput) Validate() error {
 	return nil
 }
 
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *DeleteSnapshotScheduleInput) SetVolumeARN(v string) *DeleteSnapshotScheduleInput {
+	s.VolumeARN = &v
+	return s
+}
+
 type DeleteSnapshotScheduleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5822,6 +6326,12 @@ func (s DeleteSnapshotScheduleOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSnapshotScheduleOutput) GoString() string {
 	return s.String()
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *DeleteSnapshotScheduleOutput) SetVolumeARN(v string) *DeleteSnapshotScheduleOutput {
+	s.VolumeARN = &v
+	return s
 }
 
 // DeleteTapeArchiveInput
@@ -5861,6 +6371,12 @@ func (s *DeleteTapeArchiveInput) Validate() error {
 	return nil
 }
 
+// SetTapeARN sets the TapeARN field's value.
+func (s *DeleteTapeArchiveInput) SetTapeARN(v string) *DeleteTapeArchiveInput {
+	s.TapeARN = &v
+	return s
+}
+
 // DeleteTapeArchiveOutput
 type DeleteTapeArchiveOutput struct {
 	_ struct{} `type:"structure"`
@@ -5878,6 +6394,12 @@ func (s DeleteTapeArchiveOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTapeArchiveOutput) GoString() string {
 	return s.String()
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *DeleteTapeArchiveOutput) SetTapeARN(v string) *DeleteTapeArchiveOutput {
+	s.TapeARN = &v
+	return s
 }
 
 // DeleteTapeInput
@@ -5929,6 +6451,18 @@ func (s *DeleteTapeInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DeleteTapeInput) SetGatewayARN(v string) *DeleteTapeInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *DeleteTapeInput) SetTapeARN(v string) *DeleteTapeInput {
+	s.TapeARN = &v
+	return s
+}
+
 // DeleteTapeOutput
 type DeleteTapeOutput struct {
 	_ struct{} `type:"structure"`
@@ -5945,6 +6479,12 @@ func (s DeleteTapeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTapeOutput) GoString() string {
 	return s.String()
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *DeleteTapeOutput) SetTapeARN(v string) *DeleteTapeOutput {
+	s.TapeARN = &v
+	return s
 }
 
 // A JSON object containing the DeleteVolumeInput$VolumeARN to delete.
@@ -5984,6 +6524,12 @@ func (s *DeleteVolumeInput) Validate() error {
 	return nil
 }
 
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *DeleteVolumeInput) SetVolumeARN(v string) *DeleteVolumeInput {
+	s.VolumeARN = &v
+	return s
+}
+
 // A JSON object containing the of the storage volume that was deleted
 type DeleteVolumeOutput struct {
 	_ struct{} `type:"structure"`
@@ -6001,6 +6547,12 @@ func (s DeleteVolumeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVolumeOutput) GoString() string {
 	return s.String()
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *DeleteVolumeOutput) SetVolumeARN(v string) *DeleteVolumeOutput {
+	s.VolumeARN = &v
+	return s
 }
 
 // A JSON object containing the of the gateway.
@@ -6040,6 +6592,12 @@ func (s *DescribeBandwidthRateLimitInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeBandwidthRateLimitInput) SetGatewayARN(v string) *DescribeBandwidthRateLimitInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the following fields:
 type DescribeBandwidthRateLimitOutput struct {
 	_ struct{} `type:"structure"`
@@ -6065,6 +6623,24 @@ func (s DescribeBandwidthRateLimitOutput) String() string {
 // GoString returns the string representation
 func (s DescribeBandwidthRateLimitOutput) GoString() string {
 	return s.String()
+}
+
+// SetAverageDownloadRateLimitInBitsPerSec sets the AverageDownloadRateLimitInBitsPerSec field's value.
+func (s *DescribeBandwidthRateLimitOutput) SetAverageDownloadRateLimitInBitsPerSec(v int64) *DescribeBandwidthRateLimitOutput {
+	s.AverageDownloadRateLimitInBitsPerSec = &v
+	return s
+}
+
+// SetAverageUploadRateLimitInBitsPerSec sets the AverageUploadRateLimitInBitsPerSec field's value.
+func (s *DescribeBandwidthRateLimitOutput) SetAverageUploadRateLimitInBitsPerSec(v int64) *DescribeBandwidthRateLimitOutput {
+	s.AverageUploadRateLimitInBitsPerSec = &v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeBandwidthRateLimitOutput) SetGatewayARN(v string) *DescribeBandwidthRateLimitOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 type DescribeCacheInput struct {
@@ -6103,6 +6679,12 @@ func (s *DescribeCacheInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeCacheInput) SetGatewayARN(v string) *DescribeCacheInput {
+	s.GatewayARN = &v
+	return s
+}
+
 type DescribeCacheOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6131,6 +6713,48 @@ func (s DescribeCacheOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCacheOutput) GoString() string {
 	return s.String()
+}
+
+// SetCacheAllocatedInBytes sets the CacheAllocatedInBytes field's value.
+func (s *DescribeCacheOutput) SetCacheAllocatedInBytes(v int64) *DescribeCacheOutput {
+	s.CacheAllocatedInBytes = &v
+	return s
+}
+
+// SetCacheDirtyPercentage sets the CacheDirtyPercentage field's value.
+func (s *DescribeCacheOutput) SetCacheDirtyPercentage(v float64) *DescribeCacheOutput {
+	s.CacheDirtyPercentage = &v
+	return s
+}
+
+// SetCacheHitPercentage sets the CacheHitPercentage field's value.
+func (s *DescribeCacheOutput) SetCacheHitPercentage(v float64) *DescribeCacheOutput {
+	s.CacheHitPercentage = &v
+	return s
+}
+
+// SetCacheMissPercentage sets the CacheMissPercentage field's value.
+func (s *DescribeCacheOutput) SetCacheMissPercentage(v float64) *DescribeCacheOutput {
+	s.CacheMissPercentage = &v
+	return s
+}
+
+// SetCacheUsedPercentage sets the CacheUsedPercentage field's value.
+func (s *DescribeCacheOutput) SetCacheUsedPercentage(v float64) *DescribeCacheOutput {
+	s.CacheUsedPercentage = &v
+	return s
+}
+
+// SetDiskIds sets the DiskIds field's value.
+func (s *DescribeCacheOutput) SetDiskIds(v []*string) *DescribeCacheOutput {
+	s.DiskIds = v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeCacheOutput) SetGatewayARN(v string) *DescribeCacheOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 type DescribeCachediSCSIVolumesInput struct {
@@ -6163,6 +6787,12 @@ func (s *DescribeCachediSCSIVolumesInput) Validate() error {
 	return nil
 }
 
+// SetVolumeARNs sets the VolumeARNs field's value.
+func (s *DescribeCachediSCSIVolumesInput) SetVolumeARNs(v []*string) *DescribeCachediSCSIVolumesInput {
+	s.VolumeARNs = v
+	return s
+}
+
 // A JSON object containing the following fields:
 type DescribeCachediSCSIVolumesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6180,6 +6810,12 @@ func (s DescribeCachediSCSIVolumesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCachediSCSIVolumesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCachediSCSIVolumes sets the CachediSCSIVolumes field's value.
+func (s *DescribeCachediSCSIVolumesOutput) SetCachediSCSIVolumes(v []*CachediSCSIVolume) *DescribeCachediSCSIVolumesOutput {
+	s.CachediSCSIVolumes = v
+	return s
 }
 
 // A JSON object containing the Amazon Resource Name (ARN) of the iSCSI volume
@@ -6220,6 +6856,12 @@ func (s *DescribeChapCredentialsInput) Validate() error {
 	return nil
 }
 
+// SetTargetARN sets the TargetARN field's value.
+func (s *DescribeChapCredentialsInput) SetTargetARN(v string) *DescribeChapCredentialsInput {
+	s.TargetARN = &v
+	return s
+}
+
 // A JSON object containing a .
 type DescribeChapCredentialsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6250,6 +6892,12 @@ func (s DescribeChapCredentialsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeChapCredentialsOutput) GoString() string {
 	return s.String()
+}
+
+// SetChapCredentials sets the ChapCredentials field's value.
+func (s *DescribeChapCredentialsOutput) SetChapCredentials(v []*ChapInfo) *DescribeChapCredentialsOutput {
+	s.ChapCredentials = v
+	return s
 }
 
 // A JSON object containing the id of the gateway.
@@ -6287,6 +6935,12 @@ func (s *DescribeGatewayInformationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeGatewayInformationInput) SetGatewayARN(v string) *DescribeGatewayInformationInput {
+	s.GatewayARN = &v
+	return s
 }
 
 // A JSON object containing the following fields:
@@ -6339,6 +6993,60 @@ func (s DescribeGatewayInformationOutput) GoString() string {
 	return s.String()
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeGatewayInformationOutput) SetGatewayARN(v string) *DescribeGatewayInformationOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *DescribeGatewayInformationOutput) SetGatewayId(v string) *DescribeGatewayInformationOutput {
+	s.GatewayId = &v
+	return s
+}
+
+// SetGatewayName sets the GatewayName field's value.
+func (s *DescribeGatewayInformationOutput) SetGatewayName(v string) *DescribeGatewayInformationOutput {
+	s.GatewayName = &v
+	return s
+}
+
+// SetGatewayNetworkInterfaces sets the GatewayNetworkInterfaces field's value.
+func (s *DescribeGatewayInformationOutput) SetGatewayNetworkInterfaces(v []*NetworkInterface) *DescribeGatewayInformationOutput {
+	s.GatewayNetworkInterfaces = v
+	return s
+}
+
+// SetGatewayState sets the GatewayState field's value.
+func (s *DescribeGatewayInformationOutput) SetGatewayState(v string) *DescribeGatewayInformationOutput {
+	s.GatewayState = &v
+	return s
+}
+
+// SetGatewayTimezone sets the GatewayTimezone field's value.
+func (s *DescribeGatewayInformationOutput) SetGatewayTimezone(v string) *DescribeGatewayInformationOutput {
+	s.GatewayTimezone = &v
+	return s
+}
+
+// SetGatewayType sets the GatewayType field's value.
+func (s *DescribeGatewayInformationOutput) SetGatewayType(v string) *DescribeGatewayInformationOutput {
+	s.GatewayType = &v
+	return s
+}
+
+// SetLastSoftwareUpdate sets the LastSoftwareUpdate field's value.
+func (s *DescribeGatewayInformationOutput) SetLastSoftwareUpdate(v string) *DescribeGatewayInformationOutput {
+	s.LastSoftwareUpdate = &v
+	return s
+}
+
+// SetNextUpdateAvailabilityDate sets the NextUpdateAvailabilityDate field's value.
+func (s *DescribeGatewayInformationOutput) SetNextUpdateAvailabilityDate(v string) *DescribeGatewayInformationOutput {
+	s.NextUpdateAvailabilityDate = &v
+	return s
+}
+
 // A JSON object containing the of the gateway.
 type DescribeMaintenanceStartTimeInput struct {
 	_ struct{} `type:"structure"`
@@ -6376,6 +7084,12 @@ func (s *DescribeMaintenanceStartTimeInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeMaintenanceStartTimeInput) SetGatewayARN(v string) *DescribeMaintenanceStartTimeInput {
+	s.GatewayARN = &v
+	return s
+}
+
 type DescribeMaintenanceStartTimeOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6400,6 +7114,36 @@ func (s DescribeMaintenanceStartTimeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeMaintenanceStartTimeOutput) GoString() string {
 	return s.String()
+}
+
+// SetDayOfWeek sets the DayOfWeek field's value.
+func (s *DescribeMaintenanceStartTimeOutput) SetDayOfWeek(v int64) *DescribeMaintenanceStartTimeOutput {
+	s.DayOfWeek = &v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeMaintenanceStartTimeOutput) SetGatewayARN(v string) *DescribeMaintenanceStartTimeOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetHourOfDay sets the HourOfDay field's value.
+func (s *DescribeMaintenanceStartTimeOutput) SetHourOfDay(v int64) *DescribeMaintenanceStartTimeOutput {
+	s.HourOfDay = &v
+	return s
+}
+
+// SetMinuteOfHour sets the MinuteOfHour field's value.
+func (s *DescribeMaintenanceStartTimeOutput) SetMinuteOfHour(v int64) *DescribeMaintenanceStartTimeOutput {
+	s.MinuteOfHour = &v
+	return s
+}
+
+// SetTimezone sets the Timezone field's value.
+func (s *DescribeMaintenanceStartTimeOutput) SetTimezone(v string) *DescribeMaintenanceStartTimeOutput {
+	s.Timezone = &v
+	return s
 }
 
 // A JSON object containing the DescribeSnapshotScheduleInput$VolumeARN of the
@@ -6440,6 +7184,12 @@ func (s *DescribeSnapshotScheduleInput) Validate() error {
 	return nil
 }
 
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *DescribeSnapshotScheduleInput) SetVolumeARN(v string) *DescribeSnapshotScheduleInput {
+	s.VolumeARN = &v
+	return s
+}
+
 type DescribeSnapshotScheduleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6462,6 +7212,36 @@ func (s DescribeSnapshotScheduleOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSnapshotScheduleOutput) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *DescribeSnapshotScheduleOutput) SetDescription(v string) *DescribeSnapshotScheduleOutput {
+	s.Description = &v
+	return s
+}
+
+// SetRecurrenceInHours sets the RecurrenceInHours field's value.
+func (s *DescribeSnapshotScheduleOutput) SetRecurrenceInHours(v int64) *DescribeSnapshotScheduleOutput {
+	s.RecurrenceInHours = &v
+	return s
+}
+
+// SetStartAt sets the StartAt field's value.
+func (s *DescribeSnapshotScheduleOutput) SetStartAt(v int64) *DescribeSnapshotScheduleOutput {
+	s.StartAt = &v
+	return s
+}
+
+// SetTimezone sets the Timezone field's value.
+func (s *DescribeSnapshotScheduleOutput) SetTimezone(v string) *DescribeSnapshotScheduleOutput {
+	s.Timezone = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *DescribeSnapshotScheduleOutput) SetVolumeARN(v string) *DescribeSnapshotScheduleOutput {
+	s.VolumeARN = &v
+	return s
 }
 
 // A JSON object containing a list of DescribeStorediSCSIVolumesInput$VolumeARNs.
@@ -6499,6 +7279,12 @@ func (s *DescribeStorediSCSIVolumesInput) Validate() error {
 	return nil
 }
 
+// SetVolumeARNs sets the VolumeARNs field's value.
+func (s *DescribeStorediSCSIVolumesInput) SetVolumeARNs(v []*string) *DescribeStorediSCSIVolumesInput {
+	s.VolumeARNs = v
+	return s
+}
+
 type DescribeStorediSCSIVolumesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6513,6 +7299,12 @@ func (s DescribeStorediSCSIVolumesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeStorediSCSIVolumesOutput) GoString() string {
 	return s.String()
+}
+
+// SetStorediSCSIVolumes sets the StorediSCSIVolumes field's value.
+func (s *DescribeStorediSCSIVolumesOutput) SetStorediSCSIVolumes(v []*StorediSCSIVolume) *DescribeStorediSCSIVolumesOutput {
+	s.StorediSCSIVolumes = v
+	return s
 }
 
 // DescribeTapeArchivesInput
@@ -6558,6 +7350,24 @@ func (s *DescribeTapeArchivesInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *DescribeTapeArchivesInput) SetLimit(v int64) *DescribeTapeArchivesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTapeArchivesInput) SetMarker(v string) *DescribeTapeArchivesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetTapeARNs sets the TapeARNs field's value.
+func (s *DescribeTapeArchivesInput) SetTapeARNs(v []*string) *DescribeTapeArchivesInput {
+	s.TapeARNs = v
+	return s
+}
+
 // DescribeTapeArchivesOutput
 type DescribeTapeArchivesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6584,6 +7394,18 @@ func (s DescribeTapeArchivesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTapeArchivesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTapeArchivesOutput) SetMarker(v string) *DescribeTapeArchivesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetTapeArchives sets the TapeArchives field's value.
+func (s *DescribeTapeArchivesOutput) SetTapeArchives(v []*TapeArchive) *DescribeTapeArchivesOutput {
+	s.TapeArchives = v
+	return s
 }
 
 // DescribeTapeRecoveryPointsInput
@@ -6637,6 +7459,24 @@ func (s *DescribeTapeRecoveryPointsInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeTapeRecoveryPointsInput) SetGatewayARN(v string) *DescribeTapeRecoveryPointsInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeTapeRecoveryPointsInput) SetLimit(v int64) *DescribeTapeRecoveryPointsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTapeRecoveryPointsInput) SetMarker(v string) *DescribeTapeRecoveryPointsInput {
+	s.Marker = &v
+	return s
+}
+
 // DescribeTapeRecoveryPointsOutput
 type DescribeTapeRecoveryPointsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6665,6 +7505,24 @@ func (s DescribeTapeRecoveryPointsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTapeRecoveryPointsOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeTapeRecoveryPointsOutput) SetGatewayARN(v string) *DescribeTapeRecoveryPointsOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTapeRecoveryPointsOutput) SetMarker(v string) *DescribeTapeRecoveryPointsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetTapeRecoveryPointInfos sets the TapeRecoveryPointInfos field's value.
+func (s *DescribeTapeRecoveryPointsOutput) SetTapeRecoveryPointInfos(v []*TapeRecoveryPointInfo) *DescribeTapeRecoveryPointsOutput {
+	s.TapeRecoveryPointInfos = v
+	return s
 }
 
 // DescribeTapesInput
@@ -6728,6 +7586,30 @@ func (s *DescribeTapesInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeTapesInput) SetGatewayARN(v string) *DescribeTapesInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeTapesInput) SetLimit(v int64) *DescribeTapesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTapesInput) SetMarker(v string) *DescribeTapesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetTapeARNs sets the TapeARNs field's value.
+func (s *DescribeTapesInput) SetTapeARNs(v []*string) *DescribeTapesInput {
+	s.TapeARNs = v
+	return s
+}
+
 // DescribeTapesOutput
 type DescribeTapesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6751,6 +7633,18 @@ func (s DescribeTapesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTapesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeTapesOutput) SetMarker(v string) *DescribeTapesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetTapes sets the Tapes field's value.
+func (s *DescribeTapesOutput) SetTapes(v []*Tape) *DescribeTapesOutput {
+	s.Tapes = v
+	return s
 }
 
 type DescribeUploadBufferInput struct {
@@ -6789,6 +7683,12 @@ func (s *DescribeUploadBufferInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeUploadBufferInput) SetGatewayARN(v string) *DescribeUploadBufferInput {
+	s.GatewayARN = &v
+	return s
+}
+
 type DescribeUploadBufferOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6811,6 +7711,30 @@ func (s DescribeUploadBufferOutput) String() string {
 // GoString returns the string representation
 func (s DescribeUploadBufferOutput) GoString() string {
 	return s.String()
+}
+
+// SetDiskIds sets the DiskIds field's value.
+func (s *DescribeUploadBufferOutput) SetDiskIds(v []*string) *DescribeUploadBufferOutput {
+	s.DiskIds = v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeUploadBufferOutput) SetGatewayARN(v string) *DescribeUploadBufferOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetUploadBufferAllocatedInBytes sets the UploadBufferAllocatedInBytes field's value.
+func (s *DescribeUploadBufferOutput) SetUploadBufferAllocatedInBytes(v int64) *DescribeUploadBufferOutput {
+	s.UploadBufferAllocatedInBytes = &v
+	return s
+}
+
+// SetUploadBufferUsedInBytes sets the UploadBufferUsedInBytes field's value.
+func (s *DescribeUploadBufferOutput) SetUploadBufferUsedInBytes(v int64) *DescribeUploadBufferOutput {
+	s.UploadBufferUsedInBytes = &v
+	return s
 }
 
 // DescribeVTLDevicesInput
@@ -6872,6 +7796,30 @@ func (s *DescribeVTLDevicesInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeVTLDevicesInput) SetGatewayARN(v string) *DescribeVTLDevicesInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeVTLDevicesInput) SetLimit(v int64) *DescribeVTLDevicesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeVTLDevicesInput) SetMarker(v string) *DescribeVTLDevicesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetVTLDeviceARNs sets the VTLDeviceARNs field's value.
+func (s *DescribeVTLDevicesInput) SetVTLDeviceARNs(v []*string) *DescribeVTLDevicesInput {
+	s.VTLDeviceARNs = v
+	return s
+}
+
 // DescribeVTLDevicesOutput
 type DescribeVTLDevicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6899,6 +7847,24 @@ func (s DescribeVTLDevicesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeVTLDevicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeVTLDevicesOutput) SetGatewayARN(v string) *DescribeVTLDevicesOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeVTLDevicesOutput) SetMarker(v string) *DescribeVTLDevicesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetVTLDevices sets the VTLDevices field's value.
+func (s *DescribeVTLDevicesOutput) SetVTLDevices(v []*VTLDevice) *DescribeVTLDevicesOutput {
+	s.VTLDevices = v
+	return s
 }
 
 // A JSON object containing the of the gateway.
@@ -6938,6 +7904,12 @@ func (s *DescribeWorkingStorageInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeWorkingStorageInput) SetGatewayARN(v string) *DescribeWorkingStorageInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the following fields:
 type DescribeWorkingStorageOutput struct {
 	_ struct{} `type:"structure"`
@@ -6971,6 +7943,30 @@ func (s DescribeWorkingStorageOutput) GoString() string {
 	return s.String()
 }
 
+// SetDiskIds sets the DiskIds field's value.
+func (s *DescribeWorkingStorageOutput) SetDiskIds(v []*string) *DescribeWorkingStorageOutput {
+	s.DiskIds = v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DescribeWorkingStorageOutput) SetGatewayARN(v string) *DescribeWorkingStorageOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetWorkingStorageAllocatedInBytes sets the WorkingStorageAllocatedInBytes field's value.
+func (s *DescribeWorkingStorageOutput) SetWorkingStorageAllocatedInBytes(v int64) *DescribeWorkingStorageOutput {
+	s.WorkingStorageAllocatedInBytes = &v
+	return s
+}
+
+// SetWorkingStorageUsedInBytes sets the WorkingStorageUsedInBytes field's value.
+func (s *DescribeWorkingStorageOutput) SetWorkingStorageUsedInBytes(v int64) *DescribeWorkingStorageOutput {
+	s.WorkingStorageUsedInBytes = &v
+	return s
+}
+
 // Lists iSCSI information about a VTL device.
 type DeviceiSCSIAttributes struct {
 	_ struct{} `type:"structure"`
@@ -6997,6 +7993,30 @@ func (s DeviceiSCSIAttributes) String() string {
 // GoString returns the string representation
 func (s DeviceiSCSIAttributes) GoString() string {
 	return s.String()
+}
+
+// SetChapEnabled sets the ChapEnabled field's value.
+func (s *DeviceiSCSIAttributes) SetChapEnabled(v bool) *DeviceiSCSIAttributes {
+	s.ChapEnabled = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *DeviceiSCSIAttributes) SetNetworkInterfaceId(v string) *DeviceiSCSIAttributes {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetNetworkInterfacePort sets the NetworkInterfacePort field's value.
+func (s *DeviceiSCSIAttributes) SetNetworkInterfacePort(v int64) *DeviceiSCSIAttributes {
+	s.NetworkInterfacePort = &v
+	return s
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *DeviceiSCSIAttributes) SetTargetARN(v string) *DeviceiSCSIAttributes {
+	s.TargetARN = &v
+	return s
 }
 
 // DisableGatewayInput
@@ -7036,6 +8056,12 @@ func (s *DisableGatewayInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DisableGatewayInput) SetGatewayARN(v string) *DisableGatewayInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // DisableGatewayOutput
 type DisableGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -7052,6 +8078,12 @@ func (s DisableGatewayOutput) String() string {
 // GoString returns the string representation
 func (s DisableGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *DisableGatewayOutput) SetGatewayARN(v string) *DisableGatewayOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 type Disk struct {
@@ -7082,6 +8114,48 @@ func (s Disk) GoString() string {
 	return s.String()
 }
 
+// SetDiskAllocationResource sets the DiskAllocationResource field's value.
+func (s *Disk) SetDiskAllocationResource(v string) *Disk {
+	s.DiskAllocationResource = &v
+	return s
+}
+
+// SetDiskAllocationType sets the DiskAllocationType field's value.
+func (s *Disk) SetDiskAllocationType(v string) *Disk {
+	s.DiskAllocationType = &v
+	return s
+}
+
+// SetDiskId sets the DiskId field's value.
+func (s *Disk) SetDiskId(v string) *Disk {
+	s.DiskId = &v
+	return s
+}
+
+// SetDiskNode sets the DiskNode field's value.
+func (s *Disk) SetDiskNode(v string) *Disk {
+	s.DiskNode = &v
+	return s
+}
+
+// SetDiskPath sets the DiskPath field's value.
+func (s *Disk) SetDiskPath(v string) *Disk {
+	s.DiskPath = &v
+	return s
+}
+
+// SetDiskSizeInBytes sets the DiskSizeInBytes field's value.
+func (s *Disk) SetDiskSizeInBytes(v int64) *Disk {
+	s.DiskSizeInBytes = &v
+	return s
+}
+
+// SetDiskStatus sets the DiskStatus field's value.
+func (s *Disk) SetDiskStatus(v string) *Disk {
+	s.DiskStatus = &v
+	return s
+}
+
 // Provides additional information about an error that was returned by the service
 // as an or. See the errorCode and errorDetails members for more information
 // about the error.
@@ -7103,6 +8177,18 @@ func (s Error) String() string {
 // GoString returns the string representation
 func (s Error) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *Error) SetErrorCode(v string) *Error {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorDetails sets the ErrorDetails field's value.
+func (s *Error) SetErrorDetails(v map[string]*string) *Error {
+	s.ErrorDetails = v
+	return s
 }
 
 // Describes a gateway object.
@@ -7138,6 +8224,36 @@ func (s GatewayInfo) String() string {
 // GoString returns the string representation
 func (s GatewayInfo) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *GatewayInfo) SetGatewayARN(v string) *GatewayInfo {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *GatewayInfo) SetGatewayId(v string) *GatewayInfo {
+	s.GatewayId = &v
+	return s
+}
+
+// SetGatewayName sets the GatewayName field's value.
+func (s *GatewayInfo) SetGatewayName(v string) *GatewayInfo {
+	s.GatewayName = &v
+	return s
+}
+
+// SetGatewayOperationalState sets the GatewayOperationalState field's value.
+func (s *GatewayInfo) SetGatewayOperationalState(v string) *GatewayInfo {
+	s.GatewayOperationalState = &v
+	return s
+}
+
+// SetGatewayType sets the GatewayType field's value.
+func (s *GatewayInfo) SetGatewayType(v string) *GatewayInfo {
+	s.GatewayType = &v
+	return s
 }
 
 // A JSON object containing zero or more of the following fields:
@@ -7183,6 +8299,18 @@ func (s *ListGatewaysInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListGatewaysInput) SetLimit(v int64) *ListGatewaysInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListGatewaysInput) SetMarker(v string) *ListGatewaysInput {
+	s.Marker = &v
+	return s
+}
+
 type ListGatewaysOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7199,6 +8327,18 @@ func (s ListGatewaysOutput) String() string {
 // GoString returns the string representation
 func (s ListGatewaysOutput) GoString() string {
 	return s.String()
+}
+
+// SetGateways sets the Gateways field's value.
+func (s *ListGatewaysOutput) SetGateways(v []*GatewayInfo) *ListGatewaysOutput {
+	s.Gateways = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListGatewaysOutput) SetMarker(v string) *ListGatewaysOutput {
+	s.Marker = &v
+	return s
 }
 
 // A JSON object containing the of the gateway.
@@ -7238,6 +8378,12 @@ func (s *ListLocalDisksInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ListLocalDisksInput) SetGatewayARN(v string) *ListLocalDisksInput {
+	s.GatewayARN = &v
+	return s
+}
+
 type ListLocalDisksOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7256,6 +8402,18 @@ func (s ListLocalDisksOutput) String() string {
 // GoString returns the string representation
 func (s ListLocalDisksOutput) GoString() string {
 	return s.String()
+}
+
+// SetDisks sets the Disks field's value.
+func (s *ListLocalDisksOutput) SetDisks(v []*Disk) *ListLocalDisksOutput {
+	s.Disks = v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ListLocalDisksOutput) SetGatewayARN(v string) *ListLocalDisksOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // ListTagsForResourceInput
@@ -7309,6 +8467,24 @@ func (s *ListTagsForResourceInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListTagsForResourceInput) SetLimit(v int64) *ListTagsForResourceInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListTagsForResourceInput) SetMarker(v string) *ListTagsForResourceInput {
+	s.Marker = &v
+	return s
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *ListTagsForResourceInput) SetResourceARN(v string) *ListTagsForResourceInput {
+	s.ResourceARN = &v
+	return s
+}
+
 // ListTagsForResourceOutput
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -7333,6 +8509,24 @@ func (s ListTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ListTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListTagsForResourceOutput) SetMarker(v string) *ListTagsForResourceOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *ListTagsForResourceOutput) SetResourceARN(v string) *ListTagsForResourceOutput {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput {
+	s.Tags = v
+	return s
 }
 
 // A JSON object that contains one or more of the following fields:
@@ -7384,6 +8578,24 @@ func (s *ListTapesInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListTapesInput) SetLimit(v int64) *ListTapesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListTapesInput) SetMarker(v string) *ListTapesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetTapeARNs sets the TapeARNs field's value.
+func (s *ListTapesInput) SetTapeARNs(v []*string) *ListTapesInput {
+	s.TapeARNs = v
+	return s
+}
+
 // A JSON object containing the following fields:
 //
 //    * ListTapesOutput$Marker
@@ -7412,6 +8624,18 @@ func (s ListTapesOutput) String() string {
 // GoString returns the string representation
 func (s ListTapesOutput) GoString() string {
 	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListTapesOutput) SetMarker(v string) *ListTapesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetTapeInfos sets the TapeInfos field's value.
+func (s *ListTapesOutput) SetTapeInfos(v []*TapeInfo) *ListTapesOutput {
+	s.TapeInfos = v
+	return s
 }
 
 // ListVolumeInitiatorsInput
@@ -7451,6 +8675,12 @@ func (s *ListVolumeInitiatorsInput) Validate() error {
 	return nil
 }
 
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *ListVolumeInitiatorsInput) SetVolumeARN(v string) *ListVolumeInitiatorsInput {
+	s.VolumeARN = &v
+	return s
+}
+
 // ListVolumeInitiatorsOutput
 type ListVolumeInitiatorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7468,6 +8698,12 @@ func (s ListVolumeInitiatorsOutput) String() string {
 // GoString returns the string representation
 func (s ListVolumeInitiatorsOutput) GoString() string {
 	return s.String()
+}
+
+// SetInitiators sets the Initiators field's value.
+func (s *ListVolumeInitiatorsOutput) SetInitiators(v []*string) *ListVolumeInitiatorsOutput {
+	s.Initiators = v
+	return s
 }
 
 type ListVolumeRecoveryPointsInput struct {
@@ -7506,6 +8742,12 @@ func (s *ListVolumeRecoveryPointsInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ListVolumeRecoveryPointsInput) SetGatewayARN(v string) *ListVolumeRecoveryPointsInput {
+	s.GatewayARN = &v
+	return s
+}
+
 type ListVolumeRecoveryPointsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7524,6 +8766,18 @@ func (s ListVolumeRecoveryPointsOutput) String() string {
 // GoString returns the string representation
 func (s ListVolumeRecoveryPointsOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ListVolumeRecoveryPointsOutput) SetGatewayARN(v string) *ListVolumeRecoveryPointsOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetVolumeRecoveryPointInfos sets the VolumeRecoveryPointInfos field's value.
+func (s *ListVolumeRecoveryPointsOutput) SetVolumeRecoveryPointInfos(v []*VolumeRecoveryPointInfo) *ListVolumeRecoveryPointsOutput {
+	s.VolumeRecoveryPointInfos = v
+	return s
 }
 
 // A JSON object that contains one or more of the following fields:
@@ -7577,6 +8831,24 @@ func (s *ListVolumesInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ListVolumesInput) SetGatewayARN(v string) *ListVolumesInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListVolumesInput) SetLimit(v int64) *ListVolumesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListVolumesInput) SetMarker(v string) *ListVolumesInput {
+	s.Marker = &v
+	return s
+}
+
 type ListVolumesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7597,6 +8869,24 @@ func (s ListVolumesOutput) String() string {
 // GoString returns the string representation
 func (s ListVolumesOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ListVolumesOutput) SetGatewayARN(v string) *ListVolumesOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListVolumesOutput) SetMarker(v string) *ListVolumesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetVolumeInfos sets the VolumeInfos field's value.
+func (s *ListVolumesOutput) SetVolumeInfos(v []*VolumeInfo) *ListVolumesOutput {
+	s.VolumeInfos = v
+	return s
 }
 
 // Describes a gateway's network interface.
@@ -7624,6 +8914,24 @@ func (s NetworkInterface) String() string {
 // GoString returns the string representation
 func (s NetworkInterface) GoString() string {
 	return s.String()
+}
+
+// SetIpv4Address sets the Ipv4Address field's value.
+func (s *NetworkInterface) SetIpv4Address(v string) *NetworkInterface {
+	s.Ipv4Address = &v
+	return s
+}
+
+// SetIpv6Address sets the Ipv6Address field's value.
+func (s *NetworkInterface) SetIpv6Address(v string) *NetworkInterface {
+	s.Ipv6Address = &v
+	return s
+}
+
+// SetMacAddress sets the MacAddress field's value.
+func (s *NetworkInterface) SetMacAddress(v string) *NetworkInterface {
+	s.MacAddress = &v
+	return s
 }
 
 // RemoveTagsFromResourceInput
@@ -7672,6 +8980,18 @@ func (s *RemoveTagsFromResourceInput) Validate() error {
 	return nil
 }
 
+// SetResourceARN sets the ResourceARN field's value.
+func (s *RemoveTagsFromResourceInput) SetResourceARN(v string) *RemoveTagsFromResourceInput {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *RemoveTagsFromResourceInput) SetTagKeys(v []*string) *RemoveTagsFromResourceInput {
+	s.TagKeys = v
+	return s
+}
+
 // RemoveTagsFromResourceOutput
 type RemoveTagsFromResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -7689,6 +9009,12 @@ func (s RemoveTagsFromResourceOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromResourceOutput) GoString() string {
 	return s.String()
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *RemoveTagsFromResourceOutput) SetResourceARN(v string) *RemoveTagsFromResourceOutput {
+	s.ResourceARN = &v
+	return s
 }
 
 type ResetCacheInput struct {
@@ -7727,6 +9053,12 @@ func (s *ResetCacheInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ResetCacheInput) SetGatewayARN(v string) *ResetCacheInput {
+	s.GatewayARN = &v
+	return s
+}
+
 type ResetCacheOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7743,6 +9075,12 @@ func (s ResetCacheOutput) String() string {
 // GoString returns the string representation
 func (s ResetCacheOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ResetCacheOutput) SetGatewayARN(v string) *ResetCacheOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // RetrieveTapeArchiveInput
@@ -7798,6 +9136,18 @@ func (s *RetrieveTapeArchiveInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *RetrieveTapeArchiveInput) SetGatewayARN(v string) *RetrieveTapeArchiveInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *RetrieveTapeArchiveInput) SetTapeARN(v string) *RetrieveTapeArchiveInput {
+	s.TapeARN = &v
+	return s
+}
+
 // RetrieveTapeArchiveOutput
 type RetrieveTapeArchiveOutput struct {
 	_ struct{} `type:"structure"`
@@ -7814,6 +9164,12 @@ func (s RetrieveTapeArchiveOutput) String() string {
 // GoString returns the string representation
 func (s RetrieveTapeArchiveOutput) GoString() string {
 	return s.String()
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *RetrieveTapeArchiveOutput) SetTapeARN(v string) *RetrieveTapeArchiveOutput {
+	s.TapeARN = &v
+	return s
 }
 
 // RetrieveTapeRecoveryPointInput
@@ -7865,6 +9221,18 @@ func (s *RetrieveTapeRecoveryPointInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *RetrieveTapeRecoveryPointInput) SetGatewayARN(v string) *RetrieveTapeRecoveryPointInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *RetrieveTapeRecoveryPointInput) SetTapeARN(v string) *RetrieveTapeRecoveryPointInput {
+	s.TapeARN = &v
+	return s
+}
+
 // RetrieveTapeRecoveryPointOutput
 type RetrieveTapeRecoveryPointOutput struct {
 	_ struct{} `type:"structure"`
@@ -7882,6 +9250,12 @@ func (s RetrieveTapeRecoveryPointOutput) String() string {
 // GoString returns the string representation
 func (s RetrieveTapeRecoveryPointOutput) GoString() string {
 	return s.String()
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *RetrieveTapeRecoveryPointOutput) SetTapeARN(v string) *RetrieveTapeRecoveryPointOutput {
+	s.TapeARN = &v
+	return s
 }
 
 // SetLocalConsolePasswordInput
@@ -7932,6 +9306,18 @@ func (s *SetLocalConsolePasswordInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *SetLocalConsolePasswordInput) SetGatewayARN(v string) *SetLocalConsolePasswordInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetLocalConsolePassword sets the LocalConsolePassword field's value.
+func (s *SetLocalConsolePasswordInput) SetLocalConsolePassword(v string) *SetLocalConsolePasswordInput {
+	s.LocalConsolePassword = &v
+	return s
+}
+
 type SetLocalConsolePasswordOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7948,6 +9334,12 @@ func (s SetLocalConsolePasswordOutput) String() string {
 // GoString returns the string representation
 func (s SetLocalConsolePasswordOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *SetLocalConsolePasswordOutput) SetGatewayARN(v string) *SetLocalConsolePasswordOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // A JSON object containing the of the gateway to shut down.
@@ -7987,6 +9379,12 @@ func (s *ShutdownGatewayInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ShutdownGatewayInput) SetGatewayARN(v string) *ShutdownGatewayInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the of the gateway that was shut down.
 type ShutdownGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -8004,6 +9402,12 @@ func (s ShutdownGatewayOutput) String() string {
 // GoString returns the string representation
 func (s ShutdownGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *ShutdownGatewayOutput) SetGatewayARN(v string) *ShutdownGatewayOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // A JSON object containing the of the gateway to start.
@@ -8043,6 +9447,12 @@ func (s *StartGatewayInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *StartGatewayInput) SetGatewayARN(v string) *StartGatewayInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the of the gateway that was restarted.
 type StartGatewayOutput struct {
 	_ struct{} `type:"structure"`
@@ -8060,6 +9470,12 @@ func (s StartGatewayOutput) String() string {
 // GoString returns the string representation
 func (s StartGatewayOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *StartGatewayOutput) SetGatewayARN(v string) *StartGatewayOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 type StorediSCSIVolume struct {
@@ -8095,6 +9511,66 @@ func (s StorediSCSIVolume) String() string {
 // GoString returns the string representation
 func (s StorediSCSIVolume) GoString() string {
 	return s.String()
+}
+
+// SetPreservedExistingData sets the PreservedExistingData field's value.
+func (s *StorediSCSIVolume) SetPreservedExistingData(v bool) *StorediSCSIVolume {
+	s.PreservedExistingData = &v
+	return s
+}
+
+// SetSourceSnapshotId sets the SourceSnapshotId field's value.
+func (s *StorediSCSIVolume) SetSourceSnapshotId(v string) *StorediSCSIVolume {
+	s.SourceSnapshotId = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *StorediSCSIVolume) SetVolumeARN(v string) *StorediSCSIVolume {
+	s.VolumeARN = &v
+	return s
+}
+
+// SetVolumeDiskId sets the VolumeDiskId field's value.
+func (s *StorediSCSIVolume) SetVolumeDiskId(v string) *StorediSCSIVolume {
+	s.VolumeDiskId = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *StorediSCSIVolume) SetVolumeId(v string) *StorediSCSIVolume {
+	s.VolumeId = &v
+	return s
+}
+
+// SetVolumeProgress sets the VolumeProgress field's value.
+func (s *StorediSCSIVolume) SetVolumeProgress(v float64) *StorediSCSIVolume {
+	s.VolumeProgress = &v
+	return s
+}
+
+// SetVolumeSizeInBytes sets the VolumeSizeInBytes field's value.
+func (s *StorediSCSIVolume) SetVolumeSizeInBytes(v int64) *StorediSCSIVolume {
+	s.VolumeSizeInBytes = &v
+	return s
+}
+
+// SetVolumeStatus sets the VolumeStatus field's value.
+func (s *StorediSCSIVolume) SetVolumeStatus(v string) *StorediSCSIVolume {
+	s.VolumeStatus = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *StorediSCSIVolume) SetVolumeType(v string) *StorediSCSIVolume {
+	s.VolumeType = &v
+	return s
+}
+
+// SetVolumeiSCSIAttributes sets the VolumeiSCSIAttributes field's value.
+func (s *StorediSCSIVolume) SetVolumeiSCSIAttributes(v *VolumeiSCSIAttributes) *StorediSCSIVolume {
+	s.VolumeiSCSIAttributes = v
+	return s
 }
 
 type Tag struct {
@@ -8136,6 +9612,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // Describes a virtual tape object.
 type Tape struct {
 	_ struct{} `type:"structure"`
@@ -8171,6 +9659,42 @@ func (s Tape) String() string {
 // GoString returns the string representation
 func (s Tape) GoString() string {
 	return s.String()
+}
+
+// SetProgress sets the Progress field's value.
+func (s *Tape) SetProgress(v float64) *Tape {
+	s.Progress = &v
+	return s
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *Tape) SetTapeARN(v string) *Tape {
+	s.TapeARN = &v
+	return s
+}
+
+// SetTapeBarcode sets the TapeBarcode field's value.
+func (s *Tape) SetTapeBarcode(v string) *Tape {
+	s.TapeBarcode = &v
+	return s
+}
+
+// SetTapeSizeInBytes sets the TapeSizeInBytes field's value.
+func (s *Tape) SetTapeSizeInBytes(v int64) *Tape {
+	s.TapeSizeInBytes = &v
+	return s
+}
+
+// SetTapeStatus sets the TapeStatus field's value.
+func (s *Tape) SetTapeStatus(v string) *Tape {
+	s.TapeStatus = &v
+	return s
+}
+
+// SetVTLDevice sets the VTLDevice field's value.
+func (s *Tape) SetVTLDevice(v string) *Tape {
+	s.VTLDevice = &v
+	return s
 }
 
 // Represents a virtual tape that is archived in the virtual tape shelf (VTS).
@@ -8212,6 +9736,42 @@ func (s TapeArchive) GoString() string {
 	return s.String()
 }
 
+// SetCompletionTime sets the CompletionTime field's value.
+func (s *TapeArchive) SetCompletionTime(v time.Time) *TapeArchive {
+	s.CompletionTime = &v
+	return s
+}
+
+// SetRetrievedTo sets the RetrievedTo field's value.
+func (s *TapeArchive) SetRetrievedTo(v string) *TapeArchive {
+	s.RetrievedTo = &v
+	return s
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *TapeArchive) SetTapeARN(v string) *TapeArchive {
+	s.TapeARN = &v
+	return s
+}
+
+// SetTapeBarcode sets the TapeBarcode field's value.
+func (s *TapeArchive) SetTapeBarcode(v string) *TapeArchive {
+	s.TapeBarcode = &v
+	return s
+}
+
+// SetTapeSizeInBytes sets the TapeSizeInBytes field's value.
+func (s *TapeArchive) SetTapeSizeInBytes(v int64) *TapeArchive {
+	s.TapeSizeInBytes = &v
+	return s
+}
+
+// SetTapeStatus sets the TapeStatus field's value.
+func (s *TapeArchive) SetTapeStatus(v string) *TapeArchive {
+	s.TapeStatus = &v
+	return s
+}
+
 // Describes a virtual tape.
 type TapeInfo struct {
 	_ struct{} `type:"structure"`
@@ -8243,6 +9803,36 @@ func (s TapeInfo) GoString() string {
 	return s.String()
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *TapeInfo) SetGatewayARN(v string) *TapeInfo {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *TapeInfo) SetTapeARN(v string) *TapeInfo {
+	s.TapeARN = &v
+	return s
+}
+
+// SetTapeBarcode sets the TapeBarcode field's value.
+func (s *TapeInfo) SetTapeBarcode(v string) *TapeInfo {
+	s.TapeBarcode = &v
+	return s
+}
+
+// SetTapeSizeInBytes sets the TapeSizeInBytes field's value.
+func (s *TapeInfo) SetTapeSizeInBytes(v int64) *TapeInfo {
+	s.TapeSizeInBytes = &v
+	return s
+}
+
+// SetTapeStatus sets the TapeStatus field's value.
+func (s *TapeInfo) SetTapeStatus(v string) *TapeInfo {
+	s.TapeStatus = &v
+	return s
+}
+
 // Describes a recovery point.
 type TapeRecoveryPointInfo struct {
 	_ struct{} `type:"structure"`
@@ -8271,6 +9861,30 @@ func (s TapeRecoveryPointInfo) String() string {
 // GoString returns the string representation
 func (s TapeRecoveryPointInfo) GoString() string {
 	return s.String()
+}
+
+// SetTapeARN sets the TapeARN field's value.
+func (s *TapeRecoveryPointInfo) SetTapeARN(v string) *TapeRecoveryPointInfo {
+	s.TapeARN = &v
+	return s
+}
+
+// SetTapeRecoveryPointTime sets the TapeRecoveryPointTime field's value.
+func (s *TapeRecoveryPointInfo) SetTapeRecoveryPointTime(v time.Time) *TapeRecoveryPointInfo {
+	s.TapeRecoveryPointTime = &v
+	return s
+}
+
+// SetTapeSizeInBytes sets the TapeSizeInBytes field's value.
+func (s *TapeRecoveryPointInfo) SetTapeSizeInBytes(v int64) *TapeRecoveryPointInfo {
+	s.TapeSizeInBytes = &v
+	return s
+}
+
+// SetTapeStatus sets the TapeStatus field's value.
+func (s *TapeRecoveryPointInfo) SetTapeStatus(v string) *TapeRecoveryPointInfo {
+	s.TapeStatus = &v
+	return s
 }
 
 // A JSON object containing one or more of the following fields:
@@ -8326,6 +9940,24 @@ func (s *UpdateBandwidthRateLimitInput) Validate() error {
 	return nil
 }
 
+// SetAverageDownloadRateLimitInBitsPerSec sets the AverageDownloadRateLimitInBitsPerSec field's value.
+func (s *UpdateBandwidthRateLimitInput) SetAverageDownloadRateLimitInBitsPerSec(v int64) *UpdateBandwidthRateLimitInput {
+	s.AverageDownloadRateLimitInBitsPerSec = &v
+	return s
+}
+
+// SetAverageUploadRateLimitInBitsPerSec sets the AverageUploadRateLimitInBitsPerSec field's value.
+func (s *UpdateBandwidthRateLimitInput) SetAverageUploadRateLimitInBitsPerSec(v int64) *UpdateBandwidthRateLimitInput {
+	s.AverageUploadRateLimitInBitsPerSec = &v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *UpdateBandwidthRateLimitInput) SetGatewayARN(v string) *UpdateBandwidthRateLimitInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the of the gateway whose throttle information was
 // updated.
 type UpdateBandwidthRateLimitOutput struct {
@@ -8344,6 +9976,12 @@ func (s UpdateBandwidthRateLimitOutput) String() string {
 // GoString returns the string representation
 func (s UpdateBandwidthRateLimitOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *UpdateBandwidthRateLimitOutput) SetGatewayARN(v string) *UpdateBandwidthRateLimitOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // A JSON object containing one or more of the following fields:
@@ -8427,6 +10065,30 @@ func (s *UpdateChapCredentialsInput) Validate() error {
 	return nil
 }
 
+// SetInitiatorName sets the InitiatorName field's value.
+func (s *UpdateChapCredentialsInput) SetInitiatorName(v string) *UpdateChapCredentialsInput {
+	s.InitiatorName = &v
+	return s
+}
+
+// SetSecretToAuthenticateInitiator sets the SecretToAuthenticateInitiator field's value.
+func (s *UpdateChapCredentialsInput) SetSecretToAuthenticateInitiator(v string) *UpdateChapCredentialsInput {
+	s.SecretToAuthenticateInitiator = &v
+	return s
+}
+
+// SetSecretToAuthenticateTarget sets the SecretToAuthenticateTarget field's value.
+func (s *UpdateChapCredentialsInput) SetSecretToAuthenticateTarget(v string) *UpdateChapCredentialsInput {
+	s.SecretToAuthenticateTarget = &v
+	return s
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *UpdateChapCredentialsInput) SetTargetARN(v string) *UpdateChapCredentialsInput {
+	s.TargetARN = &v
+	return s
+}
+
 // A JSON object containing the following fields:
 type UpdateChapCredentialsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8448,6 +10110,18 @@ func (s UpdateChapCredentialsOutput) String() string {
 // GoString returns the string representation
 func (s UpdateChapCredentialsOutput) GoString() string {
 	return s.String()
+}
+
+// SetInitiatorName sets the InitiatorName field's value.
+func (s *UpdateChapCredentialsOutput) SetInitiatorName(v string) *UpdateChapCredentialsOutput {
+	s.InitiatorName = &v
+	return s
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *UpdateChapCredentialsOutput) SetTargetARN(v string) *UpdateChapCredentialsOutput {
+	s.TargetARN = &v
+	return s
 }
 
 type UpdateGatewayInformationInput struct {
@@ -8497,6 +10171,24 @@ func (s *UpdateGatewayInformationInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *UpdateGatewayInformationInput) SetGatewayARN(v string) *UpdateGatewayInformationInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetGatewayName sets the GatewayName field's value.
+func (s *UpdateGatewayInformationInput) SetGatewayName(v string) *UpdateGatewayInformationInput {
+	s.GatewayName = &v
+	return s
+}
+
+// SetGatewayTimezone sets the GatewayTimezone field's value.
+func (s *UpdateGatewayInformationInput) SetGatewayTimezone(v string) *UpdateGatewayInformationInput {
+	s.GatewayTimezone = &v
+	return s
+}
+
 // A JSON object containing the ARN of the gateway that was updated.
 type UpdateGatewayInformationOutput struct {
 	_ struct{} `type:"structure"`
@@ -8516,6 +10208,18 @@ func (s UpdateGatewayInformationOutput) String() string {
 // GoString returns the string representation
 func (s UpdateGatewayInformationOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *UpdateGatewayInformationOutput) SetGatewayARN(v string) *UpdateGatewayInformationOutput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetGatewayName sets the GatewayName field's value.
+func (s *UpdateGatewayInformationOutput) SetGatewayName(v string) *UpdateGatewayInformationOutput {
+	s.GatewayName = &v
+	return s
 }
 
 // A JSON object containing the of the gateway to update.
@@ -8555,6 +10259,12 @@ func (s *UpdateGatewaySoftwareNowInput) Validate() error {
 	return nil
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *UpdateGatewaySoftwareNowInput) SetGatewayARN(v string) *UpdateGatewaySoftwareNowInput {
+	s.GatewayARN = &v
+	return s
+}
+
 // A JSON object containing the of the gateway that was updated.
 type UpdateGatewaySoftwareNowOutput struct {
 	_ struct{} `type:"structure"`
@@ -8572,6 +10282,12 @@ func (s UpdateGatewaySoftwareNowOutput) String() string {
 // GoString returns the string representation
 func (s UpdateGatewaySoftwareNowOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *UpdateGatewaySoftwareNowOutput) SetGatewayARN(v string) *UpdateGatewaySoftwareNowOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // A JSON object containing the following fields:
@@ -8645,6 +10361,30 @@ func (s *UpdateMaintenanceStartTimeInput) Validate() error {
 	return nil
 }
 
+// SetDayOfWeek sets the DayOfWeek field's value.
+func (s *UpdateMaintenanceStartTimeInput) SetDayOfWeek(v int64) *UpdateMaintenanceStartTimeInput {
+	s.DayOfWeek = &v
+	return s
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *UpdateMaintenanceStartTimeInput) SetGatewayARN(v string) *UpdateMaintenanceStartTimeInput {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetHourOfDay sets the HourOfDay field's value.
+func (s *UpdateMaintenanceStartTimeInput) SetHourOfDay(v int64) *UpdateMaintenanceStartTimeInput {
+	s.HourOfDay = &v
+	return s
+}
+
+// SetMinuteOfHour sets the MinuteOfHour field's value.
+func (s *UpdateMaintenanceStartTimeInput) SetMinuteOfHour(v int64) *UpdateMaintenanceStartTimeInput {
+	s.MinuteOfHour = &v
+	return s
+}
+
 // A JSON object containing the of the gateway whose maintenance start time
 // is updated.
 type UpdateMaintenanceStartTimeOutput struct {
@@ -8663,6 +10403,12 @@ func (s UpdateMaintenanceStartTimeOutput) String() string {
 // GoString returns the string representation
 func (s UpdateMaintenanceStartTimeOutput) GoString() string {
 	return s.String()
+}
+
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *UpdateMaintenanceStartTimeOutput) SetGatewayARN(v string) *UpdateMaintenanceStartTimeOutput {
+	s.GatewayARN = &v
+	return s
 }
 
 // A JSON object containing one or more of the following fields:
@@ -8737,6 +10483,30 @@ func (s *UpdateSnapshotScheduleInput) Validate() error {
 	return nil
 }
 
+// SetDescription sets the Description field's value.
+func (s *UpdateSnapshotScheduleInput) SetDescription(v string) *UpdateSnapshotScheduleInput {
+	s.Description = &v
+	return s
+}
+
+// SetRecurrenceInHours sets the RecurrenceInHours field's value.
+func (s *UpdateSnapshotScheduleInput) SetRecurrenceInHours(v int64) *UpdateSnapshotScheduleInput {
+	s.RecurrenceInHours = &v
+	return s
+}
+
+// SetStartAt sets the StartAt field's value.
+func (s *UpdateSnapshotScheduleInput) SetStartAt(v int64) *UpdateSnapshotScheduleInput {
+	s.StartAt = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *UpdateSnapshotScheduleInput) SetVolumeARN(v string) *UpdateSnapshotScheduleInput {
+	s.VolumeARN = &v
+	return s
+}
+
 // A JSON object containing the of the updated storage volume.
 type UpdateSnapshotScheduleOutput struct {
 	_ struct{} `type:"structure"`
@@ -8752,6 +10522,12 @@ func (s UpdateSnapshotScheduleOutput) String() string {
 // GoString returns the string representation
 func (s UpdateSnapshotScheduleOutput) GoString() string {
 	return s.String()
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *UpdateSnapshotScheduleOutput) SetVolumeARN(v string) *UpdateSnapshotScheduleOutput {
+	s.VolumeARN = &v
+	return s
 }
 
 type UpdateVTLDeviceTypeInput struct {
@@ -8802,6 +10578,18 @@ func (s *UpdateVTLDeviceTypeInput) Validate() error {
 	return nil
 }
 
+// SetDeviceType sets the DeviceType field's value.
+func (s *UpdateVTLDeviceTypeInput) SetDeviceType(v string) *UpdateVTLDeviceTypeInput {
+	s.DeviceType = &v
+	return s
+}
+
+// SetVTLDeviceARN sets the VTLDeviceARN field's value.
+func (s *UpdateVTLDeviceTypeInput) SetVTLDeviceARN(v string) *UpdateVTLDeviceTypeInput {
+	s.VTLDeviceARN = &v
+	return s
+}
+
 // UpdateVTLDeviceTypeOutput
 type UpdateVTLDeviceTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -8818,6 +10606,12 @@ func (s UpdateVTLDeviceTypeOutput) String() string {
 // GoString returns the string representation
 func (s UpdateVTLDeviceTypeOutput) GoString() string {
 	return s.String()
+}
+
+// SetVTLDeviceARN sets the VTLDeviceARN field's value.
+func (s *UpdateVTLDeviceTypeOutput) SetVTLDeviceARN(v string) *UpdateVTLDeviceTypeOutput {
+	s.VTLDeviceARN = &v
+	return s
 }
 
 // Represents a device object associated with a gateway-VTL.
@@ -8846,6 +10640,36 @@ func (s VTLDevice) String() string {
 // GoString returns the string representation
 func (s VTLDevice) GoString() string {
 	return s.String()
+}
+
+// SetDeviceiSCSIAttributes sets the DeviceiSCSIAttributes field's value.
+func (s *VTLDevice) SetDeviceiSCSIAttributes(v *DeviceiSCSIAttributes) *VTLDevice {
+	s.DeviceiSCSIAttributes = v
+	return s
+}
+
+// SetVTLDeviceARN sets the VTLDeviceARN field's value.
+func (s *VTLDevice) SetVTLDeviceARN(v string) *VTLDevice {
+	s.VTLDeviceARN = &v
+	return s
+}
+
+// SetVTLDeviceProductIdentifier sets the VTLDeviceProductIdentifier field's value.
+func (s *VTLDevice) SetVTLDeviceProductIdentifier(v string) *VTLDevice {
+	s.VTLDeviceProductIdentifier = &v
+	return s
+}
+
+// SetVTLDeviceType sets the VTLDeviceType field's value.
+func (s *VTLDevice) SetVTLDeviceType(v string) *VTLDevice {
+	s.VTLDeviceType = &v
+	return s
+}
+
+// SetVTLDeviceVendor sets the VTLDeviceVendor field's value.
+func (s *VTLDevice) SetVTLDeviceVendor(v string) *VTLDevice {
+	s.VTLDeviceVendor = &v
+	return s
 }
 
 // Describes a storage volume object.
@@ -8899,6 +10723,42 @@ func (s VolumeInfo) GoString() string {
 	return s.String()
 }
 
+// SetGatewayARN sets the GatewayARN field's value.
+func (s *VolumeInfo) SetGatewayARN(v string) *VolumeInfo {
+	s.GatewayARN = &v
+	return s
+}
+
+// SetGatewayId sets the GatewayId field's value.
+func (s *VolumeInfo) SetGatewayId(v string) *VolumeInfo {
+	s.GatewayId = &v
+	return s
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *VolumeInfo) SetVolumeARN(v string) *VolumeInfo {
+	s.VolumeARN = &v
+	return s
+}
+
+// SetVolumeId sets the VolumeId field's value.
+func (s *VolumeInfo) SetVolumeId(v string) *VolumeInfo {
+	s.VolumeId = &v
+	return s
+}
+
+// SetVolumeSizeInBytes sets the VolumeSizeInBytes field's value.
+func (s *VolumeInfo) SetVolumeSizeInBytes(v int64) *VolumeInfo {
+	s.VolumeSizeInBytes = &v
+	return s
+}
+
+// SetVolumeType sets the VolumeType field's value.
+func (s *VolumeInfo) SetVolumeType(v string) *VolumeInfo {
+	s.VolumeType = &v
+	return s
+}
+
 type VolumeRecoveryPointInfo struct {
 	_ struct{} `type:"structure"`
 
@@ -8919,6 +10779,30 @@ func (s VolumeRecoveryPointInfo) String() string {
 // GoString returns the string representation
 func (s VolumeRecoveryPointInfo) GoString() string {
 	return s.String()
+}
+
+// SetVolumeARN sets the VolumeARN field's value.
+func (s *VolumeRecoveryPointInfo) SetVolumeARN(v string) *VolumeRecoveryPointInfo {
+	s.VolumeARN = &v
+	return s
+}
+
+// SetVolumeRecoveryPointTime sets the VolumeRecoveryPointTime field's value.
+func (s *VolumeRecoveryPointInfo) SetVolumeRecoveryPointTime(v string) *VolumeRecoveryPointInfo {
+	s.VolumeRecoveryPointTime = &v
+	return s
+}
+
+// SetVolumeSizeInBytes sets the VolumeSizeInBytes field's value.
+func (s *VolumeRecoveryPointInfo) SetVolumeSizeInBytes(v int64) *VolumeRecoveryPointInfo {
+	s.VolumeSizeInBytes = &v
+	return s
+}
+
+// SetVolumeUsageInBytes sets the VolumeUsageInBytes field's value.
+func (s *VolumeRecoveryPointInfo) SetVolumeUsageInBytes(v int64) *VolumeRecoveryPointInfo {
+	s.VolumeUsageInBytes = &v
+	return s
 }
 
 // Lists iSCSI information about a volume.
@@ -8949,6 +10833,36 @@ func (s VolumeiSCSIAttributes) String() string {
 // GoString returns the string representation
 func (s VolumeiSCSIAttributes) GoString() string {
 	return s.String()
+}
+
+// SetChapEnabled sets the ChapEnabled field's value.
+func (s *VolumeiSCSIAttributes) SetChapEnabled(v bool) *VolumeiSCSIAttributes {
+	s.ChapEnabled = &v
+	return s
+}
+
+// SetLunNumber sets the LunNumber field's value.
+func (s *VolumeiSCSIAttributes) SetLunNumber(v int64) *VolumeiSCSIAttributes {
+	s.LunNumber = &v
+	return s
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *VolumeiSCSIAttributes) SetNetworkInterfaceId(v string) *VolumeiSCSIAttributes {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetNetworkInterfacePort sets the NetworkInterfacePort field's value.
+func (s *VolumeiSCSIAttributes) SetNetworkInterfacePort(v int64) *VolumeiSCSIAttributes {
+	s.NetworkInterfacePort = &v
+	return s
+}
+
+// SetTargetARN sets the TargetARN field's value.
+func (s *VolumeiSCSIAttributes) SetTargetARN(v string) *VolumeiSCSIAttributes {
+	s.TargetARN = &v
+	return s
 }
 
 const (

--- a/service/sts/api.go
+++ b/service/sts/api.go
@@ -1094,6 +1094,48 @@ func (s *AssumeRoleInput) Validate() error {
 	return nil
 }
 
+// SetDurationSeconds sets the DurationSeconds field's value.
+func (s *AssumeRoleInput) SetDurationSeconds(v int64) *AssumeRoleInput {
+	s.DurationSeconds = &v
+	return s
+}
+
+// SetExternalId sets the ExternalId field's value.
+func (s *AssumeRoleInput) SetExternalId(v string) *AssumeRoleInput {
+	s.ExternalId = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *AssumeRoleInput) SetPolicy(v string) *AssumeRoleInput {
+	s.Policy = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *AssumeRoleInput) SetRoleArn(v string) *AssumeRoleInput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRoleSessionName sets the RoleSessionName field's value.
+func (s *AssumeRoleInput) SetRoleSessionName(v string) *AssumeRoleInput {
+	s.RoleSessionName = &v
+	return s
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *AssumeRoleInput) SetSerialNumber(v string) *AssumeRoleInput {
+	s.SerialNumber = &v
+	return s
+}
+
+// SetTokenCode sets the TokenCode field's value.
+func (s *AssumeRoleInput) SetTokenCode(v string) *AssumeRoleInput {
+	s.TokenCode = &v
+	return s
+}
+
 // Contains the response to a successful AssumeRole request, including temporary
 // AWS credentials that can be used to make AWS requests.
 type AssumeRoleOutput struct {
@@ -1129,6 +1171,24 @@ func (s AssumeRoleOutput) String() string {
 // GoString returns the string representation
 func (s AssumeRoleOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssumedRoleUser sets the AssumedRoleUser field's value.
+func (s *AssumeRoleOutput) SetAssumedRoleUser(v *AssumedRoleUser) *AssumeRoleOutput {
+	s.AssumedRoleUser = v
+	return s
+}
+
+// SetCredentials sets the Credentials field's value.
+func (s *AssumeRoleOutput) SetCredentials(v *Credentials) *AssumeRoleOutput {
+	s.Credentials = v
+	return s
+}
+
+// SetPackedPolicySize sets the PackedPolicySize field's value.
+func (s *AssumeRoleOutput) SetPackedPolicySize(v int64) *AssumeRoleOutput {
+	s.PackedPolicySize = &v
+	return s
 }
 
 type AssumeRoleWithSAMLInput struct {
@@ -1239,6 +1299,36 @@ func (s *AssumeRoleWithSAMLInput) Validate() error {
 	return nil
 }
 
+// SetDurationSeconds sets the DurationSeconds field's value.
+func (s *AssumeRoleWithSAMLInput) SetDurationSeconds(v int64) *AssumeRoleWithSAMLInput {
+	s.DurationSeconds = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *AssumeRoleWithSAMLInput) SetPolicy(v string) *AssumeRoleWithSAMLInput {
+	s.Policy = &v
+	return s
+}
+
+// SetPrincipalArn sets the PrincipalArn field's value.
+func (s *AssumeRoleWithSAMLInput) SetPrincipalArn(v string) *AssumeRoleWithSAMLInput {
+	s.PrincipalArn = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *AssumeRoleWithSAMLInput) SetRoleArn(v string) *AssumeRoleWithSAMLInput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetSAMLAssertion sets the SAMLAssertion field's value.
+func (s *AssumeRoleWithSAMLInput) SetSAMLAssertion(v string) *AssumeRoleWithSAMLInput {
+	s.SAMLAssertion = &v
+	return s
+}
+
 // Contains the response to a successful AssumeRoleWithSAML request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type AssumeRoleWithSAMLOutput struct {
@@ -1302,6 +1392,54 @@ func (s AssumeRoleWithSAMLOutput) String() string {
 // GoString returns the string representation
 func (s AssumeRoleWithSAMLOutput) GoString() string {
 	return s.String()
+}
+
+// SetAssumedRoleUser sets the AssumedRoleUser field's value.
+func (s *AssumeRoleWithSAMLOutput) SetAssumedRoleUser(v *AssumedRoleUser) *AssumeRoleWithSAMLOutput {
+	s.AssumedRoleUser = v
+	return s
+}
+
+// SetAudience sets the Audience field's value.
+func (s *AssumeRoleWithSAMLOutput) SetAudience(v string) *AssumeRoleWithSAMLOutput {
+	s.Audience = &v
+	return s
+}
+
+// SetCredentials sets the Credentials field's value.
+func (s *AssumeRoleWithSAMLOutput) SetCredentials(v *Credentials) *AssumeRoleWithSAMLOutput {
+	s.Credentials = v
+	return s
+}
+
+// SetIssuer sets the Issuer field's value.
+func (s *AssumeRoleWithSAMLOutput) SetIssuer(v string) *AssumeRoleWithSAMLOutput {
+	s.Issuer = &v
+	return s
+}
+
+// SetNameQualifier sets the NameQualifier field's value.
+func (s *AssumeRoleWithSAMLOutput) SetNameQualifier(v string) *AssumeRoleWithSAMLOutput {
+	s.NameQualifier = &v
+	return s
+}
+
+// SetPackedPolicySize sets the PackedPolicySize field's value.
+func (s *AssumeRoleWithSAMLOutput) SetPackedPolicySize(v int64) *AssumeRoleWithSAMLOutput {
+	s.PackedPolicySize = &v
+	return s
+}
+
+// SetSubject sets the Subject field's value.
+func (s *AssumeRoleWithSAMLOutput) SetSubject(v string) *AssumeRoleWithSAMLOutput {
+	s.Subject = &v
+	return s
+}
+
+// SetSubjectType sets the SubjectType field's value.
+func (s *AssumeRoleWithSAMLOutput) SetSubjectType(v string) *AssumeRoleWithSAMLOutput {
+	s.SubjectType = &v
+	return s
 }
 
 type AssumeRoleWithWebIdentityInput struct {
@@ -1429,6 +1567,42 @@ func (s *AssumeRoleWithWebIdentityInput) Validate() error {
 	return nil
 }
 
+// SetDurationSeconds sets the DurationSeconds field's value.
+func (s *AssumeRoleWithWebIdentityInput) SetDurationSeconds(v int64) *AssumeRoleWithWebIdentityInput {
+	s.DurationSeconds = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *AssumeRoleWithWebIdentityInput) SetPolicy(v string) *AssumeRoleWithWebIdentityInput {
+	s.Policy = &v
+	return s
+}
+
+// SetProviderId sets the ProviderId field's value.
+func (s *AssumeRoleWithWebIdentityInput) SetProviderId(v string) *AssumeRoleWithWebIdentityInput {
+	s.ProviderId = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *AssumeRoleWithWebIdentityInput) SetRoleArn(v string) *AssumeRoleWithWebIdentityInput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRoleSessionName sets the RoleSessionName field's value.
+func (s *AssumeRoleWithWebIdentityInput) SetRoleSessionName(v string) *AssumeRoleWithWebIdentityInput {
+	s.RoleSessionName = &v
+	return s
+}
+
+// SetWebIdentityToken sets the WebIdentityToken field's value.
+func (s *AssumeRoleWithWebIdentityInput) SetWebIdentityToken(v string) *AssumeRoleWithWebIdentityInput {
+	s.WebIdentityToken = &v
+	return s
+}
+
 // Contains the response to a successful AssumeRoleWithWebIdentity request,
 // including temporary AWS credentials that can be used to make AWS requests.
 type AssumeRoleWithWebIdentityOutput struct {
@@ -1485,6 +1659,42 @@ func (s AssumeRoleWithWebIdentityOutput) GoString() string {
 	return s.String()
 }
 
+// SetAssumedRoleUser sets the AssumedRoleUser field's value.
+func (s *AssumeRoleWithWebIdentityOutput) SetAssumedRoleUser(v *AssumedRoleUser) *AssumeRoleWithWebIdentityOutput {
+	s.AssumedRoleUser = v
+	return s
+}
+
+// SetAudience sets the Audience field's value.
+func (s *AssumeRoleWithWebIdentityOutput) SetAudience(v string) *AssumeRoleWithWebIdentityOutput {
+	s.Audience = &v
+	return s
+}
+
+// SetCredentials sets the Credentials field's value.
+func (s *AssumeRoleWithWebIdentityOutput) SetCredentials(v *Credentials) *AssumeRoleWithWebIdentityOutput {
+	s.Credentials = v
+	return s
+}
+
+// SetPackedPolicySize sets the PackedPolicySize field's value.
+func (s *AssumeRoleWithWebIdentityOutput) SetPackedPolicySize(v int64) *AssumeRoleWithWebIdentityOutput {
+	s.PackedPolicySize = &v
+	return s
+}
+
+// SetProvider sets the Provider field's value.
+func (s *AssumeRoleWithWebIdentityOutput) SetProvider(v string) *AssumeRoleWithWebIdentityOutput {
+	s.Provider = &v
+	return s
+}
+
+// SetSubjectFromWebIdentityToken sets the SubjectFromWebIdentityToken field's value.
+func (s *AssumeRoleWithWebIdentityOutput) SetSubjectFromWebIdentityToken(v string) *AssumeRoleWithWebIdentityOutput {
+	s.SubjectFromWebIdentityToken = &v
+	return s
+}
+
 // The identifiers for the temporary security credentials that the operation
 // returns.
 type AssumedRoleUser struct {
@@ -1514,6 +1724,18 @@ func (s AssumedRoleUser) String() string {
 // GoString returns the string representation
 func (s AssumedRoleUser) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *AssumedRoleUser) SetArn(v string) *AssumedRoleUser {
+	s.Arn = &v
+	return s
+}
+
+// SetAssumedRoleId sets the AssumedRoleId field's value.
+func (s *AssumedRoleUser) SetAssumedRoleId(v string) *AssumedRoleUser {
+	s.AssumedRoleId = &v
+	return s
 }
 
 // AWS credentials for API authentication.
@@ -1551,6 +1773,30 @@ func (s Credentials) GoString() string {
 	return s.String()
 }
 
+// SetAccessKeyId sets the AccessKeyId field's value.
+func (s *Credentials) SetAccessKeyId(v string) *Credentials {
+	s.AccessKeyId = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *Credentials) SetExpiration(v time.Time) *Credentials {
+	s.Expiration = &v
+	return s
+}
+
+// SetSecretAccessKey sets the SecretAccessKey field's value.
+func (s *Credentials) SetSecretAccessKey(v string) *Credentials {
+	s.SecretAccessKey = &v
+	return s
+}
+
+// SetSessionToken sets the SessionToken field's value.
+func (s *Credentials) SetSessionToken(v string) *Credentials {
+	s.SessionToken = &v
+	return s
+}
+
 type DecodeAuthorizationMessageInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1586,6 +1832,12 @@ func (s *DecodeAuthorizationMessageInput) Validate() error {
 	return nil
 }
 
+// SetEncodedMessage sets the EncodedMessage field's value.
+func (s *DecodeAuthorizationMessageInput) SetEncodedMessage(v string) *DecodeAuthorizationMessageInput {
+	s.EncodedMessage = &v
+	return s
+}
+
 // A document that contains additional information about the authorization status
 // of a request from an encoded message that is returned in response to an AWS
 // request.
@@ -1604,6 +1856,12 @@ func (s DecodeAuthorizationMessageOutput) String() string {
 // GoString returns the string representation
 func (s DecodeAuthorizationMessageOutput) GoString() string {
 	return s.String()
+}
+
+// SetDecodedMessage sets the DecodedMessage field's value.
+func (s *DecodeAuthorizationMessageOutput) SetDecodedMessage(v string) *DecodeAuthorizationMessageOutput {
+	s.DecodedMessage = &v
+	return s
 }
 
 // Identifiers for the federated user that is associated with the credentials.
@@ -1633,6 +1891,18 @@ func (s FederatedUser) String() string {
 // GoString returns the string representation
 func (s FederatedUser) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *FederatedUser) SetArn(v string) *FederatedUser {
+	s.Arn = &v
+	return s
+}
+
+// SetFederatedUserId sets the FederatedUserId field's value.
+func (s *FederatedUser) SetFederatedUserId(v string) *FederatedUser {
+	s.FederatedUserId = &v
+	return s
 }
 
 type GetCallerIdentityInput struct {
@@ -1676,6 +1946,24 @@ func (s GetCallerIdentityOutput) String() string {
 // GoString returns the string representation
 func (s GetCallerIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// SetAccount sets the Account field's value.
+func (s *GetCallerIdentityOutput) SetAccount(v string) *GetCallerIdentityOutput {
+	s.Account = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *GetCallerIdentityOutput) SetArn(v string) *GetCallerIdentityOutput {
+	s.Arn = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *GetCallerIdentityOutput) SetUserId(v string) *GetCallerIdentityOutput {
+	s.UserId = &v
+	return s
 }
 
 type GetFederationTokenInput struct {
@@ -1767,6 +2055,24 @@ func (s *GetFederationTokenInput) Validate() error {
 	return nil
 }
 
+// SetDurationSeconds sets the DurationSeconds field's value.
+func (s *GetFederationTokenInput) SetDurationSeconds(v int64) *GetFederationTokenInput {
+	s.DurationSeconds = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetFederationTokenInput) SetName(v string) *GetFederationTokenInput {
+	s.Name = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetFederationTokenInput) SetPolicy(v string) *GetFederationTokenInput {
+	s.Policy = &v
+	return s
+}
+
 // Contains the response to a successful GetFederationToken request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type GetFederationTokenOutput struct {
@@ -1801,6 +2107,24 @@ func (s GetFederationTokenOutput) String() string {
 // GoString returns the string representation
 func (s GetFederationTokenOutput) GoString() string {
 	return s.String()
+}
+
+// SetCredentials sets the Credentials field's value.
+func (s *GetFederationTokenOutput) SetCredentials(v *Credentials) *GetFederationTokenOutput {
+	s.Credentials = v
+	return s
+}
+
+// SetFederatedUser sets the FederatedUser field's value.
+func (s *GetFederationTokenOutput) SetFederatedUser(v *FederatedUser) *GetFederationTokenOutput {
+	s.FederatedUser = v
+	return s
+}
+
+// SetPackedPolicySize sets the PackedPolicySize field's value.
+func (s *GetFederationTokenOutput) SetPackedPolicySize(v int64) *GetFederationTokenOutput {
+	s.PackedPolicySize = &v
+	return s
 }
 
 type GetSessionTokenInput struct {
@@ -1868,6 +2192,24 @@ func (s *GetSessionTokenInput) Validate() error {
 	return nil
 }
 
+// SetDurationSeconds sets the DurationSeconds field's value.
+func (s *GetSessionTokenInput) SetDurationSeconds(v int64) *GetSessionTokenInput {
+	s.DurationSeconds = &v
+	return s
+}
+
+// SetSerialNumber sets the SerialNumber field's value.
+func (s *GetSessionTokenInput) SetSerialNumber(v string) *GetSessionTokenInput {
+	s.SerialNumber = &v
+	return s
+}
+
+// SetTokenCode sets the TokenCode field's value.
+func (s *GetSessionTokenInput) SetTokenCode(v string) *GetSessionTokenInput {
+	s.TokenCode = &v
+	return s
+}
+
 // Contains the response to a successful GetSessionToken request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type GetSessionTokenOutput struct {
@@ -1891,4 +2233,10 @@ func (s GetSessionTokenOutput) String() string {
 // GoString returns the string representation
 func (s GetSessionTokenOutput) GoString() string {
 	return s.String()
+}
+
+// SetCredentials sets the Credentials field's value.
+func (s *GetSessionTokenOutput) SetCredentials(v *Credentials) *GetSessionTokenOutput {
+	s.Credentials = v
+	return s
 }

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -1200,6 +1200,18 @@ func (s *AddAttachmentsToSetInput) Validate() error {
 	return nil
 }
 
+// SetAttachmentSetId sets the AttachmentSetId field's value.
+func (s *AddAttachmentsToSetInput) SetAttachmentSetId(v string) *AddAttachmentsToSetInput {
+	s.AttachmentSetId = &v
+	return s
+}
+
+// SetAttachments sets the Attachments field's value.
+func (s *AddAttachmentsToSetInput) SetAttachments(v []*Attachment) *AddAttachmentsToSetInput {
+	s.Attachments = v
+	return s
+}
+
 // The ID and expiry time of the attachment set returned by the AddAttachmentsToSet
 // operation.
 type AddAttachmentsToSetOutput struct {
@@ -1223,6 +1235,18 @@ func (s AddAttachmentsToSetOutput) String() string {
 // GoString returns the string representation
 func (s AddAttachmentsToSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttachmentSetId sets the AttachmentSetId field's value.
+func (s *AddAttachmentsToSetOutput) SetAttachmentSetId(v string) *AddAttachmentsToSetOutput {
+	s.AttachmentSetId = &v
+	return s
+}
+
+// SetExpiryTime sets the ExpiryTime field's value.
+func (s *AddAttachmentsToSetOutput) SetExpiryTime(v string) *AddAttachmentsToSetOutput {
+	s.ExpiryTime = &v
+	return s
 }
 
 // To be written.
@@ -1273,6 +1297,30 @@ func (s *AddCommunicationToCaseInput) Validate() error {
 	return nil
 }
 
+// SetAttachmentSetId sets the AttachmentSetId field's value.
+func (s *AddCommunicationToCaseInput) SetAttachmentSetId(v string) *AddCommunicationToCaseInput {
+	s.AttachmentSetId = &v
+	return s
+}
+
+// SetCaseId sets the CaseId field's value.
+func (s *AddCommunicationToCaseInput) SetCaseId(v string) *AddCommunicationToCaseInput {
+	s.CaseId = &v
+	return s
+}
+
+// SetCcEmailAddresses sets the CcEmailAddresses field's value.
+func (s *AddCommunicationToCaseInput) SetCcEmailAddresses(v []*string) *AddCommunicationToCaseInput {
+	s.CcEmailAddresses = v
+	return s
+}
+
+// SetCommunicationBody sets the CommunicationBody field's value.
+func (s *AddCommunicationToCaseInput) SetCommunicationBody(v string) *AddCommunicationToCaseInput {
+	s.CommunicationBody = &v
+	return s
+}
+
 // The result of the AddCommunicationToCase operation.
 type AddCommunicationToCaseOutput struct {
 	_ struct{} `type:"structure"`
@@ -1289,6 +1337,12 @@ func (s AddCommunicationToCaseOutput) String() string {
 // GoString returns the string representation
 func (s AddCommunicationToCaseOutput) GoString() string {
 	return s.String()
+}
+
+// SetResult sets the Result field's value.
+func (s *AddCommunicationToCaseOutput) SetResult(v bool) *AddCommunicationToCaseOutput {
+	s.Result = &v
+	return s
 }
 
 // An attachment to a case communication. The attachment consists of the file
@@ -1315,6 +1369,18 @@ func (s Attachment) GoString() string {
 	return s.String()
 }
 
+// SetData sets the Data field's value.
+func (s *Attachment) SetData(v []byte) *Attachment {
+	s.Data = v
+	return s
+}
+
+// SetFileName sets the FileName field's value.
+func (s *Attachment) SetFileName(v string) *Attachment {
+	s.FileName = &v
+	return s
+}
+
 // The file name and ID of an attachment to a case communication. You can use
 // the ID to retrieve the attachment with the DescribeAttachment operation.
 type AttachmentDetails struct {
@@ -1335,6 +1401,18 @@ func (s AttachmentDetails) String() string {
 // GoString returns the string representation
 func (s AttachmentDetails) GoString() string {
 	return s.String()
+}
+
+// SetAttachmentId sets the AttachmentId field's value.
+func (s *AttachmentDetails) SetAttachmentId(v string) *AttachmentDetails {
+	s.AttachmentId = &v
+	return s
+}
+
+// SetFileName sets the FileName field's value.
+func (s *AttachmentDetails) SetFileName(v string) *AttachmentDetails {
+	s.FileName = &v
+	return s
 }
 
 // A JSON-formatted object that contains the metadata for a support case. It
@@ -1429,6 +1507,78 @@ func (s CaseDetails) GoString() string {
 	return s.String()
 }
 
+// SetCaseId sets the CaseId field's value.
+func (s *CaseDetails) SetCaseId(v string) *CaseDetails {
+	s.CaseId = &v
+	return s
+}
+
+// SetCategoryCode sets the CategoryCode field's value.
+func (s *CaseDetails) SetCategoryCode(v string) *CaseDetails {
+	s.CategoryCode = &v
+	return s
+}
+
+// SetCcEmailAddresses sets the CcEmailAddresses field's value.
+func (s *CaseDetails) SetCcEmailAddresses(v []*string) *CaseDetails {
+	s.CcEmailAddresses = v
+	return s
+}
+
+// SetDisplayId sets the DisplayId field's value.
+func (s *CaseDetails) SetDisplayId(v string) *CaseDetails {
+	s.DisplayId = &v
+	return s
+}
+
+// SetLanguage sets the Language field's value.
+func (s *CaseDetails) SetLanguage(v string) *CaseDetails {
+	s.Language = &v
+	return s
+}
+
+// SetRecentCommunications sets the RecentCommunications field's value.
+func (s *CaseDetails) SetRecentCommunications(v *RecentCaseCommunications) *CaseDetails {
+	s.RecentCommunications = v
+	return s
+}
+
+// SetServiceCode sets the ServiceCode field's value.
+func (s *CaseDetails) SetServiceCode(v string) *CaseDetails {
+	s.ServiceCode = &v
+	return s
+}
+
+// SetSeverityCode sets the SeverityCode field's value.
+func (s *CaseDetails) SetSeverityCode(v string) *CaseDetails {
+	s.SeverityCode = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CaseDetails) SetStatus(v string) *CaseDetails {
+	s.Status = &v
+	return s
+}
+
+// SetSubject sets the Subject field's value.
+func (s *CaseDetails) SetSubject(v string) *CaseDetails {
+	s.Subject = &v
+	return s
+}
+
+// SetSubmittedBy sets the SubmittedBy field's value.
+func (s *CaseDetails) SetSubmittedBy(v string) *CaseDetails {
+	s.SubmittedBy = &v
+	return s
+}
+
+// SetTimeCreated sets the TimeCreated field's value.
+func (s *CaseDetails) SetTimeCreated(v string) *CaseDetails {
+	s.TimeCreated = &v
+	return s
+}
+
 // A JSON-formatted name/value pair that represents the category name and category
 // code of the problem, selected from the DescribeServices response for each
 // AWS service.
@@ -1450,6 +1600,18 @@ func (s Category) String() string {
 // GoString returns the string representation
 func (s Category) GoString() string {
 	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *Category) SetCode(v string) *Category {
+	s.Code = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Category) SetName(v string) *Category {
+	s.Name = &v
+	return s
 }
 
 // A communication associated with an AWS Support case. The communication consists
@@ -1483,6 +1645,36 @@ func (s Communication) String() string {
 // GoString returns the string representation
 func (s Communication) GoString() string {
 	return s.String()
+}
+
+// SetAttachmentSet sets the AttachmentSet field's value.
+func (s *Communication) SetAttachmentSet(v []*AttachmentDetails) *Communication {
+	s.AttachmentSet = v
+	return s
+}
+
+// SetBody sets the Body field's value.
+func (s *Communication) SetBody(v string) *Communication {
+	s.Body = &v
+	return s
+}
+
+// SetCaseId sets the CaseId field's value.
+func (s *Communication) SetCaseId(v string) *Communication {
+	s.CaseId = &v
+	return s
+}
+
+// SetSubmittedBy sets the SubmittedBy field's value.
+func (s *Communication) SetSubmittedBy(v string) *Communication {
+	s.SubmittedBy = &v
+	return s
+}
+
+// SetTimeCreated sets the TimeCreated field's value.
+func (s *Communication) SetTimeCreated(v string) *Communication {
+	s.TimeCreated = &v
+	return s
 }
 
 type CreateCaseInput struct {
@@ -1558,6 +1750,60 @@ func (s *CreateCaseInput) Validate() error {
 	return nil
 }
 
+// SetAttachmentSetId sets the AttachmentSetId field's value.
+func (s *CreateCaseInput) SetAttachmentSetId(v string) *CreateCaseInput {
+	s.AttachmentSetId = &v
+	return s
+}
+
+// SetCategoryCode sets the CategoryCode field's value.
+func (s *CreateCaseInput) SetCategoryCode(v string) *CreateCaseInput {
+	s.CategoryCode = &v
+	return s
+}
+
+// SetCcEmailAddresses sets the CcEmailAddresses field's value.
+func (s *CreateCaseInput) SetCcEmailAddresses(v []*string) *CreateCaseInput {
+	s.CcEmailAddresses = v
+	return s
+}
+
+// SetCommunicationBody sets the CommunicationBody field's value.
+func (s *CreateCaseInput) SetCommunicationBody(v string) *CreateCaseInput {
+	s.CommunicationBody = &v
+	return s
+}
+
+// SetIssueType sets the IssueType field's value.
+func (s *CreateCaseInput) SetIssueType(v string) *CreateCaseInput {
+	s.IssueType = &v
+	return s
+}
+
+// SetLanguage sets the Language field's value.
+func (s *CreateCaseInput) SetLanguage(v string) *CreateCaseInput {
+	s.Language = &v
+	return s
+}
+
+// SetServiceCode sets the ServiceCode field's value.
+func (s *CreateCaseInput) SetServiceCode(v string) *CreateCaseInput {
+	s.ServiceCode = &v
+	return s
+}
+
+// SetSeverityCode sets the SeverityCode field's value.
+func (s *CreateCaseInput) SetSeverityCode(v string) *CreateCaseInput {
+	s.SeverityCode = &v
+	return s
+}
+
+// SetSubject sets the Subject field's value.
+func (s *CreateCaseInput) SetSubject(v string) *CreateCaseInput {
+	s.Subject = &v
+	return s
+}
+
 // The AWS Support case ID returned by a successful completion of the CreateCase
 // operation.
 type CreateCaseOutput struct {
@@ -1576,6 +1822,12 @@ func (s CreateCaseOutput) String() string {
 // GoString returns the string representation
 func (s CreateCaseOutput) GoString() string {
 	return s.String()
+}
+
+// SetCaseId sets the CaseId field's value.
+func (s *CreateCaseOutput) SetCaseId(v string) *CreateCaseOutput {
+	s.CaseId = &v
+	return s
 }
 
 type DescribeAttachmentInput struct {
@@ -1611,6 +1863,12 @@ func (s *DescribeAttachmentInput) Validate() error {
 	return nil
 }
 
+// SetAttachmentId sets the AttachmentId field's value.
+func (s *DescribeAttachmentInput) SetAttachmentId(v string) *DescribeAttachmentInput {
+	s.AttachmentId = &v
+	return s
+}
+
 // The content and file name of the attachment returned by the DescribeAttachment
 // operation.
 type DescribeAttachmentOutput struct {
@@ -1628,6 +1886,12 @@ func (s DescribeAttachmentOutput) String() string {
 // GoString returns the string representation
 func (s DescribeAttachmentOutput) GoString() string {
 	return s.String()
+}
+
+// SetAttachment sets the Attachment field's value.
+func (s *DescribeAttachmentOutput) SetAttachment(v *Attachment) *DescribeAttachmentOutput {
+	s.Attachment = v
+	return s
 }
 
 type DescribeCasesInput struct {
@@ -1691,6 +1955,60 @@ func (s *DescribeCasesInput) Validate() error {
 	return nil
 }
 
+// SetAfterTime sets the AfterTime field's value.
+func (s *DescribeCasesInput) SetAfterTime(v string) *DescribeCasesInput {
+	s.AfterTime = &v
+	return s
+}
+
+// SetBeforeTime sets the BeforeTime field's value.
+func (s *DescribeCasesInput) SetBeforeTime(v string) *DescribeCasesInput {
+	s.BeforeTime = &v
+	return s
+}
+
+// SetCaseIdList sets the CaseIdList field's value.
+func (s *DescribeCasesInput) SetCaseIdList(v []*string) *DescribeCasesInput {
+	s.CaseIdList = v
+	return s
+}
+
+// SetDisplayId sets the DisplayId field's value.
+func (s *DescribeCasesInput) SetDisplayId(v string) *DescribeCasesInput {
+	s.DisplayId = &v
+	return s
+}
+
+// SetIncludeCommunications sets the IncludeCommunications field's value.
+func (s *DescribeCasesInput) SetIncludeCommunications(v bool) *DescribeCasesInput {
+	s.IncludeCommunications = &v
+	return s
+}
+
+// SetIncludeResolvedCases sets the IncludeResolvedCases field's value.
+func (s *DescribeCasesInput) SetIncludeResolvedCases(v bool) *DescribeCasesInput {
+	s.IncludeResolvedCases = &v
+	return s
+}
+
+// SetLanguage sets the Language field's value.
+func (s *DescribeCasesInput) SetLanguage(v string) *DescribeCasesInput {
+	s.Language = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeCasesInput) SetMaxResults(v int64) *DescribeCasesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeCasesInput) SetNextToken(v string) *DescribeCasesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Returns an array of CaseDetails objects and a nextToken that defines a point
 // for pagination in the result set.
 type DescribeCasesOutput struct {
@@ -1711,6 +2029,18 @@ func (s DescribeCasesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCasesOutput) GoString() string {
 	return s.String()
+}
+
+// SetCases sets the Cases field's value.
+func (s *DescribeCasesOutput) SetCases(v []*CaseDetails) *DescribeCasesOutput {
+	s.Cases = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeCasesOutput) SetNextToken(v string) *DescribeCasesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeCommunicationsInput struct {
@@ -1763,6 +2093,36 @@ func (s *DescribeCommunicationsInput) Validate() error {
 	return nil
 }
 
+// SetAfterTime sets the AfterTime field's value.
+func (s *DescribeCommunicationsInput) SetAfterTime(v string) *DescribeCommunicationsInput {
+	s.AfterTime = &v
+	return s
+}
+
+// SetBeforeTime sets the BeforeTime field's value.
+func (s *DescribeCommunicationsInput) SetBeforeTime(v string) *DescribeCommunicationsInput {
+	s.BeforeTime = &v
+	return s
+}
+
+// SetCaseId sets the CaseId field's value.
+func (s *DescribeCommunicationsInput) SetCaseId(v string) *DescribeCommunicationsInput {
+	s.CaseId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeCommunicationsInput) SetMaxResults(v int64) *DescribeCommunicationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeCommunicationsInput) SetNextToken(v string) *DescribeCommunicationsInput {
+	s.NextToken = &v
+	return s
+}
+
 // The communications returned by the DescribeCommunications operation.
 type DescribeCommunicationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1782,6 +2142,18 @@ func (s DescribeCommunicationsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeCommunicationsOutput) GoString() string {
 	return s.String()
+}
+
+// SetCommunications sets the Communications field's value.
+func (s *DescribeCommunicationsOutput) SetCommunications(v []*Communication) *DescribeCommunicationsOutput {
+	s.Communications = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeCommunicationsOutput) SetNextToken(v string) *DescribeCommunicationsOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeServicesInput struct {
@@ -1806,6 +2178,18 @@ func (s DescribeServicesInput) GoString() string {
 	return s.String()
 }
 
+// SetLanguage sets the Language field's value.
+func (s *DescribeServicesInput) SetLanguage(v string) *DescribeServicesInput {
+	s.Language = &v
+	return s
+}
+
+// SetServiceCodeList sets the ServiceCodeList field's value.
+func (s *DescribeServicesInput) SetServiceCodeList(v []*string) *DescribeServicesInput {
+	s.ServiceCodeList = v
+	return s
+}
+
 // The list of AWS services returned by the DescribeServices operation.
 type DescribeServicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1822,6 +2206,12 @@ func (s DescribeServicesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeServicesOutput) GoString() string {
 	return s.String()
+}
+
+// SetServices sets the Services field's value.
+func (s *DescribeServicesOutput) SetServices(v []*Service) *DescribeServicesOutput {
+	s.Services = v
+	return s
 }
 
 type DescribeSeverityLevelsInput struct {
@@ -1843,6 +2233,12 @@ func (s DescribeSeverityLevelsInput) GoString() string {
 	return s.String()
 }
 
+// SetLanguage sets the Language field's value.
+func (s *DescribeSeverityLevelsInput) SetLanguage(v string) *DescribeSeverityLevelsInput {
+	s.Language = &v
+	return s
+}
+
 // The list of severity levels returned by the DescribeSeverityLevels operation.
 type DescribeSeverityLevelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1860,6 +2256,12 @@ func (s DescribeSeverityLevelsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSeverityLevelsOutput) GoString() string {
 	return s.String()
+}
+
+// SetSeverityLevels sets the SeverityLevels field's value.
+func (s *DescribeSeverityLevelsOutput) SetSeverityLevels(v []*SeverityLevel) *DescribeSeverityLevelsOutput {
+	s.SeverityLevels = v
+	return s
 }
 
 type DescribeTrustedAdvisorCheckRefreshStatusesInput struct {
@@ -1896,6 +2298,12 @@ func (s *DescribeTrustedAdvisorCheckRefreshStatusesInput) Validate() error {
 	return nil
 }
 
+// SetCheckIds sets the CheckIds field's value.
+func (s *DescribeTrustedAdvisorCheckRefreshStatusesInput) SetCheckIds(v []*string) *DescribeTrustedAdvisorCheckRefreshStatusesInput {
+	s.CheckIds = v
+	return s
+}
+
 // The statuses of the Trusted Advisor checks returned by the DescribeTrustedAdvisorCheckRefreshStatuses
 // operation.
 type DescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
@@ -1915,6 +2323,12 @@ func (s DescribeTrustedAdvisorCheckRefreshStatusesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTrustedAdvisorCheckRefreshStatusesOutput) GoString() string {
 	return s.String()
+}
+
+// SetStatuses sets the Statuses field's value.
+func (s *DescribeTrustedAdvisorCheckRefreshStatusesOutput) SetStatuses(v []*TrustedAdvisorCheckRefreshStatus) *DescribeTrustedAdvisorCheckRefreshStatusesOutput {
+	s.Statuses = v
+	return s
 }
 
 type DescribeTrustedAdvisorCheckResultInput struct {
@@ -1954,6 +2368,18 @@ func (s *DescribeTrustedAdvisorCheckResultInput) Validate() error {
 	return nil
 }
 
+// SetCheckId sets the CheckId field's value.
+func (s *DescribeTrustedAdvisorCheckResultInput) SetCheckId(v string) *DescribeTrustedAdvisorCheckResultInput {
+	s.CheckId = &v
+	return s
+}
+
+// SetLanguage sets the Language field's value.
+func (s *DescribeTrustedAdvisorCheckResultInput) SetLanguage(v string) *DescribeTrustedAdvisorCheckResultInput {
+	s.Language = &v
+	return s
+}
+
 // The result of the Trusted Advisor check returned by the DescribeTrustedAdvisorCheckResult
 // operation.
 type DescribeTrustedAdvisorCheckResultOutput struct {
@@ -1971,6 +2397,12 @@ func (s DescribeTrustedAdvisorCheckResultOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTrustedAdvisorCheckResultOutput) GoString() string {
 	return s.String()
+}
+
+// SetResult sets the Result field's value.
+func (s *DescribeTrustedAdvisorCheckResultOutput) SetResult(v *TrustedAdvisorCheckResult) *DescribeTrustedAdvisorCheckResultOutput {
+	s.Result = v
+	return s
 }
 
 type DescribeTrustedAdvisorCheckSummariesInput struct {
@@ -2005,6 +2437,12 @@ func (s *DescribeTrustedAdvisorCheckSummariesInput) Validate() error {
 	return nil
 }
 
+// SetCheckIds sets the CheckIds field's value.
+func (s *DescribeTrustedAdvisorCheckSummariesInput) SetCheckIds(v []*string) *DescribeTrustedAdvisorCheckSummariesInput {
+	s.CheckIds = v
+	return s
+}
+
 // The summaries of the Trusted Advisor checks returned by the DescribeTrustedAdvisorCheckSummaries
 // operation.
 type DescribeTrustedAdvisorCheckSummariesOutput struct {
@@ -2024,6 +2462,12 @@ func (s DescribeTrustedAdvisorCheckSummariesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTrustedAdvisorCheckSummariesOutput) GoString() string {
 	return s.String()
+}
+
+// SetSummaries sets the Summaries field's value.
+func (s *DescribeTrustedAdvisorCheckSummariesOutput) SetSummaries(v []*TrustedAdvisorCheckSummary) *DescribeTrustedAdvisorCheckSummariesOutput {
+	s.Summaries = v
+	return s
 }
 
 type DescribeTrustedAdvisorChecksInput struct {
@@ -2060,6 +2504,12 @@ func (s *DescribeTrustedAdvisorChecksInput) Validate() error {
 	return nil
 }
 
+// SetLanguage sets the Language field's value.
+func (s *DescribeTrustedAdvisorChecksInput) SetLanguage(v string) *DescribeTrustedAdvisorChecksInput {
+	s.Language = &v
+	return s
+}
+
 // Information about the Trusted Advisor checks returned by the DescribeTrustedAdvisorChecks
 // operation.
 type DescribeTrustedAdvisorChecksOutput struct {
@@ -2081,6 +2531,12 @@ func (s DescribeTrustedAdvisorChecksOutput) GoString() string {
 	return s.String()
 }
 
+// SetChecks sets the Checks field's value.
+func (s *DescribeTrustedAdvisorChecksOutput) SetChecks(v []*TrustedAdvisorCheckDescription) *DescribeTrustedAdvisorChecksOutput {
+	s.Checks = v
+	return s
+}
+
 // The five most recent communications associated with the case.
 type RecentCaseCommunications struct {
 	_ struct{} `type:"structure"`
@@ -2100,6 +2556,18 @@ func (s RecentCaseCommunications) String() string {
 // GoString returns the string representation
 func (s RecentCaseCommunications) GoString() string {
 	return s.String()
+}
+
+// SetCommunications sets the Communications field's value.
+func (s *RecentCaseCommunications) SetCommunications(v []*Communication) *RecentCaseCommunications {
+	s.Communications = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *RecentCaseCommunications) SetNextToken(v string) *RecentCaseCommunications {
+	s.NextToken = &v
+	return s
 }
 
 type RefreshTrustedAdvisorCheckInput struct {
@@ -2136,6 +2604,12 @@ func (s *RefreshTrustedAdvisorCheckInput) Validate() error {
 	return nil
 }
 
+// SetCheckId sets the CheckId field's value.
+func (s *RefreshTrustedAdvisorCheckInput) SetCheckId(v string) *RefreshTrustedAdvisorCheckInput {
+	s.CheckId = &v
+	return s
+}
+
 // The current refresh status of a Trusted Advisor check.
 type RefreshTrustedAdvisorCheckOutput struct {
 	_ struct{} `type:"structure"`
@@ -2157,6 +2631,12 @@ func (s RefreshTrustedAdvisorCheckOutput) GoString() string {
 	return s.String()
 }
 
+// SetStatus sets the Status field's value.
+func (s *RefreshTrustedAdvisorCheckOutput) SetStatus(v *TrustedAdvisorCheckRefreshStatus) *RefreshTrustedAdvisorCheckOutput {
+	s.Status = v
+	return s
+}
+
 type ResolveCaseInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2173,6 +2653,12 @@ func (s ResolveCaseInput) String() string {
 // GoString returns the string representation
 func (s ResolveCaseInput) GoString() string {
 	return s.String()
+}
+
+// SetCaseId sets the CaseId field's value.
+func (s *ResolveCaseInput) SetCaseId(v string) *ResolveCaseInput {
+	s.CaseId = &v
+	return s
 }
 
 // The status of the case returned by the ResolveCase operation.
@@ -2194,6 +2680,18 @@ func (s ResolveCaseOutput) String() string {
 // GoString returns the string representation
 func (s ResolveCaseOutput) GoString() string {
 	return s.String()
+}
+
+// SetFinalCaseStatus sets the FinalCaseStatus field's value.
+func (s *ResolveCaseOutput) SetFinalCaseStatus(v string) *ResolveCaseOutput {
+	s.FinalCaseStatus = &v
+	return s
+}
+
+// SetInitialCaseStatus sets the InitialCaseStatus field's value.
+func (s *ResolveCaseOutput) SetInitialCaseStatus(v string) *ResolveCaseOutput {
+	s.InitialCaseStatus = &v
+	return s
 }
 
 // Information about an AWS service returned by the DescribeServices operation.
@@ -2224,6 +2722,24 @@ func (s Service) GoString() string {
 	return s.String()
 }
 
+// SetCategories sets the Categories field's value.
+func (s *Service) SetCategories(v []*Category) *Service {
+	s.Categories = v
+	return s
+}
+
+// SetCode sets the Code field's value.
+func (s *Service) SetCode(v string) *Service {
+	s.Code = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Service) SetName(v string) *Service {
+	s.Name = &v
+	return s
+}
+
 // A code and name pair that represent a severity level that can be applied
 // to a support case.
 type SeverityLevel struct {
@@ -2247,6 +2763,18 @@ func (s SeverityLevel) GoString() string {
 	return s.String()
 }
 
+// SetCode sets the Code field's value.
+func (s *SeverityLevel) SetCode(v string) *SeverityLevel {
+	s.Code = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *SeverityLevel) SetName(v string) *SeverityLevel {
+	s.Name = &v
+	return s
+}
+
 // The container for summary information that relates to the category of the
 // Trusted Advisor check.
 type TrustedAdvisorCategorySpecificSummary struct {
@@ -2265,6 +2793,12 @@ func (s TrustedAdvisorCategorySpecificSummary) String() string {
 // GoString returns the string representation
 func (s TrustedAdvisorCategorySpecificSummary) GoString() string {
 	return s.String()
+}
+
+// SetCostOptimizing sets the CostOptimizing field's value.
+func (s *TrustedAdvisorCategorySpecificSummary) SetCostOptimizing(v *TrustedAdvisorCostOptimizingSummary) *TrustedAdvisorCategorySpecificSummary {
+	s.CostOptimizing = v
+	return s
 }
 
 // The description and metadata for a Trusted Advisor check.
@@ -2312,6 +2846,36 @@ func (s TrustedAdvisorCheckDescription) GoString() string {
 	return s.String()
 }
 
+// SetCategory sets the Category field's value.
+func (s *TrustedAdvisorCheckDescription) SetCategory(v string) *TrustedAdvisorCheckDescription {
+	s.Category = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *TrustedAdvisorCheckDescription) SetDescription(v string) *TrustedAdvisorCheckDescription {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *TrustedAdvisorCheckDescription) SetId(v string) *TrustedAdvisorCheckDescription {
+	s.Id = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *TrustedAdvisorCheckDescription) SetMetadata(v []*string) *TrustedAdvisorCheckDescription {
+	s.Metadata = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *TrustedAdvisorCheckDescription) SetName(v string) *TrustedAdvisorCheckDescription {
+	s.Name = &v
+	return s
+}
+
 // The refresh status of a Trusted Advisor check.
 type TrustedAdvisorCheckRefreshStatus struct {
 	_ struct{} `type:"structure"`
@@ -2342,6 +2906,24 @@ func (s TrustedAdvisorCheckRefreshStatus) String() string {
 // GoString returns the string representation
 func (s TrustedAdvisorCheckRefreshStatus) GoString() string {
 	return s.String()
+}
+
+// SetCheckId sets the CheckId field's value.
+func (s *TrustedAdvisorCheckRefreshStatus) SetCheckId(v string) *TrustedAdvisorCheckRefreshStatus {
+	s.CheckId = &v
+	return s
+}
+
+// SetMillisUntilNextRefreshable sets the MillisUntilNextRefreshable field's value.
+func (s *TrustedAdvisorCheckRefreshStatus) SetMillisUntilNextRefreshable(v int64) *TrustedAdvisorCheckRefreshStatus {
+	s.MillisUntilNextRefreshable = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *TrustedAdvisorCheckRefreshStatus) SetStatus(v string) *TrustedAdvisorCheckRefreshStatus {
+	s.Status = &v
+	return s
 }
 
 // The results of a Trusted Advisor check returned by DescribeTrustedAdvisorCheckResult.
@@ -2392,6 +2974,42 @@ func (s TrustedAdvisorCheckResult) GoString() string {
 	return s.String()
 }
 
+// SetCategorySpecificSummary sets the CategorySpecificSummary field's value.
+func (s *TrustedAdvisorCheckResult) SetCategorySpecificSummary(v *TrustedAdvisorCategorySpecificSummary) *TrustedAdvisorCheckResult {
+	s.CategorySpecificSummary = v
+	return s
+}
+
+// SetCheckId sets the CheckId field's value.
+func (s *TrustedAdvisorCheckResult) SetCheckId(v string) *TrustedAdvisorCheckResult {
+	s.CheckId = &v
+	return s
+}
+
+// SetFlaggedResources sets the FlaggedResources field's value.
+func (s *TrustedAdvisorCheckResult) SetFlaggedResources(v []*TrustedAdvisorResourceDetail) *TrustedAdvisorCheckResult {
+	s.FlaggedResources = v
+	return s
+}
+
+// SetResourcesSummary sets the ResourcesSummary field's value.
+func (s *TrustedAdvisorCheckResult) SetResourcesSummary(v *TrustedAdvisorResourcesSummary) *TrustedAdvisorCheckResult {
+	s.ResourcesSummary = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *TrustedAdvisorCheckResult) SetStatus(v string) *TrustedAdvisorCheckResult {
+	s.Status = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *TrustedAdvisorCheckResult) SetTimestamp(v string) *TrustedAdvisorCheckResult {
+	s.Timestamp = &v
+	return s
+}
+
 // A summary of a Trusted Advisor check result, including the alert status,
 // last refresh, and number of resources examined.
 type TrustedAdvisorCheckSummary struct {
@@ -2439,6 +3057,42 @@ func (s TrustedAdvisorCheckSummary) GoString() string {
 	return s.String()
 }
 
+// SetCategorySpecificSummary sets the CategorySpecificSummary field's value.
+func (s *TrustedAdvisorCheckSummary) SetCategorySpecificSummary(v *TrustedAdvisorCategorySpecificSummary) *TrustedAdvisorCheckSummary {
+	s.CategorySpecificSummary = v
+	return s
+}
+
+// SetCheckId sets the CheckId field's value.
+func (s *TrustedAdvisorCheckSummary) SetCheckId(v string) *TrustedAdvisorCheckSummary {
+	s.CheckId = &v
+	return s
+}
+
+// SetHasFlaggedResources sets the HasFlaggedResources field's value.
+func (s *TrustedAdvisorCheckSummary) SetHasFlaggedResources(v bool) *TrustedAdvisorCheckSummary {
+	s.HasFlaggedResources = &v
+	return s
+}
+
+// SetResourcesSummary sets the ResourcesSummary field's value.
+func (s *TrustedAdvisorCheckSummary) SetResourcesSummary(v *TrustedAdvisorResourcesSummary) *TrustedAdvisorCheckSummary {
+	s.ResourcesSummary = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *TrustedAdvisorCheckSummary) SetStatus(v string) *TrustedAdvisorCheckSummary {
+	s.Status = &v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *TrustedAdvisorCheckSummary) SetTimestamp(v string) *TrustedAdvisorCheckSummary {
+	s.Timestamp = &v
+	return s
+}
+
 // The estimated cost savings that might be realized if the recommended actions
 // are taken.
 type TrustedAdvisorCostOptimizingSummary struct {
@@ -2465,6 +3119,18 @@ func (s TrustedAdvisorCostOptimizingSummary) String() string {
 // GoString returns the string representation
 func (s TrustedAdvisorCostOptimizingSummary) GoString() string {
 	return s.String()
+}
+
+// SetEstimatedMonthlySavings sets the EstimatedMonthlySavings field's value.
+func (s *TrustedAdvisorCostOptimizingSummary) SetEstimatedMonthlySavings(v float64) *TrustedAdvisorCostOptimizingSummary {
+	s.EstimatedMonthlySavings = &v
+	return s
+}
+
+// SetEstimatedPercentMonthlySavings sets the EstimatedPercentMonthlySavings field's value.
+func (s *TrustedAdvisorCostOptimizingSummary) SetEstimatedPercentMonthlySavings(v float64) *TrustedAdvisorCostOptimizingSummary {
+	s.EstimatedPercentMonthlySavings = &v
+	return s
 }
 
 // Contains information about a resource identified by a Trusted Advisor check.
@@ -2508,6 +3174,36 @@ func (s TrustedAdvisorResourceDetail) GoString() string {
 	return s.String()
 }
 
+// SetIsSuppressed sets the IsSuppressed field's value.
+func (s *TrustedAdvisorResourceDetail) SetIsSuppressed(v bool) *TrustedAdvisorResourceDetail {
+	s.IsSuppressed = &v
+	return s
+}
+
+// SetMetadata sets the Metadata field's value.
+func (s *TrustedAdvisorResourceDetail) SetMetadata(v []*string) *TrustedAdvisorResourceDetail {
+	s.Metadata = v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *TrustedAdvisorResourceDetail) SetRegion(v string) *TrustedAdvisorResourceDetail {
+	s.Region = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *TrustedAdvisorResourceDetail) SetResourceId(v string) *TrustedAdvisorResourceDetail {
+	s.ResourceId = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *TrustedAdvisorResourceDetail) SetStatus(v string) *TrustedAdvisorResourceDetail {
+	s.Status = &v
+	return s
+}
+
 // Details about AWS resources that were analyzed in a call to Trusted Advisor
 // DescribeTrustedAdvisorCheckSummaries.
 type TrustedAdvisorResourcesSummary struct {
@@ -2545,4 +3241,28 @@ func (s TrustedAdvisorResourcesSummary) String() string {
 // GoString returns the string representation
 func (s TrustedAdvisorResourcesSummary) GoString() string {
 	return s.String()
+}
+
+// SetResourcesFlagged sets the ResourcesFlagged field's value.
+func (s *TrustedAdvisorResourcesSummary) SetResourcesFlagged(v int64) *TrustedAdvisorResourcesSummary {
+	s.ResourcesFlagged = &v
+	return s
+}
+
+// SetResourcesIgnored sets the ResourcesIgnored field's value.
+func (s *TrustedAdvisorResourcesSummary) SetResourcesIgnored(v int64) *TrustedAdvisorResourcesSummary {
+	s.ResourcesIgnored = &v
+	return s
+}
+
+// SetResourcesProcessed sets the ResourcesProcessed field's value.
+func (s *TrustedAdvisorResourcesSummary) SetResourcesProcessed(v int64) *TrustedAdvisorResourcesSummary {
+	s.ResourcesProcessed = &v
+	return s
+}
+
+// SetResourcesSuppressed sets the ResourcesSuppressed field's value.
+func (s *TrustedAdvisorResourcesSummary) SetResourcesSuppressed(v int64) *TrustedAdvisorResourcesSummary {
+	s.ResourcesSuppressed = &v
+	return s
 }

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -3241,6 +3241,18 @@ func (s ActivityTaskCancelRequestedEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetActivityId sets the ActivityId field's value.
+func (s *ActivityTaskCancelRequestedEventAttributes) SetActivityId(v string) *ActivityTaskCancelRequestedEventAttributes {
+	s.ActivityId = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *ActivityTaskCancelRequestedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *ActivityTaskCancelRequestedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
 // Provides details of the ActivityTaskCanceled event.
 type ActivityTaskCanceledEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -3278,6 +3290,30 @@ func (s ActivityTaskCanceledEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDetails sets the Details field's value.
+func (s *ActivityTaskCanceledEventAttributes) SetDetails(v string) *ActivityTaskCanceledEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetLatestCancelRequestedEventId sets the LatestCancelRequestedEventId field's value.
+func (s *ActivityTaskCanceledEventAttributes) SetLatestCancelRequestedEventId(v int64) *ActivityTaskCanceledEventAttributes {
+	s.LatestCancelRequestedEventId = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *ActivityTaskCanceledEventAttributes) SetScheduledEventId(v int64) *ActivityTaskCanceledEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ActivityTaskCanceledEventAttributes) SetStartedEventId(v int64) *ActivityTaskCanceledEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
 // Provides details of the ActivityTaskCompleted event.
 type ActivityTaskCompletedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -3308,6 +3344,24 @@ func (s ActivityTaskCompletedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ActivityTaskCompletedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetResult sets the Result field's value.
+func (s *ActivityTaskCompletedEventAttributes) SetResult(v string) *ActivityTaskCompletedEventAttributes {
+	s.Result = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *ActivityTaskCompletedEventAttributes) SetScheduledEventId(v int64) *ActivityTaskCompletedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ActivityTaskCompletedEventAttributes) SetStartedEventId(v int64) *ActivityTaskCompletedEventAttributes {
+	s.StartedEventId = &v
+	return s
 }
 
 // Provides details of the ActivityTaskFailed event.
@@ -3343,6 +3397,30 @@ func (s ActivityTaskFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ActivityTaskFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetDetails sets the Details field's value.
+func (s *ActivityTaskFailedEventAttributes) SetDetails(v string) *ActivityTaskFailedEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *ActivityTaskFailedEventAttributes) SetReason(v string) *ActivityTaskFailedEventAttributes {
+	s.Reason = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *ActivityTaskFailedEventAttributes) SetScheduledEventId(v int64) *ActivityTaskFailedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ActivityTaskFailedEventAttributes) SetStartedEventId(v int64) *ActivityTaskFailedEventAttributes {
+	s.StartedEventId = &v
+	return s
 }
 
 // Provides details of the ActivityTaskScheduled event.
@@ -3418,6 +3496,72 @@ func (s ActivityTaskScheduledEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetActivityId sets the ActivityId field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetActivityId(v string) *ActivityTaskScheduledEventAttributes {
+	s.ActivityId = &v
+	return s
+}
+
+// SetActivityType sets the ActivityType field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetActivityType(v *ActivityType) *ActivityTaskScheduledEventAttributes {
+	s.ActivityType = v
+	return s
+}
+
+// SetControl sets the Control field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetControl(v string) *ActivityTaskScheduledEventAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetDecisionTaskCompletedEventId(v int64) *ActivityTaskScheduledEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetHeartbeatTimeout sets the HeartbeatTimeout field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetHeartbeatTimeout(v string) *ActivityTaskScheduledEventAttributes {
+	s.HeartbeatTimeout = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetInput(v string) *ActivityTaskScheduledEventAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetScheduleToCloseTimeout sets the ScheduleToCloseTimeout field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetScheduleToCloseTimeout(v string) *ActivityTaskScheduledEventAttributes {
+	s.ScheduleToCloseTimeout = &v
+	return s
+}
+
+// SetScheduleToStartTimeout sets the ScheduleToStartTimeout field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetScheduleToStartTimeout(v string) *ActivityTaskScheduledEventAttributes {
+	s.ScheduleToStartTimeout = &v
+	return s
+}
+
+// SetStartToCloseTimeout sets the StartToCloseTimeout field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetStartToCloseTimeout(v string) *ActivityTaskScheduledEventAttributes {
+	s.StartToCloseTimeout = &v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetTaskList(v *TaskList) *ActivityTaskScheduledEventAttributes {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *ActivityTaskScheduledEventAttributes) SetTaskPriority(v string) *ActivityTaskScheduledEventAttributes {
+	s.TaskPriority = &v
+	return s
+}
+
 // Provides details of the ActivityTaskStarted event.
 type ActivityTaskStartedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -3442,6 +3586,18 @@ func (s ActivityTaskStartedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ActivityTaskStartedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *ActivityTaskStartedEventAttributes) SetIdentity(v string) *ActivityTaskStartedEventAttributes {
+	s.Identity = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *ActivityTaskStartedEventAttributes) SetScheduledEventId(v int64) *ActivityTaskStartedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
 }
 
 // Provides details of the ActivityTaskTimedOut event.
@@ -3480,6 +3636,30 @@ func (s ActivityTaskTimedOutEventAttributes) String() string {
 // GoString returns the string representation
 func (s ActivityTaskTimedOutEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetDetails sets the Details field's value.
+func (s *ActivityTaskTimedOutEventAttributes) SetDetails(v string) *ActivityTaskTimedOutEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *ActivityTaskTimedOutEventAttributes) SetScheduledEventId(v int64) *ActivityTaskTimedOutEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ActivityTaskTimedOutEventAttributes) SetStartedEventId(v int64) *ActivityTaskTimedOutEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetTimeoutType sets the TimeoutType field's value.
+func (s *ActivityTaskTimedOutEventAttributes) SetTimeoutType(v string) *ActivityTaskTimedOutEventAttributes {
+	s.TimeoutType = &v
+	return s
 }
 
 // Represents an activity type.
@@ -3533,6 +3713,18 @@ func (s *ActivityType) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *ActivityType) SetName(v string) *ActivityType {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *ActivityType) SetVersion(v string) *ActivityType {
+	s.Version = &v
+	return s
 }
 
 // Configuration settings registered with the activity type.
@@ -3607,6 +3799,42 @@ func (s ActivityTypeConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetDefaultTaskHeartbeatTimeout sets the DefaultTaskHeartbeatTimeout field's value.
+func (s *ActivityTypeConfiguration) SetDefaultTaskHeartbeatTimeout(v string) *ActivityTypeConfiguration {
+	s.DefaultTaskHeartbeatTimeout = &v
+	return s
+}
+
+// SetDefaultTaskList sets the DefaultTaskList field's value.
+func (s *ActivityTypeConfiguration) SetDefaultTaskList(v *TaskList) *ActivityTypeConfiguration {
+	s.DefaultTaskList = v
+	return s
+}
+
+// SetDefaultTaskPriority sets the DefaultTaskPriority field's value.
+func (s *ActivityTypeConfiguration) SetDefaultTaskPriority(v string) *ActivityTypeConfiguration {
+	s.DefaultTaskPriority = &v
+	return s
+}
+
+// SetDefaultTaskScheduleToCloseTimeout sets the DefaultTaskScheduleToCloseTimeout field's value.
+func (s *ActivityTypeConfiguration) SetDefaultTaskScheduleToCloseTimeout(v string) *ActivityTypeConfiguration {
+	s.DefaultTaskScheduleToCloseTimeout = &v
+	return s
+}
+
+// SetDefaultTaskScheduleToStartTimeout sets the DefaultTaskScheduleToStartTimeout field's value.
+func (s *ActivityTypeConfiguration) SetDefaultTaskScheduleToStartTimeout(v string) *ActivityTypeConfiguration {
+	s.DefaultTaskScheduleToStartTimeout = &v
+	return s
+}
+
+// SetDefaultTaskStartToCloseTimeout sets the DefaultTaskStartToCloseTimeout field's value.
+func (s *ActivityTypeConfiguration) SetDefaultTaskStartToCloseTimeout(v string) *ActivityTypeConfiguration {
+	s.DefaultTaskStartToCloseTimeout = &v
+	return s
+}
+
 // Detailed information about an activity type.
 type ActivityTypeInfo struct {
 	_ struct{} `type:"structure"`
@@ -3641,6 +3869,36 @@ func (s ActivityTypeInfo) String() string {
 // GoString returns the string representation
 func (s ActivityTypeInfo) GoString() string {
 	return s.String()
+}
+
+// SetActivityType sets the ActivityType field's value.
+func (s *ActivityTypeInfo) SetActivityType(v *ActivityType) *ActivityTypeInfo {
+	s.ActivityType = v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *ActivityTypeInfo) SetCreationDate(v time.Time) *ActivityTypeInfo {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDeprecationDate sets the DeprecationDate field's value.
+func (s *ActivityTypeInfo) SetDeprecationDate(v time.Time) *ActivityTypeInfo {
+	s.DeprecationDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ActivityTypeInfo) SetDescription(v string) *ActivityTypeInfo {
+	s.Description = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ActivityTypeInfo) SetStatus(v string) *ActivityTypeInfo {
+	s.Status = &v
+	return s
 }
 
 // Provides details of the CancelTimer decision.
@@ -3696,6 +3954,12 @@ func (s *CancelTimerDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetTimerId sets the TimerId field's value.
+func (s *CancelTimerDecisionAttributes) SetTimerId(v string) *CancelTimerDecisionAttributes {
+	s.TimerId = &v
+	return s
+}
+
 // Provides details of the CancelTimerFailed event.
 type CancelTimerFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -3734,6 +3998,24 @@ func (s CancelTimerFailedEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetCause sets the Cause field's value.
+func (s *CancelTimerFailedEventAttributes) SetCause(v string) *CancelTimerFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *CancelTimerFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *CancelTimerFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetTimerId sets the TimerId field's value.
+func (s *CancelTimerFailedEventAttributes) SetTimerId(v string) *CancelTimerFailedEventAttributes {
+	s.TimerId = &v
+	return s
+}
+
 // Provides details of the CancelWorkflowExecution decision.
 //
 // Access Control
@@ -3769,6 +4051,12 @@ func (s CancelWorkflowExecutionDecisionAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDetails sets the Details field's value.
+func (s *CancelWorkflowExecutionDecisionAttributes) SetDetails(v string) *CancelWorkflowExecutionDecisionAttributes {
+	s.Details = &v
+	return s
+}
+
 // Provides details of the CancelWorkflowExecutionFailed event.
 type CancelWorkflowExecutionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -3800,6 +4088,18 @@ func (s CancelWorkflowExecutionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s CancelWorkflowExecutionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *CancelWorkflowExecutionFailedEventAttributes) SetCause(v string) *CancelWorkflowExecutionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *CancelWorkflowExecutionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *CancelWorkflowExecutionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
 }
 
 // Provide details of the ChildWorkflowExecutionCanceled event.
@@ -3845,6 +4145,36 @@ func (s ChildWorkflowExecutionCanceledEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDetails sets the Details field's value.
+func (s *ChildWorkflowExecutionCanceledEventAttributes) SetDetails(v string) *ChildWorkflowExecutionCanceledEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *ChildWorkflowExecutionCanceledEventAttributes) SetInitiatedEventId(v int64) *ChildWorkflowExecutionCanceledEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ChildWorkflowExecutionCanceledEventAttributes) SetStartedEventId(v int64) *ChildWorkflowExecutionCanceledEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *ChildWorkflowExecutionCanceledEventAttributes) SetWorkflowExecution(v *WorkflowExecution) *ChildWorkflowExecutionCanceledEventAttributes {
+	s.WorkflowExecution = v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *ChildWorkflowExecutionCanceledEventAttributes) SetWorkflowType(v *WorkflowType) *ChildWorkflowExecutionCanceledEventAttributes {
+	s.WorkflowType = v
+	return s
+}
+
 // Provides details of the ChildWorkflowExecutionCompleted event.
 type ChildWorkflowExecutionCompletedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -3886,6 +4216,36 @@ func (s ChildWorkflowExecutionCompletedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ChildWorkflowExecutionCompletedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *ChildWorkflowExecutionCompletedEventAttributes) SetInitiatedEventId(v int64) *ChildWorkflowExecutionCompletedEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *ChildWorkflowExecutionCompletedEventAttributes) SetResult(v string) *ChildWorkflowExecutionCompletedEventAttributes {
+	s.Result = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ChildWorkflowExecutionCompletedEventAttributes) SetStartedEventId(v int64) *ChildWorkflowExecutionCompletedEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *ChildWorkflowExecutionCompletedEventAttributes) SetWorkflowExecution(v *WorkflowExecution) *ChildWorkflowExecutionCompletedEventAttributes {
+	s.WorkflowExecution = v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *ChildWorkflowExecutionCompletedEventAttributes) SetWorkflowType(v *WorkflowType) *ChildWorkflowExecutionCompletedEventAttributes {
+	s.WorkflowType = v
+	return s
 }
 
 // Provides details of the ChildWorkflowExecutionFailed event.
@@ -3934,6 +4294,42 @@ func (s ChildWorkflowExecutionFailedEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDetails sets the Details field's value.
+func (s *ChildWorkflowExecutionFailedEventAttributes) SetDetails(v string) *ChildWorkflowExecutionFailedEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *ChildWorkflowExecutionFailedEventAttributes) SetInitiatedEventId(v int64) *ChildWorkflowExecutionFailedEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *ChildWorkflowExecutionFailedEventAttributes) SetReason(v string) *ChildWorkflowExecutionFailedEventAttributes {
+	s.Reason = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ChildWorkflowExecutionFailedEventAttributes) SetStartedEventId(v int64) *ChildWorkflowExecutionFailedEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *ChildWorkflowExecutionFailedEventAttributes) SetWorkflowExecution(v *WorkflowExecution) *ChildWorkflowExecutionFailedEventAttributes {
+	s.WorkflowExecution = v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *ChildWorkflowExecutionFailedEventAttributes) SetWorkflowType(v *WorkflowType) *ChildWorkflowExecutionFailedEventAttributes {
+	s.WorkflowType = v
+	return s
+}
+
 // Provides details of the ChildWorkflowExecutionStarted event.
 type ChildWorkflowExecutionStartedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -3965,6 +4361,24 @@ func (s ChildWorkflowExecutionStartedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ChildWorkflowExecutionStartedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *ChildWorkflowExecutionStartedEventAttributes) SetInitiatedEventId(v int64) *ChildWorkflowExecutionStartedEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *ChildWorkflowExecutionStartedEventAttributes) SetWorkflowExecution(v *WorkflowExecution) *ChildWorkflowExecutionStartedEventAttributes {
+	s.WorkflowExecution = v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *ChildWorkflowExecutionStartedEventAttributes) SetWorkflowType(v *WorkflowType) *ChildWorkflowExecutionStartedEventAttributes {
+	s.WorkflowType = v
+	return s
 }
 
 // Provides details of the ChildWorkflowExecutionTerminated event.
@@ -4005,6 +4419,30 @@ func (s ChildWorkflowExecutionTerminatedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ChildWorkflowExecutionTerminatedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *ChildWorkflowExecutionTerminatedEventAttributes) SetInitiatedEventId(v int64) *ChildWorkflowExecutionTerminatedEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ChildWorkflowExecutionTerminatedEventAttributes) SetStartedEventId(v int64) *ChildWorkflowExecutionTerminatedEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *ChildWorkflowExecutionTerminatedEventAttributes) SetWorkflowExecution(v *WorkflowExecution) *ChildWorkflowExecutionTerminatedEventAttributes {
+	s.WorkflowExecution = v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *ChildWorkflowExecutionTerminatedEventAttributes) SetWorkflowType(v *WorkflowType) *ChildWorkflowExecutionTerminatedEventAttributes {
+	s.WorkflowType = v
+	return s
 }
 
 // Provides details of the ChildWorkflowExecutionTimedOut event.
@@ -4053,6 +4491,36 @@ func (s ChildWorkflowExecutionTimedOutEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *ChildWorkflowExecutionTimedOutEventAttributes) SetInitiatedEventId(v int64) *ChildWorkflowExecutionTimedOutEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *ChildWorkflowExecutionTimedOutEventAttributes) SetStartedEventId(v int64) *ChildWorkflowExecutionTimedOutEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetTimeoutType sets the TimeoutType field's value.
+func (s *ChildWorkflowExecutionTimedOutEventAttributes) SetTimeoutType(v string) *ChildWorkflowExecutionTimedOutEventAttributes {
+	s.TimeoutType = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *ChildWorkflowExecutionTimedOutEventAttributes) SetWorkflowExecution(v *WorkflowExecution) *ChildWorkflowExecutionTimedOutEventAttributes {
+	s.WorkflowExecution = v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *ChildWorkflowExecutionTimedOutEventAttributes) SetWorkflowType(v *WorkflowType) *ChildWorkflowExecutionTimedOutEventAttributes {
+	s.WorkflowType = v
+	return s
+}
+
 // Used to filter the closed workflow executions in visibility APIs by their
 // close status.
 type CloseStatusFilter struct {
@@ -4086,6 +4554,12 @@ func (s *CloseStatusFilter) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetStatus sets the Status field's value.
+func (s *CloseStatusFilter) SetStatus(v string) *CloseStatusFilter {
+	s.Status = &v
+	return s
 }
 
 // Provides details of the CompleteWorkflowExecution decision.
@@ -4124,6 +4598,12 @@ func (s CompleteWorkflowExecutionDecisionAttributes) GoString() string {
 	return s.String()
 }
 
+// SetResult sets the Result field's value.
+func (s *CompleteWorkflowExecutionDecisionAttributes) SetResult(v string) *CompleteWorkflowExecutionDecisionAttributes {
+	s.Result = &v
+	return s
+}
+
 // Provides details of the CompleteWorkflowExecutionFailed event.
 type CompleteWorkflowExecutionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -4155,6 +4635,18 @@ func (s CompleteWorkflowExecutionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s CompleteWorkflowExecutionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *CompleteWorkflowExecutionFailedEventAttributes) SetCause(v string) *CompleteWorkflowExecutionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *CompleteWorkflowExecutionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *CompleteWorkflowExecutionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
 }
 
 // Provides details of the ContinueAsNewWorkflowExecution decision.
@@ -4292,6 +4784,60 @@ func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetChildPolicy(v string) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetExecutionStartToCloseTimeout sets the ExecutionStartToCloseTimeout field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetExecutionStartToCloseTimeout(v string) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.ExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetInput(v string) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetLambdaRole sets the LambdaRole field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetLambdaRole(v string) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.LambdaRole = &v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetTagList(v []*string) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.TagList = v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetTaskList(v *TaskList) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetTaskPriority(v string) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.TaskPriority = &v
+	return s
+}
+
+// SetTaskStartToCloseTimeout sets the TaskStartToCloseTimeout field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetTaskStartToCloseTimeout(v string) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.TaskStartToCloseTimeout = &v
+	return s
+}
+
+// SetWorkflowTypeVersion sets the WorkflowTypeVersion field's value.
+func (s *ContinueAsNewWorkflowExecutionDecisionAttributes) SetWorkflowTypeVersion(v string) *ContinueAsNewWorkflowExecutionDecisionAttributes {
+	s.WorkflowTypeVersion = &v
+	return s
+}
+
 // Provides details of the ContinueAsNewWorkflowExecutionFailed event.
 type ContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -4323,6 +4869,18 @@ func (s ContinueAsNewWorkflowExecutionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ContinueAsNewWorkflowExecutionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *ContinueAsNewWorkflowExecutionFailedEventAttributes) SetCause(v string) *ContinueAsNewWorkflowExecutionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *ContinueAsNewWorkflowExecutionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *ContinueAsNewWorkflowExecutionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
 }
 
 type CountClosedWorkflowExecutionsInput struct {
@@ -4431,6 +4989,48 @@ func (s *CountClosedWorkflowExecutionsInput) Validate() error {
 	return nil
 }
 
+// SetCloseStatusFilter sets the CloseStatusFilter field's value.
+func (s *CountClosedWorkflowExecutionsInput) SetCloseStatusFilter(v *CloseStatusFilter) *CountClosedWorkflowExecutionsInput {
+	s.CloseStatusFilter = v
+	return s
+}
+
+// SetCloseTimeFilter sets the CloseTimeFilter field's value.
+func (s *CountClosedWorkflowExecutionsInput) SetCloseTimeFilter(v *ExecutionTimeFilter) *CountClosedWorkflowExecutionsInput {
+	s.CloseTimeFilter = v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *CountClosedWorkflowExecutionsInput) SetDomain(v string) *CountClosedWorkflowExecutionsInput {
+	s.Domain = &v
+	return s
+}
+
+// SetExecutionFilter sets the ExecutionFilter field's value.
+func (s *CountClosedWorkflowExecutionsInput) SetExecutionFilter(v *WorkflowExecutionFilter) *CountClosedWorkflowExecutionsInput {
+	s.ExecutionFilter = v
+	return s
+}
+
+// SetStartTimeFilter sets the StartTimeFilter field's value.
+func (s *CountClosedWorkflowExecutionsInput) SetStartTimeFilter(v *ExecutionTimeFilter) *CountClosedWorkflowExecutionsInput {
+	s.StartTimeFilter = v
+	return s
+}
+
+// SetTagFilter sets the TagFilter field's value.
+func (s *CountClosedWorkflowExecutionsInput) SetTagFilter(v *TagFilter) *CountClosedWorkflowExecutionsInput {
+	s.TagFilter = v
+	return s
+}
+
+// SetTypeFilter sets the TypeFilter field's value.
+func (s *CountClosedWorkflowExecutionsInput) SetTypeFilter(v *WorkflowTypeFilter) *CountClosedWorkflowExecutionsInput {
+	s.TypeFilter = v
+	return s
+}
+
 type CountOpenWorkflowExecutionsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4515,6 +5115,36 @@ func (s *CountOpenWorkflowExecutionsInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *CountOpenWorkflowExecutionsInput) SetDomain(v string) *CountOpenWorkflowExecutionsInput {
+	s.Domain = &v
+	return s
+}
+
+// SetExecutionFilter sets the ExecutionFilter field's value.
+func (s *CountOpenWorkflowExecutionsInput) SetExecutionFilter(v *WorkflowExecutionFilter) *CountOpenWorkflowExecutionsInput {
+	s.ExecutionFilter = v
+	return s
+}
+
+// SetStartTimeFilter sets the StartTimeFilter field's value.
+func (s *CountOpenWorkflowExecutionsInput) SetStartTimeFilter(v *ExecutionTimeFilter) *CountOpenWorkflowExecutionsInput {
+	s.StartTimeFilter = v
+	return s
+}
+
+// SetTagFilter sets the TagFilter field's value.
+func (s *CountOpenWorkflowExecutionsInput) SetTagFilter(v *TagFilter) *CountOpenWorkflowExecutionsInput {
+	s.TagFilter = v
+	return s
+}
+
+// SetTypeFilter sets the TypeFilter field's value.
+func (s *CountOpenWorkflowExecutionsInput) SetTypeFilter(v *WorkflowTypeFilter) *CountOpenWorkflowExecutionsInput {
+	s.TypeFilter = v
+	return s
+}
+
 type CountPendingActivityTasksInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4563,6 +5193,18 @@ func (s *CountPendingActivityTasksInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *CountPendingActivityTasksInput) SetDomain(v string) *CountPendingActivityTasksInput {
+	s.Domain = &v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *CountPendingActivityTasksInput) SetTaskList(v *TaskList) *CountPendingActivityTasksInput {
+	s.TaskList = v
+	return s
+}
+
 type CountPendingDecisionTasksInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4609,6 +5251,18 @@ func (s *CountPendingDecisionTasksInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomain sets the Domain field's value.
+func (s *CountPendingDecisionTasksInput) SetDomain(v string) *CountPendingDecisionTasksInput {
+	s.Domain = &v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *CountPendingDecisionTasksInput) SetTaskList(v *TaskList) *CountPendingDecisionTasksInput {
+	s.TaskList = v
+	return s
 }
 
 // Specifies a decision made by the decider. A decision can be one of these
@@ -4900,6 +5554,90 @@ func (s *Decision) Validate() error {
 	return nil
 }
 
+// SetCancelTimerDecisionAttributes sets the CancelTimerDecisionAttributes field's value.
+func (s *Decision) SetCancelTimerDecisionAttributes(v *CancelTimerDecisionAttributes) *Decision {
+	s.CancelTimerDecisionAttributes = v
+	return s
+}
+
+// SetCancelWorkflowExecutionDecisionAttributes sets the CancelWorkflowExecutionDecisionAttributes field's value.
+func (s *Decision) SetCancelWorkflowExecutionDecisionAttributes(v *CancelWorkflowExecutionDecisionAttributes) *Decision {
+	s.CancelWorkflowExecutionDecisionAttributes = v
+	return s
+}
+
+// SetCompleteWorkflowExecutionDecisionAttributes sets the CompleteWorkflowExecutionDecisionAttributes field's value.
+func (s *Decision) SetCompleteWorkflowExecutionDecisionAttributes(v *CompleteWorkflowExecutionDecisionAttributes) *Decision {
+	s.CompleteWorkflowExecutionDecisionAttributes = v
+	return s
+}
+
+// SetContinueAsNewWorkflowExecutionDecisionAttributes sets the ContinueAsNewWorkflowExecutionDecisionAttributes field's value.
+func (s *Decision) SetContinueAsNewWorkflowExecutionDecisionAttributes(v *ContinueAsNewWorkflowExecutionDecisionAttributes) *Decision {
+	s.ContinueAsNewWorkflowExecutionDecisionAttributes = v
+	return s
+}
+
+// SetDecisionType sets the DecisionType field's value.
+func (s *Decision) SetDecisionType(v string) *Decision {
+	s.DecisionType = &v
+	return s
+}
+
+// SetFailWorkflowExecutionDecisionAttributes sets the FailWorkflowExecutionDecisionAttributes field's value.
+func (s *Decision) SetFailWorkflowExecutionDecisionAttributes(v *FailWorkflowExecutionDecisionAttributes) *Decision {
+	s.FailWorkflowExecutionDecisionAttributes = v
+	return s
+}
+
+// SetRecordMarkerDecisionAttributes sets the RecordMarkerDecisionAttributes field's value.
+func (s *Decision) SetRecordMarkerDecisionAttributes(v *RecordMarkerDecisionAttributes) *Decision {
+	s.RecordMarkerDecisionAttributes = v
+	return s
+}
+
+// SetRequestCancelActivityTaskDecisionAttributes sets the RequestCancelActivityTaskDecisionAttributes field's value.
+func (s *Decision) SetRequestCancelActivityTaskDecisionAttributes(v *RequestCancelActivityTaskDecisionAttributes) *Decision {
+	s.RequestCancelActivityTaskDecisionAttributes = v
+	return s
+}
+
+// SetRequestCancelExternalWorkflowExecutionDecisionAttributes sets the RequestCancelExternalWorkflowExecutionDecisionAttributes field's value.
+func (s *Decision) SetRequestCancelExternalWorkflowExecutionDecisionAttributes(v *RequestCancelExternalWorkflowExecutionDecisionAttributes) *Decision {
+	s.RequestCancelExternalWorkflowExecutionDecisionAttributes = v
+	return s
+}
+
+// SetScheduleActivityTaskDecisionAttributes sets the ScheduleActivityTaskDecisionAttributes field's value.
+func (s *Decision) SetScheduleActivityTaskDecisionAttributes(v *ScheduleActivityTaskDecisionAttributes) *Decision {
+	s.ScheduleActivityTaskDecisionAttributes = v
+	return s
+}
+
+// SetScheduleLambdaFunctionDecisionAttributes sets the ScheduleLambdaFunctionDecisionAttributes field's value.
+func (s *Decision) SetScheduleLambdaFunctionDecisionAttributes(v *ScheduleLambdaFunctionDecisionAttributes) *Decision {
+	s.ScheduleLambdaFunctionDecisionAttributes = v
+	return s
+}
+
+// SetSignalExternalWorkflowExecutionDecisionAttributes sets the SignalExternalWorkflowExecutionDecisionAttributes field's value.
+func (s *Decision) SetSignalExternalWorkflowExecutionDecisionAttributes(v *SignalExternalWorkflowExecutionDecisionAttributes) *Decision {
+	s.SignalExternalWorkflowExecutionDecisionAttributes = v
+	return s
+}
+
+// SetStartChildWorkflowExecutionDecisionAttributes sets the StartChildWorkflowExecutionDecisionAttributes field's value.
+func (s *Decision) SetStartChildWorkflowExecutionDecisionAttributes(v *StartChildWorkflowExecutionDecisionAttributes) *Decision {
+	s.StartChildWorkflowExecutionDecisionAttributes = v
+	return s
+}
+
+// SetStartTimerDecisionAttributes sets the StartTimerDecisionAttributes field's value.
+func (s *Decision) SetStartTimerDecisionAttributes(v *StartTimerDecisionAttributes) *Decision {
+	s.StartTimerDecisionAttributes = v
+	return s
+}
+
 // Provides details of the DecisionTaskCompleted event.
 type DecisionTaskCompletedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -4930,6 +5668,24 @@ func (s DecisionTaskCompletedEventAttributes) String() string {
 // GoString returns the string representation
 func (s DecisionTaskCompletedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetExecutionContext sets the ExecutionContext field's value.
+func (s *DecisionTaskCompletedEventAttributes) SetExecutionContext(v string) *DecisionTaskCompletedEventAttributes {
+	s.ExecutionContext = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *DecisionTaskCompletedEventAttributes) SetScheduledEventId(v int64) *DecisionTaskCompletedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *DecisionTaskCompletedEventAttributes) SetStartedEventId(v int64) *DecisionTaskCompletedEventAttributes {
+	s.StartedEventId = &v
+	return s
 }
 
 // Provides details about the DecisionTaskScheduled event.
@@ -4969,6 +5725,24 @@ func (s DecisionTaskScheduledEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetStartToCloseTimeout sets the StartToCloseTimeout field's value.
+func (s *DecisionTaskScheduledEventAttributes) SetStartToCloseTimeout(v string) *DecisionTaskScheduledEventAttributes {
+	s.StartToCloseTimeout = &v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *DecisionTaskScheduledEventAttributes) SetTaskList(v *TaskList) *DecisionTaskScheduledEventAttributes {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *DecisionTaskScheduledEventAttributes) SetTaskPriority(v string) *DecisionTaskScheduledEventAttributes {
+	s.TaskPriority = &v
+	return s
+}
+
 // Provides details of the DecisionTaskStarted event.
 type DecisionTaskStartedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -4993,6 +5767,18 @@ func (s DecisionTaskStartedEventAttributes) String() string {
 // GoString returns the string representation
 func (s DecisionTaskStartedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *DecisionTaskStartedEventAttributes) SetIdentity(v string) *DecisionTaskStartedEventAttributes {
+	s.Identity = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *DecisionTaskStartedEventAttributes) SetScheduledEventId(v int64) *DecisionTaskStartedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
 }
 
 // Provides details of the DecisionTaskTimedOut event.
@@ -5027,6 +5813,24 @@ func (s DecisionTaskTimedOutEventAttributes) String() string {
 // GoString returns the string representation
 func (s DecisionTaskTimedOutEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *DecisionTaskTimedOutEventAttributes) SetScheduledEventId(v int64) *DecisionTaskTimedOutEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *DecisionTaskTimedOutEventAttributes) SetStartedEventId(v int64) *DecisionTaskTimedOutEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetTimeoutType sets the TimeoutType field's value.
+func (s *DecisionTaskTimedOutEventAttributes) SetTimeoutType(v string) *DecisionTaskTimedOutEventAttributes {
+	s.TimeoutType = &v
+	return s
 }
 
 type DeprecateActivityTypeInput struct {
@@ -5077,6 +5881,18 @@ func (s *DeprecateActivityTypeInput) Validate() error {
 	return nil
 }
 
+// SetActivityType sets the ActivityType field's value.
+func (s *DeprecateActivityTypeInput) SetActivityType(v *ActivityType) *DeprecateActivityTypeInput {
+	s.ActivityType = v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *DeprecateActivityTypeInput) SetDomain(v string) *DeprecateActivityTypeInput {
+	s.Domain = &v
+	return s
+}
+
 type DeprecateActivityTypeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5124,6 +5940,12 @@ func (s *DeprecateDomainInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DeprecateDomainInput) SetName(v string) *DeprecateDomainInput {
+	s.Name = &v
+	return s
 }
 
 type DeprecateDomainOutput struct {
@@ -5186,6 +6008,18 @@ func (s *DeprecateWorkflowTypeInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomain sets the Domain field's value.
+func (s *DeprecateWorkflowTypeInput) SetDomain(v string) *DeprecateWorkflowTypeInput {
+	s.Domain = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *DeprecateWorkflowTypeInput) SetWorkflowType(v *WorkflowType) *DeprecateWorkflowTypeInput {
+	s.WorkflowType = v
+	return s
 }
 
 type DeprecateWorkflowTypeOutput struct {
@@ -5251,6 +6085,18 @@ func (s *DescribeActivityTypeInput) Validate() error {
 	return nil
 }
 
+// SetActivityType sets the ActivityType field's value.
+func (s *DescribeActivityTypeInput) SetActivityType(v *ActivityType) *DescribeActivityTypeInput {
+	s.ActivityType = v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *DescribeActivityTypeInput) SetDomain(v string) *DescribeActivityTypeInput {
+	s.Domain = &v
+	return s
+}
+
 // Detailed information about an activity type.
 type DescribeActivityTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -5283,6 +6129,18 @@ func (s DescribeActivityTypeOutput) String() string {
 // GoString returns the string representation
 func (s DescribeActivityTypeOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *DescribeActivityTypeOutput) SetConfiguration(v *ActivityTypeConfiguration) *DescribeActivityTypeOutput {
+	s.Configuration = v
+	return s
+}
+
+// SetTypeInfo sets the TypeInfo field's value.
+func (s *DescribeActivityTypeOutput) SetTypeInfo(v *ActivityTypeInfo) *DescribeActivityTypeOutput {
+	s.TypeInfo = v
+	return s
 }
 
 type DescribeDomainInput struct {
@@ -5320,6 +6178,12 @@ func (s *DescribeDomainInput) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *DescribeDomainInput) SetName(v string) *DescribeDomainInput {
+	s.Name = &v
+	return s
+}
+
 // Contains details of a domain.
 type DescribeDomainOutput struct {
 	_ struct{} `type:"structure"`
@@ -5343,6 +6207,18 @@ func (s DescribeDomainOutput) String() string {
 // GoString returns the string representation
 func (s DescribeDomainOutput) GoString() string {
 	return s.String()
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *DescribeDomainOutput) SetConfiguration(v *DomainConfiguration) *DescribeDomainOutput {
+	s.Configuration = v
+	return s
+}
+
+// SetDomainInfo sets the DomainInfo field's value.
+func (s *DescribeDomainOutput) SetDomainInfo(v *DomainInfo) *DescribeDomainOutput {
+	s.DomainInfo = v
+	return s
 }
 
 type DescribeWorkflowExecutionInput struct {
@@ -5393,6 +6269,18 @@ func (s *DescribeWorkflowExecutionInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *DescribeWorkflowExecutionInput) SetDomain(v string) *DescribeWorkflowExecutionInput {
+	s.Domain = &v
+	return s
+}
+
+// SetExecution sets the Execution field's value.
+func (s *DescribeWorkflowExecutionInput) SetExecution(v *WorkflowExecution) *DescribeWorkflowExecutionInput {
+	s.Execution = v
+	return s
+}
+
 // Contains details about a workflow execution.
 type DescribeWorkflowExecutionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5433,6 +6321,36 @@ func (s DescribeWorkflowExecutionOutput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkflowExecutionOutput) GoString() string {
 	return s.String()
+}
+
+// SetExecutionConfiguration sets the ExecutionConfiguration field's value.
+func (s *DescribeWorkflowExecutionOutput) SetExecutionConfiguration(v *WorkflowExecutionConfiguration) *DescribeWorkflowExecutionOutput {
+	s.ExecutionConfiguration = v
+	return s
+}
+
+// SetExecutionInfo sets the ExecutionInfo field's value.
+func (s *DescribeWorkflowExecutionOutput) SetExecutionInfo(v *WorkflowExecutionInfo) *DescribeWorkflowExecutionOutput {
+	s.ExecutionInfo = v
+	return s
+}
+
+// SetLatestActivityTaskTimestamp sets the LatestActivityTaskTimestamp field's value.
+func (s *DescribeWorkflowExecutionOutput) SetLatestActivityTaskTimestamp(v time.Time) *DescribeWorkflowExecutionOutput {
+	s.LatestActivityTaskTimestamp = &v
+	return s
+}
+
+// SetLatestExecutionContext sets the LatestExecutionContext field's value.
+func (s *DescribeWorkflowExecutionOutput) SetLatestExecutionContext(v string) *DescribeWorkflowExecutionOutput {
+	s.LatestExecutionContext = &v
+	return s
+}
+
+// SetOpenCounts sets the OpenCounts field's value.
+func (s *DescribeWorkflowExecutionOutput) SetOpenCounts(v *WorkflowExecutionOpenCounts) *DescribeWorkflowExecutionOutput {
+	s.OpenCounts = v
+	return s
 }
 
 type DescribeWorkflowTypeInput struct {
@@ -5483,6 +6401,18 @@ func (s *DescribeWorkflowTypeInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *DescribeWorkflowTypeInput) SetDomain(v string) *DescribeWorkflowTypeInput {
+	s.Domain = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *DescribeWorkflowTypeInput) SetWorkflowType(v *WorkflowType) *DescribeWorkflowTypeInput {
+	s.WorkflowType = v
+	return s
+}
+
 // Contains details about a workflow type.
 type DescribeWorkflowTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -5517,6 +6447,18 @@ func (s DescribeWorkflowTypeOutput) GoString() string {
 	return s.String()
 }
 
+// SetConfiguration sets the Configuration field's value.
+func (s *DescribeWorkflowTypeOutput) SetConfiguration(v *WorkflowTypeConfiguration) *DescribeWorkflowTypeOutput {
+	s.Configuration = v
+	return s
+}
+
+// SetTypeInfo sets the TypeInfo field's value.
+func (s *DescribeWorkflowTypeOutput) SetTypeInfo(v *WorkflowTypeInfo) *DescribeWorkflowTypeOutput {
+	s.TypeInfo = v
+	return s
+}
+
 // Contains the configuration settings of a domain.
 type DomainConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -5535,6 +6477,12 @@ func (s DomainConfiguration) String() string {
 // GoString returns the string representation
 func (s DomainConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetWorkflowExecutionRetentionPeriodInDays sets the WorkflowExecutionRetentionPeriodInDays field's value.
+func (s *DomainConfiguration) SetWorkflowExecutionRetentionPeriodInDays(v string) *DomainConfiguration {
+	s.WorkflowExecutionRetentionPeriodInDays = &v
+	return s
 }
 
 // Contains general information about a domain.
@@ -5570,6 +6518,24 @@ func (s DomainInfo) String() string {
 // GoString returns the string representation
 func (s DomainInfo) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *DomainInfo) SetDescription(v string) *DomainInfo {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DomainInfo) SetName(v string) *DomainInfo {
+	s.Name = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DomainInfo) SetStatus(v string) *DomainInfo {
+	s.Status = &v
+	return s
 }
 
 // Used to filter the workflow executions in visibility APIs by various time-based
@@ -5612,6 +6578,18 @@ func (s *ExecutionTimeFilter) Validate() error {
 	return nil
 }
 
+// SetLatestDate sets the LatestDate field's value.
+func (s *ExecutionTimeFilter) SetLatestDate(v time.Time) *ExecutionTimeFilter {
+	s.LatestDate = &v
+	return s
+}
+
+// SetOldestDate sets the OldestDate field's value.
+func (s *ExecutionTimeFilter) SetOldestDate(v time.Time) *ExecutionTimeFilter {
+	s.OldestDate = &v
+	return s
+}
+
 // Provides details of the ExternalWorkflowExecutionCancelRequested event.
 type ExternalWorkflowExecutionCancelRequestedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -5640,6 +6618,18 @@ func (s ExternalWorkflowExecutionCancelRequestedEventAttributes) GoString() stri
 	return s.String()
 }
 
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *ExternalWorkflowExecutionCancelRequestedEventAttributes) SetInitiatedEventId(v int64) *ExternalWorkflowExecutionCancelRequestedEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *ExternalWorkflowExecutionCancelRequestedEventAttributes) SetWorkflowExecution(v *WorkflowExecution) *ExternalWorkflowExecutionCancelRequestedEventAttributes {
+	s.WorkflowExecution = v
+	return s
+}
+
 // Provides details of the ExternalWorkflowExecutionSignaled event.
 type ExternalWorkflowExecutionSignaledEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -5666,6 +6656,18 @@ func (s ExternalWorkflowExecutionSignaledEventAttributes) String() string {
 // GoString returns the string representation
 func (s ExternalWorkflowExecutionSignaledEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *ExternalWorkflowExecutionSignaledEventAttributes) SetInitiatedEventId(v int64) *ExternalWorkflowExecutionSignaledEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *ExternalWorkflowExecutionSignaledEventAttributes) SetWorkflowExecution(v *WorkflowExecution) *ExternalWorkflowExecutionSignaledEventAttributes {
+	s.WorkflowExecution = v
+	return s
 }
 
 // Provides details of the FailWorkflowExecution decision.
@@ -5706,6 +6708,18 @@ func (s FailWorkflowExecutionDecisionAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDetails sets the Details field's value.
+func (s *FailWorkflowExecutionDecisionAttributes) SetDetails(v string) *FailWorkflowExecutionDecisionAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *FailWorkflowExecutionDecisionAttributes) SetReason(v string) *FailWorkflowExecutionDecisionAttributes {
+	s.Reason = &v
+	return s
+}
+
 // Provides details of the FailWorkflowExecutionFailed event.
 type FailWorkflowExecutionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -5737,6 +6751,18 @@ func (s FailWorkflowExecutionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s FailWorkflowExecutionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *FailWorkflowExecutionFailedEventAttributes) SetCause(v string) *FailWorkflowExecutionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *FailWorkflowExecutionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *FailWorkflowExecutionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
 }
 
 type GetWorkflowExecutionHistoryInput struct {
@@ -5808,6 +6834,36 @@ func (s *GetWorkflowExecutionHistoryInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *GetWorkflowExecutionHistoryInput) SetDomain(v string) *GetWorkflowExecutionHistoryInput {
+	s.Domain = &v
+	return s
+}
+
+// SetExecution sets the Execution field's value.
+func (s *GetWorkflowExecutionHistoryInput) SetExecution(v *WorkflowExecution) *GetWorkflowExecutionHistoryInput {
+	s.Execution = v
+	return s
+}
+
+// SetMaximumPageSize sets the MaximumPageSize field's value.
+func (s *GetWorkflowExecutionHistoryInput) SetMaximumPageSize(v int64) *GetWorkflowExecutionHistoryInput {
+	s.MaximumPageSize = &v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *GetWorkflowExecutionHistoryInput) SetNextPageToken(v string) *GetWorkflowExecutionHistoryInput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetReverseOrder sets the ReverseOrder field's value.
+func (s *GetWorkflowExecutionHistoryInput) SetReverseOrder(v bool) *GetWorkflowExecutionHistoryInput {
+	s.ReverseOrder = &v
+	return s
+}
+
 // Paginated representation of a workflow history for a workflow execution.
 // This is the up to date, complete and authoritative record of the events related
 // to all tasks and events in the life of the workflow execution.
@@ -5836,6 +6892,18 @@ func (s GetWorkflowExecutionHistoryOutput) String() string {
 // GoString returns the string representation
 func (s GetWorkflowExecutionHistoryOutput) GoString() string {
 	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *GetWorkflowExecutionHistoryOutput) SetEvents(v []*HistoryEvent) *GetWorkflowExecutionHistoryOutput {
+	s.Events = v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *GetWorkflowExecutionHistoryOutput) SetNextPageToken(v string) *GetWorkflowExecutionHistoryOutput {
+	s.NextPageToken = &v
+	return s
 }
 
 // Event within a workflow execution. A history event can be one of these types:
@@ -6219,6 +7287,348 @@ func (s HistoryEvent) GoString() string {
 	return s.String()
 }
 
+// SetActivityTaskCancelRequestedEventAttributes sets the ActivityTaskCancelRequestedEventAttributes field's value.
+func (s *HistoryEvent) SetActivityTaskCancelRequestedEventAttributes(v *ActivityTaskCancelRequestedEventAttributes) *HistoryEvent {
+	s.ActivityTaskCancelRequestedEventAttributes = v
+	return s
+}
+
+// SetActivityTaskCanceledEventAttributes sets the ActivityTaskCanceledEventAttributes field's value.
+func (s *HistoryEvent) SetActivityTaskCanceledEventAttributes(v *ActivityTaskCanceledEventAttributes) *HistoryEvent {
+	s.ActivityTaskCanceledEventAttributes = v
+	return s
+}
+
+// SetActivityTaskCompletedEventAttributes sets the ActivityTaskCompletedEventAttributes field's value.
+func (s *HistoryEvent) SetActivityTaskCompletedEventAttributes(v *ActivityTaskCompletedEventAttributes) *HistoryEvent {
+	s.ActivityTaskCompletedEventAttributes = v
+	return s
+}
+
+// SetActivityTaskFailedEventAttributes sets the ActivityTaskFailedEventAttributes field's value.
+func (s *HistoryEvent) SetActivityTaskFailedEventAttributes(v *ActivityTaskFailedEventAttributes) *HistoryEvent {
+	s.ActivityTaskFailedEventAttributes = v
+	return s
+}
+
+// SetActivityTaskScheduledEventAttributes sets the ActivityTaskScheduledEventAttributes field's value.
+func (s *HistoryEvent) SetActivityTaskScheduledEventAttributes(v *ActivityTaskScheduledEventAttributes) *HistoryEvent {
+	s.ActivityTaskScheduledEventAttributes = v
+	return s
+}
+
+// SetActivityTaskStartedEventAttributes sets the ActivityTaskStartedEventAttributes field's value.
+func (s *HistoryEvent) SetActivityTaskStartedEventAttributes(v *ActivityTaskStartedEventAttributes) *HistoryEvent {
+	s.ActivityTaskStartedEventAttributes = v
+	return s
+}
+
+// SetActivityTaskTimedOutEventAttributes sets the ActivityTaskTimedOutEventAttributes field's value.
+func (s *HistoryEvent) SetActivityTaskTimedOutEventAttributes(v *ActivityTaskTimedOutEventAttributes) *HistoryEvent {
+	s.ActivityTaskTimedOutEventAttributes = v
+	return s
+}
+
+// SetCancelTimerFailedEventAttributes sets the CancelTimerFailedEventAttributes field's value.
+func (s *HistoryEvent) SetCancelTimerFailedEventAttributes(v *CancelTimerFailedEventAttributes) *HistoryEvent {
+	s.CancelTimerFailedEventAttributes = v
+	return s
+}
+
+// SetCancelWorkflowExecutionFailedEventAttributes sets the CancelWorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetCancelWorkflowExecutionFailedEventAttributes(v *CancelWorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.CancelWorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetChildWorkflowExecutionCanceledEventAttributes sets the ChildWorkflowExecutionCanceledEventAttributes field's value.
+func (s *HistoryEvent) SetChildWorkflowExecutionCanceledEventAttributes(v *ChildWorkflowExecutionCanceledEventAttributes) *HistoryEvent {
+	s.ChildWorkflowExecutionCanceledEventAttributes = v
+	return s
+}
+
+// SetChildWorkflowExecutionCompletedEventAttributes sets the ChildWorkflowExecutionCompletedEventAttributes field's value.
+func (s *HistoryEvent) SetChildWorkflowExecutionCompletedEventAttributes(v *ChildWorkflowExecutionCompletedEventAttributes) *HistoryEvent {
+	s.ChildWorkflowExecutionCompletedEventAttributes = v
+	return s
+}
+
+// SetChildWorkflowExecutionFailedEventAttributes sets the ChildWorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetChildWorkflowExecutionFailedEventAttributes(v *ChildWorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.ChildWorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetChildWorkflowExecutionStartedEventAttributes sets the ChildWorkflowExecutionStartedEventAttributes field's value.
+func (s *HistoryEvent) SetChildWorkflowExecutionStartedEventAttributes(v *ChildWorkflowExecutionStartedEventAttributes) *HistoryEvent {
+	s.ChildWorkflowExecutionStartedEventAttributes = v
+	return s
+}
+
+// SetChildWorkflowExecutionTerminatedEventAttributes sets the ChildWorkflowExecutionTerminatedEventAttributes field's value.
+func (s *HistoryEvent) SetChildWorkflowExecutionTerminatedEventAttributes(v *ChildWorkflowExecutionTerminatedEventAttributes) *HistoryEvent {
+	s.ChildWorkflowExecutionTerminatedEventAttributes = v
+	return s
+}
+
+// SetChildWorkflowExecutionTimedOutEventAttributes sets the ChildWorkflowExecutionTimedOutEventAttributes field's value.
+func (s *HistoryEvent) SetChildWorkflowExecutionTimedOutEventAttributes(v *ChildWorkflowExecutionTimedOutEventAttributes) *HistoryEvent {
+	s.ChildWorkflowExecutionTimedOutEventAttributes = v
+	return s
+}
+
+// SetCompleteWorkflowExecutionFailedEventAttributes sets the CompleteWorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetCompleteWorkflowExecutionFailedEventAttributes(v *CompleteWorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.CompleteWorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetContinueAsNewWorkflowExecutionFailedEventAttributes sets the ContinueAsNewWorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetContinueAsNewWorkflowExecutionFailedEventAttributes(v *ContinueAsNewWorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.ContinueAsNewWorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetDecisionTaskCompletedEventAttributes sets the DecisionTaskCompletedEventAttributes field's value.
+func (s *HistoryEvent) SetDecisionTaskCompletedEventAttributes(v *DecisionTaskCompletedEventAttributes) *HistoryEvent {
+	s.DecisionTaskCompletedEventAttributes = v
+	return s
+}
+
+// SetDecisionTaskScheduledEventAttributes sets the DecisionTaskScheduledEventAttributes field's value.
+func (s *HistoryEvent) SetDecisionTaskScheduledEventAttributes(v *DecisionTaskScheduledEventAttributes) *HistoryEvent {
+	s.DecisionTaskScheduledEventAttributes = v
+	return s
+}
+
+// SetDecisionTaskStartedEventAttributes sets the DecisionTaskStartedEventAttributes field's value.
+func (s *HistoryEvent) SetDecisionTaskStartedEventAttributes(v *DecisionTaskStartedEventAttributes) *HistoryEvent {
+	s.DecisionTaskStartedEventAttributes = v
+	return s
+}
+
+// SetDecisionTaskTimedOutEventAttributes sets the DecisionTaskTimedOutEventAttributes field's value.
+func (s *HistoryEvent) SetDecisionTaskTimedOutEventAttributes(v *DecisionTaskTimedOutEventAttributes) *HistoryEvent {
+	s.DecisionTaskTimedOutEventAttributes = v
+	return s
+}
+
+// SetEventId sets the EventId field's value.
+func (s *HistoryEvent) SetEventId(v int64) *HistoryEvent {
+	s.EventId = &v
+	return s
+}
+
+// SetEventTimestamp sets the EventTimestamp field's value.
+func (s *HistoryEvent) SetEventTimestamp(v time.Time) *HistoryEvent {
+	s.EventTimestamp = &v
+	return s
+}
+
+// SetEventType sets the EventType field's value.
+func (s *HistoryEvent) SetEventType(v string) *HistoryEvent {
+	s.EventType = &v
+	return s
+}
+
+// SetExternalWorkflowExecutionCancelRequestedEventAttributes sets the ExternalWorkflowExecutionCancelRequestedEventAttributes field's value.
+func (s *HistoryEvent) SetExternalWorkflowExecutionCancelRequestedEventAttributes(v *ExternalWorkflowExecutionCancelRequestedEventAttributes) *HistoryEvent {
+	s.ExternalWorkflowExecutionCancelRequestedEventAttributes = v
+	return s
+}
+
+// SetExternalWorkflowExecutionSignaledEventAttributes sets the ExternalWorkflowExecutionSignaledEventAttributes field's value.
+func (s *HistoryEvent) SetExternalWorkflowExecutionSignaledEventAttributes(v *ExternalWorkflowExecutionSignaledEventAttributes) *HistoryEvent {
+	s.ExternalWorkflowExecutionSignaledEventAttributes = v
+	return s
+}
+
+// SetFailWorkflowExecutionFailedEventAttributes sets the FailWorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetFailWorkflowExecutionFailedEventAttributes(v *FailWorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.FailWorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetLambdaFunctionCompletedEventAttributes sets the LambdaFunctionCompletedEventAttributes field's value.
+func (s *HistoryEvent) SetLambdaFunctionCompletedEventAttributes(v *LambdaFunctionCompletedEventAttributes) *HistoryEvent {
+	s.LambdaFunctionCompletedEventAttributes = v
+	return s
+}
+
+// SetLambdaFunctionFailedEventAttributes sets the LambdaFunctionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetLambdaFunctionFailedEventAttributes(v *LambdaFunctionFailedEventAttributes) *HistoryEvent {
+	s.LambdaFunctionFailedEventAttributes = v
+	return s
+}
+
+// SetLambdaFunctionScheduledEventAttributes sets the LambdaFunctionScheduledEventAttributes field's value.
+func (s *HistoryEvent) SetLambdaFunctionScheduledEventAttributes(v *LambdaFunctionScheduledEventAttributes) *HistoryEvent {
+	s.LambdaFunctionScheduledEventAttributes = v
+	return s
+}
+
+// SetLambdaFunctionStartedEventAttributes sets the LambdaFunctionStartedEventAttributes field's value.
+func (s *HistoryEvent) SetLambdaFunctionStartedEventAttributes(v *LambdaFunctionStartedEventAttributes) *HistoryEvent {
+	s.LambdaFunctionStartedEventAttributes = v
+	return s
+}
+
+// SetLambdaFunctionTimedOutEventAttributes sets the LambdaFunctionTimedOutEventAttributes field's value.
+func (s *HistoryEvent) SetLambdaFunctionTimedOutEventAttributes(v *LambdaFunctionTimedOutEventAttributes) *HistoryEvent {
+	s.LambdaFunctionTimedOutEventAttributes = v
+	return s
+}
+
+// SetMarkerRecordedEventAttributes sets the MarkerRecordedEventAttributes field's value.
+func (s *HistoryEvent) SetMarkerRecordedEventAttributes(v *MarkerRecordedEventAttributes) *HistoryEvent {
+	s.MarkerRecordedEventAttributes = v
+	return s
+}
+
+// SetRecordMarkerFailedEventAttributes sets the RecordMarkerFailedEventAttributes field's value.
+func (s *HistoryEvent) SetRecordMarkerFailedEventAttributes(v *RecordMarkerFailedEventAttributes) *HistoryEvent {
+	s.RecordMarkerFailedEventAttributes = v
+	return s
+}
+
+// SetRequestCancelActivityTaskFailedEventAttributes sets the RequestCancelActivityTaskFailedEventAttributes field's value.
+func (s *HistoryEvent) SetRequestCancelActivityTaskFailedEventAttributes(v *RequestCancelActivityTaskFailedEventAttributes) *HistoryEvent {
+	s.RequestCancelActivityTaskFailedEventAttributes = v
+	return s
+}
+
+// SetRequestCancelExternalWorkflowExecutionFailedEventAttributes sets the RequestCancelExternalWorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetRequestCancelExternalWorkflowExecutionFailedEventAttributes(v *RequestCancelExternalWorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.RequestCancelExternalWorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetRequestCancelExternalWorkflowExecutionInitiatedEventAttributes sets the RequestCancelExternalWorkflowExecutionInitiatedEventAttributes field's value.
+func (s *HistoryEvent) SetRequestCancelExternalWorkflowExecutionInitiatedEventAttributes(v *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) *HistoryEvent {
+	s.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes = v
+	return s
+}
+
+// SetScheduleActivityTaskFailedEventAttributes sets the ScheduleActivityTaskFailedEventAttributes field's value.
+func (s *HistoryEvent) SetScheduleActivityTaskFailedEventAttributes(v *ScheduleActivityTaskFailedEventAttributes) *HistoryEvent {
+	s.ScheduleActivityTaskFailedEventAttributes = v
+	return s
+}
+
+// SetScheduleLambdaFunctionFailedEventAttributes sets the ScheduleLambdaFunctionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetScheduleLambdaFunctionFailedEventAttributes(v *ScheduleLambdaFunctionFailedEventAttributes) *HistoryEvent {
+	s.ScheduleLambdaFunctionFailedEventAttributes = v
+	return s
+}
+
+// SetSignalExternalWorkflowExecutionFailedEventAttributes sets the SignalExternalWorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetSignalExternalWorkflowExecutionFailedEventAttributes(v *SignalExternalWorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.SignalExternalWorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetSignalExternalWorkflowExecutionInitiatedEventAttributes sets the SignalExternalWorkflowExecutionInitiatedEventAttributes field's value.
+func (s *HistoryEvent) SetSignalExternalWorkflowExecutionInitiatedEventAttributes(v *SignalExternalWorkflowExecutionInitiatedEventAttributes) *HistoryEvent {
+	s.SignalExternalWorkflowExecutionInitiatedEventAttributes = v
+	return s
+}
+
+// SetStartChildWorkflowExecutionFailedEventAttributes sets the StartChildWorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetStartChildWorkflowExecutionFailedEventAttributes(v *StartChildWorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.StartChildWorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetStartChildWorkflowExecutionInitiatedEventAttributes sets the StartChildWorkflowExecutionInitiatedEventAttributes field's value.
+func (s *HistoryEvent) SetStartChildWorkflowExecutionInitiatedEventAttributes(v *StartChildWorkflowExecutionInitiatedEventAttributes) *HistoryEvent {
+	s.StartChildWorkflowExecutionInitiatedEventAttributes = v
+	return s
+}
+
+// SetStartLambdaFunctionFailedEventAttributes sets the StartLambdaFunctionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetStartLambdaFunctionFailedEventAttributes(v *StartLambdaFunctionFailedEventAttributes) *HistoryEvent {
+	s.StartLambdaFunctionFailedEventAttributes = v
+	return s
+}
+
+// SetStartTimerFailedEventAttributes sets the StartTimerFailedEventAttributes field's value.
+func (s *HistoryEvent) SetStartTimerFailedEventAttributes(v *StartTimerFailedEventAttributes) *HistoryEvent {
+	s.StartTimerFailedEventAttributes = v
+	return s
+}
+
+// SetTimerCanceledEventAttributes sets the TimerCanceledEventAttributes field's value.
+func (s *HistoryEvent) SetTimerCanceledEventAttributes(v *TimerCanceledEventAttributes) *HistoryEvent {
+	s.TimerCanceledEventAttributes = v
+	return s
+}
+
+// SetTimerFiredEventAttributes sets the TimerFiredEventAttributes field's value.
+func (s *HistoryEvent) SetTimerFiredEventAttributes(v *TimerFiredEventAttributes) *HistoryEvent {
+	s.TimerFiredEventAttributes = v
+	return s
+}
+
+// SetTimerStartedEventAttributes sets the TimerStartedEventAttributes field's value.
+func (s *HistoryEvent) SetTimerStartedEventAttributes(v *TimerStartedEventAttributes) *HistoryEvent {
+	s.TimerStartedEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionCancelRequestedEventAttributes sets the WorkflowExecutionCancelRequestedEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionCancelRequestedEventAttributes(v *WorkflowExecutionCancelRequestedEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionCancelRequestedEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionCanceledEventAttributes sets the WorkflowExecutionCanceledEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionCanceledEventAttributes(v *WorkflowExecutionCanceledEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionCanceledEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionCompletedEventAttributes sets the WorkflowExecutionCompletedEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionCompletedEventAttributes(v *WorkflowExecutionCompletedEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionCompletedEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionContinuedAsNewEventAttributes sets the WorkflowExecutionContinuedAsNewEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionContinuedAsNewEventAttributes(v *WorkflowExecutionContinuedAsNewEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionContinuedAsNewEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionFailedEventAttributes sets the WorkflowExecutionFailedEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionFailedEventAttributes(v *WorkflowExecutionFailedEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionFailedEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionSignaledEventAttributes sets the WorkflowExecutionSignaledEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionSignaledEventAttributes(v *WorkflowExecutionSignaledEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionSignaledEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionStartedEventAttributes sets the WorkflowExecutionStartedEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionStartedEventAttributes(v *WorkflowExecutionStartedEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionStartedEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionTerminatedEventAttributes sets the WorkflowExecutionTerminatedEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionTerminatedEventAttributes(v *WorkflowExecutionTerminatedEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionTerminatedEventAttributes = v
+	return s
+}
+
+// SetWorkflowExecutionTimedOutEventAttributes sets the WorkflowExecutionTimedOutEventAttributes field's value.
+func (s *HistoryEvent) SetWorkflowExecutionTimedOutEventAttributes(v *WorkflowExecutionTimedOutEventAttributes) *HistoryEvent {
+	s.WorkflowExecutionTimedOutEventAttributes = v
+	return s
+}
+
 // Provides details for the LambdaFunctionCompleted event.
 type LambdaFunctionCompletedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -6247,6 +7657,24 @@ func (s LambdaFunctionCompletedEventAttributes) String() string {
 // GoString returns the string representation
 func (s LambdaFunctionCompletedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetResult sets the Result field's value.
+func (s *LambdaFunctionCompletedEventAttributes) SetResult(v string) *LambdaFunctionCompletedEventAttributes {
+	s.Result = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *LambdaFunctionCompletedEventAttributes) SetScheduledEventId(v int64) *LambdaFunctionCompletedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *LambdaFunctionCompletedEventAttributes) SetStartedEventId(v int64) *LambdaFunctionCompletedEventAttributes {
+	s.StartedEventId = &v
+	return s
 }
 
 // Provides details for the LambdaFunctionFailed event.
@@ -6280,6 +7708,30 @@ func (s LambdaFunctionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s LambdaFunctionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetDetails sets the Details field's value.
+func (s *LambdaFunctionFailedEventAttributes) SetDetails(v string) *LambdaFunctionFailedEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *LambdaFunctionFailedEventAttributes) SetReason(v string) *LambdaFunctionFailedEventAttributes {
+	s.Reason = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *LambdaFunctionFailedEventAttributes) SetScheduledEventId(v int64) *LambdaFunctionFailedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *LambdaFunctionFailedEventAttributes) SetStartedEventId(v int64) *LambdaFunctionFailedEventAttributes {
+	s.StartedEventId = &v
+	return s
 }
 
 // Provides details for the LambdaFunctionScheduled event.
@@ -6322,6 +7774,36 @@ func (s LambdaFunctionScheduledEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *LambdaFunctionScheduledEventAttributes) SetDecisionTaskCompletedEventId(v int64) *LambdaFunctionScheduledEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *LambdaFunctionScheduledEventAttributes) SetId(v string) *LambdaFunctionScheduledEventAttributes {
+	s.Id = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *LambdaFunctionScheduledEventAttributes) SetInput(v string) *LambdaFunctionScheduledEventAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *LambdaFunctionScheduledEventAttributes) SetName(v string) *LambdaFunctionScheduledEventAttributes {
+	s.Name = &v
+	return s
+}
+
+// SetStartToCloseTimeout sets the StartToCloseTimeout field's value.
+func (s *LambdaFunctionScheduledEventAttributes) SetStartToCloseTimeout(v string) *LambdaFunctionScheduledEventAttributes {
+	s.StartToCloseTimeout = &v
+	return s
+}
+
 // Provides details for the LambdaFunctionStarted event.
 type LambdaFunctionStartedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -6342,6 +7824,12 @@ func (s LambdaFunctionStartedEventAttributes) String() string {
 // GoString returns the string representation
 func (s LambdaFunctionStartedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *LambdaFunctionStartedEventAttributes) SetScheduledEventId(v int64) *LambdaFunctionStartedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
 }
 
 // Provides details for the LambdaFunctionTimedOut event.
@@ -6372,6 +7860,24 @@ func (s LambdaFunctionTimedOutEventAttributes) String() string {
 // GoString returns the string representation
 func (s LambdaFunctionTimedOutEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *LambdaFunctionTimedOutEventAttributes) SetScheduledEventId(v int64) *LambdaFunctionTimedOutEventAttributes {
+	s.ScheduledEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *LambdaFunctionTimedOutEventAttributes) SetStartedEventId(v int64) *LambdaFunctionTimedOutEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetTimeoutType sets the TimeoutType field's value.
+func (s *LambdaFunctionTimedOutEventAttributes) SetTimeoutType(v string) *LambdaFunctionTimedOutEventAttributes {
+	s.TimeoutType = &v
+	return s
 }
 
 type ListActivityTypesInput struct {
@@ -6444,6 +7950,42 @@ func (s *ListActivityTypesInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *ListActivityTypesInput) SetDomain(v string) *ListActivityTypesInput {
+	s.Domain = &v
+	return s
+}
+
+// SetMaximumPageSize sets the MaximumPageSize field's value.
+func (s *ListActivityTypesInput) SetMaximumPageSize(v int64) *ListActivityTypesInput {
+	s.MaximumPageSize = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ListActivityTypesInput) SetName(v string) *ListActivityTypesInput {
+	s.Name = &v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListActivityTypesInput) SetNextPageToken(v string) *ListActivityTypesInput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetRegistrationStatus sets the RegistrationStatus field's value.
+func (s *ListActivityTypesInput) SetRegistrationStatus(v string) *ListActivityTypesInput {
+	s.RegistrationStatus = &v
+	return s
+}
+
+// SetReverseOrder sets the ReverseOrder field's value.
+func (s *ListActivityTypesInput) SetReverseOrder(v bool) *ListActivityTypesInput {
+	s.ReverseOrder = &v
+	return s
+}
+
 // Contains a paginated list of activity type information structures.
 type ListActivityTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6470,6 +8012,18 @@ func (s ListActivityTypesOutput) String() string {
 // GoString returns the string representation
 func (s ListActivityTypesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListActivityTypesOutput) SetNextPageToken(v string) *ListActivityTypesOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetTypeInfos sets the TypeInfos field's value.
+func (s *ListActivityTypesOutput) SetTypeInfos(v []*ActivityTypeInfo) *ListActivityTypesOutput {
+	s.TypeInfos = v
+	return s
 }
 
 type ListClosedWorkflowExecutionsInput struct {
@@ -6603,6 +8157,66 @@ func (s *ListClosedWorkflowExecutionsInput) Validate() error {
 	return nil
 }
 
+// SetCloseStatusFilter sets the CloseStatusFilter field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetCloseStatusFilter(v *CloseStatusFilter) *ListClosedWorkflowExecutionsInput {
+	s.CloseStatusFilter = v
+	return s
+}
+
+// SetCloseTimeFilter sets the CloseTimeFilter field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetCloseTimeFilter(v *ExecutionTimeFilter) *ListClosedWorkflowExecutionsInput {
+	s.CloseTimeFilter = v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetDomain(v string) *ListClosedWorkflowExecutionsInput {
+	s.Domain = &v
+	return s
+}
+
+// SetExecutionFilter sets the ExecutionFilter field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetExecutionFilter(v *WorkflowExecutionFilter) *ListClosedWorkflowExecutionsInput {
+	s.ExecutionFilter = v
+	return s
+}
+
+// SetMaximumPageSize sets the MaximumPageSize field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetMaximumPageSize(v int64) *ListClosedWorkflowExecutionsInput {
+	s.MaximumPageSize = &v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetNextPageToken(v string) *ListClosedWorkflowExecutionsInput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetReverseOrder sets the ReverseOrder field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetReverseOrder(v bool) *ListClosedWorkflowExecutionsInput {
+	s.ReverseOrder = &v
+	return s
+}
+
+// SetStartTimeFilter sets the StartTimeFilter field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetStartTimeFilter(v *ExecutionTimeFilter) *ListClosedWorkflowExecutionsInput {
+	s.StartTimeFilter = v
+	return s
+}
+
+// SetTagFilter sets the TagFilter field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetTagFilter(v *TagFilter) *ListClosedWorkflowExecutionsInput {
+	s.TagFilter = v
+	return s
+}
+
+// SetTypeFilter sets the TypeFilter field's value.
+func (s *ListClosedWorkflowExecutionsInput) SetTypeFilter(v *WorkflowTypeFilter) *ListClosedWorkflowExecutionsInput {
+	s.TypeFilter = v
+	return s
+}
+
 type ListDomainsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6656,6 +8270,30 @@ func (s *ListDomainsInput) Validate() error {
 	return nil
 }
 
+// SetMaximumPageSize sets the MaximumPageSize field's value.
+func (s *ListDomainsInput) SetMaximumPageSize(v int64) *ListDomainsInput {
+	s.MaximumPageSize = &v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListDomainsInput) SetNextPageToken(v string) *ListDomainsInput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetRegistrationStatus sets the RegistrationStatus field's value.
+func (s *ListDomainsInput) SetRegistrationStatus(v string) *ListDomainsInput {
+	s.RegistrationStatus = &v
+	return s
+}
+
+// SetReverseOrder sets the ReverseOrder field's value.
+func (s *ListDomainsInput) SetReverseOrder(v bool) *ListDomainsInput {
+	s.ReverseOrder = &v
+	return s
+}
+
 // Contains a paginated collection of DomainInfo structures.
 type ListDomainsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6682,6 +8320,18 @@ func (s ListDomainsOutput) String() string {
 // GoString returns the string representation
 func (s ListDomainsOutput) GoString() string {
 	return s.String()
+}
+
+// SetDomainInfos sets the DomainInfos field's value.
+func (s *ListDomainsOutput) SetDomainInfos(v []*DomainInfo) *ListDomainsOutput {
+	s.DomainInfos = v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListDomainsOutput) SetNextPageToken(v string) *ListDomainsOutput {
+	s.NextPageToken = &v
+	return s
 }
 
 type ListOpenWorkflowExecutionsInput struct {
@@ -6788,6 +8438,54 @@ func (s *ListOpenWorkflowExecutionsInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *ListOpenWorkflowExecutionsInput) SetDomain(v string) *ListOpenWorkflowExecutionsInput {
+	s.Domain = &v
+	return s
+}
+
+// SetExecutionFilter sets the ExecutionFilter field's value.
+func (s *ListOpenWorkflowExecutionsInput) SetExecutionFilter(v *WorkflowExecutionFilter) *ListOpenWorkflowExecutionsInput {
+	s.ExecutionFilter = v
+	return s
+}
+
+// SetMaximumPageSize sets the MaximumPageSize field's value.
+func (s *ListOpenWorkflowExecutionsInput) SetMaximumPageSize(v int64) *ListOpenWorkflowExecutionsInput {
+	s.MaximumPageSize = &v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListOpenWorkflowExecutionsInput) SetNextPageToken(v string) *ListOpenWorkflowExecutionsInput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetReverseOrder sets the ReverseOrder field's value.
+func (s *ListOpenWorkflowExecutionsInput) SetReverseOrder(v bool) *ListOpenWorkflowExecutionsInput {
+	s.ReverseOrder = &v
+	return s
+}
+
+// SetStartTimeFilter sets the StartTimeFilter field's value.
+func (s *ListOpenWorkflowExecutionsInput) SetStartTimeFilter(v *ExecutionTimeFilter) *ListOpenWorkflowExecutionsInput {
+	s.StartTimeFilter = v
+	return s
+}
+
+// SetTagFilter sets the TagFilter field's value.
+func (s *ListOpenWorkflowExecutionsInput) SetTagFilter(v *TagFilter) *ListOpenWorkflowExecutionsInput {
+	s.TagFilter = v
+	return s
+}
+
+// SetTypeFilter sets the TypeFilter field's value.
+func (s *ListOpenWorkflowExecutionsInput) SetTypeFilter(v *WorkflowTypeFilter) *ListOpenWorkflowExecutionsInput {
+	s.TypeFilter = v
+	return s
+}
+
 type ListWorkflowTypesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6859,6 +8557,42 @@ func (s *ListWorkflowTypesInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *ListWorkflowTypesInput) SetDomain(v string) *ListWorkflowTypesInput {
+	s.Domain = &v
+	return s
+}
+
+// SetMaximumPageSize sets the MaximumPageSize field's value.
+func (s *ListWorkflowTypesInput) SetMaximumPageSize(v int64) *ListWorkflowTypesInput {
+	s.MaximumPageSize = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ListWorkflowTypesInput) SetName(v string) *ListWorkflowTypesInput {
+	s.Name = &v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListWorkflowTypesInput) SetNextPageToken(v string) *ListWorkflowTypesInput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetRegistrationStatus sets the RegistrationStatus field's value.
+func (s *ListWorkflowTypesInput) SetRegistrationStatus(v string) *ListWorkflowTypesInput {
+	s.RegistrationStatus = &v
+	return s
+}
+
+// SetReverseOrder sets the ReverseOrder field's value.
+func (s *ListWorkflowTypesInput) SetReverseOrder(v bool) *ListWorkflowTypesInput {
+	s.ReverseOrder = &v
+	return s
+}
+
 // Contains a paginated list of information structures about workflow types.
 type ListWorkflowTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6885,6 +8619,18 @@ func (s ListWorkflowTypesOutput) String() string {
 // GoString returns the string representation
 func (s ListWorkflowTypesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *ListWorkflowTypesOutput) SetNextPageToken(v string) *ListWorkflowTypesOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetTypeInfos sets the TypeInfos field's value.
+func (s *ListWorkflowTypesOutput) SetTypeInfos(v []*WorkflowTypeInfo) *ListWorkflowTypesOutput {
+	s.TypeInfos = v
+	return s
 }
 
 // Provides details of the MarkerRecorded event.
@@ -6918,6 +8664,24 @@ func (s MarkerRecordedEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *MarkerRecordedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *MarkerRecordedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *MarkerRecordedEventAttributes) SetDetails(v string) *MarkerRecordedEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetMarkerName sets the MarkerName field's value.
+func (s *MarkerRecordedEventAttributes) SetMarkerName(v string) *MarkerRecordedEventAttributes {
+	s.MarkerName = &v
+	return s
+}
+
 // Contains the count of tasks in a task list.
 type PendingTaskCount struct {
 	_ struct{} `type:"structure"`
@@ -6940,6 +8704,18 @@ func (s PendingTaskCount) String() string {
 // GoString returns the string representation
 func (s PendingTaskCount) GoString() string {
 	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *PendingTaskCount) SetCount(v int64) *PendingTaskCount {
+	s.Count = &v
+	return s
+}
+
+// SetTruncated sets the Truncated field's value.
+func (s *PendingTaskCount) SetTruncated(v bool) *PendingTaskCount {
+	s.Truncated = &v
+	return s
 }
 
 type PollForActivityTaskInput struct {
@@ -6999,6 +8775,24 @@ func (s *PollForActivityTaskInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *PollForActivityTaskInput) SetDomain(v string) *PollForActivityTaskInput {
+	s.Domain = &v
+	return s
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *PollForActivityTaskInput) SetIdentity(v string) *PollForActivityTaskInput {
+	s.Identity = &v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *PollForActivityTaskInput) SetTaskList(v *TaskList) *PollForActivityTaskInput {
+	s.TaskList = v
+	return s
+}
+
 // Unit of work sent to an activity worker.
 type PollForActivityTaskOutput struct {
 	_ struct{} `type:"structure"`
@@ -7043,6 +8837,42 @@ func (s PollForActivityTaskOutput) String() string {
 // GoString returns the string representation
 func (s PollForActivityTaskOutput) GoString() string {
 	return s.String()
+}
+
+// SetActivityId sets the ActivityId field's value.
+func (s *PollForActivityTaskOutput) SetActivityId(v string) *PollForActivityTaskOutput {
+	s.ActivityId = &v
+	return s
+}
+
+// SetActivityType sets the ActivityType field's value.
+func (s *PollForActivityTaskOutput) SetActivityType(v *ActivityType) *PollForActivityTaskOutput {
+	s.ActivityType = v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *PollForActivityTaskOutput) SetInput(v string) *PollForActivityTaskOutput {
+	s.Input = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *PollForActivityTaskOutput) SetStartedEventId(v int64) *PollForActivityTaskOutput {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetTaskToken sets the TaskToken field's value.
+func (s *PollForActivityTaskOutput) SetTaskToken(v string) *PollForActivityTaskOutput {
+	s.TaskToken = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *PollForActivityTaskOutput) SetWorkflowExecution(v *WorkflowExecution) *PollForActivityTaskOutput {
+	s.WorkflowExecution = v
+	return s
 }
 
 type PollForDecisionTaskInput struct {
@@ -7128,6 +8958,42 @@ func (s *PollForDecisionTaskInput) Validate() error {
 	return nil
 }
 
+// SetDomain sets the Domain field's value.
+func (s *PollForDecisionTaskInput) SetDomain(v string) *PollForDecisionTaskInput {
+	s.Domain = &v
+	return s
+}
+
+// SetIdentity sets the Identity field's value.
+func (s *PollForDecisionTaskInput) SetIdentity(v string) *PollForDecisionTaskInput {
+	s.Identity = &v
+	return s
+}
+
+// SetMaximumPageSize sets the MaximumPageSize field's value.
+func (s *PollForDecisionTaskInput) SetMaximumPageSize(v int64) *PollForDecisionTaskInput {
+	s.MaximumPageSize = &v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *PollForDecisionTaskInput) SetNextPageToken(v string) *PollForDecisionTaskInput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetReverseOrder sets the ReverseOrder field's value.
+func (s *PollForDecisionTaskInput) SetReverseOrder(v bool) *PollForDecisionTaskInput {
+	s.ReverseOrder = &v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *PollForDecisionTaskInput) SetTaskList(v *TaskList) *PollForDecisionTaskInput {
+	s.TaskList = v
+	return s
+}
+
 // A structure that represents a decision task. Decision tasks are sent to deciders
 // in order for them to make decisions.
 type PollForDecisionTaskOutput struct {
@@ -7186,6 +9052,48 @@ func (s PollForDecisionTaskOutput) GoString() string {
 	return s.String()
 }
 
+// SetEvents sets the Events field's value.
+func (s *PollForDecisionTaskOutput) SetEvents(v []*HistoryEvent) *PollForDecisionTaskOutput {
+	s.Events = v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *PollForDecisionTaskOutput) SetNextPageToken(v string) *PollForDecisionTaskOutput {
+	s.NextPageToken = &v
+	return s
+}
+
+// SetPreviousStartedEventId sets the PreviousStartedEventId field's value.
+func (s *PollForDecisionTaskOutput) SetPreviousStartedEventId(v int64) *PollForDecisionTaskOutput {
+	s.PreviousStartedEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *PollForDecisionTaskOutput) SetStartedEventId(v int64) *PollForDecisionTaskOutput {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetTaskToken sets the TaskToken field's value.
+func (s *PollForDecisionTaskOutput) SetTaskToken(v string) *PollForDecisionTaskOutput {
+	s.TaskToken = &v
+	return s
+}
+
+// SetWorkflowExecution sets the WorkflowExecution field's value.
+func (s *PollForDecisionTaskOutput) SetWorkflowExecution(v *WorkflowExecution) *PollForDecisionTaskOutput {
+	s.WorkflowExecution = v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *PollForDecisionTaskOutput) SetWorkflowType(v *WorkflowType) *PollForDecisionTaskOutput {
+	s.WorkflowType = v
+	return s
+}
+
 type RecordActivityTaskHeartbeatInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7228,6 +9136,18 @@ func (s *RecordActivityTaskHeartbeatInput) Validate() error {
 	return nil
 }
 
+// SetDetails sets the Details field's value.
+func (s *RecordActivityTaskHeartbeatInput) SetDetails(v string) *RecordActivityTaskHeartbeatInput {
+	s.Details = &v
+	return s
+}
+
+// SetTaskToken sets the TaskToken field's value.
+func (s *RecordActivityTaskHeartbeatInput) SetTaskToken(v string) *RecordActivityTaskHeartbeatInput {
+	s.TaskToken = &v
+	return s
+}
+
 // Status information about an activity task.
 type RecordActivityTaskHeartbeatOutput struct {
 	_ struct{} `type:"structure"`
@@ -7246,6 +9166,12 @@ func (s RecordActivityTaskHeartbeatOutput) String() string {
 // GoString returns the string representation
 func (s RecordActivityTaskHeartbeatOutput) GoString() string {
 	return s.String()
+}
+
+// SetCancelRequested sets the CancelRequested field's value.
+func (s *RecordActivityTaskHeartbeatOutput) SetCancelRequested(v bool) *RecordActivityTaskHeartbeatOutput {
+	s.CancelRequested = &v
+	return s
 }
 
 // Provides details of the RecordMarker decision.
@@ -7304,6 +9230,18 @@ func (s *RecordMarkerDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetDetails sets the Details field's value.
+func (s *RecordMarkerDecisionAttributes) SetDetails(v string) *RecordMarkerDecisionAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetMarkerName sets the MarkerName field's value.
+func (s *RecordMarkerDecisionAttributes) SetMarkerName(v string) *RecordMarkerDecisionAttributes {
+	s.MarkerName = &v
+	return s
+}
+
 // Provides details of the RecordMarkerFailed event.
 type RecordMarkerFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -7340,6 +9278,24 @@ func (s RecordMarkerFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s RecordMarkerFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *RecordMarkerFailedEventAttributes) SetCause(v string) *RecordMarkerFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *RecordMarkerFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *RecordMarkerFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetMarkerName sets the MarkerName field's value.
+func (s *RecordMarkerFailedEventAttributes) SetMarkerName(v string) *RecordMarkerFailedEventAttributes {
+	s.MarkerName = &v
+	return s
 }
 
 type RegisterActivityTypeInput struct {
@@ -7468,6 +9424,66 @@ func (s *RegisterActivityTypeInput) Validate() error {
 	return nil
 }
 
+// SetDefaultTaskHeartbeatTimeout sets the DefaultTaskHeartbeatTimeout field's value.
+func (s *RegisterActivityTypeInput) SetDefaultTaskHeartbeatTimeout(v string) *RegisterActivityTypeInput {
+	s.DefaultTaskHeartbeatTimeout = &v
+	return s
+}
+
+// SetDefaultTaskList sets the DefaultTaskList field's value.
+func (s *RegisterActivityTypeInput) SetDefaultTaskList(v *TaskList) *RegisterActivityTypeInput {
+	s.DefaultTaskList = v
+	return s
+}
+
+// SetDefaultTaskPriority sets the DefaultTaskPriority field's value.
+func (s *RegisterActivityTypeInput) SetDefaultTaskPriority(v string) *RegisterActivityTypeInput {
+	s.DefaultTaskPriority = &v
+	return s
+}
+
+// SetDefaultTaskScheduleToCloseTimeout sets the DefaultTaskScheduleToCloseTimeout field's value.
+func (s *RegisterActivityTypeInput) SetDefaultTaskScheduleToCloseTimeout(v string) *RegisterActivityTypeInput {
+	s.DefaultTaskScheduleToCloseTimeout = &v
+	return s
+}
+
+// SetDefaultTaskScheduleToStartTimeout sets the DefaultTaskScheduleToStartTimeout field's value.
+func (s *RegisterActivityTypeInput) SetDefaultTaskScheduleToStartTimeout(v string) *RegisterActivityTypeInput {
+	s.DefaultTaskScheduleToStartTimeout = &v
+	return s
+}
+
+// SetDefaultTaskStartToCloseTimeout sets the DefaultTaskStartToCloseTimeout field's value.
+func (s *RegisterActivityTypeInput) SetDefaultTaskStartToCloseTimeout(v string) *RegisterActivityTypeInput {
+	s.DefaultTaskStartToCloseTimeout = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *RegisterActivityTypeInput) SetDescription(v string) *RegisterActivityTypeInput {
+	s.Description = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *RegisterActivityTypeInput) SetDomain(v string) *RegisterActivityTypeInput {
+	s.Domain = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RegisterActivityTypeInput) SetName(v string) *RegisterActivityTypeInput {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *RegisterActivityTypeInput) SetVersion(v string) *RegisterActivityTypeInput {
+	s.Version = &v
+	return s
+}
+
 type RegisterActivityTypeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7544,6 +9560,24 @@ func (s *RegisterDomainInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDescription sets the Description field's value.
+func (s *RegisterDomainInput) SetDescription(v string) *RegisterDomainInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RegisterDomainInput) SetName(v string) *RegisterDomainInput {
+	s.Name = &v
+	return s
+}
+
+// SetWorkflowExecutionRetentionPeriodInDays sets the WorkflowExecutionRetentionPeriodInDays field's value.
+func (s *RegisterDomainInput) SetWorkflowExecutionRetentionPeriodInDays(v string) *RegisterDomainInput {
+	s.WorkflowExecutionRetentionPeriodInDays = &v
+	return s
 }
 
 type RegisterDomainOutput struct {
@@ -7699,6 +9733,66 @@ func (s *RegisterWorkflowTypeInput) Validate() error {
 	return nil
 }
 
+// SetDefaultChildPolicy sets the DefaultChildPolicy field's value.
+func (s *RegisterWorkflowTypeInput) SetDefaultChildPolicy(v string) *RegisterWorkflowTypeInput {
+	s.DefaultChildPolicy = &v
+	return s
+}
+
+// SetDefaultExecutionStartToCloseTimeout sets the DefaultExecutionStartToCloseTimeout field's value.
+func (s *RegisterWorkflowTypeInput) SetDefaultExecutionStartToCloseTimeout(v string) *RegisterWorkflowTypeInput {
+	s.DefaultExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetDefaultLambdaRole sets the DefaultLambdaRole field's value.
+func (s *RegisterWorkflowTypeInput) SetDefaultLambdaRole(v string) *RegisterWorkflowTypeInput {
+	s.DefaultLambdaRole = &v
+	return s
+}
+
+// SetDefaultTaskList sets the DefaultTaskList field's value.
+func (s *RegisterWorkflowTypeInput) SetDefaultTaskList(v *TaskList) *RegisterWorkflowTypeInput {
+	s.DefaultTaskList = v
+	return s
+}
+
+// SetDefaultTaskPriority sets the DefaultTaskPriority field's value.
+func (s *RegisterWorkflowTypeInput) SetDefaultTaskPriority(v string) *RegisterWorkflowTypeInput {
+	s.DefaultTaskPriority = &v
+	return s
+}
+
+// SetDefaultTaskStartToCloseTimeout sets the DefaultTaskStartToCloseTimeout field's value.
+func (s *RegisterWorkflowTypeInput) SetDefaultTaskStartToCloseTimeout(v string) *RegisterWorkflowTypeInput {
+	s.DefaultTaskStartToCloseTimeout = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *RegisterWorkflowTypeInput) SetDescription(v string) *RegisterWorkflowTypeInput {
+	s.Description = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *RegisterWorkflowTypeInput) SetDomain(v string) *RegisterWorkflowTypeInput {
+	s.Domain = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RegisterWorkflowTypeInput) SetName(v string) *RegisterWorkflowTypeInput {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *RegisterWorkflowTypeInput) SetVersion(v string) *RegisterWorkflowTypeInput {
+	s.Version = &v
+	return s
+}
+
 type RegisterWorkflowTypeOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7766,6 +9860,12 @@ func (s *RequestCancelActivityTaskDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetActivityId sets the ActivityId field's value.
+func (s *RequestCancelActivityTaskDecisionAttributes) SetActivityId(v string) *RequestCancelActivityTaskDecisionAttributes {
+	s.ActivityId = &v
+	return s
+}
+
 // Provides details of the RequestCancelActivityTaskFailed event.
 type RequestCancelActivityTaskFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -7802,6 +9902,24 @@ func (s RequestCancelActivityTaskFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s RequestCancelActivityTaskFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetActivityId sets the ActivityId field's value.
+func (s *RequestCancelActivityTaskFailedEventAttributes) SetActivityId(v string) *RequestCancelActivityTaskFailedEventAttributes {
+	s.ActivityId = &v
+	return s
+}
+
+// SetCause sets the Cause field's value.
+func (s *RequestCancelActivityTaskFailedEventAttributes) SetCause(v string) *RequestCancelActivityTaskFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *RequestCancelActivityTaskFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *RequestCancelActivityTaskFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
 }
 
 // Provides details of the RequestCancelExternalWorkflowExecution decision.
@@ -7864,6 +9982,24 @@ func (s *RequestCancelExternalWorkflowExecutionDecisionAttributes) Validate() er
 	return nil
 }
 
+// SetControl sets the Control field's value.
+func (s *RequestCancelExternalWorkflowExecutionDecisionAttributes) SetControl(v string) *RequestCancelExternalWorkflowExecutionDecisionAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *RequestCancelExternalWorkflowExecutionDecisionAttributes) SetRunId(v string) *RequestCancelExternalWorkflowExecutionDecisionAttributes {
+	s.RunId = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *RequestCancelExternalWorkflowExecutionDecisionAttributes) SetWorkflowId(v string) *RequestCancelExternalWorkflowExecutionDecisionAttributes {
+	s.WorkflowId = &v
+	return s
+}
+
 // Provides details of the RequestCancelExternalWorkflowExecutionFailed event.
 type RequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -7916,6 +10052,42 @@ func (s RequestCancelExternalWorkflowExecutionFailedEventAttributes) GoString() 
 	return s.String()
 }
 
+// SetCause sets the Cause field's value.
+func (s *RequestCancelExternalWorkflowExecutionFailedEventAttributes) SetCause(v string) *RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetControl sets the Control field's value.
+func (s *RequestCancelExternalWorkflowExecutionFailedEventAttributes) SetControl(v string) *RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *RequestCancelExternalWorkflowExecutionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *RequestCancelExternalWorkflowExecutionFailedEventAttributes) SetInitiatedEventId(v int64) *RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *RequestCancelExternalWorkflowExecutionFailedEventAttributes) SetRunId(v string) *RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+	s.RunId = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *RequestCancelExternalWorkflowExecutionFailedEventAttributes) SetWorkflowId(v string) *RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+	s.WorkflowId = &v
+	return s
+}
+
 // Provides details of the RequestCancelExternalWorkflowExecutionInitiated event.
 type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -7949,6 +10121,30 @@ func (s RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) String()
 // GoString returns the string representation
 func (s RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetControl sets the Control field's value.
+func (s *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) SetControl(v string) *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) SetRunId(v string) *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
+	s.RunId = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) SetWorkflowId(v string) *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
+	s.WorkflowId = &v
+	return s
 }
 
 type RequestCancelWorkflowExecutionInput struct {
@@ -7998,6 +10194,24 @@ func (s *RequestCancelWorkflowExecutionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomain sets the Domain field's value.
+func (s *RequestCancelWorkflowExecutionInput) SetDomain(v string) *RequestCancelWorkflowExecutionInput {
+	s.Domain = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *RequestCancelWorkflowExecutionInput) SetRunId(v string) *RequestCancelWorkflowExecutionInput {
+	s.RunId = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *RequestCancelWorkflowExecutionInput) SetWorkflowId(v string) *RequestCancelWorkflowExecutionInput {
+	s.WorkflowId = &v
+	return s
 }
 
 type RequestCancelWorkflowExecutionOutput struct {
@@ -8054,6 +10268,18 @@ func (s *RespondActivityTaskCanceledInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDetails sets the Details field's value.
+func (s *RespondActivityTaskCanceledInput) SetDetails(v string) *RespondActivityTaskCanceledInput {
+	s.Details = &v
+	return s
+}
+
+// SetTaskToken sets the TaskToken field's value.
+func (s *RespondActivityTaskCanceledInput) SetTaskToken(v string) *RespondActivityTaskCanceledInput {
+	s.TaskToken = &v
+	return s
 }
 
 type RespondActivityTaskCanceledOutput struct {
@@ -8113,6 +10339,18 @@ func (s *RespondActivityTaskCompletedInput) Validate() error {
 	return nil
 }
 
+// SetResult sets the Result field's value.
+func (s *RespondActivityTaskCompletedInput) SetResult(v string) *RespondActivityTaskCompletedInput {
+	s.Result = &v
+	return s
+}
+
+// SetTaskToken sets the TaskToken field's value.
+func (s *RespondActivityTaskCompletedInput) SetTaskToken(v string) *RespondActivityTaskCompletedInput {
+	s.TaskToken = &v
+	return s
+}
+
 type RespondActivityTaskCompletedOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8170,6 +10408,24 @@ func (s *RespondActivityTaskFailedInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDetails sets the Details field's value.
+func (s *RespondActivityTaskFailedInput) SetDetails(v string) *RespondActivityTaskFailedInput {
+	s.Details = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *RespondActivityTaskFailedInput) SetReason(v string) *RespondActivityTaskFailedInput {
+	s.Reason = &v
+	return s
+}
+
+// SetTaskToken sets the TaskToken field's value.
+func (s *RespondActivityTaskFailedInput) SetTaskToken(v string) *RespondActivityTaskFailedInput {
+	s.TaskToken = &v
+	return s
 }
 
 type RespondActivityTaskFailedOutput struct {
@@ -8240,6 +10496,24 @@ func (s *RespondDecisionTaskCompletedInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDecisions sets the Decisions field's value.
+func (s *RespondDecisionTaskCompletedInput) SetDecisions(v []*Decision) *RespondDecisionTaskCompletedInput {
+	s.Decisions = v
+	return s
+}
+
+// SetExecutionContext sets the ExecutionContext field's value.
+func (s *RespondDecisionTaskCompletedInput) SetExecutionContext(v string) *RespondDecisionTaskCompletedInput {
+	s.ExecutionContext = &v
+	return s
+}
+
+// SetTaskToken sets the TaskToken field's value.
+func (s *RespondDecisionTaskCompletedInput) SetTaskToken(v string) *RespondDecisionTaskCompletedInput {
+	s.TaskToken = &v
+	return s
 }
 
 type RespondDecisionTaskCompletedOutput struct {
@@ -8414,6 +10688,66 @@ func (s *ScheduleActivityTaskDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetActivityId sets the ActivityId field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetActivityId(v string) *ScheduleActivityTaskDecisionAttributes {
+	s.ActivityId = &v
+	return s
+}
+
+// SetActivityType sets the ActivityType field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetActivityType(v *ActivityType) *ScheduleActivityTaskDecisionAttributes {
+	s.ActivityType = v
+	return s
+}
+
+// SetControl sets the Control field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetControl(v string) *ScheduleActivityTaskDecisionAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetHeartbeatTimeout sets the HeartbeatTimeout field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetHeartbeatTimeout(v string) *ScheduleActivityTaskDecisionAttributes {
+	s.HeartbeatTimeout = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetInput(v string) *ScheduleActivityTaskDecisionAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetScheduleToCloseTimeout sets the ScheduleToCloseTimeout field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetScheduleToCloseTimeout(v string) *ScheduleActivityTaskDecisionAttributes {
+	s.ScheduleToCloseTimeout = &v
+	return s
+}
+
+// SetScheduleToStartTimeout sets the ScheduleToStartTimeout field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetScheduleToStartTimeout(v string) *ScheduleActivityTaskDecisionAttributes {
+	s.ScheduleToStartTimeout = &v
+	return s
+}
+
+// SetStartToCloseTimeout sets the StartToCloseTimeout field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetStartToCloseTimeout(v string) *ScheduleActivityTaskDecisionAttributes {
+	s.StartToCloseTimeout = &v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetTaskList(v *TaskList) *ScheduleActivityTaskDecisionAttributes {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *ScheduleActivityTaskDecisionAttributes) SetTaskPriority(v string) *ScheduleActivityTaskDecisionAttributes {
+	s.TaskPriority = &v
+	return s
+}
+
 // Provides details of the ScheduleActivityTaskFailed event.
 type ScheduleActivityTaskFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -8455,6 +10789,30 @@ func (s ScheduleActivityTaskFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ScheduleActivityTaskFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetActivityId sets the ActivityId field's value.
+func (s *ScheduleActivityTaskFailedEventAttributes) SetActivityId(v string) *ScheduleActivityTaskFailedEventAttributes {
+	s.ActivityId = &v
+	return s
+}
+
+// SetActivityType sets the ActivityType field's value.
+func (s *ScheduleActivityTaskFailedEventAttributes) SetActivityType(v *ActivityType) *ScheduleActivityTaskFailedEventAttributes {
+	s.ActivityType = v
+	return s
+}
+
+// SetCause sets the Cause field's value.
+func (s *ScheduleActivityTaskFailedEventAttributes) SetCause(v string) *ScheduleActivityTaskFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *ScheduleActivityTaskFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *ScheduleActivityTaskFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
 }
 
 // Provides details of the ScheduleLambdaFunction decision.
@@ -8539,6 +10897,30 @@ func (s *ScheduleLambdaFunctionDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetId sets the Id field's value.
+func (s *ScheduleLambdaFunctionDecisionAttributes) SetId(v string) *ScheduleLambdaFunctionDecisionAttributes {
+	s.Id = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *ScheduleLambdaFunctionDecisionAttributes) SetInput(v string) *ScheduleLambdaFunctionDecisionAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ScheduleLambdaFunctionDecisionAttributes) SetName(v string) *ScheduleLambdaFunctionDecisionAttributes {
+	s.Name = &v
+	return s
+}
+
+// SetStartToCloseTimeout sets the StartToCloseTimeout field's value.
+func (s *ScheduleLambdaFunctionDecisionAttributes) SetStartToCloseTimeout(v string) *ScheduleLambdaFunctionDecisionAttributes {
+	s.StartToCloseTimeout = &v
+	return s
+}
+
 // Provides details for the ScheduleLambdaFunctionFailed event.
 type ScheduleLambdaFunctionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -8580,6 +10962,30 @@ func (s ScheduleLambdaFunctionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s ScheduleLambdaFunctionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *ScheduleLambdaFunctionFailedEventAttributes) SetCause(v string) *ScheduleLambdaFunctionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *ScheduleLambdaFunctionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *ScheduleLambdaFunctionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ScheduleLambdaFunctionFailedEventAttributes) SetId(v string) *ScheduleLambdaFunctionFailedEventAttributes {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ScheduleLambdaFunctionFailedEventAttributes) SetName(v string) *ScheduleLambdaFunctionFailedEventAttributes {
+	s.Name = &v
+	return s
 }
 
 // Provides details of the SignalExternalWorkflowExecution decision.
@@ -8658,6 +11064,36 @@ func (s *SignalExternalWorkflowExecutionDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetControl sets the Control field's value.
+func (s *SignalExternalWorkflowExecutionDecisionAttributes) SetControl(v string) *SignalExternalWorkflowExecutionDecisionAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *SignalExternalWorkflowExecutionDecisionAttributes) SetInput(v string) *SignalExternalWorkflowExecutionDecisionAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *SignalExternalWorkflowExecutionDecisionAttributes) SetRunId(v string) *SignalExternalWorkflowExecutionDecisionAttributes {
+	s.RunId = &v
+	return s
+}
+
+// SetSignalName sets the SignalName field's value.
+func (s *SignalExternalWorkflowExecutionDecisionAttributes) SetSignalName(v string) *SignalExternalWorkflowExecutionDecisionAttributes {
+	s.SignalName = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *SignalExternalWorkflowExecutionDecisionAttributes) SetWorkflowId(v string) *SignalExternalWorkflowExecutionDecisionAttributes {
+	s.WorkflowId = &v
+	return s
+}
+
 // Provides details of the SignalExternalWorkflowExecutionFailed event.
 type SignalExternalWorkflowExecutionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -8711,6 +11147,42 @@ func (s SignalExternalWorkflowExecutionFailedEventAttributes) GoString() string 
 	return s.String()
 }
 
+// SetCause sets the Cause field's value.
+func (s *SignalExternalWorkflowExecutionFailedEventAttributes) SetCause(v string) *SignalExternalWorkflowExecutionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetControl sets the Control field's value.
+func (s *SignalExternalWorkflowExecutionFailedEventAttributes) SetControl(v string) *SignalExternalWorkflowExecutionFailedEventAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *SignalExternalWorkflowExecutionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *SignalExternalWorkflowExecutionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *SignalExternalWorkflowExecutionFailedEventAttributes) SetInitiatedEventId(v int64) *SignalExternalWorkflowExecutionFailedEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *SignalExternalWorkflowExecutionFailedEventAttributes) SetRunId(v string) *SignalExternalWorkflowExecutionFailedEventAttributes {
+	s.RunId = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *SignalExternalWorkflowExecutionFailedEventAttributes) SetWorkflowId(v string) *SignalExternalWorkflowExecutionFailedEventAttributes {
+	s.WorkflowId = &v
+	return s
+}
+
 // Provides details of the SignalExternalWorkflowExecutionInitiated event.
 type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -8752,6 +11224,42 @@ func (s SignalExternalWorkflowExecutionInitiatedEventAttributes) String() string
 // GoString returns the string representation
 func (s SignalExternalWorkflowExecutionInitiatedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetControl sets the Control field's value.
+func (s *SignalExternalWorkflowExecutionInitiatedEventAttributes) SetControl(v string) *SignalExternalWorkflowExecutionInitiatedEventAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *SignalExternalWorkflowExecutionInitiatedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *SignalExternalWorkflowExecutionInitiatedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *SignalExternalWorkflowExecutionInitiatedEventAttributes) SetInput(v string) *SignalExternalWorkflowExecutionInitiatedEventAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *SignalExternalWorkflowExecutionInitiatedEventAttributes) SetRunId(v string) *SignalExternalWorkflowExecutionInitiatedEventAttributes {
+	s.RunId = &v
+	return s
+}
+
+// SetSignalName sets the SignalName field's value.
+func (s *SignalExternalWorkflowExecutionInitiatedEventAttributes) SetSignalName(v string) *SignalExternalWorkflowExecutionInitiatedEventAttributes {
+	s.SignalName = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *SignalExternalWorkflowExecutionInitiatedEventAttributes) SetWorkflowId(v string) *SignalExternalWorkflowExecutionInitiatedEventAttributes {
+	s.WorkflowId = &v
+	return s
 }
 
 type SignalWorkflowExecutionInput struct {
@@ -8816,6 +11324,36 @@ func (s *SignalWorkflowExecutionInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetDomain sets the Domain field's value.
+func (s *SignalWorkflowExecutionInput) SetDomain(v string) *SignalWorkflowExecutionInput {
+	s.Domain = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *SignalWorkflowExecutionInput) SetInput(v string) *SignalWorkflowExecutionInput {
+	s.Input = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *SignalWorkflowExecutionInput) SetRunId(v string) *SignalWorkflowExecutionInput {
+	s.RunId = &v
+	return s
+}
+
+// SetSignalName sets the SignalName field's value.
+func (s *SignalWorkflowExecutionInput) SetSignalName(v string) *SignalWorkflowExecutionInput {
+	s.SignalName = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *SignalWorkflowExecutionInput) SetWorkflowId(v string) *SignalWorkflowExecutionInput {
+	s.WorkflowId = &v
+	return s
 }
 
 type SignalWorkflowExecutionOutput struct {
@@ -9002,6 +11540,72 @@ func (s *StartChildWorkflowExecutionDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetChildPolicy(v string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetControl sets the Control field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetControl(v string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetExecutionStartToCloseTimeout sets the ExecutionStartToCloseTimeout field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetExecutionStartToCloseTimeout(v string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.ExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetInput(v string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetLambdaRole sets the LambdaRole field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetLambdaRole(v string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.LambdaRole = &v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetTagList(v []*string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.TagList = v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetTaskList(v *TaskList) *StartChildWorkflowExecutionDecisionAttributes {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetTaskPriority(v string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.TaskPriority = &v
+	return s
+}
+
+// SetTaskStartToCloseTimeout sets the TaskStartToCloseTimeout field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetTaskStartToCloseTimeout(v string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.TaskStartToCloseTimeout = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetWorkflowId(v string) *StartChildWorkflowExecutionDecisionAttributes {
+	s.WorkflowId = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *StartChildWorkflowExecutionDecisionAttributes) SetWorkflowType(v *WorkflowType) *StartChildWorkflowExecutionDecisionAttributes {
+	s.WorkflowType = v
+	return s
+}
+
 // Provides details of the StartChildWorkflowExecutionFailed event.
 type StartChildWorkflowExecutionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -9054,6 +11658,42 @@ func (s StartChildWorkflowExecutionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s StartChildWorkflowExecutionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *StartChildWorkflowExecutionFailedEventAttributes) SetCause(v string) *StartChildWorkflowExecutionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetControl sets the Control field's value.
+func (s *StartChildWorkflowExecutionFailedEventAttributes) SetControl(v string) *StartChildWorkflowExecutionFailedEventAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *StartChildWorkflowExecutionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *StartChildWorkflowExecutionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetInitiatedEventId sets the InitiatedEventId field's value.
+func (s *StartChildWorkflowExecutionFailedEventAttributes) SetInitiatedEventId(v int64) *StartChildWorkflowExecutionFailedEventAttributes {
+	s.InitiatedEventId = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *StartChildWorkflowExecutionFailedEventAttributes) SetWorkflowId(v string) *StartChildWorkflowExecutionFailedEventAttributes {
+	s.WorkflowId = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *StartChildWorkflowExecutionFailedEventAttributes) SetWorkflowType(v *WorkflowType) *StartChildWorkflowExecutionFailedEventAttributes {
+	s.WorkflowType = v
+	return s
 }
 
 // Provides details of the StartChildWorkflowExecutionInitiated event.
@@ -9149,6 +11789,78 @@ func (s StartChildWorkflowExecutionInitiatedEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetChildPolicy(v string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetControl sets the Control field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetControl(v string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetExecutionStartToCloseTimeout sets the ExecutionStartToCloseTimeout field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetExecutionStartToCloseTimeout(v string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.ExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetInput(v string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetLambdaRole sets the LambdaRole field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetLambdaRole(v string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.LambdaRole = &v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetTagList(v []*string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.TagList = v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetTaskList(v *TaskList) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetTaskPriority(v string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.TaskPriority = &v
+	return s
+}
+
+// SetTaskStartToCloseTimeout sets the TaskStartToCloseTimeout field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetTaskStartToCloseTimeout(v string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.TaskStartToCloseTimeout = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetWorkflowId(v string) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.WorkflowId = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *StartChildWorkflowExecutionInitiatedEventAttributes) SetWorkflowType(v *WorkflowType) *StartChildWorkflowExecutionInitiatedEventAttributes {
+	s.WorkflowType = v
+	return s
+}
+
 // Provides details for the StartLambdaFunctionFailed event.
 type StartLambdaFunctionFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -9178,6 +11890,24 @@ func (s StartLambdaFunctionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s StartLambdaFunctionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *StartLambdaFunctionFailedEventAttributes) SetCause(v string) *StartLambdaFunctionFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *StartLambdaFunctionFailedEventAttributes) SetMessage(v string) *StartLambdaFunctionFailedEventAttributes {
+	s.Message = &v
+	return s
+}
+
+// SetScheduledEventId sets the ScheduledEventId field's value.
+func (s *StartLambdaFunctionFailedEventAttributes) SetScheduledEventId(v int64) *StartLambdaFunctionFailedEventAttributes {
+	s.ScheduledEventId = &v
+	return s
 }
 
 // Provides details of the StartTimer decision.
@@ -9255,6 +11985,24 @@ func (s *StartTimerDecisionAttributes) Validate() error {
 	return nil
 }
 
+// SetControl sets the Control field's value.
+func (s *StartTimerDecisionAttributes) SetControl(v string) *StartTimerDecisionAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetStartToFireTimeout sets the StartToFireTimeout field's value.
+func (s *StartTimerDecisionAttributes) SetStartToFireTimeout(v string) *StartTimerDecisionAttributes {
+	s.StartToFireTimeout = &v
+	return s
+}
+
+// SetTimerId sets the TimerId field's value.
+func (s *StartTimerDecisionAttributes) SetTimerId(v string) *StartTimerDecisionAttributes {
+	s.TimerId = &v
+	return s
+}
+
 // Provides details of the StartTimerFailed event.
 type StartTimerFailedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -9291,6 +12039,24 @@ func (s StartTimerFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s StartTimerFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetCause sets the Cause field's value.
+func (s *StartTimerFailedEventAttributes) SetCause(v string) *StartTimerFailedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *StartTimerFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *StartTimerFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetTimerId sets the TimerId field's value.
+func (s *StartTimerFailedEventAttributes) SetTimerId(v string) *StartTimerFailedEventAttributes {
+	s.TimerId = &v
+	return s
 }
 
 type StartWorkflowExecutionInput struct {
@@ -9458,6 +12224,72 @@ func (s *StartWorkflowExecutionInput) Validate() error {
 	return nil
 }
 
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *StartWorkflowExecutionInput) SetChildPolicy(v string) *StartWorkflowExecutionInput {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *StartWorkflowExecutionInput) SetDomain(v string) *StartWorkflowExecutionInput {
+	s.Domain = &v
+	return s
+}
+
+// SetExecutionStartToCloseTimeout sets the ExecutionStartToCloseTimeout field's value.
+func (s *StartWorkflowExecutionInput) SetExecutionStartToCloseTimeout(v string) *StartWorkflowExecutionInput {
+	s.ExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *StartWorkflowExecutionInput) SetInput(v string) *StartWorkflowExecutionInput {
+	s.Input = &v
+	return s
+}
+
+// SetLambdaRole sets the LambdaRole field's value.
+func (s *StartWorkflowExecutionInput) SetLambdaRole(v string) *StartWorkflowExecutionInput {
+	s.LambdaRole = &v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *StartWorkflowExecutionInput) SetTagList(v []*string) *StartWorkflowExecutionInput {
+	s.TagList = v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *StartWorkflowExecutionInput) SetTaskList(v *TaskList) *StartWorkflowExecutionInput {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *StartWorkflowExecutionInput) SetTaskPriority(v string) *StartWorkflowExecutionInput {
+	s.TaskPriority = &v
+	return s
+}
+
+// SetTaskStartToCloseTimeout sets the TaskStartToCloseTimeout field's value.
+func (s *StartWorkflowExecutionInput) SetTaskStartToCloseTimeout(v string) *StartWorkflowExecutionInput {
+	s.TaskStartToCloseTimeout = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *StartWorkflowExecutionInput) SetWorkflowId(v string) *StartWorkflowExecutionInput {
+	s.WorkflowId = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *StartWorkflowExecutionInput) SetWorkflowType(v *WorkflowType) *StartWorkflowExecutionInput {
+	s.WorkflowType = v
+	return s
+}
+
 // Specifies the runId of a workflow execution.
 type StartWorkflowExecutionOutput struct {
 	_ struct{} `type:"structure"`
@@ -9475,6 +12307,12 @@ func (s StartWorkflowExecutionOutput) String() string {
 // GoString returns the string representation
 func (s StartWorkflowExecutionOutput) GoString() string {
 	return s.String()
+}
+
+// SetRunId sets the RunId field's value.
+func (s *StartWorkflowExecutionOutput) SetRunId(v string) *StartWorkflowExecutionOutput {
+	s.RunId = &v
+	return s
 }
 
 // Used to filter the workflow executions in visibility APIs based on a tag.
@@ -9514,6 +12352,12 @@ func (s *TagFilter) Validate() error {
 	return nil
 }
 
+// SetTag sets the Tag field's value.
+func (s *TagFilter) SetTag(v string) *TagFilter {
+	s.Tag = &v
+	return s
+}
+
 // Represents a task list.
 type TaskList struct {
 	_ struct{} `type:"structure"`
@@ -9548,6 +12392,12 @@ func (s *TaskList) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *TaskList) SetName(v string) *TaskList {
+	s.Name = &v
+	return s
 }
 
 type TerminateWorkflowExecutionInput struct {
@@ -9625,6 +12475,42 @@ func (s *TerminateWorkflowExecutionInput) Validate() error {
 	return nil
 }
 
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *TerminateWorkflowExecutionInput) SetChildPolicy(v string) *TerminateWorkflowExecutionInput {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *TerminateWorkflowExecutionInput) SetDetails(v string) *TerminateWorkflowExecutionInput {
+	s.Details = &v
+	return s
+}
+
+// SetDomain sets the Domain field's value.
+func (s *TerminateWorkflowExecutionInput) SetDomain(v string) *TerminateWorkflowExecutionInput {
+	s.Domain = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *TerminateWorkflowExecutionInput) SetReason(v string) *TerminateWorkflowExecutionInput {
+	s.Reason = &v
+	return s
+}
+
+// SetRunId sets the RunId field's value.
+func (s *TerminateWorkflowExecutionInput) SetRunId(v string) *TerminateWorkflowExecutionInput {
+	s.RunId = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *TerminateWorkflowExecutionInput) SetWorkflowId(v string) *TerminateWorkflowExecutionInput {
+	s.WorkflowId = &v
+	return s
+}
+
 type TerminateWorkflowExecutionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -9674,6 +12560,24 @@ func (s TimerCanceledEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *TimerCanceledEventAttributes) SetDecisionTaskCompletedEventId(v int64) *TimerCanceledEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *TimerCanceledEventAttributes) SetStartedEventId(v int64) *TimerCanceledEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetTimerId sets the TimerId field's value.
+func (s *TimerCanceledEventAttributes) SetTimerId(v string) *TimerCanceledEventAttributes {
+	s.TimerId = &v
+	return s
+}
+
 // Provides details of the TimerFired event.
 type TimerFiredEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -9699,6 +12603,18 @@ func (s TimerFiredEventAttributes) String() string {
 // GoString returns the string representation
 func (s TimerFiredEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetStartedEventId sets the StartedEventId field's value.
+func (s *TimerFiredEventAttributes) SetStartedEventId(v int64) *TimerFiredEventAttributes {
+	s.StartedEventId = &v
+	return s
+}
+
+// SetTimerId sets the TimerId field's value.
+func (s *TimerFiredEventAttributes) SetTimerId(v string) *TimerFiredEventAttributes {
+	s.TimerId = &v
+	return s
 }
 
 // Provides details of the TimerStarted event.
@@ -9739,6 +12655,30 @@ func (s TimerStartedEventAttributes) String() string {
 // GoString returns the string representation
 func (s TimerStartedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetControl sets the Control field's value.
+func (s *TimerStartedEventAttributes) SetControl(v string) *TimerStartedEventAttributes {
+	s.Control = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *TimerStartedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *TimerStartedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetStartToFireTimeout sets the StartToFireTimeout field's value.
+func (s *TimerStartedEventAttributes) SetStartToFireTimeout(v string) *TimerStartedEventAttributes {
+	s.StartToFireTimeout = &v
+	return s
+}
+
+// SetTimerId sets the TimerId field's value.
+func (s *TimerStartedEventAttributes) SetTimerId(v string) *TimerStartedEventAttributes {
+	s.TimerId = &v
+	return s
 }
 
 // Represents a workflow execution.
@@ -9788,6 +12728,18 @@ func (s *WorkflowExecution) Validate() error {
 	return nil
 }
 
+// SetRunId sets the RunId field's value.
+func (s *WorkflowExecution) SetRunId(v string) *WorkflowExecution {
+	s.RunId = &v
+	return s
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *WorkflowExecution) SetWorkflowId(v string) *WorkflowExecution {
+	s.WorkflowId = &v
+	return s
+}
+
 // Provides details of the WorkflowExecutionCancelRequested event.
 type WorkflowExecutionCancelRequestedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -9818,6 +12770,24 @@ func (s WorkflowExecutionCancelRequestedEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetCause sets the Cause field's value.
+func (s *WorkflowExecutionCancelRequestedEventAttributes) SetCause(v string) *WorkflowExecutionCancelRequestedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetExternalInitiatedEventId sets the ExternalInitiatedEventId field's value.
+func (s *WorkflowExecutionCancelRequestedEventAttributes) SetExternalInitiatedEventId(v int64) *WorkflowExecutionCancelRequestedEventAttributes {
+	s.ExternalInitiatedEventId = &v
+	return s
+}
+
+// SetExternalWorkflowExecution sets the ExternalWorkflowExecution field's value.
+func (s *WorkflowExecutionCancelRequestedEventAttributes) SetExternalWorkflowExecution(v *WorkflowExecution) *WorkflowExecutionCancelRequestedEventAttributes {
+	s.ExternalWorkflowExecution = v
+	return s
+}
+
 // Provides details of the WorkflowExecutionCanceled event.
 type WorkflowExecutionCanceledEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -9844,6 +12814,18 @@ func (s WorkflowExecutionCanceledEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *WorkflowExecutionCanceledEventAttributes) SetDecisionTaskCompletedEventId(v int64) *WorkflowExecutionCanceledEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *WorkflowExecutionCanceledEventAttributes) SetDetails(v string) *WorkflowExecutionCanceledEventAttributes {
+	s.Details = &v
+	return s
+}
+
 // Provides details of the WorkflowExecutionCompleted event.
 type WorkflowExecutionCompletedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -9868,6 +12850,18 @@ func (s WorkflowExecutionCompletedEventAttributes) String() string {
 // GoString returns the string representation
 func (s WorkflowExecutionCompletedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *WorkflowExecutionCompletedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *WorkflowExecutionCompletedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetResult sets the Result field's value.
+func (s *WorkflowExecutionCompletedEventAttributes) SetResult(v string) *WorkflowExecutionCompletedEventAttributes {
+	s.Result = &v
+	return s
 }
 
 // The configuration settings for a workflow execution including timeout values,
@@ -9936,6 +12930,42 @@ func (s WorkflowExecutionConfiguration) String() string {
 // GoString returns the string representation
 func (s WorkflowExecutionConfiguration) GoString() string {
 	return s.String()
+}
+
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *WorkflowExecutionConfiguration) SetChildPolicy(v string) *WorkflowExecutionConfiguration {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetExecutionStartToCloseTimeout sets the ExecutionStartToCloseTimeout field's value.
+func (s *WorkflowExecutionConfiguration) SetExecutionStartToCloseTimeout(v string) *WorkflowExecutionConfiguration {
+	s.ExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetLambdaRole sets the LambdaRole field's value.
+func (s *WorkflowExecutionConfiguration) SetLambdaRole(v string) *WorkflowExecutionConfiguration {
+	s.LambdaRole = &v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *WorkflowExecutionConfiguration) SetTaskList(v *TaskList) *WorkflowExecutionConfiguration {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *WorkflowExecutionConfiguration) SetTaskPriority(v string) *WorkflowExecutionConfiguration {
+	s.TaskPriority = &v
+	return s
+}
+
+// SetTaskStartToCloseTimeout sets the TaskStartToCloseTimeout field's value.
+func (s *WorkflowExecutionConfiguration) SetTaskStartToCloseTimeout(v string) *WorkflowExecutionConfiguration {
+	s.TaskStartToCloseTimeout = &v
+	return s
 }
 
 // Provides details of the WorkflowExecutionContinuedAsNew event.
@@ -10017,6 +13047,72 @@ func (s WorkflowExecutionContinuedAsNewEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetChildPolicy(v string) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetDecisionTaskCompletedEventId(v int64) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetExecutionStartToCloseTimeout sets the ExecutionStartToCloseTimeout field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetExecutionStartToCloseTimeout(v string) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.ExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetInput(v string) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetLambdaRole sets the LambdaRole field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetLambdaRole(v string) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.LambdaRole = &v
+	return s
+}
+
+// SetNewExecutionRunId sets the NewExecutionRunId field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetNewExecutionRunId(v string) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.NewExecutionRunId = &v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetTagList(v []*string) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.TagList = v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetTaskList(v *TaskList) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetTaskPriority(v string) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.TaskPriority = &v
+	return s
+}
+
+// SetTaskStartToCloseTimeout sets the TaskStartToCloseTimeout field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetTaskStartToCloseTimeout(v string) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.TaskStartToCloseTimeout = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *WorkflowExecutionContinuedAsNewEventAttributes) SetWorkflowType(v *WorkflowType) *WorkflowExecutionContinuedAsNewEventAttributes {
+	s.WorkflowType = v
+	return s
+}
+
 // Contains the count of workflow executions returned from CountOpenWorkflowExecutions
 // or CountClosedWorkflowExecutions
 type WorkflowExecutionCount struct {
@@ -10040,6 +13136,18 @@ func (s WorkflowExecutionCount) String() string {
 // GoString returns the string representation
 func (s WorkflowExecutionCount) GoString() string {
 	return s.String()
+}
+
+// SetCount sets the Count field's value.
+func (s *WorkflowExecutionCount) SetCount(v int64) *WorkflowExecutionCount {
+	s.Count = &v
+	return s
+}
+
+// SetTruncated sets the Truncated field's value.
+func (s *WorkflowExecutionCount) SetTruncated(v bool) *WorkflowExecutionCount {
+	s.Truncated = &v
+	return s
 }
 
 // Provides details of the WorkflowExecutionFailed event.
@@ -10069,6 +13177,24 @@ func (s WorkflowExecutionFailedEventAttributes) String() string {
 // GoString returns the string representation
 func (s WorkflowExecutionFailedEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetDecisionTaskCompletedEventId sets the DecisionTaskCompletedEventId field's value.
+func (s *WorkflowExecutionFailedEventAttributes) SetDecisionTaskCompletedEventId(v int64) *WorkflowExecutionFailedEventAttributes {
+	s.DecisionTaskCompletedEventId = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *WorkflowExecutionFailedEventAttributes) SetDetails(v string) *WorkflowExecutionFailedEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *WorkflowExecutionFailedEventAttributes) SetReason(v string) *WorkflowExecutionFailedEventAttributes {
+	s.Reason = &v
+	return s
 }
 
 // Used to filter the workflow executions in visibility APIs by their workflowId.
@@ -10105,6 +13231,12 @@ func (s *WorkflowExecutionFilter) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetWorkflowId sets the WorkflowId field's value.
+func (s *WorkflowExecutionFilter) SetWorkflowId(v string) *WorkflowExecutionFilter {
+	s.WorkflowId = &v
+	return s
 }
 
 // Contains information about a workflow execution.
@@ -10173,6 +13305,60 @@ func (s WorkflowExecutionInfo) GoString() string {
 	return s.String()
 }
 
+// SetCancelRequested sets the CancelRequested field's value.
+func (s *WorkflowExecutionInfo) SetCancelRequested(v bool) *WorkflowExecutionInfo {
+	s.CancelRequested = &v
+	return s
+}
+
+// SetCloseStatus sets the CloseStatus field's value.
+func (s *WorkflowExecutionInfo) SetCloseStatus(v string) *WorkflowExecutionInfo {
+	s.CloseStatus = &v
+	return s
+}
+
+// SetCloseTimestamp sets the CloseTimestamp field's value.
+func (s *WorkflowExecutionInfo) SetCloseTimestamp(v time.Time) *WorkflowExecutionInfo {
+	s.CloseTimestamp = &v
+	return s
+}
+
+// SetExecution sets the Execution field's value.
+func (s *WorkflowExecutionInfo) SetExecution(v *WorkflowExecution) *WorkflowExecutionInfo {
+	s.Execution = v
+	return s
+}
+
+// SetExecutionStatus sets the ExecutionStatus field's value.
+func (s *WorkflowExecutionInfo) SetExecutionStatus(v string) *WorkflowExecutionInfo {
+	s.ExecutionStatus = &v
+	return s
+}
+
+// SetParent sets the Parent field's value.
+func (s *WorkflowExecutionInfo) SetParent(v *WorkflowExecution) *WorkflowExecutionInfo {
+	s.Parent = v
+	return s
+}
+
+// SetStartTimestamp sets the StartTimestamp field's value.
+func (s *WorkflowExecutionInfo) SetStartTimestamp(v time.Time) *WorkflowExecutionInfo {
+	s.StartTimestamp = &v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *WorkflowExecutionInfo) SetTagList(v []*string) *WorkflowExecutionInfo {
+	s.TagList = v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *WorkflowExecutionInfo) SetWorkflowType(v *WorkflowType) *WorkflowExecutionInfo {
+	s.WorkflowType = v
+	return s
+}
+
 // Contains a paginated list of information about workflow executions.
 type WorkflowExecutionInfos struct {
 	_ struct{} `type:"structure"`
@@ -10199,6 +13385,18 @@ func (s WorkflowExecutionInfos) String() string {
 // GoString returns the string representation
 func (s WorkflowExecutionInfos) GoString() string {
 	return s.String()
+}
+
+// SetExecutionInfos sets the ExecutionInfos field's value.
+func (s *WorkflowExecutionInfos) SetExecutionInfos(v []*WorkflowExecutionInfo) *WorkflowExecutionInfos {
+	s.ExecutionInfos = v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *WorkflowExecutionInfos) SetNextPageToken(v string) *WorkflowExecutionInfos {
+	s.NextPageToken = &v
+	return s
 }
 
 // Contains the counts of open tasks, child workflow executions and timers for
@@ -10242,6 +13440,36 @@ func (s WorkflowExecutionOpenCounts) GoString() string {
 	return s.String()
 }
 
+// SetOpenActivityTasks sets the OpenActivityTasks field's value.
+func (s *WorkflowExecutionOpenCounts) SetOpenActivityTasks(v int64) *WorkflowExecutionOpenCounts {
+	s.OpenActivityTasks = &v
+	return s
+}
+
+// SetOpenChildWorkflowExecutions sets the OpenChildWorkflowExecutions field's value.
+func (s *WorkflowExecutionOpenCounts) SetOpenChildWorkflowExecutions(v int64) *WorkflowExecutionOpenCounts {
+	s.OpenChildWorkflowExecutions = &v
+	return s
+}
+
+// SetOpenDecisionTasks sets the OpenDecisionTasks field's value.
+func (s *WorkflowExecutionOpenCounts) SetOpenDecisionTasks(v int64) *WorkflowExecutionOpenCounts {
+	s.OpenDecisionTasks = &v
+	return s
+}
+
+// SetOpenLambdaFunctions sets the OpenLambdaFunctions field's value.
+func (s *WorkflowExecutionOpenCounts) SetOpenLambdaFunctions(v int64) *WorkflowExecutionOpenCounts {
+	s.OpenLambdaFunctions = &v
+	return s
+}
+
+// SetOpenTimers sets the OpenTimers field's value.
+func (s *WorkflowExecutionOpenCounts) SetOpenTimers(v int64) *WorkflowExecutionOpenCounts {
+	s.OpenTimers = &v
+	return s
+}
+
 // Provides details of the WorkflowExecutionSignaled event.
 type WorkflowExecutionSignaledEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -10277,6 +13505,30 @@ func (s WorkflowExecutionSignaledEventAttributes) String() string {
 // GoString returns the string representation
 func (s WorkflowExecutionSignaledEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetExternalInitiatedEventId sets the ExternalInitiatedEventId field's value.
+func (s *WorkflowExecutionSignaledEventAttributes) SetExternalInitiatedEventId(v int64) *WorkflowExecutionSignaledEventAttributes {
+	s.ExternalInitiatedEventId = &v
+	return s
+}
+
+// SetExternalWorkflowExecution sets the ExternalWorkflowExecution field's value.
+func (s *WorkflowExecutionSignaledEventAttributes) SetExternalWorkflowExecution(v *WorkflowExecution) *WorkflowExecutionSignaledEventAttributes {
+	s.ExternalWorkflowExecution = v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *WorkflowExecutionSignaledEventAttributes) SetInput(v string) *WorkflowExecutionSignaledEventAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetSignalName sets the SignalName field's value.
+func (s *WorkflowExecutionSignaledEventAttributes) SetSignalName(v string) *WorkflowExecutionSignaledEventAttributes {
+	s.SignalName = &v
+	return s
 }
 
 // Provides details of WorkflowExecutionStarted event.
@@ -10363,6 +13615,78 @@ func (s WorkflowExecutionStartedEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetChildPolicy(v string) *WorkflowExecutionStartedEventAttributes {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetContinuedExecutionRunId sets the ContinuedExecutionRunId field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetContinuedExecutionRunId(v string) *WorkflowExecutionStartedEventAttributes {
+	s.ContinuedExecutionRunId = &v
+	return s
+}
+
+// SetExecutionStartToCloseTimeout sets the ExecutionStartToCloseTimeout field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetExecutionStartToCloseTimeout(v string) *WorkflowExecutionStartedEventAttributes {
+	s.ExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetInput sets the Input field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetInput(v string) *WorkflowExecutionStartedEventAttributes {
+	s.Input = &v
+	return s
+}
+
+// SetLambdaRole sets the LambdaRole field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetLambdaRole(v string) *WorkflowExecutionStartedEventAttributes {
+	s.LambdaRole = &v
+	return s
+}
+
+// SetParentInitiatedEventId sets the ParentInitiatedEventId field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetParentInitiatedEventId(v int64) *WorkflowExecutionStartedEventAttributes {
+	s.ParentInitiatedEventId = &v
+	return s
+}
+
+// SetParentWorkflowExecution sets the ParentWorkflowExecution field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetParentWorkflowExecution(v *WorkflowExecution) *WorkflowExecutionStartedEventAttributes {
+	s.ParentWorkflowExecution = v
+	return s
+}
+
+// SetTagList sets the TagList field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetTagList(v []*string) *WorkflowExecutionStartedEventAttributes {
+	s.TagList = v
+	return s
+}
+
+// SetTaskList sets the TaskList field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetTaskList(v *TaskList) *WorkflowExecutionStartedEventAttributes {
+	s.TaskList = v
+	return s
+}
+
+// SetTaskPriority sets the TaskPriority field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetTaskPriority(v string) *WorkflowExecutionStartedEventAttributes {
+	s.TaskPriority = &v
+	return s
+}
+
+// SetTaskStartToCloseTimeout sets the TaskStartToCloseTimeout field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetTaskStartToCloseTimeout(v string) *WorkflowExecutionStartedEventAttributes {
+	s.TaskStartToCloseTimeout = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *WorkflowExecutionStartedEventAttributes) SetWorkflowType(v *WorkflowType) *WorkflowExecutionStartedEventAttributes {
+	s.WorkflowType = v
+	return s
+}
+
 // Provides details of the WorkflowExecutionTerminated event.
 type WorkflowExecutionTerminatedEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -10404,6 +13728,30 @@ func (s WorkflowExecutionTerminatedEventAttributes) GoString() string {
 	return s.String()
 }
 
+// SetCause sets the Cause field's value.
+func (s *WorkflowExecutionTerminatedEventAttributes) SetCause(v string) *WorkflowExecutionTerminatedEventAttributes {
+	s.Cause = &v
+	return s
+}
+
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *WorkflowExecutionTerminatedEventAttributes) SetChildPolicy(v string) *WorkflowExecutionTerminatedEventAttributes {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetDetails sets the Details field's value.
+func (s *WorkflowExecutionTerminatedEventAttributes) SetDetails(v string) *WorkflowExecutionTerminatedEventAttributes {
+	s.Details = &v
+	return s
+}
+
+// SetReason sets the Reason field's value.
+func (s *WorkflowExecutionTerminatedEventAttributes) SetReason(v string) *WorkflowExecutionTerminatedEventAttributes {
+	s.Reason = &v
+	return s
+}
+
 // Provides details of the WorkflowExecutionTimedOut event.
 type WorkflowExecutionTimedOutEventAttributes struct {
 	_ struct{} `type:"structure"`
@@ -10437,6 +13785,18 @@ func (s WorkflowExecutionTimedOutEventAttributes) String() string {
 // GoString returns the string representation
 func (s WorkflowExecutionTimedOutEventAttributes) GoString() string {
 	return s.String()
+}
+
+// SetChildPolicy sets the ChildPolicy field's value.
+func (s *WorkflowExecutionTimedOutEventAttributes) SetChildPolicy(v string) *WorkflowExecutionTimedOutEventAttributes {
+	s.ChildPolicy = &v
+	return s
+}
+
+// SetTimeoutType sets the TimeoutType field's value.
+func (s *WorkflowExecutionTimedOutEventAttributes) SetTimeoutType(v string) *WorkflowExecutionTimedOutEventAttributes {
+	s.TimeoutType = &v
+	return s
 }
 
 // Represents a workflow type.
@@ -10490,6 +13850,18 @@ func (s *WorkflowType) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *WorkflowType) SetName(v string) *WorkflowType {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *WorkflowType) SetVersion(v string) *WorkflowType {
+	s.Version = &v
+	return s
 }
 
 // The configuration settings of a workflow type.
@@ -10568,6 +13940,42 @@ func (s WorkflowTypeConfiguration) GoString() string {
 	return s.String()
 }
 
+// SetDefaultChildPolicy sets the DefaultChildPolicy field's value.
+func (s *WorkflowTypeConfiguration) SetDefaultChildPolicy(v string) *WorkflowTypeConfiguration {
+	s.DefaultChildPolicy = &v
+	return s
+}
+
+// SetDefaultExecutionStartToCloseTimeout sets the DefaultExecutionStartToCloseTimeout field's value.
+func (s *WorkflowTypeConfiguration) SetDefaultExecutionStartToCloseTimeout(v string) *WorkflowTypeConfiguration {
+	s.DefaultExecutionStartToCloseTimeout = &v
+	return s
+}
+
+// SetDefaultLambdaRole sets the DefaultLambdaRole field's value.
+func (s *WorkflowTypeConfiguration) SetDefaultLambdaRole(v string) *WorkflowTypeConfiguration {
+	s.DefaultLambdaRole = &v
+	return s
+}
+
+// SetDefaultTaskList sets the DefaultTaskList field's value.
+func (s *WorkflowTypeConfiguration) SetDefaultTaskList(v *TaskList) *WorkflowTypeConfiguration {
+	s.DefaultTaskList = v
+	return s
+}
+
+// SetDefaultTaskPriority sets the DefaultTaskPriority field's value.
+func (s *WorkflowTypeConfiguration) SetDefaultTaskPriority(v string) *WorkflowTypeConfiguration {
+	s.DefaultTaskPriority = &v
+	return s
+}
+
+// SetDefaultTaskStartToCloseTimeout sets the DefaultTaskStartToCloseTimeout field's value.
+func (s *WorkflowTypeConfiguration) SetDefaultTaskStartToCloseTimeout(v string) *WorkflowTypeConfiguration {
+	s.DefaultTaskStartToCloseTimeout = &v
+	return s
+}
+
 // Used to filter workflow execution query results by type. Each parameter,
 // if specified, defines a rule that must be satisfied by each returned result.
 type WorkflowTypeFilter struct {
@@ -10608,6 +14016,18 @@ func (s *WorkflowTypeFilter) Validate() error {
 	return nil
 }
 
+// SetName sets the Name field's value.
+func (s *WorkflowTypeFilter) SetName(v string) *WorkflowTypeFilter {
+	s.Name = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *WorkflowTypeFilter) SetVersion(v string) *WorkflowTypeFilter {
+	s.Version = &v
+	return s
+}
+
 // Contains information about a workflow type.
 type WorkflowTypeInfo struct {
 	_ struct{} `type:"structure"`
@@ -10643,6 +14063,36 @@ func (s WorkflowTypeInfo) String() string {
 // GoString returns the string representation
 func (s WorkflowTypeInfo) GoString() string {
 	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *WorkflowTypeInfo) SetCreationDate(v time.Time) *WorkflowTypeInfo {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDeprecationDate sets the DeprecationDate field's value.
+func (s *WorkflowTypeInfo) SetDeprecationDate(v time.Time) *WorkflowTypeInfo {
+	s.DeprecationDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *WorkflowTypeInfo) SetDescription(v string) *WorkflowTypeInfo {
+	s.Description = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *WorkflowTypeInfo) SetStatus(v string) *WorkflowTypeInfo {
+	s.Status = &v
+	return s
+}
+
+// SetWorkflowType sets the WorkflowType field's value.
+func (s *WorkflowTypeInfo) SetWorkflowType(v *WorkflowType) *WorkflowTypeInfo {
+	s.WorkflowType = v
+	return s
 }
 
 const (

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -4266,6 +4266,24 @@ func (s *ActivatedRule) Validate() error {
 	return nil
 }
 
+// SetAction sets the Action field's value.
+func (s *ActivatedRule) SetAction(v *WafAction) *ActivatedRule {
+	s.Action = v
+	return s
+}
+
+// SetPriority sets the Priority field's value.
+func (s *ActivatedRule) SetPriority(v int64) *ActivatedRule {
+	s.Priority = &v
+	return s
+}
+
+// SetRuleId sets the RuleId field's value.
+func (s *ActivatedRule) SetRuleId(v string) *ActivatedRule {
+	s.RuleId = &v
+	return s
+}
+
 // In a GetByteMatchSet request, ByteMatchSet is a complex type that contains
 // the ByteMatchSetId and Name of a ByteMatchSet, and the values that you specified
 // when you updated the ByteMatchSet.
@@ -4310,6 +4328,24 @@ func (s ByteMatchSet) GoString() string {
 	return s.String()
 }
 
+// SetByteMatchSetId sets the ByteMatchSetId field's value.
+func (s *ByteMatchSet) SetByteMatchSetId(v string) *ByteMatchSet {
+	s.ByteMatchSetId = &v
+	return s
+}
+
+// SetByteMatchTuples sets the ByteMatchTuples field's value.
+func (s *ByteMatchSet) SetByteMatchTuples(v []*ByteMatchTuple) *ByteMatchSet {
+	s.ByteMatchTuples = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ByteMatchSet) SetName(v string) *ByteMatchSet {
+	s.Name = &v
+	return s
+}
+
 // Returned by ListByteMatchSets. Each ByteMatchSetSummary object includes the
 // Name and ByteMatchSetId for one ByteMatchSet.
 type ByteMatchSetSummary struct {
@@ -4339,6 +4375,18 @@ func (s ByteMatchSetSummary) String() string {
 // GoString returns the string representation
 func (s ByteMatchSetSummary) GoString() string {
 	return s.String()
+}
+
+// SetByteMatchSetId sets the ByteMatchSetId field's value.
+func (s *ByteMatchSetSummary) SetByteMatchSetId(v string) *ByteMatchSetSummary {
+	s.ByteMatchSetId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ByteMatchSetSummary) SetName(v string) *ByteMatchSetSummary {
+	s.Name = &v
+	return s
 }
 
 // In an UpdateByteMatchSet request, ByteMatchSetUpdate specifies whether to
@@ -4389,6 +4437,18 @@ func (s *ByteMatchSetUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAction sets the Action field's value.
+func (s *ByteMatchSetUpdate) SetAction(v string) *ByteMatchSetUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetByteMatchTuple sets the ByteMatchTuple field's value.
+func (s *ByteMatchSetUpdate) SetByteMatchTuple(v *ByteMatchTuple) *ByteMatchSetUpdate {
+	s.ByteMatchTuple = v
+	return s
 }
 
 // The bytes (typically a string that corresponds with ASCII characters) that
@@ -4615,6 +4675,30 @@ func (s *ByteMatchTuple) Validate() error {
 	return nil
 }
 
+// SetFieldToMatch sets the FieldToMatch field's value.
+func (s *ByteMatchTuple) SetFieldToMatch(v *FieldToMatch) *ByteMatchTuple {
+	s.FieldToMatch = v
+	return s
+}
+
+// SetPositionalConstraint sets the PositionalConstraint field's value.
+func (s *ByteMatchTuple) SetPositionalConstraint(v string) *ByteMatchTuple {
+	s.PositionalConstraint = &v
+	return s
+}
+
+// SetTargetString sets the TargetString field's value.
+func (s *ByteMatchTuple) SetTargetString(v []byte) *ByteMatchTuple {
+	s.TargetString = v
+	return s
+}
+
+// SetTextTransformation sets the TextTransformation field's value.
+func (s *ByteMatchTuple) SetTextTransformation(v string) *ByteMatchTuple {
+	s.TextTransformation = &v
+	return s
+}
+
 type CreateByteMatchSetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4662,6 +4746,18 @@ func (s *CreateByteMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateByteMatchSetInput) SetChangeToken(v string) *CreateByteMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateByteMatchSetInput) SetName(v string) *CreateByteMatchSetInput {
+	s.Name = &v
+	return s
+}
+
 type CreateByteMatchSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4682,6 +4778,18 @@ func (s CreateByteMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s CreateByteMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetByteMatchSet sets the ByteMatchSet field's value.
+func (s *CreateByteMatchSetOutput) SetByteMatchSet(v *ByteMatchSet) *CreateByteMatchSetOutput {
+	s.ByteMatchSet = v
+	return s
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateByteMatchSetOutput) SetChangeToken(v string) *CreateByteMatchSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type CreateIPSetInput struct {
@@ -4731,6 +4839,18 @@ func (s *CreateIPSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateIPSetInput) SetChangeToken(v string) *CreateIPSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateIPSetInput) SetName(v string) *CreateIPSetInput {
+	s.Name = &v
+	return s
+}
+
 type CreateIPSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4751,6 +4871,18 @@ func (s CreateIPSetOutput) String() string {
 // GoString returns the string representation
 func (s CreateIPSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateIPSetOutput) SetChangeToken(v string) *CreateIPSetOutput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetIPSet sets the IPSet field's value.
+func (s *CreateIPSetOutput) SetIPSet(v *IPSet) *CreateIPSetOutput {
+	s.IPSet = v
+	return s
 }
 
 type CreateRuleInput struct {
@@ -4811,6 +4943,24 @@ func (s *CreateRuleInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateRuleInput) SetChangeToken(v string) *CreateRuleInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *CreateRuleInput) SetMetricName(v string) *CreateRuleInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateRuleInput) SetName(v string) *CreateRuleInput {
+	s.Name = &v
+	return s
+}
+
 type CreateRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4831,6 +4981,18 @@ func (s CreateRuleOutput) String() string {
 // GoString returns the string representation
 func (s CreateRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateRuleOutput) SetChangeToken(v string) *CreateRuleOutput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetRule sets the Rule field's value.
+func (s *CreateRuleOutput) SetRule(v *Rule) *CreateRuleOutput {
+	s.Rule = v
+	return s
 }
 
 type CreateSizeConstraintSetInput struct {
@@ -4880,6 +5042,18 @@ func (s *CreateSizeConstraintSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateSizeConstraintSetInput) SetChangeToken(v string) *CreateSizeConstraintSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateSizeConstraintSetInput) SetName(v string) *CreateSizeConstraintSetInput {
+	s.Name = &v
+	return s
+}
+
 type CreateSizeConstraintSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -4900,6 +5074,18 @@ func (s CreateSizeConstraintSetOutput) String() string {
 // GoString returns the string representation
 func (s CreateSizeConstraintSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateSizeConstraintSetOutput) SetChangeToken(v string) *CreateSizeConstraintSetOutput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetSizeConstraintSet sets the SizeConstraintSet field's value.
+func (s *CreateSizeConstraintSetOutput) SetSizeConstraintSet(v *SizeConstraintSet) *CreateSizeConstraintSetOutput {
+	s.SizeConstraintSet = v
+	return s
 }
 
 // A request to create a SqlInjectionMatchSet.
@@ -4950,6 +5136,18 @@ func (s *CreateSqlInjectionMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateSqlInjectionMatchSetInput) SetChangeToken(v string) *CreateSqlInjectionMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateSqlInjectionMatchSetInput) SetName(v string) *CreateSqlInjectionMatchSetInput {
+	s.Name = &v
+	return s
+}
+
 // The response to a CreateSqlInjectionMatchSet request.
 type CreateSqlInjectionMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -4971,6 +5169,18 @@ func (s CreateSqlInjectionMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s CreateSqlInjectionMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateSqlInjectionMatchSetOutput) SetChangeToken(v string) *CreateSqlInjectionMatchSetOutput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetSqlInjectionMatchSet sets the SqlInjectionMatchSet field's value.
+func (s *CreateSqlInjectionMatchSetOutput) SetSqlInjectionMatchSet(v *SqlInjectionMatchSet) *CreateSqlInjectionMatchSetOutput {
+	s.SqlInjectionMatchSet = v
+	return s
 }
 
 type CreateWebACLInput struct {
@@ -5045,6 +5255,30 @@ func (s *CreateWebACLInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateWebACLInput) SetChangeToken(v string) *CreateWebACLInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetDefaultAction sets the DefaultAction field's value.
+func (s *CreateWebACLInput) SetDefaultAction(v *WafAction) *CreateWebACLInput {
+	s.DefaultAction = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *CreateWebACLInput) SetMetricName(v string) *CreateWebACLInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateWebACLInput) SetName(v string) *CreateWebACLInput {
+	s.Name = &v
+	return s
+}
+
 type CreateWebACLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5065,6 +5299,18 @@ func (s CreateWebACLOutput) String() string {
 // GoString returns the string representation
 func (s CreateWebACLOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateWebACLOutput) SetChangeToken(v string) *CreateWebACLOutput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetWebACL sets the WebACL field's value.
+func (s *CreateWebACLOutput) SetWebACL(v *WebACL) *CreateWebACLOutput {
+	s.WebACL = v
+	return s
 }
 
 // A request to create an XssMatchSet.
@@ -5115,6 +5361,18 @@ func (s *CreateXssMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateXssMatchSetInput) SetChangeToken(v string) *CreateXssMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateXssMatchSetInput) SetName(v string) *CreateXssMatchSetInput {
+	s.Name = &v
+	return s
+}
+
 // The response to a CreateXssMatchSet request.
 type CreateXssMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -5136,6 +5394,18 @@ func (s CreateXssMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s CreateXssMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateXssMatchSetOutput) SetChangeToken(v string) *CreateXssMatchSetOutput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetXssMatchSet sets the XssMatchSet field's value.
+func (s *CreateXssMatchSetOutput) SetXssMatchSet(v *XssMatchSet) *CreateXssMatchSetOutput {
+	s.XssMatchSet = v
+	return s
 }
 
 type DeleteByteMatchSetInput struct {
@@ -5185,6 +5455,18 @@ func (s *DeleteByteMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetByteMatchSetId sets the ByteMatchSetId field's value.
+func (s *DeleteByteMatchSetInput) SetByteMatchSetId(v string) *DeleteByteMatchSetInput {
+	s.ByteMatchSetId = &v
+	return s
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteByteMatchSetInput) SetChangeToken(v string) *DeleteByteMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
 type DeleteByteMatchSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5202,6 +5484,12 @@ func (s DeleteByteMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteByteMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteByteMatchSetOutput) SetChangeToken(v string) *DeleteByteMatchSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type DeleteIPSetInput struct {
@@ -5251,6 +5539,18 @@ func (s *DeleteIPSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteIPSetInput) SetChangeToken(v string) *DeleteIPSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetIPSetId sets the IPSetId field's value.
+func (s *DeleteIPSetInput) SetIPSetId(v string) *DeleteIPSetInput {
+	s.IPSetId = &v
+	return s
+}
+
 type DeleteIPSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5268,6 +5568,12 @@ func (s DeleteIPSetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIPSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteIPSetOutput) SetChangeToken(v string) *DeleteIPSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type DeleteRuleInput struct {
@@ -5317,6 +5623,18 @@ func (s *DeleteRuleInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteRuleInput) SetChangeToken(v string) *DeleteRuleInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetRuleId sets the RuleId field's value.
+func (s *DeleteRuleInput) SetRuleId(v string) *DeleteRuleInput {
+	s.RuleId = &v
+	return s
+}
+
 type DeleteRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5334,6 +5652,12 @@ func (s DeleteRuleOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteRuleOutput) SetChangeToken(v string) *DeleteRuleOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type DeleteSizeConstraintSetInput struct {
@@ -5383,6 +5707,18 @@ func (s *DeleteSizeConstraintSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteSizeConstraintSetInput) SetChangeToken(v string) *DeleteSizeConstraintSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetSizeConstraintSetId sets the SizeConstraintSetId field's value.
+func (s *DeleteSizeConstraintSetInput) SetSizeConstraintSetId(v string) *DeleteSizeConstraintSetInput {
+	s.SizeConstraintSetId = &v
+	return s
+}
+
 type DeleteSizeConstraintSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5400,6 +5736,12 @@ func (s DeleteSizeConstraintSetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSizeConstraintSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteSizeConstraintSetOutput) SetChangeToken(v string) *DeleteSizeConstraintSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 // A request to delete a SqlInjectionMatchSet from AWS WAF.
@@ -5450,6 +5792,18 @@ func (s *DeleteSqlInjectionMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteSqlInjectionMatchSetInput) SetChangeToken(v string) *DeleteSqlInjectionMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetSqlInjectionMatchSetId sets the SqlInjectionMatchSetId field's value.
+func (s *DeleteSqlInjectionMatchSetInput) SetSqlInjectionMatchSetId(v string) *DeleteSqlInjectionMatchSetInput {
+	s.SqlInjectionMatchSetId = &v
+	return s
+}
+
 // The response to a request to delete a SqlInjectionMatchSet from AWS WAF.
 type DeleteSqlInjectionMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -5468,6 +5822,12 @@ func (s DeleteSqlInjectionMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSqlInjectionMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteSqlInjectionMatchSetOutput) SetChangeToken(v string) *DeleteSqlInjectionMatchSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type DeleteWebACLInput struct {
@@ -5517,6 +5877,18 @@ func (s *DeleteWebACLInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteWebACLInput) SetChangeToken(v string) *DeleteWebACLInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetWebACLId sets the WebACLId field's value.
+func (s *DeleteWebACLInput) SetWebACLId(v string) *DeleteWebACLInput {
+	s.WebACLId = &v
+	return s
+}
+
 type DeleteWebACLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5534,6 +5906,12 @@ func (s DeleteWebACLOutput) String() string {
 // GoString returns the string representation
 func (s DeleteWebACLOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteWebACLOutput) SetChangeToken(v string) *DeleteWebACLOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 // A request to delete an XssMatchSet from AWS WAF.
@@ -5584,6 +5962,18 @@ func (s *DeleteXssMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteXssMatchSetInput) SetChangeToken(v string) *DeleteXssMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetXssMatchSetId sets the XssMatchSetId field's value.
+func (s *DeleteXssMatchSetInput) SetXssMatchSetId(v string) *DeleteXssMatchSetInput {
+	s.XssMatchSetId = &v
+	return s
+}
+
 // The response to a request to delete an XssMatchSet from AWS WAF.
 type DeleteXssMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -5602,6 +5992,12 @@ func (s DeleteXssMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteXssMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteXssMatchSetOutput) SetChangeToken(v string) *DeleteXssMatchSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 // Specifies where in a web request to look for TargetString.
@@ -5667,6 +6063,18 @@ func (s *FieldToMatch) Validate() error {
 	return nil
 }
 
+// SetData sets the Data field's value.
+func (s *FieldToMatch) SetData(v string) *FieldToMatch {
+	s.Data = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *FieldToMatch) SetType(v string) *FieldToMatch {
+	s.Type = &v
+	return s
+}
+
 type GetByteMatchSetInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5703,6 +6111,12 @@ func (s *GetByteMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetByteMatchSetId sets the ByteMatchSetId field's value.
+func (s *GetByteMatchSetInput) SetByteMatchSetId(v string) *GetByteMatchSetInput {
+	s.ByteMatchSetId = &v
+	return s
+}
+
 type GetByteMatchSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5727,6 +6141,12 @@ func (s GetByteMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s GetByteMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetByteMatchSet sets the ByteMatchSet field's value.
+func (s *GetByteMatchSetOutput) SetByteMatchSet(v *ByteMatchSet) *GetByteMatchSetOutput {
+	s.ByteMatchSet = v
+	return s
 }
 
 type GetChangeTokenInput struct {
@@ -5759,6 +6179,12 @@ func (s GetChangeTokenOutput) String() string {
 // GoString returns the string representation
 func (s GetChangeTokenOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *GetChangeTokenOutput) SetChangeToken(v string) *GetChangeTokenOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type GetChangeTokenStatusInput struct {
@@ -5797,6 +6223,12 @@ func (s *GetChangeTokenStatusInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *GetChangeTokenStatusInput) SetChangeToken(v string) *GetChangeTokenStatusInput {
+	s.ChangeToken = &v
+	return s
+}
+
 type GetChangeTokenStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5812,6 +6244,12 @@ func (s GetChangeTokenStatusOutput) String() string {
 // GoString returns the string representation
 func (s GetChangeTokenStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeTokenStatus sets the ChangeTokenStatus field's value.
+func (s *GetChangeTokenStatusOutput) SetChangeTokenStatus(v string) *GetChangeTokenStatusOutput {
+	s.ChangeTokenStatus = &v
+	return s
 }
 
 type GetIPSetInput struct {
@@ -5850,6 +6288,12 @@ func (s *GetIPSetInput) Validate() error {
 	return nil
 }
 
+// SetIPSetId sets the IPSetId field's value.
+func (s *GetIPSetInput) SetIPSetId(v string) *GetIPSetInput {
+	s.IPSetId = &v
+	return s
+}
+
 type GetIPSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5871,6 +6315,12 @@ func (s GetIPSetOutput) String() string {
 // GoString returns the string representation
 func (s GetIPSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetIPSet sets the IPSet field's value.
+func (s *GetIPSetOutput) SetIPSet(v *IPSet) *GetIPSetOutput {
+	s.IPSet = v
+	return s
 }
 
 type GetRuleInput struct {
@@ -5909,6 +6359,12 @@ func (s *GetRuleInput) Validate() error {
 	return nil
 }
 
+// SetRuleId sets the RuleId field's value.
+func (s *GetRuleInput) SetRuleId(v string) *GetRuleInput {
+	s.RuleId = &v
+	return s
+}
+
 type GetRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -5930,6 +6386,12 @@ func (s GetRuleOutput) String() string {
 // GoString returns the string representation
 func (s GetRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetRule sets the Rule field's value.
+func (s *GetRuleOutput) SetRule(v *Rule) *GetRuleOutput {
+	s.Rule = v
+	return s
 }
 
 type GetSampledRequestsInput struct {
@@ -6015,6 +6477,30 @@ func (s *GetSampledRequestsInput) Validate() error {
 	return nil
 }
 
+// SetMaxItems sets the MaxItems field's value.
+func (s *GetSampledRequestsInput) SetMaxItems(v int64) *GetSampledRequestsInput {
+	s.MaxItems = &v
+	return s
+}
+
+// SetRuleId sets the RuleId field's value.
+func (s *GetSampledRequestsInput) SetRuleId(v string) *GetSampledRequestsInput {
+	s.RuleId = &v
+	return s
+}
+
+// SetTimeWindow sets the TimeWindow field's value.
+func (s *GetSampledRequestsInput) SetTimeWindow(v *TimeWindow) *GetSampledRequestsInput {
+	s.TimeWindow = v
+	return s
+}
+
+// SetWebAclId sets the WebAclId field's value.
+func (s *GetSampledRequestsInput) SetWebAclId(v string) *GetSampledRequestsInput {
+	s.WebAclId = &v
+	return s
+}
+
 type GetSampledRequestsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6042,6 +6528,24 @@ func (s GetSampledRequestsOutput) String() string {
 // GoString returns the string representation
 func (s GetSampledRequestsOutput) GoString() string {
 	return s.String()
+}
+
+// SetPopulationSize sets the PopulationSize field's value.
+func (s *GetSampledRequestsOutput) SetPopulationSize(v int64) *GetSampledRequestsOutput {
+	s.PopulationSize = &v
+	return s
+}
+
+// SetSampledRequests sets the SampledRequests field's value.
+func (s *GetSampledRequestsOutput) SetSampledRequests(v []*SampledHTTPRequest) *GetSampledRequestsOutput {
+	s.SampledRequests = v
+	return s
+}
+
+// SetTimeWindow sets the TimeWindow field's value.
+func (s *GetSampledRequestsOutput) SetTimeWindow(v *TimeWindow) *GetSampledRequestsOutput {
+	s.TimeWindow = v
+	return s
 }
 
 type GetSizeConstraintSetInput struct {
@@ -6080,6 +6584,12 @@ func (s *GetSizeConstraintSetInput) Validate() error {
 	return nil
 }
 
+// SetSizeConstraintSetId sets the SizeConstraintSetId field's value.
+func (s *GetSizeConstraintSetInput) SetSizeConstraintSetId(v string) *GetSizeConstraintSetInput {
+	s.SizeConstraintSetId = &v
+	return s
+}
+
 type GetSizeConstraintSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6105,6 +6615,12 @@ func (s GetSizeConstraintSetOutput) String() string {
 // GoString returns the string representation
 func (s GetSizeConstraintSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetSizeConstraintSet sets the SizeConstraintSet field's value.
+func (s *GetSizeConstraintSetOutput) SetSizeConstraintSet(v *SizeConstraintSet) *GetSizeConstraintSetOutput {
+	s.SizeConstraintSet = v
+	return s
 }
 
 // A request to get a SqlInjectionMatchSet.
@@ -6144,6 +6660,12 @@ func (s *GetSqlInjectionMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetSqlInjectionMatchSetId sets the SqlInjectionMatchSetId field's value.
+func (s *GetSqlInjectionMatchSetInput) SetSqlInjectionMatchSetId(v string) *GetSqlInjectionMatchSetInput {
+	s.SqlInjectionMatchSetId = &v
+	return s
+}
+
 // The response to a GetSqlInjectionMatchSet request.
 type GetSqlInjectionMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -6169,6 +6691,12 @@ func (s GetSqlInjectionMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s GetSqlInjectionMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetSqlInjectionMatchSet sets the SqlInjectionMatchSet field's value.
+func (s *GetSqlInjectionMatchSetOutput) SetSqlInjectionMatchSet(v *SqlInjectionMatchSet) *GetSqlInjectionMatchSetOutput {
+	s.SqlInjectionMatchSet = v
+	return s
 }
 
 type GetWebACLInput struct {
@@ -6207,6 +6735,12 @@ func (s *GetWebACLInput) Validate() error {
 	return nil
 }
 
+// SetWebACLId sets the WebACLId field's value.
+func (s *GetWebACLInput) SetWebACLId(v string) *GetWebACLInput {
+	s.WebACLId = &v
+	return s
+}
+
 type GetWebACLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6233,6 +6767,12 @@ func (s GetWebACLOutput) String() string {
 // GoString returns the string representation
 func (s GetWebACLOutput) GoString() string {
 	return s.String()
+}
+
+// SetWebACL sets the WebACL field's value.
+func (s *GetWebACLOutput) SetWebACL(v *WebACL) *GetWebACLOutput {
+	s.WebACL = v
+	return s
 }
 
 // A request to get an XssMatchSet.
@@ -6272,6 +6812,12 @@ func (s *GetXssMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetXssMatchSetId sets the XssMatchSetId field's value.
+func (s *GetXssMatchSetInput) SetXssMatchSetId(v string) *GetXssMatchSetInput {
+	s.XssMatchSetId = &v
+	return s
+}
+
 // The response to a GetXssMatchSet request.
 type GetXssMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -6298,6 +6844,12 @@ func (s GetXssMatchSetOutput) GoString() string {
 	return s.String()
 }
 
+// SetXssMatchSet sets the XssMatchSet field's value.
+func (s *GetXssMatchSetOutput) SetXssMatchSet(v *XssMatchSet) *GetXssMatchSetOutput {
+	s.XssMatchSet = v
+	return s
+}
+
 // The response from a GetSampledRequests request includes an HTTPHeader complex
 // type that appears as Headers in the response syntax. HTTPHeader contains
 // the names and values of all of the headers that appear in one of the web
@@ -6320,6 +6872,18 @@ func (s HTTPHeader) String() string {
 // GoString returns the string representation
 func (s HTTPHeader) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *HTTPHeader) SetName(v string) *HTTPHeader {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *HTTPHeader) SetValue(v string) *HTTPHeader {
+	s.Value = &v
+	return s
 }
 
 // The response from a GetSampledRequests request includes an HTTPRequest complex
@@ -6369,6 +6933,42 @@ func (s HTTPRequest) GoString() string {
 	return s.String()
 }
 
+// SetClientIP sets the ClientIP field's value.
+func (s *HTTPRequest) SetClientIP(v string) *HTTPRequest {
+	s.ClientIP = &v
+	return s
+}
+
+// SetCountry sets the Country field's value.
+func (s *HTTPRequest) SetCountry(v string) *HTTPRequest {
+	s.Country = &v
+	return s
+}
+
+// SetHTTPVersion sets the HTTPVersion field's value.
+func (s *HTTPRequest) SetHTTPVersion(v string) *HTTPRequest {
+	s.HTTPVersion = &v
+	return s
+}
+
+// SetHeaders sets the Headers field's value.
+func (s *HTTPRequest) SetHeaders(v []*HTTPHeader) *HTTPRequest {
+	s.Headers = v
+	return s
+}
+
+// SetMethod sets the Method field's value.
+func (s *HTTPRequest) SetMethod(v string) *HTTPRequest {
+	s.Method = &v
+	return s
+}
+
+// SetURI sets the URI field's value.
+func (s *HTTPRequest) SetURI(v string) *HTTPRequest {
+	s.URI = &v
+	return s
+}
+
 // Contains one or more IP addresses or blocks of IP addresses specified in
 // Classless Inter-Domain Routing (CIDR) notation. To specify an individual
 // IP address, you specify the four-part IP address followed by a /32, for example,
@@ -6415,6 +7015,24 @@ func (s IPSet) String() string {
 // GoString returns the string representation
 func (s IPSet) GoString() string {
 	return s.String()
+}
+
+// SetIPSetDescriptors sets the IPSetDescriptors field's value.
+func (s *IPSet) SetIPSetDescriptors(v []*IPSetDescriptor) *IPSet {
+	s.IPSetDescriptors = v
+	return s
+}
+
+// SetIPSetId sets the IPSetId field's value.
+func (s *IPSet) SetIPSetId(v string) *IPSet {
+	s.IPSetId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *IPSet) SetName(v string) *IPSet {
+	s.Name = &v
+	return s
 }
 
 // Specifies the IP address type (IPV4) and the IP address range (in CIDR format)
@@ -6470,6 +7088,18 @@ func (s *IPSetDescriptor) Validate() error {
 	return nil
 }
 
+// SetType sets the Type field's value.
+func (s *IPSetDescriptor) SetType(v string) *IPSetDescriptor {
+	s.Type = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *IPSetDescriptor) SetValue(v string) *IPSetDescriptor {
+	s.Value = &v
+	return s
+}
+
 // Contains the identifier and the name of the IPSet.
 type IPSetSummary struct {
 	_ struct{} `type:"structure"`
@@ -6495,6 +7125,18 @@ func (s IPSetSummary) String() string {
 // GoString returns the string representation
 func (s IPSetSummary) GoString() string {
 	return s.String()
+}
+
+// SetIPSetId sets the IPSetId field's value.
+func (s *IPSetSummary) SetIPSetId(v string) *IPSetSummary {
+	s.IPSetId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *IPSetSummary) SetName(v string) *IPSetSummary {
+	s.Name = &v
+	return s
 }
 
 // Specifies the type of update to perform to an IPSet with UpdateIPSet.
@@ -6544,6 +7186,18 @@ func (s *IPSetUpdate) Validate() error {
 	return nil
 }
 
+// SetAction sets the Action field's value.
+func (s *IPSetUpdate) SetAction(v string) *IPSetUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetIPSetDescriptor sets the IPSetDescriptor field's value.
+func (s *IPSetUpdate) SetIPSetDescriptor(v *IPSetDescriptor) *IPSetUpdate {
+	s.IPSetDescriptor = v
+	return s
+}
+
 type ListByteMatchSetsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6584,6 +7238,18 @@ func (s *ListByteMatchSetsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListByteMatchSetsInput) SetLimit(v int64) *ListByteMatchSetsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListByteMatchSetsInput) SetNextMarker(v string) *ListByteMatchSetsInput {
+	s.NextMarker = &v
+	return s
+}
+
 type ListByteMatchSetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6606,6 +7272,18 @@ func (s ListByteMatchSetsOutput) String() string {
 // GoString returns the string representation
 func (s ListByteMatchSetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetByteMatchSets sets the ByteMatchSets field's value.
+func (s *ListByteMatchSetsOutput) SetByteMatchSets(v []*ByteMatchSetSummary) *ListByteMatchSetsOutput {
+	s.ByteMatchSets = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListByteMatchSetsOutput) SetNextMarker(v string) *ListByteMatchSetsOutput {
+	s.NextMarker = &v
+	return s
 }
 
 type ListIPSetsInput struct {
@@ -6648,6 +7326,18 @@ func (s *ListIPSetsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListIPSetsInput) SetLimit(v int64) *ListIPSetsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListIPSetsInput) SetNextMarker(v string) *ListIPSetsInput {
+	s.NextMarker = &v
+	return s
+}
+
 type ListIPSetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6669,6 +7359,18 @@ func (s ListIPSetsOutput) String() string {
 // GoString returns the string representation
 func (s ListIPSetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetIPSets sets the IPSets field's value.
+func (s *ListIPSetsOutput) SetIPSets(v []*IPSetSummary) *ListIPSetsOutput {
+	s.IPSets = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListIPSetsOutput) SetNextMarker(v string) *ListIPSetsOutput {
+	s.NextMarker = &v
+	return s
 }
 
 type ListRulesInput struct {
@@ -6710,6 +7412,18 @@ func (s *ListRulesInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListRulesInput) SetLimit(v int64) *ListRulesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListRulesInput) SetNextMarker(v string) *ListRulesInput {
+	s.NextMarker = &v
+	return s
+}
+
 type ListRulesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6731,6 +7445,18 @@ func (s ListRulesOutput) String() string {
 // GoString returns the string representation
 func (s ListRulesOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListRulesOutput) SetNextMarker(v string) *ListRulesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *ListRulesOutput) SetRules(v []*RuleSummary) *ListRulesOutput {
+	s.Rules = v
+	return s
 }
 
 type ListSizeConstraintSetsInput struct {
@@ -6773,6 +7499,18 @@ func (s *ListSizeConstraintSetsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListSizeConstraintSetsInput) SetLimit(v int64) *ListSizeConstraintSetsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListSizeConstraintSetsInput) SetNextMarker(v string) *ListSizeConstraintSetsInput {
+	s.NextMarker = &v
+	return s
+}
+
 type ListSizeConstraintSetsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6795,6 +7533,18 @@ func (s ListSizeConstraintSetsOutput) String() string {
 // GoString returns the string representation
 func (s ListSizeConstraintSetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListSizeConstraintSetsOutput) SetNextMarker(v string) *ListSizeConstraintSetsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetSizeConstraintSets sets the SizeConstraintSets field's value.
+func (s *ListSizeConstraintSetsOutput) SetSizeConstraintSets(v []*SizeConstraintSetSummary) *ListSizeConstraintSetsOutput {
+	s.SizeConstraintSets = v
+	return s
 }
 
 // A request to list the SqlInjectionMatchSet objects created by the current
@@ -6839,6 +7589,18 @@ func (s *ListSqlInjectionMatchSetsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListSqlInjectionMatchSetsInput) SetLimit(v int64) *ListSqlInjectionMatchSetsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListSqlInjectionMatchSetsInput) SetNextMarker(v string) *ListSqlInjectionMatchSetsInput {
+	s.NextMarker = &v
+	return s
+}
+
 // The response to a ListSqlInjectionMatchSets request.
 type ListSqlInjectionMatchSetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6862,6 +7624,18 @@ func (s ListSqlInjectionMatchSetsOutput) String() string {
 // GoString returns the string representation
 func (s ListSqlInjectionMatchSetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListSqlInjectionMatchSetsOutput) SetNextMarker(v string) *ListSqlInjectionMatchSetsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetSqlInjectionMatchSets sets the SqlInjectionMatchSets field's value.
+func (s *ListSqlInjectionMatchSetsOutput) SetSqlInjectionMatchSets(v []*SqlInjectionMatchSetSummary) *ListSqlInjectionMatchSetsOutput {
+	s.SqlInjectionMatchSets = v
+	return s
 }
 
 type ListWebACLsInput struct {
@@ -6905,6 +7679,18 @@ func (s *ListWebACLsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListWebACLsInput) SetLimit(v int64) *ListWebACLsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListWebACLsInput) SetNextMarker(v string) *ListWebACLsInput {
+	s.NextMarker = &v
+	return s
+}
+
 type ListWebACLsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6926,6 +7712,18 @@ func (s ListWebACLsOutput) String() string {
 // GoString returns the string representation
 func (s ListWebACLsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListWebACLsOutput) SetNextMarker(v string) *ListWebACLsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetWebACLs sets the WebACLs field's value.
+func (s *ListWebACLsOutput) SetWebACLs(v []*WebACLSummary) *ListWebACLsOutput {
+	s.WebACLs = v
+	return s
 }
 
 // A request to list the XssMatchSet objects created by the current AWS account.
@@ -6969,6 +7767,18 @@ func (s *ListXssMatchSetsInput) Validate() error {
 	return nil
 }
 
+// SetLimit sets the Limit field's value.
+func (s *ListXssMatchSetsInput) SetLimit(v int64) *ListXssMatchSetsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListXssMatchSetsInput) SetNextMarker(v string) *ListXssMatchSetsInput {
+	s.NextMarker = &v
+	return s
+}
+
 // The response to a ListXssMatchSets request.
 type ListXssMatchSetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6992,6 +7802,18 @@ func (s ListXssMatchSetsOutput) String() string {
 // GoString returns the string representation
 func (s ListXssMatchSetsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListXssMatchSetsOutput) SetNextMarker(v string) *ListXssMatchSetsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetXssMatchSets sets the XssMatchSets field's value.
+func (s *ListXssMatchSetsOutput) SetXssMatchSets(v []*XssMatchSetSummary) *ListXssMatchSetsOutput {
+	s.XssMatchSets = v
+	return s
 }
 
 // Specifies the ByteMatchSet, IPSet, SqlInjectionMatchSet, XssMatchSet, and
@@ -7060,6 +7882,24 @@ func (s *Predicate) Validate() error {
 	return nil
 }
 
+// SetDataId sets the DataId field's value.
+func (s *Predicate) SetDataId(v string) *Predicate {
+	s.DataId = &v
+	return s
+}
+
+// SetNegated sets the Negated field's value.
+func (s *Predicate) SetNegated(v bool) *Predicate {
+	s.Negated = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Predicate) SetType(v string) *Predicate {
+	s.Type = &v
+	return s
+}
+
 // A combination of ByteMatchSet, IPSet, and/or SqlInjectionMatchSet objects
 // that identify the web requests that you want to allow, block, or count. For
 // example, you might create a Rule that includes the following predicates:
@@ -7108,6 +7948,30 @@ func (s Rule) GoString() string {
 	return s.String()
 }
 
+// SetMetricName sets the MetricName field's value.
+func (s *Rule) SetMetricName(v string) *Rule {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Rule) SetName(v string) *Rule {
+	s.Name = &v
+	return s
+}
+
+// SetPredicates sets the Predicates field's value.
+func (s *Rule) SetPredicates(v []*Predicate) *Rule {
+	s.Predicates = v
+	return s
+}
+
+// SetRuleId sets the RuleId field's value.
+func (s *Rule) SetRuleId(v string) *Rule {
+	s.RuleId = &v
+	return s
+}
+
 // Contains the identifier and the friendly name or description of the Rule.
 type RuleSummary struct {
 	_ struct{} `type:"structure"`
@@ -7137,6 +8001,18 @@ func (s RuleSummary) String() string {
 // GoString returns the string representation
 func (s RuleSummary) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *RuleSummary) SetName(v string) *RuleSummary {
+	s.Name = &v
+	return s
+}
+
+// SetRuleId sets the RuleId field's value.
+func (s *RuleSummary) SetRuleId(v string) *RuleSummary {
+	s.RuleId = &v
+	return s
 }
 
 // Specifies a Predicate (such as an IPSet) and indicates whether you want to
@@ -7187,6 +8063,18 @@ func (s *RuleUpdate) Validate() error {
 	return nil
 }
 
+// SetAction sets the Action field's value.
+func (s *RuleUpdate) SetAction(v string) *RuleUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetPredicate sets the Predicate field's value.
+func (s *RuleUpdate) SetPredicate(v *Predicate) *RuleUpdate {
+	s.Predicate = v
+	return s
+}
+
 // The response from a GetSampledRequests request includes a SampledHTTPRequests
 // complex type that appears as SampledRequests in the response syntax. SampledHTTPRequests
 // contains one SampledHTTPRequest object for each web request that is returned
@@ -7223,6 +8111,30 @@ func (s SampledHTTPRequest) String() string {
 // GoString returns the string representation
 func (s SampledHTTPRequest) GoString() string {
 	return s.String()
+}
+
+// SetAction sets the Action field's value.
+func (s *SampledHTTPRequest) SetAction(v string) *SampledHTTPRequest {
+	s.Action = &v
+	return s
+}
+
+// SetRequest sets the Request field's value.
+func (s *SampledHTTPRequest) SetRequest(v *HTTPRequest) *SampledHTTPRequest {
+	s.Request = v
+	return s
+}
+
+// SetTimestamp sets the Timestamp field's value.
+func (s *SampledHTTPRequest) SetTimestamp(v time.Time) *SampledHTTPRequest {
+	s.Timestamp = &v
+	return s
+}
+
+// SetWeight sets the Weight field's value.
+func (s *SampledHTTPRequest) SetWeight(v int64) *SampledHTTPRequest {
+	s.Weight = &v
+	return s
 }
 
 // Specifies a constraint on the size of a part of the web request. AWS WAF
@@ -7388,6 +8300,30 @@ func (s *SizeConstraint) Validate() error {
 	return nil
 }
 
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *SizeConstraint) SetComparisonOperator(v string) *SizeConstraint {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetFieldToMatch sets the FieldToMatch field's value.
+func (s *SizeConstraint) SetFieldToMatch(v *FieldToMatch) *SizeConstraint {
+	s.FieldToMatch = v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *SizeConstraint) SetSize(v int64) *SizeConstraint {
+	s.Size = &v
+	return s
+}
+
+// SetTextTransformation sets the TextTransformation field's value.
+func (s *SizeConstraint) SetTextTransformation(v string) *SizeConstraint {
+	s.TextTransformation = &v
+	return s
+}
+
 // A complex type that contains SizeConstraint objects, which specify the parts
 // of web requests that you want AWS WAF to inspect the size of. If a SizeConstraintSet
 // contains more than one SizeConstraint object, a request only needs to match
@@ -7425,6 +8361,24 @@ func (s SizeConstraintSet) GoString() string {
 	return s.String()
 }
 
+// SetName sets the Name field's value.
+func (s *SizeConstraintSet) SetName(v string) *SizeConstraintSet {
+	s.Name = &v
+	return s
+}
+
+// SetSizeConstraintSetId sets the SizeConstraintSetId field's value.
+func (s *SizeConstraintSet) SetSizeConstraintSetId(v string) *SizeConstraintSet {
+	s.SizeConstraintSetId = &v
+	return s
+}
+
+// SetSizeConstraints sets the SizeConstraints field's value.
+func (s *SizeConstraintSet) SetSizeConstraints(v []*SizeConstraint) *SizeConstraintSet {
+	s.SizeConstraints = v
+	return s
+}
+
 // The Id and Name of a SizeConstraintSet.
 type SizeConstraintSetSummary struct {
 	_ struct{} `type:"structure"`
@@ -7454,6 +8408,18 @@ func (s SizeConstraintSetSummary) String() string {
 // GoString returns the string representation
 func (s SizeConstraintSetSummary) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *SizeConstraintSetSummary) SetName(v string) *SizeConstraintSetSummary {
+	s.Name = &v
+	return s
+}
+
+// SetSizeConstraintSetId sets the SizeConstraintSetId field's value.
+func (s *SizeConstraintSetSummary) SetSizeConstraintSetId(v string) *SizeConstraintSetSummary {
+	s.SizeConstraintSetId = &v
+	return s
 }
 
 // Specifies the part of a web request that you want to inspect the size of
@@ -7508,6 +8474,18 @@ func (s *SizeConstraintSetUpdate) Validate() error {
 	return nil
 }
 
+// SetAction sets the Action field's value.
+func (s *SizeConstraintSetUpdate) SetAction(v string) *SizeConstraintSetUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetSizeConstraint sets the SizeConstraint field's value.
+func (s *SizeConstraintSetUpdate) SetSizeConstraint(v *SizeConstraint) *SizeConstraintSetUpdate {
+	s.SizeConstraint = v
+	return s
+}
+
 // A complex type that contains SqlInjectionMatchTuple objects, which specify
 // the parts of web requests that you want AWS WAF to inspect for snippets of
 // malicious SQL code and, if you want AWS WAF to inspect a header, the name
@@ -7548,6 +8526,24 @@ func (s SqlInjectionMatchSet) GoString() string {
 	return s.String()
 }
 
+// SetName sets the Name field's value.
+func (s *SqlInjectionMatchSet) SetName(v string) *SqlInjectionMatchSet {
+	s.Name = &v
+	return s
+}
+
+// SetSqlInjectionMatchSetId sets the SqlInjectionMatchSetId field's value.
+func (s *SqlInjectionMatchSet) SetSqlInjectionMatchSetId(v string) *SqlInjectionMatchSet {
+	s.SqlInjectionMatchSetId = &v
+	return s
+}
+
+// SetSqlInjectionMatchTuples sets the SqlInjectionMatchTuples field's value.
+func (s *SqlInjectionMatchSet) SetSqlInjectionMatchTuples(v []*SqlInjectionMatchTuple) *SqlInjectionMatchSet {
+	s.SqlInjectionMatchTuples = v
+	return s
+}
+
 // The Id and Name of a SqlInjectionMatchSet.
 type SqlInjectionMatchSetSummary struct {
 	_ struct{} `type:"structure"`
@@ -7577,6 +8573,18 @@ func (s SqlInjectionMatchSetSummary) String() string {
 // GoString returns the string representation
 func (s SqlInjectionMatchSetSummary) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *SqlInjectionMatchSetSummary) SetName(v string) *SqlInjectionMatchSetSummary {
+	s.Name = &v
+	return s
+}
+
+// SetSqlInjectionMatchSetId sets the SqlInjectionMatchSetId field's value.
+func (s *SqlInjectionMatchSetSummary) SetSqlInjectionMatchSetId(v string) *SqlInjectionMatchSetSummary {
+	s.SqlInjectionMatchSetId = &v
+	return s
 }
 
 // Specifies the part of a web request that you want to inspect for snippets
@@ -7628,6 +8636,18 @@ func (s *SqlInjectionMatchSetUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAction sets the Action field's value.
+func (s *SqlInjectionMatchSetUpdate) SetAction(v string) *SqlInjectionMatchSetUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetSqlInjectionMatchTuple sets the SqlInjectionMatchTuple field's value.
+func (s *SqlInjectionMatchSetUpdate) SetSqlInjectionMatchTuple(v *SqlInjectionMatchTuple) *SqlInjectionMatchSetUpdate {
+	s.SqlInjectionMatchTuple = v
+	return s
 }
 
 // Specifies the part of a web request that you want AWS WAF to inspect for
@@ -7747,6 +8767,18 @@ func (s *SqlInjectionMatchTuple) Validate() error {
 	return nil
 }
 
+// SetFieldToMatch sets the FieldToMatch field's value.
+func (s *SqlInjectionMatchTuple) SetFieldToMatch(v *FieldToMatch) *SqlInjectionMatchTuple {
+	s.FieldToMatch = v
+	return s
+}
+
+// SetTextTransformation sets the TextTransformation field's value.
+func (s *SqlInjectionMatchTuple) SetTextTransformation(v string) *SqlInjectionMatchTuple {
+	s.TextTransformation = &v
+	return s
+}
+
 // In a GetSampledRequests request, the StartTime and EndTime objects specify
 // the time range for which you want AWS WAF to return a sample of web requests.
 //
@@ -7799,6 +8831,18 @@ func (s *TimeWindow) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *TimeWindow) SetEndTime(v time.Time) *TimeWindow {
+	s.EndTime = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *TimeWindow) SetStartTime(v time.Time) *TimeWindow {
+	s.StartTime = &v
+	return s
 }
 
 type UpdateByteMatchSetInput struct {
@@ -7874,6 +8918,24 @@ func (s *UpdateByteMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetByteMatchSetId sets the ByteMatchSetId field's value.
+func (s *UpdateByteMatchSetInput) SetByteMatchSetId(v string) *UpdateByteMatchSetInput {
+	s.ByteMatchSetId = &v
+	return s
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateByteMatchSetInput) SetChangeToken(v string) *UpdateByteMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *UpdateByteMatchSetInput) SetUpdates(v []*ByteMatchSetUpdate) *UpdateByteMatchSetInput {
+	s.Updates = v
+	return s
+}
+
 type UpdateByteMatchSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7891,6 +8953,12 @@ func (s UpdateByteMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateByteMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateByteMatchSetOutput) SetChangeToken(v string) *UpdateByteMatchSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type UpdateIPSetInput struct {
@@ -7963,6 +9031,24 @@ func (s *UpdateIPSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateIPSetInput) SetChangeToken(v string) *UpdateIPSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetIPSetId sets the IPSetId field's value.
+func (s *UpdateIPSetInput) SetIPSetId(v string) *UpdateIPSetInput {
+	s.IPSetId = &v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *UpdateIPSetInput) SetUpdates(v []*IPSetUpdate) *UpdateIPSetInput {
+	s.Updates = v
+	return s
+}
+
 type UpdateIPSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7980,6 +9066,12 @@ func (s UpdateIPSetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateIPSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateIPSetOutput) SetChangeToken(v string) *UpdateIPSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type UpdateRuleInput struct {
@@ -8054,6 +9146,24 @@ func (s *UpdateRuleInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateRuleInput) SetChangeToken(v string) *UpdateRuleInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetRuleId sets the RuleId field's value.
+func (s *UpdateRuleInput) SetRuleId(v string) *UpdateRuleInput {
+	s.RuleId = &v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *UpdateRuleInput) SetUpdates(v []*RuleUpdate) *UpdateRuleInput {
+	s.Updates = v
+	return s
+}
+
 type UpdateRuleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8071,6 +9181,12 @@ func (s UpdateRuleOutput) String() string {
 // GoString returns the string representation
 func (s UpdateRuleOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateRuleOutput) SetChangeToken(v string) *UpdateRuleOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type UpdateSizeConstraintSetInput struct {
@@ -8147,6 +9263,24 @@ func (s *UpdateSizeConstraintSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateSizeConstraintSetInput) SetChangeToken(v string) *UpdateSizeConstraintSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetSizeConstraintSetId sets the SizeConstraintSetId field's value.
+func (s *UpdateSizeConstraintSetInput) SetSizeConstraintSetId(v string) *UpdateSizeConstraintSetInput {
+	s.SizeConstraintSetId = &v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *UpdateSizeConstraintSetInput) SetUpdates(v []*SizeConstraintSetUpdate) *UpdateSizeConstraintSetInput {
+	s.Updates = v
+	return s
+}
+
 type UpdateSizeConstraintSetOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8164,6 +9298,12 @@ func (s UpdateSizeConstraintSetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateSizeConstraintSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateSizeConstraintSetOutput) SetChangeToken(v string) *UpdateSizeConstraintSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 // A request to update a SqlInjectionMatchSet.
@@ -8240,6 +9380,24 @@ func (s *UpdateSqlInjectionMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateSqlInjectionMatchSetInput) SetChangeToken(v string) *UpdateSqlInjectionMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetSqlInjectionMatchSetId sets the SqlInjectionMatchSetId field's value.
+func (s *UpdateSqlInjectionMatchSetInput) SetSqlInjectionMatchSetId(v string) *UpdateSqlInjectionMatchSetInput {
+	s.SqlInjectionMatchSetId = &v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *UpdateSqlInjectionMatchSetInput) SetUpdates(v []*SqlInjectionMatchSetUpdate) *UpdateSqlInjectionMatchSetInput {
+	s.Updates = v
+	return s
+}
+
 // The response to an UpdateSqlInjectionMatchSets request.
 type UpdateSqlInjectionMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -8258,6 +9416,12 @@ func (s UpdateSqlInjectionMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateSqlInjectionMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateSqlInjectionMatchSetOutput) SetChangeToken(v string) *UpdateSqlInjectionMatchSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 type UpdateWebACLInput struct {
@@ -8341,6 +9505,30 @@ func (s *UpdateWebACLInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateWebACLInput) SetChangeToken(v string) *UpdateWebACLInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetDefaultAction sets the DefaultAction field's value.
+func (s *UpdateWebACLInput) SetDefaultAction(v *WafAction) *UpdateWebACLInput {
+	s.DefaultAction = v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *UpdateWebACLInput) SetUpdates(v []*WebACLUpdate) *UpdateWebACLInput {
+	s.Updates = v
+	return s
+}
+
+// SetWebACLId sets the WebACLId field's value.
+func (s *UpdateWebACLInput) SetWebACLId(v string) *UpdateWebACLInput {
+	s.WebACLId = &v
+	return s
+}
+
 type UpdateWebACLOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -8358,6 +9546,12 @@ func (s UpdateWebACLOutput) String() string {
 // GoString returns the string representation
 func (s UpdateWebACLOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateWebACLOutput) SetChangeToken(v string) *UpdateWebACLOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 // A request to update an XssMatchSet.
@@ -8433,6 +9627,24 @@ func (s *UpdateXssMatchSetInput) Validate() error {
 	return nil
 }
 
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateXssMatchSetInput) SetChangeToken(v string) *UpdateXssMatchSetInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *UpdateXssMatchSetInput) SetUpdates(v []*XssMatchSetUpdate) *UpdateXssMatchSetInput {
+	s.Updates = v
+	return s
+}
+
+// SetXssMatchSetId sets the XssMatchSetId field's value.
+func (s *UpdateXssMatchSetInput) SetXssMatchSetId(v string) *UpdateXssMatchSetInput {
+	s.XssMatchSetId = &v
+	return s
+}
+
 // The response to an UpdateXssMatchSets request.
 type UpdateXssMatchSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -8451,6 +9663,12 @@ func (s UpdateXssMatchSetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateXssMatchSetOutput) GoString() string {
 	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateXssMatchSetOutput) SetChangeToken(v string) *UpdateXssMatchSetOutput {
+	s.ChangeToken = &v
+	return s
 }
 
 // For the action that is associated with a rule in a WebACL, specifies the
@@ -8498,6 +9716,12 @@ func (s *WafAction) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetType sets the Type field's value.
+func (s *WafAction) SetType(v string) *WafAction {
+	s.Type = &v
+	return s
 }
 
 // Contains the Rules that identify the requests that you want to allow, block,
@@ -8549,6 +9773,36 @@ func (s WebACL) GoString() string {
 	return s.String()
 }
 
+// SetDefaultAction sets the DefaultAction field's value.
+func (s *WebACL) SetDefaultAction(v *WafAction) *WebACL {
+	s.DefaultAction = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *WebACL) SetMetricName(v string) *WebACL {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *WebACL) SetName(v string) *WebACL {
+	s.Name = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *WebACL) SetRules(v []*ActivatedRule) *WebACL {
+	s.Rules = v
+	return s
+}
+
+// SetWebACLId sets the WebACLId field's value.
+func (s *WebACL) SetWebACLId(v string) *WebACL {
+	s.WebACLId = &v
+	return s
+}
+
 // Contains the identifier and the name or description of the WebACL.
 type WebACLSummary struct {
 	_ struct{} `type:"structure"`
@@ -8577,6 +9831,18 @@ func (s WebACLSummary) String() string {
 // GoString returns the string representation
 func (s WebACLSummary) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *WebACLSummary) SetName(v string) *WebACLSummary {
+	s.Name = &v
+	return s
+}
+
+// SetWebACLId sets the WebACLId field's value.
+func (s *WebACLSummary) SetWebACLId(v string) *WebACLSummary {
+	s.WebACLId = &v
+	return s
 }
 
 // Specifies whether to insert a Rule into or delete a Rule from a WebACL.
@@ -8631,6 +9897,18 @@ func (s *WebACLUpdate) Validate() error {
 	return nil
 }
 
+// SetAction sets the Action field's value.
+func (s *WebACLUpdate) SetAction(v string) *WebACLUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetActivatedRule sets the ActivatedRule field's value.
+func (s *WebACLUpdate) SetActivatedRule(v *ActivatedRule) *WebACLUpdate {
+	s.ActivatedRule = v
+	return s
+}
+
 // A complex type that contains XssMatchTuple objects, which specify the parts
 // of web requests that you want AWS WAF to inspect for cross-site scripting
 // attacks and, if you want AWS WAF to inspect a header, the name of the header.
@@ -8670,6 +9948,24 @@ func (s XssMatchSet) GoString() string {
 	return s.String()
 }
 
+// SetName sets the Name field's value.
+func (s *XssMatchSet) SetName(v string) *XssMatchSet {
+	s.Name = &v
+	return s
+}
+
+// SetXssMatchSetId sets the XssMatchSetId field's value.
+func (s *XssMatchSet) SetXssMatchSetId(v string) *XssMatchSet {
+	s.XssMatchSetId = &v
+	return s
+}
+
+// SetXssMatchTuples sets the XssMatchTuples field's value.
+func (s *XssMatchSet) SetXssMatchTuples(v []*XssMatchTuple) *XssMatchSet {
+	s.XssMatchTuples = v
+	return s
+}
+
 // The Id and Name of an XssMatchSet.
 type XssMatchSetSummary struct {
 	_ struct{} `type:"structure"`
@@ -8698,6 +9994,18 @@ func (s XssMatchSetSummary) String() string {
 // GoString returns the string representation
 func (s XssMatchSetSummary) GoString() string {
 	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *XssMatchSetSummary) SetName(v string) *XssMatchSetSummary {
+	s.Name = &v
+	return s
+}
+
+// SetXssMatchSetId sets the XssMatchSetId field's value.
+func (s *XssMatchSetSummary) SetXssMatchSetId(v string) *XssMatchSetSummary {
+	s.XssMatchSetId = &v
+	return s
 }
 
 // Specifies the part of a web request that you want to inspect for cross-site
@@ -8749,6 +10057,18 @@ func (s *XssMatchSetUpdate) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAction sets the Action field's value.
+func (s *XssMatchSetUpdate) SetAction(v string) *XssMatchSetUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetXssMatchTuple sets the XssMatchTuple field's value.
+func (s *XssMatchSetUpdate) SetXssMatchTuple(v *XssMatchTuple) *XssMatchSetUpdate {
+	s.XssMatchTuple = v
+	return s
 }
 
 // Specifies the part of a web request that you want AWS WAF to inspect for
@@ -8866,6 +10186,18 @@ func (s *XssMatchTuple) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetFieldToMatch sets the FieldToMatch field's value.
+func (s *XssMatchTuple) SetFieldToMatch(v *FieldToMatch) *XssMatchTuple {
+	s.FieldToMatch = v
+	return s
+}
+
+// SetTextTransformation sets the TextTransformation field's value.
+func (s *XssMatchTuple) SetTextTransformation(v string) *XssMatchTuple {
+	s.TextTransformation = &v
+	return s
 }
 
 const (

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -1090,6 +1090,12 @@ func (s ComputeType) GoString() string {
 	return s.String()
 }
 
+// SetName sets the Name field's value.
+func (s *ComputeType) SetName(v string) *ComputeType {
+	s.Name = &v
+	return s
+}
+
 // The request of the CreateTags operation.
 type CreateTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -1142,6 +1148,18 @@ func (s *CreateTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *CreateTagsInput) SetResourceId(v string) *CreateTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateTagsInput) SetTags(v []*Tag) *CreateTagsInput {
+	s.Tags = v
+	return s
 }
 
 // The result of the CreateTags operation.
@@ -1205,6 +1223,12 @@ func (s *CreateWorkspacesInput) Validate() error {
 	return nil
 }
 
+// SetWorkspaces sets the Workspaces field's value.
+func (s *CreateWorkspacesInput) SetWorkspaces(v []*WorkspaceRequest) *CreateWorkspacesInput {
+	s.Workspaces = v
+	return s
+}
+
 // Contains the result of the CreateWorkspaces operation.
 type CreateWorkspacesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1228,6 +1252,18 @@ func (s CreateWorkspacesOutput) String() string {
 // GoString returns the string representation
 func (s CreateWorkspacesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedRequests sets the FailedRequests field's value.
+func (s *CreateWorkspacesOutput) SetFailedRequests(v []*FailedCreateWorkspaceRequest) *CreateWorkspacesOutput {
+	s.FailedRequests = v
+	return s
+}
+
+// SetPendingRequests sets the PendingRequests field's value.
+func (s *CreateWorkspacesOutput) SetPendingRequests(v []*Workspace) *CreateWorkspacesOutput {
+	s.PendingRequests = v
+	return s
 }
 
 // Contains default WorkSpace creation information.
@@ -1261,6 +1297,36 @@ func (s DefaultWorkspaceCreationProperties) String() string {
 // GoString returns the string representation
 func (s DefaultWorkspaceCreationProperties) GoString() string {
 	return s.String()
+}
+
+// SetCustomSecurityGroupId sets the CustomSecurityGroupId field's value.
+func (s *DefaultWorkspaceCreationProperties) SetCustomSecurityGroupId(v string) *DefaultWorkspaceCreationProperties {
+	s.CustomSecurityGroupId = &v
+	return s
+}
+
+// SetDefaultOu sets the DefaultOu field's value.
+func (s *DefaultWorkspaceCreationProperties) SetDefaultOu(v string) *DefaultWorkspaceCreationProperties {
+	s.DefaultOu = &v
+	return s
+}
+
+// SetEnableInternetAccess sets the EnableInternetAccess field's value.
+func (s *DefaultWorkspaceCreationProperties) SetEnableInternetAccess(v bool) *DefaultWorkspaceCreationProperties {
+	s.EnableInternetAccess = &v
+	return s
+}
+
+// SetEnableWorkDocs sets the EnableWorkDocs field's value.
+func (s *DefaultWorkspaceCreationProperties) SetEnableWorkDocs(v bool) *DefaultWorkspaceCreationProperties {
+	s.EnableWorkDocs = &v
+	return s
+}
+
+// SetUserEnabledAsLocalAdministrator sets the UserEnabledAsLocalAdministrator field's value.
+func (s *DefaultWorkspaceCreationProperties) SetUserEnabledAsLocalAdministrator(v bool) *DefaultWorkspaceCreationProperties {
+	s.UserEnabledAsLocalAdministrator = &v
+	return s
 }
 
 // The request of the DeleteTags operation.
@@ -1305,6 +1371,18 @@ func (s *DeleteTagsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DeleteTagsInput) SetResourceId(v string) *DeleteTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *DeleteTagsInput) SetTagKeys(v []*string) *DeleteTagsInput {
+	s.TagKeys = v
+	return s
 }
 
 // The result of the DeleteTags operation.
@@ -1358,6 +1436,12 @@ func (s *DescribeTagsInput) Validate() error {
 	return nil
 }
 
+// SetResourceId sets the ResourceId field's value.
+func (s *DescribeTagsInput) SetResourceId(v string) *DescribeTagsInput {
+	s.ResourceId = &v
+	return s
+}
+
 // The result of the DescribeTags operation.
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1374,6 +1458,12 @@ func (s DescribeTagsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeTagsOutput) GoString() string {
 	return s.String()
+}
+
+// SetTagList sets the TagList field's value.
+func (s *DescribeTagsOutput) SetTagList(v []*Tag) *DescribeTagsOutput {
+	s.TagList = v
+	return s
 }
 
 // Contains the inputs for the DescribeWorkspaceBundles operation.
@@ -1425,6 +1515,24 @@ func (s *DescribeWorkspaceBundlesInput) Validate() error {
 	return nil
 }
 
+// SetBundleIds sets the BundleIds field's value.
+func (s *DescribeWorkspaceBundlesInput) SetBundleIds(v []*string) *DescribeWorkspaceBundlesInput {
+	s.BundleIds = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeWorkspaceBundlesInput) SetNextToken(v string) *DescribeWorkspaceBundlesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *DescribeWorkspaceBundlesInput) SetOwner(v string) *DescribeWorkspaceBundlesInput {
+	s.Owner = &v
+	return s
+}
+
 // Contains the results of the DescribeWorkspaceBundles operation.
 type DescribeWorkspaceBundlesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1447,6 +1555,18 @@ func (s DescribeWorkspaceBundlesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkspaceBundlesOutput) GoString() string {
 	return s.String()
+}
+
+// SetBundles sets the Bundles field's value.
+func (s *DescribeWorkspaceBundlesOutput) SetBundles(v []*WorkspaceBundle) *DescribeWorkspaceBundlesOutput {
+	s.Bundles = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeWorkspaceBundlesOutput) SetNextToken(v string) *DescribeWorkspaceBundlesOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Contains the inputs for the DescribeWorkspaceDirectories operation.
@@ -1488,6 +1608,18 @@ func (s *DescribeWorkspaceDirectoriesInput) Validate() error {
 	return nil
 }
 
+// SetDirectoryIds sets the DirectoryIds field's value.
+func (s *DescribeWorkspaceDirectoriesInput) SetDirectoryIds(v []*string) *DescribeWorkspaceDirectoriesInput {
+	s.DirectoryIds = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeWorkspaceDirectoriesInput) SetNextToken(v string) *DescribeWorkspaceDirectoriesInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the results of the DescribeWorkspaceDirectories operation.
 type DescribeWorkspaceDirectoriesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1510,6 +1642,18 @@ func (s DescribeWorkspaceDirectoriesOutput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkspaceDirectoriesOutput) GoString() string {
 	return s.String()
+}
+
+// SetDirectories sets the Directories field's value.
+func (s *DescribeWorkspaceDirectoriesOutput) SetDirectories(v []*WorkspaceDirectory) *DescribeWorkspaceDirectoriesOutput {
+	s.Directories = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeWorkspaceDirectoriesOutput) SetNextToken(v string) *DescribeWorkspaceDirectoriesOutput {
+	s.NextToken = &v
+	return s
 }
 
 type DescribeWorkspacesConnectionStatusInput struct {
@@ -1548,6 +1692,18 @@ func (s *DescribeWorkspacesConnectionStatusInput) Validate() error {
 	return nil
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeWorkspacesConnectionStatusInput) SetNextToken(v string) *DescribeWorkspacesConnectionStatusInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetWorkspaceIds sets the WorkspaceIds field's value.
+func (s *DescribeWorkspacesConnectionStatusInput) SetWorkspaceIds(v []*string) *DescribeWorkspacesConnectionStatusInput {
+	s.WorkspaceIds = v
+	return s
+}
+
 type DescribeWorkspacesConnectionStatusOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1566,6 +1722,18 @@ func (s DescribeWorkspacesConnectionStatusOutput) String() string {
 // GoString returns the string representation
 func (s DescribeWorkspacesConnectionStatusOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeWorkspacesConnectionStatusOutput) SetNextToken(v string) *DescribeWorkspacesConnectionStatusOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetWorkspacesConnectionStatus sets the WorkspacesConnectionStatus field's value.
+func (s *DescribeWorkspacesConnectionStatusOutput) SetWorkspacesConnectionStatus(v []*WorkspaceConnectionStatus) *DescribeWorkspacesConnectionStatusOutput {
+	s.WorkspacesConnectionStatus = v
+	return s
 }
 
 // Contains the inputs for the DescribeWorkspaces operation.
@@ -1635,6 +1803,42 @@ func (s *DescribeWorkspacesInput) Validate() error {
 	return nil
 }
 
+// SetBundleId sets the BundleId field's value.
+func (s *DescribeWorkspacesInput) SetBundleId(v string) *DescribeWorkspacesInput {
+	s.BundleId = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *DescribeWorkspacesInput) SetDirectoryId(v string) *DescribeWorkspacesInput {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeWorkspacesInput) SetLimit(v int64) *DescribeWorkspacesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeWorkspacesInput) SetNextToken(v string) *DescribeWorkspacesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *DescribeWorkspacesInput) SetUserName(v string) *DescribeWorkspacesInput {
+	s.UserName = &v
+	return s
+}
+
+// SetWorkspaceIds sets the WorkspaceIds field's value.
+func (s *DescribeWorkspacesInput) SetWorkspaceIds(v []*string) *DescribeWorkspacesInput {
+	s.WorkspaceIds = v
+	return s
+}
+
 // Contains the results for the DescribeWorkspaces operation.
 type DescribeWorkspacesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1662,6 +1866,18 @@ func (s DescribeWorkspacesOutput) GoString() string {
 	return s.String()
 }
 
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeWorkspacesOutput) SetNextToken(v string) *DescribeWorkspacesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetWorkspaces sets the Workspaces field's value.
+func (s *DescribeWorkspacesOutput) SetWorkspaces(v []*Workspace) *DescribeWorkspacesOutput {
+	s.Workspaces = v
+	return s
+}
+
 // Contains information about a WorkSpace that could not be created.
 type FailedCreateWorkspaceRequest struct {
 	_ struct{} `type:"structure"`
@@ -1685,6 +1901,24 @@ func (s FailedCreateWorkspaceRequest) String() string {
 // GoString returns the string representation
 func (s FailedCreateWorkspaceRequest) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *FailedCreateWorkspaceRequest) SetErrorCode(v string) *FailedCreateWorkspaceRequest {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *FailedCreateWorkspaceRequest) SetErrorMessage(v string) *FailedCreateWorkspaceRequest {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetWorkspaceRequest sets the WorkspaceRequest field's value.
+func (s *FailedCreateWorkspaceRequest) SetWorkspaceRequest(v *WorkspaceRequest) *FailedCreateWorkspaceRequest {
+	s.WorkspaceRequest = v
+	return s
 }
 
 // Contains information about a WorkSpace that could not be rebooted (RebootWorkspaces),
@@ -1711,6 +1945,24 @@ func (s FailedWorkspaceChangeRequest) String() string {
 // GoString returns the string representation
 func (s FailedWorkspaceChangeRequest) GoString() string {
 	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *FailedWorkspaceChangeRequest) SetErrorCode(v string) *FailedWorkspaceChangeRequest {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *FailedWorkspaceChangeRequest) SetErrorMessage(v string) *FailedWorkspaceChangeRequest {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *FailedWorkspaceChangeRequest) SetWorkspaceId(v string) *FailedWorkspaceChangeRequest {
+	s.WorkspaceId = &v
+	return s
 }
 
 type ModifyWorkspacePropertiesInput struct {
@@ -1751,6 +2003,18 @@ func (s *ModifyWorkspacePropertiesInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *ModifyWorkspacePropertiesInput) SetWorkspaceId(v string) *ModifyWorkspacePropertiesInput {
+	s.WorkspaceId = &v
+	return s
+}
+
+// SetWorkspaceProperties sets the WorkspaceProperties field's value.
+func (s *ModifyWorkspacePropertiesInput) SetWorkspaceProperties(v *WorkspaceProperties) *ModifyWorkspacePropertiesInput {
+	s.WorkspaceProperties = v
+	return s
 }
 
 type ModifyWorkspacePropertiesOutput struct {
@@ -1801,6 +2065,12 @@ func (s *RebootRequest) Validate() error {
 	return nil
 }
 
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *RebootRequest) SetWorkspaceId(v string) *RebootRequest {
+	s.WorkspaceId = &v
+	return s
+}
+
 // Contains the inputs for the RebootWorkspaces operation.
 type RebootWorkspacesInput struct {
 	_ struct{} `type:"structure"`
@@ -1847,6 +2117,12 @@ func (s *RebootWorkspacesInput) Validate() error {
 	return nil
 }
 
+// SetRebootWorkspaceRequests sets the RebootWorkspaceRequests field's value.
+func (s *RebootWorkspacesInput) SetRebootWorkspaceRequests(v []*RebootRequest) *RebootWorkspacesInput {
+	s.RebootWorkspaceRequests = v
+	return s
+}
+
 // Contains the results of the RebootWorkspaces operation.
 type RebootWorkspacesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1863,6 +2139,12 @@ func (s RebootWorkspacesOutput) String() string {
 // GoString returns the string representation
 func (s RebootWorkspacesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedRequests sets the FailedRequests field's value.
+func (s *RebootWorkspacesOutput) SetFailedRequests(v []*FailedWorkspaceChangeRequest) *RebootWorkspacesOutput {
+	s.FailedRequests = v
+	return s
 }
 
 // Contains information used with the RebuildWorkspaces operation to rebuild
@@ -1897,6 +2179,12 @@ func (s *RebuildRequest) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *RebuildRequest) SetWorkspaceId(v string) *RebuildRequest {
+	s.WorkspaceId = &v
+	return s
 }
 
 // Contains the inputs for the RebuildWorkspaces operation.
@@ -1945,6 +2233,12 @@ func (s *RebuildWorkspacesInput) Validate() error {
 	return nil
 }
 
+// SetRebuildWorkspaceRequests sets the RebuildWorkspaceRequests field's value.
+func (s *RebuildWorkspacesInput) SetRebuildWorkspaceRequests(v []*RebuildRequest) *RebuildWorkspacesInput {
+	s.RebuildWorkspaceRequests = v
+	return s
+}
+
 // Contains the results of the RebuildWorkspaces operation.
 type RebuildWorkspacesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1963,6 +2257,12 @@ func (s RebuildWorkspacesOutput) GoString() string {
 	return s.String()
 }
 
+// SetFailedRequests sets the FailedRequests field's value.
+func (s *RebuildWorkspacesOutput) SetFailedRequests(v []*FailedWorkspaceChangeRequest) *RebuildWorkspacesOutput {
+	s.FailedRequests = v
+	return s
+}
+
 // Describes the start request.
 type StartRequest struct {
 	_ struct{} `type:"structure"`
@@ -1979,6 +2279,12 @@ func (s StartRequest) String() string {
 // GoString returns the string representation
 func (s StartRequest) GoString() string {
 	return s.String()
+}
+
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *StartRequest) SetWorkspaceId(v string) *StartRequest {
+	s.WorkspaceId = &v
+	return s
 }
 
 type StartWorkspacesInput struct {
@@ -2016,6 +2322,12 @@ func (s *StartWorkspacesInput) Validate() error {
 	return nil
 }
 
+// SetStartWorkspaceRequests sets the StartWorkspaceRequests field's value.
+func (s *StartWorkspacesInput) SetStartWorkspaceRequests(v []*StartRequest) *StartWorkspacesInput {
+	s.StartWorkspaceRequests = v
+	return s
+}
+
 type StartWorkspacesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2031,6 +2343,12 @@ func (s StartWorkspacesOutput) String() string {
 // GoString returns the string representation
 func (s StartWorkspacesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedRequests sets the FailedRequests field's value.
+func (s *StartWorkspacesOutput) SetFailedRequests(v []*FailedWorkspaceChangeRequest) *StartWorkspacesOutput {
+	s.FailedRequests = v
+	return s
 }
 
 // Describes the stop request.
@@ -2049,6 +2367,12 @@ func (s StopRequest) String() string {
 // GoString returns the string representation
 func (s StopRequest) GoString() string {
 	return s.String()
+}
+
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *StopRequest) SetWorkspaceId(v string) *StopRequest {
+	s.WorkspaceId = &v
+	return s
 }
 
 type StopWorkspacesInput struct {
@@ -2086,6 +2410,12 @@ func (s *StopWorkspacesInput) Validate() error {
 	return nil
 }
 
+// SetStopWorkspaceRequests sets the StopWorkspaceRequests field's value.
+func (s *StopWorkspacesInput) SetStopWorkspaceRequests(v []*StopRequest) *StopWorkspacesInput {
+	s.StopWorkspaceRequests = v
+	return s
+}
+
 type StopWorkspacesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -2101,6 +2431,12 @@ func (s StopWorkspacesOutput) String() string {
 // GoString returns the string representation
 func (s StopWorkspacesOutput) GoString() string {
 	return s.String()
+}
+
+// SetFailedRequests sets the FailedRequests field's value.
+func (s *StopWorkspacesOutput) SetFailedRequests(v []*FailedWorkspaceChangeRequest) *StopWorkspacesOutput {
+	s.FailedRequests = v
+	return s
 }
 
 // Describes the tag of the WorkSpace.
@@ -2142,6 +2478,18 @@ func (s *Tag) Validate() error {
 	return nil
 }
 
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
 // Contains information used with the TerminateWorkspaces operation to terminate
 // a WorkSpace.
 type TerminateRequest struct {
@@ -2174,6 +2522,12 @@ func (s *TerminateRequest) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *TerminateRequest) SetWorkspaceId(v string) *TerminateRequest {
+	s.WorkspaceId = &v
+	return s
 }
 
 // Contains the inputs for the TerminateWorkspaces operation.
@@ -2222,6 +2576,12 @@ func (s *TerminateWorkspacesInput) Validate() error {
 	return nil
 }
 
+// SetTerminateWorkspaceRequests sets the TerminateWorkspaceRequests field's value.
+func (s *TerminateWorkspacesInput) SetTerminateWorkspaceRequests(v []*TerminateRequest) *TerminateWorkspacesInput {
+	s.TerminateWorkspaceRequests = v
+	return s
+}
+
 // Contains the results of the TerminateWorkspaces operation.
 type TerminateWorkspacesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2240,6 +2600,12 @@ func (s TerminateWorkspacesOutput) GoString() string {
 	return s.String()
 }
 
+// SetFailedRequests sets the FailedRequests field's value.
+func (s *TerminateWorkspacesOutput) SetFailedRequests(v []*FailedWorkspaceChangeRequest) *TerminateWorkspacesOutput {
+	s.FailedRequests = v
+	return s
+}
+
 // Contains information about the user storage for a WorkSpace bundle.
 type UserStorage struct {
 	_ struct{} `type:"structure"`
@@ -2256,6 +2622,12 @@ func (s UserStorage) String() string {
 // GoString returns the string representation
 func (s UserStorage) GoString() string {
 	return s.String()
+}
+
+// SetCapacity sets the Capacity field's value.
+func (s *UserStorage) SetCapacity(v string) *UserStorage {
+	s.Capacity = &v
+	return s
 }
 
 // Contains information about a WorkSpace.
@@ -2317,6 +2689,90 @@ func (s Workspace) GoString() string {
 	return s.String()
 }
 
+// SetBundleId sets the BundleId field's value.
+func (s *Workspace) SetBundleId(v string) *Workspace {
+	s.BundleId = &v
+	return s
+}
+
+// SetComputerName sets the ComputerName field's value.
+func (s *Workspace) SetComputerName(v string) *Workspace {
+	s.ComputerName = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *Workspace) SetDirectoryId(v string) *Workspace {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *Workspace) SetErrorCode(v string) *Workspace {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *Workspace) SetErrorMessage(v string) *Workspace {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetIpAddress sets the IpAddress field's value.
+func (s *Workspace) SetIpAddress(v string) *Workspace {
+	s.IpAddress = &v
+	return s
+}
+
+// SetRootVolumeEncryptionEnabled sets the RootVolumeEncryptionEnabled field's value.
+func (s *Workspace) SetRootVolumeEncryptionEnabled(v bool) *Workspace {
+	s.RootVolumeEncryptionEnabled = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Workspace) SetState(v string) *Workspace {
+	s.State = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *Workspace) SetSubnetId(v string) *Workspace {
+	s.SubnetId = &v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *Workspace) SetUserName(v string) *Workspace {
+	s.UserName = &v
+	return s
+}
+
+// SetUserVolumeEncryptionEnabled sets the UserVolumeEncryptionEnabled field's value.
+func (s *Workspace) SetUserVolumeEncryptionEnabled(v bool) *Workspace {
+	s.UserVolumeEncryptionEnabled = &v
+	return s
+}
+
+// SetVolumeEncryptionKey sets the VolumeEncryptionKey field's value.
+func (s *Workspace) SetVolumeEncryptionKey(v string) *Workspace {
+	s.VolumeEncryptionKey = &v
+	return s
+}
+
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *Workspace) SetWorkspaceId(v string) *Workspace {
+	s.WorkspaceId = &v
+	return s
+}
+
+// SetWorkspaceProperties sets the WorkspaceProperties field's value.
+func (s *Workspace) SetWorkspaceProperties(v *WorkspaceProperties) *Workspace {
+	s.WorkspaceProperties = v
+	return s
+}
+
 // Contains information about a WorkSpace bundle.
 type WorkspaceBundle struct {
 	_ struct{} `type:"structure"`
@@ -2352,6 +2808,42 @@ func (s WorkspaceBundle) GoString() string {
 	return s.String()
 }
 
+// SetBundleId sets the BundleId field's value.
+func (s *WorkspaceBundle) SetBundleId(v string) *WorkspaceBundle {
+	s.BundleId = &v
+	return s
+}
+
+// SetComputeType sets the ComputeType field's value.
+func (s *WorkspaceBundle) SetComputeType(v *ComputeType) *WorkspaceBundle {
+	s.ComputeType = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *WorkspaceBundle) SetDescription(v string) *WorkspaceBundle {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *WorkspaceBundle) SetName(v string) *WorkspaceBundle {
+	s.Name = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *WorkspaceBundle) SetOwner(v string) *WorkspaceBundle {
+	s.Owner = &v
+	return s
+}
+
+// SetUserStorage sets the UserStorage field's value.
+func (s *WorkspaceBundle) SetUserStorage(v *UserStorage) *WorkspaceBundle {
+	s.UserStorage = v
+	return s
+}
+
 // Describes the connection status of a WorkSpace.
 type WorkspaceConnectionStatus struct {
 	_ struct{} `type:"structure"`
@@ -2378,6 +2870,30 @@ func (s WorkspaceConnectionStatus) String() string {
 // GoString returns the string representation
 func (s WorkspaceConnectionStatus) GoString() string {
 	return s.String()
+}
+
+// SetConnectionState sets the ConnectionState field's value.
+func (s *WorkspaceConnectionStatus) SetConnectionState(v string) *WorkspaceConnectionStatus {
+	s.ConnectionState = &v
+	return s
+}
+
+// SetConnectionStateCheckTimestamp sets the ConnectionStateCheckTimestamp field's value.
+func (s *WorkspaceConnectionStatus) SetConnectionStateCheckTimestamp(v time.Time) *WorkspaceConnectionStatus {
+	s.ConnectionStateCheckTimestamp = &v
+	return s
+}
+
+// SetLastKnownUserConnectionTimestamp sets the LastKnownUserConnectionTimestamp field's value.
+func (s *WorkspaceConnectionStatus) SetLastKnownUserConnectionTimestamp(v time.Time) *WorkspaceConnectionStatus {
+	s.LastKnownUserConnectionTimestamp = &v
+	return s
+}
+
+// SetWorkspaceId sets the WorkspaceId field's value.
+func (s *WorkspaceConnectionStatus) SetWorkspaceId(v string) *WorkspaceConnectionStatus {
+	s.WorkspaceId = &v
+	return s
 }
 
 // Contains information about an AWS Directory Service directory for use with
@@ -2437,6 +2953,78 @@ func (s WorkspaceDirectory) GoString() string {
 	return s.String()
 }
 
+// SetAlias sets the Alias field's value.
+func (s *WorkspaceDirectory) SetAlias(v string) *WorkspaceDirectory {
+	s.Alias = &v
+	return s
+}
+
+// SetCustomerUserName sets the CustomerUserName field's value.
+func (s *WorkspaceDirectory) SetCustomerUserName(v string) *WorkspaceDirectory {
+	s.CustomerUserName = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *WorkspaceDirectory) SetDirectoryId(v string) *WorkspaceDirectory {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetDirectoryName sets the DirectoryName field's value.
+func (s *WorkspaceDirectory) SetDirectoryName(v string) *WorkspaceDirectory {
+	s.DirectoryName = &v
+	return s
+}
+
+// SetDirectoryType sets the DirectoryType field's value.
+func (s *WorkspaceDirectory) SetDirectoryType(v string) *WorkspaceDirectory {
+	s.DirectoryType = &v
+	return s
+}
+
+// SetDnsIpAddresses sets the DnsIpAddresses field's value.
+func (s *WorkspaceDirectory) SetDnsIpAddresses(v []*string) *WorkspaceDirectory {
+	s.DnsIpAddresses = v
+	return s
+}
+
+// SetIamRoleId sets the IamRoleId field's value.
+func (s *WorkspaceDirectory) SetIamRoleId(v string) *WorkspaceDirectory {
+	s.IamRoleId = &v
+	return s
+}
+
+// SetRegistrationCode sets the RegistrationCode field's value.
+func (s *WorkspaceDirectory) SetRegistrationCode(v string) *WorkspaceDirectory {
+	s.RegistrationCode = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *WorkspaceDirectory) SetState(v string) *WorkspaceDirectory {
+	s.State = &v
+	return s
+}
+
+// SetSubnetIds sets the SubnetIds field's value.
+func (s *WorkspaceDirectory) SetSubnetIds(v []*string) *WorkspaceDirectory {
+	s.SubnetIds = v
+	return s
+}
+
+// SetWorkspaceCreationProperties sets the WorkspaceCreationProperties field's value.
+func (s *WorkspaceDirectory) SetWorkspaceCreationProperties(v *DefaultWorkspaceCreationProperties) *WorkspaceDirectory {
+	s.WorkspaceCreationProperties = v
+	return s
+}
+
+// SetWorkspaceSecurityGroupId sets the WorkspaceSecurityGroupId field's value.
+func (s *WorkspaceDirectory) SetWorkspaceSecurityGroupId(v string) *WorkspaceDirectory {
+	s.WorkspaceSecurityGroupId = &v
+	return s
+}
+
 // Describes the properties of a WorkSpace.
 type WorkspaceProperties struct {
 	_ struct{} `type:"structure"`
@@ -2459,6 +3047,18 @@ func (s WorkspaceProperties) String() string {
 // GoString returns the string representation
 func (s WorkspaceProperties) GoString() string {
 	return s.String()
+}
+
+// SetRunningMode sets the RunningMode field's value.
+func (s *WorkspaceProperties) SetRunningMode(v string) *WorkspaceProperties {
+	s.RunningMode = &v
+	return s
+}
+
+// SetRunningModeAutoStopTimeoutInMinutes sets the RunningModeAutoStopTimeoutInMinutes field's value.
+func (s *WorkspaceProperties) SetRunningModeAutoStopTimeoutInMinutes(v int64) *WorkspaceProperties {
+	s.RunningModeAutoStopTimeoutInMinutes = &v
+	return s
 }
 
 // Contains information about a WorkSpace creation request.
@@ -2541,6 +3141,54 @@ func (s *WorkspaceRequest) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBundleId sets the BundleId field's value.
+func (s *WorkspaceRequest) SetBundleId(v string) *WorkspaceRequest {
+	s.BundleId = &v
+	return s
+}
+
+// SetDirectoryId sets the DirectoryId field's value.
+func (s *WorkspaceRequest) SetDirectoryId(v string) *WorkspaceRequest {
+	s.DirectoryId = &v
+	return s
+}
+
+// SetRootVolumeEncryptionEnabled sets the RootVolumeEncryptionEnabled field's value.
+func (s *WorkspaceRequest) SetRootVolumeEncryptionEnabled(v bool) *WorkspaceRequest {
+	s.RootVolumeEncryptionEnabled = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *WorkspaceRequest) SetTags(v []*Tag) *WorkspaceRequest {
+	s.Tags = v
+	return s
+}
+
+// SetUserName sets the UserName field's value.
+func (s *WorkspaceRequest) SetUserName(v string) *WorkspaceRequest {
+	s.UserName = &v
+	return s
+}
+
+// SetUserVolumeEncryptionEnabled sets the UserVolumeEncryptionEnabled field's value.
+func (s *WorkspaceRequest) SetUserVolumeEncryptionEnabled(v bool) *WorkspaceRequest {
+	s.UserVolumeEncryptionEnabled = &v
+	return s
+}
+
+// SetVolumeEncryptionKey sets the VolumeEncryptionKey field's value.
+func (s *WorkspaceRequest) SetVolumeEncryptionKey(v string) *WorkspaceRequest {
+	s.VolumeEncryptionKey = &v
+	return s
+}
+
+// SetWorkspaceProperties sets the WorkspaceProperties field's value.
+func (s *WorkspaceRequest) SetWorkspaceProperties(v *WorkspaceProperties) *WorkspaceRequest {
+	s.WorkspaceProperties = v
+	return s
 }
 
 const (


### PR DESCRIPTION
This addition adds the ability to set SDK API parameters without
directly taking the address of the value. The setters will wrap this
functionality within the setter function. The setter functions are a
convenience method that reduce the usage of `aws.String` and like utilities.

```go
// S3 List buckets call
resp, err := svc.ListBuckets((&s3.ListBucketsInput{}).
	SetPrefix("abc"),
)
```

```go
// S3 Put object with website redirect
resp, err := svc.PutObject((&s3.PutObject{}).
	SetBucket("myBucket").
	SetKey("myKey").
	SetBody(strings.NewReader("abc")).
	SetWebsiteRedirectLocation("https://example.com/something"),
)
```

```go
// EC2 Update a service's deployment
resp, err := svc.UpdateService((&ec2.UpdateServiceInput{}).
	SetService("myService").
	SetDeploymentConfiguration((&ec2.DeploymentConfiguration{}).
		SetMinimumHealthyPrecent(80),
	),
)
```