### PR TITLE
aws/request: Optimization to handler list copy to prevent multiple alloc calls.

### DIFF
--- a/aws/request/handlers.go
+++ b/aws/request/handlers.go
@@ -85,7 +85,7 @@ func (l *HandlerList) copy() HandlerList {
 	n := HandlerList{
 		AfterEachFn: l.AfterEachFn,
 	}
-	n.list = append([]NamedHandler{}, l.list...)
+	n.list = append(make([]NamedHandler, 0, len(l.list)), l.list...)
 	return n
 }
 


### PR DESCRIPTION
Use `make([]NamedHandler, 0, len(original))` instead of `[]NamedHandler{}` when copying handlers.

Some profiling via `go test -bench` and `pprof` shows that this change is significant on `request.New`, which is a hot path. In a small utility, the cost of `request.New` fell by anywhere from 0.5% to 2%.