### PR TITLE
v1.6.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Release v1.6.23 (2017-02-15)
+===
+
+Service Client Updates
+---
+* `service/kms`: Updates service API, documentation, paginators, and examples
+  * his release of AWS Key Management Service introduces the ability to tag keys. Tagging keys can help you organize your keys and track your KMS costs in the cost allocation report. This release also increases the maximum length of a key ID to accommodate ARNs that include a long key alias.
+
 Release v1.6.22 (2017-02-14)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.6.22"
+const SDKVersion = "1.6.23"

--- a/models/apis/kms/2014-11-01/api-2.json
+++ b/models/apis/kms/2014-11-01/api-2.json
@@ -78,7 +78,8 @@
         {"shape":"InvalidArnException"},
         {"shape":"UnsupportedOperationException"},
         {"shape":"KMSInternalException"},
-        {"shape":"LimitExceededException"}
+        {"shape":"LimitExceededException"},
+        {"shape":"TagException"}
       ]
     },
     "Decrypt":{
@@ -412,6 +413,21 @@
         {"shape":"InvalidMarkerException"}
       ]
     },
+    "ListResourceTags":{
+      "name":"ListResourceTags",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ListResourceTagsRequest"},
+      "output":{"shape":"ListResourceTagsResponse"},
+      "errors":[
+        {"shape":"KMSInternalException"},
+        {"shape":"NotFoundException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"InvalidMarkerException"}
+      ]
+    },
     "ListRetirableGrants":{
       "name":"ListRetirableGrants",
       "http":{
@@ -512,6 +528,37 @@
         {"shape":"DependencyTimeoutException"},
         {"shape":"KMSInternalException"},
         {"shape":"KMSInvalidStateException"}
+      ]
+    },
+    "TagResource":{
+      "name":"TagResource",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"TagResourceRequest"},
+      "errors":[
+        {"shape":"KMSInternalException"},
+        {"shape":"NotFoundException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"KMSInvalidStateException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"TagException"}
+      ]
+    },
+    "UntagResource":{
+      "name":"UntagResource",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"UntagResourceRequest"},
+      "errors":[
+        {"shape":"KMSInternalException"},
+        {"shape":"NotFoundException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"KMSInvalidStateException"},
+        {"shape":"TagException"}
       ]
     },
     "UpdateAlias":{
@@ -644,7 +691,8 @@
         "Description":{"shape":"DescriptionType"},
         "KeyUsage":{"shape":"KeyUsageType"},
         "Origin":{"shape":"OriginType"},
-        "BypassPolicyLockoutSafetyCheck":{"shape":"BooleanType"}
+        "BypassPolicyLockoutSafetyCheck":{"shape":"BooleanType"},
+        "Tags":{"shape":"TagList"}
       }
     },
     "CreateKeyResponse":{
@@ -1060,7 +1108,7 @@
     },
     "KeyIdType":{
       "type":"string",
-      "max":256,
+      "max":2048,
       "min":1
     },
     "KeyList":{
@@ -1185,6 +1233,23 @@
       "type":"structure",
       "members":{
         "Keys":{"shape":"KeyList"},
+        "NextMarker":{"shape":"MarkerType"},
+        "Truncated":{"shape":"BooleanType"}
+      }
+    },
+    "ListResourceTagsRequest":{
+      "type":"structure",
+      "required":["KeyId"],
+      "members":{
+        "KeyId":{"shape":"KeyIdType"},
+        "Limit":{"shape":"LimitType"},
+        "Marker":{"shape":"MarkerType"}
+      }
+    },
+    "ListResourceTagsResponse":{
+      "type":"structure",
+      "members":{
+        "Tags":{"shape":"TagList"},
         "NextMarker":{"shape":"MarkerType"},
         "Truncated":{"shape":"BooleanType"}
       }
@@ -1332,12 +1397,70 @@
         "DeletionDate":{"shape":"DateType"}
       }
     },
+    "Tag":{
+      "type":"structure",
+      "required":[
+        "TagKey",
+        "TagValue"
+      ],
+      "members":{
+        "TagKey":{"shape":"TagKeyType"},
+        "TagValue":{"shape":"TagValueType"}
+      }
+    },
+    "TagException":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ErrorMessageType"}
+      },
+      "exception":true
+    },
+    "TagKeyList":{
+      "type":"list",
+      "member":{"shape":"TagKeyType"}
+    },
+    "TagKeyType":{
+      "type":"string",
+      "max":128,
+      "min":1
+    },
+    "TagList":{
+      "type":"list",
+      "member":{"shape":"Tag"}
+    },
+    "TagResourceRequest":{
+      "type":"structure",
+      "required":[
+        "KeyId",
+        "Tags"
+      ],
+      "members":{
+        "KeyId":{"shape":"KeyIdType"},
+        "Tags":{"shape":"TagList"}
+      }
+    },
+    "TagValueType":{
+      "type":"string",
+      "max":256,
+      "min":0
+    },
     "UnsupportedOperationException":{
       "type":"structure",
       "members":{
         "message":{"shape":"ErrorMessageType"}
       },
       "exception":true
+    },
+    "UntagResourceRequest":{
+      "type":"structure",
+      "required":[
+        "KeyId",
+        "TagKeys"
+      ],
+      "members":{
+        "KeyId":{"shape":"KeyIdType"},
+        "TagKeys":{"shape":"TagKeyList"}
+      }
     },
     "UpdateAliasRequest":{
       "type":"structure",

--- a/models/apis/kms/2014-11-01/docs-2.json
+++ b/models/apis/kms/2014-11-01/docs-2.json
@@ -26,12 +26,15 @@
     "ListGrants": "<p>List the grants for a specified key.</p>",
     "ListKeyPolicies": "<p>Retrieves a list of policies attached to a key.</p>",
     "ListKeys": "<p>Lists the customer master keys.</p>",
+    "ListResourceTags": "<p>Returns a list of all tags for the specified customer master key (CMK).</p>",
     "ListRetirableGrants": "<p>Returns a list of all grants for which the grant's <code>RetiringPrincipal</code> matches the one specified.</p> <p>A typical use is to list all grants that you are able to retire. To retire a grant, use <a>RetireGrant</a>.</p>",
     "PutKeyPolicy": "<p>Attaches a key policy to the specified customer master key (CMK).</p> <p>For more information about key policies, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">Key Policies</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>",
     "ReEncrypt": "<p>Encrypts data on the server side with a new customer master key (CMK) without exposing the plaintext of the data on the client side. The data is first decrypted and then reencrypted. You can also use this operation to change the encryption context of a ciphertext.</p> <p>Unlike other operations, <code>ReEncrypt</code> is authorized twice, once as <code>ReEncryptFrom</code> on the source CMK and once as <code>ReEncryptTo</code> on the destination CMK. We recommend that you include the <code>\"kms:ReEncrypt*\"</code> permission in your <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">key policies</a> to permit reencryption from or to the CMK. This permission is automatically included in the key policy when you create a CMK through the console, but you must include it manually when you create a CMK programmatically or when you set a key policy with the <a>PutKeyPolicy</a> operation.</p>",
     "RetireGrant": "<p>Retires a grant. To clean up, you can retire a grant when you're done using it. You should revoke a grant when you intend to actively deny operations that depend on it. The following are permitted to call this API:</p> <ul> <li> <p>The AWS account (root user) under which the grant was created</p> </li> <li> <p>The <code>RetiringPrincipal</code>, if present in the grant</p> </li> <li> <p>The <code>GranteePrincipal</code>, if <code>RetireGrant</code> is an operation specified in the grant</p> </li> </ul> <p>You must identify the grant to retire by its grant token or by a combination of the grant ID and the Amazon Resource Name (ARN) of the customer master key (CMK). A grant token is a unique variable-length base64-encoded string. A grant ID is a 64 character unique identifier of a grant. The <a>CreateGrant</a> operation returns both.</p>",
     "RevokeGrant": "<p>Revokes a grant. You can revoke a grant to actively deny operations that depend on it.</p>",
     "ScheduleKeyDeletion": "<p>Schedules the deletion of a customer master key (CMK). You may provide a waiting period, specified in days, before deletion occurs. If you do not provide a waiting period, the default period of 30 days is used. When this operation is successful, the state of the CMK changes to <code>PendingDeletion</code>. Before the waiting period ends, you can use <a>CancelKeyDeletion</a> to cancel the deletion of the CMK. After the waiting period ends, AWS KMS deletes the CMK and all AWS KMS data associated with it, including all aliases that refer to it.</p> <important> <p>Deleting a CMK is a destructive and potentially dangerous operation. When a CMK is deleted, all data that was encrypted under the CMK is rendered unrecoverable. To restrict the use of a CMK without deleting it, use <a>DisableKey</a>.</p> </important> <p>For more information about scheduling a CMK for deletion, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html\">Deleting Customer Master Keys</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>",
+    "TagResource": "<p>Adds or overwrites one or more tags for the specified customer master key (CMK). </p> <p>Each tag consists of a tag key and a tag value. Tag keys and tag values are both required, but tag values can be empty (null) strings.</p> <p>You cannot use the same tag key more than once per CMK. For example, consider a CMK with one tag whose tag key is <code>Purpose</code> and tag value is <code>Test</code>. If you send a <code>TagResource</code> request for this CMK with a tag key of <code>Purpose</code> and a tag value of <code>Prod</code>, it does not create a second tag. Instead, the original tag is overwritten with the new tag value.</p>",
+    "UntagResource": "<p>Removes the specified tag or tags from the specified customer master key (CMK). </p> <p>To remove a tag, you specify the tag key for each tag to remove. You do not specify the tag value. To overwrite the tag value for an existing tag, use <a>TagResource</a>.</p>",
     "UpdateAlias": "<p>Updates an alias to map it to a different key.</p> <p>An alias is not a property of a key. Therefore, an alias can be mapped to and unmapped from an existing key without changing the properties of the key.</p> <p>An alias name can contain only alphanumeric characters, forward slashes (/), underscores (_), and dashes (-). An alias must start with the word \"alias\" followed by a forward slash (alias/). An alias that begins with \"aws\" after the forward slash (alias/aws...) is reserved by Amazon Web Services (AWS).</p> <p>The alias and the key it is mapped to must be in the same AWS account and the same region.</p>",
     "UpdateKeyDescription": "<p>Updates the description of a customer master key (CMK).</p>"
   },
@@ -85,14 +88,15 @@
     "BooleanType": {
       "base": null,
       "refs": {
-        "CreateKeyRequest$BypassPolicyLockoutSafetyCheck": "<p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you include a policy in the request and you intend to prevent the principal making the request from making a subsequent <a>PutKeyPolicy</a> request on the CMK.</p> <p>The default value is false.</p>",
+        "CreateKeyRequest$BypassPolicyLockoutSafetyCheck": "<p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you include a policy in the request and you intend to prevent the principal that is making the request from making a subsequent <a>PutKeyPolicy</a> request on the CMK.</p> <p>The default value is false.</p>",
         "GetKeyRotationStatusResponse$KeyRotationEnabled": "<p>A Boolean value that specifies whether key rotation is enabled.</p>",
         "KeyMetadata$Enabled": "<p>Specifies whether the CMK is enabled. When <code>KeyState</code> is <code>Enabled</code> this value is true, otherwise it is false.</p>",
-        "ListAliasesResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. If your results were truncated, you can use the <code>Marker</code> parameter to make a subsequent pagination request to retrieve more items in the list.</p>",
-        "ListGrantsResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. If your results were truncated, you can use the <code>Marker</code> parameter to make a subsequent pagination request to retrieve more items in the list.</p>",
-        "ListKeyPoliciesResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. If your results were truncated, you can use the <code>Marker</code> parameter to make a subsequent pagination request to retrieve more items in the list.</p>",
-        "ListKeysResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. If your results were truncated, you can use the <code>Marker</code> parameter to make a subsequent pagination request to retrieve more items in the list.</p>",
-        "PutKeyPolicyRequest$BypassPolicyLockoutSafetyCheck": "<p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you intend to prevent the principal making the request from making a subsequent <code>PutKeyPolicy</code> request on the CMK.</p> <p>The default value is false.</p>"
+        "ListAliasesResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. When this value is true, the list in this response is truncated. To retrieve more items, pass the value of the <code>NextMarker</code> element in this response to the <code>Marker</code> parameter in a subsequent request.</p>",
+        "ListGrantsResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. When this value is true, the list in this response is truncated. To retrieve more items, pass the value of the <code>NextMarker</code> element in this response to the <code>Marker</code> parameter in a subsequent request.</p>",
+        "ListKeyPoliciesResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. When this value is true, the list in this response is truncated. To retrieve more items, pass the value of the <code>NextMarker</code> element in this response to the <code>Marker</code> parameter in a subsequent request.</p>",
+        "ListKeysResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. When this value is true, the list in this response is truncated. To retrieve more items, pass the value of the <code>NextMarker</code> element in this response to the <code>Marker</code> parameter in a subsequent request.</p>",
+        "ListResourceTagsResponse$Truncated": "<p>A flag that indicates whether there are more items in the list. When this value is true, the list in this response is truncated. To retrieve more items, pass the value of the <code>NextMarker</code> element in this response to the <code>Marker</code> parameter in a subsequent request.</p>",
+        "PutKeyPolicyRequest$BypassPolicyLockoutSafetyCheck": "<p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent <code>PutKeyPolicy</code> request on the CMK.</p> <p>The default value is false.</p>"
       }
     },
     "CancelKeyDeletionRequest": {
@@ -288,6 +292,7 @@
         "LimitExceededException$message": null,
         "MalformedPolicyDocumentException$message": null,
         "NotFoundException$message": null,
+        "TagException$message": null,
         "UnsupportedOperationException$message": null
       }
     },
@@ -527,6 +532,7 @@
         "KeyMetadata$KeyId": "<p>The globally unique identifier for the CMK.</p>",
         "ListGrantsRequest$KeyId": "<p>A unique identifier for the customer master key. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>",
         "ListKeyPoliciesRequest$KeyId": "<p>A unique identifier for the customer master key (CMK). You can use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>",
+        "ListResourceTagsRequest$KeyId": "<p>A unique identifier for the CMK whose tags you are listing. You can use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>",
         "PutKeyPolicyRequest$KeyId": "<p>A unique identifier for the CMK.</p> <p>Use the CMK's unique identifier or its Amazon Resource Name (ARN). For example:</p> <ul> <li> <p>Unique ID: 1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> <li> <p>ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> </ul>",
         "ReEncryptRequest$DestinationKeyId": "<p>A unique identifier for the CMK to use to reencrypt the data. This value can be a globally unique identifier, a fully specified ARN to either an alias or a key, or an alias name prefixed by \"alias/\".</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Alias ARN Example - arn:aws:kms:us-east-1:123456789012:alias/MyAliasName</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Alias Name Example - alias/MyAliasName</p> </li> </ul>",
         "ReEncryptResponse$SourceKeyId": "<p>Unique identifier of the CMK used to originally encrypt the data.</p>",
@@ -535,6 +541,8 @@
         "RevokeGrantRequest$KeyId": "<p>A unique identifier for the customer master key associated with the grant. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>",
         "ScheduleKeyDeletionRequest$KeyId": "<p>The unique identifier for the customer master key (CMK) to delete.</p> <p>To specify this value, use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: 1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> <li> <p>Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> </ul> <p>To obtain the unique key ID and key ARN for a given CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
         "ScheduleKeyDeletionResponse$KeyId": "<p>The unique identifier of the customer master key (CMK) for which deletion is scheduled.</p>",
+        "TagResourceRequest$KeyId": "<p>A unique identifier for the CMK you are tagging. You can use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>",
+        "UntagResourceRequest$KeyId": "<p>A unique identifier for the CMK from which you are removing tags. You can use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>",
         "UpdateAliasRequest$TargetKeyId": "<p>Unique identifier of the customer master key to be mapped to the alias. This value can be a globally unique identifier or the fully specified ARN of a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul> <p>You can call <a>ListAliases</a> to verify that the alias is mapped to the correct <code>TargetKeyId</code>.</p>",
         "UpdateKeyDescriptionRequest$KeyId": "<p>A unique identifier for the CMK. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"
       }
@@ -584,11 +592,12 @@
     "LimitType": {
       "base": null,
       "refs": {
-        "ListAliasesRequest$Limit": "<p>When paginating results, specify the maximum number of items to return in the response. If additional items exist beyond the number you specify, the <code>Truncated</code> element in the response is set to true.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>",
-        "ListGrantsRequest$Limit": "<p>When paginating results, specify the maximum number of items to return in the response. If additional items exist beyond the number you specify, the <code>Truncated</code> element in the response is set to true.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>",
-        "ListKeyPoliciesRequest$Limit": "<p>When paginating results, specify the maximum number of items to return in the response. If additional items exist beyond the number you specify, the <code>Truncated</code> element in the response is set to true.</p> <p>This value is optional. If you include a value, it must be between 1 and 1000, inclusive. If you do not include a value, it defaults to 100.</p> <p>Currently only 1 policy can be attached to a key.</p>",
-        "ListKeysRequest$Limit": "<p>When paginating results, specify the maximum number of items to return in the response. If additional items exist beyond the number you specify, the <code>Truncated</code> element in the response is set to true.</p> <p>This value is optional. If you include a value, it must be between 1 and 1000, inclusive. If you do not include a value, it defaults to 100.</p>",
-        "ListRetirableGrantsRequest$Limit": "<p>When paginating results, specify the maximum number of items to return in the response. If additional items exist beyond the number you specify, the <code>Truncated</code> element in the response is set to true.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>"
+        "ListAliasesRequest$Limit": "<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>",
+        "ListGrantsRequest$Limit": "<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>",
+        "ListKeyPoliciesRequest$Limit": "<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 1000, inclusive. If you do not include a value, it defaults to 100.</p> <p>Currently only 1 policy can be attached to a key.</p>",
+        "ListKeysRequest$Limit": "<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 1000, inclusive. If you do not include a value, it defaults to 100.</p>",
+        "ListResourceTagsRequest$Limit": "<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 50, inclusive. If you do not include a value, it defaults to 50.</p>",
+        "ListRetirableGrantsRequest$Limit": "<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>"
       }
     },
     "ListAliasesRequest": {
@@ -631,6 +640,16 @@
       "refs": {
       }
     },
+    "ListResourceTagsRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListResourceTagsResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "ListRetirableGrantsRequest": {
       "base": null,
       "refs": {
@@ -644,15 +663,17 @@
     "MarkerType": {
       "base": null,
       "refs": {
-        "ListAliasesRequest$Marker": "<p>Use this parameter only when paginating results and only in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the response you just received.</p>",
-        "ListAliasesResponse$NextMarker": "<p>When <code>Truncated</code> is true, this value is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>",
-        "ListGrantsRequest$Marker": "<p>Use this parameter only when paginating results and only in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the response you just received.</p>",
-        "ListGrantsResponse$NextMarker": "<p>When <code>Truncated</code> is true, this value is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>",
-        "ListKeyPoliciesRequest$Marker": "<p>Use this parameter only when paginating results and only in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the response you just received.</p>",
-        "ListKeyPoliciesResponse$NextMarker": "<p>When <code>Truncated</code> is true, this value is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>",
-        "ListKeysRequest$Marker": "<p>Use this parameter only when paginating results and only in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the response you just received.</p>",
-        "ListKeysResponse$NextMarker": "<p>When <code>Truncated</code> is true, this value is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>",
-        "ListRetirableGrantsRequest$Marker": "<p>Use this parameter only when paginating results and only in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the response you just received.</p>"
+        "ListAliasesRequest$Marker": "<p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p>",
+        "ListAliasesResponse$NextMarker": "<p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p>",
+        "ListGrantsRequest$Marker": "<p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p>",
+        "ListGrantsResponse$NextMarker": "<p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p>",
+        "ListKeyPoliciesRequest$Marker": "<p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p>",
+        "ListKeyPoliciesResponse$NextMarker": "<p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p>",
+        "ListKeysRequest$Marker": "<p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p>",
+        "ListKeysResponse$NextMarker": "<p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p>",
+        "ListResourceTagsRequest$Marker": "<p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p> <p>Do not attempt to construct this value. Use only the value of <code>NextMarker</code> from the truncated response you just received.</p>",
+        "ListResourceTagsResponse$NextMarker": "<p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p> <p>Do not assume or infer any information from this value.</p>",
+        "ListRetirableGrantsRequest$Marker": "<p>Use this parameter in a subsequent request after you receive a response with truncated results. Set it to the value of <code>NextMarker</code> from the truncated response you just received.</p>"
       }
     },
     "NotFoundException": {
@@ -708,9 +729,9 @@
     "PolicyType": {
       "base": null,
       "refs": {
-        "CreateKeyRequest$Policy": "<p>The key policy to attach to the CMK.</p> <p>If you specify a policy and do not set <code>BypassPolicyLockoutSafetyCheck</code> to true, the policy must meet the following criteria:</p> <ul> <li> <p>It must allow the principal making the <code>CreateKey</code> request to make a subsequent <a>PutKeyPolicy</a> request on the CMK. This reduces the likelihood that the CMK becomes unmanageable. For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </li> <li> <p>The principal(s) specified in the key policy must exist and be visible to AWS KMS. When you create a new AWS principal (for example, an IAM user or role), you might need to enforce a delay before specifying the new principal in a key policy because the new principal might not immediately be visible to AWS KMS. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>IAM User Guide</i>.</p> </li> </ul> <p>If you do not specify a policy, AWS KMS attaches a default key policy to the CMK. For more information, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default\">Default Key Policy</a> in the <i>AWS Key Management Service Developer Guide</i>.</p> <p>The policy size limit is 32 KiB (32768 bytes).</p>",
+        "CreateKeyRequest$Policy": "<p>The key policy to attach to the CMK.</p> <p>If you specify a policy and do not set <code>BypassPolicyLockoutSafetyCheck</code> to true, the policy must meet the following criteria:</p> <ul> <li> <p>It must allow the principal that is making the <code>CreateKey</code> request to make a subsequent <a>PutKeyPolicy</a> request on the CMK. This reduces the likelihood that the CMK becomes unmanageable. For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </li> <li> <p>The principals that are specified in the key policy must exist and be visible to AWS KMS. When you create a new AWS principal (for example, an IAM user or role), you might need to enforce a delay before specifying the new principal in a key policy because the new principal might not immediately be visible to AWS KMS. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>IAM User Guide</i>.</p> </li> </ul> <p>If you do not specify a policy, AWS KMS attaches a default key policy to the CMK. For more information, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default\">Default Key Policy</a> in the <i>AWS Key Management Service Developer Guide</i>.</p> <p>The policy size limit is 32 KiB (32768 bytes).</p>",
         "GetKeyPolicyResponse$Policy": "<p>A policy document in JSON format.</p>",
-        "PutKeyPolicyRequest$Policy": "<p>The key policy to attach to the CMK.</p> <p>If you do not set <code>BypassPolicyLockoutSafetyCheck</code> to true, the policy must meet the following criteria:</p> <ul> <li> <p>It must allow the principal making the <code>PutKeyPolicy</code> request to make a subsequent <code>PutKeyPolicy</code> request on the CMK. This reduces the likelihood that the CMK becomes unmanageable. For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </li> <li> <p>The principal(s) specified in the key policy must exist and be visible to AWS KMS. When you create a new AWS principal (for example, an IAM user or role), you might need to enforce a delay before specifying the new principal in a key policy because the new principal might not immediately be visible to AWS KMS. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>IAM User Guide</i>.</p> </li> </ul> <p>The policy size limit is 32 KiB (32768 bytes).</p>"
+        "PutKeyPolicyRequest$Policy": "<p>The key policy to attach to the CMK.</p> <p>If you do not set <code>BypassPolicyLockoutSafetyCheck</code> to true, the policy must meet the following criteria:</p> <ul> <li> <p>It must allow the principal that is making the <code>PutKeyPolicy</code> request to make a subsequent <code>PutKeyPolicy</code> request on the CMK. This reduces the likelihood that the CMK becomes unmanageable. For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </li> <li> <p>The principals that are specified in the key policy must exist and be visible to AWS KMS. When you create a new AWS principal (for example, an IAM user or role), you might need to enforce a delay before specifying the new principal in a key policy because the new principal might not immediately be visible to AWS KMS. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>IAM User Guide</i>.</p> </li> </ul> <p>The policy size limit is 32 KiB (32768 bytes).</p>"
       }
     },
     "PrincipalIdType": {
@@ -759,8 +780,56 @@
       "refs": {
       }
     },
+    "Tag": {
+      "base": "<p>A key-value pair. A tag consists of a tag key and a tag value. Tag keys and tag values are both required, but tag values can be empty (null) strings.</p>",
+      "refs": {
+        "TagList$member": null
+      }
+    },
+    "TagException": {
+      "base": "<p>The request was rejected because one or more tags are not valid.</p>",
+      "refs": {
+      }
+    },
+    "TagKeyList": {
+      "base": null,
+      "refs": {
+        "UntagResourceRequest$TagKeys": "<p>One or more tag keys. Specify only the tag keys, not the tag values.</p>"
+      }
+    },
+    "TagKeyType": {
+      "base": null,
+      "refs": {
+        "Tag$TagKey": "<p>The key of the tag.</p>",
+        "TagKeyList$member": null
+      }
+    },
+    "TagList": {
+      "base": null,
+      "refs": {
+        "CreateKeyRequest$Tags": "<p>One or more tags. Each tag consists of a tag key and a tag value. Tag keys and tag values are both required, but tag values can be empty (null) strings.</p> <p>Use this parameter to tag the CMK when it is created. Alternately, you can omit this parameter and instead tag the CMK after it is created using <a>TagResource</a>.</p>",
+        "ListResourceTagsResponse$Tags": "<p>A list of tags. Each tag consists of a tag key and a tag value.</p>",
+        "TagResourceRequest$Tags": "<p>One or more tags. Each tag consists of a tag key and a tag value.</p>"
+      }
+    },
+    "TagResourceRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "TagValueType": {
+      "base": null,
+      "refs": {
+        "Tag$TagValue": "<p>The value of the tag.</p>"
+      }
+    },
     "UnsupportedOperationException": {
       "base": "<p>The request was rejected because a specified parameter is not supported or a specified resource is not valid for this operation.</p>",
+      "refs": {
+      }
+    },
+    "UntagResourceRequest": {
+      "base": null,
       "refs": {
       }
     },

--- a/models/apis/kms/2014-11-01/examples-1.json
+++ b/models/apis/kms/2014-11-01/examples-1.json
@@ -71,11 +71,19 @@
     ],
     "CreateKey": [
       {
+        "input": {
+          "Tags": [
+            {
+              "TagKey": "CreatedBy",
+              "TagValue": "ExampleUser"
+            }
+          ]
+        },
         "output": {
           "KeyMetadata": {
             "AWSAccountId": "111122223333",
             "Arn": "arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
-            "CreationDate": "2016-11-01T10:15:42-07:00",
+            "CreationDate": "2017-01-09T12:00:07-08:00",
             "Description": "",
             "Enabled": true,
             "KeyId": "1234abcd-12ab-34cd-56ef-1234567890ab",
@@ -85,6 +93,9 @@
           }
         },
         "comments": {
+          "input": {
+            "Tags": "One or more tags. Each tag consists of a tag key and a tag value."
+          },
           "output": {
             "KeyMetadata": "An object that contains information about the CMK created by this operation."
           }
@@ -634,6 +645,42 @@
         "description": "The following example lists CMKs.",
         "id": "to-list-cmks-1481071643069",
         "title": "To list customer master keys (CMKs)"
+      }
+    ],
+    "ListResourceTags": [
+      {
+        "input": {
+          "KeyId": "1234abcd-12ab-34cd-56ef-1234567890ab"
+        },
+        "output": {
+          "Tags": [
+            {
+              "TagKey": "CostCenter",
+              "TagValue": "87654"
+            },
+            {
+              "TagKey": "CreatedBy",
+              "TagValue": "ExampleUser"
+            },
+            {
+              "TagKey": "Purpose",
+              "TagValue": "Test"
+            }
+          ],
+          "Truncated": false
+        },
+        "comments": {
+          "input": {
+            "KeyId": "The identifier of the CMK whose tags you are listing. You can use the key ID or the Amazon Resource Name (ARN) of the CMK."
+          },
+          "output": {
+            "Tags": "A list of tags.",
+            "Truncated": "A boolean that indicates whether there are more items in the list. Returns true when there are more items, or false when there are not."
+          }
+        },
+        "description": "The following example lists tags for a CMK.",
+        "id": "to-list-tags-for-a-cmk-1483996855796",
+        "title": "To list tags for a customer master key (CMK)"
       }
     ],
     "ListRetirableGrants": [

--- a/models/apis/kms/2014-11-01/paginators-1.json
+++ b/models/apis/kms/2014-11-01/paginators-1.json
@@ -1,31 +1,31 @@
 {
   "pagination": {
     "ListAliases": {
-      "limit_key": "Limit",
       "input_token": "Marker",
-      "output_token": "NextMarker",
+      "limit_key": "Limit",
       "more_results": "Truncated",
+      "output_token": "NextMarker",
       "result_key": "Aliases"
     },
     "ListGrants": {
-      "limit_key": "Limit",
       "input_token": "Marker",
-      "output_token": "NextMarker",
+      "limit_key": "Limit",
       "more_results": "Truncated",
+      "output_token": "NextMarker",
       "result_key": "Grants"
     },
     "ListKeyPolicies": {
-      "limit_key": "Limit",
       "input_token": "Marker",
-      "output_token": "NextMarker",
+      "limit_key": "Limit",
       "more_results": "Truncated",
+      "output_token": "NextMarker",
       "result_key": "PolicyNames"
     },
     "ListKeys": {
-      "limit_key": "Limit",
       "input_token": "Marker",
-      "output_token": "NextMarker",
+      "limit_key": "Limit",
       "more_results": "Truncated",
+      "output_token": "NextMarker",
       "result_key": "Keys"
     }
   }

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -4,6 +4,7 @@
 package kms
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
@@ -398,6 +399,9 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 //   The request was rejected because a limit was exceeded. For more information,
 //   see Limits (http://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
 //   in the AWS Key Management Service Developer Guide.
+//
+//   * ErrCodeTagException "TagException"
+//   The request was rejected because one or more tags are not valid.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateKey
 func (c *KMS) CreateKey(input *CreateKeyInput) (*CreateKeyOutput, error) {
@@ -2434,6 +2438,83 @@ func (c *KMS) ListKeysPages(input *ListKeysInput, fn func(p *ListKeysOutput, las
 	})
 }
 
+const opListResourceTags = "ListResourceTags"
+
+// ListResourceTagsRequest generates a "aws/request.Request" representing the
+// client's request for the ListResourceTags operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListResourceTags for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListResourceTags method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListResourceTagsRequest method.
+//    req, resp := client.ListResourceTagsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListResourceTags
+func (c *KMS) ListResourceTagsRequest(input *ListResourceTagsInput) (req *request.Request, output *ListResourceTagsOutput) {
+	op := &request.Operation{
+		Name:       opListResourceTags,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListResourceTagsInput{}
+	}
+
+	output = &ListResourceTagsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListResourceTags API operation for AWS Key Management Service.
+//
+// Returns a list of all tags for the specified customer master key (CMK).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation ListResourceTags for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   The request was rejected because a specified ARN was not valid.
+//
+//   * ErrCodeInvalidMarkerException "InvalidMarkerException"
+//   The request was rejected because the marker that specifies where pagination
+//   should next begin is not valid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListResourceTags
+func (c *KMS) ListResourceTags(input *ListResourceTagsInput) (*ListResourceTagsOutput, error) {
+	req, out := c.ListResourceTagsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opListRetirableGrants = "ListRetirableGrants"
 
 // ListRetirableGrantsRequest generates a "aws/request.Request" representing the
@@ -3028,6 +3109,198 @@ func (c *KMS) ScheduleKeyDeletion(input *ScheduleKeyDeletionInput) (*ScheduleKey
 	return out, err
 }
 
+const opTagResource = "TagResource"
+
+// TagResourceRequest generates a "aws/request.Request" representing the
+// client's request for the TagResource operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See TagResource for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the TagResource method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the TagResourceRequest method.
+//    req, resp := client.TagResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/TagResource
+func (c *KMS) TagResourceRequest(input *TagResourceInput) (req *request.Request, output *TagResourceOutput) {
+	op := &request.Operation{
+		Name:       opTagResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &TagResourceInput{}
+	}
+
+	output = &TagResourceOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// TagResource API operation for AWS Key Management Service.
+//
+// Adds or overwrites one or more tags for the specified customer master key
+// (CMK).
+//
+// Each tag consists of a tag key and a tag value. Tag keys and tag values are
+// both required, but tag values can be empty (null) strings.
+//
+// You cannot use the same tag key more than once per CMK. For example, consider
+// a CMK with one tag whose tag key is Purpose and tag value is Test. If you
+// send a TagResource request for this CMK with a tag key of Purpose and a tag
+// value of Prod, it does not create a second tag. Instead, the original tag
+// is overwritten with the new tag value.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation TagResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   The request was rejected because a specified ARN was not valid.
+//
+//   * ErrCodeInvalidStateException "InvalidStateException"
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a CMK, see How
+//   Key State Affects Use of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the AWS Key Management Service Developer Guide.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The request was rejected because a limit was exceeded. For more information,
+//   see Limits (http://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
+//   in the AWS Key Management Service Developer Guide.
+//
+//   * ErrCodeTagException "TagException"
+//   The request was rejected because one or more tags are not valid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/TagResource
+func (c *KMS) TagResource(input *TagResourceInput) (*TagResourceOutput, error) {
+	req, out := c.TagResourceRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opUntagResource = "UntagResource"
+
+// UntagResourceRequest generates a "aws/request.Request" representing the
+// client's request for the UntagResource operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See UntagResource for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the UntagResource method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the UntagResourceRequest method.
+//    req, resp := client.UntagResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UntagResource
+func (c *KMS) UntagResourceRequest(input *UntagResourceInput) (req *request.Request, output *UntagResourceOutput) {
+	op := &request.Operation{
+		Name:       opUntagResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UntagResourceInput{}
+	}
+
+	output = &UntagResourceOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// UntagResource API operation for AWS Key Management Service.
+//
+// Removes the specified tag or tags from the specified customer master key
+// (CMK).
+//
+// To remove a tag, you specify the tag key for each tag to remove. You do not
+// specify the tag value. To overwrite the tag value for an existing tag, use
+// TagResource.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Key Management Service's
+// API operation UntagResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   The request was rejected because an internal exception occurred. The request
+//   can be retried.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The request was rejected because the specified entity or resource could not
+//   be found.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   The request was rejected because a specified ARN was not valid.
+//
+//   * ErrCodeInvalidStateException "InvalidStateException"
+//   The request was rejected because the state of the specified resource is not
+//   valid for this request.
+//
+//   For more information about how key state affects the use of a CMK, see How
+//   Key State Affects Use of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the AWS Key Management Service Developer Guide.
+//
+//   * ErrCodeTagException "TagException"
+//   The request was rejected because one or more tags are not valid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UntagResource
+func (c *KMS) UntagResource(input *UntagResourceInput) (*UntagResourceOutput, error) {
+	req, out := c.UntagResourceRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opUpdateAlias = "UpdateAlias"
 
 // UpdateAliasRequest generates a "aws/request.Request" representing the
@@ -3617,8 +3890,8 @@ type CreateKeyInput struct {
 	// section in the AWS Key Management Service Developer Guide.
 	//
 	// Use this parameter only when you include a policy in the request and you
-	// intend to prevent the principal making the request from making a subsequent
-	// PutKeyPolicy request on the CMK.
+	// intend to prevent the principal that is making the request from making a
+	// subsequent PutKeyPolicy request on the CMK.
 	//
 	// The default value is false.
 	BypassPolicyLockoutSafetyCheck *bool `type:"boolean"`
@@ -3651,18 +3924,18 @@ type CreateKeyInput struct {
 	// If you specify a policy and do not set BypassPolicyLockoutSafetyCheck to
 	// true, the policy must meet the following criteria:
 	//
-	//    * It must allow the principal making the CreateKey request to make a subsequent
-	//    PutKeyPolicy request on the CMK. This reduces the likelihood that the
-	//    CMK becomes unmanageable. For more information, refer to the scenario
-	//    in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    * It must allow the principal that is making the CreateKey request to
+	//    make a subsequent PutKeyPolicy request on the CMK. This reduces the likelihood
+	//    that the CMK becomes unmanageable. For more information, refer to the
+	//    scenario in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
 	//    section in the AWS Key Management Service Developer Guide.
 	//
-	//    * The principal(s) specified in the key policy must exist and be visible
-	//    to AWS KMS. When you create a new AWS principal (for example, an IAM user
-	//    or role), you might need to enforce a delay before specifying the new
-	//    principal in a key policy because the new principal might not immediately
-	//    be visible to AWS KMS. For more information, see Changes that I make are
-	//    not always immediately visible (http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    * The principals that are specified in the key policy must exist and be
+	//    visible to AWS KMS. When you create a new AWS principal (for example,
+	//    an IAM user or role), you might need to enforce a delay before specifying
+	//    the new principal in a key policy because the new principal might not
+	//    immediately be visible to AWS KMS. For more information, see Changes that
+	//    I make are not always immediately visible (http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
 	//    in the IAM User Guide.
 	//
 	// If you do not specify a policy, AWS KMS attaches a default key policy to
@@ -3671,6 +3944,13 @@ type CreateKeyInput struct {
 	//
 	// The policy size limit is 32 KiB (32768 bytes).
 	Policy *string `min:"1" type:"string"`
+
+	// One or more tags. Each tag consists of a tag key and a tag value. Tag keys
+	// and tag values are both required, but tag values can be empty (null) strings.
+	//
+	// Use this parameter to tag the CMK when it is created. Alternately, you can
+	// omit this parameter and instead tag the CMK after it is created using TagResource.
+	Tags []*Tag `type:"list"`
 }
 
 // String returns the string representation
@@ -3688,6 +3968,16 @@ func (s *CreateKeyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateKeyInput"}
 	if s.Policy != nil && len(*s.Policy) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3723,6 +4013,12 @@ func (s *CreateKeyInput) SetOrigin(v string) *CreateKeyInput {
 // SetPolicy sets the Policy field's value.
 func (s *CreateKeyInput) SetPolicy(v string) *CreateKeyInput {
 	s.Policy = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateKeyInput) SetTags(v []*Tag) *CreateKeyInput {
+	s.Tags = v
 	return s
 }
 
@@ -5562,17 +5858,17 @@ func (s *KeyMetadata) SetValidTo(v time.Time) *KeyMetadata {
 type ListAliasesInput struct {
 	_ struct{} `type:"structure"`
 
-	// When paginating results, specify the maximum number of items to return in
-	// the response. If additional items exist beyond the number you specify, the
-	// Truncated element in the response is set to true.
+	// Use this parameter to specify the maximum number of items to return. When
+	// this value is present, AWS KMS does not return more than the specified number
+	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
 	// 100, inclusive. If you do not include a value, it defaults to 50.
 	Limit *int64 `min:"1" type:"integer"`
 
-	// Use this parameter only when paginating results and only in a subsequent
-	// request after you receive a response with truncated results. Set it to the
-	// value of NextMarker from the response you just received.
+	// Use this parameter in a subsequent request after you receive a response with
+	// truncated results. Set it to the value of NextMarker from the truncated response
+	// you just received.
 	Marker *string `min:"1" type:"string"`
 }
 
@@ -5621,13 +5917,14 @@ type ListAliasesOutput struct {
 	// A list of key aliases in the user's account.
 	Aliases []*AliasListEntry `type:"list"`
 
-	// When Truncated is true, this value is present and contains the value to use
-	// for the Marker parameter in a subsequent pagination request.
+	// When Truncated is true, this element is present and contains the value to
+	// use for the Marker parameter in a subsequent request.
 	NextMarker *string `min:"1" type:"string"`
 
-	// A flag that indicates whether there are more items in the list. If your results
-	// were truncated, you can use the Marker parameter to make a subsequent pagination
-	// request to retrieve more items in the list.
+	// A flag that indicates whether there are more items in the list. When this
+	// value is true, the list in this response is truncated. To retrieve more items,
+	// pass the value of the NextMarker element in this response to the Marker parameter
+	// in a subsequent request.
 	Truncated *bool `type:"boolean"`
 }
 
@@ -5673,17 +5970,17 @@ type ListGrantsInput struct {
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// When paginating results, specify the maximum number of items to return in
-	// the response. If additional items exist beyond the number you specify, the
-	// Truncated element in the response is set to true.
+	// Use this parameter to specify the maximum number of items to return. When
+	// this value is present, AWS KMS does not return more than the specified number
+	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
 	// 100, inclusive. If you do not include a value, it defaults to 50.
 	Limit *int64 `min:"1" type:"integer"`
 
-	// Use this parameter only when paginating results and only in a subsequent
-	// request after you receive a response with truncated results. Set it to the
-	// value of NextMarker from the response you just received.
+	// Use this parameter in a subsequent request after you receive a response with
+	// truncated results. Set it to the value of NextMarker from the truncated response
+	// you just received.
 	Marker *string `min:"1" type:"string"`
 }
 
@@ -5744,13 +6041,14 @@ type ListGrantsResponse struct {
 	// A list of grants.
 	Grants []*GrantListEntry `type:"list"`
 
-	// When Truncated is true, this value is present and contains the value to use
-	// for the Marker parameter in a subsequent pagination request.
+	// When Truncated is true, this element is present and contains the value to
+	// use for the Marker parameter in a subsequent request.
 	NextMarker *string `min:"1" type:"string"`
 
-	// A flag that indicates whether there are more items in the list. If your results
-	// were truncated, you can use the Marker parameter to make a subsequent pagination
-	// request to retrieve more items in the list.
+	// A flag that indicates whether there are more items in the list. When this
+	// value is true, the list in this response is truncated. To retrieve more items,
+	// pass the value of the NextMarker element in this response to the Marker parameter
+	// in a subsequent request.
 	Truncated *bool `type:"boolean"`
 }
 
@@ -5796,9 +6094,9 @@ type ListKeyPoliciesInput struct {
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// When paginating results, specify the maximum number of items to return in
-	// the response. If additional items exist beyond the number you specify, the
-	// Truncated element in the response is set to true.
+	// Use this parameter to specify the maximum number of items to return. When
+	// this value is present, AWS KMS does not return more than the specified number
+	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
 	// 1000, inclusive. If you do not include a value, it defaults to 100.
@@ -5806,9 +6104,9 @@ type ListKeyPoliciesInput struct {
 	// Currently only 1 policy can be attached to a key.
 	Limit *int64 `min:"1" type:"integer"`
 
-	// Use this parameter only when paginating results and only in a subsequent
-	// request after you receive a response with truncated results. Set it to the
-	// value of NextMarker from the response you just received.
+	// Use this parameter in a subsequent request after you receive a response with
+	// truncated results. Set it to the value of NextMarker from the truncated response
+	// you just received.
 	Marker *string `min:"1" type:"string"`
 }
 
@@ -5866,17 +6164,18 @@ func (s *ListKeyPoliciesInput) SetMarker(v string) *ListKeyPoliciesInput {
 type ListKeyPoliciesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// When Truncated is true, this value is present and contains the value to use
-	// for the Marker parameter in a subsequent pagination request.
+	// When Truncated is true, this element is present and contains the value to
+	// use for the Marker parameter in a subsequent request.
 	NextMarker *string `min:"1" type:"string"`
 
 	// A list of policy names. Currently, there is only one policy and it is named
 	// "Default".
 	PolicyNames []*string `type:"list"`
 
-	// A flag that indicates whether there are more items in the list. If your results
-	// were truncated, you can use the Marker parameter to make a subsequent pagination
-	// request to retrieve more items in the list.
+	// A flag that indicates whether there are more items in the list. When this
+	// value is true, the list in this response is truncated. To retrieve more items,
+	// pass the value of the NextMarker element in this response to the Marker parameter
+	// in a subsequent request.
 	Truncated *bool `type:"boolean"`
 }
 
@@ -5912,17 +6211,17 @@ func (s *ListKeyPoliciesOutput) SetTruncated(v bool) *ListKeyPoliciesOutput {
 type ListKeysInput struct {
 	_ struct{} `type:"structure"`
 
-	// When paginating results, specify the maximum number of items to return in
-	// the response. If additional items exist beyond the number you specify, the
-	// Truncated element in the response is set to true.
+	// Use this parameter to specify the maximum number of items to return. When
+	// this value is present, AWS KMS does not return more than the specified number
+	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
 	// 1000, inclusive. If you do not include a value, it defaults to 100.
 	Limit *int64 `min:"1" type:"integer"`
 
-	// Use this parameter only when paginating results and only in a subsequent
-	// request after you receive a response with truncated results. Set it to the
-	// value of NextMarker from the response you just received.
+	// Use this parameter in a subsequent request after you receive a response with
+	// truncated results. Set it to the value of NextMarker from the truncated response
+	// you just received.
 	Marker *string `min:"1" type:"string"`
 }
 
@@ -5971,13 +6270,14 @@ type ListKeysOutput struct {
 	// A list of keys.
 	Keys []*KeyListEntry `type:"list"`
 
-	// When Truncated is true, this value is present and contains the value to use
-	// for the Marker parameter in a subsequent pagination request.
+	// When Truncated is true, this element is present and contains the value to
+	// use for the Marker parameter in a subsequent request.
 	NextMarker *string `min:"1" type:"string"`
 
-	// A flag that indicates whether there are more items in the list. If your results
-	// were truncated, you can use the Marker parameter to make a subsequent pagination
-	// request to retrieve more items in the list.
+	// A flag that indicates whether there are more items in the list. When this
+	// value is true, the list in this response is truncated. To retrieve more items,
+	// pass the value of the NextMarker element in this response to the Marker parameter
+	// in a subsequent request.
 	Truncated *bool `type:"boolean"`
 }
 
@@ -6009,21 +6309,150 @@ func (s *ListKeysOutput) SetTruncated(v bool) *ListKeysOutput {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListResourceTagsRequest
+type ListResourceTagsInput struct {
+	_ struct{} `type:"structure"`
+
+	// A unique identifier for the CMK whose tags you are listing. You can use the
+	// unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:
+	//
+	//    * Unique key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// Use this parameter to specify the maximum number of items to return. When
+	// this value is present, AWS KMS does not return more than the specified number
+	// of items, but it might return fewer.
+	//
+	// This value is optional. If you include a value, it must be between 1 and
+	// 50, inclusive. If you do not include a value, it defaults to 50.
+	Limit *int64 `min:"1" type:"integer"`
+
+	// Use this parameter in a subsequent request after you receive a response with
+	// truncated results. Set it to the value of NextMarker from the truncated response
+	// you just received.
+	//
+	// Do not attempt to construct this value. Use only the value of NextMarker
+	// from the truncated response you just received.
+	Marker *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListResourceTagsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListResourceTagsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListResourceTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListResourceTagsInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *ListResourceTagsInput) SetKeyId(v string) *ListResourceTagsInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListResourceTagsInput) SetLimit(v int64) *ListResourceTagsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListResourceTagsInput) SetMarker(v string) *ListResourceTagsInput {
+	s.Marker = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListResourceTagsResponse
+type ListResourceTagsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// When Truncated is true, this element is present and contains the value to
+	// use for the Marker parameter in a subsequent request.
+	//
+	// Do not assume or infer any information from this value.
+	NextMarker *string `min:"1" type:"string"`
+
+	// A list of tags. Each tag consists of a tag key and a tag value.
+	Tags []*Tag `type:"list"`
+
+	// A flag that indicates whether there are more items in the list. When this
+	// value is true, the list in this response is truncated. To retrieve more items,
+	// pass the value of the NextMarker element in this response to the Marker parameter
+	// in a subsequent request.
+	Truncated *bool `type:"boolean"`
+}
+
+// String returns the string representation
+func (s ListResourceTagsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListResourceTagsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListResourceTagsOutput) SetNextMarker(v string) *ListResourceTagsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListResourceTagsOutput) SetTags(v []*Tag) *ListResourceTagsOutput {
+	s.Tags = v
+	return s
+}
+
+// SetTruncated sets the Truncated field's value.
+func (s *ListResourceTagsOutput) SetTruncated(v bool) *ListResourceTagsOutput {
+	s.Truncated = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListRetirableGrantsRequest
 type ListRetirableGrantsInput struct {
 	_ struct{} `type:"structure"`
 
-	// When paginating results, specify the maximum number of items to return in
-	// the response. If additional items exist beyond the number you specify, the
-	// Truncated element in the response is set to true.
+	// Use this parameter to specify the maximum number of items to return. When
+	// this value is present, AWS KMS does not return more than the specified number
+	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
 	// 100, inclusive. If you do not include a value, it defaults to 50.
 	Limit *int64 `min:"1" type:"integer"`
 
-	// Use this parameter only when paginating results and only in a subsequent
-	// request after you receive a response with truncated results. Set it to the
-	// value of NextMarker from the response you just received.
+	// Use this parameter in a subsequent request after you receive a response with
+	// truncated results. Set it to the value of NextMarker from the truncated response
+	// you just received.
 	Marker *string `min:"1" type:"string"`
 
 	// The retiring principal for which to list grants.
@@ -6101,8 +6530,8 @@ type PutKeyPolicyInput struct {
 	// For more information, refer to the scenario in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
 	// section in the AWS Key Management Service Developer Guide.
 	//
-	// Use this parameter only when you intend to prevent the principal making the
-	// request from making a subsequent PutKeyPolicy request on the CMK.
+	// Use this parameter only when you intend to prevent the principal that is
+	// making the request from making a subsequent PutKeyPolicy request on the CMK.
 	//
 	// The default value is false.
 	BypassPolicyLockoutSafetyCheck *bool `type:"boolean"`
@@ -6123,18 +6552,18 @@ type PutKeyPolicyInput struct {
 	// If you do not set BypassPolicyLockoutSafetyCheck to true, the policy must
 	// meet the following criteria:
 	//
-	//    * It must allow the principal making the PutKeyPolicy request to make
-	//    a subsequent PutKeyPolicy request on the CMK. This reduces the likelihood
-	//    that the CMK becomes unmanageable. For more information, refer to the
-	//    scenario in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    * It must allow the principal that is making the PutKeyPolicy request
+	//    to make a subsequent PutKeyPolicy request on the CMK. This reduces the
+	//    likelihood that the CMK becomes unmanageable. For more information, refer
+	//    to the scenario in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
 	//    section in the AWS Key Management Service Developer Guide.
 	//
-	//    * The principal(s) specified in the key policy must exist and be visible
-	//    to AWS KMS. When you create a new AWS principal (for example, an IAM user
-	//    or role), you might need to enforce a delay before specifying the new
-	//    principal in a key policy because the new principal might not immediately
-	//    be visible to AWS KMS. For more information, see Changes that I make are
-	//    not always immediately visible (http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    * The principals that are specified in the key policy must exist and be
+	//    visible to AWS KMS. When you create a new AWS principal (for example,
+	//    an IAM user or role), you might need to enforce a delay before specifying
+	//    the new principal in a key policy because the new principal might not
+	//    immediately be visible to AWS KMS. For more information, see Changes that
+	//    I make are not always immediately visible (http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
 	//    in the IAM User Guide.
 	//
 	// The policy size limit is 32 KiB (32768 bytes).
@@ -6634,6 +7063,226 @@ func (s *ScheduleKeyDeletionOutput) SetDeletionDate(v time.Time) *ScheduleKeyDel
 func (s *ScheduleKeyDeletionOutput) SetKeyId(v string) *ScheduleKeyDeletionOutput {
 	s.KeyId = &v
 	return s
+}
+
+// A key-value pair. A tag consists of a tag key and a tag value. Tag keys and
+// tag values are both required, but tag values can be empty (null) strings.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Tag
+type Tag struct {
+	_ struct{} `type:"structure"`
+
+	// The key of the tag.
+	//
+	// TagKey is a required field
+	TagKey *string `min:"1" type:"string" required:"true"`
+
+	// The value of the tag.
+	//
+	// TagValue is a required field
+	TagValue *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.TagKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKey"))
+	}
+	if s.TagKey != nil && len(*s.TagKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TagKey", 1))
+	}
+	if s.TagValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTagKey sets the TagKey field's value.
+func (s *Tag) SetTagKey(v string) *Tag {
+	s.TagKey = &v
+	return s
+}
+
+// SetTagValue sets the TagValue field's value.
+func (s *Tag) SetTagValue(v string) *Tag {
+	s.TagValue = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/TagResourceRequest
+type TagResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// A unique identifier for the CMK you are tagging. You can use the unique key
+	// ID or the Amazon Resource Name (ARN) of the CMK. Examples:
+	//
+	//    * Unique key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// One or more tags. Each tag consists of a tag key and a tag value.
+	//
+	// Tags is a required field
+	Tags []*Tag `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s TagResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TagResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TagResourceInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *TagResourceInput) SetKeyId(v string) *TagResourceInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagResourceInput) SetTags(v []*Tag) *TagResourceInput {
+	s.Tags = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/TagResourceOutput
+type TagResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s TagResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagResourceOutput) GoString() string {
+	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UntagResourceRequest
+type UntagResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// A unique identifier for the CMK from which you are removing tags. You can
+	// use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:
+	//
+	//    * Unique key ID: 1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+	//
+	// KeyId is a required field
+	KeyId *string `min:"1" type:"string" required:"true"`
+
+	// One or more tag keys. Specify only the tag keys, not the tag values.
+	//
+	// TagKeys is a required field
+	TagKeys []*string `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s UntagResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UntagResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UntagResourceInput"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *UntagResourceInput) SetKeyId(v string) *UntagResourceInput {
+	s.KeyId = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
+	s.TagKeys = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UntagResourceOutput
+type UntagResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UntagResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagResourceOutput) GoString() string {
+	return s.String()
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateAliasRequest

--- a/service/kms/errors.go
+++ b/service/kms/errors.go
@@ -139,6 +139,12 @@ const (
 	// be found.
 	ErrCodeNotFoundException = "NotFoundException"
 
+	// ErrCodeTagException for service response error code
+	// "TagException".
+	//
+	// The request was rejected because one or more tags are not valid.
+	ErrCodeTagException = "TagException"
+
 	// ErrCodeUnsupportedOperationException for service response error code
 	// "UnsupportedOperationException".
 	//

--- a/service/kms/examples_test.go
+++ b/service/kms/examples_test.go
@@ -127,6 +127,13 @@ func ExampleKMS_CreateKey() {
 		KeyUsage:                       aws.String("KeyUsageType"),
 		Origin:                         aws.String("OriginType"),
 		Policy:                         aws.String("PolicyType"),
+		Tags: []*kms.Tag{
+			{ // Required
+				TagKey:   aws.String("TagKeyType"),   // Required
+				TagValue: aws.String("TagValueType"), // Required
+			},
+			// More values...
+		},
 	}
 	resp, err := svc.CreateKey(params)
 
@@ -695,6 +702,33 @@ func ExampleKMS_ListKeys() {
 	fmt.Println(resp)
 }
 
+func ExampleKMS_ListResourceTags() {
+	sess, err := session.NewSession()
+	if err != nil {
+		fmt.Println("failed to create session,", err)
+		return
+	}
+
+	svc := kms.New(sess)
+
+	params := &kms.ListResourceTagsInput{
+		KeyId:  aws.String("KeyIdType"), // Required
+		Limit:  aws.Int64(1),
+		Marker: aws.String("MarkerType"),
+	}
+	resp, err := svc.ListResourceTags(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleKMS_ListRetirableGrants() {
 	sess, err := session.NewSession()
 	if err != nil {
@@ -855,6 +889,67 @@ func ExampleKMS_ScheduleKeyDeletion() {
 		PendingWindowInDays: aws.Int64(1),
 	}
 	resp, err := svc.ScheduleKeyDeletion(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleKMS_TagResource() {
+	sess, err := session.NewSession()
+	if err != nil {
+		fmt.Println("failed to create session,", err)
+		return
+	}
+
+	svc := kms.New(sess)
+
+	params := &kms.TagResourceInput{
+		KeyId: aws.String("KeyIdType"), // Required
+		Tags: []*kms.Tag{ // Required
+			{ // Required
+				TagKey:   aws.String("TagKeyType"),   // Required
+				TagValue: aws.String("TagValueType"), // Required
+			},
+			// More values...
+		},
+	}
+	resp, err := svc.TagResource(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleKMS_UntagResource() {
+	sess, err := session.NewSession()
+	if err != nil {
+		fmt.Println("failed to create session,", err)
+		return
+	}
+
+	svc := kms.New(sess)
+
+	params := &kms.UntagResourceInput{
+		KeyId: aws.String("KeyIdType"), // Required
+		TagKeys: []*string{ // Required
+			aws.String("TagKeyType"), // Required
+			// More values...
+		},
+	}
+	resp, err := svc.UntagResource(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and

--- a/service/kms/kmsiface/interface.go
+++ b/service/kms/kmsiface/interface.go
@@ -163,6 +163,10 @@ type KMSAPI interface {
 
 	ListKeysPages(*kms.ListKeysInput, func(*kms.ListKeysOutput, bool) bool) error
 
+	ListResourceTagsRequest(*kms.ListResourceTagsInput) (*request.Request, *kms.ListResourceTagsOutput)
+
+	ListResourceTags(*kms.ListResourceTagsInput) (*kms.ListResourceTagsOutput, error)
+
 	ListRetirableGrantsRequest(*kms.ListRetirableGrantsInput) (*request.Request, *kms.ListGrantsResponse)
 
 	ListRetirableGrants(*kms.ListRetirableGrantsInput) (*kms.ListGrantsResponse, error)
@@ -186,6 +190,14 @@ type KMSAPI interface {
 	ScheduleKeyDeletionRequest(*kms.ScheduleKeyDeletionInput) (*request.Request, *kms.ScheduleKeyDeletionOutput)
 
 	ScheduleKeyDeletion(*kms.ScheduleKeyDeletionInput) (*kms.ScheduleKeyDeletionOutput, error)
+
+	TagResourceRequest(*kms.TagResourceInput) (*request.Request, *kms.TagResourceOutput)
+
+	TagResource(*kms.TagResourceInput) (*kms.TagResourceOutput, error)
+
+	UntagResourceRequest(*kms.UntagResourceInput) (*request.Request, *kms.UntagResourceOutput)
+
+	UntagResource(*kms.UntagResourceInput) (*kms.UntagResourceOutput, error)
 
 	UpdateAliasRequest(*kms.UpdateAliasInput) (*request.Request, *kms.UpdateAliasOutput)
 


### PR DESCRIPTION
Release v1.6.23 (2017-02-15)
===

Service Client Updates
---
* `service/kms`: Updates service API, documentation, paginators, and examples
  * his release of AWS Key Management Service introduces the ability to tag keys. Tagging keys can help you organize your keys and track your KMS costs in the cost allocation report. This release also increases the maximum length of a key ID to accommodate ARNs that include a long key alias.

