### PR TITLE
Update SDK examples and docs to use session.Must

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -22,9 +22,9 @@ type RequestRetryer interface{}
 //
 //     // Create Session with MaxRetry configuration to be shared by multiple
 //     // service clients.
-//     sess, err := session.NewSession(&aws.Config{
+//     sess := session.Must(session.NewSession(&aws.Config{
 //         MaxRetries: aws.Int(3),
-//     })
+//     }))
 //
 //     // Create S3 service client with a specific Region.
 //     svc := s3.New(sess, &aws.Config{
@@ -154,7 +154,8 @@ type Config struct {
 	// the EC2Metadata overriding the timeout for default credentials chain.
 	//
 	// Example:
-	//    sess, err := session.NewSession(aws.NewConfig().WithEC2MetadataDiableTimeoutOverride(true))
+	//    sess := session.Must(session.NewSession(aws.NewConfig()
+	//       .WithEC2MetadataDiableTimeoutOverride(true)))
 	//
 	//    svc := s3.New(sess)
 	//
@@ -174,7 +175,7 @@ type Config struct {
 	//
 	// Only supported with.
 	//
-	//     sess, err := session.NewSession()
+	//     sess := session.Must(session.NewSession())
 	//
 	//     svc := s3.New(sess, &aws.Config{
 	//         UseDualStack: aws.Bool(true),
@@ -192,7 +193,9 @@ type Config struct {
 	// Will default to false. This would only be used for empty directory names in s3 requests.
 	//
 	// Example:
-	//    sess, err := session.NewSession(&aws.Config{DisableRestProtocolURICleaning: aws.Bool(true))
+	//    sess := session.Must(session.NewSession(&aws.Config{
+	//         DisableRestProtocolURICleaning: aws.Bool(true),
+	//    }))
 	//
 	//    svc := s3.New(sess)
 	//    out, err := svc.GetObject(&s3.GetObjectInput {
@@ -207,9 +210,9 @@ type Config struct {
 //
 //     // Create Session with MaxRetry configuration to be shared by multiple
 //     // service clients.
-//     sess, err := session.NewSession(aws.NewConfig().
+//     sess := session.Must(session.NewSession(aws.NewConfig().
 //         WithMaxRetries(3),
-//     )
+//     ))
 //
 //     // Create S3 service client with a specific Region.
 //     svc := s3.New(sess, aws.NewConfig().

--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -45,16 +45,16 @@ region, and profile loaded from the environment and shared config automatically.
 Requires the AWS_PROFILE to be set, or "default" is used.
 
 	// Create Session
-	sess, err := session.NewSession()
+	sess := session.Must(session.NewSession())
 
 	// Create a Session with a custom region
-	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-east-1")})
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+	}))
 
 	// Create a S3 client instance from a session
-	sess, err := session.NewSession()
-	if err != nil {
-		// Handle Session creation error
-	}
+	sess := session.Must(session.NewSession())
+
 	svc := s3.New(sess)
 
 Create Session With Option Overrides
@@ -67,23 +67,25 @@ Use NewSessionWithOptions when you want to provide the config profile, or
 override the shared config state (AWS_SDK_LOAD_CONFIG).
 
 	// Equivalent to session.NewSession()
-	sess, err := session.NewSessionWithOptions(session.Options{})
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		// Options
+	}))
 
 	// Specify profile to load for the session's config
-	sess, err := session.NewSessionWithOptions(session.Options{
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		 Profile: "profile_name",
-	})
+	}))
 
 	// Specify profile for config and region for requests
-	sess, err := session.NewSessionWithOptions(session.Options{
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		 Config: aws.Config{Region: aws.String("us-east-1")},
 		 Profile: "profile_name",
-	})
+	}))
 
 	// Force enable Shared Config support
-	sess, err := session.NewSessionWithOptions(session.Options{
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: SharedConfigEnable,
-	})
+	}))
 
 Adding Handlers
 
@@ -93,7 +95,8 @@ handler logs every request and its payload made by a service client:
 
 	// Create a session, and add additional handlers for all service
 	// clients created with the Session to inherit. Adds logging handler.
-	sess, err := session.NewSession()
+	sess := session.Must(session.NewSession())
+	
 	sess.Handlers.Send.PushFront(func(r *request.Request) {
 		// Log every request made and its payload
 		logger.Println("Request: %s/%s, Payload: %s",

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -181,23 +181,23 @@ type Options struct {
 // to be built with retrieving credentials with AssumeRole set in the config.
 //
 //     // Equivalent to session.New
-//     sess, err := session.NewSessionWithOptions(session.Options{})
+//     sess := session.Must(session.NewSessionWithOptions(session.Options{}))
 //
 //     // Specify profile to load for the session's config
-//     sess, err := session.NewSessionWithOptions(session.Options{
+//     sess := session.Must(session.NewSessionWithOptions(session.Options{
 //          Profile: "profile_name",
-//     })
+//     }))
 //
 //     // Specify profile for config and region for requests
-//     sess, err := session.NewSessionWithOptions(session.Options{
+//     sess := session.Must(session.NewSessionWithOptions(session.Options{
 //          Config: aws.Config{Region: aws.String("us-east-1")},
 //          Profile: "profile_name",
-//     })
+//     }))
 //
 //     // Force enable Shared Config support
-//     sess, err := session.NewSessionWithOptions(session.Options{
+//     sess := session.Must(session.NewSessionWithOptions(session.Options{
 //         SharedConfigState: SharedConfigEnable,
-//     })
+//     }))
 func NewSessionWithOptions(opts Options) (*Session, error) {
 	var envCfg envConfig
 	if opts.SharedConfigState == SharedConfigEnable {

--- a/example/aws/request/handleServiceErrorCodes/handleServiceErrorCodes.go
+++ b/example/aws/request/handleServiceErrorCodes/handleServiceErrorCodes.go
@@ -32,10 +32,7 @@ func main() {
 	if len(os.Args) < 3 {
 		exitErrorf("Usage: %s <bucket> <key>", filepath.Base(os.Args[0]))
 	}
-	sess, err := session.NewSession()
-	if err != nil {
-		exitErrorf("failed to create session,", err)
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 	resp, err := svc.GetObject(&s3.GetObjectInput{

--- a/example/service/dynamodb/scanItems/scanItems.go
+++ b/example/service/dynamodb/scanItems/scanItems.go
@@ -33,10 +33,7 @@ func main() {
 	}
 
 	// Create the session that the DynamoDB service will use.
-	sess, err := session.NewSession(awscfg)
-	if err != nil {
-		exitWithError(fmt.Errorf("failed to create session, %v", err))
-	}
+	sess := session.Must(session.NewSession(awscfg))
 
 	// Create the DynamoDB service client to make the query request with.
 	svc := dynamodb.New(sess)

--- a/example/service/ec2/filterInstances/filter_ec2_by_tag.go
+++ b/example/service/ec2/filterInstances/filter_ec2_by_tag.go
@@ -18,10 +18,7 @@ import (
 // Usage:
 // filter_ec2_by_tag <name_filter>
 func main() {
-	sess, err := session.NewSession()
-	if err != nil {
-		log.Fatalf("failed to create session %v\n", err)
-	}
+	sess := session.Must(session.NewSession())
 
 	nameFilter := os.Args[1]
 	awsRegion := "us-east-1"

--- a/example/service/s3/listObjects/listObjects.go
+++ b/example/service/s3/listObjects/listObjects.go
@@ -20,16 +20,12 @@ func main() {
 		return
 	}
 
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
 	i := 0
-	err = svc.ListObjectsPages(&s3.ListObjectsInput{
+	err := svc.ListObjectsPages(&s3.ListObjectsInput{
 		Bucket: &os.Args[1],
 	}, func(p *s3.ListObjectsOutput, last bool) (shouldContinue bool) {
 		fmt.Println("Page,", i)

--- a/example/service/s3/putObjectAcl/putObjectAcl.go
+++ b/example/service/s3/putObjectAcl/putObjectAcl.go
@@ -52,11 +52,10 @@ func main() {
 		emailPtr, userPtr = nil, nil
 	}
 
-	sess, err := session.NewSession(
-		&aws.Config{
-			Region: regionPtr,
-		},
-	)
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region: regionPtr,
+	}))
+
 	svc := s3.New(sess)
 
 	resp, err := svc.PutObjectAcl(&s3.PutObjectAclInput{

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -209,11 +209,7 @@ func (o *Operation) InterfaceSignature() string {
 // tplExample defines the template for rendering an Operation example
 var tplExample = template.Must(template.New("operationExample").Parse(`
 func Example{{ .API.StructName }}_{{ .ExportedName }}() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := {{ .API.PackageName }}.New(sess)
 

--- a/service/acm/examples_test.go
+++ b/service/acm/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleACM_AddTagsToCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleACM_AddTagsToCertificate() {
 }
 
 func ExampleACM_DeleteCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -73,11 +65,7 @@ func ExampleACM_DeleteCertificate() {
 }
 
 func ExampleACM_DescribeCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -98,11 +86,7 @@ func ExampleACM_DescribeCertificate() {
 }
 
 func ExampleACM_GetCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -123,11 +107,7 @@ func ExampleACM_GetCertificate() {
 }
 
 func ExampleACM_ImportCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -151,11 +131,7 @@ func ExampleACM_ImportCertificate() {
 }
 
 func ExampleACM_ListCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -181,11 +157,7 @@ func ExampleACM_ListCertificates() {
 }
 
 func ExampleACM_ListTagsForCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -206,11 +178,7 @@ func ExampleACM_ListTagsForCertificate() {
 }
 
 func ExampleACM_RemoveTagsFromCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -238,11 +206,7 @@ func ExampleACM_RemoveTagsFromCertificate() {
 }
 
 func ExampleACM_RequestCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 
@@ -275,11 +239,7 @@ func ExampleACM_RequestCertificate() {
 }
 
 func ExampleACM_ResendValidationEmail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := acm.New(sess)
 

--- a/service/apigateway/examples_test.go
+++ b/service/apigateway/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleAPIGateway_CreateApiKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -53,11 +49,7 @@ func ExampleAPIGateway_CreateApiKey() {
 }
 
 func ExampleAPIGateway_CreateAuthorizer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -90,11 +82,7 @@ func ExampleAPIGateway_CreateAuthorizer() {
 }
 
 func ExampleAPIGateway_CreateBasePathMapping() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -118,11 +106,7 @@ func ExampleAPIGateway_CreateBasePathMapping() {
 }
 
 func ExampleAPIGateway_CreateDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -152,11 +136,7 @@ func ExampleAPIGateway_CreateDeployment() {
 }
 
 func ExampleAPIGateway_CreateDocumentationPart() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -185,11 +165,7 @@ func ExampleAPIGateway_CreateDocumentationPart() {
 }
 
 func ExampleAPIGateway_CreateDocumentationVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -213,11 +189,7 @@ func ExampleAPIGateway_CreateDocumentationVersion() {
 }
 
 func ExampleAPIGateway_CreateDomainName() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -242,11 +214,7 @@ func ExampleAPIGateway_CreateDomainName() {
 }
 
 func ExampleAPIGateway_CreateModel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -271,11 +239,7 @@ func ExampleAPIGateway_CreateModel() {
 }
 
 func ExampleAPIGateway_CreateResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -298,11 +262,7 @@ func ExampleAPIGateway_CreateResource() {
 }
 
 func ExampleAPIGateway_CreateRestApi() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -330,11 +290,7 @@ func ExampleAPIGateway_CreateRestApi() {
 }
 
 func ExampleAPIGateway_CreateStage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -365,11 +321,7 @@ func ExampleAPIGateway_CreateStage() {
 }
 
 func ExampleAPIGateway_CreateUsagePlan() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -407,11 +359,7 @@ func ExampleAPIGateway_CreateUsagePlan() {
 }
 
 func ExampleAPIGateway_CreateUsagePlanKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -434,11 +382,7 @@ func ExampleAPIGateway_CreateUsagePlanKey() {
 }
 
 func ExampleAPIGateway_DeleteApiKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -459,11 +403,7 @@ func ExampleAPIGateway_DeleteApiKey() {
 }
 
 func ExampleAPIGateway_DeleteAuthorizer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -485,11 +425,7 @@ func ExampleAPIGateway_DeleteAuthorizer() {
 }
 
 func ExampleAPIGateway_DeleteBasePathMapping() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -511,11 +447,7 @@ func ExampleAPIGateway_DeleteBasePathMapping() {
 }
 
 func ExampleAPIGateway_DeleteClientCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -536,11 +468,7 @@ func ExampleAPIGateway_DeleteClientCertificate() {
 }
 
 func ExampleAPIGateway_DeleteDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -562,11 +490,7 @@ func ExampleAPIGateway_DeleteDeployment() {
 }
 
 func ExampleAPIGateway_DeleteDocumentationPart() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -588,11 +512,7 @@ func ExampleAPIGateway_DeleteDocumentationPart() {
 }
 
 func ExampleAPIGateway_DeleteDocumentationVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -614,11 +534,7 @@ func ExampleAPIGateway_DeleteDocumentationVersion() {
 }
 
 func ExampleAPIGateway_DeleteDomainName() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -639,11 +555,7 @@ func ExampleAPIGateway_DeleteDomainName() {
 }
 
 func ExampleAPIGateway_DeleteIntegration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -666,11 +578,7 @@ func ExampleAPIGateway_DeleteIntegration() {
 }
 
 func ExampleAPIGateway_DeleteIntegrationResponse() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -694,11 +602,7 @@ func ExampleAPIGateway_DeleteIntegrationResponse() {
 }
 
 func ExampleAPIGateway_DeleteMethod() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -721,11 +625,7 @@ func ExampleAPIGateway_DeleteMethod() {
 }
 
 func ExampleAPIGateway_DeleteMethodResponse() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -749,11 +649,7 @@ func ExampleAPIGateway_DeleteMethodResponse() {
 }
 
 func ExampleAPIGateway_DeleteModel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -775,11 +671,7 @@ func ExampleAPIGateway_DeleteModel() {
 }
 
 func ExampleAPIGateway_DeleteResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -801,11 +693,7 @@ func ExampleAPIGateway_DeleteResource() {
 }
 
 func ExampleAPIGateway_DeleteRestApi() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -826,11 +714,7 @@ func ExampleAPIGateway_DeleteRestApi() {
 }
 
 func ExampleAPIGateway_DeleteStage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -852,11 +736,7 @@ func ExampleAPIGateway_DeleteStage() {
 }
 
 func ExampleAPIGateway_DeleteUsagePlan() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -877,11 +757,7 @@ func ExampleAPIGateway_DeleteUsagePlan() {
 }
 
 func ExampleAPIGateway_DeleteUsagePlanKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -903,11 +779,7 @@ func ExampleAPIGateway_DeleteUsagePlanKey() {
 }
 
 func ExampleAPIGateway_FlushStageAuthorizersCache() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -929,11 +801,7 @@ func ExampleAPIGateway_FlushStageAuthorizersCache() {
 }
 
 func ExampleAPIGateway_FlushStageCache() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -955,11 +823,7 @@ func ExampleAPIGateway_FlushStageCache() {
 }
 
 func ExampleAPIGateway_GenerateClientCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -980,11 +844,7 @@ func ExampleAPIGateway_GenerateClientCertificate() {
 }
 
 func ExampleAPIGateway_GetAccount() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1003,11 +863,7 @@ func ExampleAPIGateway_GetAccount() {
 }
 
 func ExampleAPIGateway_GetApiKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1029,11 +885,7 @@ func ExampleAPIGateway_GetApiKey() {
 }
 
 func ExampleAPIGateway_GetApiKeys() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1058,11 +910,7 @@ func ExampleAPIGateway_GetApiKeys() {
 }
 
 func ExampleAPIGateway_GetAuthorizer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1084,11 +932,7 @@ func ExampleAPIGateway_GetAuthorizer() {
 }
 
 func ExampleAPIGateway_GetAuthorizers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1111,11 +955,7 @@ func ExampleAPIGateway_GetAuthorizers() {
 }
 
 func ExampleAPIGateway_GetBasePathMapping() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1137,11 +977,7 @@ func ExampleAPIGateway_GetBasePathMapping() {
 }
 
 func ExampleAPIGateway_GetBasePathMappings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1164,11 +1000,7 @@ func ExampleAPIGateway_GetBasePathMappings() {
 }
 
 func ExampleAPIGateway_GetClientCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1189,11 +1021,7 @@ func ExampleAPIGateway_GetClientCertificate() {
 }
 
 func ExampleAPIGateway_GetClientCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1215,11 +1043,7 @@ func ExampleAPIGateway_GetClientCertificates() {
 }
 
 func ExampleAPIGateway_GetDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1241,11 +1065,7 @@ func ExampleAPIGateway_GetDeployment() {
 }
 
 func ExampleAPIGateway_GetDeployments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1268,11 +1088,7 @@ func ExampleAPIGateway_GetDeployments() {
 }
 
 func ExampleAPIGateway_GetDocumentationPart() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1294,11 +1110,7 @@ func ExampleAPIGateway_GetDocumentationPart() {
 }
 
 func ExampleAPIGateway_GetDocumentationParts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1324,11 +1136,7 @@ func ExampleAPIGateway_GetDocumentationParts() {
 }
 
 func ExampleAPIGateway_GetDocumentationVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1350,11 +1158,7 @@ func ExampleAPIGateway_GetDocumentationVersion() {
 }
 
 func ExampleAPIGateway_GetDocumentationVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1377,11 +1181,7 @@ func ExampleAPIGateway_GetDocumentationVersions() {
 }
 
 func ExampleAPIGateway_GetDomainName() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1402,11 +1202,7 @@ func ExampleAPIGateway_GetDomainName() {
 }
 
 func ExampleAPIGateway_GetDomainNames() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1428,11 +1224,7 @@ func ExampleAPIGateway_GetDomainNames() {
 }
 
 func ExampleAPIGateway_GetExport() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1460,11 +1252,7 @@ func ExampleAPIGateway_GetExport() {
 }
 
 func ExampleAPIGateway_GetIntegration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1487,11 +1275,7 @@ func ExampleAPIGateway_GetIntegration() {
 }
 
 func ExampleAPIGateway_GetIntegrationResponse() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1515,11 +1299,7 @@ func ExampleAPIGateway_GetIntegrationResponse() {
 }
 
 func ExampleAPIGateway_GetMethod() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1542,11 +1322,7 @@ func ExampleAPIGateway_GetMethod() {
 }
 
 func ExampleAPIGateway_GetMethodResponse() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1570,11 +1346,7 @@ func ExampleAPIGateway_GetMethodResponse() {
 }
 
 func ExampleAPIGateway_GetModel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1597,11 +1369,7 @@ func ExampleAPIGateway_GetModel() {
 }
 
 func ExampleAPIGateway_GetModelTemplate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1623,11 +1391,7 @@ func ExampleAPIGateway_GetModelTemplate() {
 }
 
 func ExampleAPIGateway_GetModels() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1650,11 +1414,7 @@ func ExampleAPIGateway_GetModels() {
 }
 
 func ExampleAPIGateway_GetResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1676,11 +1436,7 @@ func ExampleAPIGateway_GetResource() {
 }
 
 func ExampleAPIGateway_GetResources() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1703,11 +1459,7 @@ func ExampleAPIGateway_GetResources() {
 }
 
 func ExampleAPIGateway_GetRestApi() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1728,11 +1480,7 @@ func ExampleAPIGateway_GetRestApi() {
 }
 
 func ExampleAPIGateway_GetRestApis() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1754,11 +1502,7 @@ func ExampleAPIGateway_GetRestApis() {
 }
 
 func ExampleAPIGateway_GetSdk() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1785,11 +1529,7 @@ func ExampleAPIGateway_GetSdk() {
 }
 
 func ExampleAPIGateway_GetSdkType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1810,11 +1550,7 @@ func ExampleAPIGateway_GetSdkType() {
 }
 
 func ExampleAPIGateway_GetSdkTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1836,11 +1572,7 @@ func ExampleAPIGateway_GetSdkTypes() {
 }
 
 func ExampleAPIGateway_GetStage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1862,11 +1594,7 @@ func ExampleAPIGateway_GetStage() {
 }
 
 func ExampleAPIGateway_GetStages() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1888,11 +1616,7 @@ func ExampleAPIGateway_GetStages() {
 }
 
 func ExampleAPIGateway_GetUsage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1918,11 +1642,7 @@ func ExampleAPIGateway_GetUsage() {
 }
 
 func ExampleAPIGateway_GetUsagePlan() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1943,11 +1663,7 @@ func ExampleAPIGateway_GetUsagePlan() {
 }
 
 func ExampleAPIGateway_GetUsagePlanKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1969,11 +1685,7 @@ func ExampleAPIGateway_GetUsagePlanKey() {
 }
 
 func ExampleAPIGateway_GetUsagePlanKeys() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -1997,11 +1709,7 @@ func ExampleAPIGateway_GetUsagePlanKeys() {
 }
 
 func ExampleAPIGateway_GetUsagePlans() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2024,11 +1732,7 @@ func ExampleAPIGateway_GetUsagePlans() {
 }
 
 func ExampleAPIGateway_ImportApiKeys() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2051,11 +1755,7 @@ func ExampleAPIGateway_ImportApiKeys() {
 }
 
 func ExampleAPIGateway_ImportDocumentationParts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2079,11 +1779,7 @@ func ExampleAPIGateway_ImportDocumentationParts() {
 }
 
 func ExampleAPIGateway_ImportRestApi() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2109,11 +1805,7 @@ func ExampleAPIGateway_ImportRestApi() {
 }
 
 func ExampleAPIGateway_PutIntegration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2155,11 +1847,7 @@ func ExampleAPIGateway_PutIntegration() {
 }
 
 func ExampleAPIGateway_PutIntegrationResponse() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2193,11 +1881,7 @@ func ExampleAPIGateway_PutIntegrationResponse() {
 }
 
 func ExampleAPIGateway_PutMethod() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2232,11 +1916,7 @@ func ExampleAPIGateway_PutMethod() {
 }
 
 func ExampleAPIGateway_PutMethodResponse() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2268,11 +1948,7 @@ func ExampleAPIGateway_PutMethodResponse() {
 }
 
 func ExampleAPIGateway_PutRestApi() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2300,11 +1976,7 @@ func ExampleAPIGateway_PutRestApi() {
 }
 
 func ExampleAPIGateway_TestInvokeAuthorizer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2340,11 +2012,7 @@ func ExampleAPIGateway_TestInvokeAuthorizer() {
 }
 
 func ExampleAPIGateway_TestInvokeMethod() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2378,11 +2046,7 @@ func ExampleAPIGateway_TestInvokeMethod() {
 }
 
 func ExampleAPIGateway_UpdateAccount() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2411,11 +2075,7 @@ func ExampleAPIGateway_UpdateAccount() {
 }
 
 func ExampleAPIGateway_UpdateApiKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2445,11 +2105,7 @@ func ExampleAPIGateway_UpdateApiKey() {
 }
 
 func ExampleAPIGateway_UpdateAuthorizer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2480,11 +2136,7 @@ func ExampleAPIGateway_UpdateAuthorizer() {
 }
 
 func ExampleAPIGateway_UpdateBasePathMapping() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2515,11 +2167,7 @@ func ExampleAPIGateway_UpdateBasePathMapping() {
 }
 
 func ExampleAPIGateway_UpdateClientCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2549,11 +2197,7 @@ func ExampleAPIGateway_UpdateClientCertificate() {
 }
 
 func ExampleAPIGateway_UpdateDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2584,11 +2228,7 @@ func ExampleAPIGateway_UpdateDeployment() {
 }
 
 func ExampleAPIGateway_UpdateDocumentationPart() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2619,11 +2259,7 @@ func ExampleAPIGateway_UpdateDocumentationPart() {
 }
 
 func ExampleAPIGateway_UpdateDocumentationVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2654,11 +2290,7 @@ func ExampleAPIGateway_UpdateDocumentationVersion() {
 }
 
 func ExampleAPIGateway_UpdateDomainName() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2688,11 +2320,7 @@ func ExampleAPIGateway_UpdateDomainName() {
 }
 
 func ExampleAPIGateway_UpdateIntegration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2724,11 +2352,7 @@ func ExampleAPIGateway_UpdateIntegration() {
 }
 
 func ExampleAPIGateway_UpdateIntegrationResponse() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2761,11 +2385,7 @@ func ExampleAPIGateway_UpdateIntegrationResponse() {
 }
 
 func ExampleAPIGateway_UpdateMethod() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2797,11 +2417,7 @@ func ExampleAPIGateway_UpdateMethod() {
 }
 
 func ExampleAPIGateway_UpdateMethodResponse() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2834,11 +2450,7 @@ func ExampleAPIGateway_UpdateMethodResponse() {
 }
 
 func ExampleAPIGateway_UpdateModel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2869,11 +2481,7 @@ func ExampleAPIGateway_UpdateModel() {
 }
 
 func ExampleAPIGateway_UpdateResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2904,11 +2512,7 @@ func ExampleAPIGateway_UpdateResource() {
 }
 
 func ExampleAPIGateway_UpdateRestApi() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2938,11 +2542,7 @@ func ExampleAPIGateway_UpdateRestApi() {
 }
 
 func ExampleAPIGateway_UpdateStage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -2973,11 +2573,7 @@ func ExampleAPIGateway_UpdateStage() {
 }
 
 func ExampleAPIGateway_UpdateUsage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 
@@ -3008,11 +2604,7 @@ func ExampleAPIGateway_UpdateUsage() {
 }
 
 func ExampleAPIGateway_UpdateUsagePlan() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := apigateway.New(sess)
 

--- a/service/applicationautoscaling/examples_test.go
+++ b/service/applicationautoscaling/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleApplicationAutoScaling_DeleteScalingPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationautoscaling.New(sess)
 
@@ -44,11 +40,7 @@ func ExampleApplicationAutoScaling_DeleteScalingPolicy() {
 }
 
 func ExampleApplicationAutoScaling_DeregisterScalableTarget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationautoscaling.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleApplicationAutoScaling_DeregisterScalableTarget() {
 }
 
 func ExampleApplicationAutoScaling_DescribeScalableTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationautoscaling.New(sess)
 
@@ -103,11 +91,7 @@ func ExampleApplicationAutoScaling_DescribeScalableTargets() {
 }
 
 func ExampleApplicationAutoScaling_DescribeScalingActivities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationautoscaling.New(sess)
 
@@ -132,11 +116,7 @@ func ExampleApplicationAutoScaling_DescribeScalingActivities() {
 }
 
 func ExampleApplicationAutoScaling_DescribeScalingPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationautoscaling.New(sess)
 
@@ -165,11 +145,7 @@ func ExampleApplicationAutoScaling_DescribeScalingPolicies() {
 }
 
 func ExampleApplicationAutoScaling_PutScalingPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationautoscaling.New(sess)
 
@@ -208,11 +184,7 @@ func ExampleApplicationAutoScaling_PutScalingPolicy() {
 }
 
 func ExampleApplicationAutoScaling_RegisterScalableTarget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationautoscaling.New(sess)
 

--- a/service/applicationdiscoveryservice/examples_test.go
+++ b/service/applicationdiscoveryservice/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleApplicationDiscoveryService_AssociateConfigurationItemsToApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -45,11 +41,7 @@ func ExampleApplicationDiscoveryService_AssociateConfigurationItemsToApplication
 }
 
 func ExampleApplicationDiscoveryService_CreateApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleApplicationDiscoveryService_CreateApplication() {
 }
 
 func ExampleApplicationDiscoveryService_CreateTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -106,11 +94,7 @@ func ExampleApplicationDiscoveryService_CreateTags() {
 }
 
 func ExampleApplicationDiscoveryService_DeleteApplications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -134,11 +118,7 @@ func ExampleApplicationDiscoveryService_DeleteApplications() {
 }
 
 func ExampleApplicationDiscoveryService_DeleteTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -169,11 +149,7 @@ func ExampleApplicationDiscoveryService_DeleteTags() {
 }
 
 func ExampleApplicationDiscoveryService_DescribeAgents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -210,11 +186,7 @@ func ExampleApplicationDiscoveryService_DescribeAgents() {
 }
 
 func ExampleApplicationDiscoveryService_DescribeConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -238,11 +210,7 @@ func ExampleApplicationDiscoveryService_DescribeConfigurations() {
 }
 
 func ExampleApplicationDiscoveryService_DescribeExportConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -268,11 +236,7 @@ func ExampleApplicationDiscoveryService_DescribeExportConfigurations() {
 }
 
 func ExampleApplicationDiscoveryService_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -304,11 +268,7 @@ func ExampleApplicationDiscoveryService_DescribeTags() {
 }
 
 func ExampleApplicationDiscoveryService_DisassociateConfigurationItemsFromApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -333,11 +293,7 @@ func ExampleApplicationDiscoveryService_DisassociateConfigurationItemsFromApplic
 }
 
 func ExampleApplicationDiscoveryService_ExportConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -356,11 +312,7 @@ func ExampleApplicationDiscoveryService_ExportConfigurations() {
 }
 
 func ExampleApplicationDiscoveryService_GetDiscoverySummary() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -379,11 +331,7 @@ func ExampleApplicationDiscoveryService_GetDiscoverySummary() {
 }
 
 func ExampleApplicationDiscoveryService_ListConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -424,11 +372,7 @@ func ExampleApplicationDiscoveryService_ListConfigurations() {
 }
 
 func ExampleApplicationDiscoveryService_ListServerNeighbors() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -456,11 +400,7 @@ func ExampleApplicationDiscoveryService_ListServerNeighbors() {
 }
 
 func ExampleApplicationDiscoveryService_StartDataCollectionByAgentIds() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -484,11 +424,7 @@ func ExampleApplicationDiscoveryService_StartDataCollectionByAgentIds() {
 }
 
 func ExampleApplicationDiscoveryService_StopDataCollectionByAgentIds() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 
@@ -512,11 +448,7 @@ func ExampleApplicationDiscoveryService_StopDataCollectionByAgentIds() {
 }
 
 func ExampleApplicationDiscoveryService_UpdateApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := applicationdiscoveryservice.New(sess)
 

--- a/service/appstream/examples_test.go
+++ b/service/appstream/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleAppStream_AssociateFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleAppStream_AssociateFleet() {
 }
 
 func ExampleAppStream_CreateFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -82,11 +74,7 @@ func ExampleAppStream_CreateFleet() {
 }
 
 func ExampleAppStream_CreateStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -109,11 +97,7 @@ func ExampleAppStream_CreateStack() {
 }
 
 func ExampleAppStream_CreateStreamingURL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -139,11 +123,7 @@ func ExampleAppStream_CreateStreamingURL() {
 }
 
 func ExampleAppStream_DeleteFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -164,11 +144,7 @@ func ExampleAppStream_DeleteFleet() {
 }
 
 func ExampleAppStream_DeleteStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -189,11 +165,7 @@ func ExampleAppStream_DeleteStack() {
 }
 
 func ExampleAppStream_DescribeFleets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -218,11 +190,7 @@ func ExampleAppStream_DescribeFleets() {
 }
 
 func ExampleAppStream_DescribeImages() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -246,11 +214,7 @@ func ExampleAppStream_DescribeImages() {
 }
 
 func ExampleAppStream_DescribeSessions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -275,11 +239,7 @@ func ExampleAppStream_DescribeSessions() {
 }
 
 func ExampleAppStream_DescribeStacks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -304,11 +264,7 @@ func ExampleAppStream_DescribeStacks() {
 }
 
 func ExampleAppStream_DisassociateFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -330,11 +286,7 @@ func ExampleAppStream_DisassociateFleet() {
 }
 
 func ExampleAppStream_ExpireSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -355,11 +307,7 @@ func ExampleAppStream_ExpireSession() {
 }
 
 func ExampleAppStream_ListAssociatedFleets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -381,11 +329,7 @@ func ExampleAppStream_ListAssociatedFleets() {
 }
 
 func ExampleAppStream_ListAssociatedStacks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -407,11 +351,7 @@ func ExampleAppStream_ListAssociatedStacks() {
 }
 
 func ExampleAppStream_StartFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -432,11 +372,7 @@ func ExampleAppStream_StartFleet() {
 }
 
 func ExampleAppStream_StopFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -457,11 +393,7 @@ func ExampleAppStream_StopFleet() {
 }
 
 func ExampleAppStream_UpdateFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 
@@ -498,11 +430,7 @@ func ExampleAppStream_UpdateFleet() {
 }
 
 func ExampleAppStream_UpdateStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := appstream.New(sess)
 

--- a/service/autoscaling/examples_test.go
+++ b/service/autoscaling/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleAutoScaling_AttachInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -45,11 +41,7 @@ func ExampleAutoScaling_AttachInstances() {
 }
 
 func ExampleAutoScaling_AttachLoadBalancerTargetGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -74,11 +66,7 @@ func ExampleAutoScaling_AttachLoadBalancerTargetGroups() {
 }
 
 func ExampleAutoScaling_AttachLoadBalancers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -103,11 +91,7 @@ func ExampleAutoScaling_AttachLoadBalancers() {
 }
 
 func ExampleAutoScaling_CompleteLifecycleAction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -132,11 +116,7 @@ func ExampleAutoScaling_CompleteLifecycleAction() {
 }
 
 func ExampleAutoScaling_CreateAutoScalingGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -194,11 +174,7 @@ func ExampleAutoScaling_CreateAutoScalingGroup() {
 }
 
 func ExampleAutoScaling_CreateLaunchConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -259,11 +235,7 @@ func ExampleAutoScaling_CreateLaunchConfiguration() {
 }
 
 func ExampleAutoScaling_CreateOrUpdateTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -293,11 +265,7 @@ func ExampleAutoScaling_CreateOrUpdateTags() {
 }
 
 func ExampleAutoScaling_DeleteAutoScalingGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -319,11 +287,7 @@ func ExampleAutoScaling_DeleteAutoScalingGroup() {
 }
 
 func ExampleAutoScaling_DeleteLaunchConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -344,11 +308,7 @@ func ExampleAutoScaling_DeleteLaunchConfiguration() {
 }
 
 func ExampleAutoScaling_DeleteLifecycleHook() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -370,11 +330,7 @@ func ExampleAutoScaling_DeleteLifecycleHook() {
 }
 
 func ExampleAutoScaling_DeleteNotificationConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -396,11 +352,7 @@ func ExampleAutoScaling_DeleteNotificationConfiguration() {
 }
 
 func ExampleAutoScaling_DeletePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -422,11 +374,7 @@ func ExampleAutoScaling_DeletePolicy() {
 }
 
 func ExampleAutoScaling_DeleteScheduledAction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -448,11 +396,7 @@ func ExampleAutoScaling_DeleteScheduledAction() {
 }
 
 func ExampleAutoScaling_DeleteTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -482,11 +426,7 @@ func ExampleAutoScaling_DeleteTags() {
 }
 
 func ExampleAutoScaling_DescribeAccountLimits() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -505,11 +445,7 @@ func ExampleAutoScaling_DescribeAccountLimits() {
 }
 
 func ExampleAutoScaling_DescribeAdjustmentTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -528,11 +464,7 @@ func ExampleAutoScaling_DescribeAdjustmentTypes() {
 }
 
 func ExampleAutoScaling_DescribeAutoScalingGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -558,11 +490,7 @@ func ExampleAutoScaling_DescribeAutoScalingGroups() {
 }
 
 func ExampleAutoScaling_DescribeAutoScalingInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -588,11 +516,7 @@ func ExampleAutoScaling_DescribeAutoScalingInstances() {
 }
 
 func ExampleAutoScaling_DescribeAutoScalingNotificationTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -611,11 +535,7 @@ func ExampleAutoScaling_DescribeAutoScalingNotificationTypes() {
 }
 
 func ExampleAutoScaling_DescribeLaunchConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -641,11 +561,7 @@ func ExampleAutoScaling_DescribeLaunchConfigurations() {
 }
 
 func ExampleAutoScaling_DescribeLifecycleHookTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -664,11 +580,7 @@ func ExampleAutoScaling_DescribeLifecycleHookTypes() {
 }
 
 func ExampleAutoScaling_DescribeLifecycleHooks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -693,11 +605,7 @@ func ExampleAutoScaling_DescribeLifecycleHooks() {
 }
 
 func ExampleAutoScaling_DescribeLoadBalancerTargetGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -720,11 +628,7 @@ func ExampleAutoScaling_DescribeLoadBalancerTargetGroups() {
 }
 
 func ExampleAutoScaling_DescribeLoadBalancers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -747,11 +651,7 @@ func ExampleAutoScaling_DescribeLoadBalancers() {
 }
 
 func ExampleAutoScaling_DescribeMetricCollectionTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -770,11 +670,7 @@ func ExampleAutoScaling_DescribeMetricCollectionTypes() {
 }
 
 func ExampleAutoScaling_DescribeNotificationConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -800,11 +696,7 @@ func ExampleAutoScaling_DescribeNotificationConfigurations() {
 }
 
 func ExampleAutoScaling_DescribePolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -835,11 +727,7 @@ func ExampleAutoScaling_DescribePolicies() {
 }
 
 func ExampleAutoScaling_DescribeScalingActivities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -866,11 +754,7 @@ func ExampleAutoScaling_DescribeScalingActivities() {
 }
 
 func ExampleAutoScaling_DescribeScalingProcessTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -889,11 +773,7 @@ func ExampleAutoScaling_DescribeScalingProcessTypes() {
 }
 
 func ExampleAutoScaling_DescribeScheduledActions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -922,11 +802,7 @@ func ExampleAutoScaling_DescribeScheduledActions() {
 }
 
 func ExampleAutoScaling_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -958,11 +834,7 @@ func ExampleAutoScaling_DescribeTags() {
 }
 
 func ExampleAutoScaling_DescribeTerminationPolicyTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -981,11 +853,7 @@ func ExampleAutoScaling_DescribeTerminationPolicyTypes() {
 }
 
 func ExampleAutoScaling_DetachInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1011,11 +879,7 @@ func ExampleAutoScaling_DetachInstances() {
 }
 
 func ExampleAutoScaling_DetachLoadBalancerTargetGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1040,11 +904,7 @@ func ExampleAutoScaling_DetachLoadBalancerTargetGroups() {
 }
 
 func ExampleAutoScaling_DetachLoadBalancers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1069,11 +929,7 @@ func ExampleAutoScaling_DetachLoadBalancers() {
 }
 
 func ExampleAutoScaling_DisableMetricsCollection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1098,11 +954,7 @@ func ExampleAutoScaling_DisableMetricsCollection() {
 }
 
 func ExampleAutoScaling_EnableMetricsCollection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1128,11 +980,7 @@ func ExampleAutoScaling_EnableMetricsCollection() {
 }
 
 func ExampleAutoScaling_EnterStandby() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1158,11 +1006,7 @@ func ExampleAutoScaling_EnterStandby() {
 }
 
 func ExampleAutoScaling_ExecutePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1187,11 +1031,7 @@ func ExampleAutoScaling_ExecutePolicy() {
 }
 
 func ExampleAutoScaling_ExitStandby() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1216,11 +1056,7 @@ func ExampleAutoScaling_ExitStandby() {
 }
 
 func ExampleAutoScaling_PutLifecycleHook() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1248,11 +1084,7 @@ func ExampleAutoScaling_PutLifecycleHook() {
 }
 
 func ExampleAutoScaling_PutNotificationConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1278,11 +1110,7 @@ func ExampleAutoScaling_PutNotificationConfiguration() {
 }
 
 func ExampleAutoScaling_PutScalingPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1320,11 +1148,7 @@ func ExampleAutoScaling_PutScalingPolicy() {
 }
 
 func ExampleAutoScaling_PutScheduledUpdateGroupAction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1353,11 +1177,7 @@ func ExampleAutoScaling_PutScheduledUpdateGroupAction() {
 }
 
 func ExampleAutoScaling_RecordLifecycleActionHeartbeat() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1381,11 +1201,7 @@ func ExampleAutoScaling_RecordLifecycleActionHeartbeat() {
 }
 
 func ExampleAutoScaling_ResumeProcesses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1410,11 +1226,7 @@ func ExampleAutoScaling_ResumeProcesses() {
 }
 
 func ExampleAutoScaling_SetDesiredCapacity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1437,11 +1249,7 @@ func ExampleAutoScaling_SetDesiredCapacity() {
 }
 
 func ExampleAutoScaling_SetInstanceHealth() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1464,11 +1272,7 @@ func ExampleAutoScaling_SetInstanceHealth() {
 }
 
 func ExampleAutoScaling_SetInstanceProtection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1494,11 +1298,7 @@ func ExampleAutoScaling_SetInstanceProtection() {
 }
 
 func ExampleAutoScaling_SuspendProcesses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1523,11 +1323,7 @@ func ExampleAutoScaling_SuspendProcesses() {
 }
 
 func ExampleAutoScaling_TerminateInstanceInAutoScalingGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 
@@ -1549,11 +1345,7 @@ func ExampleAutoScaling_TerminateInstanceInAutoScalingGroup() {
 }
 
 func ExampleAutoScaling_UpdateAutoScalingGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := autoscaling.New(sess)
 

--- a/service/batch/examples_test.go
+++ b/service/batch/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleBatch_CancelJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleBatch_CancelJob() {
 }
 
 func ExampleBatch_CreateComputeEnvironment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -96,11 +88,7 @@ func ExampleBatch_CreateComputeEnvironment() {
 }
 
 func ExampleBatch_CreateJobQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -130,11 +118,7 @@ func ExampleBatch_CreateJobQueue() {
 }
 
 func ExampleBatch_DeleteComputeEnvironment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -155,11 +139,7 @@ func ExampleBatch_DeleteComputeEnvironment() {
 }
 
 func ExampleBatch_DeleteJobQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -180,11 +160,7 @@ func ExampleBatch_DeleteJobQueue() {
 }
 
 func ExampleBatch_DeregisterJobDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -205,11 +181,7 @@ func ExampleBatch_DeregisterJobDefinition() {
 }
 
 func ExampleBatch_DescribeComputeEnvironments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -235,11 +207,7 @@ func ExampleBatch_DescribeComputeEnvironments() {
 }
 
 func ExampleBatch_DescribeJobDefinitions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -267,11 +235,7 @@ func ExampleBatch_DescribeJobDefinitions() {
 }
 
 func ExampleBatch_DescribeJobQueues() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -297,11 +261,7 @@ func ExampleBatch_DescribeJobQueues() {
 }
 
 func ExampleBatch_DescribeJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -325,11 +285,7 @@ func ExampleBatch_DescribeJobs() {
 }
 
 func ExampleBatch_ListJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -353,11 +309,7 @@ func ExampleBatch_ListJobs() {
 }
 
 func ExampleBatch_RegisterJobDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -428,11 +380,7 @@ func ExampleBatch_RegisterJobDefinition() {
 }
 
 func ExampleBatch_SubmitJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -480,11 +428,7 @@ func ExampleBatch_SubmitJob() {
 }
 
 func ExampleBatch_TerminateJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -506,11 +450,7 @@ func ExampleBatch_TerminateJob() {
 }
 
 func ExampleBatch_UpdateComputeEnvironment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 
@@ -538,11 +478,7 @@ func ExampleBatch_UpdateComputeEnvironment() {
 }
 
 func ExampleBatch_UpdateJobQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := batch.New(sess)
 

--- a/service/budgets/examples_test.go
+++ b/service/budgets/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleBudgets_CreateBudget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -93,11 +89,7 @@ func ExampleBudgets_CreateBudget() {
 }
 
 func ExampleBudgets_CreateNotification() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -131,11 +123,7 @@ func ExampleBudgets_CreateNotification() {
 }
 
 func ExampleBudgets_CreateSubscriber() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -166,11 +154,7 @@ func ExampleBudgets_CreateSubscriber() {
 }
 
 func ExampleBudgets_DeleteBudget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -192,11 +176,7 @@ func ExampleBudgets_DeleteBudget() {
 }
 
 func ExampleBudgets_DeleteNotification() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -223,11 +203,7 @@ func ExampleBudgets_DeleteNotification() {
 }
 
 func ExampleBudgets_DeleteSubscriber() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -258,11 +234,7 @@ func ExampleBudgets_DeleteSubscriber() {
 }
 
 func ExampleBudgets_DescribeBudget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -284,11 +256,7 @@ func ExampleBudgets_DescribeBudget() {
 }
 
 func ExampleBudgets_DescribeBudgets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -311,11 +279,7 @@ func ExampleBudgets_DescribeBudgets() {
 }
 
 func ExampleBudgets_DescribeNotificationsForBudget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -339,11 +303,7 @@ func ExampleBudgets_DescribeNotificationsForBudget() {
 }
 
 func ExampleBudgets_DescribeSubscribersForNotification() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -372,11 +332,7 @@ func ExampleBudgets_DescribeSubscribersForNotification() {
 }
 
 func ExampleBudgets_UpdateBudget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -432,11 +388,7 @@ func ExampleBudgets_UpdateBudget() {
 }
 
 func ExampleBudgets_UpdateNotification() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 
@@ -468,11 +420,7 @@ func ExampleBudgets_UpdateNotification() {
 }
 
 func ExampleBudgets_UpdateSubscriber() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := budgets.New(sess)
 

--- a/service/clouddirectory/examples_test.go
+++ b/service/clouddirectory/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudDirectory_AddFacetToObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -65,11 +61,7 @@ func ExampleCloudDirectory_AddFacetToObject() {
 }
 
 func ExampleCloudDirectory_ApplySchema() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -91,11 +83,7 @@ func ExampleCloudDirectory_ApplySchema() {
 }
 
 func ExampleCloudDirectory_AttachObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -123,11 +111,7 @@ func ExampleCloudDirectory_AttachObject() {
 }
 
 func ExampleCloudDirectory_AttachPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -154,11 +138,7 @@ func ExampleCloudDirectory_AttachPolicy() {
 }
 
 func ExampleCloudDirectory_AttachToIndex() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -185,11 +165,7 @@ func ExampleCloudDirectory_AttachToIndex() {
 }
 
 func ExampleCloudDirectory_BatchRead() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -230,11 +206,7 @@ func ExampleCloudDirectory_BatchRead() {
 }
 
 func ExampleCloudDirectory_BatchWrite() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -372,11 +344,7 @@ func ExampleCloudDirectory_BatchWrite() {
 }
 
 func ExampleCloudDirectory_CreateDirectory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -398,11 +366,7 @@ func ExampleCloudDirectory_CreateDirectory() {
 }
 
 func ExampleCloudDirectory_CreateFacet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -457,11 +421,7 @@ func ExampleCloudDirectory_CreateFacet() {
 }
 
 func ExampleCloudDirectory_CreateIndex() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -495,11 +455,7 @@ func ExampleCloudDirectory_CreateIndex() {
 }
 
 func ExampleCloudDirectory_CreateObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -548,11 +504,7 @@ func ExampleCloudDirectory_CreateObject() {
 }
 
 func ExampleCloudDirectory_CreateSchema() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -573,11 +525,7 @@ func ExampleCloudDirectory_CreateSchema() {
 }
 
 func ExampleCloudDirectory_DeleteDirectory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -598,11 +546,7 @@ func ExampleCloudDirectory_DeleteDirectory() {
 }
 
 func ExampleCloudDirectory_DeleteFacet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -624,11 +568,7 @@ func ExampleCloudDirectory_DeleteFacet() {
 }
 
 func ExampleCloudDirectory_DeleteObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -652,11 +592,7 @@ func ExampleCloudDirectory_DeleteObject() {
 }
 
 func ExampleCloudDirectory_DeleteSchema() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -677,11 +613,7 @@ func ExampleCloudDirectory_DeleteSchema() {
 }
 
 func ExampleCloudDirectory_DetachFromIndex() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -708,11 +640,7 @@ func ExampleCloudDirectory_DetachFromIndex() {
 }
 
 func ExampleCloudDirectory_DetachObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -737,11 +665,7 @@ func ExampleCloudDirectory_DetachObject() {
 }
 
 func ExampleCloudDirectory_DetachPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -768,11 +692,7 @@ func ExampleCloudDirectory_DetachPolicy() {
 }
 
 func ExampleCloudDirectory_DisableDirectory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -793,11 +713,7 @@ func ExampleCloudDirectory_DisableDirectory() {
 }
 
 func ExampleCloudDirectory_EnableDirectory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -818,11 +734,7 @@ func ExampleCloudDirectory_EnableDirectory() {
 }
 
 func ExampleCloudDirectory_GetDirectory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -843,11 +755,7 @@ func ExampleCloudDirectory_GetDirectory() {
 }
 
 func ExampleCloudDirectory_GetFacet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -869,11 +777,7 @@ func ExampleCloudDirectory_GetFacet() {
 }
 
 func ExampleCloudDirectory_GetObjectInformation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -898,11 +802,7 @@ func ExampleCloudDirectory_GetObjectInformation() {
 }
 
 func ExampleCloudDirectory_GetSchemaAsJson() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -923,11 +823,7 @@ func ExampleCloudDirectory_GetSchemaAsJson() {
 }
 
 func ExampleCloudDirectory_ListAppliedSchemaArns() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -950,11 +846,7 @@ func ExampleCloudDirectory_ListAppliedSchemaArns() {
 }
 
 func ExampleCloudDirectory_ListAttachedIndices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -981,11 +873,7 @@ func ExampleCloudDirectory_ListAttachedIndices() {
 }
 
 func ExampleCloudDirectory_ListDevelopmentSchemaArns() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1007,11 +895,7 @@ func ExampleCloudDirectory_ListDevelopmentSchemaArns() {
 }
 
 func ExampleCloudDirectory_ListDirectories() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1034,11 +918,7 @@ func ExampleCloudDirectory_ListDirectories() {
 }
 
 func ExampleCloudDirectory_ListFacetAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1062,11 +942,7 @@ func ExampleCloudDirectory_ListFacetAttributes() {
 }
 
 func ExampleCloudDirectory_ListFacetNames() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1089,11 +965,7 @@ func ExampleCloudDirectory_ListFacetNames() {
 }
 
 func ExampleCloudDirectory_ListIndex() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1148,11 +1020,7 @@ func ExampleCloudDirectory_ListIndex() {
 }
 
 func ExampleCloudDirectory_ListObjectAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1179,11 +1047,7 @@ func ExampleCloudDirectory_ListObjectAttributes() {
 }
 
 func ExampleCloudDirectory_ListObjectChildren() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1210,11 +1074,7 @@ func ExampleCloudDirectory_ListObjectChildren() {
 }
 
 func ExampleCloudDirectory_ListObjectParents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1241,11 +1101,7 @@ func ExampleCloudDirectory_ListObjectParents() {
 }
 
 func ExampleCloudDirectory_ListObjectPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1272,11 +1128,7 @@ func ExampleCloudDirectory_ListObjectPolicies() {
 }
 
 func ExampleCloudDirectory_ListPolicyAttachments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1303,11 +1155,7 @@ func ExampleCloudDirectory_ListPolicyAttachments() {
 }
 
 func ExampleCloudDirectory_ListPublishedSchemaArns() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1329,11 +1177,7 @@ func ExampleCloudDirectory_ListPublishedSchemaArns() {
 }
 
 func ExampleCloudDirectory_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1356,11 +1200,7 @@ func ExampleCloudDirectory_ListTagsForResource() {
 }
 
 func ExampleCloudDirectory_LookupPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1386,11 +1226,7 @@ func ExampleCloudDirectory_LookupPolicy() {
 }
 
 func ExampleCloudDirectory_PublishSchema() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1413,11 +1249,7 @@ func ExampleCloudDirectory_PublishSchema() {
 }
 
 func ExampleCloudDirectory_PutSchemaFromJson() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1439,11 +1271,7 @@ func ExampleCloudDirectory_PutSchemaFromJson() {
 }
 
 func ExampleCloudDirectory_RemoveFacetFromObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1471,11 +1299,7 @@ func ExampleCloudDirectory_RemoveFacetFromObject() {
 }
 
 func ExampleCloudDirectory_TagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1503,11 +1327,7 @@ func ExampleCloudDirectory_TagResource() {
 }
 
 func ExampleCloudDirectory_UntagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1532,11 +1352,7 @@ func ExampleCloudDirectory_UntagResource() {
 }
 
 func ExampleCloudDirectory_UpdateFacet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1594,11 +1410,7 @@ func ExampleCloudDirectory_UpdateFacet() {
 }
 
 func ExampleCloudDirectory_UpdateObjectAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 
@@ -1642,11 +1454,7 @@ func ExampleCloudDirectory_UpdateObjectAttributes() {
 }
 
 func ExampleCloudDirectory_UpdateSchema() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := clouddirectory.New(sess)
 

--- a/service/cloudformation/examples_test.go
+++ b/service/cloudformation/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudFormation_CancelUpdateStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleCloudFormation_CancelUpdateStack() {
 }
 
 func ExampleCloudFormation_ContinueUpdateRollback() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleCloudFormation_ContinueUpdateRollback() {
 }
 
 func ExampleCloudFormation_CreateChangeSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -131,11 +119,7 @@ func ExampleCloudFormation_CreateChangeSet() {
 }
 
 func ExampleCloudFormation_CreateStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -191,11 +175,7 @@ func ExampleCloudFormation_CreateStack() {
 }
 
 func ExampleCloudFormation_DeleteChangeSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -217,11 +197,7 @@ func ExampleCloudFormation_DeleteChangeSet() {
 }
 
 func ExampleCloudFormation_DeleteStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -247,11 +223,7 @@ func ExampleCloudFormation_DeleteStack() {
 }
 
 func ExampleCloudFormation_DescribeAccountLimits() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -272,11 +244,7 @@ func ExampleCloudFormation_DescribeAccountLimits() {
 }
 
 func ExampleCloudFormation_DescribeChangeSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -299,11 +267,7 @@ func ExampleCloudFormation_DescribeChangeSet() {
 }
 
 func ExampleCloudFormation_DescribeStackEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -325,11 +289,7 @@ func ExampleCloudFormation_DescribeStackEvents() {
 }
 
 func ExampleCloudFormation_DescribeStackResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -351,11 +311,7 @@ func ExampleCloudFormation_DescribeStackResource() {
 }
 
 func ExampleCloudFormation_DescribeStackResources() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -378,11 +334,7 @@ func ExampleCloudFormation_DescribeStackResources() {
 }
 
 func ExampleCloudFormation_DescribeStacks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -404,11 +356,7 @@ func ExampleCloudFormation_DescribeStacks() {
 }
 
 func ExampleCloudFormation_EstimateTemplateCost() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -438,11 +386,7 @@ func ExampleCloudFormation_EstimateTemplateCost() {
 }
 
 func ExampleCloudFormation_ExecuteChangeSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -464,11 +408,7 @@ func ExampleCloudFormation_ExecuteChangeSet() {
 }
 
 func ExampleCloudFormation_GetStackPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -489,11 +429,7 @@ func ExampleCloudFormation_GetStackPolicy() {
 }
 
 func ExampleCloudFormation_GetTemplate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -516,11 +452,7 @@ func ExampleCloudFormation_GetTemplate() {
 }
 
 func ExampleCloudFormation_GetTemplateSummary() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -543,11 +475,7 @@ func ExampleCloudFormation_GetTemplateSummary() {
 }
 
 func ExampleCloudFormation_ListChangeSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -569,11 +497,7 @@ func ExampleCloudFormation_ListChangeSets() {
 }
 
 func ExampleCloudFormation_ListExports() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -594,11 +518,7 @@ func ExampleCloudFormation_ListExports() {
 }
 
 func ExampleCloudFormation_ListImports() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -620,11 +540,7 @@ func ExampleCloudFormation_ListImports() {
 }
 
 func ExampleCloudFormation_ListStackResources() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -646,11 +562,7 @@ func ExampleCloudFormation_ListStackResources() {
 }
 
 func ExampleCloudFormation_ListStacks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -675,11 +587,7 @@ func ExampleCloudFormation_ListStacks() {
 }
 
 func ExampleCloudFormation_SetStackPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -702,11 +610,7 @@ func ExampleCloudFormation_SetStackPolicy() {
 }
 
 func ExampleCloudFormation_SignalResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -730,11 +634,7 @@ func ExampleCloudFormation_SignalResource() {
 }
 
 func ExampleCloudFormation_UpdateStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 
@@ -790,11 +690,7 @@ func ExampleCloudFormation_UpdateStack() {
 }
 
 func ExampleCloudFormation_ValidateTemplate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudformation.New(sess)
 

--- a/service/cloudfront/examples_test.go
+++ b/service/cloudfront/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudFront_CreateCloudFrontOriginAccessIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -44,11 +40,7 @@ func ExampleCloudFront_CreateCloudFrontOriginAccessIdentity() {
 }
 
 func ExampleCloudFront_CreateDistribution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -301,11 +293,7 @@ func ExampleCloudFront_CreateDistribution() {
 }
 
 func ExampleCloudFront_CreateDistributionWithTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -569,11 +557,7 @@ func ExampleCloudFront_CreateDistributionWithTags() {
 }
 
 func ExampleCloudFront_CreateInvalidation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -604,11 +588,7 @@ func ExampleCloudFront_CreateInvalidation() {
 }
 
 func ExampleCloudFront_CreateStreamingDistribution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -658,11 +638,7 @@ func ExampleCloudFront_CreateStreamingDistribution() {
 }
 
 func ExampleCloudFront_CreateStreamingDistributionWithTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -723,11 +699,7 @@ func ExampleCloudFront_CreateStreamingDistributionWithTags() {
 }
 
 func ExampleCloudFront_DeleteCloudFrontOriginAccessIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -749,11 +721,7 @@ func ExampleCloudFront_DeleteCloudFrontOriginAccessIdentity() {
 }
 
 func ExampleCloudFront_DeleteDistribution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -775,11 +743,7 @@ func ExampleCloudFront_DeleteDistribution() {
 }
 
 func ExampleCloudFront_DeleteStreamingDistribution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -801,11 +765,7 @@ func ExampleCloudFront_DeleteStreamingDistribution() {
 }
 
 func ExampleCloudFront_GetCloudFrontOriginAccessIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -826,11 +786,7 @@ func ExampleCloudFront_GetCloudFrontOriginAccessIdentity() {
 }
 
 func ExampleCloudFront_GetCloudFrontOriginAccessIdentityConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -851,11 +807,7 @@ func ExampleCloudFront_GetCloudFrontOriginAccessIdentityConfig() {
 }
 
 func ExampleCloudFront_GetDistribution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -876,11 +828,7 @@ func ExampleCloudFront_GetDistribution() {
 }
 
 func ExampleCloudFront_GetDistributionConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -901,11 +849,7 @@ func ExampleCloudFront_GetDistributionConfig() {
 }
 
 func ExampleCloudFront_GetInvalidation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -927,11 +871,7 @@ func ExampleCloudFront_GetInvalidation() {
 }
 
 func ExampleCloudFront_GetStreamingDistribution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -952,11 +892,7 @@ func ExampleCloudFront_GetStreamingDistribution() {
 }
 
 func ExampleCloudFront_GetStreamingDistributionConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -977,11 +913,7 @@ func ExampleCloudFront_GetStreamingDistributionConfig() {
 }
 
 func ExampleCloudFront_ListCloudFrontOriginAccessIdentities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1003,11 +935,7 @@ func ExampleCloudFront_ListCloudFrontOriginAccessIdentities() {
 }
 
 func ExampleCloudFront_ListDistributions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1029,11 +957,7 @@ func ExampleCloudFront_ListDistributions() {
 }
 
 func ExampleCloudFront_ListDistributionsByWebACLId() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1056,11 +980,7 @@ func ExampleCloudFront_ListDistributionsByWebACLId() {
 }
 
 func ExampleCloudFront_ListInvalidations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1083,11 +1003,7 @@ func ExampleCloudFront_ListInvalidations() {
 }
 
 func ExampleCloudFront_ListStreamingDistributions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1109,11 +1025,7 @@ func ExampleCloudFront_ListStreamingDistributions() {
 }
 
 func ExampleCloudFront_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1134,11 +1046,7 @@ func ExampleCloudFront_ListTagsForResource() {
 }
 
 func ExampleCloudFront_TagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1168,11 +1076,7 @@ func ExampleCloudFront_TagResource() {
 }
 
 func ExampleCloudFront_UntagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1199,11 +1103,7 @@ func ExampleCloudFront_UntagResource() {
 }
 
 func ExampleCloudFront_UpdateCloudFrontOriginAccessIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1229,11 +1129,7 @@ func ExampleCloudFront_UpdateCloudFrontOriginAccessIdentity() {
 }
 
 func ExampleCloudFront_UpdateDistribution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 
@@ -1488,11 +1384,7 @@ func ExampleCloudFront_UpdateDistribution() {
 }
 
 func ExampleCloudFront_UpdateStreamingDistribution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudfront.New(sess)
 

--- a/service/cloudhsm/examples_test.go
+++ b/service/cloudhsm/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudHSM_AddTagsToResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleCloudHSM_AddTagsToResource() {
 }
 
 func ExampleCloudHSM_CreateHapg() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -73,11 +65,7 @@ func ExampleCloudHSM_CreateHapg() {
 }
 
 func ExampleCloudHSM_CreateHsm() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -105,11 +93,7 @@ func ExampleCloudHSM_CreateHsm() {
 }
 
 func ExampleCloudHSM_CreateLunaClient() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -131,11 +115,7 @@ func ExampleCloudHSM_CreateLunaClient() {
 }
 
 func ExampleCloudHSM_DeleteHapg() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -156,11 +136,7 @@ func ExampleCloudHSM_DeleteHapg() {
 }
 
 func ExampleCloudHSM_DeleteHsm() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -181,11 +157,7 @@ func ExampleCloudHSM_DeleteHsm() {
 }
 
 func ExampleCloudHSM_DeleteLunaClient() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -206,11 +178,7 @@ func ExampleCloudHSM_DeleteLunaClient() {
 }
 
 func ExampleCloudHSM_DescribeHapg() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -231,11 +199,7 @@ func ExampleCloudHSM_DescribeHapg() {
 }
 
 func ExampleCloudHSM_DescribeHsm() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -257,11 +221,7 @@ func ExampleCloudHSM_DescribeHsm() {
 }
 
 func ExampleCloudHSM_DescribeLunaClient() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -283,11 +243,7 @@ func ExampleCloudHSM_DescribeLunaClient() {
 }
 
 func ExampleCloudHSM_GetConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -313,11 +269,7 @@ func ExampleCloudHSM_GetConfig() {
 }
 
 func ExampleCloudHSM_ListAvailableZones() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -336,11 +288,7 @@ func ExampleCloudHSM_ListAvailableZones() {
 }
 
 func ExampleCloudHSM_ListHapgs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -361,11 +309,7 @@ func ExampleCloudHSM_ListHapgs() {
 }
 
 func ExampleCloudHSM_ListHsms() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -386,11 +330,7 @@ func ExampleCloudHSM_ListHsms() {
 }
 
 func ExampleCloudHSM_ListLunaClients() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -411,11 +351,7 @@ func ExampleCloudHSM_ListLunaClients() {
 }
 
 func ExampleCloudHSM_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -436,11 +372,7 @@ func ExampleCloudHSM_ListTagsForResource() {
 }
 
 func ExampleCloudHSM_ModifyHapg() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -466,11 +398,7 @@ func ExampleCloudHSM_ModifyHapg() {
 }
 
 func ExampleCloudHSM_ModifyHsm() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -496,11 +424,7 @@ func ExampleCloudHSM_ModifyHsm() {
 }
 
 func ExampleCloudHSM_ModifyLunaClient() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 
@@ -522,11 +446,7 @@ func ExampleCloudHSM_ModifyLunaClient() {
 }
 
 func ExampleCloudHSM_RemoveTagsFromResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudhsm.New(sess)
 

--- a/service/cloudsearch/examples_test.go
+++ b/service/cloudsearch/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudSearch_BuildSuggesters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleCloudSearch_BuildSuggesters() {
 }
 
 func ExampleCloudSearch_CreateDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -66,11 +58,7 @@ func ExampleCloudSearch_CreateDomain() {
 }
 
 func ExampleCloudSearch_DefineAnalysisScheme() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -102,11 +90,7 @@ func ExampleCloudSearch_DefineAnalysisScheme() {
 }
 
 func ExampleCloudSearch_DefineExpression() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -131,11 +115,7 @@ func ExampleCloudSearch_DefineExpression() {
 }
 
 func ExampleCloudSearch_DefineIndexField() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -243,11 +223,7 @@ func ExampleCloudSearch_DefineIndexField() {
 }
 
 func ExampleCloudSearch_DefineSuggester() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -276,11 +252,7 @@ func ExampleCloudSearch_DefineSuggester() {
 }
 
 func ExampleCloudSearch_DeleteAnalysisScheme() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -302,11 +274,7 @@ func ExampleCloudSearch_DeleteAnalysisScheme() {
 }
 
 func ExampleCloudSearch_DeleteDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -327,11 +295,7 @@ func ExampleCloudSearch_DeleteDomain() {
 }
 
 func ExampleCloudSearch_DeleteExpression() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -353,11 +317,7 @@ func ExampleCloudSearch_DeleteExpression() {
 }
 
 func ExampleCloudSearch_DeleteIndexField() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -379,11 +339,7 @@ func ExampleCloudSearch_DeleteIndexField() {
 }
 
 func ExampleCloudSearch_DeleteSuggester() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -405,11 +361,7 @@ func ExampleCloudSearch_DeleteSuggester() {
 }
 
 func ExampleCloudSearch_DescribeAnalysisSchemes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -435,11 +387,7 @@ func ExampleCloudSearch_DescribeAnalysisSchemes() {
 }
 
 func ExampleCloudSearch_DescribeAvailabilityOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -461,11 +409,7 @@ func ExampleCloudSearch_DescribeAvailabilityOptions() {
 }
 
 func ExampleCloudSearch_DescribeDomains() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -489,11 +433,7 @@ func ExampleCloudSearch_DescribeDomains() {
 }
 
 func ExampleCloudSearch_DescribeExpressions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -519,11 +459,7 @@ func ExampleCloudSearch_DescribeExpressions() {
 }
 
 func ExampleCloudSearch_DescribeIndexFields() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -549,11 +485,7 @@ func ExampleCloudSearch_DescribeIndexFields() {
 }
 
 func ExampleCloudSearch_DescribeScalingParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -574,11 +506,7 @@ func ExampleCloudSearch_DescribeScalingParameters() {
 }
 
 func ExampleCloudSearch_DescribeServiceAccessPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -600,11 +528,7 @@ func ExampleCloudSearch_DescribeServiceAccessPolicies() {
 }
 
 func ExampleCloudSearch_DescribeSuggesters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -630,11 +554,7 @@ func ExampleCloudSearch_DescribeSuggesters() {
 }
 
 func ExampleCloudSearch_IndexDocuments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -655,11 +575,7 @@ func ExampleCloudSearch_IndexDocuments() {
 }
 
 func ExampleCloudSearch_ListDomainNames() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -678,11 +594,7 @@ func ExampleCloudSearch_ListDomainNames() {
 }
 
 func ExampleCloudSearch_UpdateAvailabilityOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -704,11 +616,7 @@ func ExampleCloudSearch_UpdateAvailabilityOptions() {
 }
 
 func ExampleCloudSearch_UpdateScalingParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 
@@ -734,11 +642,7 @@ func ExampleCloudSearch_UpdateScalingParameters() {
 }
 
 func ExampleCloudSearch_UpdateServiceAccessPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearch.New(sess)
 

--- a/service/cloudsearchdomain/examples_test.go
+++ b/service/cloudsearchdomain/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudSearchDomain_Search() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearchdomain.New(sess)
 
@@ -54,11 +50,7 @@ func ExampleCloudSearchDomain_Search() {
 }
 
 func ExampleCloudSearchDomain_Suggest() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearchdomain.New(sess)
 
@@ -81,11 +73,7 @@ func ExampleCloudSearchDomain_Suggest() {
 }
 
 func ExampleCloudSearchDomain_UploadDocuments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudsearchdomain.New(sess)
 

--- a/service/cloudtrail/examples_test.go
+++ b/service/cloudtrail/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudTrail_AddTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleCloudTrail_AddTags() {
 }
 
 func ExampleCloudTrail_CreateTrail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -82,11 +74,7 @@ func ExampleCloudTrail_CreateTrail() {
 }
 
 func ExampleCloudTrail_DeleteTrail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -107,11 +95,7 @@ func ExampleCloudTrail_DeleteTrail() {
 }
 
 func ExampleCloudTrail_DescribeTrails() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -136,11 +120,7 @@ func ExampleCloudTrail_DescribeTrails() {
 }
 
 func ExampleCloudTrail_GetEventSelectors() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -161,11 +141,7 @@ func ExampleCloudTrail_GetEventSelectors() {
 }
 
 func ExampleCloudTrail_GetTrailStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -186,11 +162,7 @@ func ExampleCloudTrail_GetTrailStatus() {
 }
 
 func ExampleCloudTrail_ListPublicKeys() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -213,11 +185,7 @@ func ExampleCloudTrail_ListPublicKeys() {
 }
 
 func ExampleCloudTrail_ListTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -242,11 +210,7 @@ func ExampleCloudTrail_ListTags() {
 }
 
 func ExampleCloudTrail_LookupEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -277,11 +241,7 @@ func ExampleCloudTrail_LookupEvents() {
 }
 
 func ExampleCloudTrail_PutEventSelectors() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -319,11 +279,7 @@ func ExampleCloudTrail_PutEventSelectors() {
 }
 
 func ExampleCloudTrail_RemoveTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -351,11 +307,7 @@ func ExampleCloudTrail_RemoveTags() {
 }
 
 func ExampleCloudTrail_StartLogging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -376,11 +328,7 @@ func ExampleCloudTrail_StartLogging() {
 }
 
 func ExampleCloudTrail_StopLogging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 
@@ -401,11 +349,7 @@ func ExampleCloudTrail_StopLogging() {
 }
 
 func ExampleCloudTrail_UpdateTrail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudtrail.New(sess)
 

--- a/service/cloudwatch/examples_test.go
+++ b/service/cloudwatch/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudWatch_DeleteAlarms() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -44,11 +40,7 @@ func ExampleCloudWatch_DeleteAlarms() {
 }
 
 func ExampleCloudWatch_DescribeAlarmHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -74,11 +66,7 @@ func ExampleCloudWatch_DescribeAlarmHistory() {
 }
 
 func ExampleCloudWatch_DescribeAlarms() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -107,11 +95,7 @@ func ExampleCloudWatch_DescribeAlarms() {
 }
 
 func ExampleCloudWatch_DescribeAlarmsForMetric() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -144,11 +128,7 @@ func ExampleCloudWatch_DescribeAlarmsForMetric() {
 }
 
 func ExampleCloudWatch_DisableAlarmActions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -172,11 +152,7 @@ func ExampleCloudWatch_DisableAlarmActions() {
 }
 
 func ExampleCloudWatch_EnableAlarmActions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -200,11 +176,7 @@ func ExampleCloudWatch_EnableAlarmActions() {
 }
 
 func ExampleCloudWatch_GetMetricStatistics() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -245,11 +217,7 @@ func ExampleCloudWatch_GetMetricStatistics() {
 }
 
 func ExampleCloudWatch_ListMetrics() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -279,11 +247,7 @@ func ExampleCloudWatch_ListMetrics() {
 }
 
 func ExampleCloudWatch_PutMetricAlarm() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -334,11 +298,7 @@ func ExampleCloudWatch_PutMetricAlarm() {
 }
 
 func ExampleCloudWatch_PutMetricData() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 
@@ -381,11 +341,7 @@ func ExampleCloudWatch_PutMetricData() {
 }
 
 func ExampleCloudWatch_SetAlarmState() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatch.New(sess)
 

--- a/service/cloudwatchevents/examples_test.go
+++ b/service/cloudwatchevents/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudWatchEvents_DeleteRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleCloudWatchEvents_DeleteRule() {
 }
 
 func ExampleCloudWatchEvents_DescribeRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -66,11 +58,7 @@ func ExampleCloudWatchEvents_DescribeRule() {
 }
 
 func ExampleCloudWatchEvents_DisableRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -91,11 +79,7 @@ func ExampleCloudWatchEvents_DisableRule() {
 }
 
 func ExampleCloudWatchEvents_EnableRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -116,11 +100,7 @@ func ExampleCloudWatchEvents_EnableRule() {
 }
 
 func ExampleCloudWatchEvents_ListRuleNamesByTarget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -143,11 +123,7 @@ func ExampleCloudWatchEvents_ListRuleNamesByTarget() {
 }
 
 func ExampleCloudWatchEvents_ListRules() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -170,11 +146,7 @@ func ExampleCloudWatchEvents_ListRules() {
 }
 
 func ExampleCloudWatchEvents_ListTargetsByRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -197,11 +169,7 @@ func ExampleCloudWatchEvents_ListTargetsByRule() {
 }
 
 func ExampleCloudWatchEvents_PutEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -234,11 +202,7 @@ func ExampleCloudWatchEvents_PutEvents() {
 }
 
 func ExampleCloudWatchEvents_PutRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -264,11 +228,7 @@ func ExampleCloudWatchEvents_PutRule() {
 }
 
 func ExampleCloudWatchEvents_PutTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -298,11 +258,7 @@ func ExampleCloudWatchEvents_PutTargets() {
 }
 
 func ExampleCloudWatchEvents_RemoveTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 
@@ -327,11 +283,7 @@ func ExampleCloudWatchEvents_RemoveTargets() {
 }
 
 func ExampleCloudWatchEvents_TestEventPattern() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchevents.New(sess)
 

--- a/service/cloudwatchlogs/examples_test.go
+++ b/service/cloudwatchlogs/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCloudWatchLogs_CancelExportTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleCloudWatchLogs_CancelExportTask() {
 }
 
 func ExampleCloudWatchLogs_CreateExportTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -72,11 +64,7 @@ func ExampleCloudWatchLogs_CreateExportTask() {
 }
 
 func ExampleCloudWatchLogs_CreateLogGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -101,11 +89,7 @@ func ExampleCloudWatchLogs_CreateLogGroup() {
 }
 
 func ExampleCloudWatchLogs_CreateLogStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -127,11 +111,7 @@ func ExampleCloudWatchLogs_CreateLogStream() {
 }
 
 func ExampleCloudWatchLogs_DeleteDestination() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -152,11 +132,7 @@ func ExampleCloudWatchLogs_DeleteDestination() {
 }
 
 func ExampleCloudWatchLogs_DeleteLogGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -177,11 +153,7 @@ func ExampleCloudWatchLogs_DeleteLogGroup() {
 }
 
 func ExampleCloudWatchLogs_DeleteLogStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -203,11 +175,7 @@ func ExampleCloudWatchLogs_DeleteLogStream() {
 }
 
 func ExampleCloudWatchLogs_DeleteMetricFilter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -229,11 +197,7 @@ func ExampleCloudWatchLogs_DeleteMetricFilter() {
 }
 
 func ExampleCloudWatchLogs_DeleteRetentionPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -254,11 +218,7 @@ func ExampleCloudWatchLogs_DeleteRetentionPolicy() {
 }
 
 func ExampleCloudWatchLogs_DeleteSubscriptionFilter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -280,11 +240,7 @@ func ExampleCloudWatchLogs_DeleteSubscriptionFilter() {
 }
 
 func ExampleCloudWatchLogs_DescribeDestinations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -307,11 +263,7 @@ func ExampleCloudWatchLogs_DescribeDestinations() {
 }
 
 func ExampleCloudWatchLogs_DescribeExportTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -335,11 +287,7 @@ func ExampleCloudWatchLogs_DescribeExportTasks() {
 }
 
 func ExampleCloudWatchLogs_DescribeLogGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -362,11 +310,7 @@ func ExampleCloudWatchLogs_DescribeLogGroups() {
 }
 
 func ExampleCloudWatchLogs_DescribeLogStreams() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -392,11 +336,7 @@ func ExampleCloudWatchLogs_DescribeLogStreams() {
 }
 
 func ExampleCloudWatchLogs_DescribeMetricFilters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -422,11 +362,7 @@ func ExampleCloudWatchLogs_DescribeMetricFilters() {
 }
 
 func ExampleCloudWatchLogs_DescribeSubscriptionFilters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -450,11 +386,7 @@ func ExampleCloudWatchLogs_DescribeSubscriptionFilters() {
 }
 
 func ExampleCloudWatchLogs_FilterLogEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -485,11 +417,7 @@ func ExampleCloudWatchLogs_FilterLogEvents() {
 }
 
 func ExampleCloudWatchLogs_GetLogEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -516,11 +444,7 @@ func ExampleCloudWatchLogs_GetLogEvents() {
 }
 
 func ExampleCloudWatchLogs_ListTagsLogGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -541,11 +465,7 @@ func ExampleCloudWatchLogs_ListTagsLogGroup() {
 }
 
 func ExampleCloudWatchLogs_PutDestination() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -568,11 +488,7 @@ func ExampleCloudWatchLogs_PutDestination() {
 }
 
 func ExampleCloudWatchLogs_PutDestinationPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -594,11 +510,7 @@ func ExampleCloudWatchLogs_PutDestinationPolicy() {
 }
 
 func ExampleCloudWatchLogs_PutLogEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -628,11 +540,7 @@ func ExampleCloudWatchLogs_PutLogEvents() {
 }
 
 func ExampleCloudWatchLogs_PutMetricFilter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -664,11 +572,7 @@ func ExampleCloudWatchLogs_PutMetricFilter() {
 }
 
 func ExampleCloudWatchLogs_PutRetentionPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -690,11 +594,7 @@ func ExampleCloudWatchLogs_PutRetentionPolicy() {
 }
 
 func ExampleCloudWatchLogs_PutSubscriptionFilter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -720,11 +620,7 @@ func ExampleCloudWatchLogs_PutSubscriptionFilter() {
 }
 
 func ExampleCloudWatchLogs_TagLogGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -749,11 +645,7 @@ func ExampleCloudWatchLogs_TagLogGroup() {
 }
 
 func ExampleCloudWatchLogs_TestMetricFilter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 
@@ -778,11 +670,7 @@ func ExampleCloudWatchLogs_TestMetricFilter() {
 }
 
 func ExampleCloudWatchLogs_UntagLogGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cloudwatchlogs.New(sess)
 

--- a/service/codebuild/examples_test.go
+++ b/service/codebuild/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCodeBuild_BatchGetBuilds() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -44,11 +40,7 @@ func ExampleCodeBuild_BatchGetBuilds() {
 }
 
 func ExampleCodeBuild_BatchGetProjects() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -72,11 +64,7 @@ func ExampleCodeBuild_BatchGetProjects() {
 }
 
 func ExampleCodeBuild_CreateProject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -137,11 +125,7 @@ func ExampleCodeBuild_CreateProject() {
 }
 
 func ExampleCodeBuild_DeleteProject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -162,11 +146,7 @@ func ExampleCodeBuild_DeleteProject() {
 }
 
 func ExampleCodeBuild_ListBuilds() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -188,11 +168,7 @@ func ExampleCodeBuild_ListBuilds() {
 }
 
 func ExampleCodeBuild_ListBuildsForProject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -215,11 +191,7 @@ func ExampleCodeBuild_ListBuildsForProject() {
 }
 
 func ExampleCodeBuild_ListCuratedEnvironmentImages() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -238,11 +210,7 @@ func ExampleCodeBuild_ListCuratedEnvironmentImages() {
 }
 
 func ExampleCodeBuild_ListProjects() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -265,11 +233,7 @@ func ExampleCodeBuild_ListProjects() {
 }
 
 func ExampleCodeBuild_StartBuild() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -308,11 +272,7 @@ func ExampleCodeBuild_StartBuild() {
 }
 
 func ExampleCodeBuild_StopBuild() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 
@@ -333,11 +293,7 @@ func ExampleCodeBuild_StopBuild() {
 }
 
 func ExampleCodeBuild_UpdateProject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codebuild.New(sess)
 

--- a/service/codecommit/examples_test.go
+++ b/service/codecommit/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCodeCommit_BatchGetRepositories() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -44,11 +40,7 @@ func ExampleCodeCommit_BatchGetRepositories() {
 }
 
 func ExampleCodeCommit_CreateBranch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleCodeCommit_CreateBranch() {
 }
 
 func ExampleCodeCommit_CreateRepository() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -97,11 +85,7 @@ func ExampleCodeCommit_CreateRepository() {
 }
 
 func ExampleCodeCommit_DeleteRepository() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -122,11 +106,7 @@ func ExampleCodeCommit_DeleteRepository() {
 }
 
 func ExampleCodeCommit_GetBlob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -148,11 +128,7 @@ func ExampleCodeCommit_GetBlob() {
 }
 
 func ExampleCodeCommit_GetBranch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -174,11 +150,7 @@ func ExampleCodeCommit_GetBranch() {
 }
 
 func ExampleCodeCommit_GetCommit() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -200,11 +172,7 @@ func ExampleCodeCommit_GetCommit() {
 }
 
 func ExampleCodeCommit_GetDifferences() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -231,11 +199,7 @@ func ExampleCodeCommit_GetDifferences() {
 }
 
 func ExampleCodeCommit_GetRepository() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -256,11 +220,7 @@ func ExampleCodeCommit_GetRepository() {
 }
 
 func ExampleCodeCommit_GetRepositoryTriggers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -281,11 +241,7 @@ func ExampleCodeCommit_GetRepositoryTriggers() {
 }
 
 func ExampleCodeCommit_ListBranches() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -307,11 +263,7 @@ func ExampleCodeCommit_ListBranches() {
 }
 
 func ExampleCodeCommit_ListRepositories() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -334,11 +286,7 @@ func ExampleCodeCommit_ListRepositories() {
 }
 
 func ExampleCodeCommit_PutRepositoryTriggers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -375,11 +323,7 @@ func ExampleCodeCommit_PutRepositoryTriggers() {
 }
 
 func ExampleCodeCommit_TestRepositoryTriggers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -416,11 +360,7 @@ func ExampleCodeCommit_TestRepositoryTriggers() {
 }
 
 func ExampleCodeCommit_UpdateDefaultBranch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -442,11 +382,7 @@ func ExampleCodeCommit_UpdateDefaultBranch() {
 }
 
 func ExampleCodeCommit_UpdateRepositoryDescription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 
@@ -468,11 +404,7 @@ func ExampleCodeCommit_UpdateRepositoryDescription() {
 }
 
 func ExampleCodeCommit_UpdateRepositoryName() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codecommit.New(sess)
 

--- a/service/codedeploy/examples_test.go
+++ b/service/codedeploy/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCodeDeploy_AddTagsToOnPremisesInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -51,11 +47,7 @@ func ExampleCodeDeploy_AddTagsToOnPremisesInstances() {
 }
 
 func ExampleCodeDeploy_BatchGetApplicationRevisions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -93,11 +85,7 @@ func ExampleCodeDeploy_BatchGetApplicationRevisions() {
 }
 
 func ExampleCodeDeploy_BatchGetApplications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -121,11 +109,7 @@ func ExampleCodeDeploy_BatchGetApplications() {
 }
 
 func ExampleCodeDeploy_BatchGetDeploymentGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -150,11 +134,7 @@ func ExampleCodeDeploy_BatchGetDeploymentGroups() {
 }
 
 func ExampleCodeDeploy_BatchGetDeploymentInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -179,11 +159,7 @@ func ExampleCodeDeploy_BatchGetDeploymentInstances() {
 }
 
 func ExampleCodeDeploy_BatchGetDeployments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -207,11 +183,7 @@ func ExampleCodeDeploy_BatchGetDeployments() {
 }
 
 func ExampleCodeDeploy_BatchGetOnPremisesInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -235,11 +207,7 @@ func ExampleCodeDeploy_BatchGetOnPremisesInstances() {
 }
 
 func ExampleCodeDeploy_ContinueDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -260,11 +228,7 @@ func ExampleCodeDeploy_ContinueDeployment() {
 }
 
 func ExampleCodeDeploy_CreateApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -285,11 +249,7 @@ func ExampleCodeDeploy_CreateApplication() {
 }
 
 func ExampleCodeDeploy_CreateDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -350,11 +310,7 @@ func ExampleCodeDeploy_CreateDeployment() {
 }
 
 func ExampleCodeDeploy_CreateDeploymentConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -379,11 +335,7 @@ func ExampleCodeDeploy_CreateDeploymentConfig() {
 }
 
 func ExampleCodeDeploy_CreateDeploymentGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -480,11 +432,7 @@ func ExampleCodeDeploy_CreateDeploymentGroup() {
 }
 
 func ExampleCodeDeploy_DeleteApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -505,11 +453,7 @@ func ExampleCodeDeploy_DeleteApplication() {
 }
 
 func ExampleCodeDeploy_DeleteDeploymentConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -530,11 +474,7 @@ func ExampleCodeDeploy_DeleteDeploymentConfig() {
 }
 
 func ExampleCodeDeploy_DeleteDeploymentGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -556,11 +496,7 @@ func ExampleCodeDeploy_DeleteDeploymentGroup() {
 }
 
 func ExampleCodeDeploy_DeregisterOnPremisesInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -581,11 +517,7 @@ func ExampleCodeDeploy_DeregisterOnPremisesInstance() {
 }
 
 func ExampleCodeDeploy_GetApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -606,11 +538,7 @@ func ExampleCodeDeploy_GetApplication() {
 }
 
 func ExampleCodeDeploy_GetApplicationRevision() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -645,11 +573,7 @@ func ExampleCodeDeploy_GetApplicationRevision() {
 }
 
 func ExampleCodeDeploy_GetDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -670,11 +594,7 @@ func ExampleCodeDeploy_GetDeployment() {
 }
 
 func ExampleCodeDeploy_GetDeploymentConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -695,11 +615,7 @@ func ExampleCodeDeploy_GetDeploymentConfig() {
 }
 
 func ExampleCodeDeploy_GetDeploymentGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -721,11 +637,7 @@ func ExampleCodeDeploy_GetDeploymentGroup() {
 }
 
 func ExampleCodeDeploy_GetDeploymentInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -747,11 +659,7 @@ func ExampleCodeDeploy_GetDeploymentInstance() {
 }
 
 func ExampleCodeDeploy_GetOnPremisesInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -772,11 +680,7 @@ func ExampleCodeDeploy_GetOnPremisesInstance() {
 }
 
 func ExampleCodeDeploy_ListApplicationRevisions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -803,11 +707,7 @@ func ExampleCodeDeploy_ListApplicationRevisions() {
 }
 
 func ExampleCodeDeploy_ListApplications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -828,11 +728,7 @@ func ExampleCodeDeploy_ListApplications() {
 }
 
 func ExampleCodeDeploy_ListDeploymentConfigs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -853,11 +749,7 @@ func ExampleCodeDeploy_ListDeploymentConfigs() {
 }
 
 func ExampleCodeDeploy_ListDeploymentGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -879,11 +771,7 @@ func ExampleCodeDeploy_ListDeploymentGroups() {
 }
 
 func ExampleCodeDeploy_ListDeploymentInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -913,11 +801,7 @@ func ExampleCodeDeploy_ListDeploymentInstances() {
 }
 
 func ExampleCodeDeploy_ListDeployments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -948,11 +832,7 @@ func ExampleCodeDeploy_ListDeployments() {
 }
 
 func ExampleCodeDeploy_ListOnPremisesInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -982,11 +862,7 @@ func ExampleCodeDeploy_ListOnPremisesInstances() {
 }
 
 func ExampleCodeDeploy_RegisterApplicationRevision() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -1022,11 +898,7 @@ func ExampleCodeDeploy_RegisterApplicationRevision() {
 }
 
 func ExampleCodeDeploy_RegisterOnPremisesInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -1049,11 +921,7 @@ func ExampleCodeDeploy_RegisterOnPremisesInstance() {
 }
 
 func ExampleCodeDeploy_RemoveTagsFromOnPremisesInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -1084,11 +952,7 @@ func ExampleCodeDeploy_RemoveTagsFromOnPremisesInstances() {
 }
 
 func ExampleCodeDeploy_SkipWaitTimeForInstanceTermination() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -1109,11 +973,7 @@ func ExampleCodeDeploy_SkipWaitTimeForInstanceTermination() {
 }
 
 func ExampleCodeDeploy_StopDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -1135,11 +995,7 @@ func ExampleCodeDeploy_StopDeployment() {
 }
 
 func ExampleCodeDeploy_UpdateApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 
@@ -1161,11 +1017,7 @@ func ExampleCodeDeploy_UpdateApplication() {
 }
 
 func ExampleCodeDeploy_UpdateDeploymentGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codedeploy.New(sess)
 

--- a/service/codepipeline/examples_test.go
+++ b/service/codepipeline/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCodePipeline_AcknowledgeJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleCodePipeline_AcknowledgeJob() {
 }
 
 func ExampleCodePipeline_AcknowledgeThirdPartyJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -69,11 +61,7 @@ func ExampleCodePipeline_AcknowledgeThirdPartyJob() {
 }
 
 func ExampleCodePipeline_CreateCustomActionType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -122,11 +110,7 @@ func ExampleCodePipeline_CreateCustomActionType() {
 }
 
 func ExampleCodePipeline_CreatePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -202,11 +186,7 @@ func ExampleCodePipeline_CreatePipeline() {
 }
 
 func ExampleCodePipeline_DeleteCustomActionType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -229,11 +209,7 @@ func ExampleCodePipeline_DeleteCustomActionType() {
 }
 
 func ExampleCodePipeline_DeletePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -254,11 +230,7 @@ func ExampleCodePipeline_DeletePipeline() {
 }
 
 func ExampleCodePipeline_DisableStageTransition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -282,11 +254,7 @@ func ExampleCodePipeline_DisableStageTransition() {
 }
 
 func ExampleCodePipeline_EnableStageTransition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -309,11 +277,7 @@ func ExampleCodePipeline_EnableStageTransition() {
 }
 
 func ExampleCodePipeline_GetJobDetails() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -334,11 +298,7 @@ func ExampleCodePipeline_GetJobDetails() {
 }
 
 func ExampleCodePipeline_GetPipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -360,11 +320,7 @@ func ExampleCodePipeline_GetPipeline() {
 }
 
 func ExampleCodePipeline_GetPipelineExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -386,11 +342,7 @@ func ExampleCodePipeline_GetPipelineExecution() {
 }
 
 func ExampleCodePipeline_GetPipelineState() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -411,11 +363,7 @@ func ExampleCodePipeline_GetPipelineState() {
 }
 
 func ExampleCodePipeline_GetThirdPartyJobDetails() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -437,11 +385,7 @@ func ExampleCodePipeline_GetThirdPartyJobDetails() {
 }
 
 func ExampleCodePipeline_ListActionTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -463,11 +407,7 @@ func ExampleCodePipeline_ListActionTypes() {
 }
 
 func ExampleCodePipeline_ListPipelines() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -488,11 +428,7 @@ func ExampleCodePipeline_ListPipelines() {
 }
 
 func ExampleCodePipeline_PollForJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -523,11 +459,7 @@ func ExampleCodePipeline_PollForJobs() {
 }
 
 func ExampleCodePipeline_PollForThirdPartyJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -554,11 +486,7 @@ func ExampleCodePipeline_PollForThirdPartyJobs() {
 }
 
 func ExampleCodePipeline_PutActionRevision() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -586,11 +514,7 @@ func ExampleCodePipeline_PutActionRevision() {
 }
 
 func ExampleCodePipeline_PutApprovalResult() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -618,11 +542,7 @@ func ExampleCodePipeline_PutApprovalResult() {
 }
 
 func ExampleCodePipeline_PutJobFailureResult() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -648,11 +568,7 @@ func ExampleCodePipeline_PutJobFailureResult() {
 }
 
 func ExampleCodePipeline_PutJobSuccessResult() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -685,11 +601,7 @@ func ExampleCodePipeline_PutJobSuccessResult() {
 }
 
 func ExampleCodePipeline_PutThirdPartyJobFailureResult() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -716,11 +628,7 @@ func ExampleCodePipeline_PutThirdPartyJobFailureResult() {
 }
 
 func ExampleCodePipeline_PutThirdPartyJobSuccessResult() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -754,11 +662,7 @@ func ExampleCodePipeline_PutThirdPartyJobSuccessResult() {
 }
 
 func ExampleCodePipeline_RetryStageExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -782,11 +686,7 @@ func ExampleCodePipeline_RetryStageExecution() {
 }
 
 func ExampleCodePipeline_StartPipelineExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 
@@ -807,11 +707,7 @@ func ExampleCodePipeline_StartPipelineExecution() {
 }
 
 func ExampleCodePipeline_UpdatePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := codepipeline.New(sess)
 

--- a/service/cognitoidentity/examples_test.go
+++ b/service/cognitoidentity/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCognitoIdentity_CreateIdentityPool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -63,11 +59,7 @@ func ExampleCognitoIdentity_CreateIdentityPool() {
 }
 
 func ExampleCognitoIdentity_DeleteIdentities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -91,11 +83,7 @@ func ExampleCognitoIdentity_DeleteIdentities() {
 }
 
 func ExampleCognitoIdentity_DeleteIdentityPool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -116,11 +104,7 @@ func ExampleCognitoIdentity_DeleteIdentityPool() {
 }
 
 func ExampleCognitoIdentity_DescribeIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -141,11 +125,7 @@ func ExampleCognitoIdentity_DescribeIdentity() {
 }
 
 func ExampleCognitoIdentity_DescribeIdentityPool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -166,11 +146,7 @@ func ExampleCognitoIdentity_DescribeIdentityPool() {
 }
 
 func ExampleCognitoIdentity_GetCredentialsForIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -196,11 +172,7 @@ func ExampleCognitoIdentity_GetCredentialsForIdentity() {
 }
 
 func ExampleCognitoIdentity_GetId() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -226,11 +198,7 @@ func ExampleCognitoIdentity_GetId() {
 }
 
 func ExampleCognitoIdentity_GetIdentityPoolRoles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -251,11 +219,7 @@ func ExampleCognitoIdentity_GetIdentityPoolRoles() {
 }
 
 func ExampleCognitoIdentity_GetOpenIdToken() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -280,11 +244,7 @@ func ExampleCognitoIdentity_GetOpenIdToken() {
 }
 
 func ExampleCognitoIdentity_GetOpenIdTokenForDeveloperIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -311,11 +271,7 @@ func ExampleCognitoIdentity_GetOpenIdTokenForDeveloperIdentity() {
 }
 
 func ExampleCognitoIdentity_ListIdentities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -339,11 +295,7 @@ func ExampleCognitoIdentity_ListIdentities() {
 }
 
 func ExampleCognitoIdentity_ListIdentityPools() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -365,11 +317,7 @@ func ExampleCognitoIdentity_ListIdentityPools() {
 }
 
 func ExampleCognitoIdentity_LookupDeveloperIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -394,11 +342,7 @@ func ExampleCognitoIdentity_LookupDeveloperIdentity() {
 }
 
 func ExampleCognitoIdentity_MergeDeveloperIdentities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -422,11 +366,7 @@ func ExampleCognitoIdentity_MergeDeveloperIdentities() {
 }
 
 func ExampleCognitoIdentity_SetIdentityPoolRoles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -469,11 +409,7 @@ func ExampleCognitoIdentity_SetIdentityPoolRoles() {
 }
 
 func ExampleCognitoIdentity_UnlinkDeveloperIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -497,11 +433,7 @@ func ExampleCognitoIdentity_UnlinkDeveloperIdentity() {
 }
 
 func ExampleCognitoIdentity_UnlinkIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 
@@ -530,11 +462,7 @@ func ExampleCognitoIdentity_UnlinkIdentity() {
 }
 
 func ExampleCognitoIdentity_UpdateIdentityPool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentity.New(sess)
 

--- a/service/cognitoidentityprovider/examples_test.go
+++ b/service/cognitoidentityprovider/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCognitoIdentityProvider_AddCustomAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -59,11 +55,7 @@ func ExampleCognitoIdentityProvider_AddCustomAttributes() {
 }
 
 func ExampleCognitoIdentityProvider_AdminAddUserToGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -86,11 +78,7 @@ func ExampleCognitoIdentityProvider_AdminAddUserToGroup() {
 }
 
 func ExampleCognitoIdentityProvider_AdminConfirmSignUp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -112,11 +100,7 @@ func ExampleCognitoIdentityProvider_AdminConfirmSignUp() {
 }
 
 func ExampleCognitoIdentityProvider_AdminCreateUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -159,11 +143,7 @@ func ExampleCognitoIdentityProvider_AdminCreateUser() {
 }
 
 func ExampleCognitoIdentityProvider_AdminDeleteUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -185,11 +165,7 @@ func ExampleCognitoIdentityProvider_AdminDeleteUser() {
 }
 
 func ExampleCognitoIdentityProvider_AdminDeleteUserAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -215,11 +191,7 @@ func ExampleCognitoIdentityProvider_AdminDeleteUserAttributes() {
 }
 
 func ExampleCognitoIdentityProvider_AdminDisableUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -241,11 +213,7 @@ func ExampleCognitoIdentityProvider_AdminDisableUser() {
 }
 
 func ExampleCognitoIdentityProvider_AdminEnableUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -267,11 +235,7 @@ func ExampleCognitoIdentityProvider_AdminEnableUser() {
 }
 
 func ExampleCognitoIdentityProvider_AdminForgetDevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -294,11 +258,7 @@ func ExampleCognitoIdentityProvider_AdminForgetDevice() {
 }
 
 func ExampleCognitoIdentityProvider_AdminGetDevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -321,11 +281,7 @@ func ExampleCognitoIdentityProvider_AdminGetDevice() {
 }
 
 func ExampleCognitoIdentityProvider_AdminGetUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -347,11 +303,7 @@ func ExampleCognitoIdentityProvider_AdminGetUser() {
 }
 
 func ExampleCognitoIdentityProvider_AdminInitiateAuth() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -382,11 +334,7 @@ func ExampleCognitoIdentityProvider_AdminInitiateAuth() {
 }
 
 func ExampleCognitoIdentityProvider_AdminListDevices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -410,11 +358,7 @@ func ExampleCognitoIdentityProvider_AdminListDevices() {
 }
 
 func ExampleCognitoIdentityProvider_AdminListGroupsForUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -438,11 +382,7 @@ func ExampleCognitoIdentityProvider_AdminListGroupsForUser() {
 }
 
 func ExampleCognitoIdentityProvider_AdminRemoveUserFromGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -465,11 +405,7 @@ func ExampleCognitoIdentityProvider_AdminRemoveUserFromGroup() {
 }
 
 func ExampleCognitoIdentityProvider_AdminResetUserPassword() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -491,11 +427,7 @@ func ExampleCognitoIdentityProvider_AdminResetUserPassword() {
 }
 
 func ExampleCognitoIdentityProvider_AdminRespondToAuthChallenge() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -523,11 +455,7 @@ func ExampleCognitoIdentityProvider_AdminRespondToAuthChallenge() {
 }
 
 func ExampleCognitoIdentityProvider_AdminSetUserSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -556,11 +484,7 @@ func ExampleCognitoIdentityProvider_AdminSetUserSettings() {
 }
 
 func ExampleCognitoIdentityProvider_AdminUpdateDeviceStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -584,11 +508,7 @@ func ExampleCognitoIdentityProvider_AdminUpdateDeviceStatus() {
 }
 
 func ExampleCognitoIdentityProvider_AdminUpdateUserAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -617,11 +537,7 @@ func ExampleCognitoIdentityProvider_AdminUpdateUserAttributes() {
 }
 
 func ExampleCognitoIdentityProvider_AdminUserGlobalSignOut() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -643,11 +559,7 @@ func ExampleCognitoIdentityProvider_AdminUserGlobalSignOut() {
 }
 
 func ExampleCognitoIdentityProvider_ChangePassword() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -670,11 +582,7 @@ func ExampleCognitoIdentityProvider_ChangePassword() {
 }
 
 func ExampleCognitoIdentityProvider_ConfirmDevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -701,11 +609,7 @@ func ExampleCognitoIdentityProvider_ConfirmDevice() {
 }
 
 func ExampleCognitoIdentityProvider_ConfirmForgotPassword() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -730,11 +634,7 @@ func ExampleCognitoIdentityProvider_ConfirmForgotPassword() {
 }
 
 func ExampleCognitoIdentityProvider_ConfirmSignUp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -759,11 +659,7 @@ func ExampleCognitoIdentityProvider_ConfirmSignUp() {
 }
 
 func ExampleCognitoIdentityProvider_CreateGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -788,11 +684,7 @@ func ExampleCognitoIdentityProvider_CreateGroup() {
 }
 
 func ExampleCognitoIdentityProvider_CreateUserImportJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -815,11 +707,7 @@ func ExampleCognitoIdentityProvider_CreateUserImportJob() {
 }
 
 func ExampleCognitoIdentityProvider_CreateUserPool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -915,11 +803,7 @@ func ExampleCognitoIdentityProvider_CreateUserPool() {
 }
 
 func ExampleCognitoIdentityProvider_CreateUserPoolClient() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -955,11 +839,7 @@ func ExampleCognitoIdentityProvider_CreateUserPoolClient() {
 }
 
 func ExampleCognitoIdentityProvider_DeleteGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -981,11 +861,7 @@ func ExampleCognitoIdentityProvider_DeleteGroup() {
 }
 
 func ExampleCognitoIdentityProvider_DeleteUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1006,11 +882,7 @@ func ExampleCognitoIdentityProvider_DeleteUser() {
 }
 
 func ExampleCognitoIdentityProvider_DeleteUserAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1035,11 +907,7 @@ func ExampleCognitoIdentityProvider_DeleteUserAttributes() {
 }
 
 func ExampleCognitoIdentityProvider_DeleteUserPool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1060,11 +928,7 @@ func ExampleCognitoIdentityProvider_DeleteUserPool() {
 }
 
 func ExampleCognitoIdentityProvider_DeleteUserPoolClient() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1086,11 +950,7 @@ func ExampleCognitoIdentityProvider_DeleteUserPoolClient() {
 }
 
 func ExampleCognitoIdentityProvider_DescribeUserImportJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1112,11 +972,7 @@ func ExampleCognitoIdentityProvider_DescribeUserImportJob() {
 }
 
 func ExampleCognitoIdentityProvider_DescribeUserPool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1137,11 +993,7 @@ func ExampleCognitoIdentityProvider_DescribeUserPool() {
 }
 
 func ExampleCognitoIdentityProvider_DescribeUserPoolClient() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1163,11 +1015,7 @@ func ExampleCognitoIdentityProvider_DescribeUserPoolClient() {
 }
 
 func ExampleCognitoIdentityProvider_ForgetDevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1189,11 +1037,7 @@ func ExampleCognitoIdentityProvider_ForgetDevice() {
 }
 
 func ExampleCognitoIdentityProvider_ForgotPassword() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1216,11 +1060,7 @@ func ExampleCognitoIdentityProvider_ForgotPassword() {
 }
 
 func ExampleCognitoIdentityProvider_GetCSVHeader() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1241,11 +1081,7 @@ func ExampleCognitoIdentityProvider_GetCSVHeader() {
 }
 
 func ExampleCognitoIdentityProvider_GetDevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1267,11 +1103,7 @@ func ExampleCognitoIdentityProvider_GetDevice() {
 }
 
 func ExampleCognitoIdentityProvider_GetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1293,11 +1125,7 @@ func ExampleCognitoIdentityProvider_GetGroup() {
 }
 
 func ExampleCognitoIdentityProvider_GetUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1318,11 +1146,7 @@ func ExampleCognitoIdentityProvider_GetUser() {
 }
 
 func ExampleCognitoIdentityProvider_GetUserAttributeVerificationCode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1344,11 +1168,7 @@ func ExampleCognitoIdentityProvider_GetUserAttributeVerificationCode() {
 }
 
 func ExampleCognitoIdentityProvider_GlobalSignOut() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1369,11 +1189,7 @@ func ExampleCognitoIdentityProvider_GlobalSignOut() {
 }
 
 func ExampleCognitoIdentityProvider_InitiateAuth() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1403,11 +1219,7 @@ func ExampleCognitoIdentityProvider_InitiateAuth() {
 }
 
 func ExampleCognitoIdentityProvider_ListDevices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1430,11 +1242,7 @@ func ExampleCognitoIdentityProvider_ListDevices() {
 }
 
 func ExampleCognitoIdentityProvider_ListGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1457,11 +1265,7 @@ func ExampleCognitoIdentityProvider_ListGroups() {
 }
 
 func ExampleCognitoIdentityProvider_ListUserImportJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1484,11 +1288,7 @@ func ExampleCognitoIdentityProvider_ListUserImportJobs() {
 }
 
 func ExampleCognitoIdentityProvider_ListUserPoolClients() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1511,11 +1311,7 @@ func ExampleCognitoIdentityProvider_ListUserPoolClients() {
 }
 
 func ExampleCognitoIdentityProvider_ListUserPools() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1537,11 +1333,7 @@ func ExampleCognitoIdentityProvider_ListUserPools() {
 }
 
 func ExampleCognitoIdentityProvider_ListUsers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1569,11 +1361,7 @@ func ExampleCognitoIdentityProvider_ListUsers() {
 }
 
 func ExampleCognitoIdentityProvider_ListUsersInGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1597,11 +1385,7 @@ func ExampleCognitoIdentityProvider_ListUsersInGroup() {
 }
 
 func ExampleCognitoIdentityProvider_ResendConfirmationCode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1624,11 +1408,7 @@ func ExampleCognitoIdentityProvider_ResendConfirmationCode() {
 }
 
 func ExampleCognitoIdentityProvider_RespondToAuthChallenge() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1655,11 +1435,7 @@ func ExampleCognitoIdentityProvider_RespondToAuthChallenge() {
 }
 
 func ExampleCognitoIdentityProvider_SetUserSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1687,11 +1463,7 @@ func ExampleCognitoIdentityProvider_SetUserSettings() {
 }
 
 func ExampleCognitoIdentityProvider_SignUp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1729,11 +1501,7 @@ func ExampleCognitoIdentityProvider_SignUp() {
 }
 
 func ExampleCognitoIdentityProvider_StartUserImportJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1755,11 +1523,7 @@ func ExampleCognitoIdentityProvider_StartUserImportJob() {
 }
 
 func ExampleCognitoIdentityProvider_StopUserImportJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1781,11 +1545,7 @@ func ExampleCognitoIdentityProvider_StopUserImportJob() {
 }
 
 func ExampleCognitoIdentityProvider_UpdateDeviceStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1808,11 +1568,7 @@ func ExampleCognitoIdentityProvider_UpdateDeviceStatus() {
 }
 
 func ExampleCognitoIdentityProvider_UpdateGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1837,11 +1593,7 @@ func ExampleCognitoIdentityProvider_UpdateGroup() {
 }
 
 func ExampleCognitoIdentityProvider_UpdateUserAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1869,11 +1621,7 @@ func ExampleCognitoIdentityProvider_UpdateUserAttributes() {
 }
 
 func ExampleCognitoIdentityProvider_UpdateUserPool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1947,11 +1695,7 @@ func ExampleCognitoIdentityProvider_UpdateUserPool() {
 }
 
 func ExampleCognitoIdentityProvider_UpdateUserPoolClient() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 
@@ -1987,11 +1731,7 @@ func ExampleCognitoIdentityProvider_UpdateUserPoolClient() {
 }
 
 func ExampleCognitoIdentityProvider_VerifyUserAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitoidentityprovider.New(sess)
 

--- a/service/cognitosync/examples_test.go
+++ b/service/cognitosync/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCognitoSync_BulkPublish() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleCognitoSync_BulkPublish() {
 }
 
 func ExampleCognitoSync_DeleteDataset() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -68,11 +60,7 @@ func ExampleCognitoSync_DeleteDataset() {
 }
 
 func ExampleCognitoSync_DescribeDataset() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -95,11 +83,7 @@ func ExampleCognitoSync_DescribeDataset() {
 }
 
 func ExampleCognitoSync_DescribeIdentityPoolUsage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -120,11 +104,7 @@ func ExampleCognitoSync_DescribeIdentityPoolUsage() {
 }
 
 func ExampleCognitoSync_DescribeIdentityUsage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -146,11 +126,7 @@ func ExampleCognitoSync_DescribeIdentityUsage() {
 }
 
 func ExampleCognitoSync_GetBulkPublishDetails() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -171,11 +147,7 @@ func ExampleCognitoSync_GetBulkPublishDetails() {
 }
 
 func ExampleCognitoSync_GetCognitoEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -196,11 +168,7 @@ func ExampleCognitoSync_GetCognitoEvents() {
 }
 
 func ExampleCognitoSync_GetIdentityPoolConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -221,11 +189,7 @@ func ExampleCognitoSync_GetIdentityPoolConfiguration() {
 }
 
 func ExampleCognitoSync_ListDatasets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -249,11 +213,7 @@ func ExampleCognitoSync_ListDatasets() {
 }
 
 func ExampleCognitoSync_ListIdentityPoolUsage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -275,11 +235,7 @@ func ExampleCognitoSync_ListIdentityPoolUsage() {
 }
 
 func ExampleCognitoSync_ListRecords() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -306,11 +262,7 @@ func ExampleCognitoSync_ListRecords() {
 }
 
 func ExampleCognitoSync_RegisterDevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -334,11 +286,7 @@ func ExampleCognitoSync_RegisterDevice() {
 }
 
 func ExampleCognitoSync_SetCognitoEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -363,11 +311,7 @@ func ExampleCognitoSync_SetCognitoEvents() {
 }
 
 func ExampleCognitoSync_SetIdentityPoolConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -400,11 +344,7 @@ func ExampleCognitoSync_SetIdentityPoolConfiguration() {
 }
 
 func ExampleCognitoSync_SubscribeToDataset() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -428,11 +368,7 @@ func ExampleCognitoSync_SubscribeToDataset() {
 }
 
 func ExampleCognitoSync_UnsubscribeFromDataset() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 
@@ -456,11 +392,7 @@ func ExampleCognitoSync_UnsubscribeFromDataset() {
 }
 
 func ExampleCognitoSync_UpdateRecords() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := cognitosync.New(sess)
 

--- a/service/configservice/examples_test.go
+++ b/service/configservice/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleConfigService_DeleteConfigRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleConfigService_DeleteConfigRule() {
 }
 
 func ExampleConfigService_DeleteConfigurationRecorder() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -66,11 +58,7 @@ func ExampleConfigService_DeleteConfigurationRecorder() {
 }
 
 func ExampleConfigService_DeleteDeliveryChannel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -91,11 +79,7 @@ func ExampleConfigService_DeleteDeliveryChannel() {
 }
 
 func ExampleConfigService_DeleteEvaluationResults() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -116,11 +100,7 @@ func ExampleConfigService_DeleteEvaluationResults() {
 }
 
 func ExampleConfigService_DeliverConfigSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -141,11 +121,7 @@ func ExampleConfigService_DeliverConfigSnapshot() {
 }
 
 func ExampleConfigService_DescribeComplianceByConfigRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -174,11 +150,7 @@ func ExampleConfigService_DescribeComplianceByConfigRule() {
 }
 
 func ExampleConfigService_DescribeComplianceByResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -206,11 +178,7 @@ func ExampleConfigService_DescribeComplianceByResource() {
 }
 
 func ExampleConfigService_DescribeConfigRuleEvaluationStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -236,11 +204,7 @@ func ExampleConfigService_DescribeConfigRuleEvaluationStatus() {
 }
 
 func ExampleConfigService_DescribeConfigRules() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -265,11 +229,7 @@ func ExampleConfigService_DescribeConfigRules() {
 }
 
 func ExampleConfigService_DescribeConfigurationRecorderStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -293,11 +253,7 @@ func ExampleConfigService_DescribeConfigurationRecorderStatus() {
 }
 
 func ExampleConfigService_DescribeConfigurationRecorders() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -321,11 +277,7 @@ func ExampleConfigService_DescribeConfigurationRecorders() {
 }
 
 func ExampleConfigService_DescribeDeliveryChannelStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -349,11 +301,7 @@ func ExampleConfigService_DescribeDeliveryChannelStatus() {
 }
 
 func ExampleConfigService_DescribeDeliveryChannels() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -377,11 +325,7 @@ func ExampleConfigService_DescribeDeliveryChannels() {
 }
 
 func ExampleConfigService_GetComplianceDetailsByConfigRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -408,11 +352,7 @@ func ExampleConfigService_GetComplianceDetailsByConfigRule() {
 }
 
 func ExampleConfigService_GetComplianceDetailsByResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -439,11 +379,7 @@ func ExampleConfigService_GetComplianceDetailsByResource() {
 }
 
 func ExampleConfigService_GetComplianceSummaryByConfigRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -462,11 +398,7 @@ func ExampleConfigService_GetComplianceSummaryByConfigRule() {
 }
 
 func ExampleConfigService_GetComplianceSummaryByResourceType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -490,11 +422,7 @@ func ExampleConfigService_GetComplianceSummaryByResourceType() {
 }
 
 func ExampleConfigService_GetResourceConfigHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -521,11 +449,7 @@ func ExampleConfigService_GetResourceConfigHistory() {
 }
 
 func ExampleConfigService_ListDiscoveredResources() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -554,11 +478,7 @@ func ExampleConfigService_ListDiscoveredResources() {
 }
 
 func ExampleConfigService_PutConfigRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -608,11 +528,7 @@ func ExampleConfigService_PutConfigRule() {
 }
 
 func ExampleConfigService_PutConfigurationRecorder() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -644,11 +560,7 @@ func ExampleConfigService_PutConfigurationRecorder() {
 }
 
 func ExampleConfigService_PutDeliveryChannel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -677,11 +589,7 @@ func ExampleConfigService_PutDeliveryChannel() {
 }
 
 func ExampleConfigService_PutEvaluations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -713,11 +621,7 @@ func ExampleConfigService_PutEvaluations() {
 }
 
 func ExampleConfigService_StartConfigRulesEvaluation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -741,11 +645,7 @@ func ExampleConfigService_StartConfigRulesEvaluation() {
 }
 
 func ExampleConfigService_StartConfigurationRecorder() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 
@@ -766,11 +666,7 @@ func ExampleConfigService_StartConfigurationRecorder() {
 }
 
 func ExampleConfigService_StopConfigurationRecorder() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := configservice.New(sess)
 

--- a/service/costandusagereportservice/examples_test.go
+++ b/service/costandusagereportservice/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleCostandUsageReportService_DeleteReportDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := costandusagereportservice.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleCostandUsageReportService_DeleteReportDefinition() {
 }
 
 func ExampleCostandUsageReportService_DescribeReportDefinitions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := costandusagereportservice.New(sess)
 
@@ -67,11 +59,7 @@ func ExampleCostandUsageReportService_DescribeReportDefinitions() {
 }
 
 func ExampleCostandUsageReportService_PutReportDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := costandusagereportservice.New(sess)
 

--- a/service/databasemigrationservice/examples_test.go
+++ b/service/databasemigrationservice/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleDatabaseMigrationService_AddTagsToResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleDatabaseMigrationService_AddTagsToResource() {
 }
 
 func ExampleDatabaseMigrationService_CreateEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -91,11 +83,7 @@ func ExampleDatabaseMigrationService_CreateEndpoint() {
 }
 
 func ExampleDatabaseMigrationService_CreateReplicationInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -137,11 +125,7 @@ func ExampleDatabaseMigrationService_CreateReplicationInstance() {
 }
 
 func ExampleDatabaseMigrationService_CreateReplicationSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -174,11 +158,7 @@ func ExampleDatabaseMigrationService_CreateReplicationSubnetGroup() {
 }
 
 func ExampleDatabaseMigrationService_CreateReplicationTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -213,11 +193,7 @@ func ExampleDatabaseMigrationService_CreateReplicationTask() {
 }
 
 func ExampleDatabaseMigrationService_DeleteCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -238,11 +214,7 @@ func ExampleDatabaseMigrationService_DeleteCertificate() {
 }
 
 func ExampleDatabaseMigrationService_DeleteEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -263,11 +235,7 @@ func ExampleDatabaseMigrationService_DeleteEndpoint() {
 }
 
 func ExampleDatabaseMigrationService_DeleteReplicationInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -288,11 +256,7 @@ func ExampleDatabaseMigrationService_DeleteReplicationInstance() {
 }
 
 func ExampleDatabaseMigrationService_DeleteReplicationSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -313,11 +277,7 @@ func ExampleDatabaseMigrationService_DeleteReplicationSubnetGroup() {
 }
 
 func ExampleDatabaseMigrationService_DeleteReplicationTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -338,11 +298,7 @@ func ExampleDatabaseMigrationService_DeleteReplicationTask() {
 }
 
 func ExampleDatabaseMigrationService_DescribeAccountAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -361,11 +317,7 @@ func ExampleDatabaseMigrationService_DescribeAccountAttributes() {
 }
 
 func ExampleDatabaseMigrationService_DescribeCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -397,11 +349,7 @@ func ExampleDatabaseMigrationService_DescribeCertificates() {
 }
 
 func ExampleDatabaseMigrationService_DescribeConnections() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -433,11 +381,7 @@ func ExampleDatabaseMigrationService_DescribeConnections() {
 }
 
 func ExampleDatabaseMigrationService_DescribeEndpointTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -469,11 +413,7 @@ func ExampleDatabaseMigrationService_DescribeEndpointTypes() {
 }
 
 func ExampleDatabaseMigrationService_DescribeEndpoints() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -505,11 +445,7 @@ func ExampleDatabaseMigrationService_DescribeEndpoints() {
 }
 
 func ExampleDatabaseMigrationService_DescribeOrderableReplicationInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -531,11 +467,7 @@ func ExampleDatabaseMigrationService_DescribeOrderableReplicationInstances() {
 }
 
 func ExampleDatabaseMigrationService_DescribeRefreshSchemasStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -556,11 +488,7 @@ func ExampleDatabaseMigrationService_DescribeRefreshSchemasStatus() {
 }
 
 func ExampleDatabaseMigrationService_DescribeReplicationInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -592,11 +520,7 @@ func ExampleDatabaseMigrationService_DescribeReplicationInstances() {
 }
 
 func ExampleDatabaseMigrationService_DescribeReplicationSubnetGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -628,11 +552,7 @@ func ExampleDatabaseMigrationService_DescribeReplicationSubnetGroups() {
 }
 
 func ExampleDatabaseMigrationService_DescribeReplicationTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -664,11 +584,7 @@ func ExampleDatabaseMigrationService_DescribeReplicationTasks() {
 }
 
 func ExampleDatabaseMigrationService_DescribeSchemas() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -691,11 +607,7 @@ func ExampleDatabaseMigrationService_DescribeSchemas() {
 }
 
 func ExampleDatabaseMigrationService_DescribeTableStatistics() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -718,11 +630,7 @@ func ExampleDatabaseMigrationService_DescribeTableStatistics() {
 }
 
 func ExampleDatabaseMigrationService_ImportCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -745,11 +653,7 @@ func ExampleDatabaseMigrationService_ImportCertificate() {
 }
 
 func ExampleDatabaseMigrationService_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -770,11 +674,7 @@ func ExampleDatabaseMigrationService_ListTagsForResource() {
 }
 
 func ExampleDatabaseMigrationService_ModifyEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -806,11 +706,7 @@ func ExampleDatabaseMigrationService_ModifyEndpoint() {
 }
 
 func ExampleDatabaseMigrationService_ModifyReplicationInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -844,11 +740,7 @@ func ExampleDatabaseMigrationService_ModifyReplicationInstance() {
 }
 
 func ExampleDatabaseMigrationService_ModifyReplicationSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -874,11 +766,7 @@ func ExampleDatabaseMigrationService_ModifyReplicationSubnetGroup() {
 }
 
 func ExampleDatabaseMigrationService_ModifyReplicationTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -904,11 +792,7 @@ func ExampleDatabaseMigrationService_ModifyReplicationTask() {
 }
 
 func ExampleDatabaseMigrationService_RefreshSchemas() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -930,11 +814,7 @@ func ExampleDatabaseMigrationService_RefreshSchemas() {
 }
 
 func ExampleDatabaseMigrationService_RemoveTagsFromResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -959,11 +839,7 @@ func ExampleDatabaseMigrationService_RemoveTagsFromResource() {
 }
 
 func ExampleDatabaseMigrationService_StartReplicationTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -986,11 +862,7 @@ func ExampleDatabaseMigrationService_StartReplicationTask() {
 }
 
 func ExampleDatabaseMigrationService_StopReplicationTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 
@@ -1011,11 +883,7 @@ func ExampleDatabaseMigrationService_StopReplicationTask() {
 }
 
 func ExampleDatabaseMigrationService_TestConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := databasemigrationservice.New(sess)
 

--- a/service/datapipeline/examples_test.go
+++ b/service/datapipeline/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleDataPipeline_ActivatePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -49,11 +45,7 @@ func ExampleDataPipeline_ActivatePipeline() {
 }
 
 func ExampleDataPipeline_AddTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -81,11 +73,7 @@ func ExampleDataPipeline_AddTags() {
 }
 
 func ExampleDataPipeline_CreatePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -115,11 +103,7 @@ func ExampleDataPipeline_CreatePipeline() {
 }
 
 func ExampleDataPipeline_DeactivatePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -141,11 +125,7 @@ func ExampleDataPipeline_DeactivatePipeline() {
 }
 
 func ExampleDataPipeline_DeletePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -166,11 +146,7 @@ func ExampleDataPipeline_DeletePipeline() {
 }
 
 func ExampleDataPipeline_DescribeObjects() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -197,11 +173,7 @@ func ExampleDataPipeline_DescribeObjects() {
 }
 
 func ExampleDataPipeline_DescribePipelines() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -225,11 +197,7 @@ func ExampleDataPipeline_DescribePipelines() {
 }
 
 func ExampleDataPipeline_EvaluateExpression() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -252,11 +220,7 @@ func ExampleDataPipeline_EvaluateExpression() {
 }
 
 func ExampleDataPipeline_GetPipelineDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -278,11 +242,7 @@ func ExampleDataPipeline_GetPipelineDefinition() {
 }
 
 func ExampleDataPipeline_ListPipelines() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -303,11 +263,7 @@ func ExampleDataPipeline_ListPipelines() {
 }
 
 func ExampleDataPipeline_PollForTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -333,11 +289,7 @@ func ExampleDataPipeline_PollForTask() {
 }
 
 func ExampleDataPipeline_PutPipelineDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -393,11 +345,7 @@ func ExampleDataPipeline_PutPipelineDefinition() {
 }
 
 func ExampleDataPipeline_QueryObjects() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -436,11 +384,7 @@ func ExampleDataPipeline_QueryObjects() {
 }
 
 func ExampleDataPipeline_RemoveTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -465,11 +409,7 @@ func ExampleDataPipeline_RemoveTags() {
 }
 
 func ExampleDataPipeline_ReportTaskProgress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -498,11 +438,7 @@ func ExampleDataPipeline_ReportTaskProgress() {
 }
 
 func ExampleDataPipeline_ReportTaskRunnerHeartbeat() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -525,11 +461,7 @@ func ExampleDataPipeline_ReportTaskRunnerHeartbeat() {
 }
 
 func ExampleDataPipeline_SetStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -555,11 +487,7 @@ func ExampleDataPipeline_SetStatus() {
 }
 
 func ExampleDataPipeline_SetTaskStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 
@@ -584,11 +512,7 @@ func ExampleDataPipeline_SetTaskStatus() {
 }
 
 func ExampleDataPipeline_ValidatePipelineDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := datapipeline.New(sess)
 

--- a/service/devicefarm/examples_test.go
+++ b/service/devicefarm/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleDeviceFarm_CreateDevicePool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -51,11 +47,7 @@ func ExampleDeviceFarm_CreateDevicePool() {
 }
 
 func ExampleDeviceFarm_CreateProject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -76,11 +68,7 @@ func ExampleDeviceFarm_CreateProject() {
 }
 
 func ExampleDeviceFarm_CreateRemoteAccessSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -106,11 +94,7 @@ func ExampleDeviceFarm_CreateRemoteAccessSession() {
 }
 
 func ExampleDeviceFarm_CreateUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -134,11 +118,7 @@ func ExampleDeviceFarm_CreateUpload() {
 }
 
 func ExampleDeviceFarm_DeleteDevicePool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -159,11 +139,7 @@ func ExampleDeviceFarm_DeleteDevicePool() {
 }
 
 func ExampleDeviceFarm_DeleteProject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -184,11 +160,7 @@ func ExampleDeviceFarm_DeleteProject() {
 }
 
 func ExampleDeviceFarm_DeleteRemoteAccessSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -209,11 +181,7 @@ func ExampleDeviceFarm_DeleteRemoteAccessSession() {
 }
 
 func ExampleDeviceFarm_DeleteRun() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -234,11 +202,7 @@ func ExampleDeviceFarm_DeleteRun() {
 }
 
 func ExampleDeviceFarm_DeleteUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -259,11 +223,7 @@ func ExampleDeviceFarm_DeleteUpload() {
 }
 
 func ExampleDeviceFarm_GetAccountSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -282,11 +242,7 @@ func ExampleDeviceFarm_GetAccountSettings() {
 }
 
 func ExampleDeviceFarm_GetDevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -307,11 +263,7 @@ func ExampleDeviceFarm_GetDevice() {
 }
 
 func ExampleDeviceFarm_GetDevicePool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -332,11 +284,7 @@ func ExampleDeviceFarm_GetDevicePool() {
 }
 
 func ExampleDeviceFarm_GetDevicePoolCompatibility() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -359,11 +307,7 @@ func ExampleDeviceFarm_GetDevicePoolCompatibility() {
 }
 
 func ExampleDeviceFarm_GetJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -384,11 +328,7 @@ func ExampleDeviceFarm_GetJob() {
 }
 
 func ExampleDeviceFarm_GetOfferingStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -409,11 +349,7 @@ func ExampleDeviceFarm_GetOfferingStatus() {
 }
 
 func ExampleDeviceFarm_GetProject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -434,11 +370,7 @@ func ExampleDeviceFarm_GetProject() {
 }
 
 func ExampleDeviceFarm_GetRemoteAccessSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -459,11 +391,7 @@ func ExampleDeviceFarm_GetRemoteAccessSession() {
 }
 
 func ExampleDeviceFarm_GetRun() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -484,11 +412,7 @@ func ExampleDeviceFarm_GetRun() {
 }
 
 func ExampleDeviceFarm_GetSuite() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -509,11 +433,7 @@ func ExampleDeviceFarm_GetSuite() {
 }
 
 func ExampleDeviceFarm_GetTest() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -534,11 +454,7 @@ func ExampleDeviceFarm_GetTest() {
 }
 
 func ExampleDeviceFarm_GetUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -559,11 +475,7 @@ func ExampleDeviceFarm_GetUpload() {
 }
 
 func ExampleDeviceFarm_InstallToRemoteAccessSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -585,11 +497,7 @@ func ExampleDeviceFarm_InstallToRemoteAccessSession() {
 }
 
 func ExampleDeviceFarm_ListArtifacts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -612,11 +520,7 @@ func ExampleDeviceFarm_ListArtifacts() {
 }
 
 func ExampleDeviceFarm_ListDevicePools() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -639,11 +543,7 @@ func ExampleDeviceFarm_ListDevicePools() {
 }
 
 func ExampleDeviceFarm_ListDevices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -665,11 +565,7 @@ func ExampleDeviceFarm_ListDevices() {
 }
 
 func ExampleDeviceFarm_ListJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -691,11 +587,7 @@ func ExampleDeviceFarm_ListJobs() {
 }
 
 func ExampleDeviceFarm_ListOfferingTransactions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -716,11 +608,7 @@ func ExampleDeviceFarm_ListOfferingTransactions() {
 }
 
 func ExampleDeviceFarm_ListOfferings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -741,11 +629,7 @@ func ExampleDeviceFarm_ListOfferings() {
 }
 
 func ExampleDeviceFarm_ListProjects() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -767,11 +651,7 @@ func ExampleDeviceFarm_ListProjects() {
 }
 
 func ExampleDeviceFarm_ListRemoteAccessSessions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -793,11 +673,7 @@ func ExampleDeviceFarm_ListRemoteAccessSessions() {
 }
 
 func ExampleDeviceFarm_ListRuns() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -819,11 +695,7 @@ func ExampleDeviceFarm_ListRuns() {
 }
 
 func ExampleDeviceFarm_ListSamples() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -845,11 +717,7 @@ func ExampleDeviceFarm_ListSamples() {
 }
 
 func ExampleDeviceFarm_ListSuites() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -871,11 +739,7 @@ func ExampleDeviceFarm_ListSuites() {
 }
 
 func ExampleDeviceFarm_ListTests() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -897,11 +761,7 @@ func ExampleDeviceFarm_ListTests() {
 }
 
 func ExampleDeviceFarm_ListUniqueProblems() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -923,11 +783,7 @@ func ExampleDeviceFarm_ListUniqueProblems() {
 }
 
 func ExampleDeviceFarm_ListUploads() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -949,11 +805,7 @@ func ExampleDeviceFarm_ListUploads() {
 }
 
 func ExampleDeviceFarm_PurchaseOffering() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -975,11 +827,7 @@ func ExampleDeviceFarm_PurchaseOffering() {
 }
 
 func ExampleDeviceFarm_RenewOffering() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -1001,11 +849,7 @@ func ExampleDeviceFarm_RenewOffering() {
 }
 
 func ExampleDeviceFarm_ScheduleRun() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -1058,11 +902,7 @@ func ExampleDeviceFarm_ScheduleRun() {
 }
 
 func ExampleDeviceFarm_StopRemoteAccessSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -1083,11 +923,7 @@ func ExampleDeviceFarm_StopRemoteAccessSession() {
 }
 
 func ExampleDeviceFarm_StopRun() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -1108,11 +944,7 @@ func ExampleDeviceFarm_StopRun() {
 }
 
 func ExampleDeviceFarm_UpdateDevicePool() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 
@@ -1143,11 +975,7 @@ func ExampleDeviceFarm_UpdateDevicePool() {
 }
 
 func ExampleDeviceFarm_UpdateProject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := devicefarm.New(sess)
 

--- a/service/directconnect/examples_test.go
+++ b/service/directconnect/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleDirectConnect_AllocateConnectionOnInterconnect() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -45,11 +41,7 @@ func ExampleDirectConnect_AllocateConnectionOnInterconnect() {
 }
 
 func ExampleDirectConnect_AllocateHostedConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -74,11 +66,7 @@ func ExampleDirectConnect_AllocateHostedConnection() {
 }
 
 func ExampleDirectConnect_AllocatePrivateVirtualInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -109,11 +97,7 @@ func ExampleDirectConnect_AllocatePrivateVirtualInterface() {
 }
 
 func ExampleDirectConnect_AllocatePublicVirtualInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -150,11 +134,7 @@ func ExampleDirectConnect_AllocatePublicVirtualInterface() {
 }
 
 func ExampleDirectConnect_AssociateConnectionWithLag() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -176,11 +156,7 @@ func ExampleDirectConnect_AssociateConnectionWithLag() {
 }
 
 func ExampleDirectConnect_AssociateHostedConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -202,11 +178,7 @@ func ExampleDirectConnect_AssociateHostedConnection() {
 }
 
 func ExampleDirectConnect_AssociateVirtualInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -228,11 +200,7 @@ func ExampleDirectConnect_AssociateVirtualInterface() {
 }
 
 func ExampleDirectConnect_ConfirmConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -253,11 +221,7 @@ func ExampleDirectConnect_ConfirmConnection() {
 }
 
 func ExampleDirectConnect_ConfirmPrivateVirtualInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -279,11 +243,7 @@ func ExampleDirectConnect_ConfirmPrivateVirtualInterface() {
 }
 
 func ExampleDirectConnect_ConfirmPublicVirtualInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -304,11 +264,7 @@ func ExampleDirectConnect_ConfirmPublicVirtualInterface() {
 }
 
 func ExampleDirectConnect_CreateBGPPeer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -336,11 +292,7 @@ func ExampleDirectConnect_CreateBGPPeer() {
 }
 
 func ExampleDirectConnect_CreateConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -364,11 +316,7 @@ func ExampleDirectConnect_CreateConnection() {
 }
 
 func ExampleDirectConnect_CreateInterconnect() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -392,11 +340,7 @@ func ExampleDirectConnect_CreateInterconnect() {
 }
 
 func ExampleDirectConnect_CreateLag() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -421,11 +365,7 @@ func ExampleDirectConnect_CreateLag() {
 }
 
 func ExampleDirectConnect_CreatePrivateVirtualInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -456,11 +396,7 @@ func ExampleDirectConnect_CreatePrivateVirtualInterface() {
 }
 
 func ExampleDirectConnect_CreatePublicVirtualInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -496,11 +432,7 @@ func ExampleDirectConnect_CreatePublicVirtualInterface() {
 }
 
 func ExampleDirectConnect_DeleteBGPPeer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -523,11 +455,7 @@ func ExampleDirectConnect_DeleteBGPPeer() {
 }
 
 func ExampleDirectConnect_DeleteConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -548,11 +476,7 @@ func ExampleDirectConnect_DeleteConnection() {
 }
 
 func ExampleDirectConnect_DeleteInterconnect() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -573,11 +497,7 @@ func ExampleDirectConnect_DeleteInterconnect() {
 }
 
 func ExampleDirectConnect_DeleteLag() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -598,11 +518,7 @@ func ExampleDirectConnect_DeleteLag() {
 }
 
 func ExampleDirectConnect_DeleteVirtualInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -623,11 +539,7 @@ func ExampleDirectConnect_DeleteVirtualInterface() {
 }
 
 func ExampleDirectConnect_DescribeConnectionLoa() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -650,11 +562,7 @@ func ExampleDirectConnect_DescribeConnectionLoa() {
 }
 
 func ExampleDirectConnect_DescribeConnections() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -675,11 +583,7 @@ func ExampleDirectConnect_DescribeConnections() {
 }
 
 func ExampleDirectConnect_DescribeConnectionsOnInterconnect() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -700,11 +604,7 @@ func ExampleDirectConnect_DescribeConnectionsOnInterconnect() {
 }
 
 func ExampleDirectConnect_DescribeHostedConnections() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -725,11 +625,7 @@ func ExampleDirectConnect_DescribeHostedConnections() {
 }
 
 func ExampleDirectConnect_DescribeInterconnectLoa() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -752,11 +648,7 @@ func ExampleDirectConnect_DescribeInterconnectLoa() {
 }
 
 func ExampleDirectConnect_DescribeInterconnects() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -777,11 +669,7 @@ func ExampleDirectConnect_DescribeInterconnects() {
 }
 
 func ExampleDirectConnect_DescribeLags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -802,11 +690,7 @@ func ExampleDirectConnect_DescribeLags() {
 }
 
 func ExampleDirectConnect_DescribeLoa() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -829,11 +713,7 @@ func ExampleDirectConnect_DescribeLoa() {
 }
 
 func ExampleDirectConnect_DescribeLocations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -852,11 +732,7 @@ func ExampleDirectConnect_DescribeLocations() {
 }
 
 func ExampleDirectConnect_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -880,11 +756,7 @@ func ExampleDirectConnect_DescribeTags() {
 }
 
 func ExampleDirectConnect_DescribeVirtualGateways() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -903,11 +775,7 @@ func ExampleDirectConnect_DescribeVirtualGateways() {
 }
 
 func ExampleDirectConnect_DescribeVirtualInterfaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -929,11 +797,7 @@ func ExampleDirectConnect_DescribeVirtualInterfaces() {
 }
 
 func ExampleDirectConnect_DisassociateConnectionFromLag() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -955,11 +819,7 @@ func ExampleDirectConnect_DisassociateConnectionFromLag() {
 }
 
 func ExampleDirectConnect_TagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -987,11 +847,7 @@ func ExampleDirectConnect_TagResource() {
 }
 
 func ExampleDirectConnect_UntagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 
@@ -1016,11 +872,7 @@ func ExampleDirectConnect_UntagResource() {
 }
 
 func ExampleDirectConnect_UpdateLag() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directconnect.New(sess)
 

--- a/service/directoryservice/examples_test.go
+++ b/service/directoryservice/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleDirectoryService_AddIpRoutes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -49,11 +45,7 @@ func ExampleDirectoryService_AddIpRoutes() {
 }
 
 func ExampleDirectoryService_AddTagsToResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -81,11 +73,7 @@ func ExampleDirectoryService_AddTagsToResource() {
 }
 
 func ExampleDirectoryService_CancelSchemaExtension() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -107,11 +95,7 @@ func ExampleDirectoryService_CancelSchemaExtension() {
 }
 
 func ExampleDirectoryService_ConnectDirectory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -148,11 +132,7 @@ func ExampleDirectoryService_ConnectDirectory() {
 }
 
 func ExampleDirectoryService_CreateAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -174,11 +154,7 @@ func ExampleDirectoryService_CreateAlias() {
 }
 
 func ExampleDirectoryService_CreateComputer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -209,11 +185,7 @@ func ExampleDirectoryService_CreateComputer() {
 }
 
 func ExampleDirectoryService_CreateConditionalForwarder() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -239,11 +211,7 @@ func ExampleDirectoryService_CreateConditionalForwarder() {
 }
 
 func ExampleDirectoryService_CreateDirectory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -275,11 +243,7 @@ func ExampleDirectoryService_CreateDirectory() {
 }
 
 func ExampleDirectoryService_CreateMicrosoftAD() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -310,11 +274,7 @@ func ExampleDirectoryService_CreateMicrosoftAD() {
 }
 
 func ExampleDirectoryService_CreateSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -336,11 +296,7 @@ func ExampleDirectoryService_CreateSnapshot() {
 }
 
 func ExampleDirectoryService_CreateTrust() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -369,11 +325,7 @@ func ExampleDirectoryService_CreateTrust() {
 }
 
 func ExampleDirectoryService_DeleteConditionalForwarder() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -395,11 +347,7 @@ func ExampleDirectoryService_DeleteConditionalForwarder() {
 }
 
 func ExampleDirectoryService_DeleteDirectory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -420,11 +368,7 @@ func ExampleDirectoryService_DeleteDirectory() {
 }
 
 func ExampleDirectoryService_DeleteSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -445,11 +389,7 @@ func ExampleDirectoryService_DeleteSnapshot() {
 }
 
 func ExampleDirectoryService_DeleteTrust() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -471,11 +411,7 @@ func ExampleDirectoryService_DeleteTrust() {
 }
 
 func ExampleDirectoryService_DeregisterEventTopic() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -497,11 +433,7 @@ func ExampleDirectoryService_DeregisterEventTopic() {
 }
 
 func ExampleDirectoryService_DescribeConditionalForwarders() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -526,11 +458,7 @@ func ExampleDirectoryService_DescribeConditionalForwarders() {
 }
 
 func ExampleDirectoryService_DescribeDirectories() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -556,11 +484,7 @@ func ExampleDirectoryService_DescribeDirectories() {
 }
 
 func ExampleDirectoryService_DescribeEventTopics() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -585,11 +509,7 @@ func ExampleDirectoryService_DescribeEventTopics() {
 }
 
 func ExampleDirectoryService_DescribeSnapshots() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -616,11 +536,7 @@ func ExampleDirectoryService_DescribeSnapshots() {
 }
 
 func ExampleDirectoryService_DescribeTrusts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -647,11 +563,7 @@ func ExampleDirectoryService_DescribeTrusts() {
 }
 
 func ExampleDirectoryService_DisableRadius() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -672,11 +584,7 @@ func ExampleDirectoryService_DisableRadius() {
 }
 
 func ExampleDirectoryService_DisableSso() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -699,11 +607,7 @@ func ExampleDirectoryService_DisableSso() {
 }
 
 func ExampleDirectoryService_EnableRadius() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -737,11 +641,7 @@ func ExampleDirectoryService_EnableRadius() {
 }
 
 func ExampleDirectoryService_EnableSso() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -764,11 +664,7 @@ func ExampleDirectoryService_EnableSso() {
 }
 
 func ExampleDirectoryService_GetDirectoryLimits() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -787,11 +683,7 @@ func ExampleDirectoryService_GetDirectoryLimits() {
 }
 
 func ExampleDirectoryService_GetSnapshotLimits() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -812,11 +704,7 @@ func ExampleDirectoryService_GetSnapshotLimits() {
 }
 
 func ExampleDirectoryService_ListIpRoutes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -839,11 +727,7 @@ func ExampleDirectoryService_ListIpRoutes() {
 }
 
 func ExampleDirectoryService_ListSchemaExtensions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -866,11 +750,7 @@ func ExampleDirectoryService_ListSchemaExtensions() {
 }
 
 func ExampleDirectoryService_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -893,11 +773,7 @@ func ExampleDirectoryService_ListTagsForResource() {
 }
 
 func ExampleDirectoryService_RegisterEventTopic() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -919,11 +795,7 @@ func ExampleDirectoryService_RegisterEventTopic() {
 }
 
 func ExampleDirectoryService_RemoveIpRoutes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -948,11 +820,7 @@ func ExampleDirectoryService_RemoveIpRoutes() {
 }
 
 func ExampleDirectoryService_RemoveTagsFromResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -977,11 +845,7 @@ func ExampleDirectoryService_RemoveTagsFromResource() {
 }
 
 func ExampleDirectoryService_RestoreFromSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -1002,11 +866,7 @@ func ExampleDirectoryService_RestoreFromSnapshot() {
 }
 
 func ExampleDirectoryService_StartSchemaExtension() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -1030,11 +890,7 @@ func ExampleDirectoryService_StartSchemaExtension() {
 }
 
 func ExampleDirectoryService_UpdateConditionalForwarder() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -1060,11 +916,7 @@ func ExampleDirectoryService_UpdateConditionalForwarder() {
 }
 
 func ExampleDirectoryService_UpdateRadius() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 
@@ -1098,11 +950,7 @@ func ExampleDirectoryService_UpdateRadius() {
 }
 
 func ExampleDirectoryService_VerifyTrust() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := directoryservice.New(sess)
 

--- a/service/dynamodb/dynamodbattribute/doc.go
+++ b/service/dynamodb/dynamodbattribute/doc.go
@@ -31,11 +31,7 @@
 //
 // Marshal Go value type for DynamoDB.PutItem:
 //
-//     sess, err := session.NewSession()
-//     if err != nil {
-//         fmt.Println("Failed create session", err)
-//         return
-//     }
+//     sess := session.Must(session.NewSession())
 //
 //     svc := dynamodb.New(sess)
 //     item, err := dynamodbattribute.MarshalMap(r)

--- a/service/dynamodb/examples_test.go
+++ b/service/dynamodb/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleDynamoDB_BatchGetItem() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -93,11 +89,7 @@ func ExampleDynamoDB_BatchGetItem() {
 }
 
 func ExampleDynamoDB_BatchWriteItem() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -199,11 +191,7 @@ func ExampleDynamoDB_BatchWriteItem() {
 }
 
 func ExampleDynamoDB_CreateTable() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -290,11 +278,7 @@ func ExampleDynamoDB_CreateTable() {
 }
 
 func ExampleDynamoDB_DeleteItem() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -464,11 +448,7 @@ func ExampleDynamoDB_DeleteItem() {
 }
 
 func ExampleDynamoDB_DeleteTable() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -489,11 +469,7 @@ func ExampleDynamoDB_DeleteTable() {
 }
 
 func ExampleDynamoDB_DescribeLimits() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -512,11 +488,7 @@ func ExampleDynamoDB_DescribeLimits() {
 }
 
 func ExampleDynamoDB_DescribeTable() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -537,11 +509,7 @@ func ExampleDynamoDB_DescribeTable() {
 }
 
 func ExampleDynamoDB_GetItem() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -607,11 +575,7 @@ func ExampleDynamoDB_GetItem() {
 }
 
 func ExampleDynamoDB_ListTables() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -633,11 +597,7 @@ func ExampleDynamoDB_ListTables() {
 }
 
 func ExampleDynamoDB_ListTagsOfResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -659,11 +619,7 @@ func ExampleDynamoDB_ListTagsOfResource() {
 }
 
 func ExampleDynamoDB_PutItem() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -833,11 +789,7 @@ func ExampleDynamoDB_PutItem() {
 }
 
 func ExampleDynamoDB_Query() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -1024,11 +976,7 @@ func ExampleDynamoDB_Query() {
 }
 
 func ExampleDynamoDB_Scan() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -1175,11 +1123,7 @@ func ExampleDynamoDB_Scan() {
 }
 
 func ExampleDynamoDB_TagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -1207,11 +1151,7 @@ func ExampleDynamoDB_TagResource() {
 }
 
 func ExampleDynamoDB_UntagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -1236,11 +1176,7 @@ func ExampleDynamoDB_UntagResource() {
 }
 
 func ExampleDynamoDB_UpdateItem() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 
@@ -1448,11 +1384,7 @@ func ExampleDynamoDB_UpdateItem() {
 }
 
 func ExampleDynamoDB_UpdateTable() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodb.New(sess)
 

--- a/service/dynamodbstreams/examples_test.go
+++ b/service/dynamodbstreams/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleDynamoDBStreams_DescribeStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodbstreams.New(sess)
 
@@ -43,11 +39,7 @@ func ExampleDynamoDBStreams_DescribeStream() {
 }
 
 func ExampleDynamoDBStreams_GetRecords() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodbstreams.New(sess)
 
@@ -69,11 +61,7 @@ func ExampleDynamoDBStreams_GetRecords() {
 }
 
 func ExampleDynamoDBStreams_GetShardIterator() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodbstreams.New(sess)
 
@@ -97,11 +85,7 @@ func ExampleDynamoDBStreams_GetShardIterator() {
 }
 
 func ExampleDynamoDBStreams_ListStreams() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := dynamodbstreams.New(sess)
 

--- a/service/ec2/examples_test.go
+++ b/service/ec2/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleEC2_AcceptReservedInstancesExchangeQuote() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -52,11 +48,7 @@ func ExampleEC2_AcceptReservedInstancesExchangeQuote() {
 }
 
 func ExampleEC2_AcceptVpcPeeringConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -78,11 +70,7 @@ func ExampleEC2_AcceptVpcPeeringConnection() {
 }
 
 func ExampleEC2_AllocateAddress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -104,11 +92,7 @@ func ExampleEC2_AllocateAddress() {
 }
 
 func ExampleEC2_AllocateHosts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -133,11 +117,7 @@ func ExampleEC2_AllocateHosts() {
 }
 
 func ExampleEC2_AssignIpv6Addresses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -163,11 +143,7 @@ func ExampleEC2_AssignIpv6Addresses() {
 }
 
 func ExampleEC2_AssignPrivateIpAddresses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -194,11 +170,7 @@ func ExampleEC2_AssignPrivateIpAddresses() {
 }
 
 func ExampleEC2_AssociateAddress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -225,11 +197,7 @@ func ExampleEC2_AssociateAddress() {
 }
 
 func ExampleEC2_AssociateDhcpOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -252,11 +220,7 @@ func ExampleEC2_AssociateDhcpOptions() {
 }
 
 func ExampleEC2_AssociateIamInstanceProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -281,11 +245,7 @@ func ExampleEC2_AssociateIamInstanceProfile() {
 }
 
 func ExampleEC2_AssociateRouteTable() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -308,11 +268,7 @@ func ExampleEC2_AssociateRouteTable() {
 }
 
 func ExampleEC2_AssociateSubnetCidrBlock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -334,11 +290,7 @@ func ExampleEC2_AssociateSubnetCidrBlock() {
 }
 
 func ExampleEC2_AssociateVpcCidrBlock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -360,11 +312,7 @@ func ExampleEC2_AssociateVpcCidrBlock() {
 }
 
 func ExampleEC2_AttachClassicLinkVpc() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -391,11 +339,7 @@ func ExampleEC2_AttachClassicLinkVpc() {
 }
 
 func ExampleEC2_AttachInternetGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -418,11 +362,7 @@ func ExampleEC2_AttachInternetGateway() {
 }
 
 func ExampleEC2_AttachNetworkInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -446,11 +386,7 @@ func ExampleEC2_AttachNetworkInterface() {
 }
 
 func ExampleEC2_AttachVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -474,11 +410,7 @@ func ExampleEC2_AttachVolume() {
 }
 
 func ExampleEC2_AttachVpnGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -501,11 +433,7 @@ func ExampleEC2_AttachVpnGateway() {
 }
 
 func ExampleEC2_AuthorizeSecurityGroupEgress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -570,11 +498,7 @@ func ExampleEC2_AuthorizeSecurityGroupEgress() {
 }
 
 func ExampleEC2_AuthorizeSecurityGroupIngress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -640,11 +564,7 @@ func ExampleEC2_AuthorizeSecurityGroupIngress() {
 }
 
 func ExampleEC2_BundleInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -675,11 +595,7 @@ func ExampleEC2_BundleInstance() {
 }
 
 func ExampleEC2_CancelBundleTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -701,11 +617,7 @@ func ExampleEC2_CancelBundleTask() {
 }
 
 func ExampleEC2_CancelConversionTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -728,11 +640,7 @@ func ExampleEC2_CancelConversionTask() {
 }
 
 func ExampleEC2_CancelExportTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -753,11 +661,7 @@ func ExampleEC2_CancelExportTask() {
 }
 
 func ExampleEC2_CancelImportTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -780,11 +684,7 @@ func ExampleEC2_CancelImportTask() {
 }
 
 func ExampleEC2_CancelReservedInstancesListing() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -805,11 +705,7 @@ func ExampleEC2_CancelReservedInstancesListing() {
 }
 
 func ExampleEC2_CancelSpotFleetRequests() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -835,11 +731,7 @@ func ExampleEC2_CancelSpotFleetRequests() {
 }
 
 func ExampleEC2_CancelSpotInstanceRequests() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -864,11 +756,7 @@ func ExampleEC2_CancelSpotInstanceRequests() {
 }
 
 func ExampleEC2_ConfirmProductInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -891,11 +779,7 @@ func ExampleEC2_ConfirmProductInstance() {
 }
 
 func ExampleEC2_CopyImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -923,11 +807,7 @@ func ExampleEC2_CopyImage() {
 }
 
 func ExampleEC2_CopySnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -955,11 +835,7 @@ func ExampleEC2_CopySnapshot() {
 }
 
 func ExampleEC2_CreateCustomerGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -983,11 +859,7 @@ func ExampleEC2_CreateCustomerGateway() {
 }
 
 func ExampleEC2_CreateDhcpOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1018,11 +890,7 @@ func ExampleEC2_CreateDhcpOptions() {
 }
 
 func ExampleEC2_CreateEgressOnlyInternetGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1045,11 +913,7 @@ func ExampleEC2_CreateEgressOnlyInternetGateway() {
 }
 
 func ExampleEC2_CreateFlowLogs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1078,11 +942,7 @@ func ExampleEC2_CreateFlowLogs() {
 }
 
 func ExampleEC2_CreateImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1123,11 +983,7 @@ func ExampleEC2_CreateImage() {
 }
 
 func ExampleEC2_CreateInstanceExportTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1156,11 +1012,7 @@ func ExampleEC2_CreateInstanceExportTask() {
 }
 
 func ExampleEC2_CreateInternetGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1181,11 +1033,7 @@ func ExampleEC2_CreateInternetGateway() {
 }
 
 func ExampleEC2_CreateKeyPair() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1207,11 +1055,7 @@ func ExampleEC2_CreateKeyPair() {
 }
 
 func ExampleEC2_CreateNatGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1234,11 +1078,7 @@ func ExampleEC2_CreateNatGateway() {
 }
 
 func ExampleEC2_CreateNetworkAcl() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1260,11 +1100,7 @@ func ExampleEC2_CreateNetworkAcl() {
 }
 
 func ExampleEC2_CreateNetworkAclEntry() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1300,11 +1136,7 @@ func ExampleEC2_CreateNetworkAclEntry() {
 }
 
 func ExampleEC2_CreateNetworkInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1347,11 +1179,7 @@ func ExampleEC2_CreateNetworkInterface() {
 }
 
 func ExampleEC2_CreatePlacementGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1374,11 +1202,7 @@ func ExampleEC2_CreatePlacementGroup() {
 }
 
 func ExampleEC2_CreateReservedInstancesListing() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1409,11 +1233,7 @@ func ExampleEC2_CreateReservedInstancesListing() {
 }
 
 func ExampleEC2_CreateRoute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1443,11 +1263,7 @@ func ExampleEC2_CreateRoute() {
 }
 
 func ExampleEC2_CreateRouteTable() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1469,11 +1285,7 @@ func ExampleEC2_CreateRouteTable() {
 }
 
 func ExampleEC2_CreateSecurityGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1497,11 +1309,7 @@ func ExampleEC2_CreateSecurityGroup() {
 }
 
 func ExampleEC2_CreateSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1524,11 +1332,7 @@ func ExampleEC2_CreateSnapshot() {
 }
 
 func ExampleEC2_CreateSpotDatafeedSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1551,11 +1355,7 @@ func ExampleEC2_CreateSpotDatafeedSubscription() {
 }
 
 func ExampleEC2_CreateSubnet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1580,11 +1380,7 @@ func ExampleEC2_CreateSubnet() {
 }
 
 func ExampleEC2_CreateTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1616,11 +1412,7 @@ func ExampleEC2_CreateTags() {
 }
 
 func ExampleEC2_CreateVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1648,11 +1440,7 @@ func ExampleEC2_CreateVolume() {
 }
 
 func ExampleEC2_CreateVpc() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1676,11 +1464,7 @@ func ExampleEC2_CreateVpc() {
 }
 
 func ExampleEC2_CreateVpcEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1709,11 +1493,7 @@ func ExampleEC2_CreateVpcEndpoint() {
 }
 
 func ExampleEC2_CreateVpcPeeringConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1737,11 +1517,7 @@ func ExampleEC2_CreateVpcPeeringConnection() {
 }
 
 func ExampleEC2_CreateVpnConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1768,11 +1544,7 @@ func ExampleEC2_CreateVpnConnection() {
 }
 
 func ExampleEC2_CreateVpnConnectionRoute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1794,11 +1566,7 @@ func ExampleEC2_CreateVpnConnectionRoute() {
 }
 
 func ExampleEC2_CreateVpnGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1821,11 +1589,7 @@ func ExampleEC2_CreateVpnGateway() {
 }
 
 func ExampleEC2_DeleteCustomerGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1847,11 +1611,7 @@ func ExampleEC2_DeleteCustomerGateway() {
 }
 
 func ExampleEC2_DeleteDhcpOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1873,11 +1633,7 @@ func ExampleEC2_DeleteDhcpOptions() {
 }
 
 func ExampleEC2_DeleteEgressOnlyInternetGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1899,11 +1655,7 @@ func ExampleEC2_DeleteEgressOnlyInternetGateway() {
 }
 
 func ExampleEC2_DeleteFlowLogs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1927,11 +1679,7 @@ func ExampleEC2_DeleteFlowLogs() {
 }
 
 func ExampleEC2_DeleteInternetGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1953,11 +1701,7 @@ func ExampleEC2_DeleteInternetGateway() {
 }
 
 func ExampleEC2_DeleteKeyPair() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -1979,11 +1723,7 @@ func ExampleEC2_DeleteKeyPair() {
 }
 
 func ExampleEC2_DeleteNatGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2004,11 +1744,7 @@ func ExampleEC2_DeleteNatGateway() {
 }
 
 func ExampleEC2_DeleteNetworkAcl() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2030,11 +1766,7 @@ func ExampleEC2_DeleteNetworkAcl() {
 }
 
 func ExampleEC2_DeleteNetworkAclEntry() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2058,11 +1790,7 @@ func ExampleEC2_DeleteNetworkAclEntry() {
 }
 
 func ExampleEC2_DeleteNetworkInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2084,11 +1812,7 @@ func ExampleEC2_DeleteNetworkInterface() {
 }
 
 func ExampleEC2_DeletePlacementGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2110,11 +1834,7 @@ func ExampleEC2_DeletePlacementGroup() {
 }
 
 func ExampleEC2_DeleteRoute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2138,11 +1858,7 @@ func ExampleEC2_DeleteRoute() {
 }
 
 func ExampleEC2_DeleteRouteTable() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2164,11 +1880,7 @@ func ExampleEC2_DeleteRouteTable() {
 }
 
 func ExampleEC2_DeleteSecurityGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2191,11 +1903,7 @@ func ExampleEC2_DeleteSecurityGroup() {
 }
 
 func ExampleEC2_DeleteSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2217,11 +1925,7 @@ func ExampleEC2_DeleteSnapshot() {
 }
 
 func ExampleEC2_DeleteSpotDatafeedSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2242,11 +1946,7 @@ func ExampleEC2_DeleteSpotDatafeedSubscription() {
 }
 
 func ExampleEC2_DeleteSubnet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2268,11 +1968,7 @@ func ExampleEC2_DeleteSubnet() {
 }
 
 func ExampleEC2_DeleteTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2304,11 +2000,7 @@ func ExampleEC2_DeleteTags() {
 }
 
 func ExampleEC2_DeleteVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2330,11 +2022,7 @@ func ExampleEC2_DeleteVolume() {
 }
 
 func ExampleEC2_DeleteVpc() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2356,11 +2044,7 @@ func ExampleEC2_DeleteVpc() {
 }
 
 func ExampleEC2_DeleteVpcEndpoints() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2385,11 +2069,7 @@ func ExampleEC2_DeleteVpcEndpoints() {
 }
 
 func ExampleEC2_DeleteVpcPeeringConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2411,11 +2091,7 @@ func ExampleEC2_DeleteVpcPeeringConnection() {
 }
 
 func ExampleEC2_DeleteVpnConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2437,11 +2113,7 @@ func ExampleEC2_DeleteVpnConnection() {
 }
 
 func ExampleEC2_DeleteVpnConnectionRoute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2463,11 +2135,7 @@ func ExampleEC2_DeleteVpnConnectionRoute() {
 }
 
 func ExampleEC2_DeleteVpnGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2489,11 +2157,7 @@ func ExampleEC2_DeleteVpnGateway() {
 }
 
 func ExampleEC2_DeregisterImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2515,11 +2179,7 @@ func ExampleEC2_DeregisterImage() {
 }
 
 func ExampleEC2_DescribeAccountAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2544,11 +2204,7 @@ func ExampleEC2_DescribeAccountAttributes() {
 }
 
 func ExampleEC2_DescribeAddresses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2587,11 +2243,7 @@ func ExampleEC2_DescribeAddresses() {
 }
 
 func ExampleEC2_DescribeAvailabilityZones() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2626,11 +2278,7 @@ func ExampleEC2_DescribeAvailabilityZones() {
 }
 
 func ExampleEC2_DescribeBundleTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2665,11 +2313,7 @@ func ExampleEC2_DescribeBundleTasks() {
 }
 
 func ExampleEC2_DescribeClassicLinkInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2706,11 +2350,7 @@ func ExampleEC2_DescribeClassicLinkInstances() {
 }
 
 func ExampleEC2_DescribeConversionTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2735,11 +2375,7 @@ func ExampleEC2_DescribeConversionTasks() {
 }
 
 func ExampleEC2_DescribeCustomerGateways() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2774,11 +2410,7 @@ func ExampleEC2_DescribeCustomerGateways() {
 }
 
 func ExampleEC2_DescribeDhcpOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2813,11 +2445,7 @@ func ExampleEC2_DescribeDhcpOptions() {
 }
 
 func ExampleEC2_DescribeEgressOnlyInternetGateways() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2844,11 +2472,7 @@ func ExampleEC2_DescribeEgressOnlyInternetGateways() {
 }
 
 func ExampleEC2_DescribeExportTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2872,11 +2496,7 @@ func ExampleEC2_DescribeExportTasks() {
 }
 
 func ExampleEC2_DescribeFlowLogs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2912,11 +2532,7 @@ func ExampleEC2_DescribeFlowLogs() {
 }
 
 func ExampleEC2_DescribeHostReservationOfferings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2951,11 +2567,7 @@ func ExampleEC2_DescribeHostReservationOfferings() {
 }
 
 func ExampleEC2_DescribeHostReservations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -2991,11 +2603,7 @@ func ExampleEC2_DescribeHostReservations() {
 }
 
 func ExampleEC2_DescribeHosts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3031,11 +2639,7 @@ func ExampleEC2_DescribeHosts() {
 }
 
 func ExampleEC2_DescribeIamInstanceProfileAssociations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3071,11 +2675,7 @@ func ExampleEC2_DescribeIamInstanceProfileAssociations() {
 }
 
 func ExampleEC2_DescribeIdFormat() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3096,11 +2696,7 @@ func ExampleEC2_DescribeIdFormat() {
 }
 
 func ExampleEC2_DescribeIdentityIdFormat() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3122,11 +2718,7 @@ func ExampleEC2_DescribeIdentityIdFormat() {
 }
 
 func ExampleEC2_DescribeImageAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3149,11 +2741,7 @@ func ExampleEC2_DescribeImageAttribute() {
 }
 
 func ExampleEC2_DescribeImages() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3196,11 +2784,7 @@ func ExampleEC2_DescribeImages() {
 }
 
 func ExampleEC2_DescribeImportImageTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3237,11 +2821,7 @@ func ExampleEC2_DescribeImportImageTasks() {
 }
 
 func ExampleEC2_DescribeImportSnapshotTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3278,11 +2858,7 @@ func ExampleEC2_DescribeImportSnapshotTasks() {
 }
 
 func ExampleEC2_DescribeInstanceAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3305,11 +2881,7 @@ func ExampleEC2_DescribeInstanceAttribute() {
 }
 
 func ExampleEC2_DescribeInstanceStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3347,11 +2919,7 @@ func ExampleEC2_DescribeInstanceStatus() {
 }
 
 func ExampleEC2_DescribeInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3388,11 +2956,7 @@ func ExampleEC2_DescribeInstances() {
 }
 
 func ExampleEC2_DescribeInternetGateways() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3427,11 +2991,7 @@ func ExampleEC2_DescribeInternetGateways() {
 }
 
 func ExampleEC2_DescribeKeyPairs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3466,11 +3026,7 @@ func ExampleEC2_DescribeKeyPairs() {
 }
 
 func ExampleEC2_DescribeMovingAddresses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3507,11 +3063,7 @@ func ExampleEC2_DescribeMovingAddresses() {
 }
 
 func ExampleEC2_DescribeNatGateways() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3547,11 +3099,7 @@ func ExampleEC2_DescribeNatGateways() {
 }
 
 func ExampleEC2_DescribeNetworkAcls() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3586,11 +3134,7 @@ func ExampleEC2_DescribeNetworkAcls() {
 }
 
 func ExampleEC2_DescribeNetworkInterfaceAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3613,11 +3157,7 @@ func ExampleEC2_DescribeNetworkInterfaceAttribute() {
 }
 
 func ExampleEC2_DescribeNetworkInterfaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3652,11 +3192,7 @@ func ExampleEC2_DescribeNetworkInterfaces() {
 }
 
 func ExampleEC2_DescribePlacementGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3691,11 +3227,7 @@ func ExampleEC2_DescribePlacementGroups() {
 }
 
 func ExampleEC2_DescribePrefixLists() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3732,11 +3264,7 @@ func ExampleEC2_DescribePrefixLists() {
 }
 
 func ExampleEC2_DescribeRegions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3771,11 +3299,7 @@ func ExampleEC2_DescribeRegions() {
 }
 
 func ExampleEC2_DescribeReservedInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3812,11 +3336,7 @@ func ExampleEC2_DescribeReservedInstances() {
 }
 
 func ExampleEC2_DescribeReservedInstancesListings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3848,11 +3368,7 @@ func ExampleEC2_DescribeReservedInstancesListings() {
 }
 
 func ExampleEC2_DescribeReservedInstancesModifications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3887,11 +3403,7 @@ func ExampleEC2_DescribeReservedInstancesModifications() {
 }
 
 func ExampleEC2_DescribeReservedInstancesOfferings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3938,11 +3450,7 @@ func ExampleEC2_DescribeReservedInstancesOfferings() {
 }
 
 func ExampleEC2_DescribeRouteTables() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -3977,11 +3485,7 @@ func ExampleEC2_DescribeRouteTables() {
 }
 
 func ExampleEC2_DescribeScheduledInstanceAvailability() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4030,11 +3534,7 @@ func ExampleEC2_DescribeScheduledInstanceAvailability() {
 }
 
 func ExampleEC2_DescribeScheduledInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4075,11 +3575,7 @@ func ExampleEC2_DescribeScheduledInstances() {
 }
 
 func ExampleEC2_DescribeSecurityGroupReferences() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4104,11 +3600,7 @@ func ExampleEC2_DescribeSecurityGroupReferences() {
 }
 
 func ExampleEC2_DescribeSecurityGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4147,11 +3639,7 @@ func ExampleEC2_DescribeSecurityGroups() {
 }
 
 func ExampleEC2_DescribeSnapshotAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4174,11 +3662,7 @@ func ExampleEC2_DescribeSnapshotAttribute() {
 }
 
 func ExampleEC2_DescribeSnapshots() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4223,11 +3707,7 @@ func ExampleEC2_DescribeSnapshots() {
 }
 
 func ExampleEC2_DescribeSpotDatafeedSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4248,11 +3728,7 @@ func ExampleEC2_DescribeSpotDatafeedSubscription() {
 }
 
 func ExampleEC2_DescribeSpotFleetInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4276,11 +3752,7 @@ func ExampleEC2_DescribeSpotFleetInstances() {
 }
 
 func ExampleEC2_DescribeSpotFleetRequestHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4306,11 +3778,7 @@ func ExampleEC2_DescribeSpotFleetRequestHistory() {
 }
 
 func ExampleEC2_DescribeSpotFleetRequests() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4337,11 +3805,7 @@ func ExampleEC2_DescribeSpotFleetRequests() {
 }
 
 func ExampleEC2_DescribeSpotInstanceRequests() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4376,11 +3840,7 @@ func ExampleEC2_DescribeSpotInstanceRequests() {
 }
 
 func ExampleEC2_DescribeSpotPriceHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4424,11 +3884,7 @@ func ExampleEC2_DescribeSpotPriceHistory() {
 }
 
 func ExampleEC2_DescribeStaleSecurityGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4452,11 +3908,7 @@ func ExampleEC2_DescribeStaleSecurityGroups() {
 }
 
 func ExampleEC2_DescribeSubnets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4491,11 +3943,7 @@ func ExampleEC2_DescribeSubnets() {
 }
 
 func ExampleEC2_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4528,11 +3976,7 @@ func ExampleEC2_DescribeTags() {
 }
 
 func ExampleEC2_DescribeVolumeAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4555,11 +3999,7 @@ func ExampleEC2_DescribeVolumeAttribute() {
 }
 
 func ExampleEC2_DescribeVolumeStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4596,11 +4036,7 @@ func ExampleEC2_DescribeVolumeStatus() {
 }
 
 func ExampleEC2_DescribeVolumes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4637,11 +4073,7 @@ func ExampleEC2_DescribeVolumes() {
 }
 
 func ExampleEC2_DescribeVolumesModifications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4678,11 +4110,7 @@ func ExampleEC2_DescribeVolumesModifications() {
 }
 
 func ExampleEC2_DescribeVpcAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4705,11 +4133,7 @@ func ExampleEC2_DescribeVpcAttribute() {
 }
 
 func ExampleEC2_DescribeVpcClassicLink() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4744,11 +4168,7 @@ func ExampleEC2_DescribeVpcClassicLink() {
 }
 
 func ExampleEC2_DescribeVpcClassicLinkDnsSupport() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4774,11 +4194,7 @@ func ExampleEC2_DescribeVpcClassicLinkDnsSupport() {
 }
 
 func ExampleEC2_DescribeVpcEndpointServices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4801,11 +4217,7 @@ func ExampleEC2_DescribeVpcEndpointServices() {
 }
 
 func ExampleEC2_DescribeVpcEndpoints() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4842,11 +4254,7 @@ func ExampleEC2_DescribeVpcEndpoints() {
 }
 
 func ExampleEC2_DescribeVpcPeeringConnections() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4881,11 +4289,7 @@ func ExampleEC2_DescribeVpcPeeringConnections() {
 }
 
 func ExampleEC2_DescribeVpcs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4920,11 +4324,7 @@ func ExampleEC2_DescribeVpcs() {
 }
 
 func ExampleEC2_DescribeVpnConnections() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4959,11 +4359,7 @@ func ExampleEC2_DescribeVpnConnections() {
 }
 
 func ExampleEC2_DescribeVpnGateways() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -4998,11 +4394,7 @@ func ExampleEC2_DescribeVpnGateways() {
 }
 
 func ExampleEC2_DetachClassicLinkVpc() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5025,11 +4417,7 @@ func ExampleEC2_DetachClassicLinkVpc() {
 }
 
 func ExampleEC2_DetachInternetGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5052,11 +4440,7 @@ func ExampleEC2_DetachInternetGateway() {
 }
 
 func ExampleEC2_DetachNetworkInterface() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5079,11 +4463,7 @@ func ExampleEC2_DetachNetworkInterface() {
 }
 
 func ExampleEC2_DetachVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5108,11 +4488,7 @@ func ExampleEC2_DetachVolume() {
 }
 
 func ExampleEC2_DetachVpnGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5135,11 +4511,7 @@ func ExampleEC2_DetachVpnGateway() {
 }
 
 func ExampleEC2_DisableVgwRoutePropagation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5161,11 +4533,7 @@ func ExampleEC2_DisableVgwRoutePropagation() {
 }
 
 func ExampleEC2_DisableVpcClassicLink() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5187,11 +4555,7 @@ func ExampleEC2_DisableVpcClassicLink() {
 }
 
 func ExampleEC2_DisableVpcClassicLinkDnsSupport() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5212,11 +4576,7 @@ func ExampleEC2_DisableVpcClassicLinkDnsSupport() {
 }
 
 func ExampleEC2_DisassociateAddress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5239,11 +4599,7 @@ func ExampleEC2_DisassociateAddress() {
 }
 
 func ExampleEC2_DisassociateIamInstanceProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5264,11 +4620,7 @@ func ExampleEC2_DisassociateIamInstanceProfile() {
 }
 
 func ExampleEC2_DisassociateRouteTable() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5290,11 +4642,7 @@ func ExampleEC2_DisassociateRouteTable() {
 }
 
 func ExampleEC2_DisassociateSubnetCidrBlock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5315,11 +4663,7 @@ func ExampleEC2_DisassociateSubnetCidrBlock() {
 }
 
 func ExampleEC2_DisassociateVpcCidrBlock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5340,11 +4684,7 @@ func ExampleEC2_DisassociateVpcCidrBlock() {
 }
 
 func ExampleEC2_EnableVgwRoutePropagation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5366,11 +4706,7 @@ func ExampleEC2_EnableVgwRoutePropagation() {
 }
 
 func ExampleEC2_EnableVolumeIO() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5392,11 +4728,7 @@ func ExampleEC2_EnableVolumeIO() {
 }
 
 func ExampleEC2_EnableVpcClassicLink() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5418,11 +4750,7 @@ func ExampleEC2_EnableVpcClassicLink() {
 }
 
 func ExampleEC2_EnableVpcClassicLinkDnsSupport() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5443,11 +4771,7 @@ func ExampleEC2_EnableVpcClassicLinkDnsSupport() {
 }
 
 func ExampleEC2_GetConsoleOutput() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5469,11 +4793,7 @@ func ExampleEC2_GetConsoleOutput() {
 }
 
 func ExampleEC2_GetConsoleScreenshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5496,11 +4816,7 @@ func ExampleEC2_GetConsoleScreenshot() {
 }
 
 func ExampleEC2_GetHostReservationPurchasePreview() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5525,11 +4841,7 @@ func ExampleEC2_GetHostReservationPurchasePreview() {
 }
 
 func ExampleEC2_GetPasswordData() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5551,11 +4863,7 @@ func ExampleEC2_GetPasswordData() {
 }
 
 func ExampleEC2_GetReservedInstancesExchangeQuote() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5587,11 +4895,7 @@ func ExampleEC2_GetReservedInstancesExchangeQuote() {
 }
 
 func ExampleEC2_ImportImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5639,11 +4943,7 @@ func ExampleEC2_ImportImage() {
 }
 
 func ExampleEC2_ImportInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5707,11 +5007,7 @@ func ExampleEC2_ImportInstance() {
 }
 
 func ExampleEC2_ImportKeyPair() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5734,11 +5030,7 @@ func ExampleEC2_ImportKeyPair() {
 }
 
 func ExampleEC2_ImportSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5777,11 +5069,7 @@ func ExampleEC2_ImportSnapshot() {
 }
 
 func ExampleEC2_ImportVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5812,11 +5100,7 @@ func ExampleEC2_ImportVolume() {
 }
 
 func ExampleEC2_ModifyHosts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5841,11 +5125,7 @@ func ExampleEC2_ModifyHosts() {
 }
 
 func ExampleEC2_ModifyIdFormat() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5867,11 +5147,7 @@ func ExampleEC2_ModifyIdFormat() {
 }
 
 func ExampleEC2_ModifyIdentityIdFormat() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5894,11 +5170,7 @@ func ExampleEC2_ModifyIdentityIdFormat() {
 }
 
 func ExampleEC2_ModifyImageAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -5954,11 +5226,7 @@ func ExampleEC2_ModifyImageAttribute() {
 }
 
 func ExampleEC2_ModifyInstanceAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6028,11 +5296,7 @@ func ExampleEC2_ModifyInstanceAttribute() {
 }
 
 func ExampleEC2_ModifyInstancePlacement() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6056,11 +5320,7 @@ func ExampleEC2_ModifyInstancePlacement() {
 }
 
 func ExampleEC2_ModifyNetworkInterfaceAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6096,11 +5356,7 @@ func ExampleEC2_ModifyNetworkInterfaceAttribute() {
 }
 
 func ExampleEC2_ModifyReservedInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6135,11 +5391,7 @@ func ExampleEC2_ModifyReservedInstances() {
 }
 
 func ExampleEC2_ModifySnapshotAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6187,11 +5439,7 @@ func ExampleEC2_ModifySnapshotAttribute() {
 }
 
 func ExampleEC2_ModifySpotFleetRequest() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6214,11 +5462,7 @@ func ExampleEC2_ModifySpotFleetRequest() {
 }
 
 func ExampleEC2_ModifySubnetAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6245,11 +5489,7 @@ func ExampleEC2_ModifySubnetAttribute() {
 }
 
 func ExampleEC2_ModifyVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6274,11 +5514,7 @@ func ExampleEC2_ModifyVolume() {
 }
 
 func ExampleEC2_ModifyVolumeAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6303,11 +5539,7 @@ func ExampleEC2_ModifyVolumeAttribute() {
 }
 
 func ExampleEC2_ModifyVpcAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6334,11 +5566,7 @@ func ExampleEC2_ModifyVpcAttribute() {
 }
 
 func ExampleEC2_ModifyVpcEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6370,11 +5598,7 @@ func ExampleEC2_ModifyVpcEndpoint() {
 }
 
 func ExampleEC2_ModifyVpcPeeringConnectionOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6406,11 +5630,7 @@ func ExampleEC2_ModifyVpcPeeringConnectionOptions() {
 }
 
 func ExampleEC2_MonitorInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6435,11 +5655,7 @@ func ExampleEC2_MonitorInstances() {
 }
 
 func ExampleEC2_MoveAddressToVpc() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6461,11 +5677,7 @@ func ExampleEC2_MoveAddressToVpc() {
 }
 
 func ExampleEC2_PurchaseHostReservation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6493,11 +5705,7 @@ func ExampleEC2_PurchaseHostReservation() {
 }
 
 func ExampleEC2_PurchaseReservedInstancesOffering() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6524,11 +5732,7 @@ func ExampleEC2_PurchaseReservedInstancesOffering() {
 }
 
 func ExampleEC2_PurchaseScheduledInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6557,11 +5761,7 @@ func ExampleEC2_PurchaseScheduledInstances() {
 }
 
 func ExampleEC2_RebootInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6586,11 +5786,7 @@ func ExampleEC2_RebootInstances() {
 }
 
 func ExampleEC2_RegisterImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6641,11 +5837,7 @@ func ExampleEC2_RegisterImage() {
 }
 
 func ExampleEC2_RejectVpcPeeringConnection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6667,11 +5859,7 @@ func ExampleEC2_RejectVpcPeeringConnection() {
 }
 
 func ExampleEC2_ReleaseAddress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6694,11 +5882,7 @@ func ExampleEC2_ReleaseAddress() {
 }
 
 func ExampleEC2_ReleaseHosts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6722,11 +5906,7 @@ func ExampleEC2_ReleaseHosts() {
 }
 
 func ExampleEC2_ReplaceIamInstanceProfileAssociation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6751,11 +5931,7 @@ func ExampleEC2_ReplaceIamInstanceProfileAssociation() {
 }
 
 func ExampleEC2_ReplaceNetworkAclAssociation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6778,11 +5954,7 @@ func ExampleEC2_ReplaceNetworkAclAssociation() {
 }
 
 func ExampleEC2_ReplaceNetworkAclEntry() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6818,11 +5990,7 @@ func ExampleEC2_ReplaceNetworkAclEntry() {
 }
 
 func ExampleEC2_ReplaceRoute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6852,11 +6020,7 @@ func ExampleEC2_ReplaceRoute() {
 }
 
 func ExampleEC2_ReplaceRouteTableAssociation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6879,11 +6043,7 @@ func ExampleEC2_ReplaceRouteTableAssociation() {
 }
 
 func ExampleEC2_ReportInstanceStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -6916,11 +6076,7 @@ func ExampleEC2_ReportInstanceStatus() {
 }
 
 func ExampleEC2_RequestSpotFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7037,11 +6193,7 @@ func ExampleEC2_RequestSpotFleet() {
 }
 
 func ExampleEC2_RequestSpotInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7149,11 +6301,7 @@ func ExampleEC2_RequestSpotInstances() {
 }
 
 func ExampleEC2_ResetImageAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7176,11 +6324,7 @@ func ExampleEC2_ResetImageAttribute() {
 }
 
 func ExampleEC2_ResetInstanceAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7203,11 +6347,7 @@ func ExampleEC2_ResetInstanceAttribute() {
 }
 
 func ExampleEC2_ResetNetworkInterfaceAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7230,11 +6370,7 @@ func ExampleEC2_ResetNetworkInterfaceAttribute() {
 }
 
 func ExampleEC2_ResetSnapshotAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7257,11 +6393,7 @@ func ExampleEC2_ResetSnapshotAttribute() {
 }
 
 func ExampleEC2_RestoreAddressToClassic() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7283,11 +6415,7 @@ func ExampleEC2_RestoreAddressToClassic() {
 }
 
 func ExampleEC2_RevokeSecurityGroupEgress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7352,11 +6480,7 @@ func ExampleEC2_RevokeSecurityGroupEgress() {
 }
 
 func ExampleEC2_RevokeSecurityGroupIngress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7422,11 +6546,7 @@ func ExampleEC2_RevokeSecurityGroupIngress() {
 }
 
 func ExampleEC2_RunInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7538,11 +6658,7 @@ func ExampleEC2_RunInstances() {
 }
 
 func ExampleEC2_RunScheduledInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7638,11 +6754,7 @@ func ExampleEC2_RunScheduledInstances() {
 }
 
 func ExampleEC2_StartInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7668,11 +6780,7 @@ func ExampleEC2_StartInstances() {
 }
 
 func ExampleEC2_StopInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7698,11 +6806,7 @@ func ExampleEC2_StopInstances() {
 }
 
 func ExampleEC2_TerminateInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7727,11 +6831,7 @@ func ExampleEC2_TerminateInstances() {
 }
 
 func ExampleEC2_UnassignIpv6Addresses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7756,11 +6856,7 @@ func ExampleEC2_UnassignIpv6Addresses() {
 }
 
 func ExampleEC2_UnassignPrivateIpAddresses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 
@@ -7785,11 +6881,7 @@ func ExampleEC2_UnassignPrivateIpAddresses() {
 }
 
 func ExampleEC2_UnmonitorInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ec2.New(sess)
 

--- a/service/ecr/examples_test.go
+++ b/service/ecr/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleECR_BatchCheckLayerAvailability() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -46,11 +42,7 @@ func ExampleECR_BatchCheckLayerAvailability() {
 }
 
 func ExampleECR_BatchDeleteImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -79,11 +71,7 @@ func ExampleECR_BatchDeleteImage() {
 }
 
 func ExampleECR_BatchGetImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -116,11 +104,7 @@ func ExampleECR_BatchGetImage() {
 }
 
 func ExampleECR_CompleteLayerUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -147,11 +131,7 @@ func ExampleECR_CompleteLayerUpload() {
 }
 
 func ExampleECR_CreateRepository() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -172,11 +152,7 @@ func ExampleECR_CreateRepository() {
 }
 
 func ExampleECR_DeleteRepository() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -199,11 +175,7 @@ func ExampleECR_DeleteRepository() {
 }
 
 func ExampleECR_DeleteRepositoryPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -225,11 +197,7 @@ func ExampleECR_DeleteRepositoryPolicy() {
 }
 
 func ExampleECR_DescribeImages() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -263,11 +231,7 @@ func ExampleECR_DescribeImages() {
 }
 
 func ExampleECR_DescribeRepositories() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -294,11 +258,7 @@ func ExampleECR_DescribeRepositories() {
 }
 
 func ExampleECR_GetAuthorizationToken() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -322,11 +282,7 @@ func ExampleECR_GetAuthorizationToken() {
 }
 
 func ExampleECR_GetDownloadUrlForLayer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -349,11 +305,7 @@ func ExampleECR_GetDownloadUrlForLayer() {
 }
 
 func ExampleECR_GetRepositoryPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -375,11 +327,7 @@ func ExampleECR_GetRepositoryPolicy() {
 }
 
 func ExampleECR_InitiateLayerUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -401,11 +349,7 @@ func ExampleECR_InitiateLayerUpload() {
 }
 
 func ExampleECR_ListImages() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -432,11 +376,7 @@ func ExampleECR_ListImages() {
 }
 
 func ExampleECR_PutImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -460,11 +400,7 @@ func ExampleECR_PutImage() {
 }
 
 func ExampleECR_SetRepositoryPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 
@@ -488,11 +424,7 @@ func ExampleECR_SetRepositoryPolicy() {
 }
 
 func ExampleECR_UploadLayerPart() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecr.New(sess)
 

--- a/service/ecs/examples_test.go
+++ b/service/ecs/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleECS_CreateCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleECS_CreateCluster() {
 }
 
 func ExampleECS_CreateService() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -98,11 +90,7 @@ func ExampleECS_CreateService() {
 }
 
 func ExampleECS_DeleteAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -132,11 +120,7 @@ func ExampleECS_DeleteAttributes() {
 }
 
 func ExampleECS_DeleteCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -157,11 +141,7 @@ func ExampleECS_DeleteCluster() {
 }
 
 func ExampleECS_DeleteService() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -183,11 +163,7 @@ func ExampleECS_DeleteService() {
 }
 
 func ExampleECS_DeregisterContainerInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -210,11 +186,7 @@ func ExampleECS_DeregisterContainerInstance() {
 }
 
 func ExampleECS_DeregisterTaskDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -235,11 +207,7 @@ func ExampleECS_DeregisterTaskDefinition() {
 }
 
 func ExampleECS_DescribeClusters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -263,11 +231,7 @@ func ExampleECS_DescribeClusters() {
 }
 
 func ExampleECS_DescribeContainerInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -292,11 +256,7 @@ func ExampleECS_DescribeContainerInstances() {
 }
 
 func ExampleECS_DescribeServices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -321,11 +281,7 @@ func ExampleECS_DescribeServices() {
 }
 
 func ExampleECS_DescribeTaskDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -346,11 +302,7 @@ func ExampleECS_DescribeTaskDefinition() {
 }
 
 func ExampleECS_DescribeTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -375,11 +327,7 @@ func ExampleECS_DescribeTasks() {
 }
 
 func ExampleECS_DiscoverPollEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -401,11 +349,7 @@ func ExampleECS_DiscoverPollEndpoint() {
 }
 
 func ExampleECS_ListAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -431,11 +375,7 @@ func ExampleECS_ListAttributes() {
 }
 
 func ExampleECS_ListClusters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -457,11 +397,7 @@ func ExampleECS_ListClusters() {
 }
 
 func ExampleECS_ListContainerInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -486,11 +422,7 @@ func ExampleECS_ListContainerInstances() {
 }
 
 func ExampleECS_ListServices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -513,11 +445,7 @@ func ExampleECS_ListServices() {
 }
 
 func ExampleECS_ListTaskDefinitionFamilies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -541,11 +469,7 @@ func ExampleECS_ListTaskDefinitionFamilies() {
 }
 
 func ExampleECS_ListTaskDefinitions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -570,11 +494,7 @@ func ExampleECS_ListTaskDefinitions() {
 }
 
 func ExampleECS_ListTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -602,11 +522,7 @@ func ExampleECS_ListTasks() {
 }
 
 func ExampleECS_PutAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -636,11 +552,7 @@ func ExampleECS_PutAttributes() {
 }
 
 func ExampleECS_RegisterContainerInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -692,11 +604,7 @@ func ExampleECS_RegisterContainerInstance() {
 }
 
 func ExampleECS_RegisterTaskDefinition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -832,11 +740,7 @@ func ExampleECS_RegisterTaskDefinition() {
 }
 
 func ExampleECS_RunTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -895,11 +799,7 @@ func ExampleECS_RunTask() {
 }
 
 func ExampleECS_StartTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -947,11 +847,7 @@ func ExampleECS_StartTask() {
 }
 
 func ExampleECS_StopTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -974,11 +870,7 @@ func ExampleECS_StopTask() {
 }
 
 func ExampleECS_SubmitContainerStateChange() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -1013,11 +905,7 @@ func ExampleECS_SubmitContainerStateChange() {
 }
 
 func ExampleECS_SubmitTaskStateChange() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -1041,11 +929,7 @@ func ExampleECS_SubmitTaskStateChange() {
 }
 
 func ExampleECS_UpdateContainerAgent() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -1067,11 +951,7 @@ func ExampleECS_UpdateContainerAgent() {
 }
 
 func ExampleECS_UpdateContainerInstancesState() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 
@@ -1097,11 +977,7 @@ func ExampleECS_UpdateContainerInstancesState() {
 }
 
 func ExampleECS_UpdateService() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ecs.New(sess)
 

--- a/service/efs/examples_test.go
+++ b/service/efs/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleEFS_CreateFileSystem() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleEFS_CreateFileSystem() {
 }
 
 func ExampleEFS_CreateMountTarget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -73,11 +65,7 @@ func ExampleEFS_CreateMountTarget() {
 }
 
 func ExampleEFS_CreateTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -105,11 +93,7 @@ func ExampleEFS_CreateTags() {
 }
 
 func ExampleEFS_DeleteFileSystem() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -130,11 +114,7 @@ func ExampleEFS_DeleteFileSystem() {
 }
 
 func ExampleEFS_DeleteMountTarget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -155,11 +135,7 @@ func ExampleEFS_DeleteMountTarget() {
 }
 
 func ExampleEFS_DeleteTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -184,11 +160,7 @@ func ExampleEFS_DeleteTags() {
 }
 
 func ExampleEFS_DescribeFileSystems() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -212,11 +184,7 @@ func ExampleEFS_DescribeFileSystems() {
 }
 
 func ExampleEFS_DescribeMountTargetSecurityGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -237,11 +205,7 @@ func ExampleEFS_DescribeMountTargetSecurityGroups() {
 }
 
 func ExampleEFS_DescribeMountTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -265,11 +229,7 @@ func ExampleEFS_DescribeMountTargets() {
 }
 
 func ExampleEFS_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 
@@ -292,11 +252,7 @@ func ExampleEFS_DescribeTags() {
 }
 
 func ExampleEFS_ModifyMountTargetSecurityGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := efs.New(sess)
 

--- a/service/elasticache/examples_test.go
+++ b/service/elasticache/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleElastiCache_AddTagsToResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleElastiCache_AddTagsToResource() {
 }
 
 func ExampleElastiCache_AuthorizeCacheSecurityGroupIngress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -75,11 +67,7 @@ func ExampleElastiCache_AuthorizeCacheSecurityGroupIngress() {
 }
 
 func ExampleElastiCache_CopySnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -102,11 +90,7 @@ func ExampleElastiCache_CopySnapshot() {
 }
 
 func ExampleElastiCache_CreateCacheCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -167,11 +151,7 @@ func ExampleElastiCache_CreateCacheCluster() {
 }
 
 func ExampleElastiCache_CreateCacheParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -194,11 +174,7 @@ func ExampleElastiCache_CreateCacheParameterGroup() {
 }
 
 func ExampleElastiCache_CreateCacheSecurityGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -220,11 +196,7 @@ func ExampleElastiCache_CreateCacheSecurityGroup() {
 }
 
 func ExampleElastiCache_CreateCacheSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -250,11 +222,7 @@ func ExampleElastiCache_CreateCacheSubnetGroup() {
 }
 
 func ExampleElastiCache_CreateReplicationGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -329,11 +297,7 @@ func ExampleElastiCache_CreateReplicationGroup() {
 }
 
 func ExampleElastiCache_CreateSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -356,11 +320,7 @@ func ExampleElastiCache_CreateSnapshot() {
 }
 
 func ExampleElastiCache_DeleteCacheCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -382,11 +342,7 @@ func ExampleElastiCache_DeleteCacheCluster() {
 }
 
 func ExampleElastiCache_DeleteCacheParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -407,11 +363,7 @@ func ExampleElastiCache_DeleteCacheParameterGroup() {
 }
 
 func ExampleElastiCache_DeleteCacheSecurityGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -432,11 +384,7 @@ func ExampleElastiCache_DeleteCacheSecurityGroup() {
 }
 
 func ExampleElastiCache_DeleteCacheSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -457,11 +405,7 @@ func ExampleElastiCache_DeleteCacheSubnetGroup() {
 }
 
 func ExampleElastiCache_DeleteReplicationGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -484,11 +428,7 @@ func ExampleElastiCache_DeleteReplicationGroup() {
 }
 
 func ExampleElastiCache_DeleteSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -509,11 +449,7 @@ func ExampleElastiCache_DeleteSnapshot() {
 }
 
 func ExampleElastiCache_DescribeCacheClusters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -537,11 +473,7 @@ func ExampleElastiCache_DescribeCacheClusters() {
 }
 
 func ExampleElastiCache_DescribeCacheEngineVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -567,11 +499,7 @@ func ExampleElastiCache_DescribeCacheEngineVersions() {
 }
 
 func ExampleElastiCache_DescribeCacheParameterGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -594,11 +522,7 @@ func ExampleElastiCache_DescribeCacheParameterGroups() {
 }
 
 func ExampleElastiCache_DescribeCacheParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -622,11 +546,7 @@ func ExampleElastiCache_DescribeCacheParameters() {
 }
 
 func ExampleElastiCache_DescribeCacheSecurityGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -649,11 +569,7 @@ func ExampleElastiCache_DescribeCacheSecurityGroups() {
 }
 
 func ExampleElastiCache_DescribeCacheSubnetGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -676,11 +592,7 @@ func ExampleElastiCache_DescribeCacheSubnetGroups() {
 }
 
 func ExampleElastiCache_DescribeEngineDefaultParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -703,11 +615,7 @@ func ExampleElastiCache_DescribeEngineDefaultParameters() {
 }
 
 func ExampleElastiCache_DescribeEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -734,11 +642,7 @@ func ExampleElastiCache_DescribeEvents() {
 }
 
 func ExampleElastiCache_DescribeReplicationGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -761,11 +665,7 @@ func ExampleElastiCache_DescribeReplicationGroups() {
 }
 
 func ExampleElastiCache_DescribeReservedCacheNodes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -793,11 +693,7 @@ func ExampleElastiCache_DescribeReservedCacheNodes() {
 }
 
 func ExampleElastiCache_DescribeReservedCacheNodesOfferings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -824,11 +720,7 @@ func ExampleElastiCache_DescribeReservedCacheNodesOfferings() {
 }
 
 func ExampleElastiCache_DescribeSnapshots() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -855,11 +747,7 @@ func ExampleElastiCache_DescribeSnapshots() {
 }
 
 func ExampleElastiCache_ListAllowedNodeTypeModifications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -881,11 +769,7 @@ func ExampleElastiCache_ListAllowedNodeTypeModifications() {
 }
 
 func ExampleElastiCache_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -906,11 +790,7 @@ func ExampleElastiCache_ListTagsForResource() {
 }
 
 func ExampleElastiCache_ModifyCacheCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -959,11 +839,7 @@ func ExampleElastiCache_ModifyCacheCluster() {
 }
 
 func ExampleElastiCache_ModifyCacheParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -991,11 +867,7 @@ func ExampleElastiCache_ModifyCacheParameterGroup() {
 }
 
 func ExampleElastiCache_ModifyCacheSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -1021,11 +893,7 @@ func ExampleElastiCache_ModifyCacheSubnetGroup() {
 }
 
 func ExampleElastiCache_ModifyReplicationGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -1068,11 +936,7 @@ func ExampleElastiCache_ModifyReplicationGroup() {
 }
 
 func ExampleElastiCache_PurchaseReservedCacheNodesOffering() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -1095,11 +959,7 @@ func ExampleElastiCache_PurchaseReservedCacheNodesOffering() {
 }
 
 func ExampleElastiCache_RebootCacheCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -1124,11 +984,7 @@ func ExampleElastiCache_RebootCacheCluster() {
 }
 
 func ExampleElastiCache_RemoveTagsFromResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -1153,11 +1009,7 @@ func ExampleElastiCache_RemoveTagsFromResource() {
 }
 
 func ExampleElastiCache_ResetCacheParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 
@@ -1186,11 +1038,7 @@ func ExampleElastiCache_ResetCacheParameterGroup() {
 }
 
 func ExampleElastiCache_RevokeCacheSecurityGroupIngress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticache.New(sess)
 

--- a/service/elasticbeanstalk/examples_test.go
+++ b/service/elasticbeanstalk/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleElasticBeanstalk_AbortEnvironmentUpdate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleElasticBeanstalk_AbortEnvironmentUpdate() {
 }
 
 func ExampleElasticBeanstalk_ApplyEnvironmentManagedAction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -69,11 +61,7 @@ func ExampleElasticBeanstalk_ApplyEnvironmentManagedAction() {
 }
 
 func ExampleElasticBeanstalk_CheckDNSAvailability() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -94,11 +82,7 @@ func ExampleElasticBeanstalk_CheckDNSAvailability() {
 }
 
 func ExampleElasticBeanstalk_ComposeEnvironments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -124,11 +108,7 @@ func ExampleElasticBeanstalk_ComposeEnvironments() {
 }
 
 func ExampleElasticBeanstalk_CreateApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -165,11 +145,7 @@ func ExampleElasticBeanstalk_CreateApplication() {
 }
 
 func ExampleElasticBeanstalk_CreateApplicationVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -210,11 +186,7 @@ func ExampleElasticBeanstalk_CreateApplicationVersion() {
 }
 
 func ExampleElasticBeanstalk_CreateConfigurationTemplate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -253,11 +225,7 @@ func ExampleElasticBeanstalk_CreateConfigurationTemplate() {
 }
 
 func ExampleElasticBeanstalk_CreateEnvironment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -315,11 +283,7 @@ func ExampleElasticBeanstalk_CreateEnvironment() {
 }
 
 func ExampleElasticBeanstalk_CreatePlatformVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -355,11 +319,7 @@ func ExampleElasticBeanstalk_CreatePlatformVersion() {
 }
 
 func ExampleElasticBeanstalk_CreateStorageLocation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -378,11 +338,7 @@ func ExampleElasticBeanstalk_CreateStorageLocation() {
 }
 
 func ExampleElasticBeanstalk_DeleteApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -404,11 +360,7 @@ func ExampleElasticBeanstalk_DeleteApplication() {
 }
 
 func ExampleElasticBeanstalk_DeleteApplicationVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -431,11 +383,7 @@ func ExampleElasticBeanstalk_DeleteApplicationVersion() {
 }
 
 func ExampleElasticBeanstalk_DeleteConfigurationTemplate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -457,11 +405,7 @@ func ExampleElasticBeanstalk_DeleteConfigurationTemplate() {
 }
 
 func ExampleElasticBeanstalk_DeleteEnvironmentConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -483,11 +427,7 @@ func ExampleElasticBeanstalk_DeleteEnvironmentConfiguration() {
 }
 
 func ExampleElasticBeanstalk_DeletePlatformVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -508,11 +448,7 @@ func ExampleElasticBeanstalk_DeletePlatformVersion() {
 }
 
 func ExampleElasticBeanstalk_DescribeApplicationVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -539,11 +475,7 @@ func ExampleElasticBeanstalk_DescribeApplicationVersions() {
 }
 
 func ExampleElasticBeanstalk_DescribeApplications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -567,11 +499,7 @@ func ExampleElasticBeanstalk_DescribeApplications() {
 }
 
 func ExampleElasticBeanstalk_DescribeConfigurationOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -604,11 +532,7 @@ func ExampleElasticBeanstalk_DescribeConfigurationOptions() {
 }
 
 func ExampleElasticBeanstalk_DescribeConfigurationSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -631,11 +555,7 @@ func ExampleElasticBeanstalk_DescribeConfigurationSettings() {
 }
 
 func ExampleElasticBeanstalk_DescribeEnvironmentHealth() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -661,11 +581,7 @@ func ExampleElasticBeanstalk_DescribeEnvironmentHealth() {
 }
 
 func ExampleElasticBeanstalk_DescribeEnvironmentManagedActionHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -689,11 +605,7 @@ func ExampleElasticBeanstalk_DescribeEnvironmentManagedActionHistory() {
 }
 
 func ExampleElasticBeanstalk_DescribeEnvironmentManagedActions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -716,11 +628,7 @@ func ExampleElasticBeanstalk_DescribeEnvironmentManagedActions() {
 }
 
 func ExampleElasticBeanstalk_DescribeEnvironmentResources() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -742,11 +650,7 @@ func ExampleElasticBeanstalk_DescribeEnvironmentResources() {
 }
 
 func ExampleElasticBeanstalk_DescribeEnvironments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -778,11 +682,7 @@ func ExampleElasticBeanstalk_DescribeEnvironments() {
 }
 
 func ExampleElasticBeanstalk_DescribeEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -814,11 +714,7 @@ func ExampleElasticBeanstalk_DescribeEvents() {
 }
 
 func ExampleElasticBeanstalk_DescribeInstancesHealth() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -845,11 +741,7 @@ func ExampleElasticBeanstalk_DescribeInstancesHealth() {
 }
 
 func ExampleElasticBeanstalk_DescribePlatformVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -870,11 +762,7 @@ func ExampleElasticBeanstalk_DescribePlatformVersion() {
 }
 
 func ExampleElasticBeanstalk_ListAvailableSolutionStacks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -893,11 +781,7 @@ func ExampleElasticBeanstalk_ListAvailableSolutionStacks() {
 }
 
 func ExampleElasticBeanstalk_ListPlatformVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -930,11 +814,7 @@ func ExampleElasticBeanstalk_ListPlatformVersions() {
 }
 
 func ExampleElasticBeanstalk_RebuildEnvironment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -956,11 +836,7 @@ func ExampleElasticBeanstalk_RebuildEnvironment() {
 }
 
 func ExampleElasticBeanstalk_RequestEnvironmentInfo() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -983,11 +859,7 @@ func ExampleElasticBeanstalk_RequestEnvironmentInfo() {
 }
 
 func ExampleElasticBeanstalk_RestartAppServer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1009,11 +881,7 @@ func ExampleElasticBeanstalk_RestartAppServer() {
 }
 
 func ExampleElasticBeanstalk_RetrieveEnvironmentInfo() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1036,11 +904,7 @@ func ExampleElasticBeanstalk_RetrieveEnvironmentInfo() {
 }
 
 func ExampleElasticBeanstalk_SwapEnvironmentCNAMEs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1064,11 +928,7 @@ func ExampleElasticBeanstalk_SwapEnvironmentCNAMEs() {
 }
 
 func ExampleElasticBeanstalk_TerminateEnvironment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1092,11 +952,7 @@ func ExampleElasticBeanstalk_TerminateEnvironment() {
 }
 
 func ExampleElasticBeanstalk_UpdateApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1118,11 +974,7 @@ func ExampleElasticBeanstalk_UpdateApplication() {
 }
 
 func ExampleElasticBeanstalk_UpdateApplicationResourceLifecycle() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1158,11 +1010,7 @@ func ExampleElasticBeanstalk_UpdateApplicationResourceLifecycle() {
 }
 
 func ExampleElasticBeanstalk_UpdateApplicationVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1185,11 +1033,7 @@ func ExampleElasticBeanstalk_UpdateApplicationVersion() {
 }
 
 func ExampleElasticBeanstalk_UpdateConfigurationTemplate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1229,11 +1073,7 @@ func ExampleElasticBeanstalk_UpdateConfigurationTemplate() {
 }
 
 func ExampleElasticBeanstalk_UpdateEnvironment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 
@@ -1284,11 +1124,7 @@ func ExampleElasticBeanstalk_UpdateEnvironment() {
 }
 
 func ExampleElasticBeanstalk_ValidateConfigurationSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticbeanstalk.New(sess)
 

--- a/service/elasticsearchservice/examples_test.go
+++ b/service/elasticsearchservice/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleElasticsearchService_AddTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleElasticsearchService_AddTags() {
 }
 
 func ExampleElasticsearchService_CreateElasticsearchDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -96,11 +88,7 @@ func ExampleElasticsearchService_CreateElasticsearchDomain() {
 }
 
 func ExampleElasticsearchService_DeleteElasticsearchDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -121,11 +109,7 @@ func ExampleElasticsearchService_DeleteElasticsearchDomain() {
 }
 
 func ExampleElasticsearchService_DescribeElasticsearchDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -146,11 +130,7 @@ func ExampleElasticsearchService_DescribeElasticsearchDomain() {
 }
 
 func ExampleElasticsearchService_DescribeElasticsearchDomainConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -171,11 +151,7 @@ func ExampleElasticsearchService_DescribeElasticsearchDomainConfig() {
 }
 
 func ExampleElasticsearchService_DescribeElasticsearchDomains() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -199,11 +175,7 @@ func ExampleElasticsearchService_DescribeElasticsearchDomains() {
 }
 
 func ExampleElasticsearchService_ListDomainNames() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -222,11 +194,7 @@ func ExampleElasticsearchService_ListDomainNames() {
 }
 
 func ExampleElasticsearchService_ListTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -247,11 +215,7 @@ func ExampleElasticsearchService_ListTags() {
 }
 
 func ExampleElasticsearchService_RemoveTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 
@@ -276,11 +240,7 @@ func ExampleElasticsearchService_RemoveTags() {
 }
 
 func ExampleElasticsearchService_UpdateElasticsearchDomainConfig() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elasticsearchservice.New(sess)
 

--- a/service/elastictranscoder/examples_test.go
+++ b/service/elastictranscoder/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleElasticTranscoder_CancelJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleElasticTranscoder_CancelJob() {
 }
 
 func ExampleElasticTranscoder_CreateJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -374,11 +366,7 @@ func ExampleElasticTranscoder_CreateJob() {
 }
 
 func ExampleElasticTranscoder_CreatePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -439,11 +427,7 @@ func ExampleElasticTranscoder_CreatePipeline() {
 }
 
 func ExampleElasticTranscoder_CreatePreset() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -523,11 +507,7 @@ func ExampleElasticTranscoder_CreatePreset() {
 }
 
 func ExampleElasticTranscoder_DeletePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -548,11 +528,7 @@ func ExampleElasticTranscoder_DeletePipeline() {
 }
 
 func ExampleElasticTranscoder_DeletePreset() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -573,11 +549,7 @@ func ExampleElasticTranscoder_DeletePreset() {
 }
 
 func ExampleElasticTranscoder_ListJobsByPipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -600,11 +572,7 @@ func ExampleElasticTranscoder_ListJobsByPipeline() {
 }
 
 func ExampleElasticTranscoder_ListJobsByStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -627,11 +595,7 @@ func ExampleElasticTranscoder_ListJobsByStatus() {
 }
 
 func ExampleElasticTranscoder_ListPipelines() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -653,11 +617,7 @@ func ExampleElasticTranscoder_ListPipelines() {
 }
 
 func ExampleElasticTranscoder_ListPresets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -679,11 +639,7 @@ func ExampleElasticTranscoder_ListPresets() {
 }
 
 func ExampleElasticTranscoder_ReadJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -704,11 +660,7 @@ func ExampleElasticTranscoder_ReadJob() {
 }
 
 func ExampleElasticTranscoder_ReadPipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -729,11 +681,7 @@ func ExampleElasticTranscoder_ReadPipeline() {
 }
 
 func ExampleElasticTranscoder_ReadPreset() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -754,11 +702,7 @@ func ExampleElasticTranscoder_ReadPreset() {
 }
 
 func ExampleElasticTranscoder_TestRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -785,11 +729,7 @@ func ExampleElasticTranscoder_TestRole() {
 }
 
 func ExampleElasticTranscoder_UpdatePipeline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -850,11 +790,7 @@ func ExampleElasticTranscoder_UpdatePipeline() {
 }
 
 func ExampleElasticTranscoder_UpdatePipelineNotifications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 
@@ -881,11 +817,7 @@ func ExampleElasticTranscoder_UpdatePipelineNotifications() {
 }
 
 func ExampleElasticTranscoder_UpdatePipelineStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elastictranscoder.New(sess)
 

--- a/service/elb/examples_test.go
+++ b/service/elb/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleELB_AddTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -51,11 +47,7 @@ func ExampleELB_AddTags() {
 }
 
 func ExampleELB_ApplySecurityGroupsToLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -80,11 +72,7 @@ func ExampleELB_ApplySecurityGroupsToLoadBalancer() {
 }
 
 func ExampleELB_AttachLoadBalancerToSubnets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -109,11 +97,7 @@ func ExampleELB_AttachLoadBalancerToSubnets() {
 }
 
 func ExampleELB_ConfigureHealthCheck() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -141,11 +125,7 @@ func ExampleELB_ConfigureHealthCheck() {
 }
 
 func ExampleELB_CreateAppCookieStickinessPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -168,11 +148,7 @@ func ExampleELB_CreateAppCookieStickinessPolicy() {
 }
 
 func ExampleELB_CreateLBCookieStickinessPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -195,11 +171,7 @@ func ExampleELB_CreateLBCookieStickinessPolicy() {
 }
 
 func ExampleELB_CreateLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -250,11 +222,7 @@ func ExampleELB_CreateLoadBalancer() {
 }
 
 func ExampleELB_CreateLoadBalancerListeners() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -285,11 +253,7 @@ func ExampleELB_CreateLoadBalancerListeners() {
 }
 
 func ExampleELB_CreateLoadBalancerPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -319,11 +283,7 @@ func ExampleELB_CreateLoadBalancerPolicy() {
 }
 
 func ExampleELB_DeleteLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -344,11 +304,7 @@ func ExampleELB_DeleteLoadBalancer() {
 }
 
 func ExampleELB_DeleteLoadBalancerListeners() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -373,11 +329,7 @@ func ExampleELB_DeleteLoadBalancerListeners() {
 }
 
 func ExampleELB_DeleteLoadBalancerPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -399,11 +351,7 @@ func ExampleELB_DeleteLoadBalancerPolicy() {
 }
 
 func ExampleELB_DeregisterInstancesFromLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -430,11 +378,7 @@ func ExampleELB_DeregisterInstancesFromLoadBalancer() {
 }
 
 func ExampleELB_DescribeInstanceHealth() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -461,11 +405,7 @@ func ExampleELB_DescribeInstanceHealth() {
 }
 
 func ExampleELB_DescribeLoadBalancerAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -486,11 +426,7 @@ func ExampleELB_DescribeLoadBalancerAttributes() {
 }
 
 func ExampleELB_DescribeLoadBalancerPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -515,11 +451,7 @@ func ExampleELB_DescribeLoadBalancerPolicies() {
 }
 
 func ExampleELB_DescribeLoadBalancerPolicyTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -543,11 +475,7 @@ func ExampleELB_DescribeLoadBalancerPolicyTypes() {
 }
 
 func ExampleELB_DescribeLoadBalancers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -573,11 +501,7 @@ func ExampleELB_DescribeLoadBalancers() {
 }
 
 func ExampleELB_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -601,11 +525,7 @@ func ExampleELB_DescribeTags() {
 }
 
 func ExampleELB_DetachLoadBalancerFromSubnets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -630,11 +550,7 @@ func ExampleELB_DetachLoadBalancerFromSubnets() {
 }
 
 func ExampleELB_DisableAvailabilityZonesForLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -659,11 +575,7 @@ func ExampleELB_DisableAvailabilityZonesForLoadBalancer() {
 }
 
 func ExampleELB_EnableAvailabilityZonesForLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -688,11 +600,7 @@ func ExampleELB_EnableAvailabilityZonesForLoadBalancer() {
 }
 
 func ExampleELB_ModifyLoadBalancerAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -738,11 +646,7 @@ func ExampleELB_ModifyLoadBalancerAttributes() {
 }
 
 func ExampleELB_RegisterInstancesWithLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -769,11 +673,7 @@ func ExampleELB_RegisterInstancesWithLoadBalancer() {
 }
 
 func ExampleELB_RemoveTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -803,11 +703,7 @@ func ExampleELB_RemoveTags() {
 }
 
 func ExampleELB_SetLoadBalancerListenerSSLCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -830,11 +726,7 @@ func ExampleELB_SetLoadBalancerListenerSSLCertificate() {
 }
 
 func ExampleELB_SetLoadBalancerPoliciesForBackendServer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 
@@ -860,11 +752,7 @@ func ExampleELB_SetLoadBalancerPoliciesForBackendServer() {
 }
 
 func ExampleELB_SetLoadBalancerPoliciesOfListener() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elb.New(sess)
 

--- a/service/elbv2/examples_test.go
+++ b/service/elbv2/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleELBV2_AddTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -51,11 +47,7 @@ func ExampleELBV2_AddTags() {
 }
 
 func ExampleELBV2_CreateListener() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -92,11 +84,7 @@ func ExampleELBV2_CreateListener() {
 }
 
 func ExampleELBV2_CreateLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -134,11 +122,7 @@ func ExampleELBV2_CreateLoadBalancer() {
 }
 
 func ExampleELBV2_CreateRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -177,11 +161,7 @@ func ExampleELBV2_CreateRule() {
 }
 
 func ExampleELBV2_CreateTargetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -215,11 +195,7 @@ func ExampleELBV2_CreateTargetGroup() {
 }
 
 func ExampleELBV2_DeleteListener() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -240,11 +216,7 @@ func ExampleELBV2_DeleteListener() {
 }
 
 func ExampleELBV2_DeleteLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -265,11 +237,7 @@ func ExampleELBV2_DeleteLoadBalancer() {
 }
 
 func ExampleELBV2_DeleteRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -290,11 +258,7 @@ func ExampleELBV2_DeleteRule() {
 }
 
 func ExampleELBV2_DeleteTargetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -315,11 +279,7 @@ func ExampleELBV2_DeleteTargetGroup() {
 }
 
 func ExampleELBV2_DeregisterTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -347,11 +307,7 @@ func ExampleELBV2_DeregisterTargets() {
 }
 
 func ExampleELBV2_DescribeListeners() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -378,11 +334,7 @@ func ExampleELBV2_DescribeListeners() {
 }
 
 func ExampleELBV2_DescribeLoadBalancerAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -403,11 +355,7 @@ func ExampleELBV2_DescribeLoadBalancerAttributes() {
 }
 
 func ExampleELBV2_DescribeLoadBalancers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -437,11 +385,7 @@ func ExampleELBV2_DescribeLoadBalancers() {
 }
 
 func ExampleELBV2_DescribeRules() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -466,11 +410,7 @@ func ExampleELBV2_DescribeRules() {
 }
 
 func ExampleELBV2_DescribeSSLPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -496,11 +436,7 @@ func ExampleELBV2_DescribeSSLPolicies() {
 }
 
 func ExampleELBV2_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -524,11 +460,7 @@ func ExampleELBV2_DescribeTags() {
 }
 
 func ExampleELBV2_DescribeTargetGroupAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -549,11 +481,7 @@ func ExampleELBV2_DescribeTargetGroupAttributes() {
 }
 
 func ExampleELBV2_DescribeTargetGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -584,11 +512,7 @@ func ExampleELBV2_DescribeTargetGroups() {
 }
 
 func ExampleELBV2_DescribeTargetHealth() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -616,11 +540,7 @@ func ExampleELBV2_DescribeTargetHealth() {
 }
 
 func ExampleELBV2_ModifyListener() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -657,11 +577,7 @@ func ExampleELBV2_ModifyListener() {
 }
 
 func ExampleELBV2_ModifyLoadBalancerAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -689,11 +605,7 @@ func ExampleELBV2_ModifyLoadBalancerAttributes() {
 }
 
 func ExampleELBV2_ModifyRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -731,11 +643,7 @@ func ExampleELBV2_ModifyRule() {
 }
 
 func ExampleELBV2_ModifyTargetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -766,11 +674,7 @@ func ExampleELBV2_ModifyTargetGroup() {
 }
 
 func ExampleELBV2_ModifyTargetGroupAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -798,11 +702,7 @@ func ExampleELBV2_ModifyTargetGroupAttributes() {
 }
 
 func ExampleELBV2_RegisterTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -830,11 +730,7 @@ func ExampleELBV2_RegisterTargets() {
 }
 
 func ExampleELBV2_RemoveTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -862,11 +758,7 @@ func ExampleELBV2_RemoveTags() {
 }
 
 func ExampleELBV2_SetIpAddressType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -888,11 +780,7 @@ func ExampleELBV2_SetIpAddressType() {
 }
 
 func ExampleELBV2_SetRulePriorities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -919,11 +807,7 @@ func ExampleELBV2_SetRulePriorities() {
 }
 
 func ExampleELBV2_SetSecurityGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 
@@ -948,11 +832,7 @@ func ExampleELBV2_SetSecurityGroups() {
 }
 
 func ExampleELBV2_SetSubnets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := elbv2.New(sess)
 

--- a/service/emr/examples_test.go
+++ b/service/emr/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleEMR_AddInstanceGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -119,11 +115,7 @@ func ExampleEMR_AddInstanceGroups() {
 }
 
 func ExampleEMR_AddJobFlowSteps() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -166,11 +158,7 @@ func ExampleEMR_AddJobFlowSteps() {
 }
 
 func ExampleEMR_AddTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -198,11 +186,7 @@ func ExampleEMR_AddTags() {
 }
 
 func ExampleEMR_CancelSteps() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -227,11 +211,7 @@ func ExampleEMR_CancelSteps() {
 }
 
 func ExampleEMR_CreateSecurityConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -253,11 +233,7 @@ func ExampleEMR_CreateSecurityConfiguration() {
 }
 
 func ExampleEMR_DeleteSecurityConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -278,11 +254,7 @@ func ExampleEMR_DeleteSecurityConfiguration() {
 }
 
 func ExampleEMR_DescribeCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -303,11 +275,7 @@ func ExampleEMR_DescribeCluster() {
 }
 
 func ExampleEMR_DescribeJobFlows() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -337,11 +305,7 @@ func ExampleEMR_DescribeJobFlows() {
 }
 
 func ExampleEMR_DescribeSecurityConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -362,11 +326,7 @@ func ExampleEMR_DescribeSecurityConfiguration() {
 }
 
 func ExampleEMR_DescribeStep() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -388,11 +348,7 @@ func ExampleEMR_DescribeStep() {
 }
 
 func ExampleEMR_ListBootstrapActions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -414,11 +370,7 @@ func ExampleEMR_ListBootstrapActions() {
 }
 
 func ExampleEMR_ListClusters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -445,11 +397,7 @@ func ExampleEMR_ListClusters() {
 }
 
 func ExampleEMR_ListInstanceGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -471,11 +419,7 @@ func ExampleEMR_ListInstanceGroups() {
 }
 
 func ExampleEMR_ListInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -506,11 +450,7 @@ func ExampleEMR_ListInstances() {
 }
 
 func ExampleEMR_ListSecurityConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -531,11 +471,7 @@ func ExampleEMR_ListSecurityConfigurations() {
 }
 
 func ExampleEMR_ListSteps() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -565,11 +501,7 @@ func ExampleEMR_ListSteps() {
 }
 
 func ExampleEMR_ModifyInstanceGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -615,11 +547,7 @@ func ExampleEMR_ModifyInstanceGroups() {
 }
 
 func ExampleEMR_PutAutoScalingPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -681,11 +609,7 @@ func ExampleEMR_PutAutoScalingPolicy() {
 }
 
 func ExampleEMR_RemoveAutoScalingPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -707,11 +631,7 @@ func ExampleEMR_RemoveAutoScalingPolicy() {
 }
 
 func ExampleEMR_RemoveTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -736,11 +656,7 @@ func ExampleEMR_RemoveTags() {
 }
 
 func ExampleEMR_RunJobFlow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -957,11 +873,7 @@ func ExampleEMR_RunJobFlow() {
 }
 
 func ExampleEMR_SetTerminationProtection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -986,11 +898,7 @@ func ExampleEMR_SetTerminationProtection() {
 }
 
 func ExampleEMR_SetVisibleToAllUsers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 
@@ -1015,11 +923,7 @@ func ExampleEMR_SetVisibleToAllUsers() {
 }
 
 func ExampleEMR_TerminateJobFlows() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := emr.New(sess)
 

--- a/service/firehose/examples_test.go
+++ b/service/firehose/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleFirehose_CreateDeliveryStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := firehose.New(sess)
 
@@ -256,11 +252,7 @@ func ExampleFirehose_CreateDeliveryStream() {
 }
 
 func ExampleFirehose_DeleteDeliveryStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := firehose.New(sess)
 
@@ -281,11 +273,7 @@ func ExampleFirehose_DeleteDeliveryStream() {
 }
 
 func ExampleFirehose_DescribeDeliveryStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := firehose.New(sess)
 
@@ -308,11 +296,7 @@ func ExampleFirehose_DescribeDeliveryStream() {
 }
 
 func ExampleFirehose_ListDeliveryStreams() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := firehose.New(sess)
 
@@ -334,11 +318,7 @@ func ExampleFirehose_ListDeliveryStreams() {
 }
 
 func ExampleFirehose_PutRecord() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := firehose.New(sess)
 
@@ -362,11 +342,7 @@ func ExampleFirehose_PutRecord() {
 }
 
 func ExampleFirehose_PutRecordBatch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := firehose.New(sess)
 
@@ -393,11 +369,7 @@ func ExampleFirehose_PutRecordBatch() {
 }
 
 func ExampleFirehose_UpdateDestination() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := firehose.New(sess)
 

--- a/service/gamelift/examples_test.go
+++ b/service/gamelift/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleGameLift_CreateAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -47,11 +43,7 @@ func ExampleGameLift_CreateAlias() {
 }
 
 func ExampleGameLift_CreateBuild() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -79,11 +71,7 @@ func ExampleGameLift_CreateBuild() {
 }
 
 func ExampleGameLift_CreateFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -137,11 +125,7 @@ func ExampleGameLift_CreateFleet() {
 }
 
 func ExampleGameLift_CreateGameSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -174,11 +158,7 @@ func ExampleGameLift_CreateGameSession() {
 }
 
 func ExampleGameLift_CreateGameSessionQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -206,11 +186,7 @@ func ExampleGameLift_CreateGameSessionQueue() {
 }
 
 func ExampleGameLift_CreatePlayerSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -233,11 +209,7 @@ func ExampleGameLift_CreatePlayerSession() {
 }
 
 func ExampleGameLift_CreatePlayerSessions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -266,11 +238,7 @@ func ExampleGameLift_CreatePlayerSessions() {
 }
 
 func ExampleGameLift_DeleteAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -291,11 +259,7 @@ func ExampleGameLift_DeleteAlias() {
 }
 
 func ExampleGameLift_DeleteBuild() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -316,11 +280,7 @@ func ExampleGameLift_DeleteBuild() {
 }
 
 func ExampleGameLift_DeleteFleet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -341,11 +301,7 @@ func ExampleGameLift_DeleteFleet() {
 }
 
 func ExampleGameLift_DeleteGameSessionQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -366,11 +322,7 @@ func ExampleGameLift_DeleteGameSessionQueue() {
 }
 
 func ExampleGameLift_DeleteScalingPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -392,11 +344,7 @@ func ExampleGameLift_DeleteScalingPolicy() {
 }
 
 func ExampleGameLift_DescribeAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -417,11 +365,7 @@ func ExampleGameLift_DescribeAlias() {
 }
 
 func ExampleGameLift_DescribeBuild() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -442,11 +386,7 @@ func ExampleGameLift_DescribeBuild() {
 }
 
 func ExampleGameLift_DescribeEC2InstanceLimits() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -467,11 +407,7 @@ func ExampleGameLift_DescribeEC2InstanceLimits() {
 }
 
 func ExampleGameLift_DescribeFleetAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -497,11 +433,7 @@ func ExampleGameLift_DescribeFleetAttributes() {
 }
 
 func ExampleGameLift_DescribeFleetCapacity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -527,11 +459,7 @@ func ExampleGameLift_DescribeFleetCapacity() {
 }
 
 func ExampleGameLift_DescribeFleetEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -556,11 +484,7 @@ func ExampleGameLift_DescribeFleetEvents() {
 }
 
 func ExampleGameLift_DescribeFleetPortSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -581,11 +505,7 @@ func ExampleGameLift_DescribeFleetPortSettings() {
 }
 
 func ExampleGameLift_DescribeFleetUtilization() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -611,11 +531,7 @@ func ExampleGameLift_DescribeFleetUtilization() {
 }
 
 func ExampleGameLift_DescribeGameSessionDetails() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -641,11 +557,7 @@ func ExampleGameLift_DescribeGameSessionDetails() {
 }
 
 func ExampleGameLift_DescribeGameSessionPlacement() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -666,11 +578,7 @@ func ExampleGameLift_DescribeGameSessionPlacement() {
 }
 
 func ExampleGameLift_DescribeGameSessionQueues() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -696,11 +604,7 @@ func ExampleGameLift_DescribeGameSessionQueues() {
 }
 
 func ExampleGameLift_DescribeGameSessions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -726,11 +630,7 @@ func ExampleGameLift_DescribeGameSessions() {
 }
 
 func ExampleGameLift_DescribeInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -754,11 +654,7 @@ func ExampleGameLift_DescribeInstances() {
 }
 
 func ExampleGameLift_DescribePlayerSessions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -784,11 +680,7 @@ func ExampleGameLift_DescribePlayerSessions() {
 }
 
 func ExampleGameLift_DescribeRuntimeConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -809,11 +701,7 @@ func ExampleGameLift_DescribeRuntimeConfiguration() {
 }
 
 func ExampleGameLift_DescribeScalingPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -837,11 +725,7 @@ func ExampleGameLift_DescribeScalingPolicies() {
 }
 
 func ExampleGameLift_GetGameSessionLogUrl() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -862,11 +746,7 @@ func ExampleGameLift_GetGameSessionLogUrl() {
 }
 
 func ExampleGameLift_GetInstanceAccess() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -888,11 +768,7 @@ func ExampleGameLift_GetInstanceAccess() {
 }
 
 func ExampleGameLift_ListAliases() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -916,11 +792,7 @@ func ExampleGameLift_ListAliases() {
 }
 
 func ExampleGameLift_ListBuilds() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -943,11 +815,7 @@ func ExampleGameLift_ListBuilds() {
 }
 
 func ExampleGameLift_ListFleets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -970,11 +838,7 @@ func ExampleGameLift_ListFleets() {
 }
 
 func ExampleGameLift_PutScalingPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1002,11 +866,7 @@ func ExampleGameLift_PutScalingPolicy() {
 }
 
 func ExampleGameLift_RequestUploadCredentials() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1027,11 +887,7 @@ func ExampleGameLift_RequestUploadCredentials() {
 }
 
 func ExampleGameLift_ResolveAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1052,11 +908,7 @@ func ExampleGameLift_ResolveAlias() {
 }
 
 func ExampleGameLift_SearchGameSessions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1082,11 +934,7 @@ func ExampleGameLift_SearchGameSessions() {
 }
 
 func ExampleGameLift_StartGameSessionPlacement() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1132,11 +980,7 @@ func ExampleGameLift_StartGameSessionPlacement() {
 }
 
 func ExampleGameLift_StopGameSessionPlacement() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1157,11 +1001,7 @@ func ExampleGameLift_StopGameSessionPlacement() {
 }
 
 func ExampleGameLift_UpdateAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1189,11 +1029,7 @@ func ExampleGameLift_UpdateAlias() {
 }
 
 func ExampleGameLift_UpdateBuild() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1216,11 +1052,7 @@ func ExampleGameLift_UpdateBuild() {
 }
 
 func ExampleGameLift_UpdateFleetAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1248,11 +1080,7 @@ func ExampleGameLift_UpdateFleetAttributes() {
 }
 
 func ExampleGameLift_UpdateFleetCapacity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1276,11 +1104,7 @@ func ExampleGameLift_UpdateFleetCapacity() {
 }
 
 func ExampleGameLift_UpdateFleetPortSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1319,11 +1143,7 @@ func ExampleGameLift_UpdateFleetPortSettings() {
 }
 
 func ExampleGameLift_UpdateGameSession() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1348,11 +1168,7 @@ func ExampleGameLift_UpdateGameSession() {
 }
 
 func ExampleGameLift_UpdateGameSessionQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 
@@ -1380,11 +1196,7 @@ func ExampleGameLift_UpdateGameSessionQueue() {
 }
 
 func ExampleGameLift_UpdateRuntimeConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := gamelift.New(sess)
 

--- a/service/glacier/examples_test.go
+++ b/service/glacier/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleGlacier_AbortMultipartUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -43,11 +39,7 @@ func ExampleGlacier_AbortMultipartUpload() {
 }
 
 func ExampleGlacier_AbortVaultLock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -69,11 +61,7 @@ func ExampleGlacier_AbortVaultLock() {
 }
 
 func ExampleGlacier_AddTagsToVault() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -99,11 +87,7 @@ func ExampleGlacier_AddTagsToVault() {
 }
 
 func ExampleGlacier_CompleteMultipartUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -128,11 +112,7 @@ func ExampleGlacier_CompleteMultipartUpload() {
 }
 
 func ExampleGlacier_CompleteVaultLock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -155,11 +135,7 @@ func ExampleGlacier_CompleteVaultLock() {
 }
 
 func ExampleGlacier_CreateVault() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -181,11 +157,7 @@ func ExampleGlacier_CreateVault() {
 }
 
 func ExampleGlacier_DeleteArchive() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -208,11 +180,7 @@ func ExampleGlacier_DeleteArchive() {
 }
 
 func ExampleGlacier_DeleteVault() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -234,11 +202,7 @@ func ExampleGlacier_DeleteVault() {
 }
 
 func ExampleGlacier_DeleteVaultAccessPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -260,11 +224,7 @@ func ExampleGlacier_DeleteVaultAccessPolicy() {
 }
 
 func ExampleGlacier_DeleteVaultNotifications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -286,11 +246,7 @@ func ExampleGlacier_DeleteVaultNotifications() {
 }
 
 func ExampleGlacier_DescribeJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -313,11 +269,7 @@ func ExampleGlacier_DescribeJob() {
 }
 
 func ExampleGlacier_DescribeVault() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -339,11 +291,7 @@ func ExampleGlacier_DescribeVault() {
 }
 
 func ExampleGlacier_GetDataRetrievalPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -364,11 +312,7 @@ func ExampleGlacier_GetDataRetrievalPolicy() {
 }
 
 func ExampleGlacier_GetJobOutput() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -392,11 +336,7 @@ func ExampleGlacier_GetJobOutput() {
 }
 
 func ExampleGlacier_GetVaultAccessPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -418,11 +358,7 @@ func ExampleGlacier_GetVaultAccessPolicy() {
 }
 
 func ExampleGlacier_GetVaultLock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -444,11 +380,7 @@ func ExampleGlacier_GetVaultLock() {
 }
 
 func ExampleGlacier_GetVaultNotifications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -470,11 +402,7 @@ func ExampleGlacier_GetVaultNotifications() {
 }
 
 func ExampleGlacier_InitiateJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -511,11 +439,7 @@ func ExampleGlacier_InitiateJob() {
 }
 
 func ExampleGlacier_InitiateMultipartUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -539,11 +463,7 @@ func ExampleGlacier_InitiateMultipartUpload() {
 }
 
 func ExampleGlacier_InitiateVaultLock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -568,11 +488,7 @@ func ExampleGlacier_InitiateVaultLock() {
 }
 
 func ExampleGlacier_ListJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -598,11 +514,7 @@ func ExampleGlacier_ListJobs() {
 }
 
 func ExampleGlacier_ListMultipartUploads() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -626,11 +538,7 @@ func ExampleGlacier_ListMultipartUploads() {
 }
 
 func ExampleGlacier_ListParts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -655,11 +563,7 @@ func ExampleGlacier_ListParts() {
 }
 
 func ExampleGlacier_ListProvisionedCapacity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -680,11 +584,7 @@ func ExampleGlacier_ListProvisionedCapacity() {
 }
 
 func ExampleGlacier_ListTagsForVault() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -706,11 +606,7 @@ func ExampleGlacier_ListTagsForVault() {
 }
 
 func ExampleGlacier_ListVaults() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -733,11 +629,7 @@ func ExampleGlacier_ListVaults() {
 }
 
 func ExampleGlacier_PurchaseProvisionedCapacity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -758,11 +650,7 @@ func ExampleGlacier_PurchaseProvisionedCapacity() {
 }
 
 func ExampleGlacier_RemoveTagsFromVault() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -788,11 +676,7 @@ func ExampleGlacier_RemoveTagsFromVault() {
 }
 
 func ExampleGlacier_SetDataRetrievalPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -822,11 +706,7 @@ func ExampleGlacier_SetDataRetrievalPolicy() {
 }
 
 func ExampleGlacier_SetVaultAccessPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -851,11 +731,7 @@ func ExampleGlacier_SetVaultAccessPolicy() {
 }
 
 func ExampleGlacier_SetVaultNotifications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -884,11 +760,7 @@ func ExampleGlacier_SetVaultNotifications() {
 }
 
 func ExampleGlacier_UploadArchive() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 
@@ -913,11 +785,7 @@ func ExampleGlacier_UploadArchive() {
 }
 
 func ExampleGlacier_UploadMultipartPart() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := glacier.New(sess)
 

--- a/service/health/examples_test.go
+++ b/service/health/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleHealth_DescribeAffectedEntities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := health.New(sess)
 
@@ -75,11 +71,7 @@ func ExampleHealth_DescribeAffectedEntities() {
 }
 
 func ExampleHealth_DescribeEntityAggregates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := health.New(sess)
 
@@ -103,11 +95,7 @@ func ExampleHealth_DescribeEntityAggregates() {
 }
 
 func ExampleHealth_DescribeEventAggregates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := health.New(sess)
 
@@ -196,11 +184,7 @@ func ExampleHealth_DescribeEventAggregates() {
 }
 
 func ExampleHealth_DescribeEventDetails() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := health.New(sess)
 
@@ -225,11 +209,7 @@ func ExampleHealth_DescribeEventDetails() {
 }
 
 func ExampleHealth_DescribeEventTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := health.New(sess)
 
@@ -266,11 +246,7 @@ func ExampleHealth_DescribeEventTypes() {
 }
 
 func ExampleHealth_DescribeEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := health.New(sess)
 

--- a/service/iam/examples_test.go
+++ b/service/iam/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleIAM_AddClientIDToOpenIDConnectProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleIAM_AddClientIDToOpenIDConnectProvider() {
 }
 
 func ExampleIAM_AddRoleToInstanceProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -68,11 +60,7 @@ func ExampleIAM_AddRoleToInstanceProfile() {
 }
 
 func ExampleIAM_AddUserToGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -94,11 +82,7 @@ func ExampleIAM_AddUserToGroup() {
 }
 
 func ExampleIAM_AttachGroupPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -120,11 +104,7 @@ func ExampleIAM_AttachGroupPolicy() {
 }
 
 func ExampleIAM_AttachRolePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -146,11 +126,7 @@ func ExampleIAM_AttachRolePolicy() {
 }
 
 func ExampleIAM_AttachUserPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -172,11 +148,7 @@ func ExampleIAM_AttachUserPolicy() {
 }
 
 func ExampleIAM_ChangePassword() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -198,11 +170,7 @@ func ExampleIAM_ChangePassword() {
 }
 
 func ExampleIAM_CreateAccessKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -223,11 +191,7 @@ func ExampleIAM_CreateAccessKey() {
 }
 
 func ExampleIAM_CreateAccountAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -248,11 +212,7 @@ func ExampleIAM_CreateAccountAlias() {
 }
 
 func ExampleIAM_CreateGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -274,11 +234,7 @@ func ExampleIAM_CreateGroup() {
 }
 
 func ExampleIAM_CreateInstanceProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -300,11 +256,7 @@ func ExampleIAM_CreateInstanceProfile() {
 }
 
 func ExampleIAM_CreateLoginProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -327,11 +279,7 @@ func ExampleIAM_CreateLoginProfile() {
 }
 
 func ExampleIAM_CreateOpenIDConnectProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -360,11 +308,7 @@ func ExampleIAM_CreateOpenIDConnectProvider() {
 }
 
 func ExampleIAM_CreatePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -388,11 +332,7 @@ func ExampleIAM_CreatePolicy() {
 }
 
 func ExampleIAM_CreatePolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -415,11 +355,7 @@ func ExampleIAM_CreatePolicyVersion() {
 }
 
 func ExampleIAM_CreateRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -442,11 +378,7 @@ func ExampleIAM_CreateRole() {
 }
 
 func ExampleIAM_CreateSAMLProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -468,11 +400,7 @@ func ExampleIAM_CreateSAMLProvider() {
 }
 
 func ExampleIAM_CreateServiceSpecificCredential() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -494,11 +422,7 @@ func ExampleIAM_CreateServiceSpecificCredential() {
 }
 
 func ExampleIAM_CreateUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -520,11 +444,7 @@ func ExampleIAM_CreateUser() {
 }
 
 func ExampleIAM_CreateVirtualMFADevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -546,11 +466,7 @@ func ExampleIAM_CreateVirtualMFADevice() {
 }
 
 func ExampleIAM_DeactivateMFADevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -572,11 +488,7 @@ func ExampleIAM_DeactivateMFADevice() {
 }
 
 func ExampleIAM_DeleteAccessKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -598,11 +510,7 @@ func ExampleIAM_DeleteAccessKey() {
 }
 
 func ExampleIAM_DeleteAccountAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -623,11 +531,7 @@ func ExampleIAM_DeleteAccountAlias() {
 }
 
 func ExampleIAM_DeleteAccountPasswordPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -646,11 +550,7 @@ func ExampleIAM_DeleteAccountPasswordPolicy() {
 }
 
 func ExampleIAM_DeleteGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -671,11 +571,7 @@ func ExampleIAM_DeleteGroup() {
 }
 
 func ExampleIAM_DeleteGroupPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -697,11 +593,7 @@ func ExampleIAM_DeleteGroupPolicy() {
 }
 
 func ExampleIAM_DeleteInstanceProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -722,11 +614,7 @@ func ExampleIAM_DeleteInstanceProfile() {
 }
 
 func ExampleIAM_DeleteLoginProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -747,11 +635,7 @@ func ExampleIAM_DeleteLoginProfile() {
 }
 
 func ExampleIAM_DeleteOpenIDConnectProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -772,11 +656,7 @@ func ExampleIAM_DeleteOpenIDConnectProvider() {
 }
 
 func ExampleIAM_DeletePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -797,11 +677,7 @@ func ExampleIAM_DeletePolicy() {
 }
 
 func ExampleIAM_DeletePolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -823,11 +699,7 @@ func ExampleIAM_DeletePolicyVersion() {
 }
 
 func ExampleIAM_DeleteRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -848,11 +720,7 @@ func ExampleIAM_DeleteRole() {
 }
 
 func ExampleIAM_DeleteRolePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -874,11 +742,7 @@ func ExampleIAM_DeleteRolePolicy() {
 }
 
 func ExampleIAM_DeleteSAMLProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -899,11 +763,7 @@ func ExampleIAM_DeleteSAMLProvider() {
 }
 
 func ExampleIAM_DeleteSSHPublicKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -925,11 +785,7 @@ func ExampleIAM_DeleteSSHPublicKey() {
 }
 
 func ExampleIAM_DeleteServerCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -950,11 +806,7 @@ func ExampleIAM_DeleteServerCertificate() {
 }
 
 func ExampleIAM_DeleteServiceSpecificCredential() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -976,11 +828,7 @@ func ExampleIAM_DeleteServiceSpecificCredential() {
 }
 
 func ExampleIAM_DeleteSigningCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1002,11 +850,7 @@ func ExampleIAM_DeleteSigningCertificate() {
 }
 
 func ExampleIAM_DeleteUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1027,11 +871,7 @@ func ExampleIAM_DeleteUser() {
 }
 
 func ExampleIAM_DeleteUserPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1053,11 +893,7 @@ func ExampleIAM_DeleteUserPolicy() {
 }
 
 func ExampleIAM_DeleteVirtualMFADevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1078,11 +914,7 @@ func ExampleIAM_DeleteVirtualMFADevice() {
 }
 
 func ExampleIAM_DetachGroupPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1104,11 +936,7 @@ func ExampleIAM_DetachGroupPolicy() {
 }
 
 func ExampleIAM_DetachRolePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1130,11 +958,7 @@ func ExampleIAM_DetachRolePolicy() {
 }
 
 func ExampleIAM_DetachUserPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1156,11 +980,7 @@ func ExampleIAM_DetachUserPolicy() {
 }
 
 func ExampleIAM_EnableMFADevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1184,11 +1004,7 @@ func ExampleIAM_EnableMFADevice() {
 }
 
 func ExampleIAM_GenerateCredentialReport() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1207,11 +1023,7 @@ func ExampleIAM_GenerateCredentialReport() {
 }
 
 func ExampleIAM_GetAccessKeyLastUsed() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1232,11 +1044,7 @@ func ExampleIAM_GetAccessKeyLastUsed() {
 }
 
 func ExampleIAM_GetAccountAuthorizationDetails() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1262,11 +1070,7 @@ func ExampleIAM_GetAccountAuthorizationDetails() {
 }
 
 func ExampleIAM_GetAccountPasswordPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1285,11 +1089,7 @@ func ExampleIAM_GetAccountPasswordPolicy() {
 }
 
 func ExampleIAM_GetAccountSummary() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1308,11 +1108,7 @@ func ExampleIAM_GetAccountSummary() {
 }
 
 func ExampleIAM_GetContextKeysForCustomPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1336,11 +1132,7 @@ func ExampleIAM_GetContextKeysForCustomPolicy() {
 }
 
 func ExampleIAM_GetContextKeysForPrincipalPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1365,11 +1157,7 @@ func ExampleIAM_GetContextKeysForPrincipalPolicy() {
 }
 
 func ExampleIAM_GetCredentialReport() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1388,11 +1176,7 @@ func ExampleIAM_GetCredentialReport() {
 }
 
 func ExampleIAM_GetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1415,11 +1199,7 @@ func ExampleIAM_GetGroup() {
 }
 
 func ExampleIAM_GetGroupPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1441,11 +1221,7 @@ func ExampleIAM_GetGroupPolicy() {
 }
 
 func ExampleIAM_GetInstanceProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1466,11 +1242,7 @@ func ExampleIAM_GetInstanceProfile() {
 }
 
 func ExampleIAM_GetLoginProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1491,11 +1263,7 @@ func ExampleIAM_GetLoginProfile() {
 }
 
 func ExampleIAM_GetOpenIDConnectProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1516,11 +1284,7 @@ func ExampleIAM_GetOpenIDConnectProvider() {
 }
 
 func ExampleIAM_GetPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1541,11 +1305,7 @@ func ExampleIAM_GetPolicy() {
 }
 
 func ExampleIAM_GetPolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1567,11 +1327,7 @@ func ExampleIAM_GetPolicyVersion() {
 }
 
 func ExampleIAM_GetRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1592,11 +1348,7 @@ func ExampleIAM_GetRole() {
 }
 
 func ExampleIAM_GetRolePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1618,11 +1370,7 @@ func ExampleIAM_GetRolePolicy() {
 }
 
 func ExampleIAM_GetSAMLProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1643,11 +1391,7 @@ func ExampleIAM_GetSAMLProvider() {
 }
 
 func ExampleIAM_GetSSHPublicKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1670,11 +1414,7 @@ func ExampleIAM_GetSSHPublicKey() {
 }
 
 func ExampleIAM_GetServerCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1695,11 +1435,7 @@ func ExampleIAM_GetServerCertificate() {
 }
 
 func ExampleIAM_GetUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1720,11 +1456,7 @@ func ExampleIAM_GetUser() {
 }
 
 func ExampleIAM_GetUserPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1746,11 +1478,7 @@ func ExampleIAM_GetUserPolicy() {
 }
 
 func ExampleIAM_ListAccessKeys() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1773,11 +1501,7 @@ func ExampleIAM_ListAccessKeys() {
 }
 
 func ExampleIAM_ListAccountAliases() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1799,11 +1523,7 @@ func ExampleIAM_ListAccountAliases() {
 }
 
 func ExampleIAM_ListAttachedGroupPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1827,11 +1547,7 @@ func ExampleIAM_ListAttachedGroupPolicies() {
 }
 
 func ExampleIAM_ListAttachedRolePolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1855,11 +1571,7 @@ func ExampleIAM_ListAttachedRolePolicies() {
 }
 
 func ExampleIAM_ListAttachedUserPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1883,11 +1595,7 @@ func ExampleIAM_ListAttachedUserPolicies() {
 }
 
 func ExampleIAM_ListEntitiesForPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1912,11 +1620,7 @@ func ExampleIAM_ListEntitiesForPolicy() {
 }
 
 func ExampleIAM_ListGroupPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1939,11 +1643,7 @@ func ExampleIAM_ListGroupPolicies() {
 }
 
 func ExampleIAM_ListGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1966,11 +1666,7 @@ func ExampleIAM_ListGroups() {
 }
 
 func ExampleIAM_ListGroupsForUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -1993,11 +1689,7 @@ func ExampleIAM_ListGroupsForUser() {
 }
 
 func ExampleIAM_ListInstanceProfiles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2020,11 +1712,7 @@ func ExampleIAM_ListInstanceProfiles() {
 }
 
 func ExampleIAM_ListInstanceProfilesForRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2047,11 +1735,7 @@ func ExampleIAM_ListInstanceProfilesForRole() {
 }
 
 func ExampleIAM_ListMFADevices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2074,11 +1758,7 @@ func ExampleIAM_ListMFADevices() {
 }
 
 func ExampleIAM_ListOpenIDConnectProviders() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2097,11 +1777,7 @@ func ExampleIAM_ListOpenIDConnectProviders() {
 }
 
 func ExampleIAM_ListPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2126,11 +1802,7 @@ func ExampleIAM_ListPolicies() {
 }
 
 func ExampleIAM_ListPolicyVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2153,11 +1825,7 @@ func ExampleIAM_ListPolicyVersions() {
 }
 
 func ExampleIAM_ListRolePolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2180,11 +1848,7 @@ func ExampleIAM_ListRolePolicies() {
 }
 
 func ExampleIAM_ListRoles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2207,11 +1871,7 @@ func ExampleIAM_ListRoles() {
 }
 
 func ExampleIAM_ListSAMLProviders() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2230,11 +1890,7 @@ func ExampleIAM_ListSAMLProviders() {
 }
 
 func ExampleIAM_ListSSHPublicKeys() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2257,11 +1913,7 @@ func ExampleIAM_ListSSHPublicKeys() {
 }
 
 func ExampleIAM_ListServerCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2284,11 +1936,7 @@ func ExampleIAM_ListServerCertificates() {
 }
 
 func ExampleIAM_ListServiceSpecificCredentials() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2310,11 +1958,7 @@ func ExampleIAM_ListServiceSpecificCredentials() {
 }
 
 func ExampleIAM_ListSigningCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2337,11 +1981,7 @@ func ExampleIAM_ListSigningCertificates() {
 }
 
 func ExampleIAM_ListUserPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2364,11 +2004,7 @@ func ExampleIAM_ListUserPolicies() {
 }
 
 func ExampleIAM_ListUsers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2391,11 +2027,7 @@ func ExampleIAM_ListUsers() {
 }
 
 func ExampleIAM_ListVirtualMFADevices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2418,11 +2050,7 @@ func ExampleIAM_ListVirtualMFADevices() {
 }
 
 func ExampleIAM_PutGroupPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2445,11 +2073,7 @@ func ExampleIAM_PutGroupPolicy() {
 }
 
 func ExampleIAM_PutRolePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2472,11 +2096,7 @@ func ExampleIAM_PutRolePolicy() {
 }
 
 func ExampleIAM_PutUserPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2499,11 +2119,7 @@ func ExampleIAM_PutUserPolicy() {
 }
 
 func ExampleIAM_RemoveClientIDFromOpenIDConnectProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2525,11 +2141,7 @@ func ExampleIAM_RemoveClientIDFromOpenIDConnectProvider() {
 }
 
 func ExampleIAM_RemoveRoleFromInstanceProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2551,11 +2163,7 @@ func ExampleIAM_RemoveRoleFromInstanceProfile() {
 }
 
 func ExampleIAM_RemoveUserFromGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2577,11 +2185,7 @@ func ExampleIAM_RemoveUserFromGroup() {
 }
 
 func ExampleIAM_ResetServiceSpecificCredential() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2603,11 +2207,7 @@ func ExampleIAM_ResetServiceSpecificCredential() {
 }
 
 func ExampleIAM_ResyncMFADevice() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2631,11 +2231,7 @@ func ExampleIAM_ResyncMFADevice() {
 }
 
 func ExampleIAM_SetDefaultPolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2657,11 +2253,7 @@ func ExampleIAM_SetDefaultPolicyVersion() {
 }
 
 func ExampleIAM_SimulateCustomPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2710,11 +2302,7 @@ func ExampleIAM_SimulateCustomPolicy() {
 }
 
 func ExampleIAM_SimulatePrincipalPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2764,11 +2352,7 @@ func ExampleIAM_SimulatePrincipalPolicy() {
 }
 
 func ExampleIAM_UpdateAccessKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2791,11 +2375,7 @@ func ExampleIAM_UpdateAccessKey() {
 }
 
 func ExampleIAM_UpdateAccountPasswordPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2824,11 +2404,7 @@ func ExampleIAM_UpdateAccountPasswordPolicy() {
 }
 
 func ExampleIAM_UpdateAssumeRolePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2850,11 +2426,7 @@ func ExampleIAM_UpdateAssumeRolePolicy() {
 }
 
 func ExampleIAM_UpdateGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2877,11 +2449,7 @@ func ExampleIAM_UpdateGroup() {
 }
 
 func ExampleIAM_UpdateLoginProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2904,11 +2472,7 @@ func ExampleIAM_UpdateLoginProfile() {
 }
 
 func ExampleIAM_UpdateOpenIDConnectProviderThumbprint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2933,11 +2497,7 @@ func ExampleIAM_UpdateOpenIDConnectProviderThumbprint() {
 }
 
 func ExampleIAM_UpdateSAMLProvider() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2959,11 +2519,7 @@ func ExampleIAM_UpdateSAMLProvider() {
 }
 
 func ExampleIAM_UpdateSSHPublicKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -2986,11 +2542,7 @@ func ExampleIAM_UpdateSSHPublicKey() {
 }
 
 func ExampleIAM_UpdateServerCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -3013,11 +2565,7 @@ func ExampleIAM_UpdateServerCertificate() {
 }
 
 func ExampleIAM_UpdateServiceSpecificCredential() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -3040,11 +2588,7 @@ func ExampleIAM_UpdateServiceSpecificCredential() {
 }
 
 func ExampleIAM_UpdateSigningCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -3067,11 +2611,7 @@ func ExampleIAM_UpdateSigningCertificate() {
 }
 
 func ExampleIAM_UpdateUser() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -3094,11 +2634,7 @@ func ExampleIAM_UpdateUser() {
 }
 
 func ExampleIAM_UploadSSHPublicKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -3120,11 +2656,7 @@ func ExampleIAM_UploadSSHPublicKey() {
 }
 
 func ExampleIAM_UploadServerCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 
@@ -3149,11 +2681,7 @@ func ExampleIAM_UploadServerCertificate() {
 }
 
 func ExampleIAM_UploadSigningCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iam.New(sess)
 

--- a/service/inspector/examples_test.go
+++ b/service/inspector/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleInspector_AddAttributesToFindings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -51,11 +47,7 @@ func ExampleInspector_AddAttributesToFindings() {
 }
 
 func ExampleInspector_CreateAssessmentTarget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -77,11 +69,7 @@ func ExampleInspector_CreateAssessmentTarget() {
 }
 
 func ExampleInspector_CreateAssessmentTemplate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -115,11 +103,7 @@ func ExampleInspector_CreateAssessmentTemplate() {
 }
 
 func ExampleInspector_CreateResourceGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -146,11 +130,7 @@ func ExampleInspector_CreateResourceGroup() {
 }
 
 func ExampleInspector_DeleteAssessmentRun() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -171,11 +151,7 @@ func ExampleInspector_DeleteAssessmentRun() {
 }
 
 func ExampleInspector_DeleteAssessmentTarget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -196,11 +172,7 @@ func ExampleInspector_DeleteAssessmentTarget() {
 }
 
 func ExampleInspector_DeleteAssessmentTemplate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -221,11 +193,7 @@ func ExampleInspector_DeleteAssessmentTemplate() {
 }
 
 func ExampleInspector_DescribeAssessmentRuns() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -249,11 +217,7 @@ func ExampleInspector_DescribeAssessmentRuns() {
 }
 
 func ExampleInspector_DescribeAssessmentTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -277,11 +241,7 @@ func ExampleInspector_DescribeAssessmentTargets() {
 }
 
 func ExampleInspector_DescribeAssessmentTemplates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -305,11 +265,7 @@ func ExampleInspector_DescribeAssessmentTemplates() {
 }
 
 func ExampleInspector_DescribeCrossAccountAccessRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -328,11 +284,7 @@ func ExampleInspector_DescribeCrossAccountAccessRole() {
 }
 
 func ExampleInspector_DescribeFindings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -357,11 +309,7 @@ func ExampleInspector_DescribeFindings() {
 }
 
 func ExampleInspector_DescribeResourceGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -385,11 +333,7 @@ func ExampleInspector_DescribeResourceGroups() {
 }
 
 func ExampleInspector_DescribeRulesPackages() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -414,11 +358,7 @@ func ExampleInspector_DescribeRulesPackages() {
 }
 
 func ExampleInspector_GetTelemetryMetadata() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -439,11 +379,7 @@ func ExampleInspector_GetTelemetryMetadata() {
 }
 
 func ExampleInspector_ListAssessmentRunAgents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -476,11 +412,7 @@ func ExampleInspector_ListAssessmentRunAgents() {
 }
 
 func ExampleInspector_ListAssessmentRuns() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -533,11 +465,7 @@ func ExampleInspector_ListAssessmentRuns() {
 }
 
 func ExampleInspector_ListAssessmentTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -562,11 +490,7 @@ func ExampleInspector_ListAssessmentTargets() {
 }
 
 func ExampleInspector_ListAssessmentTemplates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -603,11 +527,7 @@ func ExampleInspector_ListAssessmentTemplates() {
 }
 
 func ExampleInspector_ListEventSubscriptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -630,11 +550,7 @@ func ExampleInspector_ListEventSubscriptions() {
 }
 
 func ExampleInspector_ListFindings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -700,11 +616,7 @@ func ExampleInspector_ListFindings() {
 }
 
 func ExampleInspector_ListRulesPackages() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -726,11 +638,7 @@ func ExampleInspector_ListRulesPackages() {
 }
 
 func ExampleInspector_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -751,11 +659,7 @@ func ExampleInspector_ListTagsForResource() {
 }
 
 func ExampleInspector_PreviewAgents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -778,11 +682,7 @@ func ExampleInspector_PreviewAgents() {
 }
 
 func ExampleInspector_RegisterCrossAccountAccessRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -803,11 +703,7 @@ func ExampleInspector_RegisterCrossAccountAccessRole() {
 }
 
 func ExampleInspector_RemoveAttributesFromFindings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -835,11 +731,7 @@ func ExampleInspector_RemoveAttributesFromFindings() {
 }
 
 func ExampleInspector_SetTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -867,11 +759,7 @@ func ExampleInspector_SetTagsForResource() {
 }
 
 func ExampleInspector_StartAssessmentRun() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -893,11 +781,7 @@ func ExampleInspector_StartAssessmentRun() {
 }
 
 func ExampleInspector_StopAssessmentRun() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -918,11 +802,7 @@ func ExampleInspector_StopAssessmentRun() {
 }
 
 func ExampleInspector_SubscribeToEvent() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -945,11 +825,7 @@ func ExampleInspector_SubscribeToEvent() {
 }
 
 func ExampleInspector_UnsubscribeFromEvent() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 
@@ -972,11 +848,7 @@ func ExampleInspector_UnsubscribeFromEvent() {
 }
 
 func ExampleInspector_UpdateAssessmentTarget() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := inspector.New(sess)
 

--- a/service/iot/examples_test.go
+++ b/service/iot/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleIoT_AcceptCertificateTransfer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleIoT_AcceptCertificateTransfer() {
 }
 
 func ExampleIoT_AttachPrincipalPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -68,11 +60,7 @@ func ExampleIoT_AttachPrincipalPolicy() {
 }
 
 func ExampleIoT_AttachThingPrincipal() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -94,11 +82,7 @@ func ExampleIoT_AttachThingPrincipal() {
 }
 
 func ExampleIoT_CancelCertificateTransfer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -119,11 +103,7 @@ func ExampleIoT_CancelCertificateTransfer() {
 }
 
 func ExampleIoT_CreateCertificateFromCsr() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -145,11 +125,7 @@ func ExampleIoT_CreateCertificateFromCsr() {
 }
 
 func ExampleIoT_CreateKeysAndCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -170,11 +146,7 @@ func ExampleIoT_CreateKeysAndCertificate() {
 }
 
 func ExampleIoT_CreatePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -196,11 +168,7 @@ func ExampleIoT_CreatePolicy() {
 }
 
 func ExampleIoT_CreatePolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -223,11 +191,7 @@ func ExampleIoT_CreatePolicyVersion() {
 }
 
 func ExampleIoT_CreateThing() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -256,11 +220,7 @@ func ExampleIoT_CreateThing() {
 }
 
 func ExampleIoT_CreateThingType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -288,11 +248,7 @@ func ExampleIoT_CreateThingType() {
 }
 
 func ExampleIoT_CreateTopicRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -396,11 +352,7 @@ func ExampleIoT_CreateTopicRule() {
 }
 
 func ExampleIoT_DeleteCACertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -421,11 +373,7 @@ func ExampleIoT_DeleteCACertificate() {
 }
 
 func ExampleIoT_DeleteCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -446,11 +394,7 @@ func ExampleIoT_DeleteCertificate() {
 }
 
 func ExampleIoT_DeletePolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -471,11 +415,7 @@ func ExampleIoT_DeletePolicy() {
 }
 
 func ExampleIoT_DeletePolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -497,11 +437,7 @@ func ExampleIoT_DeletePolicyVersion() {
 }
 
 func ExampleIoT_DeleteRegistrationCode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -520,11 +456,7 @@ func ExampleIoT_DeleteRegistrationCode() {
 }
 
 func ExampleIoT_DeleteThing() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -546,11 +478,7 @@ func ExampleIoT_DeleteThing() {
 }
 
 func ExampleIoT_DeleteThingType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -571,11 +499,7 @@ func ExampleIoT_DeleteThingType() {
 }
 
 func ExampleIoT_DeleteTopicRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -596,11 +520,7 @@ func ExampleIoT_DeleteTopicRule() {
 }
 
 func ExampleIoT_DeprecateThingType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -622,11 +542,7 @@ func ExampleIoT_DeprecateThingType() {
 }
 
 func ExampleIoT_DescribeCACertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -647,11 +563,7 @@ func ExampleIoT_DescribeCACertificate() {
 }
 
 func ExampleIoT_DescribeCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -672,11 +584,7 @@ func ExampleIoT_DescribeCertificate() {
 }
 
 func ExampleIoT_DescribeEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -695,11 +603,7 @@ func ExampleIoT_DescribeEndpoint() {
 }
 
 func ExampleIoT_DescribeThing() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -720,11 +624,7 @@ func ExampleIoT_DescribeThing() {
 }
 
 func ExampleIoT_DescribeThingType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -745,11 +645,7 @@ func ExampleIoT_DescribeThingType() {
 }
 
 func ExampleIoT_DetachPrincipalPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -771,11 +667,7 @@ func ExampleIoT_DetachPrincipalPolicy() {
 }
 
 func ExampleIoT_DetachThingPrincipal() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -797,11 +689,7 @@ func ExampleIoT_DetachThingPrincipal() {
 }
 
 func ExampleIoT_DisableTopicRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -822,11 +710,7 @@ func ExampleIoT_DisableTopicRule() {
 }
 
 func ExampleIoT_EnableTopicRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -847,11 +731,7 @@ func ExampleIoT_EnableTopicRule() {
 }
 
 func ExampleIoT_GetLoggingOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -870,11 +750,7 @@ func ExampleIoT_GetLoggingOptions() {
 }
 
 func ExampleIoT_GetPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -895,11 +771,7 @@ func ExampleIoT_GetPolicy() {
 }
 
 func ExampleIoT_GetPolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -921,11 +793,7 @@ func ExampleIoT_GetPolicyVersion() {
 }
 
 func ExampleIoT_GetRegistrationCode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -944,11 +812,7 @@ func ExampleIoT_GetRegistrationCode() {
 }
 
 func ExampleIoT_GetTopicRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -969,11 +833,7 @@ func ExampleIoT_GetTopicRule() {
 }
 
 func ExampleIoT_ListCACertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -996,11 +856,7 @@ func ExampleIoT_ListCACertificates() {
 }
 
 func ExampleIoT_ListCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1023,11 +879,7 @@ func ExampleIoT_ListCertificates() {
 }
 
 func ExampleIoT_ListCertificatesByCA() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1051,11 +903,7 @@ func ExampleIoT_ListCertificatesByCA() {
 }
 
 func ExampleIoT_ListOutgoingCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1078,11 +926,7 @@ func ExampleIoT_ListOutgoingCertificates() {
 }
 
 func ExampleIoT_ListPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1105,11 +949,7 @@ func ExampleIoT_ListPolicies() {
 }
 
 func ExampleIoT_ListPolicyPrincipals() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1133,11 +973,7 @@ func ExampleIoT_ListPolicyPrincipals() {
 }
 
 func ExampleIoT_ListPolicyVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1158,11 +994,7 @@ func ExampleIoT_ListPolicyVersions() {
 }
 
 func ExampleIoT_ListPrincipalPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1186,11 +1018,7 @@ func ExampleIoT_ListPrincipalPolicies() {
 }
 
 func ExampleIoT_ListPrincipalThings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1213,11 +1041,7 @@ func ExampleIoT_ListPrincipalThings() {
 }
 
 func ExampleIoT_ListThingPrincipals() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1238,11 +1062,7 @@ func ExampleIoT_ListThingPrincipals() {
 }
 
 func ExampleIoT_ListThingTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1265,11 +1085,7 @@ func ExampleIoT_ListThingTypes() {
 }
 
 func ExampleIoT_ListThings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1294,11 +1110,7 @@ func ExampleIoT_ListThings() {
 }
 
 func ExampleIoT_ListTopicRules() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1322,11 +1134,7 @@ func ExampleIoT_ListTopicRules() {
 }
 
 func ExampleIoT_RegisterCACertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1350,11 +1158,7 @@ func ExampleIoT_RegisterCACertificate() {
 }
 
 func ExampleIoT_RegisterCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1378,11 +1182,7 @@ func ExampleIoT_RegisterCertificate() {
 }
 
 func ExampleIoT_RejectCertificateTransfer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1404,11 +1204,7 @@ func ExampleIoT_RejectCertificateTransfer() {
 }
 
 func ExampleIoT_ReplaceTopicRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1512,11 +1308,7 @@ func ExampleIoT_ReplaceTopicRule() {
 }
 
 func ExampleIoT_SetDefaultPolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1538,11 +1330,7 @@ func ExampleIoT_SetDefaultPolicyVersion() {
 }
 
 func ExampleIoT_SetLoggingOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1566,11 +1354,7 @@ func ExampleIoT_SetLoggingOptions() {
 }
 
 func ExampleIoT_TransferCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1593,11 +1377,7 @@ func ExampleIoT_TransferCertificate() {
 }
 
 func ExampleIoT_UpdateCACertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1620,11 +1400,7 @@ func ExampleIoT_UpdateCACertificate() {
 }
 
 func ExampleIoT_UpdateCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 
@@ -1646,11 +1422,7 @@ func ExampleIoT_UpdateCertificate() {
 }
 
 func ExampleIoT_UpdateThing() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iot.New(sess)
 

--- a/service/iotdataplane/examples_test.go
+++ b/service/iotdataplane/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleIoTDataPlane_DeleteThingShadow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iotdataplane.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleIoTDataPlane_DeleteThingShadow() {
 }
 
 func ExampleIoTDataPlane_GetThingShadow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iotdataplane.New(sess)
 
@@ -66,11 +58,7 @@ func ExampleIoTDataPlane_GetThingShadow() {
 }
 
 func ExampleIoTDataPlane_Publish() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iotdataplane.New(sess)
 
@@ -93,11 +81,7 @@ func ExampleIoTDataPlane_Publish() {
 }
 
 func ExampleIoTDataPlane_UpdateThingShadow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := iotdataplane.New(sess)
 

--- a/service/kinesis/examples_test.go
+++ b/service/kinesis/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleKinesis_AddTagsToStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -45,11 +41,7 @@ func ExampleKinesis_AddTagsToStream() {
 }
 
 func ExampleKinesis_CreateStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleKinesis_CreateStream() {
 }
 
 func ExampleKinesis_DecreaseStreamRetentionPeriod() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -97,11 +85,7 @@ func ExampleKinesis_DecreaseStreamRetentionPeriod() {
 }
 
 func ExampleKinesis_DeleteStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -122,11 +106,7 @@ func ExampleKinesis_DeleteStream() {
 }
 
 func ExampleKinesis_DescribeLimits() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -145,11 +125,7 @@ func ExampleKinesis_DescribeLimits() {
 }
 
 func ExampleKinesis_DescribeStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -172,11 +148,7 @@ func ExampleKinesis_DescribeStream() {
 }
 
 func ExampleKinesis_DisableEnhancedMonitoring() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -201,11 +173,7 @@ func ExampleKinesis_DisableEnhancedMonitoring() {
 }
 
 func ExampleKinesis_EnableEnhancedMonitoring() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -230,11 +198,7 @@ func ExampleKinesis_EnableEnhancedMonitoring() {
 }
 
 func ExampleKinesis_GetRecords() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -256,11 +220,7 @@ func ExampleKinesis_GetRecords() {
 }
 
 func ExampleKinesis_GetShardIterator() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -285,11 +245,7 @@ func ExampleKinesis_GetShardIterator() {
 }
 
 func ExampleKinesis_IncreaseStreamRetentionPeriod() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -311,11 +267,7 @@ func ExampleKinesis_IncreaseStreamRetentionPeriod() {
 }
 
 func ExampleKinesis_ListStreams() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -337,11 +289,7 @@ func ExampleKinesis_ListStreams() {
 }
 
 func ExampleKinesis_ListTagsForStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -364,11 +312,7 @@ func ExampleKinesis_ListTagsForStream() {
 }
 
 func ExampleKinesis_MergeShards() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -391,11 +335,7 @@ func ExampleKinesis_MergeShards() {
 }
 
 func ExampleKinesis_PutRecord() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -420,11 +360,7 @@ func ExampleKinesis_PutRecord() {
 }
 
 func ExampleKinesis_PutRecords() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -453,11 +389,7 @@ func ExampleKinesis_PutRecords() {
 }
 
 func ExampleKinesis_RemoveTagsFromStream() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -482,11 +414,7 @@ func ExampleKinesis_RemoveTagsFromStream() {
 }
 
 func ExampleKinesis_SplitShard() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 
@@ -509,11 +437,7 @@ func ExampleKinesis_SplitShard() {
 }
 
 func ExampleKinesis_UpdateShardCount() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesis.New(sess)
 

--- a/service/kinesisanalytics/examples_test.go
+++ b/service/kinesisanalytics/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleKinesisAnalytics_AddApplicationInput() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -79,11 +75,7 @@ func ExampleKinesisAnalytics_AddApplicationInput() {
 }
 
 func ExampleKinesisAnalytics_AddApplicationOutput() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -119,11 +111,7 @@ func ExampleKinesisAnalytics_AddApplicationOutput() {
 }
 
 func ExampleKinesisAnalytics_AddApplicationReferenceDataSource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -176,11 +164,7 @@ func ExampleKinesisAnalytics_AddApplicationReferenceDataSource() {
 }
 
 func ExampleKinesisAnalytics_CreateApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -260,11 +244,7 @@ func ExampleKinesisAnalytics_CreateApplication() {
 }
 
 func ExampleKinesisAnalytics_DeleteApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -286,11 +266,7 @@ func ExampleKinesisAnalytics_DeleteApplication() {
 }
 
 func ExampleKinesisAnalytics_DeleteApplicationOutput() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -313,11 +289,7 @@ func ExampleKinesisAnalytics_DeleteApplicationOutput() {
 }
 
 func ExampleKinesisAnalytics_DeleteApplicationReferenceDataSource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -340,11 +312,7 @@ func ExampleKinesisAnalytics_DeleteApplicationReferenceDataSource() {
 }
 
 func ExampleKinesisAnalytics_DescribeApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -365,11 +333,7 @@ func ExampleKinesisAnalytics_DescribeApplication() {
 }
 
 func ExampleKinesisAnalytics_DiscoverInputSchema() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -394,11 +358,7 @@ func ExampleKinesisAnalytics_DiscoverInputSchema() {
 }
 
 func ExampleKinesisAnalytics_ListApplications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -420,11 +380,7 @@ func ExampleKinesisAnalytics_ListApplications() {
 }
 
 func ExampleKinesisAnalytics_StartApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -454,11 +410,7 @@ func ExampleKinesisAnalytics_StartApplication() {
 }
 
 func ExampleKinesisAnalytics_StopApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 
@@ -479,11 +431,7 @@ func ExampleKinesisAnalytics_StopApplication() {
 }
 
 func ExampleKinesisAnalytics_UpdateApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kinesisanalytics.New(sess)
 

--- a/service/kms/examples_test.go
+++ b/service/kms/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleKMS_CancelKeyDeletion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleKMS_CancelKeyDeletion() {
 }
 
 func ExampleKMS_CreateAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -67,11 +59,7 @@ func ExampleKMS_CreateAlias() {
 }
 
 func ExampleKMS_CreateGrant() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -113,11 +101,7 @@ func ExampleKMS_CreateGrant() {
 }
 
 func ExampleKMS_CreateKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -149,11 +133,7 @@ func ExampleKMS_CreateKey() {
 }
 
 func ExampleKMS_Decrypt() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -182,11 +162,7 @@ func ExampleKMS_Decrypt() {
 }
 
 func ExampleKMS_DeleteAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -207,11 +183,7 @@ func ExampleKMS_DeleteAlias() {
 }
 
 func ExampleKMS_DeleteImportedKeyMaterial() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -232,11 +204,7 @@ func ExampleKMS_DeleteImportedKeyMaterial() {
 }
 
 func ExampleKMS_DescribeKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -261,11 +229,7 @@ func ExampleKMS_DescribeKey() {
 }
 
 func ExampleKMS_DisableKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -286,11 +250,7 @@ func ExampleKMS_DisableKey() {
 }
 
 func ExampleKMS_DisableKeyRotation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -311,11 +271,7 @@ func ExampleKMS_DisableKeyRotation() {
 }
 
 func ExampleKMS_EnableKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -336,11 +292,7 @@ func ExampleKMS_EnableKey() {
 }
 
 func ExampleKMS_EnableKeyRotation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -361,11 +313,7 @@ func ExampleKMS_EnableKeyRotation() {
 }
 
 func ExampleKMS_Encrypt() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -395,11 +343,7 @@ func ExampleKMS_Encrypt() {
 }
 
 func ExampleKMS_GenerateDataKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -430,11 +374,7 @@ func ExampleKMS_GenerateDataKey() {
 }
 
 func ExampleKMS_GenerateDataKeyWithoutPlaintext() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -465,11 +405,7 @@ func ExampleKMS_GenerateDataKeyWithoutPlaintext() {
 }
 
 func ExampleKMS_GenerateRandom() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -490,11 +426,7 @@ func ExampleKMS_GenerateRandom() {
 }
 
 func ExampleKMS_GetKeyPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -516,11 +448,7 @@ func ExampleKMS_GetKeyPolicy() {
 }
 
 func ExampleKMS_GetKeyRotationStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -541,11 +469,7 @@ func ExampleKMS_GetKeyRotationStatus() {
 }
 
 func ExampleKMS_GetParametersForImport() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -568,11 +492,7 @@ func ExampleKMS_GetParametersForImport() {
 }
 
 func ExampleKMS_ImportKeyMaterial() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -597,11 +517,7 @@ func ExampleKMS_ImportKeyMaterial() {
 }
 
 func ExampleKMS_ListAliases() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -623,11 +539,7 @@ func ExampleKMS_ListAliases() {
 }
 
 func ExampleKMS_ListGrants() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -650,11 +562,7 @@ func ExampleKMS_ListGrants() {
 }
 
 func ExampleKMS_ListKeyPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -677,11 +585,7 @@ func ExampleKMS_ListKeyPolicies() {
 }
 
 func ExampleKMS_ListKeys() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -703,11 +607,7 @@ func ExampleKMS_ListKeys() {
 }
 
 func ExampleKMS_ListResourceTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -730,11 +630,7 @@ func ExampleKMS_ListResourceTags() {
 }
 
 func ExampleKMS_ListRetirableGrants() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -757,11 +653,7 @@ func ExampleKMS_ListRetirableGrants() {
 }
 
 func ExampleKMS_PutKeyPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -785,11 +677,7 @@ func ExampleKMS_PutKeyPolicy() {
 }
 
 func ExampleKMS_ReEncrypt() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -823,11 +711,7 @@ func ExampleKMS_ReEncrypt() {
 }
 
 func ExampleKMS_RetireGrant() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -850,11 +734,7 @@ func ExampleKMS_RetireGrant() {
 }
 
 func ExampleKMS_RevokeGrant() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -876,11 +756,7 @@ func ExampleKMS_RevokeGrant() {
 }
 
 func ExampleKMS_ScheduleKeyDeletion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -902,11 +778,7 @@ func ExampleKMS_ScheduleKeyDeletion() {
 }
 
 func ExampleKMS_TagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -934,11 +806,7 @@ func ExampleKMS_TagResource() {
 }
 
 func ExampleKMS_UntagResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -963,11 +831,7 @@ func ExampleKMS_UntagResource() {
 }
 
 func ExampleKMS_UpdateAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 
@@ -989,11 +853,7 @@ func ExampleKMS_UpdateAlias() {
 }
 
 func ExampleKMS_UpdateKeyDescription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := kms.New(sess)
 

--- a/service/lambda/examples_test.go
+++ b/service/lambda/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleLambda_AddPermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleLambda_AddPermission() {
 }
 
 func ExampleLambda_CreateAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -76,11 +68,7 @@ func ExampleLambda_CreateAlias() {
 }
 
 func ExampleLambda_CreateEventSourceMapping() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -106,11 +94,7 @@ func ExampleLambda_CreateEventSourceMapping() {
 }
 
 func ExampleLambda_CreateFunction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -164,11 +148,7 @@ func ExampleLambda_CreateFunction() {
 }
 
 func ExampleLambda_DeleteAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -190,11 +170,7 @@ func ExampleLambda_DeleteAlias() {
 }
 
 func ExampleLambda_DeleteEventSourceMapping() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -215,11 +191,7 @@ func ExampleLambda_DeleteEventSourceMapping() {
 }
 
 func ExampleLambda_DeleteFunction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -241,11 +213,7 @@ func ExampleLambda_DeleteFunction() {
 }
 
 func ExampleLambda_GetAccountSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -264,11 +232,7 @@ func ExampleLambda_GetAccountSettings() {
 }
 
 func ExampleLambda_GetAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -290,11 +254,7 @@ func ExampleLambda_GetAlias() {
 }
 
 func ExampleLambda_GetEventSourceMapping() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -315,11 +275,7 @@ func ExampleLambda_GetEventSourceMapping() {
 }
 
 func ExampleLambda_GetFunction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -341,11 +297,7 @@ func ExampleLambda_GetFunction() {
 }
 
 func ExampleLambda_GetFunctionConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -367,11 +319,7 @@ func ExampleLambda_GetFunctionConfiguration() {
 }
 
 func ExampleLambda_GetPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -393,11 +341,7 @@ func ExampleLambda_GetPolicy() {
 }
 
 func ExampleLambda_Invoke() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -423,11 +367,7 @@ func ExampleLambda_Invoke() {
 }
 
 func ExampleLambda_InvokeAsync() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -449,11 +389,7 @@ func ExampleLambda_InvokeAsync() {
 }
 
 func ExampleLambda_ListAliases() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -477,11 +413,7 @@ func ExampleLambda_ListAliases() {
 }
 
 func ExampleLambda_ListEventSourceMappings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -505,11 +437,7 @@ func ExampleLambda_ListEventSourceMappings() {
 }
 
 func ExampleLambda_ListFunctions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -531,11 +459,7 @@ func ExampleLambda_ListFunctions() {
 }
 
 func ExampleLambda_ListVersionsByFunction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -558,11 +482,7 @@ func ExampleLambda_ListVersionsByFunction() {
 }
 
 func ExampleLambda_PublishVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -585,11 +505,7 @@ func ExampleLambda_PublishVersion() {
 }
 
 func ExampleLambda_RemovePermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -612,11 +528,7 @@ func ExampleLambda_RemovePermission() {
 }
 
 func ExampleLambda_UpdateAlias() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -640,11 +552,7 @@ func ExampleLambda_UpdateAlias() {
 }
 
 func ExampleLambda_UpdateEventSourceMapping() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -668,11 +576,7 @@ func ExampleLambda_UpdateEventSourceMapping() {
 }
 
 func ExampleLambda_UpdateFunctionCode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 
@@ -698,11 +602,7 @@ func ExampleLambda_UpdateFunctionCode() {
 }
 
 func ExampleLambda_UpdateFunctionConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lambda.New(sess)
 

--- a/service/lexruntimeservice/examples_test.go
+++ b/service/lexruntimeservice/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleLexRuntimeService_PostText() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lexruntimeservice.New(sess)
 

--- a/service/lightsail/examples_test.go
+++ b/service/lightsail/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleLightsail_AllocateStaticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleLightsail_AllocateStaticIp() {
 }
 
 func ExampleLightsail_AttachStaticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -67,11 +59,7 @@ func ExampleLightsail_AttachStaticIp() {
 }
 
 func ExampleLightsail_CloseInstancePublicPorts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -97,11 +85,7 @@ func ExampleLightsail_CloseInstancePublicPorts() {
 }
 
 func ExampleLightsail_CreateDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -122,11 +106,7 @@ func ExampleLightsail_CreateDomain() {
 }
 
 func ExampleLightsail_CreateDomainEntry() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -157,11 +137,7 @@ func ExampleLightsail_CreateDomainEntry() {
 }
 
 func ExampleLightsail_CreateInstanceSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -183,11 +159,7 @@ func ExampleLightsail_CreateInstanceSnapshot() {
 }
 
 func ExampleLightsail_CreateInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -217,11 +189,7 @@ func ExampleLightsail_CreateInstances() {
 }
 
 func ExampleLightsail_CreateInstancesFromSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -250,11 +218,7 @@ func ExampleLightsail_CreateInstancesFromSnapshot() {
 }
 
 func ExampleLightsail_CreateKeyPair() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -275,11 +239,7 @@ func ExampleLightsail_CreateKeyPair() {
 }
 
 func ExampleLightsail_DeleteDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -300,11 +260,7 @@ func ExampleLightsail_DeleteDomain() {
 }
 
 func ExampleLightsail_DeleteDomainEntry() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -335,11 +291,7 @@ func ExampleLightsail_DeleteDomainEntry() {
 }
 
 func ExampleLightsail_DeleteInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -360,11 +312,7 @@ func ExampleLightsail_DeleteInstance() {
 }
 
 func ExampleLightsail_DeleteInstanceSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -385,11 +333,7 @@ func ExampleLightsail_DeleteInstanceSnapshot() {
 }
 
 func ExampleLightsail_DeleteKeyPair() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -410,11 +354,7 @@ func ExampleLightsail_DeleteKeyPair() {
 }
 
 func ExampleLightsail_DetachStaticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -435,11 +375,7 @@ func ExampleLightsail_DetachStaticIp() {
 }
 
 func ExampleLightsail_DownloadDefaultKeyPair() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -458,11 +394,7 @@ func ExampleLightsail_DownloadDefaultKeyPair() {
 }
 
 func ExampleLightsail_GetActiveNames() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -483,11 +415,7 @@ func ExampleLightsail_GetActiveNames() {
 }
 
 func ExampleLightsail_GetBlueprints() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -509,11 +437,7 @@ func ExampleLightsail_GetBlueprints() {
 }
 
 func ExampleLightsail_GetBundles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -535,11 +459,7 @@ func ExampleLightsail_GetBundles() {
 }
 
 func ExampleLightsail_GetDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -560,11 +480,7 @@ func ExampleLightsail_GetDomain() {
 }
 
 func ExampleLightsail_GetDomains() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -585,11 +501,7 @@ func ExampleLightsail_GetDomains() {
 }
 
 func ExampleLightsail_GetInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -610,11 +522,7 @@ func ExampleLightsail_GetInstance() {
 }
 
 func ExampleLightsail_GetInstanceAccessDetails() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -636,11 +544,7 @@ func ExampleLightsail_GetInstanceAccessDetails() {
 }
 
 func ExampleLightsail_GetInstanceMetricData() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -670,11 +574,7 @@ func ExampleLightsail_GetInstanceMetricData() {
 }
 
 func ExampleLightsail_GetInstancePortStates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -695,11 +595,7 @@ func ExampleLightsail_GetInstancePortStates() {
 }
 
 func ExampleLightsail_GetInstanceSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -720,11 +616,7 @@ func ExampleLightsail_GetInstanceSnapshot() {
 }
 
 func ExampleLightsail_GetInstanceSnapshots() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -745,11 +637,7 @@ func ExampleLightsail_GetInstanceSnapshots() {
 }
 
 func ExampleLightsail_GetInstanceState() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -770,11 +658,7 @@ func ExampleLightsail_GetInstanceState() {
 }
 
 func ExampleLightsail_GetInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -795,11 +679,7 @@ func ExampleLightsail_GetInstances() {
 }
 
 func ExampleLightsail_GetKeyPair() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -820,11 +700,7 @@ func ExampleLightsail_GetKeyPair() {
 }
 
 func ExampleLightsail_GetKeyPairs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -845,11 +721,7 @@ func ExampleLightsail_GetKeyPairs() {
 }
 
 func ExampleLightsail_GetOperation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -870,11 +742,7 @@ func ExampleLightsail_GetOperation() {
 }
 
 func ExampleLightsail_GetOperations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -895,11 +763,7 @@ func ExampleLightsail_GetOperations() {
 }
 
 func ExampleLightsail_GetOperationsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -921,11 +785,7 @@ func ExampleLightsail_GetOperationsForResource() {
 }
 
 func ExampleLightsail_GetRegions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -946,11 +806,7 @@ func ExampleLightsail_GetRegions() {
 }
 
 func ExampleLightsail_GetStaticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -971,11 +827,7 @@ func ExampleLightsail_GetStaticIp() {
 }
 
 func ExampleLightsail_GetStaticIps() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -996,11 +848,7 @@ func ExampleLightsail_GetStaticIps() {
 }
 
 func ExampleLightsail_ImportKeyPair() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1022,11 +870,7 @@ func ExampleLightsail_ImportKeyPair() {
 }
 
 func ExampleLightsail_IsVpcPeered() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1045,11 +889,7 @@ func ExampleLightsail_IsVpcPeered() {
 }
 
 func ExampleLightsail_OpenInstancePublicPorts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1075,11 +915,7 @@ func ExampleLightsail_OpenInstancePublicPorts() {
 }
 
 func ExampleLightsail_PeerVpc() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1098,11 +934,7 @@ func ExampleLightsail_PeerVpc() {
 }
 
 func ExampleLightsail_RebootInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1123,11 +955,7 @@ func ExampleLightsail_RebootInstance() {
 }
 
 func ExampleLightsail_ReleaseStaticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1148,11 +976,7 @@ func ExampleLightsail_ReleaseStaticIp() {
 }
 
 func ExampleLightsail_StartInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1173,11 +997,7 @@ func ExampleLightsail_StartInstance() {
 }
 
 func ExampleLightsail_StopInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1198,11 +1018,7 @@ func ExampleLightsail_StopInstance() {
 }
 
 func ExampleLightsail_UnpeerVpc() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 
@@ -1221,11 +1037,7 @@ func ExampleLightsail_UnpeerVpc() {
 }
 
 func ExampleLightsail_UpdateDomainEntry() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := lightsail.New(sess)
 

--- a/service/machinelearning/examples_test.go
+++ b/service/machinelearning/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleMachineLearning_AddTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -49,11 +45,7 @@ func ExampleMachineLearning_AddTags() {
 }
 
 func ExampleMachineLearning_CreateBatchPrediction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -78,11 +70,7 @@ func ExampleMachineLearning_CreateBatchPrediction() {
 }
 
 func ExampleMachineLearning_CreateDataSourceFromRDS() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -128,11 +116,7 @@ func ExampleMachineLearning_CreateDataSourceFromRDS() {
 }
 
 func ExampleMachineLearning_CreateDataSourceFromRedshift() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -171,11 +155,7 @@ func ExampleMachineLearning_CreateDataSourceFromRedshift() {
 }
 
 func ExampleMachineLearning_CreateDataSourceFromS3() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -204,11 +184,7 @@ func ExampleMachineLearning_CreateDataSourceFromS3() {
 }
 
 func ExampleMachineLearning_CreateEvaluation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -232,11 +208,7 @@ func ExampleMachineLearning_CreateEvaluation() {
 }
 
 func ExampleMachineLearning_CreateMLModel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -266,11 +238,7 @@ func ExampleMachineLearning_CreateMLModel() {
 }
 
 func ExampleMachineLearning_CreateRealtimeEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -291,11 +259,7 @@ func ExampleMachineLearning_CreateRealtimeEndpoint() {
 }
 
 func ExampleMachineLearning_DeleteBatchPrediction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -316,11 +280,7 @@ func ExampleMachineLearning_DeleteBatchPrediction() {
 }
 
 func ExampleMachineLearning_DeleteDataSource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -341,11 +301,7 @@ func ExampleMachineLearning_DeleteDataSource() {
 }
 
 func ExampleMachineLearning_DeleteEvaluation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -366,11 +322,7 @@ func ExampleMachineLearning_DeleteEvaluation() {
 }
 
 func ExampleMachineLearning_DeleteMLModel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -391,11 +343,7 @@ func ExampleMachineLearning_DeleteMLModel() {
 }
 
 func ExampleMachineLearning_DeleteRealtimeEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -416,11 +364,7 @@ func ExampleMachineLearning_DeleteRealtimeEndpoint() {
 }
 
 func ExampleMachineLearning_DeleteTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -446,11 +390,7 @@ func ExampleMachineLearning_DeleteTags() {
 }
 
 func ExampleMachineLearning_DescribeBatchPredictions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -481,11 +421,7 @@ func ExampleMachineLearning_DescribeBatchPredictions() {
 }
 
 func ExampleMachineLearning_DescribeDataSources() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -516,11 +452,7 @@ func ExampleMachineLearning_DescribeDataSources() {
 }
 
 func ExampleMachineLearning_DescribeEvaluations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -551,11 +483,7 @@ func ExampleMachineLearning_DescribeEvaluations() {
 }
 
 func ExampleMachineLearning_DescribeMLModels() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -586,11 +514,7 @@ func ExampleMachineLearning_DescribeMLModels() {
 }
 
 func ExampleMachineLearning_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -612,11 +536,7 @@ func ExampleMachineLearning_DescribeTags() {
 }
 
 func ExampleMachineLearning_GetBatchPrediction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -637,11 +557,7 @@ func ExampleMachineLearning_GetBatchPrediction() {
 }
 
 func ExampleMachineLearning_GetDataSource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -663,11 +579,7 @@ func ExampleMachineLearning_GetDataSource() {
 }
 
 func ExampleMachineLearning_GetEvaluation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -688,11 +600,7 @@ func ExampleMachineLearning_GetEvaluation() {
 }
 
 func ExampleMachineLearning_GetMLModel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -714,11 +622,7 @@ func ExampleMachineLearning_GetMLModel() {
 }
 
 func ExampleMachineLearning_Predict() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -744,11 +648,7 @@ func ExampleMachineLearning_Predict() {
 }
 
 func ExampleMachineLearning_UpdateBatchPrediction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -770,11 +670,7 @@ func ExampleMachineLearning_UpdateBatchPrediction() {
 }
 
 func ExampleMachineLearning_UpdateDataSource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -796,11 +692,7 @@ func ExampleMachineLearning_UpdateDataSource() {
 }
 
 func ExampleMachineLearning_UpdateEvaluation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 
@@ -822,11 +714,7 @@ func ExampleMachineLearning_UpdateEvaluation() {
 }
 
 func ExampleMachineLearning_UpdateMLModel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := machinelearning.New(sess)
 

--- a/service/marketplacecommerceanalytics/examples_test.go
+++ b/service/marketplacecommerceanalytics/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleMarketplaceCommerceAnalytics_GenerateDataSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := marketplacecommerceanalytics.New(sess)
 
@@ -50,11 +46,7 @@ func ExampleMarketplaceCommerceAnalytics_GenerateDataSet() {
 }
 
 func ExampleMarketplaceCommerceAnalytics_StartSupportDataExport() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := marketplacecommerceanalytics.New(sess)
 

--- a/service/marketplacemetering/examples_test.go
+++ b/service/marketplacemetering/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleMarketplaceMetering_BatchMeterUsage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := marketplacemetering.New(sess)
 
@@ -50,11 +46,7 @@ func ExampleMarketplaceMetering_BatchMeterUsage() {
 }
 
 func ExampleMarketplaceMetering_MeterUsage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := marketplacemetering.New(sess)
 
@@ -79,11 +71,7 @@ func ExampleMarketplaceMetering_MeterUsage() {
 }
 
 func ExampleMarketplaceMetering_ResolveCustomer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := marketplacemetering.New(sess)
 

--- a/service/mobileanalytics/examples_test.go
+++ b/service/mobileanalytics/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleMobileAnalytics_PutEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := mobileanalytics.New(sess)
 

--- a/service/opsworks/examples_test.go
+++ b/service/opsworks/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleOpsWorks_AssignInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -45,11 +41,7 @@ func ExampleOpsWorks_AssignInstance() {
 }
 
 func ExampleOpsWorks_AssignVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleOpsWorks_AssignVolume() {
 }
 
 func ExampleOpsWorks_AssociateElasticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -97,11 +85,7 @@ func ExampleOpsWorks_AssociateElasticIp() {
 }
 
 func ExampleOpsWorks_AttachElasticLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -123,11 +107,7 @@ func ExampleOpsWorks_AttachElasticLoadBalancer() {
 }
 
 func ExampleOpsWorks_CloneStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -188,11 +168,7 @@ func ExampleOpsWorks_CloneStack() {
 }
 
 func ExampleOpsWorks_CreateApp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -255,11 +231,7 @@ func ExampleOpsWorks_CreateApp() {
 }
 
 func ExampleOpsWorks_CreateDeployment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -301,11 +273,7 @@ func ExampleOpsWorks_CreateDeployment() {
 }
 
 func ExampleOpsWorks_CreateInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -360,11 +328,7 @@ func ExampleOpsWorks_CreateInstance() {
 }
 
 func ExampleOpsWorks_CreateLayer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -446,11 +410,7 @@ func ExampleOpsWorks_CreateLayer() {
 }
 
 func ExampleOpsWorks_CreateStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -505,11 +465,7 @@ func ExampleOpsWorks_CreateStack() {
 }
 
 func ExampleOpsWorks_CreateUserProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -533,11 +489,7 @@ func ExampleOpsWorks_CreateUserProfile() {
 }
 
 func ExampleOpsWorks_DeleteApp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -558,11 +510,7 @@ func ExampleOpsWorks_DeleteApp() {
 }
 
 func ExampleOpsWorks_DeleteInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -585,11 +533,7 @@ func ExampleOpsWorks_DeleteInstance() {
 }
 
 func ExampleOpsWorks_DeleteLayer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -610,11 +554,7 @@ func ExampleOpsWorks_DeleteLayer() {
 }
 
 func ExampleOpsWorks_DeleteStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -635,11 +575,7 @@ func ExampleOpsWorks_DeleteStack() {
 }
 
 func ExampleOpsWorks_DeleteUserProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -660,11 +596,7 @@ func ExampleOpsWorks_DeleteUserProfile() {
 }
 
 func ExampleOpsWorks_DeregisterEcsCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -685,11 +617,7 @@ func ExampleOpsWorks_DeregisterEcsCluster() {
 }
 
 func ExampleOpsWorks_DeregisterElasticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -710,11 +638,7 @@ func ExampleOpsWorks_DeregisterElasticIp() {
 }
 
 func ExampleOpsWorks_DeregisterInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -735,11 +659,7 @@ func ExampleOpsWorks_DeregisterInstance() {
 }
 
 func ExampleOpsWorks_DeregisterRdsDbInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -760,11 +680,7 @@ func ExampleOpsWorks_DeregisterRdsDbInstance() {
 }
 
 func ExampleOpsWorks_DeregisterVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -785,11 +701,7 @@ func ExampleOpsWorks_DeregisterVolume() {
 }
 
 func ExampleOpsWorks_DescribeAgentVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -814,11 +726,7 @@ func ExampleOpsWorks_DescribeAgentVersions() {
 }
 
 func ExampleOpsWorks_DescribeApps() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -843,11 +751,7 @@ func ExampleOpsWorks_DescribeApps() {
 }
 
 func ExampleOpsWorks_DescribeCommands() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -873,11 +777,7 @@ func ExampleOpsWorks_DescribeCommands() {
 }
 
 func ExampleOpsWorks_DescribeDeployments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -903,11 +803,7 @@ func ExampleOpsWorks_DescribeDeployments() {
 }
 
 func ExampleOpsWorks_DescribeEcsClusters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -934,11 +830,7 @@ func ExampleOpsWorks_DescribeEcsClusters() {
 }
 
 func ExampleOpsWorks_DescribeElasticIps() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -964,11 +856,7 @@ func ExampleOpsWorks_DescribeElasticIps() {
 }
 
 func ExampleOpsWorks_DescribeElasticLoadBalancers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -993,11 +881,7 @@ func ExampleOpsWorks_DescribeElasticLoadBalancers() {
 }
 
 func ExampleOpsWorks_DescribeInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1023,11 +907,7 @@ func ExampleOpsWorks_DescribeInstances() {
 }
 
 func ExampleOpsWorks_DescribeLayers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1052,11 +932,7 @@ func ExampleOpsWorks_DescribeLayers() {
 }
 
 func ExampleOpsWorks_DescribeLoadBasedAutoScaling() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1080,11 +956,7 @@ func ExampleOpsWorks_DescribeLoadBasedAutoScaling() {
 }
 
 func ExampleOpsWorks_DescribeMyUserProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1103,11 +975,7 @@ func ExampleOpsWorks_DescribeMyUserProfile() {
 }
 
 func ExampleOpsWorks_DescribePermissions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1129,11 +997,7 @@ func ExampleOpsWorks_DescribePermissions() {
 }
 
 func ExampleOpsWorks_DescribeRaidArrays() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1159,11 +1023,7 @@ func ExampleOpsWorks_DescribeRaidArrays() {
 }
 
 func ExampleOpsWorks_DescribeRdsDbInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1188,11 +1048,7 @@ func ExampleOpsWorks_DescribeRdsDbInstances() {
 }
 
 func ExampleOpsWorks_DescribeServiceErrors() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1218,11 +1074,7 @@ func ExampleOpsWorks_DescribeServiceErrors() {
 }
 
 func ExampleOpsWorks_DescribeStackProvisioningParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1243,11 +1095,7 @@ func ExampleOpsWorks_DescribeStackProvisioningParameters() {
 }
 
 func ExampleOpsWorks_DescribeStackSummary() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1268,11 +1116,7 @@ func ExampleOpsWorks_DescribeStackSummary() {
 }
 
 func ExampleOpsWorks_DescribeStacks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1296,11 +1140,7 @@ func ExampleOpsWorks_DescribeStacks() {
 }
 
 func ExampleOpsWorks_DescribeTimeBasedAutoScaling() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1324,11 +1164,7 @@ func ExampleOpsWorks_DescribeTimeBasedAutoScaling() {
 }
 
 func ExampleOpsWorks_DescribeUserProfiles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1352,11 +1188,7 @@ func ExampleOpsWorks_DescribeUserProfiles() {
 }
 
 func ExampleOpsWorks_DescribeVolumes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1383,11 +1215,7 @@ func ExampleOpsWorks_DescribeVolumes() {
 }
 
 func ExampleOpsWorks_DetachElasticLoadBalancer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1409,11 +1237,7 @@ func ExampleOpsWorks_DetachElasticLoadBalancer() {
 }
 
 func ExampleOpsWorks_DisassociateElasticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1434,11 +1258,7 @@ func ExampleOpsWorks_DisassociateElasticIp() {
 }
 
 func ExampleOpsWorks_GetHostnameSuggestion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1459,11 +1279,7 @@ func ExampleOpsWorks_GetHostnameSuggestion() {
 }
 
 func ExampleOpsWorks_GrantAccess() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1485,11 +1301,7 @@ func ExampleOpsWorks_GrantAccess() {
 }
 
 func ExampleOpsWorks_RebootInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1510,11 +1322,7 @@ func ExampleOpsWorks_RebootInstance() {
 }
 
 func ExampleOpsWorks_RegisterEcsCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1536,11 +1344,7 @@ func ExampleOpsWorks_RegisterEcsCluster() {
 }
 
 func ExampleOpsWorks_RegisterElasticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1562,11 +1366,7 @@ func ExampleOpsWorks_RegisterElasticIp() {
 }
 
 func ExampleOpsWorks_RegisterInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1596,11 +1396,7 @@ func ExampleOpsWorks_RegisterInstance() {
 }
 
 func ExampleOpsWorks_RegisterRdsDbInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1624,11 +1420,7 @@ func ExampleOpsWorks_RegisterRdsDbInstance() {
 }
 
 func ExampleOpsWorks_RegisterVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1650,11 +1442,7 @@ func ExampleOpsWorks_RegisterVolume() {
 }
 
 func ExampleOpsWorks_SetLoadBasedAutoScaling() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1700,11 +1488,7 @@ func ExampleOpsWorks_SetLoadBasedAutoScaling() {
 }
 
 func ExampleOpsWorks_SetPermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1729,11 +1513,7 @@ func ExampleOpsWorks_SetPermission() {
 }
 
 func ExampleOpsWorks_SetTimeBasedAutoScaling() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1784,11 +1564,7 @@ func ExampleOpsWorks_SetTimeBasedAutoScaling() {
 }
 
 func ExampleOpsWorks_StartInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1809,11 +1585,7 @@ func ExampleOpsWorks_StartInstance() {
 }
 
 func ExampleOpsWorks_StartStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1834,11 +1606,7 @@ func ExampleOpsWorks_StartStack() {
 }
 
 func ExampleOpsWorks_StopInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1859,11 +1627,7 @@ func ExampleOpsWorks_StopInstance() {
 }
 
 func ExampleOpsWorks_StopStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1884,11 +1648,7 @@ func ExampleOpsWorks_StopStack() {
 }
 
 func ExampleOpsWorks_UnassignInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1909,11 +1669,7 @@ func ExampleOpsWorks_UnassignInstance() {
 }
 
 func ExampleOpsWorks_UnassignVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -1934,11 +1690,7 @@ func ExampleOpsWorks_UnassignVolume() {
 }
 
 func ExampleOpsWorks_UpdateApp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -2000,11 +1752,7 @@ func ExampleOpsWorks_UpdateApp() {
 }
 
 func ExampleOpsWorks_UpdateElasticIp() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -2026,11 +1774,7 @@ func ExampleOpsWorks_UpdateElasticIp() {
 }
 
 func ExampleOpsWorks_UpdateInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -2065,11 +1809,7 @@ func ExampleOpsWorks_UpdateInstance() {
 }
 
 func ExampleOpsWorks_UpdateLayer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -2150,11 +1890,7 @@ func ExampleOpsWorks_UpdateLayer() {
 }
 
 func ExampleOpsWorks_UpdateMyUserProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -2175,11 +1911,7 @@ func ExampleOpsWorks_UpdateMyUserProfile() {
 }
 
 func ExampleOpsWorks_UpdateRdsDbInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -2202,11 +1934,7 @@ func ExampleOpsWorks_UpdateRdsDbInstance() {
 }
 
 func ExampleOpsWorks_UpdateStack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -2260,11 +1988,7 @@ func ExampleOpsWorks_UpdateStack() {
 }
 
 func ExampleOpsWorks_UpdateUserProfile() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 
@@ -2288,11 +2012,7 @@ func ExampleOpsWorks_UpdateUserProfile() {
 }
 
 func ExampleOpsWorks_UpdateVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworks.New(sess)
 

--- a/service/opsworkscm/examples_test.go
+++ b/service/opsworkscm/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleOpsWorksCM_AssociateNode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -49,11 +45,7 @@ func ExampleOpsWorksCM_AssociateNode() {
 }
 
 func ExampleOpsWorksCM_CreateBackup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -75,11 +67,7 @@ func ExampleOpsWorksCM_CreateBackup() {
 }
 
 func ExampleOpsWorksCM_CreateServer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -127,11 +115,7 @@ func ExampleOpsWorksCM_CreateServer() {
 }
 
 func ExampleOpsWorksCM_DeleteBackup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -152,11 +136,7 @@ func ExampleOpsWorksCM_DeleteBackup() {
 }
 
 func ExampleOpsWorksCM_DeleteServer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -177,11 +157,7 @@ func ExampleOpsWorksCM_DeleteServer() {
 }
 
 func ExampleOpsWorksCM_DescribeAccountAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -200,11 +176,7 @@ func ExampleOpsWorksCM_DescribeAccountAttributes() {
 }
 
 func ExampleOpsWorksCM_DescribeBackups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -228,11 +200,7 @@ func ExampleOpsWorksCM_DescribeBackups() {
 }
 
 func ExampleOpsWorksCM_DescribeEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -255,11 +223,7 @@ func ExampleOpsWorksCM_DescribeEvents() {
 }
 
 func ExampleOpsWorksCM_DescribeNodeAssociationStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -281,11 +245,7 @@ func ExampleOpsWorksCM_DescribeNodeAssociationStatus() {
 }
 
 func ExampleOpsWorksCM_DescribeServers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -308,11 +268,7 @@ func ExampleOpsWorksCM_DescribeServers() {
 }
 
 func ExampleOpsWorksCM_DisassociateNode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -341,11 +297,7 @@ func ExampleOpsWorksCM_DisassociateNode() {
 }
 
 func ExampleOpsWorksCM_RestoreServer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -369,11 +321,7 @@ func ExampleOpsWorksCM_RestoreServer() {
 }
 
 func ExampleOpsWorksCM_StartMaintenance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -394,11 +342,7 @@ func ExampleOpsWorksCM_StartMaintenance() {
 }
 
 func ExampleOpsWorksCM_UpdateServer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 
@@ -423,11 +367,7 @@ func ExampleOpsWorksCM_UpdateServer() {
 }
 
 func ExampleOpsWorksCM_UpdateServerEngineAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := opsworkscm.New(sess)
 

--- a/service/pinpoint/examples_test.go
+++ b/service/pinpoint/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExamplePinpoint_CreateCampaign() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -155,11 +151,7 @@ func ExamplePinpoint_CreateCampaign() {
 }
 
 func ExamplePinpoint_CreateImportJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -190,11 +182,7 @@ func ExamplePinpoint_CreateImportJob() {
 }
 
 func ExamplePinpoint_CreateSegment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -282,11 +270,7 @@ func ExamplePinpoint_CreateSegment() {
 }
 
 func ExamplePinpoint_DeleteApnsChannel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -307,11 +291,7 @@ func ExamplePinpoint_DeleteApnsChannel() {
 }
 
 func ExamplePinpoint_DeleteCampaign() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -333,11 +313,7 @@ func ExamplePinpoint_DeleteCampaign() {
 }
 
 func ExamplePinpoint_DeleteGcmChannel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -358,11 +334,7 @@ func ExamplePinpoint_DeleteGcmChannel() {
 }
 
 func ExamplePinpoint_DeleteSegment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -384,11 +356,7 @@ func ExamplePinpoint_DeleteSegment() {
 }
 
 func ExamplePinpoint_GetApnsChannel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -409,11 +377,7 @@ func ExamplePinpoint_GetApnsChannel() {
 }
 
 func ExamplePinpoint_GetApplicationSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -434,11 +398,7 @@ func ExamplePinpoint_GetApplicationSettings() {
 }
 
 func ExamplePinpoint_GetCampaign() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -460,11 +420,7 @@ func ExamplePinpoint_GetCampaign() {
 }
 
 func ExamplePinpoint_GetCampaignActivities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -488,11 +444,7 @@ func ExamplePinpoint_GetCampaignActivities() {
 }
 
 func ExamplePinpoint_GetCampaignVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -515,11 +467,7 @@ func ExamplePinpoint_GetCampaignVersion() {
 }
 
 func ExamplePinpoint_GetCampaignVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -543,11 +491,7 @@ func ExamplePinpoint_GetCampaignVersions() {
 }
 
 func ExamplePinpoint_GetCampaigns() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -570,11 +514,7 @@ func ExamplePinpoint_GetCampaigns() {
 }
 
 func ExamplePinpoint_GetEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -596,11 +536,7 @@ func ExamplePinpoint_GetEndpoint() {
 }
 
 func ExamplePinpoint_GetGcmChannel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -621,11 +557,7 @@ func ExamplePinpoint_GetGcmChannel() {
 }
 
 func ExamplePinpoint_GetImportJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -647,11 +579,7 @@ func ExamplePinpoint_GetImportJob() {
 }
 
 func ExamplePinpoint_GetImportJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -674,11 +602,7 @@ func ExamplePinpoint_GetImportJobs() {
 }
 
 func ExamplePinpoint_GetSegment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -700,11 +624,7 @@ func ExamplePinpoint_GetSegment() {
 }
 
 func ExamplePinpoint_GetSegmentImportJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -728,11 +648,7 @@ func ExamplePinpoint_GetSegmentImportJobs() {
 }
 
 func ExamplePinpoint_GetSegmentVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -755,11 +671,7 @@ func ExamplePinpoint_GetSegmentVersion() {
 }
 
 func ExamplePinpoint_GetSegmentVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -783,11 +695,7 @@ func ExamplePinpoint_GetSegmentVersions() {
 }
 
 func ExamplePinpoint_GetSegments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -810,11 +718,7 @@ func ExamplePinpoint_GetSegments() {
 }
 
 func ExamplePinpoint_UpdateApnsChannel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -839,11 +743,7 @@ func ExamplePinpoint_UpdateApnsChannel() {
 }
 
 func ExamplePinpoint_UpdateApplicationSettings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -874,11 +774,7 @@ func ExamplePinpoint_UpdateApplicationSettings() {
 }
 
 func ExamplePinpoint_UpdateCampaign() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -1014,11 +910,7 @@ func ExamplePinpoint_UpdateCampaign() {
 }
 
 func ExamplePinpoint_UpdateEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -1087,11 +979,7 @@ func ExamplePinpoint_UpdateEndpoint() {
 }
 
 func ExamplePinpoint_UpdateEndpointsBatch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -1165,11 +1053,7 @@ func ExamplePinpoint_UpdateEndpointsBatch() {
 }
 
 func ExamplePinpoint_UpdateGcmChannel() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 
@@ -1193,11 +1077,7 @@ func ExamplePinpoint_UpdateGcmChannel() {
 }
 
 func ExamplePinpoint_UpdateSegment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := pinpoint.New(sess)
 

--- a/service/polly/examples_test.go
+++ b/service/polly/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExamplePolly_DeleteLexicon() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := polly.New(sess)
 
@@ -41,11 +37,7 @@ func ExamplePolly_DeleteLexicon() {
 }
 
 func ExamplePolly_DescribeVoices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := polly.New(sess)
 
@@ -67,11 +59,7 @@ func ExamplePolly_DescribeVoices() {
 }
 
 func ExamplePolly_GetLexicon() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := polly.New(sess)
 
@@ -92,11 +80,7 @@ func ExamplePolly_GetLexicon() {
 }
 
 func ExamplePolly_ListLexicons() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := polly.New(sess)
 
@@ -117,11 +101,7 @@ func ExamplePolly_ListLexicons() {
 }
 
 func ExamplePolly_PutLexicon() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := polly.New(sess)
 
@@ -143,11 +123,7 @@ func ExamplePolly_PutLexicon() {
 }
 
 func ExamplePolly_SynthesizeSpeech() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := polly.New(sess)
 

--- a/service/rds/examples_test.go
+++ b/service/rds/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleRDS_AddRoleToDBCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleRDS_AddRoleToDBCluster() {
 }
 
 func ExampleRDS_AddSourceIdentifierToSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -68,11 +60,7 @@ func ExampleRDS_AddSourceIdentifierToSubscription() {
 }
 
 func ExampleRDS_AddTagsToResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -100,11 +88,7 @@ func ExampleRDS_AddTagsToResource() {
 }
 
 func ExampleRDS_ApplyPendingMaintenanceAction() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -127,11 +111,7 @@ func ExampleRDS_ApplyPendingMaintenanceAction() {
 }
 
 func ExampleRDS_AuthorizeDBSecurityGroupIngress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -156,11 +136,7 @@ func ExampleRDS_AuthorizeDBSecurityGroupIngress() {
 }
 
 func ExampleRDS_CopyDBClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -190,11 +166,7 @@ func ExampleRDS_CopyDBClusterParameterGroup() {
 }
 
 func ExampleRDS_CopyDBClusterSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -223,11 +195,7 @@ func ExampleRDS_CopyDBClusterSnapshot() {
 }
 
 func ExampleRDS_CopyDBParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -257,11 +225,7 @@ func ExampleRDS_CopyDBParameterGroup() {
 }
 
 func ExampleRDS_CopyDBSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -295,11 +259,7 @@ func ExampleRDS_CopyDBSnapshot() {
 }
 
 func ExampleRDS_CopyOptionGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -329,11 +289,7 @@ func ExampleRDS_CopyOptionGroup() {
 }
 
 func ExampleRDS_CreateDBCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -385,11 +341,7 @@ func ExampleRDS_CreateDBCluster() {
 }
 
 func ExampleRDS_CreateDBClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -419,11 +371,7 @@ func ExampleRDS_CreateDBClusterParameterGroup() {
 }
 
 func ExampleRDS_CreateDBClusterSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -452,11 +400,7 @@ func ExampleRDS_CreateDBClusterSnapshot() {
 }
 
 func ExampleRDS_CreateDBInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -526,11 +470,7 @@ func ExampleRDS_CreateDBInstance() {
 }
 
 func ExampleRDS_CreateDBInstanceReadReplica() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -575,11 +515,7 @@ func ExampleRDS_CreateDBInstanceReadReplica() {
 }
 
 func ExampleRDS_CreateDBParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -609,11 +545,7 @@ func ExampleRDS_CreateDBParameterGroup() {
 }
 
 func ExampleRDS_CreateDBSecurityGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -642,11 +574,7 @@ func ExampleRDS_CreateDBSecurityGroup() {
 }
 
 func ExampleRDS_CreateDBSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -675,11 +603,7 @@ func ExampleRDS_CreateDBSnapshot() {
 }
 
 func ExampleRDS_CreateDBSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -712,11 +636,7 @@ func ExampleRDS_CreateDBSubnetGroup() {
 }
 
 func ExampleRDS_CreateEventSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -755,11 +675,7 @@ func ExampleRDS_CreateEventSubscription() {
 }
 
 func ExampleRDS_CreateOptionGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -790,11 +706,7 @@ func ExampleRDS_CreateOptionGroup() {
 }
 
 func ExampleRDS_DeleteDBCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -817,11 +729,7 @@ func ExampleRDS_DeleteDBCluster() {
 }
 
 func ExampleRDS_DeleteDBClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -842,11 +750,7 @@ func ExampleRDS_DeleteDBClusterParameterGroup() {
 }
 
 func ExampleRDS_DeleteDBClusterSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -867,11 +771,7 @@ func ExampleRDS_DeleteDBClusterSnapshot() {
 }
 
 func ExampleRDS_DeleteDBInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -894,11 +794,7 @@ func ExampleRDS_DeleteDBInstance() {
 }
 
 func ExampleRDS_DeleteDBParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -919,11 +815,7 @@ func ExampleRDS_DeleteDBParameterGroup() {
 }
 
 func ExampleRDS_DeleteDBSecurityGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -944,11 +836,7 @@ func ExampleRDS_DeleteDBSecurityGroup() {
 }
 
 func ExampleRDS_DeleteDBSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -969,11 +857,7 @@ func ExampleRDS_DeleteDBSnapshot() {
 }
 
 func ExampleRDS_DeleteDBSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -994,11 +878,7 @@ func ExampleRDS_DeleteDBSubnetGroup() {
 }
 
 func ExampleRDS_DeleteEventSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1019,11 +899,7 @@ func ExampleRDS_DeleteEventSubscription() {
 }
 
 func ExampleRDS_DeleteOptionGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1044,11 +920,7 @@ func ExampleRDS_DeleteOptionGroup() {
 }
 
 func ExampleRDS_DescribeAccountAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1067,11 +939,7 @@ func ExampleRDS_DescribeAccountAttributes() {
 }
 
 func ExampleRDS_DescribeCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1104,11 +972,7 @@ func ExampleRDS_DescribeCertificates() {
 }
 
 func ExampleRDS_DescribeDBClusterParameterGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1141,11 +1005,7 @@ func ExampleRDS_DescribeDBClusterParameterGroups() {
 }
 
 func ExampleRDS_DescribeDBClusterParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1179,11 +1039,7 @@ func ExampleRDS_DescribeDBClusterParameters() {
 }
 
 func ExampleRDS_DescribeDBClusterSnapshotAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1204,11 +1060,7 @@ func ExampleRDS_DescribeDBClusterSnapshotAttributes() {
 }
 
 func ExampleRDS_DescribeDBClusterSnapshots() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1245,11 +1097,7 @@ func ExampleRDS_DescribeDBClusterSnapshots() {
 }
 
 func ExampleRDS_DescribeDBClusters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1282,11 +1130,7 @@ func ExampleRDS_DescribeDBClusters() {
 }
 
 func ExampleRDS_DescribeDBEngineVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1324,11 +1168,7 @@ func ExampleRDS_DescribeDBEngineVersions() {
 }
 
 func ExampleRDS_DescribeDBInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1361,11 +1201,7 @@ func ExampleRDS_DescribeDBInstances() {
 }
 
 func ExampleRDS_DescribeDBLogFiles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1401,11 +1237,7 @@ func ExampleRDS_DescribeDBLogFiles() {
 }
 
 func ExampleRDS_DescribeDBParameterGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1438,11 +1270,7 @@ func ExampleRDS_DescribeDBParameterGroups() {
 }
 
 func ExampleRDS_DescribeDBParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1476,11 +1304,7 @@ func ExampleRDS_DescribeDBParameters() {
 }
 
 func ExampleRDS_DescribeDBSecurityGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1513,11 +1337,7 @@ func ExampleRDS_DescribeDBSecurityGroups() {
 }
 
 func ExampleRDS_DescribeDBSnapshotAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1538,11 +1358,7 @@ func ExampleRDS_DescribeDBSnapshotAttributes() {
 }
 
 func ExampleRDS_DescribeDBSnapshots() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1579,11 +1395,7 @@ func ExampleRDS_DescribeDBSnapshots() {
 }
 
 func ExampleRDS_DescribeDBSubnetGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1616,11 +1428,7 @@ func ExampleRDS_DescribeDBSubnetGroups() {
 }
 
 func ExampleRDS_DescribeEngineDefaultClusterParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1653,11 +1461,7 @@ func ExampleRDS_DescribeEngineDefaultClusterParameters() {
 }
 
 func ExampleRDS_DescribeEngineDefaultParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1690,11 +1494,7 @@ func ExampleRDS_DescribeEngineDefaultParameters() {
 }
 
 func ExampleRDS_DescribeEventCategories() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1725,11 +1525,7 @@ func ExampleRDS_DescribeEventCategories() {
 }
 
 func ExampleRDS_DescribeEventSubscriptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1762,11 +1558,7 @@ func ExampleRDS_DescribeEventSubscriptions() {
 }
 
 func ExampleRDS_DescribeEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1807,11 +1599,7 @@ func ExampleRDS_DescribeEvents() {
 }
 
 func ExampleRDS_DescribeOptionGroupOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1845,11 +1633,7 @@ func ExampleRDS_DescribeOptionGroupOptions() {
 }
 
 func ExampleRDS_DescribeOptionGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1884,11 +1668,7 @@ func ExampleRDS_DescribeOptionGroups() {
 }
 
 func ExampleRDS_DescribeOrderableDBInstanceOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1925,11 +1705,7 @@ func ExampleRDS_DescribeOrderableDBInstanceOptions() {
 }
 
 func ExampleRDS_DescribePendingMaintenanceActions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -1962,11 +1738,7 @@ func ExampleRDS_DescribePendingMaintenanceActions() {
 }
 
 func ExampleRDS_DescribeReservedDBInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2005,11 +1777,7 @@ func ExampleRDS_DescribeReservedDBInstances() {
 }
 
 func ExampleRDS_DescribeReservedDBInstancesOfferings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2047,11 +1815,7 @@ func ExampleRDS_DescribeReservedDBInstancesOfferings() {
 }
 
 func ExampleRDS_DescribeSourceRegions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2084,11 +1848,7 @@ func ExampleRDS_DescribeSourceRegions() {
 }
 
 func ExampleRDS_DownloadDBLogFilePortion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2112,11 +1872,7 @@ func ExampleRDS_DownloadDBLogFilePortion() {
 }
 
 func ExampleRDS_FailoverDBCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2138,11 +1894,7 @@ func ExampleRDS_FailoverDBCluster() {
 }
 
 func ExampleRDS_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2173,11 +1925,7 @@ func ExampleRDS_ListTagsForResource() {
 }
 
 func ExampleRDS_ModifyDBCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2211,11 +1959,7 @@ func ExampleRDS_ModifyDBCluster() {
 }
 
 func ExampleRDS_ModifyDBClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2251,11 +1995,7 @@ func ExampleRDS_ModifyDBClusterParameterGroup() {
 }
 
 func ExampleRDS_ModifyDBClusterSnapshotAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2285,11 +2025,7 @@ func ExampleRDS_ModifyDBClusterSnapshotAttribute() {
 }
 
 func ExampleRDS_ModifyDBInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2347,11 +2083,7 @@ func ExampleRDS_ModifyDBInstance() {
 }
 
 func ExampleRDS_ModifyDBParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2387,11 +2119,7 @@ func ExampleRDS_ModifyDBParameterGroup() {
 }
 
 func ExampleRDS_ModifyDBSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2413,11 +2141,7 @@ func ExampleRDS_ModifyDBSnapshot() {
 }
 
 func ExampleRDS_ModifyDBSnapshotAttribute() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2447,11 +2171,7 @@ func ExampleRDS_ModifyDBSnapshotAttribute() {
 }
 
 func ExampleRDS_ModifyDBSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2477,11 +2197,7 @@ func ExampleRDS_ModifyDBSubnetGroup() {
 }
 
 func ExampleRDS_ModifyEventSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2509,11 +2225,7 @@ func ExampleRDS_ModifyEventSubscription() {
 }
 
 func ExampleRDS_ModifyOptionGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2569,11 +2281,7 @@ func ExampleRDS_ModifyOptionGroup() {
 }
 
 func ExampleRDS_PromoteReadReplica() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2596,11 +2304,7 @@ func ExampleRDS_PromoteReadReplica() {
 }
 
 func ExampleRDS_PromoteReadReplicaDBCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2621,11 +2325,7 @@ func ExampleRDS_PromoteReadReplicaDBCluster() {
 }
 
 func ExampleRDS_PurchaseReservedDBInstancesOffering() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2655,11 +2355,7 @@ func ExampleRDS_PurchaseReservedDBInstancesOffering() {
 }
 
 func ExampleRDS_RebootDBInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2681,11 +2377,7 @@ func ExampleRDS_RebootDBInstance() {
 }
 
 func ExampleRDS_RemoveRoleFromDBCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2707,11 +2399,7 @@ func ExampleRDS_RemoveRoleFromDBCluster() {
 }
 
 func ExampleRDS_RemoveSourceIdentifierFromSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2733,11 +2421,7 @@ func ExampleRDS_RemoveSourceIdentifierFromSubscription() {
 }
 
 func ExampleRDS_RemoveTagsFromResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2762,11 +2446,7 @@ func ExampleRDS_RemoveTagsFromResource() {
 }
 
 func ExampleRDS_ResetDBClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2803,11 +2483,7 @@ func ExampleRDS_ResetDBClusterParameterGroup() {
 }
 
 func ExampleRDS_ResetDBParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2844,11 +2520,7 @@ func ExampleRDS_ResetDBParameterGroup() {
 }
 
 func ExampleRDS_RestoreDBClusterFromS3() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2904,11 +2576,7 @@ func ExampleRDS_RestoreDBClusterFromS3() {
 }
 
 func ExampleRDS_RestoreDBClusterFromSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2952,11 +2620,7 @@ func ExampleRDS_RestoreDBClusterFromSnapshot() {
 }
 
 func ExampleRDS_RestoreDBClusterToPointInTime() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -2995,11 +2659,7 @@ func ExampleRDS_RestoreDBClusterToPointInTime() {
 }
 
 func ExampleRDS_RestoreDBInstanceFromDBSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -3046,11 +2706,7 @@ func ExampleRDS_RestoreDBInstanceFromDBSnapshot() {
 }
 
 func ExampleRDS_RestoreDBInstanceToPointInTime() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 
@@ -3099,11 +2755,7 @@ func ExampleRDS_RestoreDBInstanceToPointInTime() {
 }
 
 func ExampleRDS_RevokeDBSecurityGroupIngress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rds.New(sess)
 

--- a/service/redshift/examples_test.go
+++ b/service/redshift/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleRedshift_AuthorizeClusterSecurityGroupIngress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -44,11 +40,7 @@ func ExampleRedshift_AuthorizeClusterSecurityGroupIngress() {
 }
 
 func ExampleRedshift_AuthorizeSnapshotAccess() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleRedshift_AuthorizeSnapshotAccess() {
 }
 
 func ExampleRedshift_CopyClusterSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -98,11 +86,7 @@ func ExampleRedshift_CopyClusterSnapshot() {
 }
 
 func ExampleRedshift_CreateCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -164,11 +148,7 @@ func ExampleRedshift_CreateCluster() {
 }
 
 func ExampleRedshift_CreateClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -198,11 +178,7 @@ func ExampleRedshift_CreateClusterParameterGroup() {
 }
 
 func ExampleRedshift_CreateClusterSecurityGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -231,11 +207,7 @@ func ExampleRedshift_CreateClusterSecurityGroup() {
 }
 
 func ExampleRedshift_CreateClusterSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -264,11 +236,7 @@ func ExampleRedshift_CreateClusterSnapshot() {
 }
 
 func ExampleRedshift_CreateClusterSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -301,11 +269,7 @@ func ExampleRedshift_CreateClusterSubnetGroup() {
 }
 
 func ExampleRedshift_CreateEventSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -345,11 +309,7 @@ func ExampleRedshift_CreateEventSubscription() {
 }
 
 func ExampleRedshift_CreateHsmClientCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -377,11 +337,7 @@ func ExampleRedshift_CreateHsmClientCertificate() {
 }
 
 func ExampleRedshift_CreateHsmConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -414,11 +370,7 @@ func ExampleRedshift_CreateHsmConfiguration() {
 }
 
 func ExampleRedshift_CreateSnapshotCopyGrant() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -447,11 +399,7 @@ func ExampleRedshift_CreateSnapshotCopyGrant() {
 }
 
 func ExampleRedshift_CreateTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -479,11 +427,7 @@ func ExampleRedshift_CreateTags() {
 }
 
 func ExampleRedshift_DeleteCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -506,11 +450,7 @@ func ExampleRedshift_DeleteCluster() {
 }
 
 func ExampleRedshift_DeleteClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -531,11 +471,7 @@ func ExampleRedshift_DeleteClusterParameterGroup() {
 }
 
 func ExampleRedshift_DeleteClusterSecurityGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -556,11 +492,7 @@ func ExampleRedshift_DeleteClusterSecurityGroup() {
 }
 
 func ExampleRedshift_DeleteClusterSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -582,11 +514,7 @@ func ExampleRedshift_DeleteClusterSnapshot() {
 }
 
 func ExampleRedshift_DeleteClusterSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -607,11 +535,7 @@ func ExampleRedshift_DeleteClusterSubnetGroup() {
 }
 
 func ExampleRedshift_DeleteEventSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -632,11 +556,7 @@ func ExampleRedshift_DeleteEventSubscription() {
 }
 
 func ExampleRedshift_DeleteHsmClientCertificate() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -657,11 +577,7 @@ func ExampleRedshift_DeleteHsmClientCertificate() {
 }
 
 func ExampleRedshift_DeleteHsmConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -682,11 +598,7 @@ func ExampleRedshift_DeleteHsmConfiguration() {
 }
 
 func ExampleRedshift_DeleteSnapshotCopyGrant() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -707,11 +619,7 @@ func ExampleRedshift_DeleteSnapshotCopyGrant() {
 }
 
 func ExampleRedshift_DeleteTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -736,11 +644,7 @@ func ExampleRedshift_DeleteTags() {
 }
 
 func ExampleRedshift_DescribeClusterParameterGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -771,11 +675,7 @@ func ExampleRedshift_DescribeClusterParameterGroups() {
 }
 
 func ExampleRedshift_DescribeClusterParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -799,11 +699,7 @@ func ExampleRedshift_DescribeClusterParameters() {
 }
 
 func ExampleRedshift_DescribeClusterSecurityGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -834,11 +730,7 @@ func ExampleRedshift_DescribeClusterSecurityGroups() {
 }
 
 func ExampleRedshift_DescribeClusterSnapshots() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -874,11 +766,7 @@ func ExampleRedshift_DescribeClusterSnapshots() {
 }
 
 func ExampleRedshift_DescribeClusterSubnetGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -909,11 +797,7 @@ func ExampleRedshift_DescribeClusterSubnetGroups() {
 }
 
 func ExampleRedshift_DescribeClusterVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -937,11 +821,7 @@ func ExampleRedshift_DescribeClusterVersions() {
 }
 
 func ExampleRedshift_DescribeClusters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -972,11 +852,7 @@ func ExampleRedshift_DescribeClusters() {
 }
 
 func ExampleRedshift_DescribeDefaultClusterParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -999,11 +875,7 @@ func ExampleRedshift_DescribeDefaultClusterParameters() {
 }
 
 func ExampleRedshift_DescribeEventCategories() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1024,11 +896,7 @@ func ExampleRedshift_DescribeEventCategories() {
 }
 
 func ExampleRedshift_DescribeEventSubscriptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1051,11 +919,7 @@ func ExampleRedshift_DescribeEventSubscriptions() {
 }
 
 func ExampleRedshift_DescribeEvents() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1082,11 +946,7 @@ func ExampleRedshift_DescribeEvents() {
 }
 
 func ExampleRedshift_DescribeHsmClientCertificates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1117,11 +977,7 @@ func ExampleRedshift_DescribeHsmClientCertificates() {
 }
 
 func ExampleRedshift_DescribeHsmConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1152,11 +1008,7 @@ func ExampleRedshift_DescribeHsmConfigurations() {
 }
 
 func ExampleRedshift_DescribeLoggingStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1177,11 +1029,7 @@ func ExampleRedshift_DescribeLoggingStatus() {
 }
 
 func ExampleRedshift_DescribeOrderableClusterOptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1205,11 +1053,7 @@ func ExampleRedshift_DescribeOrderableClusterOptions() {
 }
 
 func ExampleRedshift_DescribeReservedNodeOfferings() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1232,11 +1076,7 @@ func ExampleRedshift_DescribeReservedNodeOfferings() {
 }
 
 func ExampleRedshift_DescribeReservedNodes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1259,11 +1099,7 @@ func ExampleRedshift_DescribeReservedNodes() {
 }
 
 func ExampleRedshift_DescribeResize() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1284,11 +1120,7 @@ func ExampleRedshift_DescribeResize() {
 }
 
 func ExampleRedshift_DescribeSnapshotCopyGrants() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1319,11 +1151,7 @@ func ExampleRedshift_DescribeSnapshotCopyGrants() {
 }
 
 func ExampleRedshift_DescribeTableRestoreStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1347,11 +1175,7 @@ func ExampleRedshift_DescribeTableRestoreStatus() {
 }
 
 func ExampleRedshift_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1383,11 +1207,7 @@ func ExampleRedshift_DescribeTags() {
 }
 
 func ExampleRedshift_DisableLogging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1408,11 +1228,7 @@ func ExampleRedshift_DisableLogging() {
 }
 
 func ExampleRedshift_DisableSnapshotCopy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1433,11 +1249,7 @@ func ExampleRedshift_DisableSnapshotCopy() {
 }
 
 func ExampleRedshift_EnableLogging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1460,11 +1272,7 @@ func ExampleRedshift_EnableLogging() {
 }
 
 func ExampleRedshift_EnableSnapshotCopy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1488,11 +1296,7 @@ func ExampleRedshift_EnableSnapshotCopy() {
 }
 
 func ExampleRedshift_ModifyCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1536,11 +1340,7 @@ func ExampleRedshift_ModifyCluster() {
 }
 
 func ExampleRedshift_ModifyClusterIamRoles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1569,11 +1369,7 @@ func ExampleRedshift_ModifyClusterIamRoles() {
 }
 
 func ExampleRedshift_ModifyClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1608,11 +1404,7 @@ func ExampleRedshift_ModifyClusterParameterGroup() {
 }
 
 func ExampleRedshift_ModifyClusterSubnetGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1638,11 +1430,7 @@ func ExampleRedshift_ModifyClusterSubnetGroup() {
 }
 
 func ExampleRedshift_ModifyEventSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1675,11 +1463,7 @@ func ExampleRedshift_ModifyEventSubscription() {
 }
 
 func ExampleRedshift_ModifySnapshotCopyRetentionPeriod() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1701,11 +1485,7 @@ func ExampleRedshift_ModifySnapshotCopyRetentionPeriod() {
 }
 
 func ExampleRedshift_PurchaseReservedNodeOffering() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1727,11 +1507,7 @@ func ExampleRedshift_PurchaseReservedNodeOffering() {
 }
 
 func ExampleRedshift_RebootCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1752,11 +1528,7 @@ func ExampleRedshift_RebootCluster() {
 }
 
 func ExampleRedshift_ResetClusterParameterGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1792,11 +1564,7 @@ func ExampleRedshift_ResetClusterParameterGroup() {
 }
 
 func ExampleRedshift_RestoreFromClusterSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1847,11 +1615,7 @@ func ExampleRedshift_RestoreFromClusterSnapshot() {
 }
 
 func ExampleRedshift_RestoreTableFromClusterSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1879,11 +1643,7 @@ func ExampleRedshift_RestoreTableFromClusterSnapshot() {
 }
 
 func ExampleRedshift_RevokeClusterSecurityGroupIngress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1907,11 +1667,7 @@ func ExampleRedshift_RevokeClusterSecurityGroupIngress() {
 }
 
 func ExampleRedshift_RevokeSnapshotAccess() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 
@@ -1934,11 +1690,7 @@ func ExampleRedshift_RevokeSnapshotAccess() {
 }
 
 func ExampleRedshift_RotateEncryptionKey() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := redshift.New(sess)
 

--- a/service/rekognition/examples_test.go
+++ b/service/rekognition/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleRekognition_CompareFaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -57,11 +53,7 @@ func ExampleRekognition_CompareFaces() {
 }
 
 func ExampleRekognition_CreateCollection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -82,11 +74,7 @@ func ExampleRekognition_CreateCollection() {
 }
 
 func ExampleRekognition_DeleteCollection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -107,11 +95,7 @@ func ExampleRekognition_DeleteCollection() {
 }
 
 func ExampleRekognition_DeleteFaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -136,11 +120,7 @@ func ExampleRekognition_DeleteFaces() {
 }
 
 func ExampleRekognition_DetectFaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -172,11 +152,7 @@ func ExampleRekognition_DetectFaces() {
 }
 
 func ExampleRekognition_DetectLabels() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -206,11 +182,7 @@ func ExampleRekognition_DetectLabels() {
 }
 
 func ExampleRekognition_IndexFaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -244,11 +216,7 @@ func ExampleRekognition_IndexFaces() {
 }
 
 func ExampleRekognition_ListCollections() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -270,11 +238,7 @@ func ExampleRekognition_ListCollections() {
 }
 
 func ExampleRekognition_ListFaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -297,11 +261,7 @@ func ExampleRekognition_ListFaces() {
 }
 
 func ExampleRekognition_SearchFaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 
@@ -325,11 +285,7 @@ func ExampleRekognition_SearchFaces() {
 }
 
 func ExampleRekognition_SearchFacesByImage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := rekognition.New(sess)
 

--- a/service/route53/examples_test.go
+++ b/service/route53/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleRoute53_AssociateVPCWithHostedZone() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -46,11 +42,7 @@ func ExampleRoute53_AssociateVPCWithHostedZone() {
 }
 
 func ExampleRoute53_ChangeResourceRecordSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -107,11 +99,7 @@ func ExampleRoute53_ChangeResourceRecordSets() {
 }
 
 func ExampleRoute53_ChangeTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -144,11 +132,7 @@ func ExampleRoute53_ChangeTagsForResource() {
 }
 
 func ExampleRoute53_CreateHealthCheck() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -196,11 +180,7 @@ func ExampleRoute53_CreateHealthCheck() {
 }
 
 func ExampleRoute53_CreateHostedZone() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -231,11 +211,7 @@ func ExampleRoute53_CreateHostedZone() {
 }
 
 func ExampleRoute53_CreateReusableDelegationSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -257,11 +233,7 @@ func ExampleRoute53_CreateReusableDelegationSet() {
 }
 
 func ExampleRoute53_CreateTrafficPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -284,11 +256,7 @@ func ExampleRoute53_CreateTrafficPolicy() {
 }
 
 func ExampleRoute53_CreateTrafficPolicyInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -313,11 +281,7 @@ func ExampleRoute53_CreateTrafficPolicyInstance() {
 }
 
 func ExampleRoute53_CreateTrafficPolicyVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -340,11 +304,7 @@ func ExampleRoute53_CreateTrafficPolicyVersion() {
 }
 
 func ExampleRoute53_CreateVPCAssociationAuthorization() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -369,11 +329,7 @@ func ExampleRoute53_CreateVPCAssociationAuthorization() {
 }
 
 func ExampleRoute53_DeleteHealthCheck() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -394,11 +350,7 @@ func ExampleRoute53_DeleteHealthCheck() {
 }
 
 func ExampleRoute53_DeleteHostedZone() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -419,11 +371,7 @@ func ExampleRoute53_DeleteHostedZone() {
 }
 
 func ExampleRoute53_DeleteReusableDelegationSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -444,11 +392,7 @@ func ExampleRoute53_DeleteReusableDelegationSet() {
 }
 
 func ExampleRoute53_DeleteTrafficPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -470,11 +414,7 @@ func ExampleRoute53_DeleteTrafficPolicy() {
 }
 
 func ExampleRoute53_DeleteTrafficPolicyInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -495,11 +435,7 @@ func ExampleRoute53_DeleteTrafficPolicyInstance() {
 }
 
 func ExampleRoute53_DeleteVPCAssociationAuthorization() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -524,11 +460,7 @@ func ExampleRoute53_DeleteVPCAssociationAuthorization() {
 }
 
 func ExampleRoute53_DisassociateVPCFromHostedZone() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -554,11 +486,7 @@ func ExampleRoute53_DisassociateVPCFromHostedZone() {
 }
 
 func ExampleRoute53_GetChange() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -579,11 +507,7 @@ func ExampleRoute53_GetChange() {
 }
 
 func ExampleRoute53_GetCheckerIpRanges() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -602,11 +526,7 @@ func ExampleRoute53_GetCheckerIpRanges() {
 }
 
 func ExampleRoute53_GetGeoLocation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -629,11 +549,7 @@ func ExampleRoute53_GetGeoLocation() {
 }
 
 func ExampleRoute53_GetHealthCheck() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -654,11 +570,7 @@ func ExampleRoute53_GetHealthCheck() {
 }
 
 func ExampleRoute53_GetHealthCheckCount() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -677,11 +589,7 @@ func ExampleRoute53_GetHealthCheckCount() {
 }
 
 func ExampleRoute53_GetHealthCheckLastFailureReason() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -702,11 +610,7 @@ func ExampleRoute53_GetHealthCheckLastFailureReason() {
 }
 
 func ExampleRoute53_GetHealthCheckStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -727,11 +631,7 @@ func ExampleRoute53_GetHealthCheckStatus() {
 }
 
 func ExampleRoute53_GetHostedZone() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -752,11 +652,7 @@ func ExampleRoute53_GetHostedZone() {
 }
 
 func ExampleRoute53_GetHostedZoneCount() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -775,11 +671,7 @@ func ExampleRoute53_GetHostedZoneCount() {
 }
 
 func ExampleRoute53_GetReusableDelegationSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -800,11 +692,7 @@ func ExampleRoute53_GetReusableDelegationSet() {
 }
 
 func ExampleRoute53_GetTrafficPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -826,11 +714,7 @@ func ExampleRoute53_GetTrafficPolicy() {
 }
 
 func ExampleRoute53_GetTrafficPolicyInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -851,11 +735,7 @@ func ExampleRoute53_GetTrafficPolicyInstance() {
 }
 
 func ExampleRoute53_GetTrafficPolicyInstanceCount() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -874,11 +754,7 @@ func ExampleRoute53_GetTrafficPolicyInstanceCount() {
 }
 
 func ExampleRoute53_ListGeoLocations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -902,11 +778,7 @@ func ExampleRoute53_ListGeoLocations() {
 }
 
 func ExampleRoute53_ListHealthChecks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -928,11 +800,7 @@ func ExampleRoute53_ListHealthChecks() {
 }
 
 func ExampleRoute53_ListHostedZones() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -955,11 +823,7 @@ func ExampleRoute53_ListHostedZones() {
 }
 
 func ExampleRoute53_ListHostedZonesByName() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -982,11 +846,7 @@ func ExampleRoute53_ListHostedZonesByName() {
 }
 
 func ExampleRoute53_ListResourceRecordSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1011,11 +871,7 @@ func ExampleRoute53_ListResourceRecordSets() {
 }
 
 func ExampleRoute53_ListReusableDelegationSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1037,11 +893,7 @@ func ExampleRoute53_ListReusableDelegationSets() {
 }
 
 func ExampleRoute53_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1063,11 +915,7 @@ func ExampleRoute53_ListTagsForResource() {
 }
 
 func ExampleRoute53_ListTagsForResources() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1092,11 +940,7 @@ func ExampleRoute53_ListTagsForResources() {
 }
 
 func ExampleRoute53_ListTrafficPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1118,11 +962,7 @@ func ExampleRoute53_ListTrafficPolicies() {
 }
 
 func ExampleRoute53_ListTrafficPolicyInstances() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1146,11 +986,7 @@ func ExampleRoute53_ListTrafficPolicyInstances() {
 }
 
 func ExampleRoute53_ListTrafficPolicyInstancesByHostedZone() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1174,11 +1010,7 @@ func ExampleRoute53_ListTrafficPolicyInstancesByHostedZone() {
 }
 
 func ExampleRoute53_ListTrafficPolicyInstancesByPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1204,11 +1036,7 @@ func ExampleRoute53_ListTrafficPolicyInstancesByPolicy() {
 }
 
 func ExampleRoute53_ListTrafficPolicyVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1231,11 +1059,7 @@ func ExampleRoute53_ListTrafficPolicyVersions() {
 }
 
 func ExampleRoute53_ListVPCAssociationAuthorizations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1258,11 +1082,7 @@ func ExampleRoute53_ListVPCAssociationAuthorizations() {
 }
 
 func ExampleRoute53_TestDNSAnswer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1288,11 +1108,7 @@ func ExampleRoute53_TestDNSAnswer() {
 }
 
 func ExampleRoute53_UpdateHealthCheck() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1336,11 +1152,7 @@ func ExampleRoute53_UpdateHealthCheck() {
 }
 
 func ExampleRoute53_UpdateHostedZoneComment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1362,11 +1174,7 @@ func ExampleRoute53_UpdateHostedZoneComment() {
 }
 
 func ExampleRoute53_UpdateTrafficPolicyComment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 
@@ -1389,11 +1197,7 @@ func ExampleRoute53_UpdateTrafficPolicyComment() {
 }
 
 func ExampleRoute53_UpdateTrafficPolicyInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53.New(sess)
 

--- a/service/route53domains/examples_test.go
+++ b/service/route53domains/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleRoute53Domains_CheckDomainAvailability() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleRoute53Domains_CheckDomainAvailability() {
 }
 
 func ExampleRoute53Domains_DeleteTagsForDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleRoute53Domains_DeleteTagsForDomain() {
 }
 
 func ExampleRoute53Domains_DisableDomainAutoRenew() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -96,11 +84,7 @@ func ExampleRoute53Domains_DisableDomainAutoRenew() {
 }
 
 func ExampleRoute53Domains_DisableDomainTransferLock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -121,11 +105,7 @@ func ExampleRoute53Domains_DisableDomainTransferLock() {
 }
 
 func ExampleRoute53Domains_EnableDomainAutoRenew() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -146,11 +126,7 @@ func ExampleRoute53Domains_EnableDomainAutoRenew() {
 }
 
 func ExampleRoute53Domains_EnableDomainTransferLock() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -171,11 +147,7 @@ func ExampleRoute53Domains_EnableDomainTransferLock() {
 }
 
 func ExampleRoute53Domains_GetContactReachabilityStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -196,11 +168,7 @@ func ExampleRoute53Domains_GetContactReachabilityStatus() {
 }
 
 func ExampleRoute53Domains_GetDomainDetail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -221,11 +189,7 @@ func ExampleRoute53Domains_GetDomainDetail() {
 }
 
 func ExampleRoute53Domains_GetDomainSuggestions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -248,11 +212,7 @@ func ExampleRoute53Domains_GetDomainSuggestions() {
 }
 
 func ExampleRoute53Domains_GetOperationDetail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -273,11 +233,7 @@ func ExampleRoute53Domains_GetOperationDetail() {
 }
 
 func ExampleRoute53Domains_ListDomains() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -299,11 +255,7 @@ func ExampleRoute53Domains_ListDomains() {
 }
 
 func ExampleRoute53Domains_ListOperations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -325,11 +277,7 @@ func ExampleRoute53Domains_ListOperations() {
 }
 
 func ExampleRoute53Domains_ListTagsForDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -350,11 +298,7 @@ func ExampleRoute53Domains_ListTagsForDomain() {
 }
 
 func ExampleRoute53Domains_RegisterDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -447,11 +391,7 @@ func ExampleRoute53Domains_RegisterDomain() {
 }
 
 func ExampleRoute53Domains_RenewDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -474,11 +414,7 @@ func ExampleRoute53Domains_RenewDomain() {
 }
 
 func ExampleRoute53Domains_ResendContactReachabilityEmail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -499,11 +435,7 @@ func ExampleRoute53Domains_ResendContactReachabilityEmail() {
 }
 
 func ExampleRoute53Domains_RetrieveDomainAuthCode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -524,11 +456,7 @@ func ExampleRoute53Domains_RetrieveDomainAuthCode() {
 }
 
 func ExampleRoute53Domains_TransferDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -632,11 +560,7 @@ func ExampleRoute53Domains_TransferDomain() {
 }
 
 func ExampleRoute53Domains_UpdateDomainContact() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -723,11 +647,7 @@ func ExampleRoute53Domains_UpdateDomainContact() {
 }
 
 func ExampleRoute53Domains_UpdateDomainContactPrivacy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -751,11 +671,7 @@ func ExampleRoute53Domains_UpdateDomainContactPrivacy() {
 }
 
 func ExampleRoute53Domains_UpdateDomainNameservers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -787,11 +703,7 @@ func ExampleRoute53Domains_UpdateDomainNameservers() {
 }
 
 func ExampleRoute53Domains_UpdateTagsForDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 
@@ -819,11 +731,7 @@ func ExampleRoute53Domains_UpdateTagsForDomain() {
 }
 
 func ExampleRoute53Domains_ViewBilling() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := route53domains.New(sess)
 

--- a/service/s3/examples_test.go
+++ b/service/s3/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleS3_AbortMultipartUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -44,11 +40,7 @@ func ExampleS3_AbortMultipartUpload() {
 }
 
 func ExampleS3_CompleteMultipartUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -81,11 +73,7 @@ func ExampleS3_CompleteMultipartUpload() {
 }
 
 func ExampleS3_CopyObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -141,11 +129,7 @@ func ExampleS3_CopyObject() {
 }
 
 func ExampleS3_CreateBucket() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -175,11 +159,7 @@ func ExampleS3_CreateBucket() {
 }
 
 func ExampleS3_CreateMultipartUpload() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -224,11 +204,7 @@ func ExampleS3_CreateMultipartUpload() {
 }
 
 func ExampleS3_DeleteBucket() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -249,11 +225,7 @@ func ExampleS3_DeleteBucket() {
 }
 
 func ExampleS3_DeleteBucketAnalyticsConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -275,11 +247,7 @@ func ExampleS3_DeleteBucketAnalyticsConfiguration() {
 }
 
 func ExampleS3_DeleteBucketCors() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -300,11 +268,7 @@ func ExampleS3_DeleteBucketCors() {
 }
 
 func ExampleS3_DeleteBucketInventoryConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -326,11 +290,7 @@ func ExampleS3_DeleteBucketInventoryConfiguration() {
 }
 
 func ExampleS3_DeleteBucketLifecycle() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -351,11 +311,7 @@ func ExampleS3_DeleteBucketLifecycle() {
 }
 
 func ExampleS3_DeleteBucketMetricsConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -377,11 +333,7 @@ func ExampleS3_DeleteBucketMetricsConfiguration() {
 }
 
 func ExampleS3_DeleteBucketPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -402,11 +354,7 @@ func ExampleS3_DeleteBucketPolicy() {
 }
 
 func ExampleS3_DeleteBucketReplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -427,11 +375,7 @@ func ExampleS3_DeleteBucketReplication() {
 }
 
 func ExampleS3_DeleteBucketTagging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -452,11 +396,7 @@ func ExampleS3_DeleteBucketTagging() {
 }
 
 func ExampleS3_DeleteBucketWebsite() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -477,11 +417,7 @@ func ExampleS3_DeleteBucketWebsite() {
 }
 
 func ExampleS3_DeleteObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -506,11 +442,7 @@ func ExampleS3_DeleteObject() {
 }
 
 func ExampleS3_DeleteObjectTagging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -533,11 +465,7 @@ func ExampleS3_DeleteObjectTagging() {
 }
 
 func ExampleS3_DeleteObjects() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -570,11 +498,7 @@ func ExampleS3_DeleteObjects() {
 }
 
 func ExampleS3_GetBucketAccelerateConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -595,11 +519,7 @@ func ExampleS3_GetBucketAccelerateConfiguration() {
 }
 
 func ExampleS3_GetBucketAcl() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -620,11 +540,7 @@ func ExampleS3_GetBucketAcl() {
 }
 
 func ExampleS3_GetBucketAnalyticsConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -646,11 +562,7 @@ func ExampleS3_GetBucketAnalyticsConfiguration() {
 }
 
 func ExampleS3_GetBucketCors() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -671,11 +583,7 @@ func ExampleS3_GetBucketCors() {
 }
 
 func ExampleS3_GetBucketInventoryConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -697,11 +605,7 @@ func ExampleS3_GetBucketInventoryConfiguration() {
 }
 
 func ExampleS3_GetBucketLifecycle() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -722,11 +626,7 @@ func ExampleS3_GetBucketLifecycle() {
 }
 
 func ExampleS3_GetBucketLifecycleConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -747,11 +647,7 @@ func ExampleS3_GetBucketLifecycleConfiguration() {
 }
 
 func ExampleS3_GetBucketLocation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -772,11 +668,7 @@ func ExampleS3_GetBucketLocation() {
 }
 
 func ExampleS3_GetBucketLogging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -797,11 +689,7 @@ func ExampleS3_GetBucketLogging() {
 }
 
 func ExampleS3_GetBucketMetricsConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -823,11 +711,7 @@ func ExampleS3_GetBucketMetricsConfiguration() {
 }
 
 func ExampleS3_GetBucketNotification() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -848,11 +732,7 @@ func ExampleS3_GetBucketNotification() {
 }
 
 func ExampleS3_GetBucketNotificationConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -873,11 +753,7 @@ func ExampleS3_GetBucketNotificationConfiguration() {
 }
 
 func ExampleS3_GetBucketPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -898,11 +774,7 @@ func ExampleS3_GetBucketPolicy() {
 }
 
 func ExampleS3_GetBucketReplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -923,11 +795,7 @@ func ExampleS3_GetBucketReplication() {
 }
 
 func ExampleS3_GetBucketRequestPayment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -948,11 +816,7 @@ func ExampleS3_GetBucketRequestPayment() {
 }
 
 func ExampleS3_GetBucketTagging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -973,11 +837,7 @@ func ExampleS3_GetBucketTagging() {
 }
 
 func ExampleS3_GetBucketVersioning() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -998,11 +858,7 @@ func ExampleS3_GetBucketVersioning() {
 }
 
 func ExampleS3_GetBucketWebsite() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1023,11 +879,7 @@ func ExampleS3_GetBucketWebsite() {
 }
 
 func ExampleS3_GetObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1066,11 +918,7 @@ func ExampleS3_GetObject() {
 }
 
 func ExampleS3_GetObjectAcl() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1094,11 +942,7 @@ func ExampleS3_GetObjectAcl() {
 }
 
 func ExampleS3_GetObjectTagging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1121,11 +965,7 @@ func ExampleS3_GetObjectTagging() {
 }
 
 func ExampleS3_GetObjectTorrent() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1148,11 +988,7 @@ func ExampleS3_GetObjectTorrent() {
 }
 
 func ExampleS3_HeadBucket() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1173,11 +1009,7 @@ func ExampleS3_HeadBucket() {
 }
 
 func ExampleS3_HeadObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1210,11 +1042,7 @@ func ExampleS3_HeadObject() {
 }
 
 func ExampleS3_ListBucketAnalyticsConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1236,11 +1064,7 @@ func ExampleS3_ListBucketAnalyticsConfigurations() {
 }
 
 func ExampleS3_ListBucketInventoryConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1262,11 +1086,7 @@ func ExampleS3_ListBucketInventoryConfigurations() {
 }
 
 func ExampleS3_ListBucketMetricsConfigurations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1288,11 +1108,7 @@ func ExampleS3_ListBucketMetricsConfigurations() {
 }
 
 func ExampleS3_ListBuckets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1311,11 +1127,7 @@ func ExampleS3_ListBuckets() {
 }
 
 func ExampleS3_ListMultipartUploads() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1342,11 +1154,7 @@ func ExampleS3_ListMultipartUploads() {
 }
 
 func ExampleS3_ListObjectVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1373,11 +1181,7 @@ func ExampleS3_ListObjectVersions() {
 }
 
 func ExampleS3_ListObjects() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1404,11 +1208,7 @@ func ExampleS3_ListObjects() {
 }
 
 func ExampleS3_ListObjectsV2() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1437,11 +1237,7 @@ func ExampleS3_ListObjectsV2() {
 }
 
 func ExampleS3_ListParts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1467,11 +1263,7 @@ func ExampleS3_ListParts() {
 }
 
 func ExampleS3_PutBucketAccelerateConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1495,11 +1287,7 @@ func ExampleS3_PutBucketAccelerateConfiguration() {
 }
 
 func ExampleS3_PutBucketAcl() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1545,11 +1333,7 @@ func ExampleS3_PutBucketAcl() {
 }
 
 func ExampleS3_PutBucketAnalyticsConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1604,11 +1388,7 @@ func ExampleS3_PutBucketAnalyticsConfiguration() {
 }
 
 func ExampleS3_PutBucketCors() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1653,11 +1433,7 @@ func ExampleS3_PutBucketCors() {
 }
 
 func ExampleS3_PutBucketInventoryConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1702,11 +1478,7 @@ func ExampleS3_PutBucketInventoryConfiguration() {
 }
 
 func ExampleS3_PutBucketLifecycle() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1757,11 +1529,7 @@ func ExampleS3_PutBucketLifecycle() {
 }
 
 func ExampleS3_PutBucketLifecycleConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1835,11 +1603,7 @@ func ExampleS3_PutBucketLifecycleConfiguration() {
 }
 
 func ExampleS3_PutBucketLogging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1879,11 +1643,7 @@ func ExampleS3_PutBucketLogging() {
 }
 
 func ExampleS3_PutBucketMetricsConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1925,11 +1685,7 @@ func ExampleS3_PutBucketMetricsConfiguration() {
 }
 
 func ExampleS3_PutBucketNotification() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -1980,11 +1736,7 @@ func ExampleS3_PutBucketNotification() {
 }
 
 func ExampleS3_PutBucketNotificationConfiguration() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2073,11 +1825,7 @@ func ExampleS3_PutBucketNotificationConfiguration() {
 }
 
 func ExampleS3_PutBucketPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2099,11 +1847,7 @@ func ExampleS3_PutBucketPolicy() {
 }
 
 func ExampleS3_PutBucketReplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2139,11 +1883,7 @@ func ExampleS3_PutBucketReplication() {
 }
 
 func ExampleS3_PutBucketRequestPayment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2167,11 +1907,7 @@ func ExampleS3_PutBucketRequestPayment() {
 }
 
 func ExampleS3_PutBucketTagging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2201,11 +1937,7 @@ func ExampleS3_PutBucketTagging() {
 }
 
 func ExampleS3_PutBucketVersioning() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2231,11 +1963,7 @@ func ExampleS3_PutBucketVersioning() {
 }
 
 func ExampleS3_PutBucketWebsite() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2284,11 +2012,7 @@ func ExampleS3_PutBucketWebsite() {
 }
 
 func ExampleS3_PutObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2336,11 +2060,7 @@ func ExampleS3_PutObject() {
 }
 
 func ExampleS3_PutObjectAcl() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2389,11 +2109,7 @@ func ExampleS3_PutObjectAcl() {
 }
 
 func ExampleS3_PutObjectTagging() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2425,11 +2141,7 @@ func ExampleS3_PutObjectTagging() {
 }
 
 func ExampleS3_RestoreObject() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2459,11 +2171,7 @@ func ExampleS3_RestoreObject() {
 }
 
 func ExampleS3_UploadPart() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 
@@ -2493,11 +2201,7 @@ func ExampleS3_UploadPart() {
 }
 
 func ExampleS3_UploadPartCopy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := s3.New(sess)
 

--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -50,7 +50,7 @@ type Downloader struct {
 //
 // Example:
 //     // The session the S3 Downloader will use
-//     sess, err := session.NewSession()
+//     sess := session.Must(session.NewSession())
 //
 //     // Create a downloader with the session and default options
 //     downloader := s3manager.NewDownloader(sess)
@@ -79,7 +79,7 @@ func NewDownloader(c client.ConfigProvider, options ...func(*Downloader)) *Downl
 //
 // Example:
 //     // The session the S3 Downloader will use
-//     sess, err := session.NewSession()
+//     sess := session.Must(session.NewSession())
 //
 //     // The S3 client the S3 Downloader will use
 //     s3Svc := s3.new(sess)

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -241,7 +241,7 @@ type Uploader struct {
 //
 // Example:
 //     // The session the S3 Uploader will use
-//     sess, err := session.NewSession()
+//     sess := session.Must(session.NewSession())
 //
 //     // Create an uploader with the session and default options
 //     uploader := s3manager.NewUploader(sess)
@@ -272,7 +272,7 @@ func NewUploader(c client.ConfigProvider, options ...func(*Uploader)) *Uploader 
 //
 // Example:
 //     // The session the S3 Uploader will use
-//     sess, err := session.NewSession()
+//     sess := session.Must(session.NewSession())
 //
 //     // S3 service client the Upload manager will use.
 //     s3Svc := s3.New(sess)

--- a/service/servicecatalog/examples_test.go
+++ b/service/servicecatalog/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleServiceCatalog_AcceptPortfolioShare() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleServiceCatalog_AcceptPortfolioShare() {
 }
 
 func ExampleServiceCatalog_AssociatePrincipalWithPortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -70,11 +62,7 @@ func ExampleServiceCatalog_AssociatePrincipalWithPortfolio() {
 }
 
 func ExampleServiceCatalog_AssociateProductWithPortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -98,11 +86,7 @@ func ExampleServiceCatalog_AssociateProductWithPortfolio() {
 }
 
 func ExampleServiceCatalog_CreateConstraint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -129,11 +113,7 @@ func ExampleServiceCatalog_CreateConstraint() {
 }
 
 func ExampleServiceCatalog_CreatePortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -165,11 +145,7 @@ func ExampleServiceCatalog_CreatePortfolio() {
 }
 
 func ExampleServiceCatalog_CreatePortfolioShare() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -192,11 +168,7 @@ func ExampleServiceCatalog_CreatePortfolioShare() {
 }
 
 func ExampleServiceCatalog_CreateProduct() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -242,11 +214,7 @@ func ExampleServiceCatalog_CreateProduct() {
 }
 
 func ExampleServiceCatalog_CreateProvisioningArtifact() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -278,11 +246,7 @@ func ExampleServiceCatalog_CreateProvisioningArtifact() {
 }
 
 func ExampleServiceCatalog_DeleteConstraint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -304,11 +268,7 @@ func ExampleServiceCatalog_DeleteConstraint() {
 }
 
 func ExampleServiceCatalog_DeletePortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -330,11 +290,7 @@ func ExampleServiceCatalog_DeletePortfolio() {
 }
 
 func ExampleServiceCatalog_DeletePortfolioShare() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -357,11 +313,7 @@ func ExampleServiceCatalog_DeletePortfolioShare() {
 }
 
 func ExampleServiceCatalog_DeleteProduct() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -383,11 +335,7 @@ func ExampleServiceCatalog_DeleteProduct() {
 }
 
 func ExampleServiceCatalog_DeleteProvisioningArtifact() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -410,11 +358,7 @@ func ExampleServiceCatalog_DeleteProvisioningArtifact() {
 }
 
 func ExampleServiceCatalog_DescribeConstraint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -436,11 +380,7 @@ func ExampleServiceCatalog_DescribeConstraint() {
 }
 
 func ExampleServiceCatalog_DescribePortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -462,11 +402,7 @@ func ExampleServiceCatalog_DescribePortfolio() {
 }
 
 func ExampleServiceCatalog_DescribeProduct() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -488,11 +424,7 @@ func ExampleServiceCatalog_DescribeProduct() {
 }
 
 func ExampleServiceCatalog_DescribeProductAsAdmin() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -514,11 +446,7 @@ func ExampleServiceCatalog_DescribeProductAsAdmin() {
 }
 
 func ExampleServiceCatalog_DescribeProductView() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -540,11 +468,7 @@ func ExampleServiceCatalog_DescribeProductView() {
 }
 
 func ExampleServiceCatalog_DescribeProvisioningArtifact() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -567,11 +491,7 @@ func ExampleServiceCatalog_DescribeProvisioningArtifact() {
 }
 
 func ExampleServiceCatalog_DescribeProvisioningParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -595,11 +515,7 @@ func ExampleServiceCatalog_DescribeProvisioningParameters() {
 }
 
 func ExampleServiceCatalog_DescribeRecord() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -623,11 +539,7 @@ func ExampleServiceCatalog_DescribeRecord() {
 }
 
 func ExampleServiceCatalog_DisassociatePrincipalFromPortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -650,11 +562,7 @@ func ExampleServiceCatalog_DisassociatePrincipalFromPortfolio() {
 }
 
 func ExampleServiceCatalog_DisassociateProductFromPortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -677,11 +585,7 @@ func ExampleServiceCatalog_DisassociateProductFromPortfolio() {
 }
 
 func ExampleServiceCatalog_ListAcceptedPortfolioShares() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -704,11 +608,7 @@ func ExampleServiceCatalog_ListAcceptedPortfolioShares() {
 }
 
 func ExampleServiceCatalog_ListConstraintsForPortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -733,11 +633,7 @@ func ExampleServiceCatalog_ListConstraintsForPortfolio() {
 }
 
 func ExampleServiceCatalog_ListLaunchPaths() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -761,11 +657,7 @@ func ExampleServiceCatalog_ListLaunchPaths() {
 }
 
 func ExampleServiceCatalog_ListPortfolioAccess() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -787,11 +679,7 @@ func ExampleServiceCatalog_ListPortfolioAccess() {
 }
 
 func ExampleServiceCatalog_ListPortfolios() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -814,11 +702,7 @@ func ExampleServiceCatalog_ListPortfolios() {
 }
 
 func ExampleServiceCatalog_ListPortfoliosForProduct() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -842,11 +726,7 @@ func ExampleServiceCatalog_ListPortfoliosForProduct() {
 }
 
 func ExampleServiceCatalog_ListPrincipalsForPortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -870,11 +750,7 @@ func ExampleServiceCatalog_ListPrincipalsForPortfolio() {
 }
 
 func ExampleServiceCatalog_ListProvisioningArtifacts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -896,11 +772,7 @@ func ExampleServiceCatalog_ListProvisioningArtifacts() {
 }
 
 func ExampleServiceCatalog_ListRecordHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -931,11 +803,7 @@ func ExampleServiceCatalog_ListRecordHistory() {
 }
 
 func ExampleServiceCatalog_ProvisionProduct() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -979,11 +847,7 @@ func ExampleServiceCatalog_ProvisionProduct() {
 }
 
 func ExampleServiceCatalog_RejectPortfolioShare() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1005,11 +869,7 @@ func ExampleServiceCatalog_RejectPortfolioShare() {
 }
 
 func ExampleServiceCatalog_ScanProvisionedProducts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1036,11 +896,7 @@ func ExampleServiceCatalog_ScanProvisionedProducts() {
 }
 
 func ExampleServiceCatalog_SearchProducts() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1072,11 +928,7 @@ func ExampleServiceCatalog_SearchProducts() {
 }
 
 func ExampleServiceCatalog_SearchProductsAsAdmin() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1110,11 +962,7 @@ func ExampleServiceCatalog_SearchProductsAsAdmin() {
 }
 
 func ExampleServiceCatalog_TerminateProvisionedProduct() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1139,11 +987,7 @@ func ExampleServiceCatalog_TerminateProvisionedProduct() {
 }
 
 func ExampleServiceCatalog_UpdateConstraint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1166,11 +1010,7 @@ func ExampleServiceCatalog_UpdateConstraint() {
 }
 
 func ExampleServiceCatalog_UpdatePortfolio() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1206,11 +1046,7 @@ func ExampleServiceCatalog_UpdatePortfolio() {
 }
 
 func ExampleServiceCatalog_UpdateProduct() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1250,11 +1086,7 @@ func ExampleServiceCatalog_UpdateProduct() {
 }
 
 func ExampleServiceCatalog_UpdateProvisionedProduct() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 
@@ -1289,11 +1121,7 @@ func ExampleServiceCatalog_UpdateProvisionedProduct() {
 }
 
 func ExampleServiceCatalog_UpdateProvisioningArtifact() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := servicecatalog.New(sess)
 

--- a/service/ses/examples_test.go
+++ b/service/ses/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSES_CloneReceiptRuleSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleSES_CloneReceiptRuleSet() {
 }
 
 func ExampleSES_CreateConfigurationSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -69,11 +61,7 @@ func ExampleSES_CreateConfigurationSet() {
 }
 
 func ExampleSES_CreateConfigurationSetEventDestination() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -116,11 +104,7 @@ func ExampleSES_CreateConfigurationSetEventDestination() {
 }
 
 func ExampleSES_CreateReceiptFilter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -147,11 +131,7 @@ func ExampleSES_CreateReceiptFilter() {
 }
 
 func ExampleSES_CreateReceiptRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -222,11 +202,7 @@ func ExampleSES_CreateReceiptRule() {
 }
 
 func ExampleSES_CreateReceiptRuleSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -247,11 +223,7 @@ func ExampleSES_CreateReceiptRuleSet() {
 }
 
 func ExampleSES_DeleteConfigurationSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -272,11 +244,7 @@ func ExampleSES_DeleteConfigurationSet() {
 }
 
 func ExampleSES_DeleteConfigurationSetEventDestination() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -298,11 +266,7 @@ func ExampleSES_DeleteConfigurationSetEventDestination() {
 }
 
 func ExampleSES_DeleteIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -323,11 +287,7 @@ func ExampleSES_DeleteIdentity() {
 }
 
 func ExampleSES_DeleteIdentityPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -349,11 +309,7 @@ func ExampleSES_DeleteIdentityPolicy() {
 }
 
 func ExampleSES_DeleteReceiptFilter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -374,11 +330,7 @@ func ExampleSES_DeleteReceiptFilter() {
 }
 
 func ExampleSES_DeleteReceiptRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -400,11 +352,7 @@ func ExampleSES_DeleteReceiptRule() {
 }
 
 func ExampleSES_DeleteReceiptRuleSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -425,11 +373,7 @@ func ExampleSES_DeleteReceiptRuleSet() {
 }
 
 func ExampleSES_DeleteVerifiedEmailAddress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -450,11 +394,7 @@ func ExampleSES_DeleteVerifiedEmailAddress() {
 }
 
 func ExampleSES_DescribeActiveReceiptRuleSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -473,11 +413,7 @@ func ExampleSES_DescribeActiveReceiptRuleSet() {
 }
 
 func ExampleSES_DescribeConfigurationSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -502,11 +438,7 @@ func ExampleSES_DescribeConfigurationSet() {
 }
 
 func ExampleSES_DescribeReceiptRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -528,11 +460,7 @@ func ExampleSES_DescribeReceiptRule() {
 }
 
 func ExampleSES_DescribeReceiptRuleSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -553,11 +481,7 @@ func ExampleSES_DescribeReceiptRuleSet() {
 }
 
 func ExampleSES_GetIdentityDkimAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -581,11 +505,7 @@ func ExampleSES_GetIdentityDkimAttributes() {
 }
 
 func ExampleSES_GetIdentityMailFromDomainAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -609,11 +529,7 @@ func ExampleSES_GetIdentityMailFromDomainAttributes() {
 }
 
 func ExampleSES_GetIdentityNotificationAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -637,11 +553,7 @@ func ExampleSES_GetIdentityNotificationAttributes() {
 }
 
 func ExampleSES_GetIdentityPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -666,11 +578,7 @@ func ExampleSES_GetIdentityPolicies() {
 }
 
 func ExampleSES_GetIdentityVerificationAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -694,11 +602,7 @@ func ExampleSES_GetIdentityVerificationAttributes() {
 }
 
 func ExampleSES_GetSendQuota() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -717,11 +621,7 @@ func ExampleSES_GetSendQuota() {
 }
 
 func ExampleSES_GetSendStatistics() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -740,11 +640,7 @@ func ExampleSES_GetSendStatistics() {
 }
 
 func ExampleSES_ListConfigurationSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -766,11 +662,7 @@ func ExampleSES_ListConfigurationSets() {
 }
 
 func ExampleSES_ListIdentities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -793,11 +685,7 @@ func ExampleSES_ListIdentities() {
 }
 
 func ExampleSES_ListIdentityPolicies() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -818,11 +706,7 @@ func ExampleSES_ListIdentityPolicies() {
 }
 
 func ExampleSES_ListReceiptFilters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -841,11 +725,7 @@ func ExampleSES_ListReceiptFilters() {
 }
 
 func ExampleSES_ListReceiptRuleSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -866,11 +746,7 @@ func ExampleSES_ListReceiptRuleSets() {
 }
 
 func ExampleSES_ListVerifiedEmailAddresses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -889,11 +765,7 @@ func ExampleSES_ListVerifiedEmailAddresses() {
 }
 
 func ExampleSES_PutIdentityPolicy() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -916,11 +788,7 @@ func ExampleSES_PutIdentityPolicy() {
 }
 
 func ExampleSES_ReorderReceiptRuleSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -945,11 +813,7 @@ func ExampleSES_ReorderReceiptRuleSet() {
 }
 
 func ExampleSES_SendBounce() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1007,11 +871,7 @@ func ExampleSES_SendBounce() {
 }
 
 func ExampleSES_SendEmail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1077,11 +937,7 @@ func ExampleSES_SendEmail() {
 }
 
 func ExampleSES_SendRawEmail() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1120,11 +976,7 @@ func ExampleSES_SendRawEmail() {
 }
 
 func ExampleSES_SetActiveReceiptRuleSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1145,11 +997,7 @@ func ExampleSES_SetActiveReceiptRuleSet() {
 }
 
 func ExampleSES_SetIdentityDkimEnabled() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1171,11 +1019,7 @@ func ExampleSES_SetIdentityDkimEnabled() {
 }
 
 func ExampleSES_SetIdentityFeedbackForwardingEnabled() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1197,11 +1041,7 @@ func ExampleSES_SetIdentityFeedbackForwardingEnabled() {
 }
 
 func ExampleSES_SetIdentityHeadersInNotificationsEnabled() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1224,11 +1064,7 @@ func ExampleSES_SetIdentityHeadersInNotificationsEnabled() {
 }
 
 func ExampleSES_SetIdentityMailFromDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1251,11 +1087,7 @@ func ExampleSES_SetIdentityMailFromDomain() {
 }
 
 func ExampleSES_SetIdentityNotificationTopic() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1278,11 +1110,7 @@ func ExampleSES_SetIdentityNotificationTopic() {
 }
 
 func ExampleSES_SetReceiptRulePosition() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1305,11 +1133,7 @@ func ExampleSES_SetReceiptRulePosition() {
 }
 
 func ExampleSES_UpdateConfigurationSetEventDestination() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1352,11 +1176,7 @@ func ExampleSES_UpdateConfigurationSetEventDestination() {
 }
 
 func ExampleSES_UpdateReceiptRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1426,11 +1246,7 @@ func ExampleSES_UpdateReceiptRule() {
 }
 
 func ExampleSES_VerifyDomainDkim() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1451,11 +1267,7 @@ func ExampleSES_VerifyDomainDkim() {
 }
 
 func ExampleSES_VerifyDomainIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1476,11 +1288,7 @@ func ExampleSES_VerifyDomainIdentity() {
 }
 
 func ExampleSES_VerifyEmailAddress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 
@@ -1501,11 +1309,7 @@ func ExampleSES_VerifyEmailAddress() {
 }
 
 func ExampleSES_VerifyEmailIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ses.New(sess)
 

--- a/service/sfn/examples_test.go
+++ b/service/sfn/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSFN_CreateActivity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleSFN_CreateActivity() {
 }
 
 func ExampleSFN_CreateStateMachine() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -68,11 +60,7 @@ func ExampleSFN_CreateStateMachine() {
 }
 
 func ExampleSFN_DeleteActivity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -93,11 +81,7 @@ func ExampleSFN_DeleteActivity() {
 }
 
 func ExampleSFN_DeleteStateMachine() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -118,11 +102,7 @@ func ExampleSFN_DeleteStateMachine() {
 }
 
 func ExampleSFN_DescribeActivity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -143,11 +123,7 @@ func ExampleSFN_DescribeActivity() {
 }
 
 func ExampleSFN_DescribeExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -168,11 +144,7 @@ func ExampleSFN_DescribeExecution() {
 }
 
 func ExampleSFN_DescribeStateMachine() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -193,11 +165,7 @@ func ExampleSFN_DescribeStateMachine() {
 }
 
 func ExampleSFN_GetActivityTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -219,11 +187,7 @@ func ExampleSFN_GetActivityTask() {
 }
 
 func ExampleSFN_GetExecutionHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -247,11 +211,7 @@ func ExampleSFN_GetExecutionHistory() {
 }
 
 func ExampleSFN_ListActivities() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -273,11 +233,7 @@ func ExampleSFN_ListActivities() {
 }
 
 func ExampleSFN_ListExecutions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -301,11 +257,7 @@ func ExampleSFN_ListExecutions() {
 }
 
 func ExampleSFN_ListStateMachines() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -327,11 +279,7 @@ func ExampleSFN_ListStateMachines() {
 }
 
 func ExampleSFN_SendTaskFailure() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -354,11 +302,7 @@ func ExampleSFN_SendTaskFailure() {
 }
 
 func ExampleSFN_SendTaskHeartbeat() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -379,11 +323,7 @@ func ExampleSFN_SendTaskHeartbeat() {
 }
 
 func ExampleSFN_SendTaskSuccess() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -405,11 +345,7 @@ func ExampleSFN_SendTaskSuccess() {
 }
 
 func ExampleSFN_StartExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 
@@ -432,11 +368,7 @@ func ExampleSFN_StartExecution() {
 }
 
 func ExampleSFN_StopExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sfn.New(sess)
 

--- a/service/shield/examples_test.go
+++ b/service/shield/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleShield_CreateProtection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleShield_CreateProtection() {
 }
 
 func ExampleShield_CreateSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 
@@ -65,11 +57,7 @@ func ExampleShield_CreateSubscription() {
 }
 
 func ExampleShield_DeleteProtection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 
@@ -90,11 +78,7 @@ func ExampleShield_DeleteProtection() {
 }
 
 func ExampleShield_DeleteSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 
@@ -113,11 +97,7 @@ func ExampleShield_DeleteSubscription() {
 }
 
 func ExampleShield_DescribeAttack() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 
@@ -138,11 +118,7 @@ func ExampleShield_DescribeAttack() {
 }
 
 func ExampleShield_DescribeProtection() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 
@@ -163,11 +139,7 @@ func ExampleShield_DescribeProtection() {
 }
 
 func ExampleShield_DescribeSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 
@@ -186,11 +158,7 @@ func ExampleShield_DescribeSubscription() {
 }
 
 func ExampleShield_ListAttacks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 
@@ -224,11 +192,7 @@ func ExampleShield_ListAttacks() {
 }
 
 func ExampleShield_ListProtections() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := shield.New(sess)
 

--- a/service/simpledb/examples_test.go
+++ b/service/simpledb/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSimpleDB_BatchDeleteAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -54,11 +50,7 @@ func ExampleSimpleDB_BatchDeleteAttributes() {
 }
 
 func ExampleSimpleDB_BatchPutAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -93,11 +85,7 @@ func ExampleSimpleDB_BatchPutAttributes() {
 }
 
 func ExampleSimpleDB_CreateDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -118,11 +106,7 @@ func ExampleSimpleDB_CreateDomain() {
 }
 
 func ExampleSimpleDB_DeleteAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -156,11 +140,7 @@ func ExampleSimpleDB_DeleteAttributes() {
 }
 
 func ExampleSimpleDB_DeleteDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -181,11 +161,7 @@ func ExampleSimpleDB_DeleteDomain() {
 }
 
 func ExampleSimpleDB_DomainMetadata() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -206,11 +182,7 @@ func ExampleSimpleDB_DomainMetadata() {
 }
 
 func ExampleSimpleDB_GetAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -237,11 +209,7 @@ func ExampleSimpleDB_GetAttributes() {
 }
 
 func ExampleSimpleDB_ListDomains() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -263,11 +231,7 @@ func ExampleSimpleDB_ListDomains() {
 }
 
 func ExampleSimpleDB_PutAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 
@@ -302,11 +266,7 @@ func ExampleSimpleDB_PutAttributes() {
 }
 
 func ExampleSimpleDB_Select() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := simpledb.New(sess)
 

--- a/service/sms/examples_test.go
+++ b/service/sms/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSMS_CreateReplicationJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -46,11 +42,7 @@ func ExampleSMS_CreateReplicationJob() {
 }
 
 func ExampleSMS_DeleteReplicationJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -71,11 +63,7 @@ func ExampleSMS_DeleteReplicationJob() {
 }
 
 func ExampleSMS_DeleteServerCatalog() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -94,11 +82,7 @@ func ExampleSMS_DeleteServerCatalog() {
 }
 
 func ExampleSMS_DisassociateConnector() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -119,11 +103,7 @@ func ExampleSMS_DisassociateConnector() {
 }
 
 func ExampleSMS_GetConnectors() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -145,11 +125,7 @@ func ExampleSMS_GetConnectors() {
 }
 
 func ExampleSMS_GetReplicationJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -172,11 +148,7 @@ func ExampleSMS_GetReplicationJobs() {
 }
 
 func ExampleSMS_GetReplicationRuns() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -199,11 +171,7 @@ func ExampleSMS_GetReplicationRuns() {
 }
 
 func ExampleSMS_GetServers() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -225,11 +193,7 @@ func ExampleSMS_GetServers() {
 }
 
 func ExampleSMS_ImportServerCatalog() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -248,11 +212,7 @@ func ExampleSMS_ImportServerCatalog() {
 }
 
 func ExampleSMS_StartOnDemandReplicationRun() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 
@@ -274,11 +234,7 @@ func ExampleSMS_StartOnDemandReplicationRun() {
 }
 
 func ExampleSMS_UpdateReplicationJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sms.New(sess)
 

--- a/service/snowball/examples_test.go
+++ b/service/snowball/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSnowball_CancelCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -41,11 +37,7 @@ func ExampleSnowball_CancelCluster() {
 }
 
 func ExampleSnowball_CancelJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -66,11 +58,7 @@ func ExampleSnowball_CancelJob() {
 }
 
 func ExampleSnowball_CreateAddress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -105,11 +93,7 @@ func ExampleSnowball_CreateAddress() {
 }
 
 func ExampleSnowball_CreateCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -168,11 +152,7 @@ func ExampleSnowball_CreateCluster() {
 }
 
 func ExampleSnowball_CreateJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -233,11 +213,7 @@ func ExampleSnowball_CreateJob() {
 }
 
 func ExampleSnowball_DescribeAddress() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -258,11 +234,7 @@ func ExampleSnowball_DescribeAddress() {
 }
 
 func ExampleSnowball_DescribeAddresses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -284,11 +256,7 @@ func ExampleSnowball_DescribeAddresses() {
 }
 
 func ExampleSnowball_DescribeCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -309,11 +277,7 @@ func ExampleSnowball_DescribeCluster() {
 }
 
 func ExampleSnowball_DescribeJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -334,11 +298,7 @@ func ExampleSnowball_DescribeJob() {
 }
 
 func ExampleSnowball_GetJobManifest() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -359,11 +319,7 @@ func ExampleSnowball_GetJobManifest() {
 }
 
 func ExampleSnowball_GetJobUnlockCode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -384,11 +340,7 @@ func ExampleSnowball_GetJobUnlockCode() {
 }
 
 func ExampleSnowball_GetSnowballUsage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -407,11 +359,7 @@ func ExampleSnowball_GetSnowballUsage() {
 }
 
 func ExampleSnowball_ListClusterJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -434,11 +382,7 @@ func ExampleSnowball_ListClusterJobs() {
 }
 
 func ExampleSnowball_ListClusters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -460,11 +404,7 @@ func ExampleSnowball_ListClusters() {
 }
 
 func ExampleSnowball_ListJobs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -486,11 +426,7 @@ func ExampleSnowball_ListJobs() {
 }
 
 func ExampleSnowball_UpdateCluster() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 
@@ -547,11 +483,7 @@ func ExampleSnowball_UpdateCluster() {
 }
 
 func ExampleSnowball_UpdateJob() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := snowball.New(sess)
 

--- a/service/sns/examples_test.go
+++ b/service/sns/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSNS_AddPermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -50,11 +46,7 @@ func ExampleSNS_AddPermission() {
 }
 
 func ExampleSNS_CheckIfPhoneNumberIsOptedOut() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -75,11 +67,7 @@ func ExampleSNS_CheckIfPhoneNumberIsOptedOut() {
 }
 
 func ExampleSNS_ConfirmSubscription() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -102,11 +90,7 @@ func ExampleSNS_ConfirmSubscription() {
 }
 
 func ExampleSNS_CreatePlatformApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -132,11 +116,7 @@ func ExampleSNS_CreatePlatformApplication() {
 }
 
 func ExampleSNS_CreatePlatformEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -163,11 +143,7 @@ func ExampleSNS_CreatePlatformEndpoint() {
 }
 
 func ExampleSNS_CreateTopic() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -188,11 +164,7 @@ func ExampleSNS_CreateTopic() {
 }
 
 func ExampleSNS_DeleteEndpoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -213,11 +185,7 @@ func ExampleSNS_DeleteEndpoint() {
 }
 
 func ExampleSNS_DeletePlatformApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -238,11 +206,7 @@ func ExampleSNS_DeletePlatformApplication() {
 }
 
 func ExampleSNS_DeleteTopic() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -263,11 +227,7 @@ func ExampleSNS_DeleteTopic() {
 }
 
 func ExampleSNS_GetEndpointAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -288,11 +248,7 @@ func ExampleSNS_GetEndpointAttributes() {
 }
 
 func ExampleSNS_GetPlatformApplicationAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -313,11 +269,7 @@ func ExampleSNS_GetPlatformApplicationAttributes() {
 }
 
 func ExampleSNS_GetSMSAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -341,11 +293,7 @@ func ExampleSNS_GetSMSAttributes() {
 }
 
 func ExampleSNS_GetSubscriptionAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -366,11 +314,7 @@ func ExampleSNS_GetSubscriptionAttributes() {
 }
 
 func ExampleSNS_GetTopicAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -391,11 +335,7 @@ func ExampleSNS_GetTopicAttributes() {
 }
 
 func ExampleSNS_ListEndpointsByPlatformApplication() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -417,11 +357,7 @@ func ExampleSNS_ListEndpointsByPlatformApplication() {
 }
 
 func ExampleSNS_ListPhoneNumbersOptedOut() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -442,11 +378,7 @@ func ExampleSNS_ListPhoneNumbersOptedOut() {
 }
 
 func ExampleSNS_ListPlatformApplications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -467,11 +399,7 @@ func ExampleSNS_ListPlatformApplications() {
 }
 
 func ExampleSNS_ListSubscriptions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -492,11 +420,7 @@ func ExampleSNS_ListSubscriptions() {
 }
 
 func ExampleSNS_ListSubscriptionsByTopic() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -518,11 +442,7 @@ func ExampleSNS_ListSubscriptionsByTopic() {
 }
 
 func ExampleSNS_ListTopics() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -543,11 +463,7 @@ func ExampleSNS_ListTopics() {
 }
 
 func ExampleSNS_OptInPhoneNumber() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -568,11 +484,7 @@ func ExampleSNS_OptInPhoneNumber() {
 }
 
 func ExampleSNS_Publish() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -606,11 +518,7 @@ func ExampleSNS_Publish() {
 }
 
 func ExampleSNS_RemovePermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -632,11 +540,7 @@ func ExampleSNS_RemovePermission() {
 }
 
 func ExampleSNS_SetEndpointAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -661,11 +565,7 @@ func ExampleSNS_SetEndpointAttributes() {
 }
 
 func ExampleSNS_SetPlatformApplicationAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -690,11 +590,7 @@ func ExampleSNS_SetPlatformApplicationAttributes() {
 }
 
 func ExampleSNS_SetSMSAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -718,11 +614,7 @@ func ExampleSNS_SetSMSAttributes() {
 }
 
 func ExampleSNS_SetSubscriptionAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -745,11 +637,7 @@ func ExampleSNS_SetSubscriptionAttributes() {
 }
 
 func ExampleSNS_SetTopicAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -772,11 +660,7 @@ func ExampleSNS_SetTopicAttributes() {
 }
 
 func ExampleSNS_Subscribe() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 
@@ -799,11 +683,7 @@ func ExampleSNS_Subscribe() {
 }
 
 func ExampleSNS_Unsubscribe() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sns.New(sess)
 

--- a/service/sqs/examples_test.go
+++ b/service/sqs/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSQS_AddPermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -50,11 +46,7 @@ func ExampleSQS_AddPermission() {
 }
 
 func ExampleSQS_ChangeMessageVisibility() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -77,11 +69,7 @@ func ExampleSQS_ChangeMessageVisibility() {
 }
 
 func ExampleSQS_ChangeMessageVisibilityBatch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -110,11 +98,7 @@ func ExampleSQS_ChangeMessageVisibilityBatch() {
 }
 
 func ExampleSQS_CreateQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -139,11 +123,7 @@ func ExampleSQS_CreateQueue() {
 }
 
 func ExampleSQS_DeleteMessage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -165,11 +145,7 @@ func ExampleSQS_DeleteMessage() {
 }
 
 func ExampleSQS_DeleteMessageBatch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -197,11 +173,7 @@ func ExampleSQS_DeleteMessageBatch() {
 }
 
 func ExampleSQS_DeleteQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -222,11 +194,7 @@ func ExampleSQS_DeleteQueue() {
 }
 
 func ExampleSQS_GetQueueAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -251,11 +219,7 @@ func ExampleSQS_GetQueueAttributes() {
 }
 
 func ExampleSQS_GetQueueUrl() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -277,11 +241,7 @@ func ExampleSQS_GetQueueUrl() {
 }
 
 func ExampleSQS_ListDeadLetterSourceQueues() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -302,11 +262,7 @@ func ExampleSQS_ListDeadLetterSourceQueues() {
 }
 
 func ExampleSQS_ListQueues() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -327,11 +283,7 @@ func ExampleSQS_ListQueues() {
 }
 
 func ExampleSQS_PurgeQueue() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -352,11 +304,7 @@ func ExampleSQS_PurgeQueue() {
 }
 
 func ExampleSQS_ReceiveMessage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -389,11 +337,7 @@ func ExampleSQS_ReceiveMessage() {
 }
 
 func ExampleSQS_RemovePermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -415,11 +359,7 @@ func ExampleSQS_RemovePermission() {
 }
 
 func ExampleSQS_SendMessage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -460,11 +400,7 @@ func ExampleSQS_SendMessage() {
 }
 
 func ExampleSQS_SendMessageBatch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 
@@ -511,11 +447,7 @@ func ExampleSQS_SendMessageBatch() {
 }
 
 func ExampleSQS_SetQueueAttributes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sqs.New(sess)
 

--- a/service/ssm/examples_test.go
+++ b/service/ssm/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSSM_AddTagsToResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -49,11 +45,7 @@ func ExampleSSM_AddTagsToResource() {
 }
 
 func ExampleSSM_CancelCommand() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -78,11 +70,7 @@ func ExampleSSM_CancelCommand() {
 }
 
 func ExampleSSM_CreateActivation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -107,11 +95,7 @@ func ExampleSSM_CreateActivation() {
 }
 
 func ExampleSSM_CreateAssociation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -159,11 +143,7 @@ func ExampleSSM_CreateAssociation() {
 }
 
 func ExampleSSM_CreateAssociationBatch() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -216,11 +196,7 @@ func ExampleSSM_CreateAssociationBatch() {
 }
 
 func ExampleSSM_CreateDocument() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -243,11 +219,7 @@ func ExampleSSM_CreateDocument() {
 }
 
 func ExampleSSM_CreateMaintenanceWindow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -273,11 +245,7 @@ func ExampleSSM_CreateMaintenanceWindow() {
 }
 
 func ExampleSSM_CreatePatchBaseline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -340,11 +308,7 @@ func ExampleSSM_CreatePatchBaseline() {
 }
 
 func ExampleSSM_DeleteActivation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -365,11 +329,7 @@ func ExampleSSM_DeleteActivation() {
 }
 
 func ExampleSSM_DeleteAssociation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -392,11 +352,7 @@ func ExampleSSM_DeleteAssociation() {
 }
 
 func ExampleSSM_DeleteDocument() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -417,11 +373,7 @@ func ExampleSSM_DeleteDocument() {
 }
 
 func ExampleSSM_DeleteMaintenanceWindow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -442,11 +394,7 @@ func ExampleSSM_DeleteMaintenanceWindow() {
 }
 
 func ExampleSSM_DeleteParameter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -467,11 +415,7 @@ func ExampleSSM_DeleteParameter() {
 }
 
 func ExampleSSM_DeletePatchBaseline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -492,11 +436,7 @@ func ExampleSSM_DeletePatchBaseline() {
 }
 
 func ExampleSSM_DeregisterManagedInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -517,11 +457,7 @@ func ExampleSSM_DeregisterManagedInstance() {
 }
 
 func ExampleSSM_DeregisterPatchBaselineForPatchGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -543,11 +479,7 @@ func ExampleSSM_DeregisterPatchBaselineForPatchGroup() {
 }
 
 func ExampleSSM_DeregisterTargetFromMaintenanceWindow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -569,11 +501,7 @@ func ExampleSSM_DeregisterTargetFromMaintenanceWindow() {
 }
 
 func ExampleSSM_DeregisterTaskFromMaintenanceWindow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -595,11 +523,7 @@ func ExampleSSM_DeregisterTaskFromMaintenanceWindow() {
 }
 
 func ExampleSSM_DescribeActivations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -631,11 +555,7 @@ func ExampleSSM_DescribeActivations() {
 }
 
 func ExampleSSM_DescribeAssociation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -658,11 +578,7 @@ func ExampleSSM_DescribeAssociation() {
 }
 
 func ExampleSSM_DescribeAutomationExecutions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -694,11 +610,7 @@ func ExampleSSM_DescribeAutomationExecutions() {
 }
 
 func ExampleSSM_DescribeAvailablePatches() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -730,11 +642,7 @@ func ExampleSSM_DescribeAvailablePatches() {
 }
 
 func ExampleSSM_DescribeDocument() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -756,11 +664,7 @@ func ExampleSSM_DescribeDocument() {
 }
 
 func ExampleSSM_DescribeDocumentPermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -782,11 +686,7 @@ func ExampleSSM_DescribeDocumentPermission() {
 }
 
 func ExampleSSM_DescribeEffectiveInstanceAssociations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -809,11 +709,7 @@ func ExampleSSM_DescribeEffectiveInstanceAssociations() {
 }
 
 func ExampleSSM_DescribeEffectivePatchesForPatchBaseline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -836,11 +732,7 @@ func ExampleSSM_DescribeEffectivePatchesForPatchBaseline() {
 }
 
 func ExampleSSM_DescribeInstanceAssociationsStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -863,11 +755,7 @@ func ExampleSSM_DescribeInstanceAssociationsStatus() {
 }
 
 func ExampleSSM_DescribeInstanceInformation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -909,11 +797,7 @@ func ExampleSSM_DescribeInstanceInformation() {
 }
 
 func ExampleSSM_DescribeInstancePatchStates() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -939,11 +823,7 @@ func ExampleSSM_DescribeInstancePatchStates() {
 }
 
 func ExampleSSM_DescribeInstancePatchStatesForPatchGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -977,11 +857,7 @@ func ExampleSSM_DescribeInstancePatchStatesForPatchGroup() {
 }
 
 func ExampleSSM_DescribeInstancePatches() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1014,11 +890,7 @@ func ExampleSSM_DescribeInstancePatches() {
 }
 
 func ExampleSSM_DescribeMaintenanceWindowExecutionTaskInvocations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1052,11 +924,7 @@ func ExampleSSM_DescribeMaintenanceWindowExecutionTaskInvocations() {
 }
 
 func ExampleSSM_DescribeMaintenanceWindowExecutionTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1089,11 +957,7 @@ func ExampleSSM_DescribeMaintenanceWindowExecutionTasks() {
 }
 
 func ExampleSSM_DescribeMaintenanceWindowExecutions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1126,11 +990,7 @@ func ExampleSSM_DescribeMaintenanceWindowExecutions() {
 }
 
 func ExampleSSM_DescribeMaintenanceWindowTargets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1163,11 +1023,7 @@ func ExampleSSM_DescribeMaintenanceWindowTargets() {
 }
 
 func ExampleSSM_DescribeMaintenanceWindowTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1200,11 +1056,7 @@ func ExampleSSM_DescribeMaintenanceWindowTasks() {
 }
 
 func ExampleSSM_DescribeMaintenanceWindows() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1236,11 +1088,7 @@ func ExampleSSM_DescribeMaintenanceWindows() {
 }
 
 func ExampleSSM_DescribeParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1272,11 +1120,7 @@ func ExampleSSM_DescribeParameters() {
 }
 
 func ExampleSSM_DescribePatchBaselines() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1308,11 +1152,7 @@ func ExampleSSM_DescribePatchBaselines() {
 }
 
 func ExampleSSM_DescribePatchGroupState() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1333,11 +1173,7 @@ func ExampleSSM_DescribePatchGroupState() {
 }
 
 func ExampleSSM_DescribePatchGroups() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1359,11 +1195,7 @@ func ExampleSSM_DescribePatchGroups() {
 }
 
 func ExampleSSM_GetAutomationExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1384,11 +1216,7 @@ func ExampleSSM_GetAutomationExecution() {
 }
 
 func ExampleSSM_GetCommandInvocation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1411,11 +1239,7 @@ func ExampleSSM_GetCommandInvocation() {
 }
 
 func ExampleSSM_GetDefaultPatchBaseline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1434,11 +1258,7 @@ func ExampleSSM_GetDefaultPatchBaseline() {
 }
 
 func ExampleSSM_GetDeployablePatchSnapshotForInstance() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1460,11 +1280,7 @@ func ExampleSSM_GetDeployablePatchSnapshotForInstance() {
 }
 
 func ExampleSSM_GetDocument() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1486,11 +1302,7 @@ func ExampleSSM_GetDocument() {
 }
 
 func ExampleSSM_GetInventory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1529,11 +1341,7 @@ func ExampleSSM_GetInventory() {
 }
 
 func ExampleSSM_GetInventorySchema() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1556,11 +1364,7 @@ func ExampleSSM_GetInventorySchema() {
 }
 
 func ExampleSSM_GetMaintenanceWindow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1581,11 +1385,7 @@ func ExampleSSM_GetMaintenanceWindow() {
 }
 
 func ExampleSSM_GetMaintenanceWindowExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1606,11 +1406,7 @@ func ExampleSSM_GetMaintenanceWindowExecution() {
 }
 
 func ExampleSSM_GetMaintenanceWindowExecutionTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1632,11 +1428,7 @@ func ExampleSSM_GetMaintenanceWindowExecutionTask() {
 }
 
 func ExampleSSM_GetParameterHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1660,11 +1452,7 @@ func ExampleSSM_GetParameterHistory() {
 }
 
 func ExampleSSM_GetParameters() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1689,11 +1477,7 @@ func ExampleSSM_GetParameters() {
 }
 
 func ExampleSSM_GetPatchBaseline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1714,11 +1498,7 @@ func ExampleSSM_GetPatchBaseline() {
 }
 
 func ExampleSSM_GetPatchBaselineForPatchGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1739,11 +1519,7 @@ func ExampleSSM_GetPatchBaselineForPatchGroup() {
 }
 
 func ExampleSSM_ListAssociations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1772,11 +1548,7 @@ func ExampleSSM_ListAssociations() {
 }
 
 func ExampleSSM_ListCommandInvocations() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1808,11 +1580,7 @@ func ExampleSSM_ListCommandInvocations() {
 }
 
 func ExampleSSM_ListCommands() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1843,11 +1611,7 @@ func ExampleSSM_ListCommands() {
 }
 
 func ExampleSSM_ListDocumentVersions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1870,11 +1634,7 @@ func ExampleSSM_ListDocumentVersions() {
 }
 
 func ExampleSSM_ListDocuments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1903,11 +1663,7 @@ func ExampleSSM_ListDocuments() {
 }
 
 func ExampleSSM_ListInventoryEntries() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1942,11 +1698,7 @@ func ExampleSSM_ListInventoryEntries() {
 }
 
 func ExampleSSM_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -1968,11 +1720,7 @@ func ExampleSSM_ListTagsForResource() {
 }
 
 func ExampleSSM_ModifyDocumentPermission() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2002,11 +1750,7 @@ func ExampleSSM_ModifyDocumentPermission() {
 }
 
 func ExampleSSM_PutInventory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2043,11 +1787,7 @@ func ExampleSSM_PutInventory() {
 }
 
 func ExampleSSM_PutParameter() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2073,11 +1813,7 @@ func ExampleSSM_PutParameter() {
 }
 
 func ExampleSSM_RegisterDefaultPatchBaseline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2098,11 +1834,7 @@ func ExampleSSM_RegisterDefaultPatchBaseline() {
 }
 
 func ExampleSSM_RegisterPatchBaselineForPatchGroup() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2124,11 +1856,7 @@ func ExampleSSM_RegisterPatchBaselineForPatchGroup() {
 }
 
 func ExampleSSM_RegisterTargetWithMaintenanceWindow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2162,11 +1890,7 @@ func ExampleSSM_RegisterTargetWithMaintenanceWindow() {
 }
 
 func ExampleSSM_RegisterTaskWithMaintenanceWindow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2218,11 +1942,7 @@ func ExampleSSM_RegisterTaskWithMaintenanceWindow() {
 }
 
 func ExampleSSM_RemoveTagsFromResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2248,11 +1968,7 @@ func ExampleSSM_RemoveTagsFromResource() {
 }
 
 func ExampleSSM_SendCommand() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2312,11 +2028,7 @@ func ExampleSSM_SendCommand() {
 }
 
 func ExampleSSM_StartAutomationExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2345,11 +2057,7 @@ func ExampleSSM_StartAutomationExecution() {
 }
 
 func ExampleSSM_StopAutomationExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2370,11 +2078,7 @@ func ExampleSSM_StopAutomationExecution() {
 }
 
 func ExampleSSM_UpdateAssociation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2411,11 +2115,7 @@ func ExampleSSM_UpdateAssociation() {
 }
 
 func ExampleSSM_UpdateAssociationStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2443,11 +2143,7 @@ func ExampleSSM_UpdateAssociationStatus() {
 }
 
 func ExampleSSM_UpdateDocument() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2470,11 +2166,7 @@ func ExampleSSM_UpdateDocument() {
 }
 
 func ExampleSSM_UpdateDocumentDefaultVersion() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2496,11 +2188,7 @@ func ExampleSSM_UpdateDocumentDefaultVersion() {
 }
 
 func ExampleSSM_UpdateMaintenanceWindow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2527,11 +2215,7 @@ func ExampleSSM_UpdateMaintenanceWindow() {
 }
 
 func ExampleSSM_UpdateManagedInstanceRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 
@@ -2553,11 +2237,7 @@ func ExampleSSM_UpdateManagedInstanceRole() {
 }
 
 func ExampleSSM_UpdatePatchBaseline() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := ssm.New(sess)
 

--- a/service/storagegateway/examples_test.go
+++ b/service/storagegateway/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleStorageGateway_ActivateGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -47,11 +43,7 @@ func ExampleStorageGateway_ActivateGateway() {
 }
 
 func ExampleStorageGateway_AddCache() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -76,11 +68,7 @@ func ExampleStorageGateway_AddCache() {
 }
 
 func ExampleStorageGateway_AddTagsToResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -108,11 +96,7 @@ func ExampleStorageGateway_AddTagsToResource() {
 }
 
 func ExampleStorageGateway_AddUploadBuffer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -137,11 +121,7 @@ func ExampleStorageGateway_AddUploadBuffer() {
 }
 
 func ExampleStorageGateway_AddWorkingStorage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -166,11 +146,7 @@ func ExampleStorageGateway_AddWorkingStorage() {
 }
 
 func ExampleStorageGateway_CancelArchival() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -192,11 +168,7 @@ func ExampleStorageGateway_CancelArchival() {
 }
 
 func ExampleStorageGateway_CancelRetrieval() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -218,11 +190,7 @@ func ExampleStorageGateway_CancelRetrieval() {
 }
 
 func ExampleStorageGateway_CreateCachediSCSIVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -249,11 +217,7 @@ func ExampleStorageGateway_CreateCachediSCSIVolume() {
 }
 
 func ExampleStorageGateway_CreateNFSFileShare() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -290,11 +254,7 @@ func ExampleStorageGateway_CreateNFSFileShare() {
 }
 
 func ExampleStorageGateway_CreateSnapshot() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -316,11 +276,7 @@ func ExampleStorageGateway_CreateSnapshot() {
 }
 
 func ExampleStorageGateway_CreateSnapshotFromVolumeRecoveryPoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -342,11 +298,7 @@ func ExampleStorageGateway_CreateSnapshotFromVolumeRecoveryPoint() {
 }
 
 func ExampleStorageGateway_CreateStorediSCSIVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -372,11 +324,7 @@ func ExampleStorageGateway_CreateStorediSCSIVolume() {
 }
 
 func ExampleStorageGateway_CreateTapeWithBarcode() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -399,11 +347,7 @@ func ExampleStorageGateway_CreateTapeWithBarcode() {
 }
 
 func ExampleStorageGateway_CreateTapes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -428,11 +372,7 @@ func ExampleStorageGateway_CreateTapes() {
 }
 
 func ExampleStorageGateway_DeleteBandwidthRateLimit() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -454,11 +394,7 @@ func ExampleStorageGateway_DeleteBandwidthRateLimit() {
 }
 
 func ExampleStorageGateway_DeleteChapCredentials() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -480,11 +416,7 @@ func ExampleStorageGateway_DeleteChapCredentials() {
 }
 
 func ExampleStorageGateway_DeleteFileShare() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -505,11 +437,7 @@ func ExampleStorageGateway_DeleteFileShare() {
 }
 
 func ExampleStorageGateway_DeleteGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -530,11 +458,7 @@ func ExampleStorageGateway_DeleteGateway() {
 }
 
 func ExampleStorageGateway_DeleteSnapshotSchedule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -555,11 +479,7 @@ func ExampleStorageGateway_DeleteSnapshotSchedule() {
 }
 
 func ExampleStorageGateway_DeleteTape() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -581,11 +501,7 @@ func ExampleStorageGateway_DeleteTape() {
 }
 
 func ExampleStorageGateway_DeleteTapeArchive() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -606,11 +522,7 @@ func ExampleStorageGateway_DeleteTapeArchive() {
 }
 
 func ExampleStorageGateway_DeleteVolume() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -631,11 +543,7 @@ func ExampleStorageGateway_DeleteVolume() {
 }
 
 func ExampleStorageGateway_DescribeBandwidthRateLimit() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -656,11 +564,7 @@ func ExampleStorageGateway_DescribeBandwidthRateLimit() {
 }
 
 func ExampleStorageGateway_DescribeCache() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -681,11 +585,7 @@ func ExampleStorageGateway_DescribeCache() {
 }
 
 func ExampleStorageGateway_DescribeCachediSCSIVolumes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -709,11 +609,7 @@ func ExampleStorageGateway_DescribeCachediSCSIVolumes() {
 }
 
 func ExampleStorageGateway_DescribeChapCredentials() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -734,11 +630,7 @@ func ExampleStorageGateway_DescribeChapCredentials() {
 }
 
 func ExampleStorageGateway_DescribeGatewayInformation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -759,11 +651,7 @@ func ExampleStorageGateway_DescribeGatewayInformation() {
 }
 
 func ExampleStorageGateway_DescribeMaintenanceStartTime() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -784,11 +672,7 @@ func ExampleStorageGateway_DescribeMaintenanceStartTime() {
 }
 
 func ExampleStorageGateway_DescribeNFSFileShares() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -812,11 +696,7 @@ func ExampleStorageGateway_DescribeNFSFileShares() {
 }
 
 func ExampleStorageGateway_DescribeSnapshotSchedule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -837,11 +717,7 @@ func ExampleStorageGateway_DescribeSnapshotSchedule() {
 }
 
 func ExampleStorageGateway_DescribeStorediSCSIVolumes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -865,11 +741,7 @@ func ExampleStorageGateway_DescribeStorediSCSIVolumes() {
 }
 
 func ExampleStorageGateway_DescribeTapeArchives() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -895,11 +767,7 @@ func ExampleStorageGateway_DescribeTapeArchives() {
 }
 
 func ExampleStorageGateway_DescribeTapeRecoveryPoints() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -922,11 +790,7 @@ func ExampleStorageGateway_DescribeTapeRecoveryPoints() {
 }
 
 func ExampleStorageGateway_DescribeTapes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -953,11 +817,7 @@ func ExampleStorageGateway_DescribeTapes() {
 }
 
 func ExampleStorageGateway_DescribeUploadBuffer() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -978,11 +838,7 @@ func ExampleStorageGateway_DescribeUploadBuffer() {
 }
 
 func ExampleStorageGateway_DescribeVTLDevices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1009,11 +865,7 @@ func ExampleStorageGateway_DescribeVTLDevices() {
 }
 
 func ExampleStorageGateway_DescribeWorkingStorage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1034,11 +886,7 @@ func ExampleStorageGateway_DescribeWorkingStorage() {
 }
 
 func ExampleStorageGateway_DisableGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1059,11 +907,7 @@ func ExampleStorageGateway_DisableGateway() {
 }
 
 func ExampleStorageGateway_ListFileShares() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1086,11 +930,7 @@ func ExampleStorageGateway_ListFileShares() {
 }
 
 func ExampleStorageGateway_ListGateways() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1112,11 +952,7 @@ func ExampleStorageGateway_ListGateways() {
 }
 
 func ExampleStorageGateway_ListLocalDisks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1137,11 +973,7 @@ func ExampleStorageGateway_ListLocalDisks() {
 }
 
 func ExampleStorageGateway_ListTagsForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1164,11 +996,7 @@ func ExampleStorageGateway_ListTagsForResource() {
 }
 
 func ExampleStorageGateway_ListTapes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1194,11 +1022,7 @@ func ExampleStorageGateway_ListTapes() {
 }
 
 func ExampleStorageGateway_ListVolumeInitiators() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1219,11 +1043,7 @@ func ExampleStorageGateway_ListVolumeInitiators() {
 }
 
 func ExampleStorageGateway_ListVolumeRecoveryPoints() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1244,11 +1064,7 @@ func ExampleStorageGateway_ListVolumeRecoveryPoints() {
 }
 
 func ExampleStorageGateway_ListVolumes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1271,11 +1087,7 @@ func ExampleStorageGateway_ListVolumes() {
 }
 
 func ExampleStorageGateway_RemoveTagsFromResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1300,11 +1112,7 @@ func ExampleStorageGateway_RemoveTagsFromResource() {
 }
 
 func ExampleStorageGateway_ResetCache() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1325,11 +1133,7 @@ func ExampleStorageGateway_ResetCache() {
 }
 
 func ExampleStorageGateway_RetrieveTapeArchive() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1351,11 +1155,7 @@ func ExampleStorageGateway_RetrieveTapeArchive() {
 }
 
 func ExampleStorageGateway_RetrieveTapeRecoveryPoint() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1377,11 +1177,7 @@ func ExampleStorageGateway_RetrieveTapeRecoveryPoint() {
 }
 
 func ExampleStorageGateway_SetLocalConsolePassword() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1403,11 +1199,7 @@ func ExampleStorageGateway_SetLocalConsolePassword() {
 }
 
 func ExampleStorageGateway_ShutdownGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1428,11 +1220,7 @@ func ExampleStorageGateway_ShutdownGateway() {
 }
 
 func ExampleStorageGateway_StartGateway() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1453,11 +1241,7 @@ func ExampleStorageGateway_StartGateway() {
 }
 
 func ExampleStorageGateway_UpdateBandwidthRateLimit() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1480,11 +1264,7 @@ func ExampleStorageGateway_UpdateBandwidthRateLimit() {
 }
 
 func ExampleStorageGateway_UpdateChapCredentials() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1508,11 +1288,7 @@ func ExampleStorageGateway_UpdateChapCredentials() {
 }
 
 func ExampleStorageGateway_UpdateGatewayInformation() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1535,11 +1311,7 @@ func ExampleStorageGateway_UpdateGatewayInformation() {
 }
 
 func ExampleStorageGateway_UpdateGatewaySoftwareNow() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1560,11 +1332,7 @@ func ExampleStorageGateway_UpdateGatewaySoftwareNow() {
 }
 
 func ExampleStorageGateway_UpdateMaintenanceStartTime() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1588,11 +1356,7 @@ func ExampleStorageGateway_UpdateMaintenanceStartTime() {
 }
 
 func ExampleStorageGateway_UpdateNFSFileShare() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1626,11 +1390,7 @@ func ExampleStorageGateway_UpdateNFSFileShare() {
 }
 
 func ExampleStorageGateway_UpdateSnapshotSchedule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 
@@ -1654,11 +1414,7 @@ func ExampleStorageGateway_UpdateSnapshotSchedule() {
 }
 
 func ExampleStorageGateway_UpdateVTLDeviceType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := storagegateway.New(sess)
 

--- a/service/sts/examples_test.go
+++ b/service/sts/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSTS_AssumeRole() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sts.New(sess)
 
@@ -47,11 +43,7 @@ func ExampleSTS_AssumeRole() {
 }
 
 func ExampleSTS_AssumeRoleWithSAML() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sts.New(sess)
 
@@ -76,11 +68,7 @@ func ExampleSTS_AssumeRoleWithSAML() {
 }
 
 func ExampleSTS_AssumeRoleWithWebIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sts.New(sess)
 
@@ -106,11 +94,7 @@ func ExampleSTS_AssumeRoleWithWebIdentity() {
 }
 
 func ExampleSTS_DecodeAuthorizationMessage() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sts.New(sess)
 
@@ -131,11 +115,7 @@ func ExampleSTS_DecodeAuthorizationMessage() {
 }
 
 func ExampleSTS_GetCallerIdentity() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sts.New(sess)
 
@@ -154,11 +134,7 @@ func ExampleSTS_GetCallerIdentity() {
 }
 
 func ExampleSTS_GetFederationToken() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sts.New(sess)
 
@@ -181,11 +157,7 @@ func ExampleSTS_GetFederationToken() {
 }
 
 func ExampleSTS_GetSessionToken() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := sts.New(sess)
 

--- a/service/support/examples_test.go
+++ b/service/support/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSupport_AddAttachmentsToSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleSupport_AddAttachmentsToSet() {
 }
 
 func ExampleSupport_AddCommunicationToCase() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -79,11 +71,7 @@ func ExampleSupport_AddCommunicationToCase() {
 }
 
 func ExampleSupport_CreateCase() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -115,11 +103,7 @@ func ExampleSupport_CreateCase() {
 }
 
 func ExampleSupport_DescribeAttachment() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -140,11 +124,7 @@ func ExampleSupport_DescribeAttachment() {
 }
 
 func ExampleSupport_DescribeCases() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -176,11 +156,7 @@ func ExampleSupport_DescribeCases() {
 }
 
 func ExampleSupport_DescribeCommunications() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -205,11 +181,7 @@ func ExampleSupport_DescribeCommunications() {
 }
 
 func ExampleSupport_DescribeServices() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -234,11 +206,7 @@ func ExampleSupport_DescribeServices() {
 }
 
 func ExampleSupport_DescribeSeverityLevels() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -259,11 +227,7 @@ func ExampleSupport_DescribeSeverityLevels() {
 }
 
 func ExampleSupport_DescribeTrustedAdvisorCheckRefreshStatuses() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -287,11 +251,7 @@ func ExampleSupport_DescribeTrustedAdvisorCheckRefreshStatuses() {
 }
 
 func ExampleSupport_DescribeTrustedAdvisorCheckResult() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -313,11 +273,7 @@ func ExampleSupport_DescribeTrustedAdvisorCheckResult() {
 }
 
 func ExampleSupport_DescribeTrustedAdvisorCheckSummaries() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -341,11 +297,7 @@ func ExampleSupport_DescribeTrustedAdvisorCheckSummaries() {
 }
 
 func ExampleSupport_DescribeTrustedAdvisorChecks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -366,11 +318,7 @@ func ExampleSupport_DescribeTrustedAdvisorChecks() {
 }
 
 func ExampleSupport_RefreshTrustedAdvisorCheck() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 
@@ -391,11 +339,7 @@ func ExampleSupport_RefreshTrustedAdvisorCheck() {
 }
 
 func ExampleSupport_ResolveCase() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := support.New(sess)
 

--- a/service/swf/examples_test.go
+++ b/service/swf/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleSWF_CountClosedWorkflowExecutions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -62,11 +58,7 @@ func ExampleSWF_CountClosedWorkflowExecutions() {
 }
 
 func ExampleSWF_CountOpenWorkflowExecutions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -101,11 +93,7 @@ func ExampleSWF_CountOpenWorkflowExecutions() {
 }
 
 func ExampleSWF_CountPendingActivityTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -129,11 +117,7 @@ func ExampleSWF_CountPendingActivityTasks() {
 }
 
 func ExampleSWF_CountPendingDecisionTasks() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -157,11 +141,7 @@ func ExampleSWF_CountPendingDecisionTasks() {
 }
 
 func ExampleSWF_DeprecateActivityType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -186,11 +166,7 @@ func ExampleSWF_DeprecateActivityType() {
 }
 
 func ExampleSWF_DeprecateDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -211,11 +187,7 @@ func ExampleSWF_DeprecateDomain() {
 }
 
 func ExampleSWF_DeprecateWorkflowType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -240,11 +212,7 @@ func ExampleSWF_DeprecateWorkflowType() {
 }
 
 func ExampleSWF_DescribeActivityType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -269,11 +237,7 @@ func ExampleSWF_DescribeActivityType() {
 }
 
 func ExampleSWF_DescribeDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -294,11 +258,7 @@ func ExampleSWF_DescribeDomain() {
 }
 
 func ExampleSWF_DescribeWorkflowExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -323,11 +283,7 @@ func ExampleSWF_DescribeWorkflowExecution() {
 }
 
 func ExampleSWF_DescribeWorkflowType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -352,11 +308,7 @@ func ExampleSWF_DescribeWorkflowType() {
 }
 
 func ExampleSWF_GetWorkflowExecutionHistory() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -384,11 +336,7 @@ func ExampleSWF_GetWorkflowExecutionHistory() {
 }
 
 func ExampleSWF_ListActivityTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -414,11 +362,7 @@ func ExampleSWF_ListActivityTypes() {
 }
 
 func ExampleSWF_ListClosedWorkflowExecutions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -463,11 +407,7 @@ func ExampleSWF_ListClosedWorkflowExecutions() {
 }
 
 func ExampleSWF_ListDomains() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -491,11 +431,7 @@ func ExampleSWF_ListDomains() {
 }
 
 func ExampleSWF_ListOpenWorkflowExecutions() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -533,11 +469,7 @@ func ExampleSWF_ListOpenWorkflowExecutions() {
 }
 
 func ExampleSWF_ListWorkflowTypes() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -563,11 +495,7 @@ func ExampleSWF_ListWorkflowTypes() {
 }
 
 func ExampleSWF_PollForActivityTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -592,11 +520,7 @@ func ExampleSWF_PollForActivityTask() {
 }
 
 func ExampleSWF_PollForDecisionTask() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -624,11 +548,7 @@ func ExampleSWF_PollForDecisionTask() {
 }
 
 func ExampleSWF_RecordActivityTaskHeartbeat() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -650,11 +570,7 @@ func ExampleSWF_RecordActivityTaskHeartbeat() {
 }
 
 func ExampleSWF_RegisterActivityType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -686,11 +602,7 @@ func ExampleSWF_RegisterActivityType() {
 }
 
 func ExampleSWF_RegisterDomain() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -713,11 +625,7 @@ func ExampleSWF_RegisterDomain() {
 }
 
 func ExampleSWF_RegisterWorkflowType() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -749,11 +657,7 @@ func ExampleSWF_RegisterWorkflowType() {
 }
 
 func ExampleSWF_RequestCancelWorkflowExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -776,11 +680,7 @@ func ExampleSWF_RequestCancelWorkflowExecution() {
 }
 
 func ExampleSWF_RespondActivityTaskCanceled() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -802,11 +702,7 @@ func ExampleSWF_RespondActivityTaskCanceled() {
 }
 
 func ExampleSWF_RespondActivityTaskCompleted() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -828,11 +724,7 @@ func ExampleSWF_RespondActivityTaskCompleted() {
 }
 
 func ExampleSWF_RespondActivityTaskFailed() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -855,11 +747,7 @@ func ExampleSWF_RespondActivityTaskFailed() {
 }
 
 func ExampleSWF_RespondDecisionTaskCompleted() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -984,11 +872,7 @@ func ExampleSWF_RespondDecisionTaskCompleted() {
 }
 
 func ExampleSWF_SignalWorkflowExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -1013,11 +897,7 @@ func ExampleSWF_SignalWorkflowExecution() {
 }
 
 func ExampleSWF_StartWorkflowExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 
@@ -1056,11 +936,7 @@ func ExampleSWF_StartWorkflowExecution() {
 }
 
 func ExampleSWF_TerminateWorkflowExecution() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := swf.New(sess)
 

--- a/service/waf/examples_test.go
+++ b/service/waf/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleWAF_CreateByteMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -42,11 +38,7 @@ func ExampleWAF_CreateByteMatchSet() {
 }
 
 func ExampleWAF_CreateIPSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -68,11 +60,7 @@ func ExampleWAF_CreateIPSet() {
 }
 
 func ExampleWAF_CreateRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -95,11 +83,7 @@ func ExampleWAF_CreateRule() {
 }
 
 func ExampleWAF_CreateSizeConstraintSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -121,11 +105,7 @@ func ExampleWAF_CreateSizeConstraintSet() {
 }
 
 func ExampleWAF_CreateSqlInjectionMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -147,11 +127,7 @@ func ExampleWAF_CreateSqlInjectionMatchSet() {
 }
 
 func ExampleWAF_CreateWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -177,11 +153,7 @@ func ExampleWAF_CreateWebACL() {
 }
 
 func ExampleWAF_CreateXssMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -203,11 +175,7 @@ func ExampleWAF_CreateXssMatchSet() {
 }
 
 func ExampleWAF_DeleteByteMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -229,11 +197,7 @@ func ExampleWAF_DeleteByteMatchSet() {
 }
 
 func ExampleWAF_DeleteIPSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -255,11 +219,7 @@ func ExampleWAF_DeleteIPSet() {
 }
 
 func ExampleWAF_DeleteRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -281,11 +241,7 @@ func ExampleWAF_DeleteRule() {
 }
 
 func ExampleWAF_DeleteSizeConstraintSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -307,11 +263,7 @@ func ExampleWAF_DeleteSizeConstraintSet() {
 }
 
 func ExampleWAF_DeleteSqlInjectionMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -333,11 +285,7 @@ func ExampleWAF_DeleteSqlInjectionMatchSet() {
 }
 
 func ExampleWAF_DeleteWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -359,11 +307,7 @@ func ExampleWAF_DeleteWebACL() {
 }
 
 func ExampleWAF_DeleteXssMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -385,11 +329,7 @@ func ExampleWAF_DeleteXssMatchSet() {
 }
 
 func ExampleWAF_GetByteMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -410,11 +350,7 @@ func ExampleWAF_GetByteMatchSet() {
 }
 
 func ExampleWAF_GetChangeToken() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -433,11 +369,7 @@ func ExampleWAF_GetChangeToken() {
 }
 
 func ExampleWAF_GetChangeTokenStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -458,11 +390,7 @@ func ExampleWAF_GetChangeTokenStatus() {
 }
 
 func ExampleWAF_GetIPSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -483,11 +411,7 @@ func ExampleWAF_GetIPSet() {
 }
 
 func ExampleWAF_GetRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -508,11 +432,7 @@ func ExampleWAF_GetRule() {
 }
 
 func ExampleWAF_GetSampledRequests() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -539,11 +459,7 @@ func ExampleWAF_GetSampledRequests() {
 }
 
 func ExampleWAF_GetSizeConstraintSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -564,11 +480,7 @@ func ExampleWAF_GetSizeConstraintSet() {
 }
 
 func ExampleWAF_GetSqlInjectionMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -589,11 +501,7 @@ func ExampleWAF_GetSqlInjectionMatchSet() {
 }
 
 func ExampleWAF_GetWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -614,11 +522,7 @@ func ExampleWAF_GetWebACL() {
 }
 
 func ExampleWAF_GetXssMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -639,11 +543,7 @@ func ExampleWAF_GetXssMatchSet() {
 }
 
 func ExampleWAF_ListByteMatchSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -665,11 +565,7 @@ func ExampleWAF_ListByteMatchSets() {
 }
 
 func ExampleWAF_ListIPSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -691,11 +587,7 @@ func ExampleWAF_ListIPSets() {
 }
 
 func ExampleWAF_ListRules() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -717,11 +609,7 @@ func ExampleWAF_ListRules() {
 }
 
 func ExampleWAF_ListSizeConstraintSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -743,11 +631,7 @@ func ExampleWAF_ListSizeConstraintSets() {
 }
 
 func ExampleWAF_ListSqlInjectionMatchSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -769,11 +653,7 @@ func ExampleWAF_ListSqlInjectionMatchSets() {
 }
 
 func ExampleWAF_ListWebACLs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -795,11 +675,7 @@ func ExampleWAF_ListWebACLs() {
 }
 
 func ExampleWAF_ListXssMatchSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -821,11 +697,7 @@ func ExampleWAF_ListXssMatchSets() {
 }
 
 func ExampleWAF_UpdateByteMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -862,11 +734,7 @@ func ExampleWAF_UpdateByteMatchSet() {
 }
 
 func ExampleWAF_UpdateIPSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -898,11 +766,7 @@ func ExampleWAF_UpdateIPSet() {
 }
 
 func ExampleWAF_UpdateRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -935,11 +799,7 @@ func ExampleWAF_UpdateRule() {
 }
 
 func ExampleWAF_UpdateSizeConstraintSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -976,11 +836,7 @@ func ExampleWAF_UpdateSizeConstraintSet() {
 }
 
 func ExampleWAF_UpdateSqlInjectionMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -1015,11 +871,7 @@ func ExampleWAF_UpdateSqlInjectionMatchSet() {
 }
 
 func ExampleWAF_UpdateWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 
@@ -1057,11 +909,7 @@ func ExampleWAF_UpdateWebACL() {
 }
 
 func ExampleWAF_UpdateXssMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := waf.New(sess)
 

--- a/service/wafregional/examples_test.go
+++ b/service/wafregional/examples_test.go
@@ -17,11 +17,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleWAFRegional_AssociateWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -43,11 +39,7 @@ func ExampleWAFRegional_AssociateWebACL() {
 }
 
 func ExampleWAFRegional_CreateByteMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -69,11 +61,7 @@ func ExampleWAFRegional_CreateByteMatchSet() {
 }
 
 func ExampleWAFRegional_CreateIPSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -95,11 +83,7 @@ func ExampleWAFRegional_CreateIPSet() {
 }
 
 func ExampleWAFRegional_CreateRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -122,11 +106,7 @@ func ExampleWAFRegional_CreateRule() {
 }
 
 func ExampleWAFRegional_CreateSizeConstraintSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -148,11 +128,7 @@ func ExampleWAFRegional_CreateSizeConstraintSet() {
 }
 
 func ExampleWAFRegional_CreateSqlInjectionMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -174,11 +150,7 @@ func ExampleWAFRegional_CreateSqlInjectionMatchSet() {
 }
 
 func ExampleWAFRegional_CreateWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -204,11 +176,7 @@ func ExampleWAFRegional_CreateWebACL() {
 }
 
 func ExampleWAFRegional_CreateXssMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -230,11 +198,7 @@ func ExampleWAFRegional_CreateXssMatchSet() {
 }
 
 func ExampleWAFRegional_DeleteByteMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -256,11 +220,7 @@ func ExampleWAFRegional_DeleteByteMatchSet() {
 }
 
 func ExampleWAFRegional_DeleteIPSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -282,11 +242,7 @@ func ExampleWAFRegional_DeleteIPSet() {
 }
 
 func ExampleWAFRegional_DeleteRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -308,11 +264,7 @@ func ExampleWAFRegional_DeleteRule() {
 }
 
 func ExampleWAFRegional_DeleteSizeConstraintSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -334,11 +286,7 @@ func ExampleWAFRegional_DeleteSizeConstraintSet() {
 }
 
 func ExampleWAFRegional_DeleteSqlInjectionMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -360,11 +308,7 @@ func ExampleWAFRegional_DeleteSqlInjectionMatchSet() {
 }
 
 func ExampleWAFRegional_DeleteWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -386,11 +330,7 @@ func ExampleWAFRegional_DeleteWebACL() {
 }
 
 func ExampleWAFRegional_DeleteXssMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -412,11 +352,7 @@ func ExampleWAFRegional_DeleteXssMatchSet() {
 }
 
 func ExampleWAFRegional_DisassociateWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -437,11 +373,7 @@ func ExampleWAFRegional_DisassociateWebACL() {
 }
 
 func ExampleWAFRegional_GetByteMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -462,11 +394,7 @@ func ExampleWAFRegional_GetByteMatchSet() {
 }
 
 func ExampleWAFRegional_GetChangeToken() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -485,11 +413,7 @@ func ExampleWAFRegional_GetChangeToken() {
 }
 
 func ExampleWAFRegional_GetChangeTokenStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -510,11 +434,7 @@ func ExampleWAFRegional_GetChangeTokenStatus() {
 }
 
 func ExampleWAFRegional_GetIPSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -535,11 +455,7 @@ func ExampleWAFRegional_GetIPSet() {
 }
 
 func ExampleWAFRegional_GetRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -560,11 +476,7 @@ func ExampleWAFRegional_GetRule() {
 }
 
 func ExampleWAFRegional_GetSampledRequests() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -591,11 +503,7 @@ func ExampleWAFRegional_GetSampledRequests() {
 }
 
 func ExampleWAFRegional_GetSizeConstraintSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -616,11 +524,7 @@ func ExampleWAFRegional_GetSizeConstraintSet() {
 }
 
 func ExampleWAFRegional_GetSqlInjectionMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -641,11 +545,7 @@ func ExampleWAFRegional_GetSqlInjectionMatchSet() {
 }
 
 func ExampleWAFRegional_GetWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -666,11 +566,7 @@ func ExampleWAFRegional_GetWebACL() {
 }
 
 func ExampleWAFRegional_GetWebACLForResource() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -691,11 +587,7 @@ func ExampleWAFRegional_GetWebACLForResource() {
 }
 
 func ExampleWAFRegional_GetXssMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -716,11 +608,7 @@ func ExampleWAFRegional_GetXssMatchSet() {
 }
 
 func ExampleWAFRegional_ListByteMatchSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -742,11 +630,7 @@ func ExampleWAFRegional_ListByteMatchSets() {
 }
 
 func ExampleWAFRegional_ListIPSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -768,11 +652,7 @@ func ExampleWAFRegional_ListIPSets() {
 }
 
 func ExampleWAFRegional_ListResourcesForWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -793,11 +673,7 @@ func ExampleWAFRegional_ListResourcesForWebACL() {
 }
 
 func ExampleWAFRegional_ListRules() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -819,11 +695,7 @@ func ExampleWAFRegional_ListRules() {
 }
 
 func ExampleWAFRegional_ListSizeConstraintSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -845,11 +717,7 @@ func ExampleWAFRegional_ListSizeConstraintSets() {
 }
 
 func ExampleWAFRegional_ListSqlInjectionMatchSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -871,11 +739,7 @@ func ExampleWAFRegional_ListSqlInjectionMatchSets() {
 }
 
 func ExampleWAFRegional_ListWebACLs() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -897,11 +761,7 @@ func ExampleWAFRegional_ListWebACLs() {
 }
 
 func ExampleWAFRegional_ListXssMatchSets() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -923,11 +783,7 @@ func ExampleWAFRegional_ListXssMatchSets() {
 }
 
 func ExampleWAFRegional_UpdateByteMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -964,11 +820,7 @@ func ExampleWAFRegional_UpdateByteMatchSet() {
 }
 
 func ExampleWAFRegional_UpdateIPSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -1000,11 +852,7 @@ func ExampleWAFRegional_UpdateIPSet() {
 }
 
 func ExampleWAFRegional_UpdateRule() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -1037,11 +885,7 @@ func ExampleWAFRegional_UpdateRule() {
 }
 
 func ExampleWAFRegional_UpdateSizeConstraintSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -1078,11 +922,7 @@ func ExampleWAFRegional_UpdateSizeConstraintSet() {
 }
 
 func ExampleWAFRegional_UpdateSqlInjectionMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -1117,11 +957,7 @@ func ExampleWAFRegional_UpdateSqlInjectionMatchSet() {
 }
 
 func ExampleWAFRegional_UpdateWebACL() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 
@@ -1159,11 +995,7 @@ func ExampleWAFRegional_UpdateWebACL() {
 }
 
 func ExampleWAFRegional_UpdateXssMatchSet() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := wafregional.New(sess)
 

--- a/service/workspaces/examples_test.go
+++ b/service/workspaces/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleWorkSpaces_CreateTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -48,11 +44,7 @@ func ExampleWorkSpaces_CreateTags() {
 }
 
 func ExampleWorkSpaces_CreateWorkspaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -94,11 +86,7 @@ func ExampleWorkSpaces_CreateWorkspaces() {
 }
 
 func ExampleWorkSpaces_DeleteTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -123,11 +111,7 @@ func ExampleWorkSpaces_DeleteTags() {
 }
 
 func ExampleWorkSpaces_DescribeTags() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -148,11 +132,7 @@ func ExampleWorkSpaces_DescribeTags() {
 }
 
 func ExampleWorkSpaces_DescribeWorkspaceBundles() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -178,11 +158,7 @@ func ExampleWorkSpaces_DescribeWorkspaceBundles() {
 }
 
 func ExampleWorkSpaces_DescribeWorkspaceDirectories() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -207,11 +183,7 @@ func ExampleWorkSpaces_DescribeWorkspaceDirectories() {
 }
 
 func ExampleWorkSpaces_DescribeWorkspaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -240,11 +212,7 @@ func ExampleWorkSpaces_DescribeWorkspaces() {
 }
 
 func ExampleWorkSpaces_DescribeWorkspacesConnectionStatus() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -269,11 +237,7 @@ func ExampleWorkSpaces_DescribeWorkspacesConnectionStatus() {
 }
 
 func ExampleWorkSpaces_ModifyWorkspaceProperties() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -298,11 +262,7 @@ func ExampleWorkSpaces_ModifyWorkspaceProperties() {
 }
 
 func ExampleWorkSpaces_RebootWorkspaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -328,11 +288,7 @@ func ExampleWorkSpaces_RebootWorkspaces() {
 }
 
 func ExampleWorkSpaces_RebuildWorkspaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -358,11 +314,7 @@ func ExampleWorkSpaces_RebuildWorkspaces() {
 }
 
 func ExampleWorkSpaces_StartWorkspaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -388,11 +340,7 @@ func ExampleWorkSpaces_StartWorkspaces() {
 }
 
 func ExampleWorkSpaces_StopWorkspaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 
@@ -418,11 +366,7 @@ func ExampleWorkSpaces_StopWorkspaces() {
 }
 
 func ExampleWorkSpaces_TerminateWorkspaces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := workspaces.New(sess)
 

--- a/service/xray/examples_test.go
+++ b/service/xray/examples_test.go
@@ -16,11 +16,7 @@ var _ time.Duration
 var _ bytes.Buffer
 
 func ExampleXRay_BatchGetTraces() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := xray.New(sess)
 
@@ -45,11 +41,7 @@ func ExampleXRay_BatchGetTraces() {
 }
 
 func ExampleXRay_GetServiceGraph() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := xray.New(sess)
 
@@ -72,11 +64,7 @@ func ExampleXRay_GetServiceGraph() {
 }
 
 func ExampleXRay_GetTraceGraph() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := xray.New(sess)
 
@@ -101,11 +89,7 @@ func ExampleXRay_GetTraceGraph() {
 }
 
 func ExampleXRay_GetTraceSummaries() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := xray.New(sess)
 
@@ -130,11 +114,7 @@ func ExampleXRay_GetTraceSummaries() {
 }
 
 func ExampleXRay_PutTelemetryRecords() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := xray.New(sess)
 
@@ -175,11 +155,7 @@ func ExampleXRay_PutTelemetryRecords() {
 }
 
 func ExampleXRay_PutTraceSegments() {
-	sess, err := session.NewSession()
-	if err != nil {
-		fmt.Println("failed to create session,", err)
-		return
-	}
+	sess := session.Must(session.NewSession())
 
 	svc := xray.New(sess)
 


### PR DESCRIPTION
Updates the SDK's example and docs to use `session.Must` where possible to highlight its usage as apposed to session error checking that is most cases errors will be terminal to the application anyways.

Fix #928