### PR TITLE
Make awsutil.Prettify more friendly for blobs

### DIFF
--- a/aws/awsutil/prettify.go
+++ b/aws/awsutil/prettify.go
@@ -63,10 +63,10 @@ func prettify(v reflect.Value, indent int, buf *bytes.Buffer) {
 	case reflect.Slice:
 		strtype := v.Type().String()
 		if strtype == "[]uint8" {
-			buf.WriteString("<binary>")
+			fmt.Fprintf(buf, "<binary> len %d", v.Len())
 			break
 		}
-		
+
 		nl, id, id2 := "", "", ""
 		if v.Len() > 3 {
 			nl, id, id2 = "\n", strings.Repeat(" ", indent), strings.Repeat(" ", indent+2)

--- a/aws/awsutil/prettify.go
+++ b/aws/awsutil/prettify.go
@@ -61,6 +61,12 @@ func prettify(v reflect.Value, indent int, buf *bytes.Buffer) {
 
 		buf.WriteString("\n" + strings.Repeat(" ", indent) + "}")
 	case reflect.Slice:
+		strtype := v.Type().String()
+		if strtype == "[]uint8" {
+			buf.WriteString("<binary>")
+			break
+		}
+		
 		nl, id, id2 := "", "", ""
 		if v.Len() > 3 {
 			nl, id, id2 = "\n", strings.Repeat(" ", indent), strings.Repeat(" ", indent+2)

--- a/service/dynamodb/dynamodbattribute/marshaler_examples_test.go
+++ b/service/dynamodb/dynamodbattribute/marshaler_examples_test.go
@@ -33,7 +33,7 @@ func ExampleMarshal() {
 	// Output:
 	// err <nil>
 	// Bytes {
-	//   B: [48,49]
+	//   B: <binary>
 	// }
 	// MyField {
 	//   S: "MyFieldValue"

--- a/service/dynamodb/dynamodbattribute/marshaler_examples_test.go
+++ b/service/dynamodb/dynamodbattribute/marshaler_examples_test.go
@@ -33,7 +33,7 @@ func ExampleMarshal() {
 	// Output:
 	// err <nil>
 	// Bytes {
-	//   B: <binary>
+	//   B: <binary> len 2
 	// }
 	// MyField {
 	//   S: "MyFieldValue"


### PR DESCRIPTION
Change the current behavior of the prettifier for `[]byte`:
```
Data: [
  42,
  36,
  69,
  1
]
```
With something more friendly:
```
Data: <binary>
```