### PR TITLE
Removing broken shape

### DIFF
--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -161,9 +161,7 @@ func (s *Shape) GoStructValueType(name string, ref *ShapeRef) string {
 func (s *Shape) GoStructType(name string, ref *ShapeRef) string {
 	if (ref.Streaming || ref.Shape.Streaming) && s.Payload == name {
 		rtype := "io.ReadSeeker"
-		if len(s.refs) > 1 {
-			rtype = "aws.ReaderSeekCloser"
-		} else if strings.HasSuffix(s.ShapeName, "Output") {
+		if strings.HasSuffix(s.ShapeName, "Output") {
 			rtype = "io.ReadCloser"
 		}
 


### PR DESCRIPTION
This removes the broken shape `aws.ReadSeekerCloser` which isn't defined in the `aws` package. In addition, the logic seems to not make too much sense.