### PR TITLE
private/model/api: This adds support for jsonvalue trait for restjson

### DIFF
--- a/aws/jsonvalue.go
+++ b/aws/jsonvalue.go
@@ -1,0 +1,11 @@
+package aws
+
+// JSONValue is a representation of a grab bag type that will be marshaled
+// into a json string. This type can be used just like any other map.
+//
+//	Example:
+//	values := JSONValue{
+//		"Foo": "Bar",
+//	}
+//	values["Baz"] = "Qux"
+type JSONValue map[string]interface{}

--- a/models/protocol_tests/input/rest-json.json
+++ b/models/protocol_tests/input/rest-json.json
@@ -1300,5 +1300,67 @@
         }
       }
     ]
+  },
+  {
+    "description": "JSON value trait",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Attr": {
+            "shape": "StringType",
+              "jsonvalue": true,
+              "location": "header",
+              "locationName": "X-Amz-Foo"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Attr": {"Foo":"Bar"}
+        },
+        "serialized": {
+          "uri": "/",
+          "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
+          "body": ""
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+        },
+        "serialized": {
+          "uri": "/",
+          "headers": {},
+          "body": ""
+        }
+      }
+    ]
   }
 ]

--- a/models/protocol_tests/output/query.json
+++ b/models/protocol_tests/output/query.json
@@ -757,6 +757,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -767,7 +768,7 @@
         "response": {
           "status_code": 200,
           "headers": {},
-          "body": "<OperationNameResponse><Foo/><RequestId>requestid</RequestId></OperationNameResponse>"
+          "body": "<OperationNameResponse><OperationNameResult><Foo/></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"
         }
       }
     ]

--- a/models/protocol_tests/output/rest-json.json
+++ b/models/protocol_tests/output/rest-json.json
@@ -604,5 +604,45 @@
         }
       }
     ]
+  },
+  {
+    "description": "JSON value trait",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Attr": {
+            "shape": "StringType",
+              "jsonvalue": true,
+              "location": "header",
+              "locationName": "X-Amz-Foo"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Attr": {"Foo":"Bar"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
+          "body": ""
+        }
+      }
+    ]
   }
 ]

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -638,6 +638,12 @@ func resolveShapeValidations(s *Shape, ancestry ...*Shape) {
 	ancestry = append(ancestry, s)
 	for _, name := range children {
 		ref := s.MemberRefs[name]
+		// Since this is a grab bag we will just continue since
+		// we can't validate because we don't know the valued shape.
+		if ref.JSONValue {
+			continue
+		}
+
 		nestedShape := ref.Shape.NestedShape()
 
 		var v *ShapeValidation

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -271,6 +271,11 @@ func (e *example) traverseAny(s *Shape, required, payload bool) string {
 		str = e.traverseList(s, required, payload)
 	case "map":
 		str = e.traverseMap(s, required, payload)
+	case "jsonvalue":
+		str = "aws.JSONValue{\"key\": \"value\"}"
+		if required {
+			str += " // Required"
+		}
 	default:
 		str = e.traverseScalar(s, required, payload)
 	}

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -70,6 +70,14 @@ type referenceResolver struct {
 	visited map[*ShapeRef]bool
 }
 
+var jsonvalueShape = &Shape{
+	ShapeName: "JSONValue",
+	Type:      "jsonvalue",
+	ValueRef: ShapeRef{
+		JSONValue: true,
+	},
+}
+
 // resolveReference updates a shape reference to reference the API and
 // its shape definition. All other nested references are also resolved.
 func (r *referenceResolver) resolveReference(ref *ShapeRef) {
@@ -78,6 +86,11 @@ func (r *referenceResolver) resolveReference(ref *ShapeRef) {
 	}
 
 	if shape, ok := r.API.Shapes[ref.ShapeName]; ok {
+		if ref.JSONValue {
+			ref.ShapeName = "JSONValue"
+			r.API.Shapes[ref.ShapeName] = jsonvalueShape
+		}
+
 		ref.API = r.API   // resolve reference back to API
 		ref.Shape = shape // resolve shape reference
 

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -29,6 +29,7 @@ type ShapeRef struct {
 	XMLNamespace     XMLInfo
 	Payload          string
 	IdempotencyToken bool `json:"idempotencyToken"`
+	JSONValue        bool `json:"jsonvalue"`
 	Deprecated       bool `json:"deprecated"`
 
 	OrigShapeName string `json:"-"`
@@ -147,11 +148,15 @@ func (s *Shape) GoTypeWithPkgName() string {
 // GenAccessors returns if the shape's reference should have setters generated.
 func (s *ShapeRef) UseIndirection() bool {
 	switch s.Shape.Type {
-	case "map", "list", "blob", "structure":
+	case "map", "list", "blob", "structure", "jsonvalue":
 		return false
 	}
 
 	if s.Streaming || s.Shape.Streaming {
+		return false
+	}
+
+	if s.JSONValue {
 		return false
 	}
 
@@ -181,6 +186,11 @@ func (s *Shape) GoStructType(name string, ref *ShapeRef) string {
 
 		s.API.imports["io"] = true
 		return rtype
+	}
+
+	if ref.JSONValue {
+		s.API.imports["github.com/aws/aws-sdk-go/aws"] = true
+		return "aws.JSONValue"
 	}
 
 	for _, v := range s.Validations {
@@ -235,6 +245,8 @@ func goType(s *Shape, withPkgName bool) string {
 		return "*" + s.ShapeName
 	case "map":
 		return "map[string]" + s.ValueRef.GoType()
+	case "jsonvalue":
+		return "aws.JSONValue"
 	case "list":
 		return "[]" + s.MemberRef.GoType()
 	case "boolean":
@@ -343,6 +355,7 @@ func (ref *ShapeRef) GoTags(toplevel bool, isRequired bool) string {
 	if ref.Deprecated || ref.Shape.Deprecated {
 		tags = append(tags, ShapeTag{"deprecated", "true"})
 	}
+
 	// All shapes have a type
 	tags = append(tags, ShapeTag{"type", ref.Shape.Type})
 

--- a/private/protocol/ec2query/build_test.go
+++ b/private/protocol/ec2query/build_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/ec2query/unmarshal_test.go
+++ b/private/protocol/ec2query/unmarshal_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}
@@ -2371,7 +2373,7 @@ func TestOutputService14ProtocolTestNamedMapCase1(t *testing.T) {
 func TestOutputService15ProtocolTestEmptyStringCase1(t *testing.T) {
 	svc := NewOutputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 
-	buf := bytes.NewReader([]byte("<OperationNameResponse><Foo/><RequestId>requestid</RequestId></OperationNameResponse>"))
+	buf := bytes.NewReader([]byte("<OperationNameResponse><OperationNameResult><Foo/></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"))
 	req, out := svc.OutputService15TestCaseOperation1Request(nil)
 	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
 

--- a/private/protocol/rest/build.go
+++ b/private/protocol/rest/build.go
@@ -4,6 +4,7 @@ package rest
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -82,8 +83,12 @@ func buildLocationElements(r *request.Request, v reflect.Value, buildGETQuery bo
 			if name == "" {
 				name = field.Name
 			}
-			if m.Kind() == reflect.Ptr {
+			if kind := m.Kind(); kind == reflect.Ptr {
 				m = m.Elem()
+			} else if kind == reflect.Interface {
+				if !m.Elem().IsValid() {
+					continue
+				}
 			}
 			if !m.IsValid() {
 				continue
@@ -95,16 +100,16 @@ func buildLocationElements(r *request.Request, v reflect.Value, buildGETQuery bo
 			var err error
 			switch field.Tag.Get("location") {
 			case "headers": // header maps
-				err = buildHeaderMap(&r.HTTPRequest.Header, m, field.Tag.Get("locationName"))
+				err = buildHeaderMap(&r.HTTPRequest.Header, m, field.Tag)
 			case "header":
-				err = buildHeader(&r.HTTPRequest.Header, m, name)
+				err = buildHeader(&r.HTTPRequest.Header, m, name, field.Tag)
 			case "uri":
-				err = buildURI(r.HTTPRequest.URL, m, name)
+				err = buildURI(r.HTTPRequest.URL, m, name, field.Tag)
 			case "querystring":
-				err = buildQueryString(query, m, name)
+				err = buildQueryString(query, m, name, field.Tag)
 			default:
 				if buildGETQuery {
-					err = buildQueryString(query, m, name)
+					err = buildQueryString(query, m, name, field.Tag)
 				}
 			}
 			r.Error = err
@@ -145,8 +150,8 @@ func buildBody(r *request.Request, v reflect.Value) {
 	}
 }
 
-func buildHeader(header *http.Header, v reflect.Value, name string) error {
-	str, err := convertType(v)
+func buildHeader(header *http.Header, v reflect.Value, name string, tag reflect.StructTag) error {
+	str, err := convertType(v, tag)
 	if err == errValueNotSet {
 		return nil
 	} else if err != nil {
@@ -158,9 +163,10 @@ func buildHeader(header *http.Header, v reflect.Value, name string) error {
 	return nil
 }
 
-func buildHeaderMap(header *http.Header, v reflect.Value, prefix string) error {
+func buildHeaderMap(header *http.Header, v reflect.Value, tag reflect.StructTag) error {
+	prefix := tag.Get("locationName")
 	for _, key := range v.MapKeys() {
-		str, err := convertType(v.MapIndex(key))
+		str, err := convertType(v.MapIndex(key), tag)
 		if err == errValueNotSet {
 			continue
 		} else if err != nil {
@@ -173,8 +179,8 @@ func buildHeaderMap(header *http.Header, v reflect.Value, prefix string) error {
 	return nil
 }
 
-func buildURI(u *url.URL, v reflect.Value, name string) error {
-	value, err := convertType(v)
+func buildURI(u *url.URL, v reflect.Value, name string, tag reflect.StructTag) error {
+	value, err := convertType(v, tag)
 	if err == errValueNotSet {
 		return nil
 	} else if err != nil {
@@ -190,7 +196,7 @@ func buildURI(u *url.URL, v reflect.Value, name string) error {
 	return nil
 }
 
-func buildQueryString(query url.Values, v reflect.Value, name string) error {
+func buildQueryString(query url.Values, v reflect.Value, name string, tag reflect.StructTag) error {
 	switch value := v.Interface().(type) {
 	case []*string:
 		for _, item := range value {
@@ -207,7 +213,7 @@ func buildQueryString(query url.Values, v reflect.Value, name string) error {
 			}
 		}
 	default:
-		str, err := convertType(v)
+		str, err := convertType(v, tag)
 		if err == errValueNotSet {
 			return nil
 		} else if err != nil {
@@ -246,7 +252,7 @@ func EscapePath(path string, encodeSep bool) string {
 	return buf.String()
 }
 
-func convertType(v reflect.Value) (string, error) {
+func convertType(v reflect.Value, tag reflect.StructTag) (string, error) {
 	v = reflect.Indirect(v)
 	if !v.IsValid() {
 		return "", errValueNotSet
@@ -266,6 +272,16 @@ func convertType(v reflect.Value) (string, error) {
 		str = strconv.FormatFloat(value, 'f', -1, 64)
 	case time.Time:
 		str = value.UTC().Format(RFC822)
+	case aws.JSONValue:
+		b, err := json.Marshal(value)
+		if err != nil {
+			return "", err
+		}
+		if tag.Get("location") == "header" {
+			str = base64.StdEncoding.EncodeToString(b)
+		} else {
+			str = string(b)
+		}
 	default:
 		err := fmt.Errorf("Unsupported value for param %v (%s)", v.Interface(), v.Type())
 		return "", err

--- a/private/protocol/rest/unmarshal.go
+++ b/private/protocol/rest/unmarshal.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -111,7 +113,7 @@ func unmarshalLocationElements(r *request.Request, v reflect.Value) {
 			case "statusCode":
 				unmarshalStatusCode(m, r.HTTPResponse.StatusCode)
 			case "header":
-				err := unmarshalHeader(m, r.HTTPResponse.Header.Get(name))
+				err := unmarshalHeader(m, r.HTTPResponse.Header.Get(name), field.Tag)
 				if err != nil {
 					r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 					break
@@ -158,8 +160,8 @@ func unmarshalHeaderMap(r reflect.Value, headers http.Header, prefix string) err
 	return nil
 }
 
-func unmarshalHeader(v reflect.Value, header string) error {
-	if !v.IsValid() || (header == "" && v.Elem().Kind() != reflect.String) {
+func unmarshalHeader(v reflect.Value, header string, tag reflect.StructTag) error {
+	if !v.IsValid() || (tag.Get("type") != "jsonvalue" && header == "" && v.Elem().Kind() != reflect.String) {
 		return nil
 	}
 
@@ -196,6 +198,22 @@ func unmarshalHeader(v reflect.Value, header string) error {
 			return err
 		}
 		v.Set(reflect.ValueOf(&t))
+	case aws.JSONValue:
+		b := []byte(header)
+		var err error
+		if tag.Get("location") == "header" {
+			b, err = base64.StdEncoding.DecodeString(header)
+			if err != nil {
+				return err
+			}
+		}
+
+		m := aws.JSONValue{}
+		err = json.Unmarshal(b, &m)
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.ValueOf(m))
 	default:
 		err := fmt.Errorf("Unsupported value for param %v (%s)", v.Interface(), v.Type())
 		return err

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}
@@ -3503,6 +3505,195 @@ func (s *InputService20TestShapeInputShape) SetToken(v string) *InputService20Te
 	return s
 }
 
+// The service client's operations are safe to be used concurrently.
+// It is not safe to mutate any of the client's properties though.
+type InputService21ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the InputService21ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a InputService21ProtocolTest client from just a session.
+//     svc := inputservice21protocoltest.New(mySession)
+//
+//     // Create a InputService21ProtocolTest client with additional configuration
+//     svc := inputservice21protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewInputService21ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *InputService21ProtocolTest {
+	c := p.ClientConfig("inputservice21protocoltest", cfgs...)
+	return newInputService21ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newInputService21ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *InputService21ProtocolTest {
+	svc := &InputService21ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "inputservice21protocoltest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "2014-01-01",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restjson.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restjson.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restjson.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restjson.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a InputService21ProtocolTest operation and runs any
+// custom request initialization.
+func (c *InputService21ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opInputService21TestCaseOperation1 = "OperationName"
+
+// InputService21TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the InputService21TestCaseOperation1 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService21TestCaseOperation1 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService21TestCaseOperation1 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService21TestCaseOperation1Request method.
+//    req, resp := client.InputService21TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation1Request(input *InputService21TestShapeInputShape) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opInputService21TestCaseOperation1,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InputService21TestShapeInputShape{}
+	}
+
+	output = &InputService21TestShapeInputService21TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService21TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService21TestCaseOperation1 for usage and error information.
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation1(input *InputService21TestShapeInputShape) (*InputService21TestShapeInputService21TestCaseOperation1Output, error) {
+	req, out := c.InputService21TestCaseOperation1Request(input)
+	err := req.Send()
+	return out, err
+}
+
+const opInputService21TestCaseOperation2 = "OperationName"
+
+// InputService21TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService21TestCaseOperation2 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See InputService21TestCaseOperation2 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the InputService21TestCaseOperation2 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the InputService21TestCaseOperation2Request method.
+//    req, resp := client.InputService21TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation2Request(input *InputService21TestShapeInputShape) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService21TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InputService21TestShapeInputShape{}
+	}
+
+	output = &InputService21TestShapeInputService21TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService21TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService21TestCaseOperation2 for usage and error information.
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation2(input *InputService21TestShapeInputShape) (*InputService21TestShapeInputService21TestCaseOperation2Output, error) {
+	req, out := c.InputService21TestCaseOperation2Request(input)
+	err := req.Send()
+	return out, err
+}
+
+type InputService21TestShapeInputService21TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService21TestShapeInputService21TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService21TestShapeInputShape struct {
+	_ struct{} `type:"structure"`
+
+	Attr aws.JSONValue `location:"header" locationName:"X-Amz-Foo" type:"jsonvalue"`
+}
+
+// SetAttr sets the Attr field's value.
+func (s *InputService21TestShapeInputShape) SetAttr(v aws.JSONValue) *InputService21TestShapeInputShape {
+	s.Attr = v
+	return s
+}
+
 //
 // Tests begin here
 //
@@ -4248,6 +4439,42 @@ func TestInputService20ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService21ProtocolTestJSONValueTraitCase1(t *testing.T) {
+	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService21TestShapeInputShape{}
+	input.Attr = aws.JSONValue{"Foo": "Bar"}
+	req, _ := svc.InputService21TestCaseOperation1Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restjson.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
+
+	// assert headers
+	assert.Equal(t, "eyJGb28iOiJCYXIifQ==", r.Header.Get("X-Amz-Foo"))
+
+}
+
+func TestInputService21ProtocolTestJSONValueTraitCase2(t *testing.T) {
+	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService21TestShapeInputShape{}
+	req, _ := svc.InputService21TestCaseOperation2Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restjson.Build(req)
+	assert.NoError(t, req.Error)
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
 

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}
@@ -1580,6 +1582,131 @@ func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetStr
 	return s
 }
 
+// The service client's operations are safe to be used concurrently.
+// It is not safe to mutate any of the client's properties though.
+type OutputService12ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the OutputService12ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a OutputService12ProtocolTest client from just a session.
+//     svc := outputservice12protocoltest.New(mySession)
+//
+//     // Create a OutputService12ProtocolTest client with additional configuration
+//     svc := outputservice12protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewOutputService12ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *OutputService12ProtocolTest {
+	c := p.ClientConfig("outputservice12protocoltest", cfgs...)
+	return newOutputService12ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newOutputService12ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *OutputService12ProtocolTest {
+	svc := &OutputService12ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "outputservice12protocoltest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restjson.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restjson.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restjson.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restjson.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a OutputService12ProtocolTest operation and runs any
+// custom request initialization.
+func (c *OutputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opOutputService12TestCaseOperation1 = "OperationName"
+
+// OutputService12TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the OutputService12TestCaseOperation1 operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See OutputService12TestCaseOperation1 for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the OutputService12TestCaseOperation1 method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the OutputService12TestCaseOperation1Request method.
+//    req, resp := client.OutputService12TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1Request(input *OutputService12TestShapeOutputService12TestCaseOperation1Input) (req *request.Request, output *OutputService12TestShapeOutputService12TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:     opOutputService12TestCaseOperation1,
+		HTTPPath: "/",
+	}
+
+	if input == nil {
+		input = &OutputService12TestShapeOutputService12TestCaseOperation1Input{}
+	}
+
+	output = &OutputService12TestShapeOutputService12TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// OutputService12TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation OutputService12TestCaseOperation1 for usage and error information.
+func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1(input *OutputService12TestShapeOutputService12TestCaseOperation1Input) (*OutputService12TestShapeOutputService12TestCaseOperation1Output, error) {
+	req, out := c.OutputService12TestCaseOperation1Request(input)
+	err := req.Send()
+	return out, err
+}
+
+type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+}
+
+type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
+	Attr aws.JSONValue `location:"header" locationName:"X-Amz-Foo" type:"jsonvalue"`
+}
+
+// SetAttr sets the Attr field's value.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetAttr(v aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
+	s.Attr = v
+	return s
+}
+
 //
 // Tests begin here
 //
@@ -1830,4 +1957,24 @@ func TestOutputService11ProtocolTestStreamingPayloadCase1(t *testing.T) {
 	assert.NotNil(t, out) // ensure out variable is used
 	assert.Equal(t, "abc", string(out.Stream))
 
+}
+
+func TestOutputService12ProtocolTestJSONValueTraitCase1(t *testing.T) {
+	svc := NewOutputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+
+	buf := bytes.NewReader([]byte(""))
+	req, out := svc.OutputService12TestCaseOperation1Request(nil)
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+
+	// set headers
+	req.HTTPResponse.Header.Set("X-Amz-Foo", "eyJGb28iOiJCYXIifQ==")
+
+	// unmarshal response
+	restjson.UnmarshalMeta(req)
+	restjson.Unmarshal(req)
+	assert.NoError(t, req.Error)
+
+	// assert response
+	assert.NotNil(t, out) // ensure out variable is used
+	reflect.DeepEqual(out.Attr, map[string]interface{}{"Foo": "Bar"})
 }

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var _ = url.Values{}
 var _ = io.EOF
 var _ = aws.String
 var _ = fmt.Println
+var _ = reflect.Value{}
 
 func init() {
 	protocol.RandReader = &awstesting.ZeroReader{}


### PR DESCRIPTION
The JSON value trait will be a way of signifying unstructured header types. This modifies the `restjson` protocol to support the type. When encountering this tag field on marshaling, `jsonvalue:"true"`, we will `json` and `base64 encode the object.