### PR TITLE
service/route53: Fix URL path cleaning for Route53 API requests

### DIFF
--- a/service/route53/customizations.go
+++ b/service/route53/customizations.go
@@ -1,6 +1,7 @@
 package route53
 
 import (
+	"net/url"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -29,17 +30,13 @@ func sanitizeURL(r *request.Request) {
 	r.HTTPRequest.URL.RawPath = reSanitizeURL.ReplaceAllString(
 		r.HTTPRequest.URL.RawPath, "/")
 
-	// Save off the raw path so that it can be reset to the new URL. Parse
-	// will not set RawPath.
-	rawPath := r.HTTPRequest.URL.RawPath
-
 	// Update Path so that it reflects the cleaned RawPath
-	u, err := r.HTTPRequest.URL.Parse(rawPath)
+	updated, err := url.Parse(r.HTTPRequest.URL.RawPath)
 	if err != nil {
 		r.Error = awserr.New("SerializationError", "failed to clean Route53 URL", err)
 		return
 	}
 
-	r.HTTPRequest.URL = u
-	r.HTTPRequest.URL.RawPath = rawPath
+	// Take the updated path so the requests's URL Path has parity with RawPath.
+	r.HTTPRequest.URL.Path = updated.Path
 }

--- a/service/route53/customizations.go
+++ b/service/route53/customizations.go
@@ -27,8 +27,8 @@ func init() {
 var reSanitizeURL = regexp.MustCompile(`\/%2F\w+%2F`)
 
 func sanitizeURL(r *request.Request) {
-	r.HTTPRequest.URL.RawPath = reSanitizeURL.ReplaceAllString(
-		r.HTTPRequest.URL.RawPath, "/")
+	r.HTTPRequest.URL.RawPath =
+		reSanitizeURL.ReplaceAllString(r.HTTPRequest.URL.RawPath, "/")
 
 	// Update Path so that it reflects the cleaned RawPath
 	updated, err := url.Parse(r.HTTPRequest.URL.RawPath)

--- a/service/route53/customizations.go
+++ b/service/route53/customizations.go
@@ -3,6 +3,7 @@ package route53
 import (
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
@@ -25,6 +26,20 @@ func init() {
 var reSanitizeURL = regexp.MustCompile(`\/%2F\w+%2F`)
 
 func sanitizeURL(r *request.Request) {
-	r.HTTPRequest.URL.RawPath =
-		reSanitizeURL.ReplaceAllString(r.HTTPRequest.URL.RawPath, "/")
+	r.HTTPRequest.URL.RawPath = reSanitizeURL.ReplaceAllString(
+		r.HTTPRequest.URL.RawPath, "/")
+
+	// Save off the raw path so that it can be reset to the new URL. Parse
+	// will not set RawPath.
+	rawPath := r.HTTPRequest.URL.RawPath
+
+	// Update Path so that it reflects the cleaned RawPath
+	u, err := r.HTTPRequest.URL.Parse(rawPath)
+	if err != nil {
+		r.Error = awserr.New("SerializationError", "failed to clean Route53 URL", err)
+		return
+	}
+
+	r.HTTPRequest.URL = u
+	r.HTTPRequest.URL.RawPath = rawPath
 }

--- a/service/route53/customizations_test.go
+++ b/service/route53/customizations_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
 func TestBuildCorrectURI(t *testing.T) {
+	const expectPath = "/2013-04-01/hostedzone/ABCDEFG"
+
 	svc := route53.New(unit.Session)
 	svc.Handlers.Validate.Clear()
 	req, _ := svc.GetHostedZoneRequest(&route53.GetHostedZoneInput{
@@ -18,5 +19,11 @@ func TestBuildCorrectURI(t *testing.T) {
 
 	req.Build()
 
-	awstesting.Match(t, `\/hostedzone\/ABCDEFG$`, req.HTTPRequest.URL.String())
+	if a, e := req.HTTPRequest.URL.Path, expectPath; a != e {
+		t.Errorf("expect path %q, got %q", e, a)
+	}
+
+	if a, e := req.HTTPRequest.URL.RawPath, expectPath; a != e {
+		t.Errorf("expect raw path %q, got %q", e, a)
+	}
 }

--- a/service/route53/customizations_test.go
+++ b/service/route53/customizations_test.go
@@ -17,6 +17,8 @@ func TestBuildCorrectURI(t *testing.T) {
 		Id: aws.String("/hostedzone/ABCDEFG"),
 	})
 
+	req.HTTPRequest.URL.RawQuery = "abc=123"
+
 	req.Build()
 
 	if a, e := req.HTTPRequest.URL.Path, expectPath; a != e {
@@ -25,5 +27,9 @@ func TestBuildCorrectURI(t *testing.T) {
 
 	if a, e := req.HTTPRequest.URL.RawPath, expectPath; a != e {
 		t.Errorf("expect raw path %q, got %q", e, a)
+	}
+
+	if a, e := req.HTTPRequest.URL.RawQuery, "abc=123"; a != e {
+		t.Errorf("expect query to be %q, got %q", e, a)
 	}
 }


### PR DESCRIPTION
In SDK release v1.6.3 fix for REST protocol aboslute URL and HTTP2 broke
Route53's URL cleaning logic that removed duplicate "hostedzone"
elements from the URL. This change fixes the URL cleaning to ensure that
the modified URL RawPath is propagated to the URL's base path. RawPath
was being ignored by URL's EscapedPath method because it was not a valid
escaping of the original uncleaned Path.

Fix #1005