### PR TITLE
v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Release v1.7.1 (2017-02-24)
+===
+
+Service Client Updates
+---
+* `service/elasticsearchservice`: Updates service API, documentation, paginators, and examples
+  * Added three new API calls to existing Amazon Elasticsearch service to expose Amazon Elasticsearch imposed limits to customers.
+
 Release v1.7.0 (2017-02-23)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.7.0"
+const SDKVersion = "1.7.1"

--- a/models/apis/es/2015-01-01/api-2.json
+++ b/models/apis/es/2015-01-01/api-2.json
@@ -1,12 +1,12 @@
 {
   "version":"2.0",
   "metadata":{
-    "uid":"es-2015-01-01",
     "apiVersion":"2015-01-01",
     "endpointPrefix":"es",
     "protocol":"rest-json",
     "serviceFullName":"Amazon Elasticsearch Service",
-    "signatureVersion":"v4"
+    "signatureVersion":"v4",
+    "uid":"es-2015-01-01"
   },
   "operations":{
     "AddTags":{
@@ -100,6 +100,23 @@
         {"shape":"ValidationException"}
       ]
     },
+    "DescribeElasticsearchInstanceTypeLimits":{
+      "name":"DescribeElasticsearchInstanceTypeLimits",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2015-01-01/es/instanceTypeLimits/{ElasticsearchVersion}/{InstanceType}"
+      },
+      "input":{"shape":"DescribeElasticsearchInstanceTypeLimitsRequest"},
+      "output":{"shape":"DescribeElasticsearchInstanceTypeLimitsResponse"},
+      "errors":[
+        {"shape":"BaseException"},
+        {"shape":"InternalException"},
+        {"shape":"InvalidTypeException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ValidationException"}
+      ]
+    },
     "ListDomainNames":{
       "name":"ListDomainNames",
       "http":{
@@ -109,6 +126,36 @@
       "output":{"shape":"ListDomainNamesResponse"},
       "errors":[
         {"shape":"BaseException"},
+        {"shape":"ValidationException"}
+      ]
+    },
+    "ListElasticsearchInstanceTypes":{
+      "name":"ListElasticsearchInstanceTypes",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2015-01-01/es/instanceTypes/{ElasticsearchVersion}"
+      },
+      "input":{"shape":"ListElasticsearchInstanceTypesRequest"},
+      "output":{"shape":"ListElasticsearchInstanceTypesResponse"},
+      "errors":[
+        {"shape":"BaseException"},
+        {"shape":"InternalException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ValidationException"}
+      ]
+    },
+    "ListElasticsearchVersions":{
+      "name":"ListElasticsearchVersions",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2015-01-01/es/versions"
+      },
+      "input":{"shape":"ListElasticsearchVersionsRequest"},
+      "output":{"shape":"ListElasticsearchVersionsResponse"},
+      "errors":[
+        {"shape":"BaseException"},
+        {"shape":"InternalException"},
+        {"shape":"ResourceNotFoundException"},
         {"shape":"ValidationException"}
       ]
     },
@@ -181,6 +228,17 @@
         "ARN":{"shape":"ARN"},
         "TagList":{"shape":"TagList"}
       }
+    },
+    "AdditionalLimit":{
+      "type":"structure",
+      "members":{
+        "LimitName":{"shape":"LimitName"},
+        "LimitValues":{"shape":"LimitValueList"}
+      }
+    },
+    "AdditionalLimitList":{
+      "type":"list",
+      "member":{"shape":"AdditionalLimit"}
     },
     "AdvancedOptions":{
       "type":"map",
@@ -292,6 +350,36 @@
         "DomainStatusList":{"shape":"ElasticsearchDomainStatusList"}
       }
     },
+    "DescribeElasticsearchInstanceTypeLimitsRequest":{
+      "type":"structure",
+      "required":[
+        "InstanceType",
+        "ElasticsearchVersion"
+      ],
+      "members":{
+        "DomainName":{
+          "shape":"DomainName",
+          "location":"querystring",
+          "locationName":"domainName"
+        },
+        "InstanceType":{
+          "shape":"ESPartitionInstanceType",
+          "location":"uri",
+          "locationName":"InstanceType"
+        },
+        "ElasticsearchVersion":{
+          "shape":"ElasticsearchVersionString",
+          "location":"uri",
+          "locationName":"ElasticsearchVersion"
+        }
+      }
+    },
+    "DescribeElasticsearchInstanceTypeLimitsResponse":{
+      "type":"structure",
+      "members":{
+        "LimitsByRole":{"shape":"LimitsByRole"}
+      }
+    },
     "DisabledOperationException":{
       "type":"structure",
       "members":{
@@ -365,7 +453,22 @@
         "r3.4xlarge.elasticsearch",
         "r3.8xlarge.elasticsearch",
         "i2.xlarge.elasticsearch",
-        "i2.2xlarge.elasticsearch"
+        "i2.2xlarge.elasticsearch",
+        "d2.xlarge.elasticsearch",
+        "d2.2xlarge.elasticsearch",
+        "d2.4xlarge.elasticsearch",
+        "d2.8xlarge.elasticsearch",
+        "c4.large.elasticsearch",
+        "c4.xlarge.elasticsearch",
+        "c4.2xlarge.elasticsearch",
+        "c4.4xlarge.elasticsearch",
+        "c4.8xlarge.elasticsearch",
+        "r4.large.elasticsearch",
+        "r4.xlarge.elasticsearch",
+        "r4.2xlarge.elasticsearch",
+        "r4.4xlarge.elasticsearch",
+        "r4.8xlarge.elasticsearch",
+        "r4.16xlarge.elasticsearch"
       ]
     },
     "ElasticsearchClusterConfig":{
@@ -429,6 +532,14 @@
       "type":"list",
       "member":{"shape":"ElasticsearchDomainStatus"}
     },
+    "ElasticsearchInstanceTypeList":{
+      "type":"list",
+      "member":{"shape":"ESPartitionInstanceType"}
+    },
+    "ElasticsearchVersionList":{
+      "type":"list",
+      "member":{"shape":"ElasticsearchVersionString"}
+    },
     "ElasticsearchVersionStatus":{
       "type":"structure",
       "required":[
@@ -442,6 +553,20 @@
     },
     "ElasticsearchVersionString":{"type":"string"},
     "ErrorMessage":{"type":"string"},
+    "InstanceCountLimits":{
+      "type":"structure",
+      "members":{
+        "MinimumInstanceCount":{"shape":"MinimumInstanceCount"},
+        "MaximumInstanceCount":{"shape":"MaximumInstanceCount"}
+      }
+    },
+    "InstanceLimits":{
+      "type":"structure",
+      "members":{
+        "InstanceCountLimits":{"shape":"InstanceCountLimits"}
+      }
+    },
+    "InstanceRole":{"type":"string"},
     "IntegerClass":{"type":"integer"},
     "InternalException":{
       "type":"structure",
@@ -464,10 +589,84 @@
       "error":{"httpStatusCode":409},
       "exception":true
     },
+    "LimitName":{"type":"string"},
+    "LimitValue":{"type":"string"},
+    "LimitValueList":{
+      "type":"list",
+      "member":{"shape":"LimitValue"}
+    },
+    "Limits":{
+      "type":"structure",
+      "members":{
+        "StorageTypes":{"shape":"StorageTypeList"},
+        "InstanceLimits":{"shape":"InstanceLimits"},
+        "AdditionalLimits":{"shape":"AdditionalLimitList"}
+      }
+    },
+    "LimitsByRole":{
+      "type":"map",
+      "key":{"shape":"InstanceRole"},
+      "value":{"shape":"Limits"}
+    },
     "ListDomainNamesResponse":{
       "type":"structure",
       "members":{
         "DomainNames":{"shape":"DomainInfoList"}
+      }
+    },
+    "ListElasticsearchInstanceTypesRequest":{
+      "type":"structure",
+      "required":["ElasticsearchVersion"],
+      "members":{
+        "ElasticsearchVersion":{
+          "shape":"ElasticsearchVersionString",
+          "location":"uri",
+          "locationName":"ElasticsearchVersion"
+        },
+        "DomainName":{
+          "shape":"DomainName",
+          "location":"querystring",
+          "locationName":"domainName"
+        },
+        "MaxResults":{
+          "shape":"MaxResults",
+          "location":"querystring",
+          "locationName":"maxResults"
+        },
+        "NextToken":{
+          "shape":"NextToken",
+          "location":"querystring",
+          "locationName":"nextToken"
+        }
+      }
+    },
+    "ListElasticsearchInstanceTypesResponse":{
+      "type":"structure",
+      "members":{
+        "ElasticsearchInstanceTypes":{"shape":"ElasticsearchInstanceTypeList"},
+        "NextToken":{"shape":"NextToken"}
+      }
+    },
+    "ListElasticsearchVersionsRequest":{
+      "type":"structure",
+      "members":{
+        "MaxResults":{
+          "shape":"MaxResults",
+          "location":"querystring",
+          "locationName":"maxResults"
+        },
+        "NextToken":{
+          "shape":"NextToken",
+          "location":"querystring",
+          "locationName":"nextToken"
+        }
+      }
+    },
+    "ListElasticsearchVersionsResponse":{
+      "type":"structure",
+      "members":{
+        "ElasticsearchVersions":{"shape":"ElasticsearchVersionList"},
+        "NextToken":{"shape":"NextToken"}
       }
     },
     "ListTagsRequest":{
@@ -487,6 +686,13 @@
         "TagList":{"shape":"TagList"}
       }
     },
+    "MaxResults":{
+      "type":"integer",
+      "max":100
+    },
+    "MaximumInstanceCount":{"type":"integer"},
+    "MinimumInstanceCount":{"type":"integer"},
+    "NextToken":{"type":"string"},
     "OptionState":{
       "type":"string",
       "enum":[
@@ -554,6 +760,31 @@
         "Status":{"shape":"OptionStatus"}
       }
     },
+    "StorageSubTypeName":{"type":"string"},
+    "StorageType":{
+      "type":"structure",
+      "members":{
+        "StorageTypeName":{"shape":"StorageTypeName"},
+        "StorageSubTypeName":{"shape":"StorageSubTypeName"},
+        "StorageTypeLimits":{"shape":"StorageTypeLimitList"}
+      }
+    },
+    "StorageTypeLimit":{
+      "type":"structure",
+      "members":{
+        "LimitName":{"shape":"LimitName"},
+        "LimitValues":{"shape":"LimitValueList"}
+      }
+    },
+    "StorageTypeLimitList":{
+      "type":"list",
+      "member":{"shape":"StorageTypeLimit"}
+    },
+    "StorageTypeList":{
+      "type":"list",
+      "member":{"shape":"StorageType"}
+    },
+    "StorageTypeName":{"type":"string"},
     "String":{"type":"string"},
     "StringList":{
       "type":"list",

--- a/models/apis/es/2015-01-01/docs-2.json
+++ b/models/apis/es/2015-01-01/docs-2.json
@@ -8,7 +8,10 @@
     "DescribeElasticsearchDomain": "<p>Returns domain configuration information about the specified Elasticsearch domain, including the domain ID, domain endpoint, and domain ARN.</p>",
     "DescribeElasticsearchDomainConfig": "<p>Provides cluster configuration information about the specified Elasticsearch domain, such as the state, creation date, update version, and update date for cluster options.</p>",
     "DescribeElasticsearchDomains": "<p>Returns domain configuration information about the specified Elasticsearch domains, including the domain ID, domain endpoint, and domain ARN.</p>",
+    "DescribeElasticsearchInstanceTypeLimits": "<p> Describe Elasticsearch Limits for a given InstanceType and ElasticsearchVersion. When modifying existing Domain, specify the <code> <a>DomainName</a> </code> to know what Limits are supported for modifying. </p>",
     "ListDomainNames": "<p>Returns the name of all Elasticsearch domains owned by the current user's account. </p>",
+    "ListElasticsearchInstanceTypes": "<p>List all Elasticsearch instance types that are supported for given ElasticsearchVersion</p>",
+    "ListElasticsearchVersions": "<p>List all supported Elasticsearch versions</p>",
     "ListTags": "<p>Returns all tags for the given Elasticsearch domain.</p>",
     "RemoveTags": "<p>Removes the specified set of tags from the specified Elasticsearch domain.</p>",
     "UpdateElasticsearchDomainConfig": "<p>Modifies the cluster configuration of the specified Elasticsearch domain, setting as setting the instance type and the number of instances. </p>"
@@ -32,6 +35,18 @@
     "AddTagsRequest": {
       "base": "<p>Container for the parameters to the <code><a>AddTags</a></code> operation. Specify the tags that you want to attach to the Elasticsearch domain.</p>",
       "refs": {
+      }
+    },
+    "AdditionalLimit": {
+      "base": "<p> List of limits that are specific to a given InstanceType and for each of it's <code> <a>InstanceRole</a> </code> . </p>",
+      "refs": {
+        "AdditionalLimitList$member": null
+      }
+    },
+    "AdditionalLimitList": {
+      "base": null,
+      "refs": {
+        "Limits$AdditionalLimits": "<p> List of additional limits that are specific to a given InstanceType and for each of it's <code> <a>InstanceRole</a> </code> . </p>"
       }
     },
     "AdvancedOptions": {
@@ -116,6 +131,16 @@
       "refs": {
       }
     },
+    "DescribeElasticsearchInstanceTypeLimitsRequest": {
+      "base": "<p> Container for the parameters to <code> <a>DescribeElasticsearchInstanceTypeLimits</a> </code> operation. </p>",
+      "refs": {
+      }
+    },
+    "DescribeElasticsearchInstanceTypeLimitsResponse": {
+      "base": "<p> Container for the parameters received from <code> <a>DescribeElasticsearchInstanceTypeLimits</a> </code> operation. </p>",
+      "refs": {
+      }
+    },
     "DisabledOperationException": {
       "base": "<p>An error occured because the client wanted to access a not supported operation. Gives http status code of 409.</p>",
       "refs": {
@@ -146,9 +171,11 @@
         "DeleteElasticsearchDomainRequest$DomainName": "<p>The name of the Elasticsearch domain that you want to permanently delete.</p>",
         "DescribeElasticsearchDomainConfigRequest$DomainName": "<p>The Elasticsearch domain that you want to get information about.</p>",
         "DescribeElasticsearchDomainRequest$DomainName": "<p>The name of the Elasticsearch domain for which you want information.</p>",
+        "DescribeElasticsearchInstanceTypeLimitsRequest$DomainName": "<p> DomainName represents the name of the Domain that we are trying to modify. This should be present only if we are querying for Elasticsearch <code> <a>Limits</a> </code> for existing domain. </p>",
         "DomainInfo$DomainName": "<p> Specifies the <code>DomainName</code>.</p>",
         "DomainNameList$member": null,
         "ElasticsearchDomainStatus$DomainName": "<p>The name of an Elasticsearch domain. Domain names are unique across the domains owned by an account within an AWS region. Domain names start with a letter or number and can contain the following characters: a-z (lowercase), 0-9, and - (hyphen).</p>",
+        "ListElasticsearchInstanceTypesRequest$DomainName": "<p>DomainName represents the name of the Domain that we are trying to modify. This should be present only if we are querying for list of available Elasticsearch instance types when modifying existing domain. </p>",
         "UpdateElasticsearchDomainConfigRequest$DomainName": "<p>The name of the Elasticsearch domain that you are updating. </p>"
       }
     },
@@ -176,8 +203,10 @@
     "ESPartitionInstanceType": {
       "base": null,
       "refs": {
+        "DescribeElasticsearchInstanceTypeLimitsRequest$InstanceType": "<p> The instance type for an Elasticsearch cluster for which Elasticsearch <code> <a>Limits</a> </code> are needed. </p>",
         "ElasticsearchClusterConfig$InstanceType": "<p>The instance type for an Elasticsearch cluster.</p>",
-        "ElasticsearchClusterConfig$DedicatedMasterType": "<p>The instance type for a dedicated master node.</p>"
+        "ElasticsearchClusterConfig$DedicatedMasterType": "<p>The instance type for a dedicated master node.</p>",
+        "ElasticsearchInstanceTypeList$member": null
       }
     },
     "ElasticsearchClusterConfig": {
@@ -217,6 +246,18 @@
         "DescribeElasticsearchDomainsResponse$DomainStatusList": "<p>The status of the domains requested in the <code>DescribeElasticsearchDomains</code> request.</p>"
       }
     },
+    "ElasticsearchInstanceTypeList": {
+      "base": "<p> List of instance types supported by Amazon Elasticsearch service. </p>",
+      "refs": {
+        "ListElasticsearchInstanceTypesResponse$ElasticsearchInstanceTypes": "<p> List of instance types supported by Amazon Elasticsearch service for given <code> <a>ElasticsearchVersion</a> </code> </p>"
+      }
+    },
+    "ElasticsearchVersionList": {
+      "base": "<p>List of supported elastic search versions. </p>",
+      "refs": {
+        "ListElasticsearchVersionsResponse$ElasticsearchVersions": null
+      }
+    },
     "ElasticsearchVersionStatus": {
       "base": "<p> Status of the Elasticsearch version options for the specified Elasticsearch domain.</p>",
       "refs": {
@@ -227,14 +268,35 @@
       "base": null,
       "refs": {
         "CreateElasticsearchDomainRequest$ElasticsearchVersion": "<p>String of format X.Y to specify version for the Elasticsearch domain eg. \"1.5\" or \"2.3\". For more information, see <a href=\"http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomains\" target=\"_blank\">Creating Elasticsearch Domains</a> in the <i>Amazon Elasticsearch Service Developer Guide</i>.</p>",
+        "DescribeElasticsearchInstanceTypeLimitsRequest$ElasticsearchVersion": "<p> Version of Elasticsearch for which <code> <a>Limits</a> </code> are needed. </p>",
         "ElasticsearchDomainStatus$ElasticsearchVersion": null,
-        "ElasticsearchVersionStatus$Options": "<p> Specifies the Elasticsearch version for the specified Elasticsearch domain.</p>"
+        "ElasticsearchVersionList$member": null,
+        "ElasticsearchVersionStatus$Options": "<p> Specifies the Elasticsearch version for the specified Elasticsearch domain.</p>",
+        "ListElasticsearchInstanceTypesRequest$ElasticsearchVersion": "<p>Version of Elasticsearch for which list of supported elasticsearch instance types are needed. </p>"
       }
     },
     "ErrorMessage": {
       "base": null,
       "refs": {
         "BaseException$message": "<p>A description of the error.</p>"
+      }
+    },
+    "InstanceCountLimits": {
+      "base": "<p> InstanceCountLimits represents the limits on number of instances that be created in Amazon Elasticsearch for given InstanceType. </p>",
+      "refs": {
+        "InstanceLimits$InstanceCountLimits": null
+      }
+    },
+    "InstanceLimits": {
+      "base": "<p>InstanceLimits represents the list of instance related attributes that are available for given InstanceType. </p>",
+      "refs": {
+        "Limits$InstanceLimits": null
+      }
+    },
+    "InstanceRole": {
+      "base": null,
+      "refs": {
+        "LimitsByRole$key": null
       }
     },
     "IntegerClass": {
@@ -262,8 +324,60 @@
       "refs": {
       }
     },
+    "LimitName": {
+      "base": null,
+      "refs": {
+        "AdditionalLimit$LimitName": "<p> Name of Additional Limit is specific to a given InstanceType and for each of it's <code> <a>InstanceRole</a> </code> etc. <br/> Attributes and their details: <br/> <ul> <li>MaximumNumberOfDataNodesSupported</li> This attribute will be present in Master node only to specify how much data nodes upto which given <code> <a>ESPartitionInstanceType</a> </code> can support as master node. <li>MaximumNumberOfDataNodesWithoutMasterNode</li> This attribute will be present in Data node only to specify how much data nodes of given <code> <a>ESPartitionInstanceType</a> </code> upto which you don't need any master nodes to govern them. </ul> </p>",
+        "StorageTypeLimit$LimitName": "<p> Name of storage limits that are applicable for given storage type. If <code> <a>StorageType</a> </code> is ebs, following storage options are applicable <ol> <li>MinimumVolumeSize</li> Minimum amount of volume size that is applicable for given storage type.It can be empty if it is not applicable. <li>MaximumVolumeSize</li> Maximum amount of volume size that is applicable for given storage type.It can be empty if it is not applicable. <li>MaximumIops</li> Maximum amount of Iops that is applicable for given storage type.It can be empty if it is not applicable. <li>MinimumIops</li> Minimum amount of Iops that is applicable for given storage type.It can be empty if it is not applicable. </ol> </p>"
+      }
+    },
+    "LimitValue": {
+      "base": null,
+      "refs": {
+        "LimitValueList$member": null
+      }
+    },
+    "LimitValueList": {
+      "base": null,
+      "refs": {
+        "AdditionalLimit$LimitValues": "<p> Value for given <code> <a>AdditionalLimit$LimitName</a> </code> . </p>",
+        "StorageTypeLimit$LimitValues": "<p> Values for the <code> <a>StorageTypeLimit$LimitName</a> </code> . </p>"
+      }
+    },
+    "Limits": {
+      "base": "<p> Limits for given InstanceType and for each of it's role. <br/> Limits contains following <code> <a>StorageTypes,</a> </code> <code> <a>InstanceLimits</a> </code> and <code> <a>AdditionalLimits</a> </code> </p>",
+      "refs": {
+        "LimitsByRole$value": null
+      }
+    },
+    "LimitsByRole": {
+      "base": "<p> Map of Role of the Instance and Limits that are applicable. Role performed by given Instance in Elasticsearch can be one of the following: <ul> <li>Data: If the given InstanceType is used as Data node</li> <li>Master: If the given InstanceType is used as Master node</li> </ul> </p>",
+      "refs": {
+        "DescribeElasticsearchInstanceTypeLimitsResponse$LimitsByRole": null
+      }
+    },
     "ListDomainNamesResponse": {
       "base": "<p>The result of a <code>ListDomainNames</code> operation. Contains the names of all Elasticsearch domains owned by this account.</p>",
+      "refs": {
+      }
+    },
+    "ListElasticsearchInstanceTypesRequest": {
+      "base": "<p> Container for the parameters to the <code> <a>ListElasticsearchInstanceTypes</a> </code> operation. </p>",
+      "refs": {
+      }
+    },
+    "ListElasticsearchInstanceTypesResponse": {
+      "base": "<p> Container for the parameters returned by <code> <a>ListElasticsearchInstanceTypes</a> </code> operation. </p>",
+      "refs": {
+      }
+    },
+    "ListElasticsearchVersionsRequest": {
+      "base": "<p> Container for the parameters to the <code> <a>ListElasticsearchVersions</a> </code> operation. <p> Use <code> <a>MaxResults</a> </code> to control the maximum number of results to retrieve in a single call. </p> <p> Use <code> <a>NextToken</a> </code> in response to retrieve more results. If the received response does not contain a NextToken, then there are no more results to retrieve. </p> </p>",
+      "refs": {
+      }
+    },
+    "ListElasticsearchVersionsResponse": {
+      "base": "<p> Container for the parameters for response received from <code> <a>ListElasticsearchVersions</a> </code> operation. </p>",
       "refs": {
       }
     },
@@ -275,6 +389,34 @@
     "ListTagsResponse": {
       "base": "<p>The result of a <code>ListTags</code> operation. Contains tags for all requested Elasticsearch domains.</p>",
       "refs": {
+      }
+    },
+    "MaxResults": {
+      "base": "<p> Set this value to limit the number of results returned. </p>",
+      "refs": {
+        "ListElasticsearchInstanceTypesRequest$MaxResults": "<p> Set this value to limit the number of results returned. Value provided must be greater than 30 else it wont be honored. </p>",
+        "ListElasticsearchVersionsRequest$MaxResults": "<p> Set this value to limit the number of results returned. Value provided must be greater than 10 else it wont be honored. </p>"
+      }
+    },
+    "MaximumInstanceCount": {
+      "base": "<p> Maximum number of Instances that can be instantiated for given InstanceType. </p>",
+      "refs": {
+        "InstanceCountLimits$MaximumInstanceCount": null
+      }
+    },
+    "MinimumInstanceCount": {
+      "base": "<p> Minimum number of Instances that can be instantiated for given InstanceType. </p>",
+      "refs": {
+        "InstanceCountLimits$MinimumInstanceCount": null
+      }
+    },
+    "NextToken": {
+      "base": "<p> Paginated APIs accepts NextToken input to returns next page results and provides a NextToken output in the response which can be used by the client to retrieve more results. </p>",
+      "refs": {
+        "ListElasticsearchInstanceTypesRequest$NextToken": "<p>NextToken should be sent in case if earlier API call produced result containing NextToken. It is used for pagination. </p>",
+        "ListElasticsearchInstanceTypesResponse$NextToken": "<p>In case if there are more results available NextToken would be present, make further request to the same API with received NextToken to paginate remaining results. </p>",
+        "ListElasticsearchVersionsRequest$NextToken": null,
+        "ListElasticsearchVersionsResponse$NextToken": null
       }
     },
     "OptionState": {
@@ -337,6 +479,42 @@
       "base": "<p>Status of a daily automated snapshot.</p>",
       "refs": {
         "ElasticsearchDomainConfig$SnapshotOptions": "<p>Specifies the <code>SnapshotOptions</code> for the Elasticsearch domain.</p>"
+      }
+    },
+    "StorageSubTypeName": {
+      "base": "<p> SubType of the given storage type. List of available sub-storage options: For \"instance\" storageType we wont have any storageSubType, in case of \"ebs\" storageType we will have following valid storageSubTypes <ol> <li>standard</li> <li>gp2</li> <li>io1</li> </ol> Refer <code><a>VolumeType</a></code> for more information regarding above EBS storage options. </p>",
+      "refs": {
+        "StorageType$StorageSubTypeName": null
+      }
+    },
+    "StorageType": {
+      "base": "<p>StorageTypes represents the list of storage related types and their attributes that are available for given InstanceType. </p>",
+      "refs": {
+        "StorageTypeList$member": null
+      }
+    },
+    "StorageTypeLimit": {
+      "base": "<p>Limits that are applicable for given storage type. </p>",
+      "refs": {
+        "StorageTypeLimitList$member": null
+      }
+    },
+    "StorageTypeLimitList": {
+      "base": null,
+      "refs": {
+        "StorageType$StorageTypeLimits": "<p>List of limits that are applicable for given storage type. </p>"
+      }
+    },
+    "StorageTypeList": {
+      "base": null,
+      "refs": {
+        "Limits$StorageTypes": "<p>StorageType represents the list of storage related types and attributes that are available for given InstanceType. </p>"
+      }
+    },
+    "StorageTypeName": {
+      "base": "<p> Type of the storage. List of available storage options: <ol> <li>instance</li> Inbuilt storage available for the given Instance <li>ebs</li> Elastic block storage that would be attached to the given Instance </ol> </p>",
+      "refs": {
+        "StorageType$StorageTypeName": null
       }
     },
     "String": {

--- a/models/apis/es/2015-01-01/examples-1.json
+++ b/models/apis/es/2015-01-01/examples-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "examples": {
+  }
+}

--- a/models/apis/es/2015-01-01/paginators-1.json
+++ b/models/apis/es/2015-01-01/paginators-1.json
@@ -1,0 +1,14 @@
+{
+  "pagination": {
+    "ListElasticsearchInstanceTypes": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListElasticsearchVersions": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
+}

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -500,6 +500,94 @@ func (c *ElasticsearchService) DescribeElasticsearchDomains(input *DescribeElast
 	return out, err
 }
 
+const opDescribeElasticsearchInstanceTypeLimits = "DescribeElasticsearchInstanceTypeLimits"
+
+// DescribeElasticsearchInstanceTypeLimitsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeElasticsearchInstanceTypeLimits operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeElasticsearchInstanceTypeLimits for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeElasticsearchInstanceTypeLimits method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeElasticsearchInstanceTypeLimitsRequest method.
+//    req, resp := client.DescribeElasticsearchInstanceTypeLimitsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/DescribeElasticsearchInstanceTypeLimits
+func (c *ElasticsearchService) DescribeElasticsearchInstanceTypeLimitsRequest(input *DescribeElasticsearchInstanceTypeLimitsInput) (req *request.Request, output *DescribeElasticsearchInstanceTypeLimitsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeElasticsearchInstanceTypeLimits,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-01-01/es/instanceTypeLimits/{ElasticsearchVersion}/{InstanceType}",
+	}
+
+	if input == nil {
+		input = &DescribeElasticsearchInstanceTypeLimitsInput{}
+	}
+
+	output = &DescribeElasticsearchInstanceTypeLimitsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeElasticsearchInstanceTypeLimits API operation for Amazon Elasticsearch Service.
+//
+// Describe Elasticsearch Limits for a given InstanceType and ElasticsearchVersion.
+// When modifying existing Domain, specify the DomainName to know what Limits
+// are supported for modifying.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation DescribeElasticsearchInstanceTypeLimits for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBaseException "BaseException"
+//   An error occurred while processing the request.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+//   * ErrCodeInvalidTypeException "InvalidTypeException"
+//   An exception for trying to create or access sub-resource that is either invalid
+//   or not supported. Gives http status code of 409.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   An exception for trying to create more than allowed resources or sub-resources.
+//   Gives http status code of 409.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/DescribeElasticsearchInstanceTypeLimits
+func (c *ElasticsearchService) DescribeElasticsearchInstanceTypeLimits(input *DescribeElasticsearchInstanceTypeLimitsInput) (*DescribeElasticsearchInstanceTypeLimitsOutput, error) {
+	req, out := c.DescribeElasticsearchInstanceTypeLimitsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opListDomainNames = "ListDomainNames"
 
 // ListDomainNamesRequest generates a "aws/request.Request" representing the
@@ -568,6 +656,224 @@ func (c *ElasticsearchService) ListDomainNames(input *ListDomainNamesInput) (*Li
 	req, out := c.ListDomainNamesRequest(input)
 	err := req.Send()
 	return out, err
+}
+
+const opListElasticsearchInstanceTypes = "ListElasticsearchInstanceTypes"
+
+// ListElasticsearchInstanceTypesRequest generates a "aws/request.Request" representing the
+// client's request for the ListElasticsearchInstanceTypes operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListElasticsearchInstanceTypes for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListElasticsearchInstanceTypes method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListElasticsearchInstanceTypesRequest method.
+//    req, resp := client.ListElasticsearchInstanceTypesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListElasticsearchInstanceTypes
+func (c *ElasticsearchService) ListElasticsearchInstanceTypesRequest(input *ListElasticsearchInstanceTypesInput) (req *request.Request, output *ListElasticsearchInstanceTypesOutput) {
+	op := &request.Operation{
+		Name:       opListElasticsearchInstanceTypes,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-01-01/es/instanceTypes/{ElasticsearchVersion}",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListElasticsearchInstanceTypesInput{}
+	}
+
+	output = &ListElasticsearchInstanceTypesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListElasticsearchInstanceTypes API operation for Amazon Elasticsearch Service.
+//
+// List all Elasticsearch instance types that are supported for given ElasticsearchVersion
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation ListElasticsearchInstanceTypes for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBaseException "BaseException"
+//   An error occurred while processing the request.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListElasticsearchInstanceTypes
+func (c *ElasticsearchService) ListElasticsearchInstanceTypes(input *ListElasticsearchInstanceTypesInput) (*ListElasticsearchInstanceTypesOutput, error) {
+	req, out := c.ListElasticsearchInstanceTypesRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+// ListElasticsearchInstanceTypesPages iterates over the pages of a ListElasticsearchInstanceTypes operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListElasticsearchInstanceTypes method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListElasticsearchInstanceTypes operation.
+//    pageNum := 0
+//    err := client.ListElasticsearchInstanceTypesPages(params,
+//        func(page *ListElasticsearchInstanceTypesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ElasticsearchService) ListElasticsearchInstanceTypesPages(input *ListElasticsearchInstanceTypesInput, fn func(p *ListElasticsearchInstanceTypesOutput, lastPage bool) (shouldContinue bool)) error {
+	page, _ := c.ListElasticsearchInstanceTypesRequest(input)
+	page.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler("Paginator"))
+	return page.EachPage(func(p interface{}, lastPage bool) bool {
+		return fn(p.(*ListElasticsearchInstanceTypesOutput), lastPage)
+	})
+}
+
+const opListElasticsearchVersions = "ListElasticsearchVersions"
+
+// ListElasticsearchVersionsRequest generates a "aws/request.Request" representing the
+// client's request for the ListElasticsearchVersions operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListElasticsearchVersions for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListElasticsearchVersions method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListElasticsearchVersionsRequest method.
+//    req, resp := client.ListElasticsearchVersionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListElasticsearchVersions
+func (c *ElasticsearchService) ListElasticsearchVersionsRequest(input *ListElasticsearchVersionsInput) (req *request.Request, output *ListElasticsearchVersionsOutput) {
+	op := &request.Operation{
+		Name:       opListElasticsearchVersions,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-01-01/es/versions",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListElasticsearchVersionsInput{}
+	}
+
+	output = &ListElasticsearchVersionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListElasticsearchVersions API operation for Amazon Elasticsearch Service.
+//
+// List all supported Elasticsearch versions
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation ListElasticsearchVersions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBaseException "BaseException"
+//   An error occurred while processing the request.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListElasticsearchVersions
+func (c *ElasticsearchService) ListElasticsearchVersions(input *ListElasticsearchVersionsInput) (*ListElasticsearchVersionsOutput, error) {
+	req, out := c.ListElasticsearchVersionsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+// ListElasticsearchVersionsPages iterates over the pages of a ListElasticsearchVersions operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListElasticsearchVersions method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListElasticsearchVersions operation.
+//    pageNum := 0
+//    err := client.ListElasticsearchVersionsPages(params,
+//        func(page *ListElasticsearchVersionsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ElasticsearchService) ListElasticsearchVersionsPages(input *ListElasticsearchVersionsInput, fn func(p *ListElasticsearchVersionsOutput, lastPage bool) (shouldContinue bool)) error {
+	page, _ := c.ListElasticsearchVersionsRequest(input)
+	page.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler("Paginator"))
+	return page.EachPage(func(p interface{}, lastPage bool) bool {
+		return fn(p.(*ListElasticsearchVersionsOutput), lastPage)
+	})
 }
 
 const opListTags = "ListTags"
@@ -932,6 +1238,46 @@ func (s AddTagsOutput) String() string {
 // GoString returns the string representation
 func (s AddTagsOutput) GoString() string {
 	return s.String()
+}
+
+// List of limits that are specific to a given InstanceType and for each of
+// it's InstanceRole .
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/AdditionalLimit
+type AdditionalLimit struct {
+	_ struct{} `type:"structure"`
+
+	// Name of Additional Limit is specific to a given InstanceType and for each
+	// of it's InstanceRole etc. Attributes and their details: MaximumNumberOfDataNodesSupported
+	// This attribute will be present in Master node only to specify how much data
+	// nodes upto which given ESPartitionInstanceTypecan support as master node. MaximumNumberOfDataNodesWithoutMasterNode
+	// This attribute will be present in Data node only to specify how much data
+	// nodes of given ESPartitionInstanceType
+	LimitName *string `type:"string"`
+
+	// Value for given AdditionalLimit$LimitName .
+	LimitValues []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s AdditionalLimit) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AdditionalLimit) GoString() string {
+	return s.String()
+}
+
+// SetLimitName sets the LimitName field's value.
+func (s *AdditionalLimit) SetLimitName(v string) *AdditionalLimit {
+	s.LimitName = &v
+	return s
+}
+
+// SetLimitValues sets the LimitValues field's value.
+func (s *AdditionalLimit) SetLimitValues(v []*string) *AdditionalLimit {
+	s.LimitValues = v
+	return s
 }
 
 // Status of the advanced options for the specified Elasticsearch domain. Currently,
@@ -1397,6 +1743,104 @@ func (s DescribeElasticsearchDomainsOutput) GoString() string {
 // SetDomainStatusList sets the DomainStatusList field's value.
 func (s *DescribeElasticsearchDomainsOutput) SetDomainStatusList(v []*ElasticsearchDomainStatus) *DescribeElasticsearchDomainsOutput {
 	s.DomainStatusList = v
+	return s
+}
+
+// Container for the parameters to DescribeElasticsearchInstanceTypeLimits operation.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/DescribeElasticsearchInstanceTypeLimitsRequest
+type DescribeElasticsearchInstanceTypeLimitsInput struct {
+	_ struct{} `type:"structure"`
+
+	// DomainName represents the name of the Domain that we are trying to modify.
+	// This should be present only if we are querying for Elasticsearch Limits for
+	// existing domain.
+	DomainName *string `location:"querystring" locationName:"domainName" min:"3" type:"string"`
+
+	// Version of Elasticsearch for which Limits are needed.
+	//
+	// ElasticsearchVersion is a required field
+	ElasticsearchVersion *string `location:"uri" locationName:"ElasticsearchVersion" type:"string" required:"true"`
+
+	// The instance type for an Elasticsearch cluster for which Elasticsearch Limits
+	// are needed.
+	//
+	// InstanceType is a required field
+	InstanceType *string `location:"uri" locationName:"InstanceType" type:"string" required:"true" enum:"ESPartitionInstanceType"`
+}
+
+// String returns the string representation
+func (s DescribeElasticsearchInstanceTypeLimitsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeElasticsearchInstanceTypeLimitsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeElasticsearchInstanceTypeLimitsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeElasticsearchInstanceTypeLimitsInput"}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.ElasticsearchVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticsearchVersion"))
+	}
+	if s.InstanceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *DescribeElasticsearchInstanceTypeLimitsInput) SetDomainName(v string) *DescribeElasticsearchInstanceTypeLimitsInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetElasticsearchVersion sets the ElasticsearchVersion field's value.
+func (s *DescribeElasticsearchInstanceTypeLimitsInput) SetElasticsearchVersion(v string) *DescribeElasticsearchInstanceTypeLimitsInput {
+	s.ElasticsearchVersion = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *DescribeElasticsearchInstanceTypeLimitsInput) SetInstanceType(v string) *DescribeElasticsearchInstanceTypeLimitsInput {
+	s.InstanceType = &v
+	return s
+}
+
+// Container for the parameters received from DescribeElasticsearchInstanceTypeLimits
+// operation.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/DescribeElasticsearchInstanceTypeLimitsResponse
+type DescribeElasticsearchInstanceTypeLimitsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Map of Role of the Instance and Limits that are applicable. Role performed
+	// by given Instance in Elasticsearch can be one of the following: Data: If
+	// the given InstanceType is used as Data node
+	// Master: If the given InstanceType is used as Master node
+	LimitsByRole map[string]*Limits `type:"map"`
+}
+
+// String returns the string representation
+func (s DescribeElasticsearchInstanceTypeLimitsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeElasticsearchInstanceTypeLimitsOutput) GoString() string {
+	return s.String()
+}
+
+// SetLimitsByRole sets the LimitsByRole field's value.
+func (s *DescribeElasticsearchInstanceTypeLimitsOutput) SetLimitsByRole(v map[string]*Limits) *DescribeElasticsearchInstanceTypeLimitsOutput {
+	s.LimitsByRole = v
 	return s
 }
 
@@ -1895,6 +2339,114 @@ func (s *ElasticsearchVersionStatus) SetStatus(v *OptionStatus) *ElasticsearchVe
 	return s
 }
 
+// InstanceCountLimits represents the limits on number of instances that be
+// created in Amazon Elasticsearch for given InstanceType.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/InstanceCountLimits
+type InstanceCountLimits struct {
+	_ struct{} `type:"structure"`
+
+	// Maximum number of Instances that can be instantiated for given InstanceType.
+	MaximumInstanceCount *int64 `type:"integer"`
+
+	// Minimum number of Instances that can be instantiated for given InstanceType.
+	MinimumInstanceCount *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s InstanceCountLimits) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceCountLimits) GoString() string {
+	return s.String()
+}
+
+// SetMaximumInstanceCount sets the MaximumInstanceCount field's value.
+func (s *InstanceCountLimits) SetMaximumInstanceCount(v int64) *InstanceCountLimits {
+	s.MaximumInstanceCount = &v
+	return s
+}
+
+// SetMinimumInstanceCount sets the MinimumInstanceCount field's value.
+func (s *InstanceCountLimits) SetMinimumInstanceCount(v int64) *InstanceCountLimits {
+	s.MinimumInstanceCount = &v
+	return s
+}
+
+// InstanceLimits represents the list of instance related attributes that are
+// available for given InstanceType.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/InstanceLimits
+type InstanceLimits struct {
+	_ struct{} `type:"structure"`
+
+	// InstanceCountLimits represents the limits on number of instances that be
+	// created in Amazon Elasticsearch for given InstanceType.
+	InstanceCountLimits *InstanceCountLimits `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceLimits) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceLimits) GoString() string {
+	return s.String()
+}
+
+// SetInstanceCountLimits sets the InstanceCountLimits field's value.
+func (s *InstanceLimits) SetInstanceCountLimits(v *InstanceCountLimits) *InstanceLimits {
+	s.InstanceCountLimits = v
+	return s
+}
+
+// Limits for given InstanceType and for each of it's role. Limits contains following StorageTypes,   InstanceLimitsand AdditionalLimits
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/Limits
+type Limits struct {
+	_ struct{} `type:"structure"`
+
+	// List of additional limits that are specific to a given InstanceType and for
+	// each of it's InstanceRole .
+	AdditionalLimits []*AdditionalLimit `type:"list"`
+
+	// InstanceLimits represents the list of instance related attributes that are
+	// available for given InstanceType.
+	InstanceLimits *InstanceLimits `type:"structure"`
+
+	// StorageType represents the list of storage related types and attributes that
+	// are available for given InstanceType.
+	StorageTypes []*StorageType `type:"list"`
+}
+
+// String returns the string representation
+func (s Limits) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Limits) GoString() string {
+	return s.String()
+}
+
+// SetAdditionalLimits sets the AdditionalLimits field's value.
+func (s *Limits) SetAdditionalLimits(v []*AdditionalLimit) *Limits {
+	s.AdditionalLimits = v
+	return s
+}
+
+// SetInstanceLimits sets the InstanceLimits field's value.
+func (s *Limits) SetInstanceLimits(v *InstanceLimits) *Limits {
+	s.InstanceLimits = v
+	return s
+}
+
+// SetStorageTypes sets the StorageTypes field's value.
+func (s *Limits) SetStorageTypes(v []*StorageType) *Limits {
+	s.StorageTypes = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListDomainNamesInput
 type ListDomainNamesInput struct {
 	_ struct{} `type:"structure"`
@@ -1933,6 +2485,197 @@ func (s ListDomainNamesOutput) GoString() string {
 // SetDomainNames sets the DomainNames field's value.
 func (s *ListDomainNamesOutput) SetDomainNames(v []*DomainInfo) *ListDomainNamesOutput {
 	s.DomainNames = v
+	return s
+}
+
+// Container for the parameters to the ListElasticsearchInstanceTypes operation.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListElasticsearchInstanceTypesRequest
+type ListElasticsearchInstanceTypesInput struct {
+	_ struct{} `type:"structure"`
+
+	// DomainName represents the name of the Domain that we are trying to modify.
+	// This should be present only if we are querying for list of available Elasticsearch
+	// instance types when modifying existing domain.
+	DomainName *string `location:"querystring" locationName:"domainName" min:"3" type:"string"`
+
+	// Version of Elasticsearch for which list of supported elasticsearch instance
+	// types are needed.
+	//
+	// ElasticsearchVersion is a required field
+	ElasticsearchVersion *string `location:"uri" locationName:"ElasticsearchVersion" type:"string" required:"true"`
+
+	// Set this value to limit the number of results returned. Value provided must
+	// be greater than 30 else it wont be honored.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+
+	// NextToken should be sent in case if earlier API call produced result containing
+	// NextToken. It is used for pagination.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s ListElasticsearchInstanceTypesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListElasticsearchInstanceTypesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListElasticsearchInstanceTypesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListElasticsearchInstanceTypesInput"}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.ElasticsearchVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("ElasticsearchVersion"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *ListElasticsearchInstanceTypesInput) SetDomainName(v string) *ListElasticsearchInstanceTypesInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetElasticsearchVersion sets the ElasticsearchVersion field's value.
+func (s *ListElasticsearchInstanceTypesInput) SetElasticsearchVersion(v string) *ListElasticsearchInstanceTypesInput {
+	s.ElasticsearchVersion = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListElasticsearchInstanceTypesInput) SetMaxResults(v int64) *ListElasticsearchInstanceTypesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListElasticsearchInstanceTypesInput) SetNextToken(v string) *ListElasticsearchInstanceTypesInput {
+	s.NextToken = &v
+	return s
+}
+
+// Container for the parameters returned by ListElasticsearchInstanceTypes operation.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListElasticsearchInstanceTypesResponse
+type ListElasticsearchInstanceTypesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// List of instance types supported by Amazon Elasticsearch service for given
+	// ElasticsearchVersion
+	ElasticsearchInstanceTypes []*string `type:"list"`
+
+	// In case if there are more results available NextToken would be present, make
+	// further request to the same API with received NextToken to paginate remaining
+	// results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListElasticsearchInstanceTypesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListElasticsearchInstanceTypesOutput) GoString() string {
+	return s.String()
+}
+
+// SetElasticsearchInstanceTypes sets the ElasticsearchInstanceTypes field's value.
+func (s *ListElasticsearchInstanceTypesOutput) SetElasticsearchInstanceTypes(v []*string) *ListElasticsearchInstanceTypesOutput {
+	s.ElasticsearchInstanceTypes = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListElasticsearchInstanceTypesOutput) SetNextToken(v string) *ListElasticsearchInstanceTypesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// Container for the parameters to the ListElasticsearchVersions operation.
+//  Use MaxResults to control the maximum number of results to retrieve in a
+// single call.
+//
+//  Use NextToken in response to retrieve more results. If the received response
+// does not contain a NextToken, then there are no more results to retrieve.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListElasticsearchVersionsRequest
+type ListElasticsearchVersionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Set this value to limit the number of results returned. Value provided must
+	// be greater than 10 else it wont be honored.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+
+	// Paginated APIs accepts NextToken input to returns next page results and provides
+	// a NextToken output in the response which can be used by the client to retrieve
+	// more results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s ListElasticsearchVersionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListElasticsearchVersionsInput) GoString() string {
+	return s.String()
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListElasticsearchVersionsInput) SetMaxResults(v int64) *ListElasticsearchVersionsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListElasticsearchVersionsInput) SetNextToken(v string) *ListElasticsearchVersionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// Container for the parameters for response received from ListElasticsearchVersions
+// operation.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/ListElasticsearchVersionsResponse
+type ListElasticsearchVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// List of supported elastic search versions.
+	ElasticsearchVersions []*string `type:"list"`
+
+	// Paginated APIs accepts NextToken input to returns next page results and provides
+	// a NextToken output in the response which can be used by the client to retrieve
+	// more results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListElasticsearchVersionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListElasticsearchVersionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetElasticsearchVersions sets the ElasticsearchVersions field's value.
+func (s *ListElasticsearchVersionsOutput) SetElasticsearchVersions(v []*string) *ListElasticsearchVersionsOutput {
+	s.ElasticsearchVersions = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListElasticsearchVersionsOutput) SetNextToken(v string) *ListElasticsearchVersionsOutput {
+	s.NextToken = &v
 	return s
 }
 
@@ -2210,6 +2953,100 @@ func (s *SnapshotOptionsStatus) SetStatus(v *OptionStatus) *SnapshotOptionsStatu
 	return s
 }
 
+// StorageTypes represents the list of storage related types and their attributes
+// that are available for given InstanceType.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/StorageType
+type StorageType struct {
+	_ struct{} `type:"structure"`
+
+	// SubType of the given storage type. List of available sub-storage options:
+	// For "instance" storageType we wont have any storageSubType, in case of "ebs"
+	// storageType we will have following valid storageSubTypes standard
+	// gp2
+	// io1
+	//  Refer VolumeType for more information regarding above EBS storage options.
+	StorageSubTypeName *string `type:"string"`
+
+	// List of limits that are applicable for given storage type.
+	StorageTypeLimits []*StorageTypeLimit `type:"list"`
+
+	// Type of the storage. List of available storage options: instance
+	//  Inbuilt storage available for the given Instance ebs
+	//  Elastic block storage that would be attached to the given Instance
+	StorageTypeName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s StorageType) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StorageType) GoString() string {
+	return s.String()
+}
+
+// SetStorageSubTypeName sets the StorageSubTypeName field's value.
+func (s *StorageType) SetStorageSubTypeName(v string) *StorageType {
+	s.StorageSubTypeName = &v
+	return s
+}
+
+// SetStorageTypeLimits sets the StorageTypeLimits field's value.
+func (s *StorageType) SetStorageTypeLimits(v []*StorageTypeLimit) *StorageType {
+	s.StorageTypeLimits = v
+	return s
+}
+
+// SetStorageTypeName sets the StorageTypeName field's value.
+func (s *StorageType) SetStorageTypeName(v string) *StorageType {
+	s.StorageTypeName = &v
+	return s
+}
+
+// Limits that are applicable for given storage type.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/StorageTypeLimit
+type StorageTypeLimit struct {
+	_ struct{} `type:"structure"`
+
+	// Name of storage limits that are applicable for given storage type. If StorageType
+	// is ebs, following storage options are applicable MinimumVolumeSize
+	//  Minimum amount of volume size that is applicable for given storage type.It
+	// can be empty if it is not applicable. MaximumVolumeSize
+	//  Maximum amount of volume size that is applicable for given storage type.It
+	// can be empty if it is not applicable. MaximumIops
+	//  Maximum amount of Iops that is applicable for given storage type.It can
+	// be empty if it is not applicable. MinimumIops
+	//  Minimum amount of Iops that is applicable for given storage type.It can
+	// be empty if it is not applicable.
+	LimitName *string `type:"string"`
+
+	// Values for the StorageTypeLimit$LimitName .
+	LimitValues []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s StorageTypeLimit) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StorageTypeLimit) GoString() string {
+	return s.String()
+}
+
+// SetLimitName sets the LimitName field's value.
+func (s *StorageTypeLimit) SetLimitName(v string) *StorageTypeLimit {
+	s.LimitName = &v
+	return s
+}
+
+// SetLimitValues sets the LimitValues field's value.
+func (s *StorageTypeLimit) SetLimitValues(v []*string) *StorageTypeLimit {
+	s.LimitValues = v
+	return s
+}
+
 // Specifies a key value pair for a resource tag.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/es-2015-01-01/Tag
 type Tag struct {
@@ -2449,6 +3286,51 @@ const (
 
 	// ESPartitionInstanceTypeI22xlargeElasticsearch is a ESPartitionInstanceType enum value
 	ESPartitionInstanceTypeI22xlargeElasticsearch = "i2.2xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeD2XlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeD2XlargeElasticsearch = "d2.xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeD22xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeD22xlargeElasticsearch = "d2.2xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeD24xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeD24xlargeElasticsearch = "d2.4xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeD28xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeD28xlargeElasticsearch = "d2.8xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeC4LargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeC4LargeElasticsearch = "c4.large.elasticsearch"
+
+	// ESPartitionInstanceTypeC4XlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeC4XlargeElasticsearch = "c4.xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeC42xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeC42xlargeElasticsearch = "c4.2xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeC44xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeC44xlargeElasticsearch = "c4.4xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeC48xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeC48xlargeElasticsearch = "c4.8xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeR4LargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeR4LargeElasticsearch = "r4.large.elasticsearch"
+
+	// ESPartitionInstanceTypeR4XlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeR4XlargeElasticsearch = "r4.xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeR42xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeR42xlargeElasticsearch = "r4.2xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeR44xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeR44xlargeElasticsearch = "r4.4xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeR48xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeR48xlargeElasticsearch = "r4.8xlarge.elasticsearch"
+
+	// ESPartitionInstanceTypeR416xlargeElasticsearch is a ESPartitionInstanceType enum value
+	ESPartitionInstanceTypeR416xlargeElasticsearch = "r4.16xlarge.elasticsearch"
 )
 
 // The state of a requested change. One of the following:

--- a/service/elasticsearchservice/elasticsearchserviceiface/interface.go
+++ b/service/elasticsearchservice/elasticsearchserviceiface/interface.go
@@ -83,9 +83,25 @@ type ElasticsearchServiceAPI interface {
 
 	DescribeElasticsearchDomains(*elasticsearchservice.DescribeElasticsearchDomainsInput) (*elasticsearchservice.DescribeElasticsearchDomainsOutput, error)
 
+	DescribeElasticsearchInstanceTypeLimitsRequest(*elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsInput) (*request.Request, *elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsOutput)
+
+	DescribeElasticsearchInstanceTypeLimits(*elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsInput) (*elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsOutput, error)
+
 	ListDomainNamesRequest(*elasticsearchservice.ListDomainNamesInput) (*request.Request, *elasticsearchservice.ListDomainNamesOutput)
 
 	ListDomainNames(*elasticsearchservice.ListDomainNamesInput) (*elasticsearchservice.ListDomainNamesOutput, error)
+
+	ListElasticsearchInstanceTypesRequest(*elasticsearchservice.ListElasticsearchInstanceTypesInput) (*request.Request, *elasticsearchservice.ListElasticsearchInstanceTypesOutput)
+
+	ListElasticsearchInstanceTypes(*elasticsearchservice.ListElasticsearchInstanceTypesInput) (*elasticsearchservice.ListElasticsearchInstanceTypesOutput, error)
+
+	ListElasticsearchInstanceTypesPages(*elasticsearchservice.ListElasticsearchInstanceTypesInput, func(*elasticsearchservice.ListElasticsearchInstanceTypesOutput, bool) bool) error
+
+	ListElasticsearchVersionsRequest(*elasticsearchservice.ListElasticsearchVersionsInput) (*request.Request, *elasticsearchservice.ListElasticsearchVersionsOutput)
+
+	ListElasticsearchVersions(*elasticsearchservice.ListElasticsearchVersionsInput) (*elasticsearchservice.ListElasticsearchVersionsOutput, error)
+
+	ListElasticsearchVersionsPages(*elasticsearchservice.ListElasticsearchVersionsInput, func(*elasticsearchservice.ListElasticsearchVersionsOutput, bool) bool) error
 
 	ListTagsRequest(*elasticsearchservice.ListTagsInput) (*request.Request, *elasticsearchservice.ListTagsOutput)
 

--- a/service/elasticsearchservice/examples_test.go
+++ b/service/elasticsearchservice/examples_test.go
@@ -174,6 +174,29 @@ func ExampleElasticsearchService_DescribeElasticsearchDomains() {
 	fmt.Println(resp)
 }
 
+func ExampleElasticsearchService_DescribeElasticsearchInstanceTypeLimits() {
+	sess := session.Must(session.NewSession())
+
+	svc := elasticsearchservice.New(sess)
+
+	params := &elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsInput{
+		ElasticsearchVersion: aws.String("ElasticsearchVersionString"), // Required
+		InstanceType:         aws.String("ESPartitionInstanceType"),    // Required
+		DomainName:           aws.String("DomainName"),
+	}
+	resp, err := svc.DescribeElasticsearchInstanceTypeLimits(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleElasticsearchService_ListDomainNames() {
 	sess := session.Must(session.NewSession())
 
@@ -181,6 +204,52 @@ func ExampleElasticsearchService_ListDomainNames() {
 
 	var params *elasticsearchservice.ListDomainNamesInput
 	resp, err := svc.ListDomainNames(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleElasticsearchService_ListElasticsearchInstanceTypes() {
+	sess := session.Must(session.NewSession())
+
+	svc := elasticsearchservice.New(sess)
+
+	params := &elasticsearchservice.ListElasticsearchInstanceTypesInput{
+		ElasticsearchVersion: aws.String("ElasticsearchVersionString"), // Required
+		DomainName:           aws.String("DomainName"),
+		MaxResults:           aws.Int64(1),
+		NextToken:            aws.String("NextToken"),
+	}
+	resp, err := svc.ListElasticsearchInstanceTypes(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleElasticsearchService_ListElasticsearchVersions() {
+	sess := session.Must(session.NewSession())
+
+	svc := elasticsearchservice.New(sess)
+
+	params := &elasticsearchservice.ListElasticsearchVersionsInput{
+		MaxResults: aws.Int64(1),
+		NextToken:  aws.String("NextToken"),
+	}
+	resp, err := svc.ListElasticsearchVersions(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and


### PR DESCRIPTION
Release v1.7.1 (2017-02-24)
===

Service Client Updates
---
* `service/elasticsearchservice`: Updates service API, documentation, paginators, and examples
  * Added three new API calls to existing Amazon Elasticsearch service to expose Amazon Elasticsearch imposed limits to customers.

