### PR TITLE
convert value to actual type when unmarshalling from BOOL

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -241,7 +241,7 @@ func (d *Decoder) decodeBinary(b []byte, v reflect.Value) error {
 func (d *Decoder) decodeBool(b *bool, v reflect.Value) error {
 	switch v.Kind() {
 	case reflect.Bool, reflect.Interface:
-		v.Set(reflect.ValueOf(*b))
+		v.Set(reflect.ValueOf(*b).Convert(v.Type()))
 	default:
 		return &UnmarshalTypeError{Value: "bool", Type: v.Type()}
 	}

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -478,3 +478,19 @@ func TestDecodeEmbeddedPointerStruct(t *testing.T) {
 	// But not for absent fields.
 	assert.Nil(t, a.C)
 }
+
+func TestDecodeBooleanOverlay(t *testing.T) {
+	type BooleanOverlay bool
+
+	av := &dynamodb.AttributeValue{
+		BOOL: aws.Bool(true),
+	}
+
+	decoder := NewDecoder()
+
+	var v BooleanOverlay
+
+	err := decoder.Decode(av, &v)
+	assert.NoError(t, err)
+	assert.Equal(t, BooleanOverlay(true), v)
+}

--- a/service/dynamodb/dynamodbattribute/shared_test.go
+++ b/service/dynamodb/dynamodbattribute/shared_test.go
@@ -37,6 +37,8 @@ type testAliasedIntSlice []int
 type testAliasedMap map[string]int
 type testAliasedSlice []string
 type testAliasedByteSlice []byte
+type testAliasedBool bool
+type testAliasedBoolSlice []bool
 
 type testAliasedStruct struct {
 	Value  testAliasedString
@@ -54,6 +56,9 @@ type testAliasedStruct struct {
 
 	Value11 testAliasedIntSlice
 	Value12 testAliasedStringSlice
+
+	Value13 testAliasedBool
+	Value14 testAliasedBoolSlice
 }
 
 type testNamedPointer *int
@@ -246,6 +251,12 @@ var sharedTestCases = []struct {
 					{S: aws.String("2")},
 					{S: aws.String("3")},
 				}},
+				"Value13": {BOOL: aws.Bool(true)},
+				"Value14": {L: []*dynamodb.AttributeValue{
+					{BOOL: aws.Bool(true)},
+					{BOOL: aws.Bool(false)},
+					{BOOL: aws.Bool(true)},
+				}},
 			},
 		},
 		actual: &testAliasedStruct{},
@@ -266,6 +277,8 @@ var sharedTestCases = []struct {
 			Value10: []testAliasedString{"1", "2", "3"},
 			Value11: testAliasedIntSlice{1, 2, 3},
 			Value12: testAliasedStringSlice{"1", "2", "3"},
+			Value13: true,
+			Value14: testAliasedBoolSlice{true, false, true},
 		},
 	},
 	{


### PR DESCRIPTION
PR proposes handling bool-overlying types (`type MyType bool`) by converting when unmarshalling. The same handling can be seen here for string-overlying types: https://github.com/aws/aws-sdk-go/blob/master/service/dynamodb/dynamodbattribute/decode.go#L511
Background: We have a bool-overlying type, whose JSON encoding is 0|1, that exists for backward-compatibility. As my type cannot be assigned to bool, unmarshalling from dynamodbattribute to this type results in panic.