### PR TITLE
private/protocol/rest: Adding boolean disable protocol uri cleaning

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -182,6 +182,19 @@ type Config struct {
 	// the delay of a request see the aws/client.DefaultRetryer and
 	// aws/request.Retryer.
 	SleepDelay func(time.Duration)
+
+	// DisableRestProtocolURICleaning will not clean the URL path when making rest protocol requests.
+	// Will default to false. This would only be used for empty directory names in s3 requests.
+	//
+	// Example:
+	//    sess, err := session.NewSession(&aws.Config{DisableRestProtocolURICleaning: aws.Bool(true))
+	//
+	//    svc := s3.New(sess)
+	//    out, err := svc.GetObject(&s3.GetObjectInput {
+	//    	Bucket: aws.String("bucketname"),
+	//    	Key: aws.String("//foo//bar//moo"),
+	//    })
+	DisableRestProtocolURICleaning *bool
 }
 
 // NewConfig returns a new Config pointer that can be chained with builder
@@ -402,6 +415,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.SleepDelay != nil {
 		dst.SleepDelay = other.SleepDelay
+	}
+
+	if other.DisableRestProtocolURICleaning != nil {
+		dst.DisableRestProtocolURICleaning = other.DisableRestProtocolURICleaning
 	}
 }
 

--- a/private/protocol/rest/build.go
+++ b/private/protocol/rest/build.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -92,7 +93,7 @@ func buildLocationElements(r *request.Request, v reflect.Value) {
 	}
 
 	r.HTTPRequest.URL.RawQuery = query.Encode()
-	updatePath(r.HTTPRequest.URL, r.HTTPRequest.URL.Path)
+	updatePath(r.HTTPRequest.URL, r.HTTPRequest.URL.Path, aws.BoolValue(r.Config.DisableRestProtocolURICleaning))
 }
 
 func buildBody(r *request.Request, v reflect.Value) {
@@ -193,13 +194,15 @@ func buildQueryString(query url.Values, v reflect.Value, name string) error {
 	return nil
 }
 
-func updatePath(url *url.URL, urlPath string) {
+func updatePath(url *url.URL, urlPath string, disableRestProtocolURICleaning bool) {
 	scheme, query := url.Scheme, url.RawQuery
 
 	hasSlash := strings.HasSuffix(urlPath, "/")
 
 	// clean up path
-	urlPath = path.Clean(urlPath)
+	if !disableRestProtocolURICleaning {
+		urlPath = path.Clean(urlPath)
+	}
 	if hasSlash && !strings.HasSuffix(urlPath, "/") {
 		urlPath += "/"
 	}

--- a/private/protocol/rest/build_test.go
+++ b/private/protocol/rest/build_test.go
@@ -1,0 +1,30 @@
+package rest
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdatePathWithRaw(t *testing.T) {
+	uri := &url.URL{
+		Scheme: "https",
+		Host:   "host",
+	}
+	updatePath(uri, "//foo//bar", true)
+
+	expected := "https://host//foo//bar"
+	assert.Equal(t, expected, uri.String())
+}
+
+func TestUpdatePathNoRaw(t *testing.T) {
+	uri := &url.URL{
+		Scheme: "https",
+		Host:   "host",
+	}
+	updatePath(uri, "//foo//bar", false)
+
+	expected := "https://host/foo/bar"
+	assert.Equal(t, expected, uri.String())
+}


### PR DESCRIPTION
Fixes #920 by adding flag to dictate whether or not the SDK cleans the URL path.