### PR TITLE
Fix typos in DynamoDB example README

### DIFF
--- a/example/service/dynamodb/unitTest/README.md
+++ b/example/service/dynamodb/unitTest/README.md
@@ -12,7 +12,7 @@ type ItemGetter struct {
 }
 ```
 
-## Querying actual DyanmoDB
+## Querying actual DynamoDB
 You'll need an `*aws.Config` and `*session.Session` for these to work correctly:
 ```go
 // Setup

--- a/example/service/dynamodb/unitTest/README.md
+++ b/example/service/dynamodb/unitTest/README.md
@@ -22,7 +22,7 @@ var sess *session.Session = session.NewSession(config)
 var svc *dynamodb.DynamoDB = dynamodb.New()
 getter.DynamoDB = dynamodbiface.DynamoDBAPI(svc)
 // Finally
-getter.DyanmoDB.GetItem(/* ... */)
+getter.DynamoDB.GetItem(/* ... */)
 ```
 
 ## Querying in tests
@@ -37,7 +37,7 @@ type fakeDynamoDB struct {
 var getter = new(ItemGetter)
 getter.DynamoDB = &fakeDynamoDB{}
 // And to run it (assuming you've mocked fakeDynamoDB.GetItem)
-getter.DyanmoDB.GetItem(/* ... */)
+getter.DynamoDB.GetItem(/* ... */)
 ```
 
 ## Output


### PR DESCRIPTION
Was reading the example's README and noticed the typo. Let's fix it.