### PR TITLE
aws: Simplify WriteAtBuffers return

### DIFF
--- a/aws/types.go
+++ b/aws/types.go
@@ -114,5 +114,5 @@ func (b *WriteAtBuffer) WriteAt(p []byte, pos int64) (n int, err error) {
 func (b *WriteAtBuffer) Bytes() []byte {
 	b.m.Lock()
 	defer b.m.Unlock()
-	return b.buf[:len(b.buf):len(b.buf)]
+	return b.buf
 }


### PR DESCRIPTION
Removes the extra restrictions put on the slice returned by `WriteAtBuffer.Bytes` method. Bytes call should act similar to `bytes.Buffer`

Fix #1040 