### PR TITLE
Add guard for request operation existence

### DIFF
--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -153,7 +153,7 @@ func (r *Request) Presign(expireTime time.Duration) (string, error) {
 	r.ExpireTime = expireTime
 	r.NotHoist = false
 
-	if r.Operation.BeforePresignFn != nil {
+	if r.Operation != nil && r.Operation.BeforePresignFn != nil {
 		r = r.copy()
 		err := r.Operation.BeforePresignFn(r)
 		if err != nil {


### PR DESCRIPTION
## Why

I wrote a code to retrieve S3 pre-signed URL and its test using s3iface + gomock. 

logic: https://github.com/dtan4/s3url/blob/d9f975ec511f62a863a6b85acbadab0940563cbc/s3/s3.go#L67-L80
test: https://github.com/dtan4/s3url/blob/d9f975ec511f62a863a6b85acbadab0940563cbc/s3/s3_test.go#L87-L122

However, test fails with panic. I used aws-sdk-go v1.6.18.

```
=== RUN   TestGetPresignedURL
--- FAIL: TestGetPresignedURL (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1a51e0]

goroutine 23 [running]:
panic(0x3cbea0, 0xc420012170)
        /usr/local/Cellar/go/1.7.5/libexec/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc4200a03c0)
        /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:579 +0x25d
panic(0x3cbea0, 0xc420012170)
        /usr/local/Cellar/go/1.7.5/libexec/src/runtime/panic.go:458 +0x243
github.com/dtan4/s3url/vendor/github.com/golang/mock/gomock.(*Controller).Finish(0xc4200e93c0)
        /Users/dtan4/src/github.com/dtan4/s3url/vendor/github.com/golang/mock/gomock/controller.go:149 +0x320
panic(0x3cbea0, 0xc420012170)
        /usr/local/Cellar/go/1.7.5/libexec/src/runtime/panic.go:458 +0x243
github.com/dtan4/s3url/vendor/github.com/aws/aws-sdk-go/aws/request.(*Request).Presign(0xc420136700, 0x574fbde6000, 0xc420136700, 0xc4200ec1e0, 0x120a8, 0x20)
        /Users/dtan4/src/github.com/dtan4/s3url/vendor/github.com/aws/aws-sdk-go/aws/request/request.go:156 +0x40
github.com/dtan4/s3url/s3.(*Client).GetPresignedURL(0xc420053f38, 0x43d82b, 0x6, 0x43c9e2, 0x3, 0x64, 0x2c21c, 0xc42002d6f0, 0xc42002d6f0, 0x0)
        github.com/dtan4/s3url/s3/_test/_obj_test/s3.go:88 +0x154
github.com/dtan4/s3url/s3.TestGetPresignedURL(0xc4200a03c0)
        /Users/dtan4/src/github.com/dtan4/s3url/s3/s3_test.go:114 +0x554
testing.tRunner(0xc4200a03c0, 0x47aae0)
        /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:610 +0x81
created by testing.(*T).Run
        /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:646 +0x2ec
```

I did printf debug and then I found that `r.Operation` is not assigned at test. Calling `r.Operation.BeforePresignFn` raised panic.

## What

Add a guard to check whether `r.Operation` is assigned or not.

I worried that this solution is really suitable or not. What do you think?