### PR TITLE
Update maximum attempts for SnapshotCompleted waiter

### DIFF
--- a/models/apis/ec2/2016-11-15/waiters-2.json
+++ b/models/apis/ec2/2016-11-15/waiters-2.json
@@ -369,7 +369,7 @@
     "SnapshotCompleted": {
       "delay": 15,
       "operation": "DescribeSnapshots",
-      "maxAttempts": 40,
+      "maxAttempts": 60,
       "acceptors": [
         {
           "expected": "completed",

--- a/service/ec2/waiters.go
+++ b/service/ec2/waiters.go
@@ -638,7 +638,7 @@ func (c *EC2) WaitUntilSnapshotCompleted(input *DescribeSnapshotsInput) error {
 	waiterCfg := waiter.Config{
 		Operation:   "DescribeSnapshots",
 		Delay:       15,
-		MaxAttempts: 40,
+		MaxAttempts: 60,
 		Acceptors: []waiter.WaitAcceptor{
 			{
 				State:    "success",


### PR DESCRIPTION
Using terraform's `aws_ebs_snapshot` which in turn uses the AWS Go sdk, around 95% of the ebs snapshots attempted timed out, this is because the maxAttempts (40*15s) is limited to 10 minutes, and most of the times the snapshot of the volume takes slightly more than that, from 11 to 15 minutes. To be safe I increased it to 60 which is about 15 minutes.

Tested the effect using Terraform.