### PR TITLE
service/s3: Fix S3 HostID to be available in S3 request error message

### DIFF
--- a/service/s3/host_style_bucket_test.go
+++ b/service/s3/host_style_bucket_test.go
@@ -2,6 +2,7 @@ package s3_test
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,8 +65,12 @@ func runTests(t *testing.T, svc *s3.S3, tests []s3BucketTest) {
 		req.Build()
 		assert.Equal(t, test.url, req.HTTPRequest.URL.String(), "test case %d", i)
 		if test.errCode != "" {
-			require.Error(t, req.Error, "test case %d", i)
-			assert.Contains(t, req.Error.(awserr.Error).Code(), test.errCode, "test case %d", i)
+			if err := req.Error; err == nil {
+				t.Fatalf("%d, expect no error, got %v", err)
+			}
+			if a, e := req.Error.(awserr.Error).Code(), test.errCode; !strings.Contains(a, e) {
+				t.Errorf("%d, expect error code to contain %q, got %q", i, e, a)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds a new type s3.RequestFailure which exposes the S3 HostID value from
a S3 API operation response. This is helpful when you have an error with
S3, and need to contact support. Both RequestID and HostID are needed.

When logging the error message both will be logged. The HostID value can
also be retrieved by casting the returned error to a s3.RequestFailure
type.

	result, err := svc.GetObject(&s3.GetObjectInput{
		Bucket: aws.String("myBucket"),
		Key:    aws.String("myKey"),
	})
	if err != nil {
		if s3Err, ok := err.(s3.RequestFailure); ok {
			fmt.Printf("Request failed: id: %q, host: %q\n", s3Err.RequestID(), s3Err.HostID())
			return
		}
	}

Fix #1123