### PR TITLE
Use consistent spelling of (un)marshal(ed|ing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Service Client Updates
 SDK Feature Updates
 ---
 * `service/dynamodb/dynamodbattribute`: Add UnmarshalListOfMaps #897
-  * Adds support for unmarshalling a list of maps. This is useful for unmarshalling the DynamoDB AttributeValue list of maps returned by APIs like Query and Scan.
+  * Adds support for unmarshaling a list of maps. This is useful for unmarshaling the DynamoDB AttributeValue list of maps returned by APIs like Query and Scan.
 
 Release v1.4.18 (2016-10-17)
 ===

--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -111,7 +111,7 @@ func (m *EC2RoleProvider) Retrieve() (credentials.Value, error) {
 	}, nil
 }
 
-// A ec2RoleCredRespBody provides the shape for unmarshalling credential
+// A ec2RoleCredRespBody provides the shape for unmarshaling credential
 // request responses.
 type ec2RoleCredRespBody struct {
 	// Success State

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -133,7 +133,7 @@ func (c *EC2Metadata) Available() bool {
 	return true
 }
 
-// An EC2IAMInfo provides the shape for unmarshalling
+// An EC2IAMInfo provides the shape for unmarshaling
 // an IAM info from the metadata API
 type EC2IAMInfo struct {
 	Code               string
@@ -142,7 +142,7 @@ type EC2IAMInfo struct {
 	InstanceProfileID  string
 }
 
-// An EC2InstanceIdentityDocument provides the shape for unmarshalling
+// An EC2InstanceIdentityDocument provides the shape for unmarshaling
 // an instance identity document
 type EC2InstanceIdentityDocument struct {
 	DevpayProductCodes []string  `json:"devpayProductCodes"`


### PR DESCRIPTION
Saw similar [cr/discussion](https://groups.google.com/forum/#!topic/golang-codereviews/s_SRCVXXpws) in Go stdlib, and noticed the SDK has a few inconsistencies with the spelling also.