### PR TITLE
`private/protocol`: Fixing bugs and asserts in query protocol

### DIFF
--- a/awstesting/assert_test.go
+++ b/awstesting/assert_test.go
@@ -62,3 +62,28 @@ func TestAssertXML(t *testing.T) {
 		}
 	}
 }
+
+func TestAssertQuery(t *testing.T) {
+	cases := []struct {
+		e, a    string
+		asserts bool
+	}{
+		{
+			e:       `Action=OperationName&Version=2014-01-01&Foo=val1&Bar=val2`,
+			a:       `Action=OperationName&Version=2014-01-01&Foo=val2&Bar=val3`,
+			asserts: false,
+		},
+		{
+			e:       `Action=OperationName&Version=2014-01-01&Foo=val1&Bar=val2`,
+			a:       `Action=OperationName&Version=2014-01-01&Foo=val1&Bar=val2`,
+			asserts: true,
+		},
+	}
+
+	for i, c := range cases {
+		mockT := &testing.T{}
+		if awstesting.AssertQuery(mockT, c.e, c.a) != c.asserts {
+			t.Error("Assert Query result was not expected.", i)
+		}
+	}
+}

--- a/models/protocol_tests/input/ec2.json
+++ b/models/protocol_tests/input/ec2.json
@@ -369,7 +369,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-			"idempotencyToken": true
+              "idempotencyToken": true
           }
         }
       },
@@ -383,19 +383,15 @@
           "input": {
             "shape": "InputShape"
           },
-          "http": {
-            "method": "POST",
-            "requestUri": "/path"
-          },
           "name": "OperationName"
         },
         "params": {
           "Token": "abc123"
         },
         "serialized": {
-          "uri": "/path",
+          "uri": "/",
           "headers": {},
-          "body": "Token=abc123"
+          "body": "Action=OperationName&Version=2014-01-01&Token=abc123"
         }
       },
       {
@@ -403,18 +399,14 @@
           "input": {
             "shape": "InputShape"
           },
-          "http": {
-            "method": "POST",
-            "requestUri": "/path"
-          },
           "name": "OperationName"
         },
         "params": {
         },
         "serialized": {
-          "uri": "/path",
+          "uri": "/",
           "headers": {},
-          "body": "Token=00000000-0000-4000-8000-000000000000"
+          "body": "Action=OperationName&Version=2014-01-01&Token=00000000-0000-4000-8000-000000000000"
         }
       }
     ]

--- a/models/protocol_tests/input/json.json
+++ b/models/protocol_tests/input/json.json
@@ -488,7 +488,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-			"idempotencyToken": true
+              "idempotencyToken": true
           }
         }
       },
@@ -503,8 +503,7 @@
             "shape": "InputShape"
           },
           "http": {
-            "method": "POST",
-            "requestUri": "/path"
+            "method": "POST"
           },
           "name": "OperationName"
         },
@@ -512,7 +511,7 @@
           "Token": "abc123"
         },
         "serialized": {
-          "uri": "/path",
+          "uri": "/",
           "headers": {},
           "body": "{\"Token\": \"abc123\"}"
         }
@@ -523,15 +522,14 @@
             "shape": "InputShape"
           },
           "http": {
-            "method": "POST",
-            "requestUri": "/path"
+            "method": "POST"
           },
           "name": "OperationName"
         },
         "params": {
         },
         "serialized": {
-          "uri": "/path",
+          "uri": "/",
           "headers": {},
           "body": "{\"Token\": \"00000000-0000-4000-8000-000000000000\"}"
         }

--- a/models/protocol_tests/input/query.json
+++ b/models/protocol_tests/input/query.json
@@ -789,7 +789,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-			"idempotencyToken": true
+              "idempotencyToken": true
           }
         }
       },
@@ -804,8 +804,7 @@
             "shape": "InputShape"
           },
           "http": {
-            "method": "POST",
-            "requestUri": "/path"
+            "method": "POST"
           },
           "name": "OperationName"
         },
@@ -813,9 +812,9 @@
           "Token": "abc123"
         },
         "serialized": {
-          "uri": "/path",
+          "uri": "/",
           "headers": {},
-          "body": "Token=abc123"
+          "body": "Action=OperationName&Version=2014-01-01&Token=abc123"
         }
       },
       {
@@ -824,17 +823,16 @@
             "shape": "InputShape"
           },
           "http": {
-            "method": "POST",
-            "requestUri": "/path"
+            "method": "POST"
           },
           "name": "OperationName"
         },
         "params": {
         },
         "serialized": {
-          "uri": "/path",
+          "uri": "/",
           "headers": {},
-          "body": "Token=00000000-0000-4000-8000-000000000000"
+          "body": "Action=OperationName&Version=2014-01-01&Token=00000000-0000-4000-8000-000000000000"
         }
       }
     ]

--- a/models/protocol_tests/input/rest-json.json
+++ b/models/protocol_tests/input/rest-json.json
@@ -287,6 +287,70 @@
     ]
   },
   {
+    "description": "Boolean in querystring",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "BoolQuery": {
+            "shape": "BoolType",
+            "location": "querystring",
+            "locationName": "bool-query"
+          }
+        }
+      },
+      "BoolType": {
+        "type": "boolean"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BoolQuery": true
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?bool-query=true",
+          "headers": {}
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BoolQuery": false
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?bool-query=false",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
     "description": "URI parameter and querystring params",
     "metadata": {
       "protocol": "rest-json",
@@ -594,7 +658,7 @@
       {
         "given": {
           "http": {
-            "method": "GET",
+            "method": "POST",
             "requestUri": "/2014-01-01/{Foo}"
           },
           "input": {
@@ -613,7 +677,7 @@
       }
     ]
   },
-	{
+    {
     "description": "Blob payload",
     "metadata": {
       "protocol": "rest-json",
@@ -1187,7 +1251,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-			"idempotencyToken": true
+              "idempotencyToken": true
           }
         }
       },

--- a/models/protocol_tests/input/rest-xml.json
+++ b/models/protocol_tests/input/rest-xml.json
@@ -898,7 +898,70 @@
       }
     ]
   },
-
+  {
+    "description": "Boolean in querystring",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "BoolQuery": {
+            "shape": "BoolType",
+            "location": "querystring",
+            "locationName": "bool-query"
+          }
+        }
+      },
+      "BoolType": {
+        "type": "boolean"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BoolQuery": true
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?bool-query=true",
+          "headers": {}
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BoolQuery": false
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?bool-query=false",
+          "headers": {}
+        }
+      }
+    ]
+  },
   {
     "description": "String payload",
     "metadata": {
@@ -1580,7 +1643,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-			"idempotencyToken": true
+              "idempotencyToken": true
           }
         }
       },
@@ -1606,7 +1669,7 @@
         "serialized": {
           "uri": "/path",
           "headers": {},
-          "body": "<Token>abc123</Token>"
+          "body": "<InputShape><Token>abc123</Token></InputShape>"
         }
       },
       {
@@ -1625,7 +1688,7 @@
         "serialized": {
           "uri": "/path",
           "headers": {},
-          "body": "<Token>00000000-0000-4000-8000-000000000000</Token>"
+          "body": "<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>"
         }
       }
     ]

--- a/private/protocol/ec2query/build_test.go
+++ b/private/protocol/ec2query/build_test.go
@@ -1178,9 +1178,8 @@ const opInputService9TestCaseOperation1 = "OperationName"
 //    }
 func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
 	op := &request.Operation{
-		Name:       opInputService9TestCaseOperation1,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		Name:     opInputService9TestCaseOperation1,
+		HTTPPath: "/",
 	}
 
 	if input == nil {
@@ -1235,9 +1234,8 @@ const opInputService9TestCaseOperation2 = "OperationName"
 //    }
 func (c *InputService9ProtocolTest) InputService9TestCaseOperation2Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation2Output) {
 	op := &request.Operation{
-		Name:       opInputService9TestCaseOperation2,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		Name:     opInputService9TestCaseOperation2,
+		HTTPPath: "/",
 	}
 
 	if input == nil {
@@ -1513,10 +1511,10 @@ func TestInputService9ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body, _ := ioutil.ReadAll(r.Body)
-	awstesting.AssertQuery(t, `Token=abc123`, util.Trim(string(body)))
+	awstesting.AssertQuery(t, `Action=OperationName&Token=abc123&Version=2014-01-01`, util.Trim(string(body)))
 
 	// assert URL
-	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
 
@@ -1535,10 +1533,10 @@ func TestInputService9ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body, _ := ioutil.ReadAll(r.Body)
-	awstesting.AssertQuery(t, `Token=00000000-0000-4000-8000-000000000000`, util.Trim(string(body)))
+	awstesting.AssertQuery(t, `Action=OperationName&Token=00000000-0000-4000-8000-000000000000&Version=2014-01-01`, util.Trim(string(body)))
 
 	// assert URL
-	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
 

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -1309,7 +1309,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input
 	op := &request.Operation{
 		Name:       opInputService7TestCaseOperation1,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/",
 	}
 
 	if input == nil {
@@ -1366,7 +1366,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation2Request(input
 	op := &request.Operation{
 		Name:       opInputService7TestCaseOperation2,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/",
 	}
 
 	if input == nil {
@@ -1797,7 +1797,7 @@ func TestInputService7ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	awstesting.AssertJSON(t, `{"Token":"abc123"}`, util.Trim(string(body)))
 
 	// assert URL
-	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
 
@@ -1819,7 +1819,7 @@ func TestInputService7ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	awstesting.AssertJSON(t, `{"Token":"00000000-0000-4000-8000-000000000000"}`, util.Trim(string(body)))
 
 	// assert URL
-	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
 

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -2280,7 +2280,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(inp
 	op := &request.Operation{
 		Name:       opInputService13TestCaseOperation1,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/",
 	}
 
 	if input == nil {
@@ -2337,7 +2337,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(inp
 	op := &request.Operation{
 		Name:       opInputService13TestCaseOperation2,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/",
 	}
 
 	if input == nil {
@@ -2983,10 +2983,10 @@ func TestInputService13ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body, _ := ioutil.ReadAll(r.Body)
-	awstesting.AssertQuery(t, `Token=abc123`, util.Trim(string(body)))
+	awstesting.AssertQuery(t, `Action=OperationName&Token=abc123&Version=2014-01-01`, util.Trim(string(body)))
 
 	// assert URL
-	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
 
@@ -3005,10 +3005,10 @@ func TestInputService13ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body, _ := ioutil.ReadAll(r.Body)
-	awstesting.AssertQuery(t, `Token=00000000-0000-4000-8000-000000000000`, util.Trim(string(body)))
+	awstesting.AssertQuery(t, `Action=OperationName&Token=00000000-0000-4000-8000-000000000000&Version=2014-01-01`, util.Trim(string(body)))
 
 	// assert URL
-	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
 

--- a/private/protocol/query/queryutil/queryutil.go
+++ b/private/protocol/query/queryutil/queryutil.go
@@ -80,7 +80,6 @@ func (q *queryParser) parseStruct(v url.Values, value reflect.Value, prefix stri
 			continue
 		}
 
-
 		if protocol.CanSetIdempotencyToken(value.Field(i), field) {
 			token := protocol.GetIdempotencyToken()
 			elemValue = reflect.ValueOf(token)
@@ -124,7 +123,11 @@ func (q *queryParser) parseList(v url.Values, value reflect.Value, prefix string
 
 	// check for unflattened list member
 	if !q.isEC2 && tag.Get("flattened") == "" {
-		prefix += ".member"
+		if listName := tag.Get("locationNameList"); listName == "" {
+			prefix += ".member"
+		} else {
+			prefix += "." + listName
+		}
 	}
 
 	for i := 0; i < value.Len(); i++ {

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -899,15 +899,15 @@ const opInputService7TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputService7TestCaseOperation1Input) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputShape) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService7TestCaseOperation1,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2014-01-01/jobsByPipeline/{PipelineId}",
+		HTTPPath:   "/path",
 	}
 
 	if input == nil {
-		input = &InputService7TestShapeInputService7TestCaseOperation1Input{}
+		input = &InputService7TestShapeInputShape{}
 	}
 
 	output = &InputService7TestShapeInputService7TestCaseOperation1Output{}
@@ -925,42 +925,87 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService7TestCaseOperation1 for usage and error information.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *InputService7TestShapeInputService7TestCaseOperation1Input) (*InputService7TestShapeInputService7TestCaseOperation1Output, error) {
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *InputService7TestShapeInputShape) (*InputService7TestShapeInputService7TestCaseOperation1Output, error) {
 	req, out := c.InputService7TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-type InputService7TestShapeInputService7TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+const opInputService7TestCaseOperation2 = "OperationName"
 
-	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
+// InputService7TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService7TestCaseOperation2 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService7TestCaseOperation2 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService7TestCaseOperation2 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService7TestCaseOperation2Request method.
+//    req, resp := client.InputService7TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation2Request(input *InputService7TestShapeInputShape) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService7TestCaseOperation2,
+		HTTPMethod: "GET",
+		HTTPPath:   "/path",
+	}
 
-	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
+	if input == nil {
+		input = &InputService7TestShapeInputShape{}
+	}
 
-	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
+	output = &InputService7TestShapeInputService7TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
 }
 
-// SetAscending sets the Ascending field's value.
-func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetAscending(v string) *InputService7TestShapeInputService7TestCaseOperation1Input {
-	s.Ascending = &v
-	return s
-}
-
-// SetPageToken sets the PageToken field's value.
-func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetPageToken(v string) *InputService7TestShapeInputService7TestCaseOperation1Input {
-	s.PageToken = &v
-	return s
-}
-
-// SetPipelineId sets the PipelineId field's value.
-func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetPipelineId(v string) *InputService7TestShapeInputService7TestCaseOperation1Input {
-	s.PipelineId = &v
-	return s
+// InputService7TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService7TestCaseOperation2 for usage and error information.
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation2(input *InputService7TestShapeInputShape) (*InputService7TestShapeInputService7TestCaseOperation2Output, error) {
+	req, out := c.InputService7TestCaseOperation2Request(input)
+	err := req.Send()
+	return out, err
 }
 
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService7TestShapeInputService7TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService7TestShapeInputShape struct {
+	_ struct{} `type:"structure"`
+
+	BoolQuery *bool `location:"querystring" locationName:"bool-query" type:"boolean"`
+}
+
+// SetBoolQuery sets the BoolQuery field's value.
+func (s *InputService7TestShapeInputShape) SetBoolQuery(v bool) *InputService7TestShapeInputShape {
+	s.BoolQuery = &v
+	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -1046,7 +1091,7 @@ const opInputService8TestCaseOperation1 = "OperationName"
 func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputService8TestCaseOperation1Input) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService8TestCaseOperation1,
-		HTTPMethod: "POST",
+		HTTPMethod: "GET",
 		HTTPPath:   "/2014-01-01/jobsByPipeline/{PipelineId}",
 	}
 
@@ -1080,8 +1125,6 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 
 	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
 
-	Config *InputService8TestShapeStructType `type:"structure"`
-
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
 	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
@@ -1090,12 +1133,6 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 // SetAscending sets the Ascending field's value.
 func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetAscending(v string) *InputService8TestShapeInputService8TestCaseOperation1Input {
 	s.Ascending = &v
-	return s
-}
-
-// SetConfig sets the Config field's value.
-func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetConfig(v *InputService8TestShapeStructType) *InputService8TestShapeInputService8TestCaseOperation1Input {
-	s.Config = v
 	return s
 }
 
@@ -1113,26 +1150,6 @@ func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetPipeline
 
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService8TestShapeStructType struct {
-	_ struct{} `type:"structure"`
-
-	A *string `type:"string"`
-
-	B *string `type:"string"`
-}
-
-// SetA sets the A field's value.
-func (s *InputService8TestShapeStructType) SetA(v string) *InputService8TestShapeStructType {
-	s.A = &v
-	return s
-}
-
-// SetB sets the B field's value.
-func (s *InputService8TestShapeStructType) SetB(v string) *InputService8TestShapeStructType {
-	s.B = &v
-	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -1252,8 +1269,6 @@ type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 
 	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
 
-	Checksum *string `location:"header" locationName:"x-amz-checksum" type:"string"`
-
 	Config *InputService9TestShapeStructType `type:"structure"`
 
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
@@ -1264,12 +1279,6 @@ type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 // SetAscending sets the Ascending field's value.
 func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetAscending(v string) *InputService9TestShapeInputService9TestCaseOperation1Input {
 	s.Ascending = &v
-	return s
-}
-
-// SetChecksum sets the Checksum field's value.
-func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetChecksum(v string) *InputService9TestShapeInputService9TestCaseOperation1Input {
-	s.Checksum = &v
 	return s
 }
 
@@ -1399,7 +1408,7 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation1Request(inp
 	op := &request.Operation{
 		Name:       opInputService10TestCaseOperation1,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2014-01-01/vaults/{vaultName}/archives",
+		HTTPPath:   "/2014-01-01/jobsByPipeline/{PipelineId}",
 	}
 
 	if input == nil {
@@ -1428,32 +1437,22 @@ func (c *InputService10ProtocolTest) InputService10TestCaseOperation1(input *Inp
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Input struct {
-	_ struct{} `type:"structure" payload:"Body"`
+	_ struct{} `type:"structure"`
 
-	Body io.ReadSeeker `locationName:"body" type:"blob"`
+	Ascending *string `location:"querystring" locationName:"Ascending" type:"string"`
 
-	Checksum *string `location:"header" locationName:"x-amz-sha256-tree-hash" type:"string"`
+	Checksum *string `location:"header" locationName:"x-amz-checksum" type:"string"`
 
-	// VaultName is a required field
-	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
+	Config *InputService10TestShapeStructType `type:"structure"`
+
+	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
+
+	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
 }
 
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *InputService10TestShapeInputService10TestCaseOperation1Input) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "InputService10TestShapeInputService10TestCaseOperation1Input"}
-	if s.VaultName == nil {
-		invalidParams.Add(request.NewErrParamRequired("VaultName"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
-}
-
-// SetBody sets the Body field's value.
-func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetBody(v io.ReadSeeker) *InputService10TestShapeInputService10TestCaseOperation1Input {
-	s.Body = v
+// SetAscending sets the Ascending field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetAscending(v string) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.Ascending = &v
 	return s
 }
 
@@ -1463,14 +1462,46 @@ func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetChecks
 	return s
 }
 
-// SetVaultName sets the VaultName field's value.
-func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetVaultName(v string) *InputService10TestShapeInputService10TestCaseOperation1Input {
-	s.VaultName = &v
+// SetConfig sets the Config field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetConfig(v *InputService10TestShapeStructType) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.Config = v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetPageToken(v string) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.PageToken = &v
+	return s
+}
+
+// SetPipelineId sets the PipelineId field's value.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetPipelineId(v string) *InputService10TestShapeInputService10TestCaseOperation1Input {
+	s.PipelineId = &v
 	return s
 }
 
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService10TestShapeStructType struct {
+	_ struct{} `type:"structure"`
+
+	A *string `type:"string"`
+
+	B *string `type:"string"`
+}
+
+// SetA sets the A field's value.
+func (s *InputService10TestShapeStructType) SetA(v string) *InputService10TestShapeStructType {
+	s.A = &v
+	return s
+}
+
+// SetB sets the B field's value.
+func (s *InputService10TestShapeStructType) SetB(v string) *InputService10TestShapeStructType {
+	s.B = &v
+	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -1556,8 +1587,8 @@ const opInputService11TestCaseOperation1 = "OperationName"
 func (c *InputService11ProtocolTest) InputService11TestCaseOperation1Request(input *InputService11TestShapeInputService11TestCaseOperation1Input) (req *request.Request, output *InputService11TestShapeInputService11TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService11TestCaseOperation1,
-		HTTPMethod: "GET",
-		HTTPPath:   "/2014-01-01/{Foo}",
+		HTTPMethod: "POST",
+		HTTPPath:   "/2014-01-01/vaults/{vaultName}/archives",
 	}
 
 	if input == nil {
@@ -1586,20 +1617,21 @@ func (c *InputService11ProtocolTest) InputService11TestCaseOperation1(input *Inp
 }
 
 type InputService11TestShapeInputService11TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `type:"structure" payload:"Body"`
 
-	// Bar is automatically base64 encoded/decoded by the SDK.
-	Bar []byte `type:"blob"`
+	Body io.ReadSeeker `locationName:"body" type:"blob"`
 
-	// Foo is a required field
-	Foo *string `location:"uri" locationName:"Foo" type:"string" required:"true"`
+	Checksum *string `location:"header" locationName:"x-amz-sha256-tree-hash" type:"string"`
+
+	// VaultName is a required field
+	VaultName *string `location:"uri" locationName:"vaultName" type:"string" required:"true"`
 }
 
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *InputService11TestShapeInputService11TestCaseOperation1Input) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "InputService11TestShapeInputService11TestCaseOperation1Input"}
-	if s.Foo == nil {
-		invalidParams.Add(request.NewErrParamRequired("Foo"))
+	if s.VaultName == nil {
+		invalidParams.Add(request.NewErrParamRequired("VaultName"))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1608,15 +1640,21 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) Validate(
 	return nil
 }
 
-// SetBar sets the Bar field's value.
-func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetBar(v []byte) *InputService11TestShapeInputService11TestCaseOperation1Input {
-	s.Bar = v
+// SetBody sets the Body field's value.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetBody(v io.ReadSeeker) *InputService11TestShapeInputService11TestCaseOperation1Input {
+	s.Body = v
 	return s
 }
 
-// SetFoo sets the Foo field's value.
-func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetFoo(v string) *InputService11TestShapeInputService11TestCaseOperation1Input {
-	s.Foo = &v
+// SetChecksum sets the Checksum field's value.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetChecksum(v string) *InputService11TestShapeInputService11TestCaseOperation1Input {
+	s.Checksum = &v
+	return s
+}
+
+// SetVaultName sets the VaultName field's value.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetVaultName(v string) *InputService11TestShapeInputService11TestCaseOperation1Input {
+	s.VaultName = &v
 	return s
 }
 
@@ -1704,15 +1742,15 @@ const opInputService12TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(input *InputService12TestShapeInputShape) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation1Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService12TestCaseOperation1,
 		HTTPMethod: "POST",
-		HTTPPath:   "/",
+		HTTPPath:   "/2014-01-01/{Foo}",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputShape{}
+		input = &InputService12TestShapeInputService12TestCaseOperation1Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation1Output{}
@@ -1730,87 +1768,49 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation1 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *InputService12TestShapeInputShape) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *InputService12TestShapeInputService12TestCaseOperation1Input) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
 	req, out := c.InputService12TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-const opInputService12TestCaseOperation2 = "OperationName"
+type InputService12TestShapeInputService12TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
 
-// InputService12TestCaseOperation2Request generates a "aws/request.Request" representing the
-// client's request for the InputService12TestCaseOperation2 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService12TestCaseOperation2 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService12TestCaseOperation2 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService12TestCaseOperation2Request method.
-//    req, resp := client.InputService12TestCaseOperation2Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation2Request(input *InputService12TestShapeInputShape) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation2Output) {
-	op := &request.Operation{
-		Name:       opInputService12TestCaseOperation2,
-		HTTPMethod: "POST",
-		HTTPPath:   "/",
-	}
+	// Bar is automatically base64 encoded/decoded by the SDK.
+	Bar []byte `type:"blob"`
 
-	if input == nil {
-		input = &InputService12TestShapeInputShape{}
-	}
-
-	output = &InputService12TestShapeInputService12TestCaseOperation2Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
+	// Foo is a required field
+	Foo *string `location:"uri" locationName:"Foo" type:"string" required:"true"`
 }
 
-// InputService12TestCaseOperation2 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService12TestCaseOperation2 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation2(input *InputService12TestShapeInputShape) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
-	req, out := c.InputService12TestCaseOperation2Request(input)
-	err := req.Send()
-	return out, err
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService12TestShapeInputService12TestCaseOperation1Input"}
+	if s.Foo == nil {
+		invalidParams.Add(request.NewErrParamRequired("Foo"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBar sets the Bar field's value.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) SetBar(v []byte) *InputService12TestShapeInputService12TestCaseOperation1Input {
+	s.Bar = v
+	return s
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) SetFoo(v string) *InputService12TestShapeInputService12TestCaseOperation1Input {
+	s.Foo = &v
+	return s
 }
 
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService12TestShapeInputService12TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService12TestShapeInputShape struct {
-	_ struct{} `type:"structure" payload:"Foo"`
-
-	Foo []byte `locationName:"foo" type:"blob"`
-}
-
-// SetFoo sets the Foo field's value.
-func (s *InputService12TestShapeInputShape) SetFoo(v []byte) *InputService12TestShapeInputShape {
-	s.Foo = v
-	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -1982,18 +1982,6 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2(input *Inp
 	return out, err
 }
 
-type InputService13TestShapeFooShape struct {
-	_ struct{} `locationName:"foo" type:"structure"`
-
-	Baz *string `locationName:"baz" type:"string"`
-}
-
-// SetBaz sets the Baz field's value.
-func (s *InputService13TestShapeFooShape) SetBaz(v string) *InputService13TestShapeFooShape {
-	s.Baz = &v
-	return s
-}
-
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -2005,11 +1993,11 @@ type InputService13TestShapeInputService13TestCaseOperation2Output struct {
 type InputService13TestShapeInputShape struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
-	Foo *InputService13TestShapeFooShape `locationName:"foo" type:"structure"`
+	Foo []byte `locationName:"foo" type:"blob"`
 }
 
 // SetFoo sets the Foo field's value.
-func (s *InputService13TestShapeInputShape) SetFoo(v *InputService13TestShapeFooShape) *InputService13TestShapeInputShape {
+func (s *InputService13TestShapeInputShape) SetFoo(v []byte) *InputService13TestShapeInputShape {
 	s.Foo = v
 	return s
 }
@@ -2098,7 +2086,7 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation1Request(inp
 	op := &request.Operation{
 		Name:       opInputService14TestCaseOperation1,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/",
 	}
 
 	if input == nil {
@@ -2155,7 +2143,7 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation2Request(inp
 	op := &request.Operation{
 		Name:       opInputService14TestCaseOperation2,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path?abc=mno",
+		HTTPPath:   "/",
 	}
 
 	if input == nil {
@@ -2183,6 +2171,18 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation2(input *Inp
 	return out, err
 }
 
+type InputService14TestShapeFooShape struct {
+	_ struct{} `locationName:"foo" type:"structure"`
+
+	Baz *string `locationName:"baz" type:"string"`
+}
+
+// SetBaz sets the Baz field's value.
+func (s *InputService14TestShapeFooShape) SetBaz(v string) *InputService14TestShapeFooShape {
+	s.Baz = &v
+	return s
+}
+
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -2192,14 +2192,14 @@ type InputService14TestShapeInputService14TestCaseOperation2Output struct {
 }
 
 type InputService14TestShapeInputShape struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `type:"structure" payload:"Foo"`
 
-	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
+	Foo *InputService14TestShapeFooShape `locationName:"foo" type:"structure"`
 }
 
 // SetFoo sets the Foo field's value.
-func (s *InputService14TestShapeInputShape) SetFoo(v string) *InputService14TestShapeInputShape {
-	s.Foo = &v
+func (s *InputService14TestShapeInputShape) SetFoo(v *InputService14TestShapeFooShape) *InputService14TestShapeInputShape {
+	s.Foo = v
 	return s
 }
 
@@ -2344,7 +2344,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(inp
 	op := &request.Operation{
 		Name:       opInputService15TestCaseOperation2,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/path?abc=mno",
 	}
 
 	if input == nil {
@@ -2372,234 +2372,6 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *Inp
 	return out, err
 }
 
-const opInputService15TestCaseOperation3 = "OperationName"
-
-// InputService15TestCaseOperation3Request generates a "aws/request.Request" representing the
-// client's request for the InputService15TestCaseOperation3 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService15TestCaseOperation3 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService15TestCaseOperation3 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService15TestCaseOperation3Request method.
-//    req, resp := client.InputService15TestCaseOperation3Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation3Request(input *InputService15TestShapeInputShape) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation3Output) {
-	op := &request.Operation{
-		Name:       opInputService15TestCaseOperation3,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService15TestShapeInputShape{}
-	}
-
-	output = &InputService15TestShapeInputService15TestCaseOperation3Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService15TestCaseOperation3 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService15TestCaseOperation3 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation3(input *InputService15TestShapeInputShape) (*InputService15TestShapeInputService15TestCaseOperation3Output, error) {
-	req, out := c.InputService15TestCaseOperation3Request(input)
-	err := req.Send()
-	return out, err
-}
-
-const opInputService15TestCaseOperation4 = "OperationName"
-
-// InputService15TestCaseOperation4Request generates a "aws/request.Request" representing the
-// client's request for the InputService15TestCaseOperation4 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService15TestCaseOperation4 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService15TestCaseOperation4 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService15TestCaseOperation4Request method.
-//    req, resp := client.InputService15TestCaseOperation4Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation4Request(input *InputService15TestShapeInputShape) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation4Output) {
-	op := &request.Operation{
-		Name:       opInputService15TestCaseOperation4,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService15TestShapeInputShape{}
-	}
-
-	output = &InputService15TestShapeInputService15TestCaseOperation4Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService15TestCaseOperation4 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService15TestCaseOperation4 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation4(input *InputService15TestShapeInputShape) (*InputService15TestShapeInputService15TestCaseOperation4Output, error) {
-	req, out := c.InputService15TestCaseOperation4Request(input)
-	err := req.Send()
-	return out, err
-}
-
-const opInputService15TestCaseOperation5 = "OperationName"
-
-// InputService15TestCaseOperation5Request generates a "aws/request.Request" representing the
-// client's request for the InputService15TestCaseOperation5 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService15TestCaseOperation5 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService15TestCaseOperation5 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService15TestCaseOperation5Request method.
-//    req, resp := client.InputService15TestCaseOperation5Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation5Request(input *InputService15TestShapeInputShape) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation5Output) {
-	op := &request.Operation{
-		Name:       opInputService15TestCaseOperation5,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService15TestShapeInputShape{}
-	}
-
-	output = &InputService15TestShapeInputService15TestCaseOperation5Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService15TestCaseOperation5 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService15TestCaseOperation5 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation5(input *InputService15TestShapeInputShape) (*InputService15TestShapeInputService15TestCaseOperation5Output, error) {
-	req, out := c.InputService15TestCaseOperation5Request(input)
-	err := req.Send()
-	return out, err
-}
-
-const opInputService15TestCaseOperation6 = "OperationName"
-
-// InputService15TestCaseOperation6Request generates a "aws/request.Request" representing the
-// client's request for the InputService15TestCaseOperation6 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService15TestCaseOperation6 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService15TestCaseOperation6 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService15TestCaseOperation6Request method.
-//    req, resp := client.InputService15TestCaseOperation6Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation6Request(input *InputService15TestShapeInputShape) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation6Output) {
-	op := &request.Operation{
-		Name:       opInputService15TestCaseOperation6,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService15TestShapeInputShape{}
-	}
-
-	output = &InputService15TestShapeInputService15TestCaseOperation6Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService15TestCaseOperation6 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService15TestCaseOperation6 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation6(input *InputService15TestShapeInputShape) (*InputService15TestShapeInputService15TestCaseOperation6Output, error) {
-	req, out := c.InputService15TestCaseOperation6Request(input)
-	err := req.Send()
-	return out, err
-}
-
 type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -2608,67 +2380,15 @@ type InputService15TestShapeInputService15TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService15TestShapeInputService15TestCaseOperation3Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService15TestShapeInputService15TestCaseOperation4Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService15TestShapeInputService15TestCaseOperation5Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService15TestShapeInputService15TestCaseOperation6Output struct {
-	_ struct{} `type:"structure"`
-}
-
 type InputService15TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
-	RecursiveStruct *InputService15TestShapeRecursiveStructType `type:"structure"`
+	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 }
 
-// SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService15TestShapeInputShape) SetRecursiveStruct(v *InputService15TestShapeRecursiveStructType) *InputService15TestShapeInputShape {
-	s.RecursiveStruct = v
-	return s
-}
-
-type InputService15TestShapeRecursiveStructType struct {
-	_ struct{} `type:"structure"`
-
-	NoRecurse *string `type:"string"`
-
-	RecursiveList []*InputService15TestShapeRecursiveStructType `type:"list"`
-
-	RecursiveMap map[string]*InputService15TestShapeRecursiveStructType `type:"map"`
-
-	RecursiveStruct *InputService15TestShapeRecursiveStructType `type:"structure"`
-}
-
-// SetNoRecurse sets the NoRecurse field's value.
-func (s *InputService15TestShapeRecursiveStructType) SetNoRecurse(v string) *InputService15TestShapeRecursiveStructType {
-	s.NoRecurse = &v
-	return s
-}
-
-// SetRecursiveList sets the RecursiveList field's value.
-func (s *InputService15TestShapeRecursiveStructType) SetRecursiveList(v []*InputService15TestShapeRecursiveStructType) *InputService15TestShapeRecursiveStructType {
-	s.RecursiveList = v
-	return s
-}
-
-// SetRecursiveMap sets the RecursiveMap field's value.
-func (s *InputService15TestShapeRecursiveStructType) SetRecursiveMap(v map[string]*InputService15TestShapeRecursiveStructType) *InputService15TestShapeRecursiveStructType {
-	s.RecursiveMap = v
-	return s
-}
-
-// SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService15TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService15TestShapeRecursiveStructType) *InputService15TestShapeRecursiveStructType {
-	s.RecursiveStruct = v
+// SetFoo sets the Foo field's value.
+func (s *InputService15TestShapeInputShape) SetFoo(v string) *InputService15TestShapeInputShape {
+	s.Foo = &v
 	return s
 }
 
@@ -2841,6 +2561,234 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation2(input *Inp
 	return out, err
 }
 
+const opInputService16TestCaseOperation3 = "OperationName"
+
+// InputService16TestCaseOperation3Request generates a "aws/request.Request" representing the
+// client's request for the InputService16TestCaseOperation3 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService16TestCaseOperation3 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService16TestCaseOperation3 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService16TestCaseOperation3Request method.
+//    req, resp := client.InputService16TestCaseOperation3Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation3Request(input *InputService16TestShapeInputShape) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation3Output) {
+	op := &request.Operation{
+		Name:       opInputService16TestCaseOperation3,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService16TestShapeInputShape{}
+	}
+
+	output = &InputService16TestShapeInputService16TestCaseOperation3Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService16TestCaseOperation3 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService16TestCaseOperation3 for usage and error information.
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation3(input *InputService16TestShapeInputShape) (*InputService16TestShapeInputService16TestCaseOperation3Output, error) {
+	req, out := c.InputService16TestCaseOperation3Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService16TestCaseOperation4 = "OperationName"
+
+// InputService16TestCaseOperation4Request generates a "aws/request.Request" representing the
+// client's request for the InputService16TestCaseOperation4 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService16TestCaseOperation4 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService16TestCaseOperation4 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService16TestCaseOperation4Request method.
+//    req, resp := client.InputService16TestCaseOperation4Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation4Request(input *InputService16TestShapeInputShape) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation4Output) {
+	op := &request.Operation{
+		Name:       opInputService16TestCaseOperation4,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService16TestShapeInputShape{}
+	}
+
+	output = &InputService16TestShapeInputService16TestCaseOperation4Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService16TestCaseOperation4 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService16TestCaseOperation4 for usage and error information.
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation4(input *InputService16TestShapeInputShape) (*InputService16TestShapeInputService16TestCaseOperation4Output, error) {
+	req, out := c.InputService16TestCaseOperation4Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService16TestCaseOperation5 = "OperationName"
+
+// InputService16TestCaseOperation5Request generates a "aws/request.Request" representing the
+// client's request for the InputService16TestCaseOperation5 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService16TestCaseOperation5 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService16TestCaseOperation5 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService16TestCaseOperation5Request method.
+//    req, resp := client.InputService16TestCaseOperation5Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation5Request(input *InputService16TestShapeInputShape) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation5Output) {
+	op := &request.Operation{
+		Name:       opInputService16TestCaseOperation5,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService16TestShapeInputShape{}
+	}
+
+	output = &InputService16TestShapeInputService16TestCaseOperation5Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService16TestCaseOperation5 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService16TestCaseOperation5 for usage and error information.
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation5(input *InputService16TestShapeInputShape) (*InputService16TestShapeInputService16TestCaseOperation5Output, error) {
+	req, out := c.InputService16TestCaseOperation5Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService16TestCaseOperation6 = "OperationName"
+
+// InputService16TestCaseOperation6Request generates a "aws/request.Request" representing the
+// client's request for the InputService16TestCaseOperation6 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService16TestCaseOperation6 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService16TestCaseOperation6 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService16TestCaseOperation6Request method.
+//    req, resp := client.InputService16TestCaseOperation6Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation6Request(input *InputService16TestShapeInputShape) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation6Output) {
+	op := &request.Operation{
+		Name:       opInputService16TestCaseOperation6,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService16TestShapeInputShape{}
+	}
+
+	output = &InputService16TestShapeInputService16TestCaseOperation6Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService16TestCaseOperation6 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService16TestCaseOperation6 for usage and error information.
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation6(input *InputService16TestShapeInputShape) (*InputService16TestShapeInputService16TestCaseOperation6Output, error) {
+	req, out := c.InputService16TestCaseOperation6Request(input)
+	err := req.Send()
+	return out, err
+}
+
 type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -2849,23 +2797,67 @@ type InputService16TestShapeInputService16TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
+type InputService16TestShapeInputService16TestCaseOperation3Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService16TestShapeInputService16TestCaseOperation4Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService16TestShapeInputService16TestCaseOperation5Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService16TestShapeInputService16TestCaseOperation6Output struct {
+	_ struct{} `type:"structure"`
+}
+
 type InputService16TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
-	TimeArg *time.Time `type:"timestamp" timestampFormat:"unix"`
-
-	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
+	RecursiveStruct *InputService16TestShapeRecursiveStructType `type:"structure"`
 }
 
-// SetTimeArg sets the TimeArg field's value.
-func (s *InputService16TestShapeInputShape) SetTimeArg(v time.Time) *InputService16TestShapeInputShape {
-	s.TimeArg = &v
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService16TestShapeInputShape) SetRecursiveStruct(v *InputService16TestShapeRecursiveStructType) *InputService16TestShapeInputShape {
+	s.RecursiveStruct = v
 	return s
 }
 
-// SetTimeArgInHeader sets the TimeArgInHeader field's value.
-func (s *InputService16TestShapeInputShape) SetTimeArgInHeader(v time.Time) *InputService16TestShapeInputShape {
-	s.TimeArgInHeader = &v
+type InputService16TestShapeRecursiveStructType struct {
+	_ struct{} `type:"structure"`
+
+	NoRecurse *string `type:"string"`
+
+	RecursiveList []*InputService16TestShapeRecursiveStructType `type:"list"`
+
+	RecursiveMap map[string]*InputService16TestShapeRecursiveStructType `type:"map"`
+
+	RecursiveStruct *InputService16TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetNoRecurse sets the NoRecurse field's value.
+func (s *InputService16TestShapeRecursiveStructType) SetNoRecurse(v string) *InputService16TestShapeRecursiveStructType {
+	s.NoRecurse = &v
+	return s
+}
+
+// SetRecursiveList sets the RecursiveList field's value.
+func (s *InputService16TestShapeRecursiveStructType) SetRecursiveList(v []*InputService16TestShapeRecursiveStructType) *InputService16TestShapeRecursiveStructType {
+	s.RecursiveList = v
+	return s
+}
+
+// SetRecursiveMap sets the RecursiveMap field's value.
+func (s *InputService16TestShapeRecursiveStructType) SetRecursiveMap(v map[string]*InputService16TestShapeRecursiveStructType) *InputService16TestShapeRecursiveStructType {
+	s.RecursiveMap = v
+	return s
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService16TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService16TestShapeRecursiveStructType) *InputService16TestShapeRecursiveStructType {
+	s.RecursiveStruct = v
 	return s
 }
 
@@ -2949,7 +2941,7 @@ const opInputService17TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(input *InputService17TestShapeInputService17TestCaseOperation1Input) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation1Output) {
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(input *InputService17TestShapeInputShape) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService17TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -2957,7 +2949,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService17TestShapeInputService17TestCaseOperation1Input{}
+		input = &InputService17TestShapeInputShape{}
 	}
 
 	output = &InputService17TestShapeInputService17TestCaseOperation1Output{}
@@ -2975,26 +2967,95 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService17TestCaseOperation1 for usage and error information.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation1(input *InputService17TestShapeInputService17TestCaseOperation1Input) (*InputService17TestShapeInputService17TestCaseOperation1Output, error) {
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation1(input *InputService17TestShapeInputShape) (*InputService17TestShapeInputService17TestCaseOperation1Output, error) {
 	req, out := c.InputService17TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-type InputService17TestShapeInputService17TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+const opInputService17TestCaseOperation2 = "OperationName"
 
-	TimeArg *time.Time `locationName:"timestamp_location" type:"timestamp" timestampFormat:"unix"`
+// InputService17TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService17TestCaseOperation2 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService17TestCaseOperation2 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService17TestCaseOperation2 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService17TestCaseOperation2Request method.
+//    req, resp := client.InputService17TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation2Request(input *InputService17TestShapeInputShape) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService17TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService17TestShapeInputShape{}
+	}
+
+	output = &InputService17TestShapeInputService17TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
 }
 
-// SetTimeArg sets the TimeArg field's value.
-func (s *InputService17TestShapeInputService17TestCaseOperation1Input) SetTimeArg(v time.Time) *InputService17TestShapeInputService17TestCaseOperation1Input {
-	s.TimeArg = &v
-	return s
+// InputService17TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService17TestCaseOperation2 for usage and error information.
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation2(input *InputService17TestShapeInputShape) (*InputService17TestShapeInputService17TestCaseOperation2Output, error) {
+	req, out := c.InputService17TestCaseOperation2Request(input)
+	err := req.Send()
+	return out, err
 }
 
 type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService17TestShapeInputService17TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService17TestShapeInputShape struct {
+	_ struct{} `type:"structure"`
+
+	TimeArg *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
+}
+
+// SetTimeArg sets the TimeArg field's value.
+func (s *InputService17TestShapeInputShape) SetTimeArg(v time.Time) *InputService17TestShapeInputShape {
+	s.TimeArg = &v
+	return s
+}
+
+// SetTimeArgInHeader sets the TimeArgInHeader field's value.
+func (s *InputService17TestShapeInputShape) SetTimeArgInHeader(v time.Time) *InputService17TestShapeInputShape {
+	s.TimeArgInHeader = &v
+	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -3081,7 +3142,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(inp
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation1,
 		HTTPMethod: "POST",
-		HTTPPath:   "/",
+		HTTPPath:   "/path",
 	}
 
 	if input == nil {
@@ -3110,14 +3171,14 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *Inp
 }
 
 type InputService18TestShapeInputService18TestCaseOperation1Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+	_ struct{} `type:"structure"`
 
-	Foo *string `locationName:"foo" type:"string"`
+	TimeArg *time.Time `locationName:"timestamp_location" type:"timestamp" timestampFormat:"unix"`
 }
 
-// SetFoo sets the Foo field's value.
-func (s *InputService18TestShapeInputService18TestCaseOperation1Input) SetFoo(v string) *InputService18TestShapeInputService18TestCaseOperation1Input {
-	s.Foo = &v
+// SetTimeArg sets the TimeArg field's value.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Input) SetTimeArg(v time.Time) *InputService18TestShapeInputService18TestCaseOperation1Input {
+	s.TimeArg = &v
 	return s
 }
 
@@ -3205,15 +3266,15 @@ const opInputService19TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService19ProtocolTest) InputService19TestCaseOperation1Request(input *InputService19TestShapeInputShape) (req *request.Request, output *InputService19TestShapeInputService19TestCaseOperation1Output) {
+func (c *InputService19ProtocolTest) InputService19TestCaseOperation1Request(input *InputService19TestShapeInputService19TestCaseOperation1Input) (req *request.Request, output *InputService19TestShapeInputService19TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService19TestCaseOperation1,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/",
 	}
 
 	if input == nil {
-		input = &InputService19TestShapeInputShape{}
+		input = &InputService19TestShapeInputService19TestCaseOperation1Input{}
 	}
 
 	output = &InputService19TestShapeInputService19TestCaseOperation1Output{}
@@ -3231,85 +3292,213 @@ func (c *InputService19ProtocolTest) InputService19TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService19TestCaseOperation1 for usage and error information.
-func (c *InputService19ProtocolTest) InputService19TestCaseOperation1(input *InputService19TestShapeInputShape) (*InputService19TestShapeInputService19TestCaseOperation1Output, error) {
+func (c *InputService19ProtocolTest) InputService19TestCaseOperation1(input *InputService19TestShapeInputService19TestCaseOperation1Input) (*InputService19TestShapeInputService19TestCaseOperation1Output, error) {
 	req, out := c.InputService19TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-const opInputService19TestCaseOperation2 = "OperationName"
+type InputService19TestShapeInputService19TestCaseOperation1Input struct {
+	_ struct{} `type:"structure" payload:"Foo"`
 
-// InputService19TestCaseOperation2Request generates a "aws/request.Request" representing the
-// client's request for the InputService19TestCaseOperation2 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService19TestCaseOperation2 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService19TestCaseOperation2 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService19TestCaseOperation2Request method.
-//    req, resp := client.InputService19TestCaseOperation2Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService19ProtocolTest) InputService19TestCaseOperation2Request(input *InputService19TestShapeInputShape) (req *request.Request, output *InputService19TestShapeInputService19TestCaseOperation2Output) {
-	op := &request.Operation{
-		Name:       opInputService19TestCaseOperation2,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService19TestShapeInputShape{}
-	}
-
-	output = &InputService19TestShapeInputService19TestCaseOperation2Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
+	Foo *string `locationName:"foo" type:"string"`
 }
 
-// InputService19TestCaseOperation2 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService19TestCaseOperation2 for usage and error information.
-func (c *InputService19ProtocolTest) InputService19TestCaseOperation2(input *InputService19TestShapeInputShape) (*InputService19TestShapeInputService19TestCaseOperation2Output, error) {
-	req, out := c.InputService19TestCaseOperation2Request(input)
-	err := req.Send()
-	return out, err
+// SetFoo sets the Foo field's value.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetFoo(v string) *InputService19TestShapeInputService19TestCaseOperation1Input {
+	s.Foo = &v
+	return s
 }
 
 type InputService19TestShapeInputService19TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService19TestShapeInputService19TestCaseOperation2Output struct {
+// The service client's operations are safe to be used concurrently.
+// It is not safe to mutate any of the client's properties though.
+type InputService20ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the InputService20ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a InputService20ProtocolTest client from just a session.
+//     svc := inputservice20protocoltest.New(mySession)
+//
+//     // Create a InputService20ProtocolTest client with additional configuration
+//     svc := inputservice20protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewInputService20ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *InputService20ProtocolTest {
+	c := p.ClientConfig("inputservice20protocoltest", cfgs...)
+	return newInputService20ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newInputService20ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *InputService20ProtocolTest {
+	svc := &InputService20ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "inputservice20protocoltest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "2014-01-01",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restjson.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restjson.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restjson.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restjson.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a InputService20ProtocolTest operation and runs any
+// custom request initialization.
+func (c *InputService20ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opInputService20TestCaseOperation1 = "OperationName"
+
+// InputService20TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the InputService20TestCaseOperation1 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService20TestCaseOperation1 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService20TestCaseOperation1 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService20TestCaseOperation1Request method.
+//    req, resp := client.InputService20TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService20ProtocolTest) InputService20TestCaseOperation1Request(input *InputService20TestShapeInputShape) (req *request.Request, output *InputService20TestShapeInputService20TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opInputService20TestCaseOperation1,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService20TestShapeInputShape{}
+	}
+
+	output = &InputService20TestShapeInputService20TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService20TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService20TestCaseOperation1 for usage and error information.
+func (c *InputService20ProtocolTest) InputService20TestCaseOperation1(input *InputService20TestShapeInputShape) (*InputService20TestShapeInputService20TestCaseOperation1Output, error) {
+	req, out := c.InputService20TestCaseOperation1Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService20TestCaseOperation2 = "OperationName"
+
+// InputService20TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService20TestCaseOperation2 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService20TestCaseOperation2 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService20TestCaseOperation2 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService20TestCaseOperation2Request method.
+//    req, resp := client.InputService20TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService20ProtocolTest) InputService20TestCaseOperation2Request(input *InputService20TestShapeInputShape) (req *request.Request, output *InputService20TestShapeInputService20TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService20TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService20TestShapeInputShape{}
+	}
+
+	output = &InputService20TestShapeInputService20TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService20TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService20TestCaseOperation2 for usage and error information.
+func (c *InputService20ProtocolTest) InputService20TestCaseOperation2(input *InputService20TestShapeInputShape) (*InputService20TestShapeInputService20TestCaseOperation2Output, error) {
+	req, out := c.InputService20TestCaseOperation2Request(input)
+	err := req.Send()
+	return out, err
+}
+
+type InputService20TestShapeInputService20TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService19TestShapeInputShape struct {
+type InputService20TestShapeInputService20TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService20TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
 }
 
 // SetToken sets the Token field's value.
-func (s *InputService19TestShapeInputShape) SetToken(v string) *InputService19TestShapeInputShape {
+func (s *InputService20TestShapeInputShape) SetToken(v string) *InputService20TestShapeInputShape {
 	s.Token = &v
 	return s
 }
@@ -3446,12 +3635,10 @@ func TestInputService6ProtocolTestStringToStringListMapsInQuerystringCase1(t *te
 
 }
 
-func TestInputService7ProtocolTestURIParameterAndQuerystringParamsCase1(t *testing.T) {
+func TestInputService7ProtocolTestBooleanInQuerystringCase1(t *testing.T) {
 	svc := NewInputService7ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService7TestShapeInputService7TestCaseOperation1Input{
-		Ascending:  aws.String("true"),
-		PageToken:  aws.String("bar"),
-		PipelineId: aws.String("foo"),
+	input := &InputService7TestShapeInputShape{
+		BoolQuery: aws.Bool(true),
 	}
 	req, _ := svc.InputService7TestCaseOperation1Request(input)
 	r := req.HTTPRequest
@@ -3461,20 +3648,35 @@ func TestInputService7ProtocolTestURIParameterAndQuerystringParamsCase1(t *testi
 	assert.NoError(t, req.Error)
 
 	// assert URL
-	awstesting.AssertURL(t, "https://test/2014-01-01/jobsByPipeline/foo?Ascending=true&PageToken=bar", r.URL.String())
+	awstesting.AssertURL(t, "https://test/path?bool-query=true", r.URL.String())
 
 	// assert headers
 
 }
 
-func TestInputService8ProtocolTestURIParameterQuerystringParamsAndJSONBodyCase1(t *testing.T) {
+func TestInputService7ProtocolTestBooleanInQuerystringCase2(t *testing.T) {
+	svc := NewInputService7ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService7TestShapeInputShape{
+		BoolQuery: aws.Bool(false),
+	}
+	req, _ := svc.InputService7TestCaseOperation2Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restjson.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/path?bool-query=false", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService8ProtocolTestURIParameterAndQuerystringParamsCase1(t *testing.T) {
 	svc := NewInputService8ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 	input := &InputService8TestShapeInputService8TestCaseOperation1Input{
-		Ascending: aws.String("true"),
-		Config: &InputService8TestShapeStructType{
-			A: aws.String("one"),
-			B: aws.String("two"),
-		},
+		Ascending:  aws.String("true"),
 		PageToken:  aws.String("bar"),
 		PipelineId: aws.String("foo"),
 	}
@@ -3485,11 +3687,6 @@ func TestInputService8ProtocolTestURIParameterQuerystringParamsAndJSONBodyCase1(
 	restjson.Build(req)
 	assert.NoError(t, req.Error)
 
-	// assert body
-	assert.NotNil(t, r.Body)
-	body, _ := ioutil.ReadAll(r.Body)
-	awstesting.AssertJSON(t, `{"Config":{"A":"one","B":"two"}}`, util.Trim(string(body)))
-
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/jobsByPipeline/foo?Ascending=true&PageToken=bar", r.URL.String())
 
@@ -3497,11 +3694,10 @@ func TestInputService8ProtocolTestURIParameterQuerystringParamsAndJSONBodyCase1(
 
 }
 
-func TestInputService9ProtocolTestURIParameterQuerystringParamsHeadersAndJSONBodyCase1(t *testing.T) {
+func TestInputService9ProtocolTestURIParameterQuerystringParamsAndJSONBodyCase1(t *testing.T) {
 	svc := NewInputService9ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 	input := &InputService9TestShapeInputService9TestCaseOperation1Input{
 		Ascending: aws.String("true"),
-		Checksum:  aws.String("12345"),
 		Config: &InputService9TestShapeStructType{
 			A: aws.String("one"),
 			B: aws.String("two"),
@@ -3525,18 +3721,49 @@ func TestInputService9ProtocolTestURIParameterQuerystringParamsHeadersAndJSONBod
 	awstesting.AssertURL(t, "https://test/2014-01-01/jobsByPipeline/foo?Ascending=true&PageToken=bar", r.URL.String())
 
 	// assert headers
+
+}
+
+func TestInputService10ProtocolTestURIParameterQuerystringParamsHeadersAndJSONBodyCase1(t *testing.T) {
+	svc := NewInputService10ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService10TestShapeInputService10TestCaseOperation1Input{
+		Ascending: aws.String("true"),
+		Checksum:  aws.String("12345"),
+		Config: &InputService10TestShapeStructType{
+			A: aws.String("one"),
+			B: aws.String("two"),
+		},
+		PageToken:  aws.String("bar"),
+		PipelineId: aws.String("foo"),
+	}
+	req, _ := svc.InputService10TestCaseOperation1Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restjson.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert body
+	assert.NotNil(t, r.Body)
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertJSON(t, `{"Config":{"A":"one","B":"two"}}`, util.Trim(string(body)))
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/2014-01-01/jobsByPipeline/foo?Ascending=true&PageToken=bar", r.URL.String())
+
+	// assert headers
 	assert.Equal(t, "12345", r.Header.Get("x-amz-checksum"))
 
 }
 
-func TestInputService10ProtocolTestStreamingPayloadCase1(t *testing.T) {
-	svc := NewInputService10ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService10TestShapeInputService10TestCaseOperation1Input{
+func TestInputService11ProtocolTestStreamingPayloadCase1(t *testing.T) {
+	svc := NewInputService11ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService11TestShapeInputService11TestCaseOperation1Input{
 		Body:      bytes.NewReader([]byte("contents")),
 		Checksum:  aws.String("foo"),
 		VaultName: aws.String("name"),
 	}
-	req, _ := svc.InputService10TestCaseOperation1Request(input)
+	req, _ := svc.InputService11TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3556,13 +3783,13 @@ func TestInputService10ProtocolTestStreamingPayloadCase1(t *testing.T) {
 
 }
 
-func TestInputService11ProtocolTestSerializeBlobsInBodyCase1(t *testing.T) {
-	svc := NewInputService11ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService11TestShapeInputService11TestCaseOperation1Input{
+func TestInputService12ProtocolTestSerializeBlobsInBodyCase1(t *testing.T) {
+	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService12TestShapeInputService12TestCaseOperation1Input{
 		Bar: []byte("Blob param"),
 		Foo: aws.String("foo_name"),
 	}
-	req, _ := svc.InputService11TestCaseOperation1Request(input)
+	req, _ := svc.InputService12TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3581,12 +3808,12 @@ func TestInputService11ProtocolTestSerializeBlobsInBodyCase1(t *testing.T) {
 
 }
 
-func TestInputService12ProtocolTestBlobPayloadCase1(t *testing.T) {
-	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputShape{
+func TestInputService13ProtocolTestBlobPayloadCase1(t *testing.T) {
+	svc := NewInputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService13TestShapeInputShape{
 		Foo: []byte("bar"),
 	}
-	req, _ := svc.InputService12TestCaseOperation1Request(input)
+	req, _ := svc.InputService13TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3605,10 +3832,10 @@ func TestInputService12ProtocolTestBlobPayloadCase1(t *testing.T) {
 
 }
 
-func TestInputService12ProtocolTestBlobPayloadCase2(t *testing.T) {
-	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputShape{}
-	req, _ := svc.InputService12TestCaseOperation2Request(input)
+func TestInputService13ProtocolTestBlobPayloadCase2(t *testing.T) {
+	svc := NewInputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService13TestShapeInputShape{}
+	req, _ := svc.InputService13TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3622,14 +3849,14 @@ func TestInputService12ProtocolTestBlobPayloadCase2(t *testing.T) {
 
 }
 
-func TestInputService13ProtocolTestStructurePayloadCase1(t *testing.T) {
-	svc := NewInputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService13TestShapeInputShape{
-		Foo: &InputService13TestShapeFooShape{
+func TestInputService14ProtocolTestStructurePayloadCase1(t *testing.T) {
+	svc := NewInputService14ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService14TestShapeInputShape{
+		Foo: &InputService14TestShapeFooShape{
 			Baz: aws.String("bar"),
 		},
 	}
-	req, _ := svc.InputService13TestCaseOperation1Request(input)
+	req, _ := svc.InputService14TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3648,10 +3875,10 @@ func TestInputService13ProtocolTestStructurePayloadCase1(t *testing.T) {
 
 }
 
-func TestInputService13ProtocolTestStructurePayloadCase2(t *testing.T) {
-	svc := NewInputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService13TestShapeInputShape{}
-	req, _ := svc.InputService13TestCaseOperation2Request(input)
+func TestInputService14ProtocolTestStructurePayloadCase2(t *testing.T) {
+	svc := NewInputService14ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService14TestShapeInputShape{}
+	req, _ := svc.InputService14TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3665,10 +3892,10 @@ func TestInputService13ProtocolTestStructurePayloadCase2(t *testing.T) {
 
 }
 
-func TestInputService14ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase1(t *testing.T) {
-	svc := NewInputService14ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService14TestShapeInputShape{}
-	req, _ := svc.InputService14TestCaseOperation1Request(input)
+func TestInputService15ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase1(t *testing.T) {
+	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService15TestShapeInputShape{}
+	req, _ := svc.InputService15TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3682,12 +3909,12 @@ func TestInputService14ProtocolTestOmitsNullQueryParamsButSerializesEmptyStrings
 
 }
 
-func TestInputService14ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase2(t *testing.T) {
-	svc := NewInputService14ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService14TestShapeInputShape{
+func TestInputService15ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase2(t *testing.T) {
+	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService15TestShapeInputShape{
 		Foo: aws.String(""),
 	}
-	req, _ := svc.InputService14TestCaseOperation2Request(input)
+	req, _ := svc.InputService15TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3701,14 +3928,14 @@ func TestInputService14ProtocolTestOmitsNullQueryParamsButSerializesEmptyStrings
 
 }
 
-func TestInputService15ProtocolTestRecursiveShapesCase1(t *testing.T) {
-	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputShape{
-		RecursiveStruct: &InputService15TestShapeRecursiveStructType{
+func TestInputService16ProtocolTestRecursiveShapesCase1(t *testing.T) {
+	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService16TestShapeInputShape{
+		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
 	}
-	req, _ := svc.InputService15TestCaseOperation1Request(input)
+	req, _ := svc.InputService16TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3727,16 +3954,16 @@ func TestInputService15ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 }
 
-func TestInputService15ProtocolTestRecursiveShapesCase2(t *testing.T) {
-	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputShape{
-		RecursiveStruct: &InputService15TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService15TestShapeRecursiveStructType{
+func TestInputService16ProtocolTestRecursiveShapesCase2(t *testing.T) {
+	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService16TestShapeInputShape{
+		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
 			},
 		},
 	}
-	req, _ := svc.InputService15TestCaseOperation2Request(input)
+	req, _ := svc.InputService16TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3755,20 +3982,20 @@ func TestInputService15ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 }
 
-func TestInputService15ProtocolTestRecursiveShapesCase3(t *testing.T) {
-	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputShape{
-		RecursiveStruct: &InputService15TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService15TestShapeRecursiveStructType{
-				RecursiveStruct: &InputService15TestShapeRecursiveStructType{
-					RecursiveStruct: &InputService15TestShapeRecursiveStructType{
+func TestInputService16ProtocolTestRecursiveShapesCase3(t *testing.T) {
+	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService16TestShapeInputShape{
+		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService16TestShapeRecursiveStructType{
+				RecursiveStruct: &InputService16TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 						NoRecurse: aws.String("foo"),
 					},
 				},
 			},
 		},
 	}
-	req, _ := svc.InputService15TestCaseOperation3Request(input)
+	req, _ := svc.InputService16TestCaseOperation3Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3787,11 +4014,11 @@ func TestInputService15ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 }
 
-func TestInputService15ProtocolTestRecursiveShapesCase4(t *testing.T) {
-	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputShape{
-		RecursiveStruct: &InputService15TestShapeRecursiveStructType{
-			RecursiveList: []*InputService15TestShapeRecursiveStructType{
+func TestInputService16ProtocolTestRecursiveShapesCase4(t *testing.T) {
+	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService16TestShapeInputShape{
+		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
+			RecursiveList: []*InputService16TestShapeRecursiveStructType{
 				{
 					NoRecurse: aws.String("foo"),
 				},
@@ -3801,7 +4028,7 @@ func TestInputService15ProtocolTestRecursiveShapesCase4(t *testing.T) {
 			},
 		},
 	}
-	req, _ := svc.InputService15TestCaseOperation4Request(input)
+	req, _ := svc.InputService16TestCaseOperation4Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3820,23 +4047,23 @@ func TestInputService15ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 }
 
-func TestInputService15ProtocolTestRecursiveShapesCase5(t *testing.T) {
-	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputShape{
-		RecursiveStruct: &InputService15TestShapeRecursiveStructType{
-			RecursiveList: []*InputService15TestShapeRecursiveStructType{
+func TestInputService16ProtocolTestRecursiveShapesCase5(t *testing.T) {
+	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService16TestShapeInputShape{
+		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
+			RecursiveList: []*InputService16TestShapeRecursiveStructType{
 				{
 					NoRecurse: aws.String("foo"),
 				},
 				{
-					RecursiveStruct: &InputService15TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 						NoRecurse: aws.String("bar"),
 					},
 				},
 			},
 		},
 	}
-	req, _ := svc.InputService15TestCaseOperation5Request(input)
+	req, _ := svc.InputService16TestCaseOperation5Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3855,11 +4082,11 @@ func TestInputService15ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 }
 
-func TestInputService15ProtocolTestRecursiveShapesCase6(t *testing.T) {
-	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputShape{
-		RecursiveStruct: &InputService15TestShapeRecursiveStructType{
-			RecursiveMap: map[string]*InputService15TestShapeRecursiveStructType{
+func TestInputService16ProtocolTestRecursiveShapesCase6(t *testing.T) {
+	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService16TestShapeInputShape{
+		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
+			RecursiveMap: map[string]*InputService16TestShapeRecursiveStructType{
 				"bar": {
 					NoRecurse: aws.String("bar"),
 				},
@@ -3869,7 +4096,7 @@ func TestInputService15ProtocolTestRecursiveShapesCase6(t *testing.T) {
 			},
 		},
 	}
-	req, _ := svc.InputService15TestCaseOperation6Request(input)
+	req, _ := svc.InputService16TestCaseOperation6Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3888,12 +4115,12 @@ func TestInputService15ProtocolTestRecursiveShapesCase6(t *testing.T) {
 
 }
 
-func TestInputService16ProtocolTestTimestampValuesCase1(t *testing.T) {
-	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputShape{
+func TestInputService17ProtocolTestTimestampValuesCase1(t *testing.T) {
+	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService17TestShapeInputShape{
 		TimeArg: aws.Time(time.Unix(1422172800, 0)),
 	}
-	req, _ := svc.InputService16TestCaseOperation1Request(input)
+	req, _ := svc.InputService17TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3912,12 +4139,12 @@ func TestInputService16ProtocolTestTimestampValuesCase1(t *testing.T) {
 
 }
 
-func TestInputService16ProtocolTestTimestampValuesCase2(t *testing.T) {
-	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputShape{
+func TestInputService17ProtocolTestTimestampValuesCase2(t *testing.T) {
+	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService17TestShapeInputShape{
 		TimeArgInHeader: aws.Time(time.Unix(1422172800, 0)),
 	}
-	req, _ := svc.InputService16TestCaseOperation2Request(input)
+	req, _ := svc.InputService17TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3932,12 +4159,12 @@ func TestInputService16ProtocolTestTimestampValuesCase2(t *testing.T) {
 
 }
 
-func TestInputService17ProtocolTestNamedLocationsInJSONBodyCase1(t *testing.T) {
-	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService17TestShapeInputService17TestCaseOperation1Input{
+func TestInputService18ProtocolTestNamedLocationsInJSONBodyCase1(t *testing.T) {
+	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService18TestShapeInputService18TestCaseOperation1Input{
 		TimeArg: aws.Time(time.Unix(1422172800, 0)),
 	}
-	req, _ := svc.InputService17TestCaseOperation1Request(input)
+	req, _ := svc.InputService18TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3956,12 +4183,12 @@ func TestInputService17ProtocolTestNamedLocationsInJSONBodyCase1(t *testing.T) {
 
 }
 
-func TestInputService18ProtocolTestStringPayloadCase1(t *testing.T) {
-	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputService18TestCaseOperation1Input{
+func TestInputService19ProtocolTestStringPayloadCase1(t *testing.T) {
+	svc := NewInputService19ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService19TestShapeInputService19TestCaseOperation1Input{
 		Foo: aws.String("bar"),
 	}
-	req, _ := svc.InputService18TestCaseOperation1Request(input)
+	req, _ := svc.InputService19TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -3980,12 +4207,12 @@ func TestInputService18ProtocolTestStringPayloadCase1(t *testing.T) {
 
 }
 
-func TestInputService19ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
-	svc := NewInputService19ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService19TestShapeInputShape{
+func TestInputService20ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
+	svc := NewInputService20ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService20TestShapeInputShape{
 		Token: aws.String("abc123"),
 	}
-	req, _ := svc.InputService19TestCaseOperation1Request(input)
+	req, _ := svc.InputService20TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4004,10 +4231,10 @@ func TestInputService19ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 
 }
 
-func TestInputService19ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
-	svc := NewInputService19ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService19TestShapeInputShape{}
-	req, _ := svc.InputService19TestCaseOperation2Request(input)
+func TestInputService20ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
+	svc := NewInputService20ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService20TestShapeInputShape{}
+	req, _ := svc.InputService20TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -2239,15 +2239,15 @@ const opInputService15TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(input *InputService15TestShapeInputService15TestCaseOperation1Input) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation1Output) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(input *InputService15TestShapeInputShape) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService15TestCaseOperation1,
-		HTTPMethod: "POST",
-		HTTPPath:   "/",
+		HTTPMethod: "GET",
+		HTTPPath:   "/path",
 	}
 
 	if input == nil {
-		input = &InputService15TestShapeInputService15TestCaseOperation1Input{}
+		input = &InputService15TestShapeInputShape{}
 	}
 
 	output = &InputService15TestShapeInputService15TestCaseOperation1Output{}
@@ -2265,26 +2265,87 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService15TestCaseOperation1 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1(input *InputService15TestShapeInputService15TestCaseOperation1Input) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1(input *InputService15TestShapeInputShape) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
 	req, out := c.InputService15TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-type InputService15TestShapeInputService15TestCaseOperation1Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+const opInputService15TestCaseOperation2 = "OperationName"
 
-	Foo *string `locationName:"foo" type:"string"`
+// InputService15TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService15TestCaseOperation2 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService15TestCaseOperation2 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService15TestCaseOperation2 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService15TestCaseOperation2Request method.
+//    req, resp := client.InputService15TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(input *InputService15TestShapeInputShape) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService15TestCaseOperation2,
+		HTTPMethod: "GET",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService15TestShapeInputShape{}
+	}
+
+	output = &InputService15TestShapeInputService15TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
 }
 
-// SetFoo sets the Foo field's value.
-func (s *InputService15TestShapeInputService15TestCaseOperation1Input) SetFoo(v string) *InputService15TestShapeInputService15TestCaseOperation1Input {
-	s.Foo = &v
-	return s
+// InputService15TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService15TestCaseOperation2 for usage and error information.
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *InputService15TestShapeInputShape) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
+	req, out := c.InputService15TestCaseOperation2Request(input)
+	err := req.Send()
+	return out, err
 }
 
 type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService15TestShapeInputService15TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService15TestShapeInputShape struct {
+	_ struct{} `type:"structure"`
+
+	BoolQuery *bool `location:"querystring" locationName:"bool-query" type:"boolean"`
+}
+
+// SetBoolQuery sets the BoolQuery field's value.
+func (s *InputService15TestShapeInputShape) SetBoolQuery(v bool) *InputService15TestShapeInputShape {
+	s.BoolQuery = &v
+	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -2367,7 +2428,7 @@ const opInputService16TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(input *InputService16TestShapeInputShape) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation1Output) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(input *InputService16TestShapeInputService16TestCaseOperation1Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService16TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -2375,7 +2436,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService16TestShapeInputShape{}
+		input = &InputService16TestShapeInputService16TestCaseOperation1Input{}
 	}
 
 	output = &InputService16TestShapeInputService16TestCaseOperation1Output{}
@@ -2393,87 +2454,26 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService16TestCaseOperation1 for usage and error information.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation1(input *InputService16TestShapeInputShape) (*InputService16TestShapeInputService16TestCaseOperation1Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation1(input *InputService16TestShapeInputService16TestCaseOperation1Input) (*InputService16TestShapeInputService16TestCaseOperation1Output, error) {
 	req, out := c.InputService16TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-const opInputService16TestCaseOperation2 = "OperationName"
+type InputService16TestShapeInputService16TestCaseOperation1Input struct {
+	_ struct{} `type:"structure" payload:"Foo"`
 
-// InputService16TestCaseOperation2Request generates a "aws/request.Request" representing the
-// client's request for the InputService16TestCaseOperation2 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService16TestCaseOperation2 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService16TestCaseOperation2 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService16TestCaseOperation2Request method.
-//    req, resp := client.InputService16TestCaseOperation2Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation2Request(input *InputService16TestShapeInputShape) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation2Output) {
-	op := &request.Operation{
-		Name:       opInputService16TestCaseOperation2,
-		HTTPMethod: "POST",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &InputService16TestShapeInputShape{}
-	}
-
-	output = &InputService16TestShapeInputService16TestCaseOperation2Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
+	Foo *string `locationName:"foo" type:"string"`
 }
 
-// InputService16TestCaseOperation2 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService16TestCaseOperation2 for usage and error information.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation2(input *InputService16TestShapeInputShape) (*InputService16TestShapeInputService16TestCaseOperation2Output, error) {
-	req, out := c.InputService16TestCaseOperation2Request(input)
-	err := req.Send()
-	return out, err
+// SetFoo sets the Foo field's value.
+func (s *InputService16TestShapeInputService16TestCaseOperation1Input) SetFoo(v string) *InputService16TestShapeInputService16TestCaseOperation1Input {
+	s.Foo = &v
+	return s
 }
 
 type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService16TestShapeInputService16TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService16TestShapeInputShape struct {
-	_ struct{} `type:"structure" payload:"Foo"`
-
-	Foo []byte `locationName:"foo" type:"blob"`
-}
-
-// SetFoo sets the Foo field's value.
-func (s *InputService16TestShapeInputShape) SetFoo(v []byte) *InputService16TestShapeInputShape {
-	s.Foo = v
-	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -2645,132 +2645,6 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation2(input *Inp
 	return out, err
 }
 
-const opInputService17TestCaseOperation3 = "OperationName"
-
-// InputService17TestCaseOperation3Request generates a "aws/request.Request" representing the
-// client's request for the InputService17TestCaseOperation3 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService17TestCaseOperation3 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService17TestCaseOperation3 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService17TestCaseOperation3Request method.
-//    req, resp := client.InputService17TestCaseOperation3Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation3Request(input *InputService17TestShapeInputShape) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation3Output) {
-	op := &request.Operation{
-		Name:       opInputService17TestCaseOperation3,
-		HTTPMethod: "POST",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &InputService17TestShapeInputShape{}
-	}
-
-	output = &InputService17TestShapeInputService17TestCaseOperation3Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService17TestCaseOperation3 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService17TestCaseOperation3 for usage and error information.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation3(input *InputService17TestShapeInputShape) (*InputService17TestShapeInputService17TestCaseOperation3Output, error) {
-	req, out := c.InputService17TestCaseOperation3Request(input)
-	err := req.Send()
-	return out, err
-}
-
-const opInputService17TestCaseOperation4 = "OperationName"
-
-// InputService17TestCaseOperation4Request generates a "aws/request.Request" representing the
-// client's request for the InputService17TestCaseOperation4 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService17TestCaseOperation4 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService17TestCaseOperation4 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService17TestCaseOperation4Request method.
-//    req, resp := client.InputService17TestCaseOperation4Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation4Request(input *InputService17TestShapeInputShape) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation4Output) {
-	op := &request.Operation{
-		Name:       opInputService17TestCaseOperation4,
-		HTTPMethod: "POST",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &InputService17TestShapeInputShape{}
-	}
-
-	output = &InputService17TestShapeInputService17TestCaseOperation4Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService17TestCaseOperation4 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService17TestCaseOperation4 for usage and error information.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation4(input *InputService17TestShapeInputShape) (*InputService17TestShapeInputService17TestCaseOperation4Output, error) {
-	req, out := c.InputService17TestCaseOperation4Request(input)
-	err := req.Send()
-	return out, err
-}
-
-type InputService17TestShapeFooShape struct {
-	_ struct{} `locationName:"foo" type:"structure"`
-
-	Baz *string `locationName:"baz" type:"string"`
-}
-
-// SetBaz sets the Baz field's value.
-func (s *InputService17TestShapeFooShape) SetBaz(v string) *InputService17TestShapeFooShape {
-	s.Baz = &v
-	return s
-}
-
 type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -2779,22 +2653,14 @@ type InputService17TestShapeInputService17TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService17TestShapeInputService17TestCaseOperation3Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService17TestShapeInputService17TestCaseOperation4Output struct {
-	_ struct{} `type:"structure"`
-}
-
 type InputService17TestShapeInputShape struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
-	Foo *InputService17TestShapeFooShape `locationName:"foo" type:"structure"`
+	Foo []byte `locationName:"foo" type:"blob"`
 }
 
 // SetFoo sets the Foo field's value.
-func (s *InputService17TestShapeInputShape) SetFoo(v *InputService17TestShapeFooShape) *InputService17TestShapeInputShape {
+func (s *InputService17TestShapeInputShape) SetFoo(v []byte) *InputService17TestShapeInputShape {
 	s.Foo = v
 	return s
 }
@@ -2879,7 +2745,7 @@ const opInputService18TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(input *InputService18TestShapeInputService18TestCaseOperation1Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation1Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -2887,7 +2753,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputService18TestCaseOperation1Input{}
+		input = &InputService18TestShapeInputShape{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation1Output{}
@@ -2905,58 +2771,221 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation1 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *InputService18TestShapeInputService18TestCaseOperation1Input) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *InputService18TestShapeInputShape) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
 	req, out := c.InputService18TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-type InputService18TestShapeGrant struct {
-	_ struct{} `locationName:"Grant" type:"structure"`
+const opInputService18TestCaseOperation2 = "OperationName"
 
-	Grantee *InputService18TestShapeGrantee `type:"structure"`
+// InputService18TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService18TestCaseOperation2 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService18TestCaseOperation2 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService18TestCaseOperation2 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService18TestCaseOperation2Request method.
+//    req, resp := client.InputService18TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService18TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InputService18TestShapeInputShape{}
+	}
+
+	output = &InputService18TestShapeInputService18TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
 }
 
-// SetGrantee sets the Grantee field's value.
-func (s *InputService18TestShapeGrant) SetGrantee(v *InputService18TestShapeGrantee) *InputService18TestShapeGrant {
-	s.Grantee = v
-	return s
+// InputService18TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService18TestCaseOperation2 for usage and error information.
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *InputService18TestShapeInputShape) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
+	req, out := c.InputService18TestCaseOperation2Request(input)
+	err := req.Send()
+	return out, err
 }
 
-type InputService18TestShapeGrantee struct {
-	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+const opInputService18TestCaseOperation3 = "OperationName"
 
-	EmailAddress *string `type:"string"`
+// InputService18TestCaseOperation3Request generates a "aws/request.Request" representing the
+// client's request for the InputService18TestCaseOperation3 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService18TestCaseOperation3 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService18TestCaseOperation3 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService18TestCaseOperation3Request method.
+//    req, resp := client.InputService18TestCaseOperation3Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation3Output) {
+	op := &request.Operation{
+		Name:       opInputService18TestCaseOperation3,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
 
-	Type *string `locationName:"xsi:type" type:"string" xmlAttribute:"true"`
+	if input == nil {
+		input = &InputService18TestShapeInputShape{}
+	}
+
+	output = &InputService18TestShapeInputService18TestCaseOperation3Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
 }
 
-// SetEmailAddress sets the EmailAddress field's value.
-func (s *InputService18TestShapeGrantee) SetEmailAddress(v string) *InputService18TestShapeGrantee {
-	s.EmailAddress = &v
-	return s
+// InputService18TestCaseOperation3 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService18TestCaseOperation3 for usage and error information.
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *InputService18TestShapeInputShape) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
+	req, out := c.InputService18TestCaseOperation3Request(input)
+	err := req.Send()
+	return out, err
 }
 
-// SetType sets the Type field's value.
-func (s *InputService18TestShapeGrantee) SetType(v string) *InputService18TestShapeGrantee {
-	s.Type = &v
-	return s
+const opInputService18TestCaseOperation4 = "OperationName"
+
+// InputService18TestCaseOperation4Request generates a "aws/request.Request" representing the
+// client's request for the InputService18TestCaseOperation4 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService18TestCaseOperation4 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService18TestCaseOperation4 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService18TestCaseOperation4Request method.
+//    req, resp := client.InputService18TestCaseOperation4Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation4Output) {
+	op := &request.Operation{
+		Name:       opInputService18TestCaseOperation4,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InputService18TestShapeInputShape{}
+	}
+
+	output = &InputService18TestShapeInputService18TestCaseOperation4Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
 }
 
-type InputService18TestShapeInputService18TestCaseOperation1Input struct {
-	_ struct{} `type:"structure" payload:"Grant"`
-
-	Grant *InputService18TestShapeGrant `locationName:"Grant" type:"structure"`
+// InputService18TestCaseOperation4 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService18TestCaseOperation4 for usage and error information.
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *InputService18TestShapeInputShape) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
+	req, out := c.InputService18TestCaseOperation4Request(input)
+	err := req.Send()
+	return out, err
 }
 
-// SetGrant sets the Grant field's value.
-func (s *InputService18TestShapeInputService18TestCaseOperation1Input) SetGrant(v *InputService18TestShapeGrant) *InputService18TestShapeInputService18TestCaseOperation1Input {
-	s.Grant = v
+type InputService18TestShapeFooShape struct {
+	_ struct{} `locationName:"foo" type:"structure"`
+
+	Baz *string `locationName:"baz" type:"string"`
+}
+
+// SetBaz sets the Baz field's value.
+func (s *InputService18TestShapeFooShape) SetBaz(v string) *InputService18TestShapeFooShape {
+	s.Baz = &v
 	return s
 }
 
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService18TestShapeInputService18TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService18TestShapeInputService18TestCaseOperation3Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService18TestShapeInputService18TestCaseOperation4Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService18TestShapeInputShape struct {
+	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo *InputService18TestShapeFooShape `locationName:"foo" type:"structure"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService18TestShapeInputShape) SetFoo(v *InputService18TestShapeFooShape) *InputService18TestShapeInputShape {
+	s.Foo = v
+	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -3042,8 +3071,8 @@ const opInputService19TestCaseOperation1 = "OperationName"
 func (c *InputService19ProtocolTest) InputService19TestCaseOperation1Request(input *InputService19TestShapeInputService19TestCaseOperation1Input) (req *request.Request, output *InputService19TestShapeInputService19TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService19TestCaseOperation1,
-		HTTPMethod: "GET",
-		HTTPPath:   "/{Bucket}/{Key+}",
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
 	}
 
 	if input == nil {
@@ -3071,23 +3100,47 @@ func (c *InputService19ProtocolTest) InputService19TestCaseOperation1(input *Inp
 	return out, err
 }
 
-type InputService19TestShapeInputService19TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+type InputService19TestShapeGrant struct {
+	_ struct{} `locationName:"Grant" type:"structure"`
 
-	Bucket *string `location:"uri" type:"string"`
-
-	Key *string `location:"uri" type:"string"`
+	Grantee *InputService19TestShapeGrantee `type:"structure"`
 }
 
-// SetBucket sets the Bucket field's value.
-func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetBucket(v string) *InputService19TestShapeInputService19TestCaseOperation1Input {
-	s.Bucket = &v
+// SetGrantee sets the Grantee field's value.
+func (s *InputService19TestShapeGrant) SetGrantee(v *InputService19TestShapeGrantee) *InputService19TestShapeGrant {
+	s.Grantee = v
 	return s
 }
 
-// SetKey sets the Key field's value.
-func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetKey(v string) *InputService19TestShapeInputService19TestCaseOperation1Input {
-	s.Key = &v
+type InputService19TestShapeGrantee struct {
+	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+
+	EmailAddress *string `type:"string"`
+
+	Type *string `locationName:"xsi:type" type:"string" xmlAttribute:"true"`
+}
+
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *InputService19TestShapeGrantee) SetEmailAddress(v string) *InputService19TestShapeGrantee {
+	s.EmailAddress = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *InputService19TestShapeGrantee) SetType(v string) *InputService19TestShapeGrantee {
+	s.Type = &v
+	return s
+}
+
+type InputService19TestShapeInputService19TestCaseOperation1Input struct {
+	_ struct{} `type:"structure" payload:"Grant"`
+
+	Grant *InputService19TestShapeGrant `locationName:"Grant" type:"structure"`
+}
+
+// SetGrant sets the Grant field's value.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetGrant(v *InputService19TestShapeGrant) *InputService19TestShapeInputService19TestCaseOperation1Input {
+	s.Grant = v
 	return s
 }
 
@@ -3175,15 +3228,15 @@ const opInputService20TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService20ProtocolTest) InputService20TestCaseOperation1Request(input *InputService20TestShapeInputShape) (req *request.Request, output *InputService20TestShapeInputService20TestCaseOperation1Output) {
+func (c *InputService20ProtocolTest) InputService20TestCaseOperation1Request(input *InputService20TestShapeInputService20TestCaseOperation1Input) (req *request.Request, output *InputService20TestShapeInputService20TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService20TestCaseOperation1,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}/{Key+}",
 	}
 
 	if input == nil {
-		input = &InputService20TestShapeInputShape{}
+		input = &InputService20TestShapeInputService20TestCaseOperation1Input{}
 	}
 
 	output = &InputService20TestShapeInputService20TestCaseOperation1Output{}
@@ -3201,87 +3254,34 @@ func (c *InputService20ProtocolTest) InputService20TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService20TestCaseOperation1 for usage and error information.
-func (c *InputService20ProtocolTest) InputService20TestCaseOperation1(input *InputService20TestShapeInputShape) (*InputService20TestShapeInputService20TestCaseOperation1Output, error) {
+func (c *InputService20ProtocolTest) InputService20TestCaseOperation1(input *InputService20TestShapeInputService20TestCaseOperation1Input) (*InputService20TestShapeInputService20TestCaseOperation1Output, error) {
 	req, out := c.InputService20TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-const opInputService20TestCaseOperation2 = "OperationName"
+type InputService20TestShapeInputService20TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
 
-// InputService20TestCaseOperation2Request generates a "aws/request.Request" representing the
-// client's request for the InputService20TestCaseOperation2 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService20TestCaseOperation2 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService20TestCaseOperation2 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService20TestCaseOperation2Request method.
-//    req, resp := client.InputService20TestCaseOperation2Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService20ProtocolTest) InputService20TestCaseOperation2Request(input *InputService20TestShapeInputShape) (req *request.Request, output *InputService20TestShapeInputService20TestCaseOperation2Output) {
-	op := &request.Operation{
-		Name:       opInputService20TestCaseOperation2,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path?abc=mno",
-	}
+	Bucket *string `location:"uri" type:"string"`
 
-	if input == nil {
-		input = &InputService20TestShapeInputShape{}
-	}
-
-	output = &InputService20TestShapeInputService20TestCaseOperation2Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
+	Key *string `location:"uri" type:"string"`
 }
 
-// InputService20TestCaseOperation2 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService20TestCaseOperation2 for usage and error information.
-func (c *InputService20ProtocolTest) InputService20TestCaseOperation2(input *InputService20TestShapeInputShape) (*InputService20TestShapeInputService20TestCaseOperation2Output, error) {
-	req, out := c.InputService20TestCaseOperation2Request(input)
-	err := req.Send()
-	return out, err
+// SetBucket sets the Bucket field's value.
+func (s *InputService20TestShapeInputService20TestCaseOperation1Input) SetBucket(v string) *InputService20TestShapeInputService20TestCaseOperation1Input {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *InputService20TestShapeInputService20TestCaseOperation1Input) SetKey(v string) *InputService20TestShapeInputService20TestCaseOperation1Input {
+	s.Key = &v
+	return s
 }
 
 type InputService20TestShapeInputService20TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService20TestShapeInputService20TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService20TestShapeInputShape struct {
-	_ struct{} `type:"structure"`
-
-	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
-}
-
-// SetFoo sets the Foo field's value.
-func (s *InputService20TestShapeInputShape) SetFoo(v string) *InputService20TestShapeInputShape {
-	s.Foo = &v
-	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -3425,7 +3425,7 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation2Request(inp
 	op := &request.Operation{
 		Name:       opInputService21TestCaseOperation2,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/path?abc=mno",
 	}
 
 	if input == nil {
@@ -3453,234 +3453,6 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation2(input *Inp
 	return out, err
 }
 
-const opInputService21TestCaseOperation3 = "OperationName"
-
-// InputService21TestCaseOperation3Request generates a "aws/request.Request" representing the
-// client's request for the InputService21TestCaseOperation3 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService21TestCaseOperation3 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService21TestCaseOperation3 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService21TestCaseOperation3Request method.
-//    req, resp := client.InputService21TestCaseOperation3Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation3Request(input *InputService21TestShapeInputShape) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation3Output) {
-	op := &request.Operation{
-		Name:       opInputService21TestCaseOperation3,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService21TestShapeInputShape{}
-	}
-
-	output = &InputService21TestShapeInputService21TestCaseOperation3Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService21TestCaseOperation3 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService21TestCaseOperation3 for usage and error information.
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation3(input *InputService21TestShapeInputShape) (*InputService21TestShapeInputService21TestCaseOperation3Output, error) {
-	req, out := c.InputService21TestCaseOperation3Request(input)
-	err := req.Send()
-	return out, err
-}
-
-const opInputService21TestCaseOperation4 = "OperationName"
-
-// InputService21TestCaseOperation4Request generates a "aws/request.Request" representing the
-// client's request for the InputService21TestCaseOperation4 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService21TestCaseOperation4 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService21TestCaseOperation4 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService21TestCaseOperation4Request method.
-//    req, resp := client.InputService21TestCaseOperation4Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation4Request(input *InputService21TestShapeInputShape) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation4Output) {
-	op := &request.Operation{
-		Name:       opInputService21TestCaseOperation4,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService21TestShapeInputShape{}
-	}
-
-	output = &InputService21TestShapeInputService21TestCaseOperation4Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService21TestCaseOperation4 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService21TestCaseOperation4 for usage and error information.
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation4(input *InputService21TestShapeInputShape) (*InputService21TestShapeInputService21TestCaseOperation4Output, error) {
-	req, out := c.InputService21TestCaseOperation4Request(input)
-	err := req.Send()
-	return out, err
-}
-
-const opInputService21TestCaseOperation5 = "OperationName"
-
-// InputService21TestCaseOperation5Request generates a "aws/request.Request" representing the
-// client's request for the InputService21TestCaseOperation5 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService21TestCaseOperation5 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService21TestCaseOperation5 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService21TestCaseOperation5Request method.
-//    req, resp := client.InputService21TestCaseOperation5Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation5Request(input *InputService21TestShapeInputShape) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation5Output) {
-	op := &request.Operation{
-		Name:       opInputService21TestCaseOperation5,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService21TestShapeInputShape{}
-	}
-
-	output = &InputService21TestShapeInputService21TestCaseOperation5Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService21TestCaseOperation5 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService21TestCaseOperation5 for usage and error information.
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation5(input *InputService21TestShapeInputShape) (*InputService21TestShapeInputService21TestCaseOperation5Output, error) {
-	req, out := c.InputService21TestCaseOperation5Request(input)
-	err := req.Send()
-	return out, err
-}
-
-const opInputService21TestCaseOperation6 = "OperationName"
-
-// InputService21TestCaseOperation6Request generates a "aws/request.Request" representing the
-// client's request for the InputService21TestCaseOperation6 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService21TestCaseOperation6 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService21TestCaseOperation6 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService21TestCaseOperation6Request method.
-//    req, resp := client.InputService21TestCaseOperation6Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation6Request(input *InputService21TestShapeInputShape) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation6Output) {
-	op := &request.Operation{
-		Name:       opInputService21TestCaseOperation6,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService21TestShapeInputShape{}
-	}
-
-	output = &InputService21TestShapeInputService21TestCaseOperation6Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
-}
-
-// InputService21TestCaseOperation6 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService21TestCaseOperation6 for usage and error information.
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation6(input *InputService21TestShapeInputShape) (*InputService21TestShapeInputService21TestCaseOperation6Output, error) {
-	req, out := c.InputService21TestCaseOperation6Request(input)
-	err := req.Send()
-	return out, err
-}
-
 type InputService21TestShapeInputService21TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -3689,67 +3461,15 @@ type InputService21TestShapeInputService21TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService21TestShapeInputService21TestCaseOperation3Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService21TestShapeInputService21TestCaseOperation4Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService21TestShapeInputService21TestCaseOperation5Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService21TestShapeInputService21TestCaseOperation6Output struct {
-	_ struct{} `type:"structure"`
-}
-
 type InputService21TestShapeInputShape struct {
-	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
-
-	RecursiveStruct *InputService21TestShapeRecursiveStructType `type:"structure"`
-}
-
-// SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService21TestShapeInputShape) SetRecursiveStruct(v *InputService21TestShapeRecursiveStructType) *InputService21TestShapeInputShape {
-	s.RecursiveStruct = v
-	return s
-}
-
-type InputService21TestShapeRecursiveStructType struct {
 	_ struct{} `type:"structure"`
 
-	NoRecurse *string `type:"string"`
-
-	RecursiveList []*InputService21TestShapeRecursiveStructType `type:"list"`
-
-	RecursiveMap map[string]*InputService21TestShapeRecursiveStructType `type:"map"`
-
-	RecursiveStruct *InputService21TestShapeRecursiveStructType `type:"structure"`
+	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 }
 
-// SetNoRecurse sets the NoRecurse field's value.
-func (s *InputService21TestShapeRecursiveStructType) SetNoRecurse(v string) *InputService21TestShapeRecursiveStructType {
-	s.NoRecurse = &v
-	return s
-}
-
-// SetRecursiveList sets the RecursiveList field's value.
-func (s *InputService21TestShapeRecursiveStructType) SetRecursiveList(v []*InputService21TestShapeRecursiveStructType) *InputService21TestShapeRecursiveStructType {
-	s.RecursiveList = v
-	return s
-}
-
-// SetRecursiveMap sets the RecursiveMap field's value.
-func (s *InputService21TestShapeRecursiveStructType) SetRecursiveMap(v map[string]*InputService21TestShapeRecursiveStructType) *InputService21TestShapeRecursiveStructType {
-	s.RecursiveMap = v
-	return s
-}
-
-// SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService21TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService21TestShapeRecursiveStructType) *InputService21TestShapeRecursiveStructType {
-	s.RecursiveStruct = v
+// SetFoo sets the Foo field's value.
+func (s *InputService21TestShapeInputShape) SetFoo(v string) *InputService21TestShapeInputShape {
+	s.Foo = &v
 	return s
 }
 
@@ -3833,7 +3553,7 @@ const opInputService22TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation1Request(input *InputService22TestShapeInputService22TestCaseOperation1Input) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation1Output) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation1Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService22TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -3841,7 +3561,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService22TestShapeInputService22TestCaseOperation1Input{}
+		input = &InputService22TestShapeInputShape{}
 	}
 
 	output = &InputService22TestShapeInputService22TestCaseOperation1Output{}
@@ -3859,26 +3579,367 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService22TestCaseOperation1 for usage and error information.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation1(input *InputService22TestShapeInputService22TestCaseOperation1Input) (*InputService22TestShapeInputService22TestCaseOperation1Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation1(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation1Output, error) {
 	req, out := c.InputService22TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-type InputService22TestShapeInputService22TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+const opInputService22TestCaseOperation2 = "OperationName"
 
-	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
+// InputService22TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService22TestCaseOperation2 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService22TestCaseOperation2 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService22TestCaseOperation2 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService22TestCaseOperation2Request method.
+//    req, resp := client.InputService22TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation2Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService22TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService22TestShapeInputShape{}
+	}
+
+	output = &InputService22TestShapeInputService22TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
 }
 
-// SetTimeArgInHeader sets the TimeArgInHeader field's value.
-func (s *InputService22TestShapeInputService22TestCaseOperation1Input) SetTimeArgInHeader(v time.Time) *InputService22TestShapeInputService22TestCaseOperation1Input {
-	s.TimeArgInHeader = &v
-	return s
+// InputService22TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService22TestCaseOperation2 for usage and error information.
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation2(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation2Output, error) {
+	req, out := c.InputService22TestCaseOperation2Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService22TestCaseOperation3 = "OperationName"
+
+// InputService22TestCaseOperation3Request generates a "aws/request.Request" representing the
+// client's request for the InputService22TestCaseOperation3 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService22TestCaseOperation3 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService22TestCaseOperation3 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService22TestCaseOperation3Request method.
+//    req, resp := client.InputService22TestCaseOperation3Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation3Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation3Output) {
+	op := &request.Operation{
+		Name:       opInputService22TestCaseOperation3,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService22TestShapeInputShape{}
+	}
+
+	output = &InputService22TestShapeInputService22TestCaseOperation3Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService22TestCaseOperation3 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService22TestCaseOperation3 for usage and error information.
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation3(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation3Output, error) {
+	req, out := c.InputService22TestCaseOperation3Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService22TestCaseOperation4 = "OperationName"
+
+// InputService22TestCaseOperation4Request generates a "aws/request.Request" representing the
+// client's request for the InputService22TestCaseOperation4 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService22TestCaseOperation4 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService22TestCaseOperation4 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService22TestCaseOperation4Request method.
+//    req, resp := client.InputService22TestCaseOperation4Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation4Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation4Output) {
+	op := &request.Operation{
+		Name:       opInputService22TestCaseOperation4,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService22TestShapeInputShape{}
+	}
+
+	output = &InputService22TestShapeInputService22TestCaseOperation4Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService22TestCaseOperation4 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService22TestCaseOperation4 for usage and error information.
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation4(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation4Output, error) {
+	req, out := c.InputService22TestCaseOperation4Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService22TestCaseOperation5 = "OperationName"
+
+// InputService22TestCaseOperation5Request generates a "aws/request.Request" representing the
+// client's request for the InputService22TestCaseOperation5 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService22TestCaseOperation5 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService22TestCaseOperation5 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService22TestCaseOperation5Request method.
+//    req, resp := client.InputService22TestCaseOperation5Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation5Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation5Output) {
+	op := &request.Operation{
+		Name:       opInputService22TestCaseOperation5,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService22TestShapeInputShape{}
+	}
+
+	output = &InputService22TestShapeInputService22TestCaseOperation5Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService22TestCaseOperation5 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService22TestCaseOperation5 for usage and error information.
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation5(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation5Output, error) {
+	req, out := c.InputService22TestCaseOperation5Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService22TestCaseOperation6 = "OperationName"
+
+// InputService22TestCaseOperation6Request generates a "aws/request.Request" representing the
+// client's request for the InputService22TestCaseOperation6 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService22TestCaseOperation6 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService22TestCaseOperation6 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService22TestCaseOperation6Request method.
+//    req, resp := client.InputService22TestCaseOperation6Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation6Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation6Output) {
+	op := &request.Operation{
+		Name:       opInputService22TestCaseOperation6,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService22TestShapeInputShape{}
+	}
+
+	output = &InputService22TestShapeInputService22TestCaseOperation6Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService22TestCaseOperation6 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService22TestCaseOperation6 for usage and error information.
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation6(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation6Output, error) {
+	req, out := c.InputService22TestCaseOperation6Request(input)
+	err := req.Send()
+	return out, err
 }
 
 type InputService22TestShapeInputService22TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService22TestShapeInputService22TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService22TestShapeInputService22TestCaseOperation3Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService22TestShapeInputService22TestCaseOperation4Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService22TestShapeInputService22TestCaseOperation5Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService22TestShapeInputService22TestCaseOperation6Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService22TestShapeInputShape struct {
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	RecursiveStruct *InputService22TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService22TestShapeInputShape) SetRecursiveStruct(v *InputService22TestShapeRecursiveStructType) *InputService22TestShapeInputShape {
+	s.RecursiveStruct = v
+	return s
+}
+
+type InputService22TestShapeRecursiveStructType struct {
+	_ struct{} `type:"structure"`
+
+	NoRecurse *string `type:"string"`
+
+	RecursiveList []*InputService22TestShapeRecursiveStructType `type:"list"`
+
+	RecursiveMap map[string]*InputService22TestShapeRecursiveStructType `type:"map"`
+
+	RecursiveStruct *InputService22TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetNoRecurse sets the NoRecurse field's value.
+func (s *InputService22TestShapeRecursiveStructType) SetNoRecurse(v string) *InputService22TestShapeRecursiveStructType {
+	s.NoRecurse = &v
+	return s
+}
+
+// SetRecursiveList sets the RecursiveList field's value.
+func (s *InputService22TestShapeRecursiveStructType) SetRecursiveList(v []*InputService22TestShapeRecursiveStructType) *InputService22TestShapeRecursiveStructType {
+	s.RecursiveList = v
+	return s
+}
+
+// SetRecursiveMap sets the RecursiveMap field's value.
+func (s *InputService22TestShapeRecursiveStructType) SetRecursiveMap(v map[string]*InputService22TestShapeRecursiveStructType) *InputService22TestShapeRecursiveStructType {
+	s.RecursiveMap = v
+	return s
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService22TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService22TestShapeRecursiveStructType) *InputService22TestShapeRecursiveStructType {
+	s.RecursiveStruct = v
+	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -3961,7 +4022,7 @@ const opInputService23TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService23ProtocolTest) InputService23TestCaseOperation1Request(input *InputService23TestShapeInputShape) (req *request.Request, output *InputService23TestShapeInputService23TestCaseOperation1Output) {
+func (c *InputService23ProtocolTest) InputService23TestCaseOperation1Request(input *InputService23TestShapeInputService23TestCaseOperation1Input) (req *request.Request, output *InputService23TestShapeInputService23TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService23TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -3969,7 +4030,7 @@ func (c *InputService23ProtocolTest) InputService23TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService23TestShapeInputShape{}
+		input = &InputService23TestShapeInputService23TestCaseOperation1Input{}
 	}
 
 	output = &InputService23TestShapeInputService23TestCaseOperation1Output{}
@@ -3987,85 +4048,213 @@ func (c *InputService23ProtocolTest) InputService23TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService23TestCaseOperation1 for usage and error information.
-func (c *InputService23ProtocolTest) InputService23TestCaseOperation1(input *InputService23TestShapeInputShape) (*InputService23TestShapeInputService23TestCaseOperation1Output, error) {
+func (c *InputService23ProtocolTest) InputService23TestCaseOperation1(input *InputService23TestShapeInputService23TestCaseOperation1Input) (*InputService23TestShapeInputService23TestCaseOperation1Output, error) {
 	req, out := c.InputService23TestCaseOperation1Request(input)
 	err := req.Send()
 	return out, err
 }
 
-const opInputService23TestCaseOperation2 = "OperationName"
+type InputService23TestShapeInputService23TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
 
-// InputService23TestCaseOperation2Request generates a "aws/request.Request" representing the
-// client's request for the InputService23TestCaseOperation2 operation. The "output" return
-// value can be used to capture response data after the request's "Send" method
-// is called.
-//
-// See InputService23TestCaseOperation2 for usage and error information.
-//
-// Creating a request object using this method should be used when you want to inject
-// custom logic into the request's lifecycle using a custom handler, or if you want to
-// access properties on the request object before or after sending the request. If
-// you just want the service response, call the InputService23TestCaseOperation2 method directly
-// instead.
-//
-// Note: You must call the "Send" method on the returned request object in order
-// to execute the request.
-//
-//    // Example sending a request using the InputService23TestCaseOperation2Request method.
-//    req, resp := client.InputService23TestCaseOperation2Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *InputService23ProtocolTest) InputService23TestCaseOperation2Request(input *InputService23TestShapeInputShape) (req *request.Request, output *InputService23TestShapeInputService23TestCaseOperation2Output) {
-	op := &request.Operation{
-		Name:       opInputService23TestCaseOperation2,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
-	}
-
-	if input == nil {
-		input = &InputService23TestShapeInputShape{}
-	}
-
-	output = &InputService23TestShapeInputService23TestCaseOperation2Output{}
-	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
-	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
-	return
+	TimeArgInHeader *time.Time `location:"header" locationName:"x-amz-timearg" type:"timestamp" timestampFormat:"rfc822"`
 }
 
-// InputService23TestCaseOperation2 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation InputService23TestCaseOperation2 for usage and error information.
-func (c *InputService23ProtocolTest) InputService23TestCaseOperation2(input *InputService23TestShapeInputShape) (*InputService23TestShapeInputService23TestCaseOperation2Output, error) {
-	req, out := c.InputService23TestCaseOperation2Request(input)
-	err := req.Send()
-	return out, err
+// SetTimeArgInHeader sets the TimeArgInHeader field's value.
+func (s *InputService23TestShapeInputService23TestCaseOperation1Input) SetTimeArgInHeader(v time.Time) *InputService23TestShapeInputService23TestCaseOperation1Input {
+	s.TimeArgInHeader = &v
+	return s
 }
 
 type InputService23TestShapeInputService23TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService23TestShapeInputService23TestCaseOperation2Output struct {
+// The service client's operations are safe to be used concurrently.
+// It is not safe to mutate any of the client's properties though.
+type InputService24ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the InputService24ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a InputService24ProtocolTest client from just a session.
+//     svc := inputservice24protocoltest.New(mySession)
+//
+//     // Create a InputService24ProtocolTest client with additional configuration
+//     svc := inputservice24protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewInputService24ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *InputService24ProtocolTest {
+	c := p.ClientConfig("inputservice24protocoltest", cfgs...)
+	return newInputService24ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newInputService24ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *InputService24ProtocolTest {
+	svc := &InputService24ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "inputservice24protocoltest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "2014-01-01",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restxml.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restxml.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restxml.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restxml.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a InputService24ProtocolTest operation and runs any
+// custom request initialization.
+func (c *InputService24ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opInputService24TestCaseOperation1 = "OperationName"
+
+// InputService24TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the InputService24TestCaseOperation1 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService24TestCaseOperation1 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService24TestCaseOperation1 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService24TestCaseOperation1Request method.
+//    req, resp := client.InputService24TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation1Request(input *InputService24TestShapeInputShape) (req *request.Request, output *InputService24TestShapeInputService24TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opInputService24TestCaseOperation1,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService24TestShapeInputShape{}
+	}
+
+	output = &InputService24TestShapeInputService24TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService24TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService24TestCaseOperation1 for usage and error information.
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation1(input *InputService24TestShapeInputShape) (*InputService24TestShapeInputService24TestCaseOperation1Output, error) {
+	req, out := c.InputService24TestCaseOperation1Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService24TestCaseOperation2 = "OperationName"
+
+// InputService24TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService24TestCaseOperation2 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService24TestCaseOperation2 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService24TestCaseOperation2 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService24TestCaseOperation2Request method.
+//    req, resp := client.InputService24TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation2Request(input *InputService24TestShapeInputShape) (req *request.Request, output *InputService24TestShapeInputService24TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService24TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &InputService24TestShapeInputShape{}
+	}
+
+	output = &InputService24TestShapeInputService24TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService24TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService24TestCaseOperation2 for usage and error information.
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation2(input *InputService24TestShapeInputShape) (*InputService24TestShapeInputService24TestCaseOperation2Output, error) {
+	req, out := c.InputService24TestCaseOperation2Request(input)
+	err := req.Send()
+	return out, err
+}
+
+type InputService24TestShapeInputService24TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService23TestShapeInputShape struct {
+type InputService24TestShapeInputService24TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService24TestShapeInputShape struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
 }
 
 // SetToken sets the Token field's value.
-func (s *InputService23TestShapeInputShape) SetToken(v string) *InputService23TestShapeInputShape {
+func (s *InputService24TestShapeInputShape) SetToken(v string) *InputService24TestShapeInputShape {
 	s.Token = &v
 	return s
 }
@@ -4519,10 +4708,10 @@ func TestInputService14ProtocolTestStringToStringListMapsInQuerystringCase1(t *t
 
 }
 
-func TestInputService15ProtocolTestStringPayloadCase1(t *testing.T) {
+func TestInputService15ProtocolTestBooleanInQuerystringCase1(t *testing.T) {
 	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputService15TestCaseOperation1Input{
-		Foo: aws.String("bar"),
+	input := &InputService15TestShapeInputShape{
+		BoolQuery: aws.Bool(true),
 	}
 	req, _ := svc.InputService15TestCaseOperation1Request(input)
 	r := req.HTTPRequest
@@ -4531,22 +4720,36 @@ func TestInputService15ProtocolTestStringPayloadCase1(t *testing.T) {
 	restxml.Build(req)
 	assert.NoError(t, req.Error)
 
-	// assert body
-	assert.NotNil(t, r.Body)
-	body := util.SortXML(r.Body)
-	assert.Equal(t, `bar`, util.Trim(string(body)))
-
 	// assert URL
-	awstesting.AssertURL(t, "https://test/", r.URL.String())
+	awstesting.AssertURL(t, "https://test/path?bool-query=true", r.URL.String())
 
 	// assert headers
 
 }
 
-func TestInputService16ProtocolTestBlobPayloadCase1(t *testing.T) {
+func TestInputService15ProtocolTestBooleanInQuerystringCase2(t *testing.T) {
+	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService15TestShapeInputShape{
+		BoolQuery: aws.Bool(false),
+	}
+	req, _ := svc.InputService15TestCaseOperation2Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restxml.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/path?bool-query=false", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService16ProtocolTestStringPayloadCase1(t *testing.T) {
 	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputShape{
-		Foo: []byte("bar"),
+	input := &InputService16TestShapeInputService16TestCaseOperation1Input{
+		Foo: aws.String("bar"),
 	}
 	req, _ := svc.InputService16TestCaseOperation1Request(input)
 	r := req.HTTPRequest
@@ -4567,29 +4770,10 @@ func TestInputService16ProtocolTestBlobPayloadCase1(t *testing.T) {
 
 }
 
-func TestInputService16ProtocolTestBlobPayloadCase2(t *testing.T) {
-	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputShape{}
-	req, _ := svc.InputService16TestCaseOperation2Request(input)
-	r := req.HTTPRequest
-
-	// build request
-	restxml.Build(req)
-	assert.NoError(t, req.Error)
-
-	// assert URL
-	awstesting.AssertURL(t, "https://test/", r.URL.String())
-
-	// assert headers
-
-}
-
-func TestInputService17ProtocolTestStructurePayloadCase1(t *testing.T) {
+func TestInputService17ProtocolTestBlobPayloadCase1(t *testing.T) {
 	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 	input := &InputService17TestShapeInputShape{
-		Foo: &InputService17TestShapeFooShape{
-			Baz: aws.String("bar"),
-		},
+		Foo: []byte("bar"),
 	}
 	req, _ := svc.InputService17TestCaseOperation1Request(input)
 	r := req.HTTPRequest
@@ -4601,7 +4785,7 @@ func TestInputService17ProtocolTestStructurePayloadCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)), InputService17TestShapeInputShape{})
+	assert.Equal(t, `bar`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -4610,7 +4794,7 @@ func TestInputService17ProtocolTestStructurePayloadCase1(t *testing.T) {
 
 }
 
-func TestInputService17ProtocolTestStructurePayloadCase2(t *testing.T) {
+func TestInputService17ProtocolTestBlobPayloadCase2(t *testing.T) {
 	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 	input := &InputService17TestShapeInputShape{}
 	req, _ := svc.InputService17TestCaseOperation2Request(input)
@@ -4627,55 +4811,11 @@ func TestInputService17ProtocolTestStructurePayloadCase2(t *testing.T) {
 
 }
 
-func TestInputService17ProtocolTestStructurePayloadCase3(t *testing.T) {
-	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService17TestShapeInputShape{
-		Foo: &InputService17TestShapeFooShape{},
-	}
-	req, _ := svc.InputService17TestCaseOperation3Request(input)
-	r := req.HTTPRequest
-
-	// build request
-	restxml.Build(req)
-	assert.NoError(t, req.Error)
-
-	// assert body
-	assert.NotNil(t, r.Body)
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<foo></foo>`, util.Trim(string(body)), InputService17TestShapeInputShape{})
-
-	// assert URL
-	awstesting.AssertURL(t, "https://test/", r.URL.String())
-
-	// assert headers
-
-}
-
-func TestInputService17ProtocolTestStructurePayloadCase4(t *testing.T) {
-	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService17TestShapeInputShape{}
-	req, _ := svc.InputService17TestCaseOperation4Request(input)
-	r := req.HTTPRequest
-
-	// build request
-	restxml.Build(req)
-	assert.NoError(t, req.Error)
-
-	// assert URL
-	awstesting.AssertURL(t, "https://test/", r.URL.String())
-
-	// assert headers
-
-}
-
-func TestInputService18ProtocolTestXMLAttributeCase1(t *testing.T) {
+func TestInputService18ProtocolTestStructurePayloadCase1(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputService18TestCaseOperation1Input{
-		Grant: &InputService18TestShapeGrant{
-			Grantee: &InputService18TestShapeGrantee{
-				EmailAddress: aws.String("foo@example.com"),
-				Type:         aws.String("CanonicalUser"),
-			},
+	input := &InputService18TestShapeInputShape{
+		Foo: &InputService18TestShapeFooShape{
+			Baz: aws.String("bar"),
 		},
 	}
 	req, _ := svc.InputService18TestCaseOperation1Request(input)
@@ -4688,7 +4828,7 @@ func TestInputService18ProtocolTestXMLAttributeCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<Grant xmlns:_xmlns="xmlns" _xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="CanonicalUser"><Grantee><EmailAddress>foo@example.com</EmailAddress></Grantee></Grant>`, util.Trim(string(body)), InputService18TestShapeInputService18TestCaseOperation1Input{})
+	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)), InputService18TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -4697,13 +4837,100 @@ func TestInputService18ProtocolTestXMLAttributeCase1(t *testing.T) {
 
 }
 
-func TestInputService19ProtocolTestGreedyKeysCase1(t *testing.T) {
+func TestInputService18ProtocolTestStructurePayloadCase2(t *testing.T) {
+	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService18TestShapeInputShape{}
+	req, _ := svc.InputService18TestCaseOperation2Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restxml.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService18ProtocolTestStructurePayloadCase3(t *testing.T) {
+	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService18TestShapeInputShape{
+		Foo: &InputService18TestShapeFooShape{},
+	}
+	req, _ := svc.InputService18TestCaseOperation3Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restxml.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert body
+	assert.NotNil(t, r.Body)
+	body := util.SortXML(r.Body)
+	awstesting.AssertXML(t, `<foo></foo>`, util.Trim(string(body)), InputService18TestShapeInputShape{})
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService18ProtocolTestStructurePayloadCase4(t *testing.T) {
+	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService18TestShapeInputShape{}
+	req, _ := svc.InputService18TestCaseOperation4Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restxml.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService19ProtocolTestXMLAttributeCase1(t *testing.T) {
 	svc := NewInputService19ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 	input := &InputService19TestShapeInputService19TestCaseOperation1Input{
+		Grant: &InputService19TestShapeGrant{
+			Grantee: &InputService19TestShapeGrantee{
+				EmailAddress: aws.String("foo@example.com"),
+				Type:         aws.String("CanonicalUser"),
+			},
+		},
+	}
+	req, _ := svc.InputService19TestCaseOperation1Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restxml.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert body
+	assert.NotNil(t, r.Body)
+	body := util.SortXML(r.Body)
+	awstesting.AssertXML(t, `<Grant xmlns:_xmlns="xmlns" _xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="CanonicalUser"><Grantee><EmailAddress>foo@example.com</EmailAddress></Grantee></Grant>`, util.Trim(string(body)), InputService19TestShapeInputService19TestCaseOperation1Input{})
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService20ProtocolTestGreedyKeysCase1(t *testing.T) {
+	svc := NewInputService20ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService20TestShapeInputService20TestCaseOperation1Input{
 		Bucket: aws.String("my/bucket"),
 		Key:    aws.String("testing /123"),
 	}
-	req, _ := svc.InputService19TestCaseOperation1Request(input)
+	req, _ := svc.InputService20TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4717,10 +4944,10 @@ func TestInputService19ProtocolTestGreedyKeysCase1(t *testing.T) {
 
 }
 
-func TestInputService20ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase1(t *testing.T) {
-	svc := NewInputService20ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService20TestShapeInputShape{}
-	req, _ := svc.InputService20TestCaseOperation1Request(input)
+func TestInputService21ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase1(t *testing.T) {
+	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService21TestShapeInputShape{}
+	req, _ := svc.InputService21TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4734,12 +4961,12 @@ func TestInputService20ProtocolTestOmitsNullQueryParamsButSerializesEmptyStrings
 
 }
 
-func TestInputService20ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase2(t *testing.T) {
-	svc := NewInputService20ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService20TestShapeInputShape{
+func TestInputService21ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase2(t *testing.T) {
+	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService21TestShapeInputShape{
 		Foo: aws.String(""),
 	}
-	req, _ := svc.InputService20TestCaseOperation2Request(input)
+	req, _ := svc.InputService21TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4753,14 +4980,14 @@ func TestInputService20ProtocolTestOmitsNullQueryParamsButSerializesEmptyStrings
 
 }
 
-func TestInputService21ProtocolTestRecursiveShapesCase1(t *testing.T) {
-	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService21TestShapeInputShape{
-		RecursiveStruct: &InputService21TestShapeRecursiveStructType{
+func TestInputService22ProtocolTestRecursiveShapesCase1(t *testing.T) {
+	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService22TestShapeInputShape{
+		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
 	}
-	req, _ := svc.InputService21TestCaseOperation1Request(input)
+	req, _ := svc.InputService22TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4770,7 +4997,7 @@ func TestInputService21ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService21TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -4779,16 +5006,16 @@ func TestInputService21ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 }
 
-func TestInputService21ProtocolTestRecursiveShapesCase2(t *testing.T) {
-	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService21TestShapeInputShape{
-		RecursiveStruct: &InputService21TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService21TestShapeRecursiveStructType{
+func TestInputService22ProtocolTestRecursiveShapesCase2(t *testing.T) {
+	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService22TestShapeInputShape{
+		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
 			},
 		},
 	}
-	req, _ := svc.InputService21TestCaseOperation2Request(input)
+	req, _ := svc.InputService22TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4798,7 +5025,7 @@ func TestInputService21ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService21TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -4807,20 +5034,20 @@ func TestInputService21ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 }
 
-func TestInputService21ProtocolTestRecursiveShapesCase3(t *testing.T) {
-	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService21TestShapeInputShape{
-		RecursiveStruct: &InputService21TestShapeRecursiveStructType{
-			RecursiveStruct: &InputService21TestShapeRecursiveStructType{
-				RecursiveStruct: &InputService21TestShapeRecursiveStructType{
-					RecursiveStruct: &InputService21TestShapeRecursiveStructType{
+func TestInputService22ProtocolTestRecursiveShapesCase3(t *testing.T) {
+	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService22TestShapeInputShape{
+		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
+			RecursiveStruct: &InputService22TestShapeRecursiveStructType{
+				RecursiveStruct: &InputService22TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 						NoRecurse: aws.String("foo"),
 					},
 				},
 			},
 		},
 	}
-	req, _ := svc.InputService21TestCaseOperation3Request(input)
+	req, _ := svc.InputService22TestCaseOperation3Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4830,7 +5057,7 @@ func TestInputService21ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService21TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -4839,11 +5066,11 @@ func TestInputService21ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 }
 
-func TestInputService21ProtocolTestRecursiveShapesCase4(t *testing.T) {
-	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService21TestShapeInputShape{
-		RecursiveStruct: &InputService21TestShapeRecursiveStructType{
-			RecursiveList: []*InputService21TestShapeRecursiveStructType{
+func TestInputService22ProtocolTestRecursiveShapesCase4(t *testing.T) {
+	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService22TestShapeInputShape{
+		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
+			RecursiveList: []*InputService22TestShapeRecursiveStructType{
 				{
 					NoRecurse: aws.String("foo"),
 				},
@@ -4853,7 +5080,7 @@ func TestInputService21ProtocolTestRecursiveShapesCase4(t *testing.T) {
 			},
 		},
 	}
-	req, _ := svc.InputService21TestCaseOperation4Request(input)
+	req, _ := svc.InputService22TestCaseOperation4Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4863,7 +5090,7 @@ func TestInputService21ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService21TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -4872,23 +5099,23 @@ func TestInputService21ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 }
 
-func TestInputService21ProtocolTestRecursiveShapesCase5(t *testing.T) {
-	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService21TestShapeInputShape{
-		RecursiveStruct: &InputService21TestShapeRecursiveStructType{
-			RecursiveList: []*InputService21TestShapeRecursiveStructType{
+func TestInputService22ProtocolTestRecursiveShapesCase5(t *testing.T) {
+	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService22TestShapeInputShape{
+		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
+			RecursiveList: []*InputService22TestShapeRecursiveStructType{
 				{
 					NoRecurse: aws.String("foo"),
 				},
 				{
-					RecursiveStruct: &InputService21TestShapeRecursiveStructType{
+					RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 						NoRecurse: aws.String("bar"),
 					},
 				},
 			},
 		},
 	}
-	req, _ := svc.InputService21TestCaseOperation5Request(input)
+	req, _ := svc.InputService22TestCaseOperation5Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4898,7 +5125,7 @@ func TestInputService21ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></RecursiveStruct></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService21TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></RecursiveStruct></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -4907,11 +5134,11 @@ func TestInputService21ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 }
 
-func TestInputService21ProtocolTestRecursiveShapesCase6(t *testing.T) {
-	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService21TestShapeInputShape{
-		RecursiveStruct: &InputService21TestShapeRecursiveStructType{
-			RecursiveMap: map[string]*InputService21TestShapeRecursiveStructType{
+func TestInputService22ProtocolTestRecursiveShapesCase6(t *testing.T) {
+	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService22TestShapeInputShape{
+		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
+			RecursiveMap: map[string]*InputService22TestShapeRecursiveStructType{
 				"bar": {
 					NoRecurse: aws.String("bar"),
 				},
@@ -4921,7 +5148,7 @@ func TestInputService21ProtocolTestRecursiveShapesCase6(t *testing.T) {
 			},
 		},
 	}
-	req, _ := svc.InputService21TestCaseOperation6Request(input)
+	req, _ := svc.InputService22TestCaseOperation6Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4931,7 +5158,7 @@ func TestInputService21ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveMap xmlns="https://foo/"><entry xmlns="https://foo/"><key xmlns="https://foo/">foo</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></value></entry><entry xmlns="https://foo/"><key xmlns="https://foo/">bar</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></value></entry></RecursiveMap></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService21TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveMap xmlns="https://foo/"><entry xmlns="https://foo/"><key xmlns="https://foo/">foo</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></value></entry><entry xmlns="https://foo/"><key xmlns="https://foo/">bar</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></value></entry></RecursiveMap></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -4940,12 +5167,12 @@ func TestInputService21ProtocolTestRecursiveShapesCase6(t *testing.T) {
 
 }
 
-func TestInputService22ProtocolTestTimestampInHeaderCase1(t *testing.T) {
-	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService22TestShapeInputService22TestCaseOperation1Input{
+func TestInputService23ProtocolTestTimestampInHeaderCase1(t *testing.T) {
+	svc := NewInputService23ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService23TestShapeInputService23TestCaseOperation1Input{
 		TimeArgInHeader: aws.Time(time.Unix(1422172800, 0)),
 	}
-	req, _ := svc.InputService22TestCaseOperation1Request(input)
+	req, _ := svc.InputService23TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4960,12 +5187,12 @@ func TestInputService22ProtocolTestTimestampInHeaderCase1(t *testing.T) {
 
 }
 
-func TestInputService23ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
-	svc := NewInputService23ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService23TestShapeInputShape{
+func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
+	svc := NewInputService24ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService24TestShapeInputShape{
 		Token: aws.String("abc123"),
 	}
-	req, _ := svc.InputService23TestCaseOperation1Request(input)
+	req, _ := svc.InputService24TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4975,7 +5202,7 @@ func TestInputService23ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<Token>abc123</Token>`, util.Trim(string(body)), InputService23TestShapeInputShape{})
+	awstesting.AssertXML(t, `<InputShape><Token>abc123</Token></InputShape>`, util.Trim(string(body)), InputService24TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -4984,10 +5211,10 @@ func TestInputService23ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 
 }
 
-func TestInputService23ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
-	svc := NewInputService23ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService23TestShapeInputShape{}
-	req, _ := svc.InputService23TestCaseOperation2Request(input)
+func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
+	svc := NewInputService24ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService24TestShapeInputShape{}
+	req, _ := svc.InputService24TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
 	// build request
@@ -4997,7 +5224,7 @@ func TestInputService23ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<Token>00000000-0000-4000-8000-000000000000</Token>`, util.Trim(string(body)), InputService23TestShapeInputShape{})
+	awstesting.AssertXML(t, `<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>`, util.Trim(string(body)), InputService24TestShapeInputShape{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())


### PR DESCRIPTION
This change fixes an issue regarding lists with a list name not being used.
In addition, this regenerates and updates the protocol tests