### PR TITLE
private/model/api: Generate REST-JSON JSONVersion correctly

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -332,8 +332,10 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 			SigningRegion: signingRegion,
 			Endpoint:     endpoint,
 			APIVersion:   "{{ .Metadata.APIVersion }}",
-			{{ if eq .Metadata.Protocol "json" -}}
+			{{ if .Metadata.JSONVersion -}}
 				JSONVersion:  "{{ .Metadata.JSONVersion }}",
+			{{- end }}
+			{{ if .Metadata.TargetPrefix -}}
 				TargetPrefix: "{{ .Metadata.TargetPrefix }}",
 			{{- end }}
     		},

--- a/service/cloudsearchdomain/service.go
+++ b/service/cloudsearchdomain/service.go
@@ -65,6 +65,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2013-01-01",
+				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/cognitosync/service.go
+++ b/service/cognitosync/service.go
@@ -70,6 +70,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2014-06-30",
+				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/pinpoint/service.go
+++ b/service/pinpoint/service.go
@@ -56,6 +56,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2016-12-01",
+				JSONVersion:   "1.1",
 			},
 			handlers,
 		),


### PR DESCRIPTION
This change ensures that all service models that model the JSONVersion
and TargetPrefix metadata fields are generated correctly into the
service.go file for the service.