### PR TITLE
aws/endpoints: Add option to resolve unknown service in a partition

### DIFF
--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -24,6 +24,13 @@ type ConfigProvider interface {
 	ClientConfig(serviceName string, cfgs ...*aws.Config) Config
 }
 
+// ConfigNoResolveEndpointProvider same as ConfigProvider except it will not
+// resolve the endpoint automatically. The service client's endpoint must be
+// provided via the aws.Config.Endpoint field.
+type ConfigNoResolveEndpointProvider interface {
+	ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) Config
+}
+
 // A Client implements the base client request and response handling
 // used by all service clients.
 type Client struct {

--- a/aws/endpoints/endpoints.go
+++ b/aws/endpoints/endpoints.go
@@ -27,6 +27,25 @@ type Options struct {
 	// error will be returned. This option will prevent returning endpoints
 	// that look valid, but may not resolve to any real endpoint.
 	StrictMatching bool
+
+	// Enables resolving a service endpoint based on the region provided if the
+	// service does not exist. The service endpoint ID will be used as the service
+	// domain name prefix. By default the endpoint resolver requires the service
+	// to be known when resolving endpoints.
+	//
+	// If resolving an endpoint on the partition list the provided region will
+	// be used to determine which partition's domain name pattern to the service
+	// endpoint ID with. If both the service and region are unkonwn and resolving
+	// the endpoint on partition list an UnknownEndpointError error will be returned.
+	//
+	// If resolving and endpoint on a partition specific resolver that partition's
+	// domain name pattern will be used with the service endpoint ID. If both
+	// region and service do not exist when resolving an endpoint on a specific
+	// partition the partition's domain pattern will be used to combine the
+	// endpoint and region together.
+	//
+	// This option is ignored if StrictMatching is enabled.
+	ResolveUnknownService bool
 }
 
 // Set combines all of the option functions together.
@@ -52,6 +71,12 @@ func UseDualStackOption(o *Options) {
 // option when resolving endpoints.
 func StrictMatchingOption(o *Options) {
 	o.StrictMatching = true
+}
+
+// ResolveUnknownServiceOption sets the ResolveUnknownService option. Can be used
+// as a functional option when resolving endpoints.
+func ResolveUnknownServiceOption(o *Options) {
+	o.ResolveUnknownService = true
 }
 
 // A Resolver provides the interface for functionality to resolve endpoints.
@@ -114,15 +139,18 @@ func (p *Partition) ID() string { return p.id }
 //
 // If the service cannot be found in the metadata the UnknownServiceError
 // error will be returned. This validation will occur regardless if
-// StrictMatching is enabled.
+// StrictMatching is enabled. To enable resolving unknown services set the
+// "ResolveUnknownService" option to true. When StrictMatching is disabled
+// this option allows the partition resolver to resolve a endpoint based on
+// the service endpoint ID provided.
 //
 // When resolving endpoints you can choose to enable StrictMatching. This will
 // require the provided service and region to be known by the partition.
 // If the endpoint cannot be strictly resolved an error will be returned. This
 // mode is useful to ensure the endpoint resolved is valid. Without
-// StrictMatching enabled the enpoint returned my look valid but may not work.
+// StrictMatching enabled the endpoint returned my look valid but may not work.
 // StrictMatching requires the SDK to be updated if you want to take advantage
-// of new regions and services expantions.
+// of new regions and services expansions.
 //
 // Errors that can be returned.
 //   * UnknownServiceError

--- a/aws/endpoints/v3model.go
+++ b/aws/endpoints/v3model.go
@@ -79,12 +79,10 @@ func (p partition) EndpointFor(service, region string, opts ...func(*Options)) (
 	opt.Set(opts...)
 
 	s, hasService := p.Services[service]
-	if !hasService {
-		if !opt.ResolveUnknownService {
-			// Only return error if the resolver will not fallback to creating
-			// endpoint based on service endpoint ID passed in.
-			return resolved, NewUnknownServiceError(p.ID, service, serviceList(p.Services))
-		}
+	if !(hasService || opt.ResolveUnknownService) {
+		// Only return error if the resolver will not fallback to creating
+		// endpoint based on service endpoint ID passed in.
+		return resolved, NewUnknownServiceError(p.ID, service, serviceList(p.Services))
 	}
 
 	e, hasEndpoint := s.endpointForRegion(region)

--- a/aws/endpoints/v3model.go
+++ b/aws/endpoints/v3model.go
@@ -80,7 +80,11 @@ func (p partition) EndpointFor(service, region string, opts ...func(*Options)) (
 
 	s, hasService := p.Services[service]
 	if !hasService {
-		return resolved, NewUnknownServiceError(p.ID, service, serviceList(p.Services))
+		if !opt.ResolveUnknownService {
+			// Only return error if the resolver will not fallback to creating
+			// endpoint based on service endpoint ID passed in.
+			return resolved, NewUnknownServiceError(p.ID, service, serviceList(p.Services))
+		}
 	}
 
 	e, hasEndpoint := s.endpointForRegion(region)

--- a/aws/endpoints/v3model_test.go
+++ b/aws/endpoints/v3model_test.go
@@ -288,6 +288,17 @@ func TestResolveEndpoint_UnknownService(t *testing.T) {
 	assert.True(t, ok, "expect error to be UnknownServiceError")
 }
 
+func TestResolveEndpoint_ResolveUnknownService(t *testing.T) {
+	resolved, err := testPartitions.EndpointFor("unknown-service", "us-region-1",
+		ResolveUnknownServiceOption)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "https://unknown-service.us-region-1.amazonaws.com", resolved.URL)
+	assert.Equal(t, "us-region-1", resolved.SigningRegion)
+	assert.Equal(t, "unknown-service", resolved.SigningName)
+}
+
 func TestResolveEndpoint_UnknownMatchedRegion(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("service2", "us-region-1")
 

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -404,6 +404,10 @@ func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (
 			func(opt *endpoints.Options) {
 				opt.DisableSSL = aws.BoolValue(s.Config.DisableSSL)
 				opt.UseDualStack = aws.BoolValue(s.Config.UseDualStack)
+
+				// Suppor the condition where the service is modeled but its
+				// endpoint metadata is not available.
+				opt.ResolveUnknownService = true
 			},
 		)
 	}
@@ -415,4 +419,25 @@ func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (
 		SigningRegion: resolved.SigningRegion,
 		SigningName:   resolved.SigningName,
 	}, err
+}
+
+func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Config {
+	s = s.Copy(cfgs...)
+
+	var resolved endpoints.ResolvedEndpoint
+
+	region := aws.StringValue(s.Config.Region)
+
+	if ep := aws.StringValue(s.Config.Endpoint); len(ep) > 0 {
+		resolved.URL = endpoints.AddScheme(ep, aws.BoolValue(s.Config.DisableSSL))
+		resolved.SigningRegion = region
+	}
+
+	return client.Config{
+		Config:        s.Config,
+		Handlers:      s.Handlers,
+		Endpoint:      resolved.URL,
+		SigningRegion: resolved.SigningRegion,
+		SigningName:   resolved.SigningName,
+	}
 }

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -421,6 +421,9 @@ func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (
 	}, err
 }
 
+// ClientConfigNoResolveEndpoint is the same as ClientConfig with the exception
+// that the EndpointResolver will not be used to resolve the endpoint. The only
+// endpoint set must come from the aws.Config.Endpoint field.
 func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Config {
 	s = s.Copy(cfgs...)
 

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -405,7 +405,7 @@ func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (
 				opt.DisableSSL = aws.BoolValue(s.Config.DisableSSL)
 				opt.UseDualStack = aws.BoolValue(s.Config.UseDualStack)
 
-				// Suppor the condition where the service is modeled but its
+				// Support the condition where the service is modeled but its
 				// endpoint metadata is not available.
 				opt.ResolveUnknownService = true
 			},

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -68,6 +68,8 @@ type Metadata struct {
 	Protocol            string
 	UID                 string
 	EndpointsID         string
+
+	NoResolveEndpoint bool
 }
 
 var serviceAliases map[string]string
@@ -382,7 +384,16 @@ const (
 //     // Create a {{ .StructName }} client with additional configuration
 //     svc := {{ .PackageName }}.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *{{ .StructName }} {
-	c := p.ClientConfig({{ EndpointsIDValue . }}, cfgs...)
+	{{ if .Metadata.NoResolveEndpoint -}}
+		var c client.Config
+		if v, ok := p.(client.ConfigNoResolveEndpointProvider); ok {
+			c = v.ClientConfigNoResolveEndpoint(cfgs...)
+		} else {
+			c = p.ClientConfig({{ EndpointsIDValue . }}, cfgs...)
+		}
+	{{- else -}}
+		c := p.ClientConfig({{ EndpointsIDValue . }}, cfgs...)
+	{{- end }}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 

--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -34,6 +34,11 @@ func (a *API) customizationPasses() {
 		"s3":         s3Customizations,
 		"cloudfront": cloudfrontCustomizations,
 		"rds":        rdsCustomizations,
+
+		// Disable endpoint resolving for services that require customer
+		// to provide endpoint them selves.
+		"cloudsearchdomain": disableEndpointResolving,
+		"iotdataplane":      disableEndpointResolving,
 	}
 
 	for k, _ := range mergeServices {
@@ -162,4 +167,8 @@ func rdsCustomizations(a *API) {
 			}
 		}
 	}
+}
+
+func disableEndpointResolving(a *API) {
+	a.Metadata.NoResolveEndpoint = true
 }

--- a/service/cloudsearchdomain/service.go
+++ b/service/cloudsearchdomain/service.go
@@ -50,7 +50,12 @@ const (
 //     // Create a CloudSearchDomain client with additional configuration
 //     svc := cloudsearchdomain.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CloudSearchDomain {
-	c := p.ClientConfig(EndpointsID, cfgs...)
+	var c client.Config
+	if v, ok := p.(client.ConfigNoResolveEndpointProvider); ok {
+		c = v.ClientConfigNoResolveEndpoint(cfgs...)
+	} else {
+		c = p.ClientConfig(EndpointsID, cfgs...)
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 

--- a/service/iotdataplane/service.go
+++ b/service/iotdataplane/service.go
@@ -47,7 +47,12 @@ const (
 //     // Create a IoTDataPlane client with additional configuration
 //     svc := iotdataplane.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *IoTDataPlane {
-	c := p.ClientConfig(EndpointsID, cfgs...)
+	var c client.Config
+	if v, ok := p.(client.ConfigNoResolveEndpointProvider); ok {
+		c = v.ClientConfigNoResolveEndpoint(cfgs...)
+	} else {
+		c = p.ClientConfig(EndpointsID, cfgs...)
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 


### PR DESCRIPTION
Adds an option to the endpoint resolver that allows resolving endpoints
for a service that is not included in the endpoints metadata. In order
for this to work with the partitions list the region must be valid. When
using a specific partition the endpoint will be resolved regardless if
the region is also valid.

This option is ignored if StrictMatching option is enabled.