### PR TITLE
aws/session: Add support for side loaded CA bundles

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,0 +1,4 @@
+SDK Enhancement
+===
+* `aws/session`: Add support for side loaded CA bundles (#1117)
+  * Adds supports for side loading Certificate Authority bundle files to the SDK using AWS_CA_BUNDLE environment variable or CustomCABundle session option.

--- a/aws/session/custom_ca_bundle_test.go
+++ b/aws/session/custom_ca_bundle_test.go
@@ -196,15 +196,12 @@ func TestNewSession_WithCustomCABundle_TransportSet(t *testing.T) {
 			HTTPClient: &http.Client{
 				Transport: &http.Transport{
 					Proxy: http.ProxyFromEnvironment,
-					DialContext: (&net.Dialer{
+					Dial: (&net.Dialer{
 						Timeout:   30 * time.Second,
 						KeepAlive: 30 * time.Second,
 						DualStack: true,
-					}).DialContext,
-					MaxIdleConns:          100,
-					IdleConnTimeout:       90 * time.Second,
-					TLSHandshakeTimeout:   10 * time.Second,
-					ExpectContinueTimeout: 1 * time.Second,
+					}).Dial,
+					TLSHandshakeTimeout: 2 * time.Second,
 				},
 			},
 		},

--- a/aws/session/custom_ca_bundle_test.go
+++ b/aws/session/custom_ca_bundle_test.go
@@ -1,0 +1,212 @@
+package session
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTLSServer(cert, key []byte, done <-chan struct{}) (*httptest.Server, error) {
+	c, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, err
+	}
+
+	s := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	s.TLS = &tls.Config{
+		Certificates: []tls.Certificate{c},
+	}
+	s.TLS.BuildNameToCertificate()
+	s.StartTLS()
+
+	go func() {
+		<-done
+		s.Close()
+	}()
+
+	return s, nil
+}
+
+func setupTestCAFile(b []byte) (string, error) {
+	bundleFile, err := ioutil.TempFile(os.TempDir(), "aws-sdk-go-session-test")
+	if err != nil {
+		return "", err
+	}
+
+	_, err = bundleFile.Write(b)
+	if err != nil {
+		return "", err
+	}
+
+	defer bundleFile.Close()
+	return bundleFile.Name(), nil
+}
+
+func TestNewSession_WithCustomCABundle_Env(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	done := make(chan struct{})
+	server, err := createTLSServer(testTLSBundleCert, testTLSBundleKey, done)
+	assert.NoError(t, err)
+
+	// Write bundle to file
+	caFilename, err := setupTestCAFile(testTLSBundleCA)
+	defer func() {
+		os.Remove(caFilename)
+	}()
+	assert.NoError(t, err)
+
+	os.Setenv("AWS_CA_BUNDLE", caFilename)
+
+	s, err := NewSession(&aws.Config{
+		Endpoint:    aws.String(server.URL),
+		Region:      aws.String("mock-region"),
+		Credentials: credentials.AnonymousCredentials,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+
+	req, _ := http.NewRequest("GET", *s.Config.Endpoint, nil)
+	resp, err := s.Config.HTTPClient.Do(req)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewSession_WithCustomCABundle_Option(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	done := make(chan struct{})
+	server, err := createTLSServer(testTLSBundleCert, testTLSBundleKey, done)
+	assert.NoError(t, err)
+
+	s, err := NewSessionWithOptions(Options{
+		Config: aws.Config{
+			Endpoint:    aws.String(server.URL),
+			Region:      aws.String("mock-region"),
+			Credentials: credentials.AnonymousCredentials,
+		},
+		CustomCABundle: bytes.NewReader(testTLSBundleCA),
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+
+	req, _ := http.NewRequest("GET", *s.Config.Endpoint, nil)
+	resp, err := s.Config.HTTPClient.Do(req)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+/* Cert generation steps
+# Create the CA key
+openssl genrsa -des3 -out ca.key 1024
+
+# Create the CA Cert
+openssl req -new -sha256 -x509 -days 3650 \
+    -subj "/C=GO/ST=Gopher/O=Testing ROOT CA" \
+    -key ca.key -out ca.crt
+
+# Create config
+cat > csr_details.txt <<-EOF
+
+[req]
+default_bits = 1024
+prompt = no
+default_md = sha256
+req_extensions = SAN
+distinguished_name = dn
+
+[ dn ]
+C=GO
+ST=Gopher
+O=Testing Certificate
+OU=Testing IP
+
+[SAN]
+subjectAltName = IP:127.0.0.1
+EOF
+
+# Create certificate signing request
+openssl req -new -sha256 -nodes -newkey rsa:1024 \
+    -config <( cat csr_details.txt ) \
+    -keyout ia.key -out ia.csr
+
+# Create a signed certificate
+openssl x509 -req -days 3650 \
+    -CAcreateserial \
+    -extfile <( cat csr_details.txt ) \
+    -extensions SAN \
+    -CA ca.crt -CAkey ca.key -in ia.csr -out ia.crt
+
+# Verify
+openssl req -noout -text -in ia.csr
+openssl x509 -noout -text -in ia.crt
+*/
+var (
+	// ca.crt
+	testTLSBundleCA = []byte(`-----BEGIN CERTIFICATE-----
+MIICiTCCAfKgAwIBAgIJAJ5X1olt05XjMA0GCSqGSIb3DQEBCwUAMDgxCzAJBgNV
+BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
+QTAeFw0xNzAzMDkwMDAyMDZaFw0yNzAzMDcwMDAyMDZaMDgxCzAJBgNVBAYTAkdP
+MQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBDQTCBnzAN
+BgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAw/8DN+t9XQR60jx42rsQ2WE2Dx85rb3n
+GQxnKZZLNddsT8rDyxJNP18aFalbRbFlyln5fxWxZIblu9Xkm/HRhOpbSimSqo1y
+uDx21NVZ1YsOvXpHby71jx3gPrrhSc/t/zikhi++6D/C6m1CiIGuiJ0GBiJxtrub
+UBMXT0QtI2ECAwEAAaOBmjCBlzAdBgNVHQ4EFgQU8XG3X/YHBA6T04kdEkq6+4GV
+YykwaAYDVR0jBGEwX4AU8XG3X/YHBA6T04kdEkq6+4GVYymhPKQ6MDgxCzAJBgNV
+BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
+QYIJAJ5X1olt05XjMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADgYEAeILv
+z49+uxmPcfOZzonuOloRcpdvyjiXblYxbzz6ch8GsE7Q886FTZbvwbgLhzdwSVgG
+G8WHkodDUsymVepdqAamS3f8PdCUk8xIk9mop8LgaB9Ns0/TssxDvMr3sOD2Grb3
+xyWymTWMcj6uCiEBKtnUp4rPiefcvCRYZ17/hLE=
+-----END CERTIFICATE-----
+`)
+
+	// ai.crt
+	testTLSBundleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIICGjCCAYOgAwIBAgIJAIIu+NOoxxM0MA0GCSqGSIb3DQEBBQUAMDgxCzAJBgNV
+BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
+QTAeFw0xNzAzMDkwMDAzMTRaFw0yNzAzMDcwMDAzMTRaMFExCzAJBgNVBAYTAkdP
+MQ8wDQYDVQQIDAZHb3BoZXIxHDAaBgNVBAoME1Rlc3RpbmcgQ2VydGlmaWNhdGUx
+EzARBgNVBAsMClRlc3RpbmcgSVAwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
+AN1hWHeioo/nASvbrjwCQzXCiWiEzGkw353NxsAB54/NqDL3LXNATtiSJu8kJBrm
+Ah12IFLtWLGXjGjjYlHbQWnOR6awveeXnQZukJyRWh7m/Qlt9Ho0CgZE1U+832ac
+5GWVldNxW1Lz4I+W9/ehzqe8I80RS6eLEKfUFXGiW+9RAgMBAAGjEzARMA8GA1Ud
+EQQIMAaHBH8AAAEwDQYJKoZIhvcNAQEFBQADgYEAdF4WQHfVdPCbgv9sxgJjcR1H
+Hgw9rZ47gO1IiIhzglnLXQ6QuemRiHeYFg4kjcYBk1DJguxzDTGnUwhUXOibAB+S
+zssmrkdYYvn9aUhjc3XK3tjAoDpsPpeBeTBamuUKDHoH/dNRXxerZ8vu6uPR3Pgs
+5v/KCV6IAEcvNyOXMPo=
+-----END CERTIFICATE-----
+`)
+
+	// ai.key
+	testTLSBundleKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDdYVh3oqKP5wEr2648AkM1wolohMxpMN+dzcbAAeePzagy9y1z
+QE7YkibvJCQa5gIddiBS7Vixl4xo42JR20FpzkemsL3nl50GbpCckVoe5v0JbfR6
+NAoGRNVPvN9mnORllZXTcVtS8+CPlvf3oc6nvCPNEUunixCn1BVxolvvUQIDAQAB
+AoGBAMISrcirddGrlLZLLrKC1ULS2T0cdkqdQtwHYn4+7S5+/z42vMx1iumHLsSk
+rVY7X41OWkX4trFxhvEIrc/O48bo2zw78P7flTxHy14uxXnllU8cLThE29SlUU7j
+AVBNxJZMsXMlS/DowwD4CjFe+x4Pu9wZcReF2Z9ntzMpySABAkEA+iWoJCPE2JpS
+y78q3HYYgpNY3gF3JqQ0SI/zTNkb3YyEIUffEYq0Y9pK13HjKtdsSuX4osTIhQkS
++UgRp6tCAQJBAOKPYTfQ2FX8ijgUpHZRuEAVaxASAS0UATiLgzXxLvOh/VC2at5x
+wjOX6sD65pPz/0D8Qj52Cq6Q1TQ+377SDVECQAIy0od+yPweXxvrUjUd1JlRMjbB
+TIrKZqs8mKbUQapw0bh5KTy+O1elU4MRPS3jNtBxtP25PQnuSnxmZcFTgAECQFzg
+DiiFcsn9FuRagfkHExMiNJuH5feGxeFaP9WzI144v9GAllrOI6Bm3JNzx2ZLlg4b
+20Qju8lIEj6yr6JYFaECQHM1VSojGRKpOl9Ox/R4yYSA9RV5Gyn00/aJNxVYyPD5
+i3acL2joQm2kLD/LO8paJ4+iQdRXCOMMIpjxSNjGQjQ=
+-----END RSA PRIVATE KEY-----
+`)
+)

--- a/aws/session/custom_ca_bundle_test.go
+++ b/aws/session/custom_ca_bundle_test.go
@@ -70,6 +70,7 @@ func TestNewSession_WithCustomCABundle_Env(t *testing.T) {
 	os.Setenv("AWS_CA_BUNDLE", caFilename)
 
 	s, err := NewSession(&aws.Config{
+		HTTPClient:  &http.Client{},
 		Endpoint:    aws.String(server.URL),
 		Region:      aws.String("mock-region"),
 		Credentials: credentials.AnonymousCredentials,
@@ -94,6 +95,7 @@ func TestNewSession_WithCustomCABundle_Option(t *testing.T) {
 
 	s, err := NewSessionWithOptions(Options{
 		Config: aws.Config{
+			HTTPClient:  &http.Client{},
 			Endpoint:    aws.String(server.URL),
 			Region:      aws.String("mock-region"),
 			Credentials: credentials.AnonymousCredentials,

--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -260,7 +260,8 @@ if you want to replace the CA bundle the SDK uses for TLS requests.
 Enabling this option will attempt to merge the Transport into the SDK's HTTP
 client. If the client's Transport is not a http.Transport an error will be
 returned. If the Transport's TLS config is set this option will cause the SDK
-to overwrite the Transport's TLS config's  RootCAs value.
+to overwrite the Transport's TLS config's  RootCAs value. If the CA bundle file
+contains multiple certificates all of them will be loaded.
 
 The Session option CustomCABundle is also available when creating sessions
 to also enable this feature. CustomCABundle session option field has priority

--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -96,7 +96,7 @@ handler logs every request and its payload made by a service client:
 	// Create a session, and add additional handlers for all service
 	// clients created with the Session to inherit. Adds logging handler.
 	sess := session.Must(session.NewSession())
-	
+
 	sess.Handlers.Send.PushFront(func(r *request.Request) {
 		// Log every request made and its payload
 		logger.Println("Request: %s/%s, Payload: %s",
@@ -169,8 +169,8 @@ session option must be set to SharedConfigEnable, or AWS_SDK_LOAD_CONFIG
 environment variable set.
 
 The shared configuration instructs the SDK to assume an IAM role with MFA
-when the mfa_serial configuration field is set in the shared config 
-(~/.aws/config) or shared credentials (~/.aws/credentials) file. 
+when the mfa_serial configuration field is set in the shared config
+(~/.aws/config) or shared credentials (~/.aws/credentials) file.
 
 If mfa_serial is set in the configuration, the SDK will assume the role, and
 the AssumeRoleTokenProvider session option is not set an an error will
@@ -251,6 +251,23 @@ $HOME/.aws/config on Linux/Unix based systems, and
 
 	AWS_CONFIG_FILE=$HOME/my_shared_config
 
+Path to a custom Credentials Authority (CA) bundle PEM file that the SDK
+will use instead of the default system's root CA bundle. Use this only
+if you want to replace the CA bundle the SDK uses for TLS requests.
 
+	AWS_CA_BUNDLE=$HOME/my_custom_ca_bundle
+
+Enabling this option will attempt to merge the Transport into the SDK's HTTP
+client. If the client's Transport is not a http.Transport an error will be
+returned. If the Transport's TLS config is set this option will cause the SDK
+to overwrite the Transport's TLS config's  RootCAs value.
+
+The Session option CustomCABundle is also available when creating sessions
+to also enable this feature. CustomCABundle session option field has priority
+over the AWS_CA_BUNDLE environment variable, and will be used if both are set.
+
+Setting a custom HTTPClient in the aws.Config options will override this setting.
+To use this option and custom HTTP client, the HTTP client needs to be provided
+when creating the session. Not the service client.
 */
 package session

--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -75,6 +75,24 @@ type envConfig struct {
 	//
 	//	AWS_CONFIG_FILE=$HOME/my_shared_config
 	SharedConfigFile string
+
+	// Sets the path to a custom Credentials Authroity (CA) Bundle PEM file
+	// that the SDK will use instead of the the system's root CA bundle.
+	// Only use this if you want to configure the SDK to use a custom set
+	// of CAs.
+	//
+	// Enabling this option will attempt to merge the Transport
+	// into the SDK's HTTP client. If the client's Transport is
+	// not a http.Transport an error will be returned. If the
+	// Transport's TLS config is set this option will cause the
+	// SDK to overwrite the Transport's TLS config's  RootCAs value.
+	//
+	// Setting a custom HTTPClient in the aws.Config options will override this setting.
+	// To use this option and custom HTTP client, the HTTP client needs to be provided
+	// when creating the session. Not the service client.
+	//
+	//  AWS_CA_BUNDLE=$HOME/my_custom_ca_bundle
+	CustomCABundle string
 }
 
 var (
@@ -149,6 +167,8 @@ func envConfigLoad(enableSharedConfig bool) envConfig {
 
 	cfg.SharedCredentialsFile = sharedCredentialsFilename()
 	cfg.SharedConfigFile = sharedConfigFilename()
+
+	cfg.CustomCABundle = os.Getenv("AWS_CA_BUNDLE")
 
 	return cfg
 }

--- a/aws/session/env_config_test.go
+++ b/aws/session/env_config_test.go
@@ -94,6 +94,7 @@ func TestLoadEnvConfig(t *testing.T) {
 	cases := []struct {
 		Env                 map[string]string
 		Region, Profile     string
+		CustomCABundle      string
 		UseSharedConfigCall bool
 	}{
 		{
@@ -182,6 +183,19 @@ func TestLoadEnvConfig(t *testing.T) {
 			Region: "default_region", Profile: "default_profile",
 			UseSharedConfigCall: true,
 		},
+		{
+			Env: map[string]string{
+				"AWS_CA_BUNDLE": "custom_ca_bundle",
+			},
+			CustomCABundle: "custom_ca_bundle",
+		},
+		{
+			Env: map[string]string{
+				"AWS_CA_BUNDLE": "custom_ca_bundle",
+			},
+			CustomCABundle:      "custom_ca_bundle",
+			UseSharedConfigCall: true,
+		},
 	}
 
 	for _, c := range cases {
@@ -200,6 +214,7 @@ func TestLoadEnvConfig(t *testing.T) {
 
 		assert.Equal(t, c.Region, cfg.Region)
 		assert.Equal(t, c.Profile, cfg.Profile)
+		assert.Equal(t, c.CustomCABundle, cfg.CustomCABundle)
 	}
 }
 

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -182,7 +182,8 @@ type Options struct {
 	// Enabling this option will attempt to merge the Transport into the SDK's HTTP
 	// client. If the client's Transport is not a http.Transport an error will be
 	// returned. If the Transport's TLS config is set this option will cause the SDK
-	// to overwrite the Transport's TLS config's  RootCAs value.
+	// to overwrite the Transport's TLS config's  RootCAs value. If the CA
+	// bundle reader contains multiple certificates all of them will be loaded.
 	//
 	// The Session option CustomCABundle is also available when creating sessions
 	// to also enable this feature. CustomCABundle session option field has priority

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -1,7 +1,13 @@
 package session
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -167,6 +173,20 @@ type Options struct {
 	// This field is only used if the shared configuration is enabled, and
 	// the config enables assume role wit MFA via the mfa_serial field.
 	AssumeRoleTokenProvider func() (string, error)
+
+	// Reader for a custom Credentials Authority (CA) bundle in PEM format that
+	// the SDK will use instead of the default system's root CA bundle. Use this
+	// only if you want to replace the CA bundle the SDK uses for TLS requests.
+	//
+	// Enabling this option will attempt to merge the Transport into the SDK's HTTP
+	// client. If the client's Transport is not a http.Transport an error will be
+	// returned. If the Transport's TLS config is set this option will cause the SDK
+	// to overwrite the Transport's TLS config's  RootCAs value.
+	//
+	// The Session option CustomCABundle is also available when creating sessions
+	// to also enable this feature. CustomCABundle session option field has priority
+	// over the AWS_CA_BUNDLE environment variable, and will be used if both are set.
+	CustomCABundle io.Reader
 }
 
 // NewSessionWithOptions returns a new Session created from SDK defaults, config files,
@@ -215,6 +235,17 @@ func NewSessionWithOptions(opts Options) (*Session, error) {
 		envCfg.EnableSharedConfig = false
 	case SharedConfigEnable:
 		envCfg.EnableSharedConfig = true
+	}
+
+	// Only use AWS_CA_BUNDLE if session option is not provided.
+	if len(envCfg.CustomCABundle) != 0 && opts.CustomCABundle == nil {
+		f, err := os.Open(envCfg.CustomCABundle)
+		if err != nil {
+			// TODO wrap error
+			return nil, err
+		}
+		defer f.Close()
+		opts.CustomCABundle = f
 	}
 
 	return newSession(opts, envCfg, &opts.Config)
@@ -297,7 +328,60 @@ func newSession(opts Options, envCfg envConfig, cfgs ...*aws.Config) (*Session, 
 
 	initHandlers(s)
 
+	// Setup HTTP client with custom cert bundle if enabled
+	if opts.CustomCABundle != nil {
+		if err := loadCustomCABundle(s, opts.CustomCABundle); err != nil {
+			return nil, err
+		}
+	}
+
 	return s, nil
+}
+
+func loadCustomCABundle(s *Session, bundle io.Reader) error {
+	var t *http.Transport
+	switch v := s.Config.HTTPClient.Transport.(type) {
+	case *http.Transport:
+		t = v
+	default:
+		if s.Config.HTTPClient.Transport != nil {
+			// Transport is set to a type that is unsupported.
+			// TODO report an error?
+			return nil
+		}
+	}
+	if t == nil {
+		t = &http.Transport{}
+	}
+
+	p, err := loadCertPool(bundle)
+	if err != nil {
+		return err
+	}
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	}
+	t.TLSClientConfig.RootCAs = p
+
+	s.Config.HTTPClient.Transport = t
+
+	return nil
+}
+
+func loadCertPool(r io.Reader) (*x509.CertPool, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		// TODO better error
+		return nil, fmt.Errorf("failed to read pem file, %v", err)
+	}
+
+	p := x509.NewCertPool()
+	if !p.AppendCertsFromPEM(b) {
+		// TODO better error
+		return nil, fmt.Errorf("failed to load cert bundle")
+	}
+
+	return p, nil
 }
 
 func mergeConfigSrcs(cfg, userCfg *aws.Config, envCfg envConfig, sharedCfg sharedConfig, handlers request.Handlers, sessOpts Options) error {


### PR DESCRIPTION
Adds supports for side loading Certificate Authority bundle files to the
SDK using `AWS_CA_BUNDLE` environment variable or `CustomCABundle` session option.

TODO:
* [x] Cleanup returned errors