### PR TITLE
private/model/api: Fix Waiter and Paginators panic on nil param inputs

### DIFF
--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -381,6 +381,79 @@ func TestPaginationNilToken(t *testing.T) {
 	assert.Equal(t, []string{"first.example.com.", "second.example.com.", "third.example.com."}, results)
 }
 
+func TestPaginationNilInput(t *testing.T) {
+	// Code generation doesn't have a great way to verify the code is correct
+	// other than being run via unit tests in the SDK. This should be fixed
+	// So code generation can be validated independently.
+
+	client := s3.New(unit.Session)
+	client.Handlers.Validate.Clear()
+	client.Handlers.Send.Clear() // mock sending
+	client.Handlers.Unmarshal.Clear()
+	client.Handlers.UnmarshalMeta.Clear()
+	client.Handlers.ValidateResponse.Clear()
+	client.Handlers.Unmarshal.PushBack(func(r *request.Request) {
+		r.Data = &s3.ListObjectsOutput{}
+	})
+
+	gotToEnd := false
+	numPages := 0
+	err := client.ListObjectsPages(nil, func(p *s3.ListObjectsOutput, last bool) bool {
+		numPages++
+		if last {
+			gotToEnd = true
+		}
+		return true
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 1, numPages; e != a {
+		t.Errorf("expect %d number pages but got %d", e, a)
+	}
+	if !gotToEnd {
+		t.Errorf("expect to of gotten to end, did not")
+	}
+}
+
+func TestPaginationWithContextNilInput(t *testing.T) {
+	// Code generation doesn't have a great way to verify the code is correct
+	// other than being run via unit tests in the SDK. This should be fixed
+	// So code generation can be validated independently.
+
+	client := s3.New(unit.Session)
+	client.Handlers.Validate.Clear()
+	client.Handlers.Send.Clear() // mock sending
+	client.Handlers.Unmarshal.Clear()
+	client.Handlers.UnmarshalMeta.Clear()
+	client.Handlers.ValidateResponse.Clear()
+	client.Handlers.Unmarshal.PushBack(func(r *request.Request) {
+		r.Data = &s3.ListObjectsOutput{}
+	})
+
+	gotToEnd := false
+	numPages := 0
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
+	err := client.ListObjectsPagesWithContext(ctx, nil, func(p *s3.ListObjectsOutput, last bool) bool {
+		numPages++
+		if last {
+			gotToEnd = true
+		}
+		return true
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 1, numPages; e != a {
+		t.Errorf("expect %d number pages but got %d", e, a)
+	}
+	if !gotToEnd {
+		t.Errorf("expect to of gotten to end, did not")
+	}
+}
+
 type testPageInput struct {
 	NextToken string
 }

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -216,7 +216,10 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}PagesWithContext(` +
 	`opts ...request.Option) error {
 	p := request.Pagination {
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy {{ .InputRef.GoTypeElem }}
+			if input != nil  {
+				inCpy = *input
+			}
 			req, _ := c.{{ .ExportedName }}Request(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/private/model/api/waiters.go
+++ b/private/model/api/waiters.go
@@ -144,7 +144,11 @@ func (c *{{ .Operation.API.StructName }}) WaitUntil{{ .Name }}WithContext(` +
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.{{ .OperationName }}Request(input)
+			var inCpy {{ .Operation.InputRef.GoTypeElem }}
+			if input != nil  {
+				inCpy = *input
+			}
+			req, _ := c.{{ .OperationName }}Request(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/acm/api.go
+++ b/service/acm/api.go
@@ -628,7 +628,10 @@ func (c *ACM) ListCertificatesPages(input *ListCertificatesInput, fn func(*ListC
 func (c *ACM) ListCertificatesPagesWithContext(ctx aws.Context, input *ListCertificatesInput, fn func(*ListCertificatesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListCertificatesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListCertificatesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -3169,7 +3169,10 @@ func (c *APIGateway) GetApiKeysPages(input *GetApiKeysInput, fn func(*GetApiKeys
 func (c *APIGateway) GetApiKeysPagesWithContext(ctx aws.Context, input *GetApiKeysInput, fn func(*GetApiKeysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetApiKeysInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetApiKeysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3547,7 +3550,10 @@ func (c *APIGateway) GetBasePathMappingsPages(input *GetBasePathMappingsInput, f
 func (c *APIGateway) GetBasePathMappingsPagesWithContext(ctx aws.Context, input *GetBasePathMappingsInput, fn func(*GetBasePathMappingsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetBasePathMappingsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetBasePathMappingsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3759,7 +3765,10 @@ func (c *APIGateway) GetClientCertificatesPages(input *GetClientCertificatesInpu
 func (c *APIGateway) GetClientCertificatesPagesWithContext(ctx aws.Context, input *GetClientCertificatesInput, fn func(*GetClientCertificatesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetClientCertificatesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetClientCertificatesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3975,7 +3984,10 @@ func (c *APIGateway) GetDeploymentsPages(input *GetDeploymentsInput, fn func(*Ge
 func (c *APIGateway) GetDeploymentsPagesWithContext(ctx aws.Context, input *GetDeploymentsInput, fn func(*GetDeploymentsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetDeploymentsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetDeploymentsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4506,7 +4518,10 @@ func (c *APIGateway) GetDomainNamesPages(input *GetDomainNamesInput, fn func(*Ge
 func (c *APIGateway) GetDomainNamesPagesWithContext(ctx aws.Context, input *GetDomainNamesInput, fn func(*GetDomainNamesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetDomainNamesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetDomainNamesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5205,7 +5220,10 @@ func (c *APIGateway) GetModelsPages(input *GetModelsInput, fn func(*GetModelsOut
 func (c *APIGateway) GetModelsPagesWithContext(ctx aws.Context, input *GetModelsInput, fn func(*GetModelsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetModelsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetModelsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5419,7 +5437,10 @@ func (c *APIGateway) GetResourcesPages(input *GetResourcesInput, fn func(*GetRes
 func (c *APIGateway) GetResourcesPagesWithContext(ctx aws.Context, input *GetResourcesInput, fn func(*GetResourcesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetResourcesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetResourcesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5631,7 +5652,10 @@ func (c *APIGateway) GetRestApisPages(input *GetRestApisInput, fn func(*GetRestA
 func (c *APIGateway) GetRestApisPagesWithContext(ctx aws.Context, input *GetRestApisInput, fn func(*GetRestApisOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetRestApisInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetRestApisRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -6161,7 +6185,10 @@ func (c *APIGateway) GetUsagePages(input *GetUsageInput, fn func(*Usage, bool) b
 func (c *APIGateway) GetUsagePagesWithContext(ctx aws.Context, input *GetUsageInput, fn func(*Usage, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetUsageInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetUsageRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -6460,7 +6487,10 @@ func (c *APIGateway) GetUsagePlanKeysPages(input *GetUsagePlanKeysInput, fn func
 func (c *APIGateway) GetUsagePlanKeysPagesWithContext(ctx aws.Context, input *GetUsagePlanKeysInput, fn func(*GetUsagePlanKeysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetUsagePlanKeysInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetUsagePlanKeysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -6596,7 +6626,10 @@ func (c *APIGateway) GetUsagePlansPages(input *GetUsagePlansInput, fn func(*GetU
 func (c *APIGateway) GetUsagePlansPagesWithContext(ctx aws.Context, input *GetUsagePlansInput, fn func(*GetUsagePlansOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetUsagePlansInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetUsagePlansRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/applicationautoscaling/api.go
+++ b/service/applicationautoscaling/api.go
@@ -350,7 +350,10 @@ func (c *ApplicationAutoScaling) DescribeScalableTargetsPages(input *DescribeSca
 func (c *ApplicationAutoScaling) DescribeScalableTargetsPagesWithContext(ctx aws.Context, input *DescribeScalableTargetsInput, fn func(*DescribeScalableTargetsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeScalableTargetsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeScalableTargetsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -501,7 +504,10 @@ func (c *ApplicationAutoScaling) DescribeScalingActivitiesPages(input *DescribeS
 func (c *ApplicationAutoScaling) DescribeScalingActivitiesPagesWithContext(ctx aws.Context, input *DescribeScalingActivitiesInput, fn func(*DescribeScalingActivitiesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeScalingActivitiesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeScalingActivitiesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -660,7 +666,10 @@ func (c *ApplicationAutoScaling) DescribeScalingPoliciesPages(input *DescribeSca
 func (c *ApplicationAutoScaling) DescribeScalingPoliciesPagesWithContext(ctx aws.Context, input *DescribeScalingPoliciesInput, fn func(*DescribeScalingPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeScalingPoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeScalingPoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/appstream/waiters.go
+++ b/service/appstream/waiters.go
@@ -49,7 +49,11 @@ func (c *AppStream) WaitUntilFleetStartedWithContext(ctx aws.Context, input *Des
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeFleetsRequest(input)
+			var inCpy DescribeFleetsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeFleetsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -100,7 +104,11 @@ func (c *AppStream) WaitUntilFleetStoppedWithContext(ctx aws.Context, input *Des
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeFleetsRequest(input)
+			var inCpy DescribeFleetsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeFleetsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -1589,7 +1589,10 @@ func (c *AutoScaling) DescribeAutoScalingGroupsPages(input *DescribeAutoScalingG
 func (c *AutoScaling) DescribeAutoScalingGroupsPagesWithContext(ctx aws.Context, input *DescribeAutoScalingGroupsInput, fn func(*DescribeAutoScalingGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeAutoScalingGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeAutoScalingGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1725,7 +1728,10 @@ func (c *AutoScaling) DescribeAutoScalingInstancesPages(input *DescribeAutoScali
 func (c *AutoScaling) DescribeAutoScalingInstancesPagesWithContext(ctx aws.Context, input *DescribeAutoScalingInstancesInput, fn func(*DescribeAutoScalingInstancesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeAutoScalingInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeAutoScalingInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1942,7 +1948,10 @@ func (c *AutoScaling) DescribeLaunchConfigurationsPages(input *DescribeLaunchCon
 func (c *AutoScaling) DescribeLaunchConfigurationsPagesWithContext(ctx aws.Context, input *DescribeLaunchConfigurationsInput, fn func(*DescribeLaunchConfigurationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeLaunchConfigurationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeLaunchConfigurationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2490,7 +2499,10 @@ func (c *AutoScaling) DescribeNotificationConfigurationsPages(input *DescribeNot
 func (c *AutoScaling) DescribeNotificationConfigurationsPagesWithContext(ctx aws.Context, input *DescribeNotificationConfigurationsInput, fn func(*DescribeNotificationConfigurationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeNotificationConfigurationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeNotificationConfigurationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2626,7 +2638,10 @@ func (c *AutoScaling) DescribePoliciesPages(input *DescribePoliciesInput, fn fun
 func (c *AutoScaling) DescribePoliciesPagesWithContext(ctx aws.Context, input *DescribePoliciesInput, fn func(*DescribePoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribePoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribePoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2762,7 +2777,10 @@ func (c *AutoScaling) DescribeScalingActivitiesPages(input *DescribeScalingActiv
 func (c *AutoScaling) DescribeScalingActivitiesPagesWithContext(ctx aws.Context, input *DescribeScalingActivitiesInput, fn func(*DescribeScalingActivitiesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeScalingActivitiesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeScalingActivitiesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2980,7 +2998,10 @@ func (c *AutoScaling) DescribeScheduledActionsPages(input *DescribeScheduledActi
 func (c *AutoScaling) DescribeScheduledActionsPagesWithContext(ctx aws.Context, input *DescribeScheduledActionsInput, fn func(*DescribeScheduledActionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeScheduledActionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeScheduledActionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3125,7 +3146,10 @@ func (c *AutoScaling) DescribeTagsPages(input *DescribeTagsInput, fn func(*Descr
 func (c *AutoScaling) DescribeTagsPagesWithContext(ctx aws.Context, input *DescribeTagsInput, fn func(*DescribeTagsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeTagsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeTagsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/autoscaling/waiters.go
+++ b/service/autoscaling/waiters.go
@@ -44,7 +44,11 @@ func (c *AutoScaling) WaitUntilGroupExistsWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeAutoScalingGroupsRequest(input)
+			var inCpy DescribeAutoScalingGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeAutoScalingGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -90,7 +94,11 @@ func (c *AutoScaling) WaitUntilGroupInServiceWithContext(ctx aws.Context, input 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeAutoScalingGroupsRequest(input)
+			var inCpy DescribeAutoScalingGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeAutoScalingGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -136,7 +144,11 @@ func (c *AutoScaling) WaitUntilGroupNotExistsWithContext(ctx aws.Context, input 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeAutoScalingGroupsRequest(input)
+			var inCpy DescribeAutoScalingGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeAutoScalingGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -3023,7 +3023,10 @@ func (c *CloudDirectory) ListAppliedSchemaArnsPages(input *ListAppliedSchemaArns
 func (c *CloudDirectory) ListAppliedSchemaArnsPagesWithContext(ctx aws.Context, input *ListAppliedSchemaArnsInput, fn func(*ListAppliedSchemaArnsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAppliedSchemaArnsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAppliedSchemaArnsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3185,7 +3188,10 @@ func (c *CloudDirectory) ListAttachedIndicesPages(input *ListAttachedIndicesInpu
 func (c *CloudDirectory) ListAttachedIndicesPagesWithContext(ctx aws.Context, input *ListAttachedIndicesInput, fn func(*ListAttachedIndicesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAttachedIndicesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAttachedIndicesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3347,7 +3353,10 @@ func (c *CloudDirectory) ListDevelopmentSchemaArnsPages(input *ListDevelopmentSc
 func (c *CloudDirectory) ListDevelopmentSchemaArnsPagesWithContext(ctx aws.Context, input *ListDevelopmentSchemaArnsInput, fn func(*ListDevelopmentSchemaArnsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDevelopmentSchemaArnsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDevelopmentSchemaArnsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3506,7 +3515,10 @@ func (c *CloudDirectory) ListDirectoriesPages(input *ListDirectoriesInput, fn fu
 func (c *CloudDirectory) ListDirectoriesPagesWithContext(ctx aws.Context, input *ListDirectoriesInput, fn func(*ListDirectoriesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDirectoriesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDirectoriesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3671,7 +3683,10 @@ func (c *CloudDirectory) ListFacetAttributesPages(input *ListFacetAttributesInpu
 func (c *CloudDirectory) ListFacetAttributesPagesWithContext(ctx aws.Context, input *ListFacetAttributesInput, fn func(*ListFacetAttributesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListFacetAttributesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListFacetAttributesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3833,7 +3848,10 @@ func (c *CloudDirectory) ListFacetNamesPages(input *ListFacetNamesInput, fn func
 func (c *CloudDirectory) ListFacetNamesPagesWithContext(ctx aws.Context, input *ListFacetNamesInput, fn func(*ListFacetNamesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListFacetNamesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListFacetNamesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3998,7 +4016,10 @@ func (c *CloudDirectory) ListIndexPages(input *ListIndexInput, fn func(*ListInde
 func (c *CloudDirectory) ListIndexPagesWithContext(ctx aws.Context, input *ListIndexInput, fn func(*ListIndexOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListIndexInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListIndexRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4166,7 +4187,10 @@ func (c *CloudDirectory) ListObjectAttributesPages(input *ListObjectAttributesIn
 func (c *CloudDirectory) ListObjectAttributesPagesWithContext(ctx aws.Context, input *ListObjectAttributesInput, fn func(*ListObjectAttributesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListObjectAttributesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListObjectAttributesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4338,7 +4362,10 @@ func (c *CloudDirectory) ListObjectChildrenPages(input *ListObjectChildrenInput,
 func (c *CloudDirectory) ListObjectChildrenPagesWithContext(ctx aws.Context, input *ListObjectChildrenInput, fn func(*ListObjectChildrenOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListObjectChildrenInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListObjectChildrenRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4512,7 +4539,10 @@ func (c *CloudDirectory) ListObjectParentPathsPages(input *ListObjectParentPaths
 func (c *CloudDirectory) ListObjectParentPathsPagesWithContext(ctx aws.Context, input *ListObjectParentPathsInput, fn func(*ListObjectParentPathsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListObjectParentPathsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListObjectParentPathsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4683,7 +4713,10 @@ func (c *CloudDirectory) ListObjectParentsPages(input *ListObjectParentsInput, f
 func (c *CloudDirectory) ListObjectParentsPagesWithContext(ctx aws.Context, input *ListObjectParentsInput, fn func(*ListObjectParentsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListObjectParentsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListObjectParentsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4848,7 +4881,10 @@ func (c *CloudDirectory) ListObjectPoliciesPages(input *ListObjectPoliciesInput,
 func (c *CloudDirectory) ListObjectPoliciesPagesWithContext(ctx aws.Context, input *ListObjectPoliciesInput, fn func(*ListObjectPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListObjectPoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListObjectPoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5019,7 +5055,10 @@ func (c *CloudDirectory) ListPolicyAttachmentsPages(input *ListPolicyAttachments
 func (c *CloudDirectory) ListPolicyAttachmentsPagesWithContext(ctx aws.Context, input *ListPolicyAttachmentsInput, fn func(*ListPolicyAttachmentsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPolicyAttachmentsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPolicyAttachmentsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5181,7 +5220,10 @@ func (c *CloudDirectory) ListPublishedSchemaArnsPages(input *ListPublishedSchema
 func (c *CloudDirectory) ListPublishedSchemaArnsPagesWithContext(ctx aws.Context, input *ListPublishedSchemaArnsInput, fn func(*ListPublishedSchemaArnsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPublishedSchemaArnsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPublishedSchemaArnsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5347,7 +5389,10 @@ func (c *CloudDirectory) ListTagsForResourcePages(input *ListTagsForResourceInpu
 func (c *CloudDirectory) ListTagsForResourcePagesWithContext(ctx aws.Context, input *ListTagsForResourceInput, fn func(*ListTagsForResourceOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListTagsForResourceInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListTagsForResourceRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5520,7 +5565,10 @@ func (c *CloudDirectory) LookupPolicyPages(input *LookupPolicyInput, fn func(*Lo
 func (c *CloudDirectory) LookupPolicyPagesWithContext(ctx aws.Context, input *LookupPolicyInput, fn func(*LookupPolicyOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy LookupPolicyInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.LookupPolicyRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -811,7 +811,10 @@ func (c *CloudFormation) DescribeStackEventsPages(input *DescribeStackEventsInpu
 func (c *CloudFormation) DescribeStackEventsPagesWithContext(ctx aws.Context, input *DescribeStackEventsInput, fn func(*DescribeStackEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeStackEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeStackEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1111,7 +1114,10 @@ func (c *CloudFormation) DescribeStacksPages(input *DescribeStacksInput, fn func
 func (c *CloudFormation) DescribeStacksPagesWithContext(ctx aws.Context, input *DescribeStacksInput, fn func(*DescribeStacksOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeStacksInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeStacksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1905,7 +1911,10 @@ func (c *CloudFormation) ListStackResourcesPages(input *ListStackResourcesInput,
 func (c *CloudFormation) ListStackResourcesPagesWithContext(ctx aws.Context, input *ListStackResourcesInput, fn func(*ListStackResourcesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListStackResourcesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListStackResourcesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2036,7 +2045,10 @@ func (c *CloudFormation) ListStacksPages(input *ListStacksInput, fn func(*ListSt
 func (c *CloudFormation) ListStacksPagesWithContext(ctx aws.Context, input *ListStacksInput, fn func(*ListStacksOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListStacksInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListStacksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/cloudformation/waiters.go
+++ b/service/cloudformation/waiters.go
@@ -69,7 +69,11 @@ func (c *CloudFormation) WaitUntilStackCreateCompleteWithContext(ctx aws.Context
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeStacksRequest(input)
+			var inCpy DescribeStacksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeStacksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -140,7 +144,11 @@ func (c *CloudFormation) WaitUntilStackDeleteCompleteWithContext(ctx aws.Context
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeStacksRequest(input)
+			var inCpy DescribeStacksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeStacksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -186,7 +194,11 @@ func (c *CloudFormation) WaitUntilStackExistsWithContext(ctx aws.Context, input 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeStacksRequest(input)
+			var inCpy DescribeStacksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeStacksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -247,7 +259,11 @@ func (c *CloudFormation) WaitUntilStackUpdateCompleteWithContext(ctx aws.Context
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeStacksRequest(input)
+			var inCpy DescribeStacksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeStacksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -1874,7 +1874,10 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesPages(input *ListCloudF
 func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesPagesWithContext(ctx aws.Context, input *ListCloudFrontOriginAccessIdentitiesInput, fn func(*ListCloudFrontOriginAccessIdentitiesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListCloudFrontOriginAccessIdentitiesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListCloudFrontOriginAccessIdentitiesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2006,7 +2009,10 @@ func (c *CloudFront) ListDistributionsPages(input *ListDistributionsInput, fn fu
 func (c *CloudFront) ListDistributionsPagesWithContext(ctx aws.Context, input *ListDistributionsInput, fn func(*ListDistributionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDistributionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDistributionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2226,7 +2232,10 @@ func (c *CloudFront) ListInvalidationsPages(input *ListInvalidationsInput, fn fu
 func (c *CloudFront) ListInvalidationsPagesWithContext(ctx aws.Context, input *ListInvalidationsInput, fn func(*ListInvalidationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListInvalidationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListInvalidationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2358,7 +2367,10 @@ func (c *CloudFront) ListStreamingDistributionsPages(input *ListStreamingDistrib
 func (c *CloudFront) ListStreamingDistributionsPagesWithContext(ctx aws.Context, input *ListStreamingDistributionsInput, fn func(*ListStreamingDistributionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListStreamingDistributionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListStreamingDistributionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/cloudfront/waiters.go
+++ b/service/cloudfront/waiters.go
@@ -39,7 +39,11 @@ func (c *CloudFront) WaitUntilDistributionDeployedWithContext(ctx aws.Context, i
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetDistributionRequest(input)
+			var inCpy GetDistributionInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetDistributionRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -80,7 +84,11 @@ func (c *CloudFront) WaitUntilInvalidationCompletedWithContext(ctx aws.Context, 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetInvalidationRequest(input)
+			var inCpy GetInvalidationInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetInvalidationRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -121,7 +129,11 @@ func (c *CloudFront) WaitUntilStreamingDistributionDeployedWithContext(ctx aws.C
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetStreamingDistributionRequest(input)
+			var inCpy GetStreamingDistributionInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetStreamingDistributionRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -1061,7 +1061,10 @@ func (c *CloudTrail) LookupEventsPages(input *LookupEventsInput, fn func(*Lookup
 func (c *CloudTrail) LookupEventsPagesWithContext(ctx aws.Context, input *LookupEventsInput, fn func(*LookupEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy LookupEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.LookupEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -218,7 +218,10 @@ func (c *CloudWatch) DescribeAlarmHistoryPages(input *DescribeAlarmHistoryInput,
 func (c *CloudWatch) DescribeAlarmHistoryPagesWithContext(ctx aws.Context, input *DescribeAlarmHistoryInput, fn func(*DescribeAlarmHistoryOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeAlarmHistoryInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeAlarmHistoryRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -352,7 +355,10 @@ func (c *CloudWatch) DescribeAlarmsPages(input *DescribeAlarmsInput, fn func(*De
 func (c *CloudWatch) DescribeAlarmsPagesWithContext(ctx aws.Context, input *DescribeAlarmsInput, fn func(*DescribeAlarmsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeAlarmsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeAlarmsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -846,7 +852,10 @@ func (c *CloudWatch) ListMetricsPages(input *ListMetricsInput, fn func(*ListMetr
 func (c *CloudWatch) ListMetricsPagesWithContext(ctx aws.Context, input *ListMetricsInput, fn func(*ListMetricsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListMetricsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListMetricsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/cloudwatch/waiters.go
+++ b/service/cloudwatch/waiters.go
@@ -39,7 +39,11 @@ func (c *CloudWatch) WaitUntilAlarmExistsWithContext(ctx aws.Context, input *Des
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeAlarmsRequest(input)
+			var inCpy DescribeAlarmsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeAlarmsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -1093,7 +1093,10 @@ func (c *CloudWatchLogs) DescribeDestinationsPages(input *DescribeDestinationsIn
 func (c *CloudWatchLogs) DescribeDestinationsPagesWithContext(ctx aws.Context, input *DescribeDestinationsInput, fn func(*DescribeDestinationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDestinationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDestinationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1313,7 +1316,10 @@ func (c *CloudWatchLogs) DescribeLogGroupsPages(input *DescribeLogGroupsInput, f
 func (c *CloudWatchLogs) DescribeLogGroupsPagesWithContext(ctx aws.Context, input *DescribeLogGroupsInput, fn func(*DescribeLogGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeLogGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeLogGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1456,7 +1462,10 @@ func (c *CloudWatchLogs) DescribeLogStreamsPages(input *DescribeLogStreamsInput,
 func (c *CloudWatchLogs) DescribeLogStreamsPagesWithContext(ctx aws.Context, input *DescribeLogStreamsInput, fn func(*DescribeLogStreamsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeLogStreamsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeLogStreamsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1596,7 +1605,10 @@ func (c *CloudWatchLogs) DescribeMetricFiltersPages(input *DescribeMetricFilters
 func (c *CloudWatchLogs) DescribeMetricFiltersPagesWithContext(ctx aws.Context, input *DescribeMetricFiltersInput, fn func(*DescribeMetricFiltersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeMetricFiltersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeMetricFiltersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1736,7 +1748,10 @@ func (c *CloudWatchLogs) DescribeSubscriptionFiltersPages(input *DescribeSubscri
 func (c *CloudWatchLogs) DescribeSubscriptionFiltersPagesWithContext(ctx aws.Context, input *DescribeSubscriptionFiltersInput, fn func(*DescribeSubscriptionFiltersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeSubscriptionFiltersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeSubscriptionFiltersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1882,7 +1897,10 @@ func (c *CloudWatchLogs) FilterLogEventsPages(input *FilterLogEventsInput, fn fu
 func (c *CloudWatchLogs) FilterLogEventsPagesWithContext(ctx aws.Context, input *FilterLogEventsInput, fn func(*FilterLogEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy FilterLogEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.FilterLogEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2026,7 +2044,10 @@ func (c *CloudWatchLogs) GetLogEventsPages(input *GetLogEventsInput, fn func(*Ge
 func (c *CloudWatchLogs) GetLogEventsPagesWithContext(ctx aws.Context, input *GetLogEventsInput, fn func(*GetLogEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetLogEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetLogEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -991,7 +991,10 @@ func (c *CodeCommit) GetDifferencesPages(input *GetDifferencesInput, fn func(*Ge
 func (c *CodeCommit) GetDifferencesPagesWithContext(ctx aws.Context, input *GetDifferencesInput, fn func(*GetDifferencesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetDifferencesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetDifferencesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1367,7 +1370,10 @@ func (c *CodeCommit) ListBranchesPages(input *ListBranchesInput, fn func(*ListBr
 func (c *CodeCommit) ListBranchesPagesWithContext(ctx aws.Context, input *ListBranchesInput, fn func(*ListBranchesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListBranchesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListBranchesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1505,7 +1511,10 @@ func (c *CodeCommit) ListRepositoriesPages(input *ListRepositoriesInput, fn func
 func (c *CodeCommit) ListRepositoriesPagesWithContext(ctx aws.Context, input *ListRepositoriesInput, fn func(*ListRepositoriesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListRepositoriesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListRepositoriesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -2380,7 +2380,10 @@ func (c *CodeDeploy) ListApplicationRevisionsPages(input *ListApplicationRevisio
 func (c *CodeDeploy) ListApplicationRevisionsPagesWithContext(ctx aws.Context, input *ListApplicationRevisionsInput, fn func(*ListApplicationRevisionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListApplicationRevisionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListApplicationRevisionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2512,7 +2515,10 @@ func (c *CodeDeploy) ListApplicationsPages(input *ListApplicationsInput, fn func
 func (c *CodeDeploy) ListApplicationsPagesWithContext(ctx aws.Context, input *ListApplicationsInput, fn func(*ListApplicationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListApplicationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListApplicationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2644,7 +2650,10 @@ func (c *CodeDeploy) ListDeploymentConfigsPages(input *ListDeploymentConfigsInpu
 func (c *CodeDeploy) ListDeploymentConfigsPagesWithContext(ctx aws.Context, input *ListDeploymentConfigsInput, fn func(*ListDeploymentConfigsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDeploymentConfigsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDeploymentConfigsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2786,7 +2795,10 @@ func (c *CodeDeploy) ListDeploymentGroupsPages(input *ListDeploymentGroupsInput,
 func (c *CodeDeploy) ListDeploymentGroupsPagesWithContext(ctx aws.Context, input *ListDeploymentGroupsInput, fn func(*ListDeploymentGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDeploymentGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDeploymentGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2939,7 +2951,10 @@ func (c *CodeDeploy) ListDeploymentInstancesPages(input *ListDeploymentInstances
 func (c *CodeDeploy) ListDeploymentInstancesPagesWithContext(ctx aws.Context, input *ListDeploymentInstancesInput, fn func(*ListDeploymentInstancesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDeploymentInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDeploymentInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3097,7 +3112,10 @@ func (c *CodeDeploy) ListDeploymentsPages(input *ListDeploymentsInput, fn func(*
 func (c *CodeDeploy) ListDeploymentsPagesWithContext(ctx aws.Context, input *ListDeploymentsInput, fn func(*ListDeploymentsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDeploymentsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDeploymentsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/codedeploy/waiters.go
+++ b/service/codedeploy/waiters.go
@@ -49,7 +49,11 @@ func (c *CodeDeploy) WaitUntilDeploymentSuccessfulWithContext(ctx aws.Context, i
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetDeploymentRequest(input)
+			var inCpy GetDeploymentInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetDeploymentRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -1686,7 +1686,10 @@ func (c *ConfigService) GetResourceConfigHistoryPages(input *GetResourceConfigHi
 func (c *ConfigService) GetResourceConfigHistoryPagesWithContext(ctx aws.Context, input *GetResourceConfigHistoryInput, fn func(*GetResourceConfigHistoryOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetResourceConfigHistoryInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetResourceConfigHistoryRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/costandusagereportservice/api.go
+++ b/service/costandusagereportservice/api.go
@@ -211,7 +211,10 @@ func (c *CostandUsageReportService) DescribeReportDefinitionsPages(input *Descri
 func (c *CostandUsageReportService) DescribeReportDefinitionsPagesWithContext(ctx aws.Context, input *DescribeReportDefinitionsInput, fn func(*DescribeReportDefinitionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReportDefinitionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReportDefinitionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -617,7 +617,10 @@ func (c *DataPipeline) DescribeObjectsPages(input *DescribeObjectsInput, fn func
 func (c *DataPipeline) DescribeObjectsPagesWithContext(ctx aws.Context, input *DescribeObjectsInput, fn func(*DescribeObjectsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeObjectsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeObjectsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1045,7 +1048,10 @@ func (c *DataPipeline) ListPipelinesPages(input *ListPipelinesInput, fn func(*Li
 func (c *DataPipeline) ListPipelinesPagesWithContext(ctx aws.Context, input *ListPipelinesInput, fn func(*ListPipelinesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPipelinesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPipelinesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1396,7 +1402,10 @@ func (c *DataPipeline) QueryObjectsPages(input *QueryObjectsInput, fn func(*Quer
 func (c *DataPipeline) QueryObjectsPagesWithContext(ctx aws.Context, input *QueryObjectsInput, fn func(*QueryObjectsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy QueryObjectsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.QueryObjectsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -1665,7 +1665,10 @@ func (c *DeviceFarm) GetOfferingStatusPages(input *GetOfferingStatusInput, fn fu
 func (c *DeviceFarm) GetOfferingStatusPagesWithContext(ctx aws.Context, input *GetOfferingStatusInput, fn func(*GetOfferingStatusOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetOfferingStatusInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetOfferingStatusRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2431,7 +2434,10 @@ func (c *DeviceFarm) ListArtifactsPages(input *ListArtifactsInput, fn func(*List
 func (c *DeviceFarm) ListArtifactsPagesWithContext(ctx aws.Context, input *ListArtifactsInput, fn func(*ListArtifactsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListArtifactsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListArtifactsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2572,7 +2578,10 @@ func (c *DeviceFarm) ListDevicePoolsPages(input *ListDevicePoolsInput, fn func(*
 func (c *DeviceFarm) ListDevicePoolsPagesWithContext(ctx aws.Context, input *ListDevicePoolsInput, fn func(*ListDevicePoolsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDevicePoolsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDevicePoolsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2713,7 +2722,10 @@ func (c *DeviceFarm) ListDevicesPages(input *ListDevicesInput, fn func(*ListDevi
 func (c *DeviceFarm) ListDevicesPagesWithContext(ctx aws.Context, input *ListDevicesInput, fn func(*ListDevicesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDevicesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDevicesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2854,7 +2866,10 @@ func (c *DeviceFarm) ListJobsPages(input *ListJobsInput, fn func(*ListJobsOutput
 func (c *DeviceFarm) ListJobsPagesWithContext(ctx aws.Context, input *ListJobsInput, fn func(*ListJobsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListJobsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListJobsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3093,7 +3108,10 @@ func (c *DeviceFarm) ListOfferingTransactionsPages(input *ListOfferingTransactio
 func (c *DeviceFarm) ListOfferingTransactionsPagesWithContext(ctx aws.Context, input *ListOfferingTransactionsInput, fn func(*ListOfferingTransactionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListOfferingTransactionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListOfferingTransactionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3243,7 +3261,10 @@ func (c *DeviceFarm) ListOfferingsPages(input *ListOfferingsInput, fn func(*List
 func (c *DeviceFarm) ListOfferingsPagesWithContext(ctx aws.Context, input *ListOfferingsInput, fn func(*ListOfferingsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListOfferingsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListOfferingsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3384,7 +3405,10 @@ func (c *DeviceFarm) ListProjectsPages(input *ListProjectsInput, fn func(*ListPr
 func (c *DeviceFarm) ListProjectsPagesWithContext(ctx aws.Context, input *ListProjectsInput, fn func(*ListProjectsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListProjectsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListProjectsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3614,7 +3638,10 @@ func (c *DeviceFarm) ListRunsPages(input *ListRunsInput, fn func(*ListRunsOutput
 func (c *DeviceFarm) ListRunsPagesWithContext(ctx aws.Context, input *ListRunsInput, fn func(*ListRunsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListRunsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListRunsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3755,7 +3782,10 @@ func (c *DeviceFarm) ListSamplesPages(input *ListSamplesInput, fn func(*ListSamp
 func (c *DeviceFarm) ListSamplesPagesWithContext(ctx aws.Context, input *ListSamplesInput, fn func(*ListSamplesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListSamplesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListSamplesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3896,7 +3926,10 @@ func (c *DeviceFarm) ListSuitesPages(input *ListSuitesInput, fn func(*ListSuites
 func (c *DeviceFarm) ListSuitesPagesWithContext(ctx aws.Context, input *ListSuitesInput, fn func(*ListSuitesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListSuitesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListSuitesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4037,7 +4070,10 @@ func (c *DeviceFarm) ListTestsPages(input *ListTestsInput, fn func(*ListTestsOut
 func (c *DeviceFarm) ListTestsPagesWithContext(ctx aws.Context, input *ListTestsInput, fn func(*ListTestsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListTestsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListTestsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4178,7 +4214,10 @@ func (c *DeviceFarm) ListUniqueProblemsPages(input *ListUniqueProblemsInput, fn 
 func (c *DeviceFarm) ListUniqueProblemsPagesWithContext(ctx aws.Context, input *ListUniqueProblemsInput, fn func(*ListUniqueProblemsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListUniqueProblemsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListUniqueProblemsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4319,7 +4358,10 @@ func (c *DeviceFarm) ListUploadsPages(input *ListUploadsInput, fn func(*ListUplo
 func (c *DeviceFarm) ListUploadsPagesWithContext(ctx aws.Context, input *ListUploadsInput, fn func(*ListUploadsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListUploadsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListUploadsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -191,7 +191,10 @@ func (c *DynamoDB) BatchGetItemPages(input *BatchGetItemInput, fn func(*BatchGet
 func (c *DynamoDB) BatchGetItemPagesWithContext(ctx aws.Context, input *BatchGetItemInput, fn func(*BatchGetItemOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy BatchGetItemInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.BatchGetItemRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1237,7 +1240,10 @@ func (c *DynamoDB) ListTablesPages(input *ListTablesInput, fn func(*ListTablesOu
 func (c *DynamoDB) ListTablesPagesWithContext(ctx aws.Context, input *ListTablesInput, fn func(*ListTablesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListTablesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListTablesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1615,7 +1621,10 @@ func (c *DynamoDB) QueryPages(input *QueryInput, fn func(*QueryOutput, bool) boo
 func (c *DynamoDB) QueryPagesWithContext(ctx aws.Context, input *QueryInput, fn func(*QueryOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy QueryInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.QueryRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1779,7 +1788,10 @@ func (c *DynamoDB) ScanPages(input *ScanInput, fn func(*ScanOutput, bool) bool) 
 func (c *DynamoDB) ScanPagesWithContext(ctx aws.Context, input *ScanInput, fn func(*ScanOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ScanInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ScanRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/dynamodb/waiters.go
+++ b/service/dynamodb/waiters.go
@@ -44,7 +44,11 @@ func (c *DynamoDB) WaitUntilTableExistsWithContext(ctx aws.Context, input *Descr
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeTableRequest(input)
+			var inCpy DescribeTableInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeTableRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -85,7 +89,11 @@ func (c *DynamoDB) WaitUntilTableNotExistsWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeTableRequest(input)
+			var inCpy DescribeTableInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeTableRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -8892,7 +8892,10 @@ func (c *EC2) DescribeInstanceStatusPages(input *DescribeInstanceStatusInput, fn
 func (c *EC2) DescribeInstanceStatusPagesWithContext(ctx aws.Context, input *DescribeInstanceStatusInput, fn func(*DescribeInstanceStatusOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeInstanceStatusInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeInstanceStatusRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -9034,7 +9037,10 @@ func (c *EC2) DescribeInstancesPages(input *DescribeInstancesInput, fn func(*Des
 func (c *EC2) DescribeInstancesPagesWithContext(ctx aws.Context, input *DescribeInstancesInput, fn func(*DescribeInstancesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -9391,7 +9397,10 @@ func (c *EC2) DescribeNatGatewaysPages(input *DescribeNatGatewaysInput, fn func(
 func (c *EC2) DescribeNatGatewaysPagesWithContext(ctx aws.Context, input *DescribeNatGatewaysInput, fn func(*DescribeNatGatewaysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeNatGatewaysInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeNatGatewaysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -10161,7 +10170,10 @@ func (c *EC2) DescribeReservedInstancesModificationsPages(input *DescribeReserve
 func (c *EC2) DescribeReservedInstancesModificationsPagesWithContext(ctx aws.Context, input *DescribeReservedInstancesModificationsInput, fn func(*DescribeReservedInstancesModificationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReservedInstancesModificationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReservedInstancesModificationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -10299,7 +10311,10 @@ func (c *EC2) DescribeReservedInstancesOfferingsPages(input *DescribeReservedIns
 func (c *EC2) DescribeReservedInstancesOfferingsPagesWithContext(ctx aws.Context, input *DescribeReservedInstancesOfferingsInput, fn func(*DescribeReservedInstancesOfferingsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReservedInstancesOfferingsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReservedInstancesOfferingsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -10949,7 +10964,10 @@ func (c *EC2) DescribeSnapshotsPages(input *DescribeSnapshotsInput, fn func(*Des
 func (c *EC2) DescribeSnapshotsPagesWithContext(ctx aws.Context, input *DescribeSnapshotsInput, fn func(*DescribeSnapshotsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeSnapshotsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeSnapshotsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -11311,7 +11329,10 @@ func (c *EC2) DescribeSpotFleetRequestsPages(input *DescribeSpotFleetRequestsInp
 func (c *EC2) DescribeSpotFleetRequestsPagesWithContext(ctx aws.Context, input *DescribeSpotFleetRequestsInput, fn func(*DescribeSpotFleetRequestsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeSpotFleetRequestsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeSpotFleetRequestsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -11534,7 +11555,10 @@ func (c *EC2) DescribeSpotPriceHistoryPages(input *DescribeSpotPriceHistoryInput
 func (c *EC2) DescribeSpotPriceHistoryPagesWithContext(ctx aws.Context, input *DescribeSpotPriceHistoryInput, fn func(*DescribeSpotPriceHistoryOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeSpotPriceHistoryInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeSpotPriceHistoryRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -11820,7 +11844,10 @@ func (c *EC2) DescribeTagsPages(input *DescribeTagsInput, fn func(*DescribeTagsO
 func (c *EC2) DescribeTagsPagesWithContext(ctx aws.Context, input *DescribeTagsInput, fn func(*DescribeTagsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeTagsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeTagsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -12060,7 +12087,10 @@ func (c *EC2) DescribeVolumeStatusPages(input *DescribeVolumeStatusInput, fn fun
 func (c *EC2) DescribeVolumeStatusPagesWithContext(ctx aws.Context, input *DescribeVolumeStatusInput, fn func(*DescribeVolumeStatusOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeVolumeStatusInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeVolumeStatusRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -12197,7 +12227,10 @@ func (c *EC2) DescribeVolumesPages(input *DescribeVolumesInput, fn func(*Describ
 func (c *EC2) DescribeVolumesPagesWithContext(ctx aws.Context, input *DescribeVolumesInput, fn func(*DescribeVolumesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeVolumesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeVolumesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/ec2/waiters.go
+++ b/service/ec2/waiters.go
@@ -44,7 +44,11 @@ func (c *EC2) WaitUntilBundleTaskCompleteWithContext(ctx aws.Context, input *Des
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeBundleTasksRequest(input)
+			var inCpy DescribeBundleTasksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeBundleTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -85,7 +89,11 @@ func (c *EC2) WaitUntilConversionTaskCancelledWithContext(ctx aws.Context, input
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeConversionTasksRequest(input)
+			var inCpy DescribeConversionTasksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeConversionTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -136,7 +144,11 @@ func (c *EC2) WaitUntilConversionTaskCompletedWithContext(ctx aws.Context, input
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeConversionTasksRequest(input)
+			var inCpy DescribeConversionTasksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeConversionTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -177,7 +189,11 @@ func (c *EC2) WaitUntilConversionTaskDeletedWithContext(ctx aws.Context, input *
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeConversionTasksRequest(input)
+			var inCpy DescribeConversionTasksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeConversionTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -228,7 +244,11 @@ func (c *EC2) WaitUntilCustomerGatewayAvailableWithContext(ctx aws.Context, inpu
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeCustomerGatewaysRequest(input)
+			var inCpy DescribeCustomerGatewaysInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeCustomerGatewaysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -269,7 +289,11 @@ func (c *EC2) WaitUntilExportTaskCancelledWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeExportTasksRequest(input)
+			var inCpy DescribeExportTasksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeExportTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -310,7 +334,11 @@ func (c *EC2) WaitUntilExportTaskCompletedWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeExportTasksRequest(input)
+			var inCpy DescribeExportTasksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeExportTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -356,7 +384,11 @@ func (c *EC2) WaitUntilImageAvailableWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeImagesRequest(input)
+			var inCpy DescribeImagesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeImagesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -402,7 +434,11 @@ func (c *EC2) WaitUntilImageExistsWithContext(ctx aws.Context, input *DescribeIm
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeImagesRequest(input)
+			var inCpy DescribeImagesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeImagesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -448,7 +484,11 @@ func (c *EC2) WaitUntilInstanceExistsWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -509,7 +549,11 @@ func (c *EC2) WaitUntilInstanceRunningWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -555,7 +599,11 @@ func (c *EC2) WaitUntilInstanceStatusOkWithContext(ctx aws.Context, input *Descr
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstanceStatusRequest(input)
+			var inCpy DescribeInstanceStatusInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstanceStatusRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -606,7 +654,11 @@ func (c *EC2) WaitUntilInstanceStoppedWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -657,7 +709,11 @@ func (c *EC2) WaitUntilInstanceTerminatedWithContext(ctx aws.Context, input *Des
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -703,7 +759,11 @@ func (c *EC2) WaitUntilKeyPairExistsWithContext(ctx aws.Context, input *Describe
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeKeyPairsRequest(input)
+			var inCpy DescribeKeyPairsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeKeyPairsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -764,7 +824,11 @@ func (c *EC2) WaitUntilNatGatewayAvailableWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeNatGatewaysRequest(input)
+			var inCpy DescribeNatGatewaysInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeNatGatewaysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -810,7 +874,11 @@ func (c *EC2) WaitUntilNetworkInterfaceAvailableWithContext(ctx aws.Context, inp
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeNetworkInterfacesRequest(input)
+			var inCpy DescribeNetworkInterfacesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeNetworkInterfacesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -851,7 +919,11 @@ func (c *EC2) WaitUntilPasswordDataAvailableWithContext(ctx aws.Context, input *
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetPasswordDataRequest(input)
+			var inCpy GetPasswordDataInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetPasswordDataRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -892,7 +964,11 @@ func (c *EC2) WaitUntilSnapshotCompletedWithContext(ctx aws.Context, input *Desc
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeSnapshotsRequest(input)
+			var inCpy DescribeSnapshotsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeSnapshotsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -953,7 +1029,11 @@ func (c *EC2) WaitUntilSpotInstanceRequestFulfilledWithContext(ctx aws.Context, 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeSpotInstanceRequestsRequest(input)
+			var inCpy DescribeSpotInstanceRequestsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeSpotInstanceRequestsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -994,7 +1074,11 @@ func (c *EC2) WaitUntilSubnetAvailableWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeSubnetsRequest(input)
+			var inCpy DescribeSubnetsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeSubnetsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1035,7 +1119,11 @@ func (c *EC2) WaitUntilSystemStatusOkWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstanceStatusRequest(input)
+			var inCpy DescribeInstanceStatusInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstanceStatusRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1081,7 +1169,11 @@ func (c *EC2) WaitUntilVolumeAvailableWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVolumesRequest(input)
+			var inCpy DescribeVolumesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVolumesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1127,7 +1219,11 @@ func (c *EC2) WaitUntilVolumeDeletedWithContext(ctx aws.Context, input *Describe
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVolumesRequest(input)
+			var inCpy DescribeVolumesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVolumesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1173,7 +1269,11 @@ func (c *EC2) WaitUntilVolumeInUseWithContext(ctx aws.Context, input *DescribeVo
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVolumesRequest(input)
+			var inCpy DescribeVolumesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVolumesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1214,7 +1314,11 @@ func (c *EC2) WaitUntilVpcAvailableWithContext(ctx aws.Context, input *DescribeV
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpcsRequest(input)
+			var inCpy DescribeVpcsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVpcsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1260,7 +1364,11 @@ func (c *EC2) WaitUntilVpcExistsWithContext(ctx aws.Context, input *DescribeVpcs
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpcsRequest(input)
+			var inCpy DescribeVpcsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVpcsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1306,7 +1414,11 @@ func (c *EC2) WaitUntilVpcPeeringConnectionDeletedWithContext(ctx aws.Context, i
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpcPeeringConnectionsRequest(input)
+			var inCpy DescribeVpcPeeringConnectionsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVpcPeeringConnectionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1352,7 +1464,11 @@ func (c *EC2) WaitUntilVpcPeeringConnectionExistsWithContext(ctx aws.Context, in
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpcPeeringConnectionsRequest(input)
+			var inCpy DescribeVpcPeeringConnectionsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVpcPeeringConnectionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1403,7 +1519,11 @@ func (c *EC2) WaitUntilVpnConnectionAvailableWithContext(ctx aws.Context, input 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpnConnectionsRequest(input)
+			var inCpy DescribeVpnConnectionsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVpnConnectionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1449,7 +1569,11 @@ func (c *EC2) WaitUntilVpnConnectionDeletedWithContext(ctx aws.Context, input *D
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpnConnectionsRequest(input)
+			var inCpy DescribeVpnConnectionsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVpnConnectionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -812,7 +812,10 @@ func (c *ECR) DescribeImagesPages(input *DescribeImagesInput, fn func(*DescribeI
 func (c *ECR) DescribeImagesPagesWithContext(ctx aws.Context, input *DescribeImagesInput, fn func(*DescribeImagesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeImagesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeImagesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -952,7 +955,10 @@ func (c *ECR) DescribeRepositoriesPages(input *DescribeRepositoriesInput, fn fun
 func (c *ECR) DescribeRepositoriesPagesWithContext(ctx aws.Context, input *DescribeRepositoriesInput, fn func(*DescribeRepositoriesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeRepositoriesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeRepositoriesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1474,7 +1480,10 @@ func (c *ECR) ListImagesPages(input *ListImagesInput, fn func(*ListImagesOutput,
 func (c *ECR) ListImagesPagesWithContext(ctx aws.Context, input *ListImagesInput, fn func(*ListImagesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListImagesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListImagesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -1532,7 +1532,10 @@ func (c *ECS) ListClustersPages(input *ListClustersInput, fn func(*ListClustersO
 func (c *ECS) ListClustersPagesWithContext(ctx aws.Context, input *ListClustersInput, fn func(*ListClustersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListClustersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1681,7 +1684,10 @@ func (c *ECS) ListContainerInstancesPages(input *ListContainerInstancesInput, fn
 func (c *ECS) ListContainerInstancesPagesWithContext(ctx aws.Context, input *ListContainerInstancesInput, fn func(*ListContainerInstancesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListContainerInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListContainerInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1826,7 +1832,10 @@ func (c *ECS) ListServicesPages(input *ListServicesInput, fn func(*ListServicesO
 func (c *ECS) ListServicesPagesWithContext(ctx aws.Context, input *ListServicesInput, fn func(*ListServicesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListServicesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListServicesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1973,7 +1982,10 @@ func (c *ECS) ListTaskDefinitionFamiliesPages(input *ListTaskDefinitionFamiliesI
 func (c *ECS) ListTaskDefinitionFamiliesPagesWithContext(ctx aws.Context, input *ListTaskDefinitionFamiliesInput, fn func(*ListTaskDefinitionFamiliesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListTaskDefinitionFamiliesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListTaskDefinitionFamiliesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2116,7 +2128,10 @@ func (c *ECS) ListTaskDefinitionsPages(input *ListTaskDefinitionsInput, fn func(
 func (c *ECS) ListTaskDefinitionsPagesWithContext(ctx aws.Context, input *ListTaskDefinitionsInput, fn func(*ListTaskDefinitionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListTaskDefinitionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListTaskDefinitionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2270,7 +2285,10 @@ func (c *ECS) ListTasksPages(input *ListTasksInput, fn func(*ListTasksOutput, bo
 func (c *ECS) ListTasksPagesWithContext(ctx aws.Context, input *ListTasksInput, fn func(*ListTasksOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListTasksInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/ecs/waiters.go
+++ b/service/ecs/waiters.go
@@ -44,7 +44,11 @@ func (c *ECS) WaitUntilServicesInactiveWithContext(ctx aws.Context, input *Descr
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeServicesRequest(input)
+			var inCpy DescribeServicesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeServicesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -100,7 +104,11 @@ func (c *ECS) WaitUntilServicesStableWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeServicesRequest(input)
+			var inCpy DescribeServicesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeServicesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -151,7 +159,11 @@ func (c *ECS) WaitUntilTasksRunningWithContext(ctx aws.Context, input *DescribeT
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeTasksRequest(input)
+			var inCpy DescribeTasksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -192,7 +204,11 @@ func (c *ECS) WaitUntilTasksStoppedWithContext(ctx aws.Context, input *DescribeT
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeTasksRequest(input)
+			var inCpy DescribeTasksInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeTasksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -1813,7 +1813,10 @@ func (c *ElastiCache) DescribeCacheClustersPages(input *DescribeCacheClustersInp
 func (c *ElastiCache) DescribeCacheClustersPagesWithContext(ctx aws.Context, input *DescribeCacheClustersInput, fn func(*DescribeCacheClustersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeCacheClustersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeCacheClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1940,7 +1943,10 @@ func (c *ElastiCache) DescribeCacheEngineVersionsPages(input *DescribeCacheEngin
 func (c *ElastiCache) DescribeCacheEngineVersionsPagesWithContext(ctx aws.Context, input *DescribeCacheEngineVersionsInput, fn func(*DescribeCacheEngineVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeCacheEngineVersionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeCacheEngineVersionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2081,7 +2087,10 @@ func (c *ElastiCache) DescribeCacheParameterGroupsPages(input *DescribeCachePara
 func (c *ElastiCache) DescribeCacheParameterGroupsPagesWithContext(ctx aws.Context, input *DescribeCacheParameterGroupsInput, fn func(*DescribeCacheParameterGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeCacheParameterGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeCacheParameterGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2220,7 +2229,10 @@ func (c *ElastiCache) DescribeCacheParametersPages(input *DescribeCacheParameter
 func (c *ElastiCache) DescribeCacheParametersPagesWithContext(ctx aws.Context, input *DescribeCacheParametersInput, fn func(*DescribeCacheParametersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeCacheParametersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeCacheParametersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2360,7 +2372,10 @@ func (c *ElastiCache) DescribeCacheSecurityGroupsPages(input *DescribeCacheSecur
 func (c *ElastiCache) DescribeCacheSecurityGroupsPagesWithContext(ctx aws.Context, input *DescribeCacheSecurityGroupsInput, fn func(*DescribeCacheSecurityGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeCacheSecurityGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeCacheSecurityGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2494,7 +2509,10 @@ func (c *ElastiCache) DescribeCacheSubnetGroupsPages(input *DescribeCacheSubnetG
 func (c *ElastiCache) DescribeCacheSubnetGroupsPagesWithContext(ctx aws.Context, input *DescribeCacheSubnetGroupsInput, fn func(*DescribeCacheSubnetGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeCacheSubnetGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeCacheSubnetGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2630,7 +2648,10 @@ func (c *ElastiCache) DescribeEngineDefaultParametersPages(input *DescribeEngine
 func (c *ElastiCache) DescribeEngineDefaultParametersPagesWithContext(ctx aws.Context, input *DescribeEngineDefaultParametersInput, fn func(*DescribeEngineDefaultParametersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEngineDefaultParametersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEngineDefaultParametersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2771,7 +2792,10 @@ func (c *ElastiCache) DescribeEventsPages(input *DescribeEventsInput, fn func(*D
 func (c *ElastiCache) DescribeEventsPagesWithContext(ctx aws.Context, input *DescribeEventsInput, fn func(*DescribeEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2913,7 +2937,10 @@ func (c *ElastiCache) DescribeReplicationGroupsPages(input *DescribeReplicationG
 func (c *ElastiCache) DescribeReplicationGroupsPagesWithContext(ctx aws.Context, input *DescribeReplicationGroupsInput, fn func(*DescribeReplicationGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReplicationGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReplicationGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3052,7 +3079,10 @@ func (c *ElastiCache) DescribeReservedCacheNodesPages(input *DescribeReservedCac
 func (c *ElastiCache) DescribeReservedCacheNodesPagesWithContext(ctx aws.Context, input *DescribeReservedCacheNodesInput, fn func(*DescribeReservedCacheNodesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReservedCacheNodesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReservedCacheNodesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3190,7 +3220,10 @@ func (c *ElastiCache) DescribeReservedCacheNodesOfferingsPages(input *DescribeRe
 func (c *ElastiCache) DescribeReservedCacheNodesOfferingsPagesWithContext(ctx aws.Context, input *DescribeReservedCacheNodesOfferingsInput, fn func(*DescribeReservedCacheNodesOfferingsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReservedCacheNodesOfferingsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReservedCacheNodesOfferingsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3336,7 +3369,10 @@ func (c *ElastiCache) DescribeSnapshotsPages(input *DescribeSnapshotsInput, fn f
 func (c *ElastiCache) DescribeSnapshotsPagesWithContext(ctx aws.Context, input *DescribeSnapshotsInput, fn func(*DescribeSnapshotsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeSnapshotsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeSnapshotsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/elasticache/waiters.go
+++ b/service/elasticache/waiters.go
@@ -59,7 +59,11 @@ func (c *ElastiCache) WaitUntilCacheClusterAvailableWithContext(ctx aws.Context,
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeCacheClustersRequest(input)
+			var inCpy DescribeCacheClustersInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeCacheClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -135,7 +139,11 @@ func (c *ElastiCache) WaitUntilCacheClusterDeletedWithContext(ctx aws.Context, i
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeCacheClustersRequest(input)
+			var inCpy DescribeCacheClustersInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeCacheClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -181,7 +189,11 @@ func (c *ElastiCache) WaitUntilReplicationGroupAvailableWithContext(ctx aws.Cont
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeReplicationGroupsRequest(input)
+			var inCpy DescribeReplicationGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeReplicationGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -232,7 +244,11 @@ func (c *ElastiCache) WaitUntilReplicationGroupDeletedWithContext(ctx aws.Contex
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeReplicationGroupsRequest(input)
+			var inCpy DescribeReplicationGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeReplicationGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -2200,7 +2200,10 @@ func (c *ElasticBeanstalk) DescribeEventsPages(input *DescribeEventsInput, fn fu
 func (c *ElasticBeanstalk) DescribeEventsPagesWithContext(ctx aws.Context, input *DescribeEventsInput, fn func(*DescribeEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -909,7 +909,10 @@ func (c *ElasticsearchService) ListElasticsearchInstanceTypesPages(input *ListEl
 func (c *ElasticsearchService) ListElasticsearchInstanceTypesPagesWithContext(ctx aws.Context, input *ListElasticsearchInstanceTypesInput, fn func(*ListElasticsearchInstanceTypesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListElasticsearchInstanceTypesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListElasticsearchInstanceTypesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1054,7 +1057,10 @@ func (c *ElasticsearchService) ListElasticsearchVersionsPages(input *ListElastic
 func (c *ElasticsearchService) ListElasticsearchVersionsPagesWithContext(ctx aws.Context, input *ListElasticsearchVersionsInput, fn func(*ListElasticsearchVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListElasticsearchVersionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListElasticsearchVersionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -734,7 +734,10 @@ func (c *ElasticTranscoder) ListJobsByPipelinePages(input *ListJobsByPipelineInp
 func (c *ElasticTranscoder) ListJobsByPipelinePagesWithContext(ctx aws.Context, input *ListJobsByPipelineInput, fn func(*ListJobsByPipelineOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListJobsByPipelineInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListJobsByPipelineRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -879,7 +882,10 @@ func (c *ElasticTranscoder) ListJobsByStatusPages(input *ListJobsByStatusInput, 
 func (c *ElasticTranscoder) ListJobsByStatusPagesWithContext(ctx aws.Context, input *ListJobsByStatusInput, fn func(*ListJobsByStatusOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListJobsByStatusInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListJobsByStatusRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1018,7 +1024,10 @@ func (c *ElasticTranscoder) ListPipelinesPages(input *ListPipelinesInput, fn fun
 func (c *ElasticTranscoder) ListPipelinesPagesWithContext(ctx aws.Context, input *ListPipelinesInput, fn func(*ListPipelinesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPipelinesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPipelinesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1157,7 +1166,10 @@ func (c *ElasticTranscoder) ListPresetsPages(input *ListPresetsInput, fn func(*L
 func (c *ElasticTranscoder) ListPresetsPagesWithContext(ctx aws.Context, input *ListPresetsInput, fn func(*ListPresetsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPresetsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPresetsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/elastictranscoder/waiters.go
+++ b/service/elastictranscoder/waiters.go
@@ -49,7 +49,11 @@ func (c *ElasticTranscoder) WaitUntilJobCompleteWithContext(ctx aws.Context, inp
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.ReadJobRequest(input)
+			var inCpy ReadJobInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.ReadJobRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -1719,7 +1719,10 @@ func (c *ELB) DescribeLoadBalancersPages(input *DescribeLoadBalancersInput, fn f
 func (c *ELB) DescribeLoadBalancersPagesWithContext(ctx aws.Context, input *DescribeLoadBalancersInput, fn func(*DescribeLoadBalancersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeLoadBalancersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeLoadBalancersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/elb/waiters.go
+++ b/service/elb/waiters.go
@@ -39,7 +39,11 @@ func (c *ELB) WaitUntilAnyInstanceInServiceWithContext(ctx aws.Context, input *D
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstanceHealthRequest(input)
+			var inCpy DescribeInstanceHealthInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstanceHealthRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -85,7 +89,11 @@ func (c *ELB) WaitUntilInstanceDeregisteredWithContext(ctx aws.Context, input *D
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstanceHealthRequest(input)
+			var inCpy DescribeInstanceHealthInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstanceHealthRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -126,7 +134,11 @@ func (c *ELB) WaitUntilInstanceInServiceWithContext(ctx aws.Context, input *Desc
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstanceHealthRequest(input)
+			var inCpy DescribeInstanceHealthInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstanceHealthRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/elbv2/api.go
+++ b/service/elbv2/api.go
@@ -1107,7 +1107,10 @@ func (c *ELBV2) DescribeListenersPages(input *DescribeListenersInput, fn func(*D
 func (c *ELBV2) DescribeListenersPagesWithContext(ctx aws.Context, input *DescribeListenersInput, fn func(*DescribeListenersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeListenersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeListenersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1323,7 +1326,10 @@ func (c *ELBV2) DescribeLoadBalancersPages(input *DescribeLoadBalancersInput, fn
 func (c *ELBV2) DescribeLoadBalancersPagesWithContext(ctx aws.Context, input *DescribeLoadBalancersInput, fn func(*DescribeLoadBalancersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeLoadBalancersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeLoadBalancersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1799,7 +1805,10 @@ func (c *ELBV2) DescribeTargetGroupsPages(input *DescribeTargetGroupsInput, fn f
 func (c *ELBV2) DescribeTargetGroupsPagesWithContext(ctx aws.Context, input *DescribeTargetGroupsInput, fn func(*DescribeTargetGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeTargetGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeTargetGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/elbv2/waiters.go
+++ b/service/elbv2/waiters.go
@@ -49,7 +49,11 @@ func (c *ELBV2) WaitUntilLoadBalancerAvailableWithContext(ctx aws.Context, input
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeLoadBalancersRequest(input)
+			var inCpy DescribeLoadBalancersInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeLoadBalancersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -95,7 +99,11 @@ func (c *ELBV2) WaitUntilLoadBalancerExistsWithContext(ctx aws.Context, input *D
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeLoadBalancersRequest(input)
+			var inCpy DescribeLoadBalancersInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeLoadBalancersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -1099,7 +1099,10 @@ func (c *EMR) ListBootstrapActionsPages(input *ListBootstrapActionsInput, fn fun
 func (c *EMR) ListBootstrapActionsPagesWithContext(ctx aws.Context, input *ListBootstrapActionsInput, fn func(*ListBootstrapActionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListBootstrapActionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListBootstrapActionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1238,7 +1241,10 @@ func (c *EMR) ListClustersPages(input *ListClustersInput, fn func(*ListClustersO
 func (c *EMR) ListClustersPagesWithContext(ctx aws.Context, input *ListClustersInput, fn func(*ListClustersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListClustersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1376,7 +1382,10 @@ func (c *EMR) ListInstanceFleetsPages(input *ListInstanceFleetsInput, fn func(*L
 func (c *EMR) ListInstanceFleetsPagesWithContext(ctx aws.Context, input *ListInstanceFleetsInput, fn func(*ListInstanceFleetsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListInstanceFleetsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListInstanceFleetsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1511,7 +1520,10 @@ func (c *EMR) ListInstanceGroupsPages(input *ListInstanceGroupsInput, fn func(*L
 func (c *EMR) ListInstanceGroupsPagesWithContext(ctx aws.Context, input *ListInstanceGroupsInput, fn func(*ListInstanceGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListInstanceGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListInstanceGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1650,7 +1662,10 @@ func (c *EMR) ListInstancesPages(input *ListInstancesInput, fn func(*ListInstanc
 func (c *EMR) ListInstancesPagesWithContext(ctx aws.Context, input *ListInstancesInput, fn func(*ListInstancesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1872,7 +1887,10 @@ func (c *EMR) ListStepsPages(input *ListStepsInput, fn func(*ListStepsOutput, bo
 func (c *EMR) ListStepsPagesWithContext(ctx aws.Context, input *ListStepsInput, fn func(*ListStepsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListStepsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListStepsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/emr/waiters.go
+++ b/service/emr/waiters.go
@@ -59,7 +59,11 @@ func (c *EMR) WaitUntilClusterRunningWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeClusterRequest(input)
+			var inCpy DescribeClusterInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeClusterRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -105,7 +109,11 @@ func (c *EMR) WaitUntilClusterTerminatedWithContext(ctx aws.Context, input *Desc
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeClusterRequest(input)
+			var inCpy DescribeClusterInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeClusterRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -156,7 +164,11 @@ func (c *EMR) WaitUntilStepCompleteWithContext(ctx aws.Context, input *DescribeS
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeStepRequest(input)
+			var inCpy DescribeStepInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeStepRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -2451,7 +2451,10 @@ func (c *Glacier) ListJobsPages(input *ListJobsInput, fn func(*ListJobsOutput, b
 func (c *Glacier) ListJobsPagesWithContext(ctx aws.Context, input *ListJobsInput, fn func(*ListJobsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListJobsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListJobsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2619,7 +2622,10 @@ func (c *Glacier) ListMultipartUploadsPages(input *ListMultipartUploadsInput, fn
 func (c *Glacier) ListMultipartUploadsPagesWithContext(ctx aws.Context, input *ListMultipartUploadsInput, fn func(*ListMultipartUploadsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListMultipartUploadsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListMultipartUploadsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2781,7 +2787,10 @@ func (c *Glacier) ListPartsPages(input *ListPartsInput, fn func(*ListPartsOutput
 func (c *Glacier) ListPartsPagesWithContext(ctx aws.Context, input *ListPartsInput, fn func(*ListPartsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPartsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPartsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3112,7 +3121,10 @@ func (c *Glacier) ListVaultsPages(input *ListVaultsInput, fn func(*ListVaultsOut
 func (c *Glacier) ListVaultsPagesWithContext(ctx aws.Context, input *ListVaultsInput, fn func(*ListVaultsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListVaultsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListVaultsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/glacier/waiters.go
+++ b/service/glacier/waiters.go
@@ -44,7 +44,11 @@ func (c *Glacier) WaitUntilVaultExistsWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVaultRequest(input)
+			var inCpy DescribeVaultInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVaultRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -90,7 +94,11 @@ func (c *Glacier) WaitUntilVaultNotExistsWithContext(ctx aws.Context, input *Des
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVaultRequest(input)
+			var inCpy DescribeVaultInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeVaultRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/health/api.go
+++ b/service/health/api.go
@@ -139,7 +139,10 @@ func (c *Health) DescribeAffectedEntitiesPages(input *DescribeAffectedEntitiesIn
 func (c *Health) DescribeAffectedEntitiesPagesWithContext(ctx aws.Context, input *DescribeAffectedEntitiesInput, fn func(*DescribeAffectedEntitiesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeAffectedEntitiesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeAffectedEntitiesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -350,7 +353,10 @@ func (c *Health) DescribeEventAggregatesPages(input *DescribeEventAggregatesInpu
 func (c *Health) DescribeEventAggregatesPagesWithContext(ctx aws.Context, input *DescribeEventAggregatesInput, fn func(*DescribeEventAggregatesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventAggregatesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventAggregatesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -573,7 +579,10 @@ func (c *Health) DescribeEventTypesPages(input *DescribeEventTypesInput, fn func
 func (c *Health) DescribeEventTypesPagesWithContext(ctx aws.Context, input *DescribeEventTypesInput, fn func(*DescribeEventTypesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventTypesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventTypesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -715,7 +724,10 @@ func (c *Health) DescribeEventsPages(input *DescribeEventsInput, fn func(*Descri
 func (c *Health) DescribeEventsPagesWithContext(ctx aws.Context, input *DescribeEventsInput, fn func(*DescribeEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -4827,7 +4827,10 @@ func (c *IAM) GetAccountAuthorizationDetailsPages(input *GetAccountAuthorization
 func (c *IAM) GetAccountAuthorizationDetailsPagesWithContext(ctx aws.Context, input *GetAccountAuthorizationDetailsInput, fn func(*GetAccountAuthorizationDetailsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetAccountAuthorizationDetailsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetAccountAuthorizationDetailsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5424,7 +5427,10 @@ func (c *IAM) GetGroupPages(input *GetGroupInput, fn func(*GetGroupOutput, bool)
 func (c *IAM) GetGroupPagesWithContext(ctx aws.Context, input *GetGroupInput, fn func(*GetGroupOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetGroupInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetGroupRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -6811,7 +6817,10 @@ func (c *IAM) ListAccessKeysPages(input *ListAccessKeysInput, fn func(*ListAcces
 func (c *IAM) ListAccessKeysPagesWithContext(ctx aws.Context, input *ListAccessKeysInput, fn func(*ListAccessKeysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAccessKeysInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAccessKeysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -6947,7 +6956,10 @@ func (c *IAM) ListAccountAliasesPages(input *ListAccountAliasesInput, fn func(*L
 func (c *IAM) ListAccountAliasesPagesWithContext(ctx aws.Context, input *ListAccountAliasesInput, fn func(*ListAccountAliasesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAccountAliasesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAccountAliasesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -7099,7 +7111,10 @@ func (c *IAM) ListAttachedGroupPoliciesPages(input *ListAttachedGroupPoliciesInp
 func (c *IAM) ListAttachedGroupPoliciesPagesWithContext(ctx aws.Context, input *ListAttachedGroupPoliciesInput, fn func(*ListAttachedGroupPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAttachedGroupPoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAttachedGroupPoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -7251,7 +7266,10 @@ func (c *IAM) ListAttachedRolePoliciesPages(input *ListAttachedRolePoliciesInput
 func (c *IAM) ListAttachedRolePoliciesPagesWithContext(ctx aws.Context, input *ListAttachedRolePoliciesInput, fn func(*ListAttachedRolePoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAttachedRolePoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAttachedRolePoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -7403,7 +7421,10 @@ func (c *IAM) ListAttachedUserPoliciesPages(input *ListAttachedUserPoliciesInput
 func (c *IAM) ListAttachedUserPoliciesPagesWithContext(ctx aws.Context, input *ListAttachedUserPoliciesInput, fn func(*ListAttachedUserPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAttachedUserPoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAttachedUserPoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -7552,7 +7573,10 @@ func (c *IAM) ListEntitiesForPolicyPages(input *ListEntitiesForPolicyInput, fn f
 func (c *IAM) ListEntitiesForPolicyPagesWithContext(ctx aws.Context, input *ListEntitiesForPolicyInput, fn func(*ListEntitiesForPolicyOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListEntitiesForPolicyInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListEntitiesForPolicyRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -7700,7 +7724,10 @@ func (c *IAM) ListGroupPoliciesPages(input *ListGroupPoliciesInput, fn func(*Lis
 func (c *IAM) ListGroupPoliciesPagesWithContext(ctx aws.Context, input *ListGroupPoliciesInput, fn func(*ListGroupPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListGroupPoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListGroupPoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -7835,7 +7862,10 @@ func (c *IAM) ListGroupsPages(input *ListGroupsInput, fn func(*ListGroupsOutput,
 func (c *IAM) ListGroupsPagesWithContext(ctx aws.Context, input *ListGroupsInput, fn func(*ListGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -7974,7 +8004,10 @@ func (c *IAM) ListGroupsForUserPages(input *ListGroupsForUserInput, fn func(*Lis
 func (c *IAM) ListGroupsForUserPagesWithContext(ctx aws.Context, input *ListGroupsForUserInput, fn func(*ListGroupsForUserOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListGroupsForUserInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListGroupsForUserRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -8111,7 +8144,10 @@ func (c *IAM) ListInstanceProfilesPages(input *ListInstanceProfilesInput, fn fun
 func (c *IAM) ListInstanceProfilesPagesWithContext(ctx aws.Context, input *ListInstanceProfilesInput, fn func(*ListInstanceProfilesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListInstanceProfilesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListInstanceProfilesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -8252,7 +8288,10 @@ func (c *IAM) ListInstanceProfilesForRolePages(input *ListInstanceProfilesForRol
 func (c *IAM) ListInstanceProfilesForRolePagesWithContext(ctx aws.Context, input *ListInstanceProfilesForRoleInput, fn func(*ListInstanceProfilesForRoleOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListInstanceProfilesForRoleInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListInstanceProfilesForRoleRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -8394,7 +8433,10 @@ func (c *IAM) ListMFADevicesPages(input *ListMFADevicesInput, fn func(*ListMFADe
 func (c *IAM) ListMFADevicesPagesWithContext(ctx aws.Context, input *ListMFADevicesInput, fn func(*ListMFADevicesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListMFADevicesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListMFADevicesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -8621,7 +8663,10 @@ func (c *IAM) ListPoliciesPages(input *ListPoliciesInput, fn func(*ListPoliciesO
 func (c *IAM) ListPoliciesPagesWithContext(ctx aws.Context, input *ListPoliciesInput, fn func(*ListPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -8767,7 +8812,10 @@ func (c *IAM) ListPolicyVersionsPages(input *ListPolicyVersionsInput, fn func(*L
 func (c *IAM) ListPolicyVersionsPagesWithContext(ctx aws.Context, input *ListPolicyVersionsInput, fn func(*ListPolicyVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPolicyVersionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPolicyVersionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -8914,7 +8962,10 @@ func (c *IAM) ListRolePoliciesPages(input *ListRolePoliciesInput, fn func(*ListR
 func (c *IAM) ListRolePoliciesPagesWithContext(ctx aws.Context, input *ListRolePoliciesInput, fn func(*ListRolePoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListRolePoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListRolePoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -9051,7 +9102,10 @@ func (c *IAM) ListRolesPages(input *ListRolesInput, fn func(*ListRolesOutput, bo
 func (c *IAM) ListRolesPagesWithContext(ctx aws.Context, input *ListRolesInput, fn func(*ListRolesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListRolesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListRolesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -9277,7 +9331,10 @@ func (c *IAM) ListSSHPublicKeysPages(input *ListSSHPublicKeysInput, fn func(*Lis
 func (c *IAM) ListSSHPublicKeysPagesWithContext(ctx aws.Context, input *ListSSHPublicKeysInput, fn func(*ListSSHPublicKeysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListSSHPublicKeysInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListSSHPublicKeysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -9418,7 +9475,10 @@ func (c *IAM) ListServerCertificatesPages(input *ListServerCertificatesInput, fn
 func (c *IAM) ListServerCertificatesPagesWithContext(ctx aws.Context, input *ListServerCertificatesInput, fn func(*ListServerCertificatesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListServerCertificatesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListServerCertificatesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -9655,7 +9715,10 @@ func (c *IAM) ListSigningCertificatesPages(input *ListSigningCertificatesInput, 
 func (c *IAM) ListSigningCertificatesPagesWithContext(ctx aws.Context, input *ListSigningCertificatesInput, fn func(*ListSigningCertificatesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListSigningCertificatesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListSigningCertificatesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -9801,7 +9864,10 @@ func (c *IAM) ListUserPoliciesPages(input *ListUserPoliciesInput, fn func(*ListU
 func (c *IAM) ListUserPoliciesPagesWithContext(ctx aws.Context, input *ListUserPoliciesInput, fn func(*ListUserPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListUserPoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListUserPoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -9938,7 +10004,10 @@ func (c *IAM) ListUsersPages(input *ListUsersInput, fn func(*ListUsersOutput, bo
 func (c *IAM) ListUsersPagesWithContext(ctx aws.Context, input *ListUsersInput, fn func(*ListUsersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListUsersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListUsersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -10070,7 +10139,10 @@ func (c *IAM) ListVirtualMFADevicesPages(input *ListVirtualMFADevicesInput, fn f
 func (c *IAM) ListVirtualMFADevicesPagesWithContext(ctx aws.Context, input *ListVirtualMFADevicesInput, fn func(*ListVirtualMFADevicesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListVirtualMFADevicesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListVirtualMFADevicesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -11137,7 +11209,10 @@ func (c *IAM) SimulateCustomPolicyPages(input *SimulateCustomPolicyInput, fn fun
 func (c *IAM) SimulateCustomPolicyPagesWithContext(ctx aws.Context, input *SimulateCustomPolicyInput, fn func(*SimulatePolicyResponse, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy SimulateCustomPolicyInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.SimulateCustomPolicyRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -11304,7 +11379,10 @@ func (c *IAM) SimulatePrincipalPolicyPages(input *SimulatePrincipalPolicyInput, 
 func (c *IAM) SimulatePrincipalPolicyPagesWithContext(ctx aws.Context, input *SimulatePrincipalPolicyInput, fn func(*SimulatePolicyResponse, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy SimulatePrincipalPolicyInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.SimulatePrincipalPolicyRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/iam/waiters.go
+++ b/service/iam/waiters.go
@@ -44,7 +44,11 @@ func (c *IAM) WaitUntilInstanceProfileExistsWithContext(ctx aws.Context, input *
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetInstanceProfileRequest(input)
+			var inCpy GetInstanceProfileInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetInstanceProfileRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -90,7 +94,11 @@ func (c *IAM) WaitUntilUserExistsWithContext(ctx aws.Context, input *GetUserInpu
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetUserRequest(input)
+			var inCpy GetUserInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetUserRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -670,7 +670,10 @@ func (c *Kinesis) DescribeStreamPages(input *DescribeStreamInput, fn func(*Descr
 func (c *Kinesis) DescribeStreamPagesWithContext(ctx aws.Context, input *DescribeStreamInput, fn func(*DescribeStreamOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeStreamInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeStreamRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1383,7 +1386,10 @@ func (c *Kinesis) ListStreamsPages(input *ListStreamsInput, fn func(*ListStreams
 func (c *Kinesis) ListStreamsPagesWithContext(ctx aws.Context, input *ListStreamsInput, fn func(*ListStreamsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListStreamsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListStreamsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/kinesis/waiters.go
+++ b/service/kinesis/waiters.go
@@ -39,7 +39,11 @@ func (c *Kinesis) WaitUntilStreamExistsWithContext(ctx aws.Context, input *Descr
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeStreamRequest(input)
+			var inCpy DescribeStreamInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeStreamRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -2419,7 +2419,10 @@ func (c *KMS) ListAliasesPages(input *ListAliasesInput, fn func(*ListAliasesOutp
 func (c *KMS) ListAliasesPagesWithContext(ctx aws.Context, input *ListAliasesInput, fn func(*ListAliasesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAliasesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAliasesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2575,7 +2578,10 @@ func (c *KMS) ListGrantsPages(input *ListGrantsInput, fn func(*ListGrantsRespons
 func (c *KMS) ListGrantsPagesWithContext(ctx aws.Context, input *ListGrantsInput, fn func(*ListGrantsResponse, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListGrantsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListGrantsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2727,7 +2733,10 @@ func (c *KMS) ListKeyPoliciesPages(input *ListKeyPoliciesInput, fn func(*ListKey
 func (c *KMS) ListKeyPoliciesPagesWithContext(ctx aws.Context, input *ListKeyPoliciesInput, fn func(*ListKeyPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListKeyPoliciesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListKeyPoliciesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2868,7 +2877,10 @@ func (c *KMS) ListKeysPages(input *ListKeysInput, fn func(*ListKeysOutput, bool)
 func (c *KMS) ListKeysPagesWithContext(ctx aws.Context, input *ListKeysInput, fn func(*ListKeysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListKeysInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListKeysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -1763,7 +1763,10 @@ func (c *Lambda) ListEventSourceMappingsPages(input *ListEventSourceMappingsInpu
 func (c *Lambda) ListEventSourceMappingsPagesWithContext(ctx aws.Context, input *ListEventSourceMappingsInput, fn func(*ListEventSourceMappingsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListEventSourceMappingsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListEventSourceMappingsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1902,7 +1905,10 @@ func (c *Lambda) ListFunctionsPages(input *ListFunctionsInput, fn func(*ListFunc
 func (c *Lambda) ListFunctionsPagesWithContext(ctx aws.Context, input *ListFunctionsInput, fn func(*ListFunctionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListFunctionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListFunctionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -1468,7 +1468,10 @@ func (c *MachineLearning) DescribeBatchPredictionsPages(input *DescribeBatchPred
 func (c *MachineLearning) DescribeBatchPredictionsPagesWithContext(ctx aws.Context, input *DescribeBatchPredictionsInput, fn func(*DescribeBatchPredictionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeBatchPredictionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeBatchPredictionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1601,7 +1604,10 @@ func (c *MachineLearning) DescribeDataSourcesPages(input *DescribeDataSourcesInp
 func (c *MachineLearning) DescribeDataSourcesPagesWithContext(ctx aws.Context, input *DescribeDataSourcesInput, fn func(*DescribeDataSourcesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDataSourcesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDataSourcesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1735,7 +1741,10 @@ func (c *MachineLearning) DescribeEvaluationsPages(input *DescribeEvaluationsInp
 func (c *MachineLearning) DescribeEvaluationsPagesWithContext(ctx aws.Context, input *DescribeEvaluationsInput, fn func(*DescribeEvaluationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEvaluationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEvaluationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1868,7 +1877,10 @@ func (c *MachineLearning) DescribeMLModelsPages(input *DescribeMLModelsInput, fn
 func (c *MachineLearning) DescribeMLModelsPagesWithContext(ctx aws.Context, input *DescribeMLModelsInput, fn func(*DescribeMLModelsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeMLModelsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeMLModelsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/machinelearning/waiters.go
+++ b/service/machinelearning/waiters.go
@@ -44,7 +44,11 @@ func (c *MachineLearning) WaitUntilBatchPredictionAvailableWithContext(ctx aws.C
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeBatchPredictionsRequest(input)
+			var inCpy DescribeBatchPredictionsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeBatchPredictionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -90,7 +94,11 @@ func (c *MachineLearning) WaitUntilDataSourceAvailableWithContext(ctx aws.Contex
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeDataSourcesRequest(input)
+			var inCpy DescribeDataSourcesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeDataSourcesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -136,7 +144,11 @@ func (c *MachineLearning) WaitUntilEvaluationAvailableWithContext(ctx aws.Contex
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeEvaluationsRequest(input)
+			var inCpy DescribeEvaluationsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeEvaluationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -182,7 +194,11 @@ func (c *MachineLearning) WaitUntilMLModelAvailableWithContext(ctx aws.Context, 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeMLModelsRequest(input)
+			var inCpy DescribeMLModelsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeMLModelsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/mturk/api.go
+++ b/service/mturk/api.go
@@ -1894,7 +1894,10 @@ func (c *MTurk) ListAssignmentsForHITPages(input *ListAssignmentsForHITInput, fn
 func (c *MTurk) ListAssignmentsForHITPagesWithContext(ctx aws.Context, input *ListAssignmentsForHITInput, fn func(*ListAssignmentsForHITOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAssignmentsForHITInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAssignmentsForHITRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2031,7 +2034,10 @@ func (c *MTurk) ListBonusPaymentsPages(input *ListBonusPaymentsInput, fn func(*L
 func (c *MTurk) ListBonusPaymentsPagesWithContext(ctx aws.Context, input *ListBonusPaymentsInput, fn func(*ListBonusPaymentsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListBonusPaymentsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListBonusPaymentsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2169,7 +2175,10 @@ func (c *MTurk) ListHITsPages(input *ListHITsInput, fn func(*ListHITsOutput, boo
 func (c *MTurk) ListHITsPagesWithContext(ctx aws.Context, input *ListHITsInput, fn func(*ListHITsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListHITsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListHITsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2308,7 +2317,10 @@ func (c *MTurk) ListHITsForQualificationTypePages(input *ListHITsForQualificatio
 func (c *MTurk) ListHITsForQualificationTypePagesWithContext(ctx aws.Context, input *ListHITsForQualificationTypeInput, fn func(*ListHITsForQualificationTypeOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListHITsForQualificationTypeInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListHITsForQualificationTypeRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2447,7 +2459,10 @@ func (c *MTurk) ListQualificationRequestsPages(input *ListQualificationRequestsI
 func (c *MTurk) ListQualificationRequestsPagesWithContext(ctx aws.Context, input *ListQualificationRequestsInput, fn func(*ListQualificationRequestsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListQualificationRequestsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListQualificationRequestsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2586,7 +2601,10 @@ func (c *MTurk) ListQualificationTypesPages(input *ListQualificationTypesInput, 
 func (c *MTurk) ListQualificationTypesPagesWithContext(ctx aws.Context, input *ListQualificationTypesInput, fn func(*ListQualificationTypesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListQualificationTypesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListQualificationTypesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2726,7 +2744,10 @@ func (c *MTurk) ListReviewPolicyResultsForHITPages(input *ListReviewPolicyResult
 func (c *MTurk) ListReviewPolicyResultsForHITPagesWithContext(ctx aws.Context, input *ListReviewPolicyResultsForHITInput, fn func(*ListReviewPolicyResultsForHITOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListReviewPolicyResultsForHITInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListReviewPolicyResultsForHITRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2864,7 +2885,10 @@ func (c *MTurk) ListReviewableHITsPages(input *ListReviewableHITsInput, fn func(
 func (c *MTurk) ListReviewableHITsPagesWithContext(ctx aws.Context, input *ListReviewableHITsInput, fn func(*ListReviewableHITsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListReviewableHITsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListReviewableHITsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3001,7 +3025,10 @@ func (c *MTurk) ListWorkerBlocksPages(input *ListWorkerBlocksInput, fn func(*Lis
 func (c *MTurk) ListWorkerBlocksPagesWithContext(ctx aws.Context, input *ListWorkerBlocksInput, fn func(*ListWorkerBlocksOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListWorkerBlocksInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListWorkerBlocksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3138,7 +3165,10 @@ func (c *MTurk) ListWorkersWithQualificationTypePages(input *ListWorkersWithQual
 func (c *MTurk) ListWorkersWithQualificationTypePagesWithContext(ctx aws.Context, input *ListWorkersWithQualificationTypeInput, fn func(*ListWorkersWithQualificationTypeOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListWorkersWithQualificationTypeInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListWorkersWithQualificationTypeRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -2405,7 +2405,10 @@ func (c *OpsWorks) DescribeEcsClustersPages(input *DescribeEcsClustersInput, fn 
 func (c *OpsWorks) DescribeEcsClustersPagesWithContext(ctx aws.Context, input *DescribeEcsClustersInput, fn func(*DescribeEcsClustersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEcsClustersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEcsClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/opsworks/waiters.go
+++ b/service/opsworks/waiters.go
@@ -44,7 +44,11 @@ func (c *OpsWorks) WaitUntilAppExistsWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeAppsRequest(input)
+			var inCpy DescribeAppsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeAppsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -90,7 +94,11 @@ func (c *OpsWorks) WaitUntilDeploymentSuccessfulWithContext(ctx aws.Context, inp
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeDeploymentsRequest(input)
+			var inCpy DescribeDeploymentsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeDeploymentsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -171,7 +179,11 @@ func (c *OpsWorks) WaitUntilInstanceOnlineWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -247,7 +259,11 @@ func (c *OpsWorks) WaitUntilInstanceRegisteredWithContext(ctx aws.Context, input
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -333,7 +349,11 @@ func (c *OpsWorks) WaitUntilInstanceStoppedWithContext(ctx aws.Context, input *D
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -419,7 +439,11 @@ func (c *OpsWorks) WaitUntilInstanceTerminatedWithContext(ctx aws.Context, input
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy DescribeInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -3903,7 +3903,10 @@ func (c *RDS) DescribeDBEngineVersionsPages(input *DescribeDBEngineVersionsInput
 func (c *RDS) DescribeDBEngineVersionsPagesWithContext(ctx aws.Context, input *DescribeDBEngineVersionsInput, fn func(*DescribeDBEngineVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDBEngineVersionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDBEngineVersionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4035,7 +4038,10 @@ func (c *RDS) DescribeDBInstancesPages(input *DescribeDBInstancesInput, fn func(
 func (c *RDS) DescribeDBInstancesPagesWithContext(ctx aws.Context, input *DescribeDBInstancesInput, fn func(*DescribeDBInstancesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDBInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDBInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4167,7 +4173,10 @@ func (c *RDS) DescribeDBLogFilesPages(input *DescribeDBLogFilesInput, fn func(*D
 func (c *RDS) DescribeDBLogFilesPagesWithContext(ctx aws.Context, input *DescribeDBLogFilesInput, fn func(*DescribeDBLogFilesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDBLogFilesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDBLogFilesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4301,7 +4310,10 @@ func (c *RDS) DescribeDBParameterGroupsPages(input *DescribeDBParameterGroupsInp
 func (c *RDS) DescribeDBParameterGroupsPagesWithContext(ctx aws.Context, input *DescribeDBParameterGroupsInput, fn func(*DescribeDBParameterGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDBParameterGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDBParameterGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4433,7 +4445,10 @@ func (c *RDS) DescribeDBParametersPages(input *DescribeDBParametersInput, fn fun
 func (c *RDS) DescribeDBParametersPagesWithContext(ctx aws.Context, input *DescribeDBParametersInput, fn func(*DescribeDBParametersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDBParametersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDBParametersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4567,7 +4582,10 @@ func (c *RDS) DescribeDBSecurityGroupsPages(input *DescribeDBSecurityGroupsInput
 func (c *RDS) DescribeDBSecurityGroupsPagesWithContext(ctx aws.Context, input *DescribeDBSecurityGroupsInput, fn func(*DescribeDBSecurityGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDBSecurityGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDBSecurityGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4790,7 +4808,10 @@ func (c *RDS) DescribeDBSnapshotsPages(input *DescribeDBSnapshotsInput, fn func(
 func (c *RDS) DescribeDBSnapshotsPagesWithContext(ctx aws.Context, input *DescribeDBSnapshotsInput, fn func(*DescribeDBSnapshotsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDBSnapshotsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDBSnapshotsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4925,7 +4946,10 @@ func (c *RDS) DescribeDBSubnetGroupsPages(input *DescribeDBSubnetGroupsInput, fn
 func (c *RDS) DescribeDBSubnetGroupsPagesWithContext(ctx aws.Context, input *DescribeDBSubnetGroupsInput, fn func(*DescribeDBSubnetGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDBSubnetGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDBSubnetGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5132,7 +5156,10 @@ func (c *RDS) DescribeEngineDefaultParametersPages(input *DescribeEngineDefaultP
 func (c *RDS) DescribeEngineDefaultParametersPagesWithContext(ctx aws.Context, input *DescribeEngineDefaultParametersInput, fn func(*DescribeEngineDefaultParametersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEngineDefaultParametersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEngineDefaultParametersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5346,7 +5373,10 @@ func (c *RDS) DescribeEventSubscriptionsPages(input *DescribeEventSubscriptionsI
 func (c *RDS) DescribeEventSubscriptionsPagesWithContext(ctx aws.Context, input *DescribeEventSubscriptionsInput, fn func(*DescribeEventSubscriptionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventSubscriptionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventSubscriptionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5477,7 +5507,10 @@ func (c *RDS) DescribeEventsPages(input *DescribeEventsInput, fn func(*DescribeE
 func (c *RDS) DescribeEventsPagesWithContext(ctx aws.Context, input *DescribeEventsInput, fn func(*DescribeEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5604,7 +5637,10 @@ func (c *RDS) DescribeOptionGroupOptionsPages(input *DescribeOptionGroupOptionsI
 func (c *RDS) DescribeOptionGroupOptionsPagesWithContext(ctx aws.Context, input *DescribeOptionGroupOptionsInput, fn func(*DescribeOptionGroupOptionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeOptionGroupOptionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeOptionGroupOptionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5736,7 +5772,10 @@ func (c *RDS) DescribeOptionGroupsPages(input *DescribeOptionGroupsInput, fn fun
 func (c *RDS) DescribeOptionGroupsPagesWithContext(ctx aws.Context, input *DescribeOptionGroupsInput, fn func(*DescribeOptionGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeOptionGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeOptionGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5863,7 +5902,10 @@ func (c *RDS) DescribeOrderableDBInstanceOptionsPages(input *DescribeOrderableDB
 func (c *RDS) DescribeOrderableDBInstanceOptionsPagesWithContext(ctx aws.Context, input *DescribeOrderableDBInstanceOptionsInput, fn func(*DescribeOrderableDBInstanceOptionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeOrderableDBInstanceOptionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeOrderableDBInstanceOptionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -6077,7 +6119,10 @@ func (c *RDS) DescribeReservedDBInstancesPages(input *DescribeReservedDBInstance
 func (c *RDS) DescribeReservedDBInstancesPagesWithContext(ctx aws.Context, input *DescribeReservedDBInstancesInput, fn func(*DescribeReservedDBInstancesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReservedDBInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReservedDBInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -6209,7 +6254,10 @@ func (c *RDS) DescribeReservedDBInstancesOfferingsPages(input *DescribeReservedD
 func (c *RDS) DescribeReservedDBInstancesOfferingsPagesWithContext(ctx aws.Context, input *DescribeReservedDBInstancesOfferingsInput, fn func(*DescribeReservedDBInstancesOfferingsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReservedDBInstancesOfferingsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReservedDBInstancesOfferingsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -6421,7 +6469,10 @@ func (c *RDS) DownloadDBLogFilePortionPages(input *DownloadDBLogFilePortionInput
 func (c *RDS) DownloadDBLogFilePortionPagesWithContext(ctx aws.Context, input *DownloadDBLogFilePortionInput, fn func(*DownloadDBLogFilePortionOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DownloadDBLogFilePortionInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DownloadDBLogFilePortionRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/rds/waiters.go
+++ b/service/rds/waiters.go
@@ -64,7 +64,11 @@ func (c *RDS) WaitUntilDBInstanceAvailableWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeDBInstancesRequest(input)
+			var inCpy DescribeDBInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeDBInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -130,7 +134,11 @@ func (c *RDS) WaitUntilDBInstanceDeletedWithContext(ctx aws.Context, input *Desc
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeDBInstancesRequest(input)
+			var inCpy DescribeDBInstancesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeDBInstancesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -2474,7 +2474,10 @@ func (c *Redshift) DescribeClusterParameterGroupsPages(input *DescribeClusterPar
 func (c *Redshift) DescribeClusterParameterGroupsPagesWithContext(ctx aws.Context, input *DescribeClusterParameterGroupsInput, fn func(*DescribeClusterParameterGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeClusterParameterGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeClusterParameterGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2617,7 +2620,10 @@ func (c *Redshift) DescribeClusterParametersPages(input *DescribeClusterParamete
 func (c *Redshift) DescribeClusterParametersPagesWithContext(ctx aws.Context, input *DescribeClusterParametersInput, fn func(*DescribeClusterParametersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeClusterParametersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeClusterParametersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2769,7 +2775,10 @@ func (c *Redshift) DescribeClusterSecurityGroupsPages(input *DescribeClusterSecu
 func (c *Redshift) DescribeClusterSecurityGroupsPagesWithContext(ctx aws.Context, input *DescribeClusterSecurityGroupsInput, fn func(*DescribeClusterSecurityGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeClusterSecurityGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeClusterSecurityGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2918,7 +2927,10 @@ func (c *Redshift) DescribeClusterSnapshotsPages(input *DescribeClusterSnapshots
 func (c *Redshift) DescribeClusterSnapshotsPagesWithContext(ctx aws.Context, input *DescribeClusterSnapshotsInput, fn func(*DescribeClusterSnapshotsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeClusterSnapshotsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeClusterSnapshotsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3066,7 +3078,10 @@ func (c *Redshift) DescribeClusterSubnetGroupsPages(input *DescribeClusterSubnet
 func (c *Redshift) DescribeClusterSubnetGroupsPagesWithContext(ctx aws.Context, input *DescribeClusterSubnetGroupsInput, fn func(*DescribeClusterSubnetGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeClusterSubnetGroupsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeClusterSubnetGroupsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3197,7 +3212,10 @@ func (c *Redshift) DescribeClusterVersionsPages(input *DescribeClusterVersionsIn
 func (c *Redshift) DescribeClusterVersionsPagesWithContext(ctx aws.Context, input *DescribeClusterVersionsInput, fn func(*DescribeClusterVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeClusterVersionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeClusterVersionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3345,7 +3363,10 @@ func (c *Redshift) DescribeClustersPages(input *DescribeClustersInput, fn func(*
 func (c *Redshift) DescribeClustersPagesWithContext(ctx aws.Context, input *DescribeClustersInput, fn func(*DescribeClustersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeClustersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3476,7 +3497,10 @@ func (c *Redshift) DescribeDefaultClusterParametersPages(input *DescribeDefaultC
 func (c *Redshift) DescribeDefaultClusterParametersPagesWithContext(ctx aws.Context, input *DescribeDefaultClusterParametersInput, fn func(*DescribeDefaultClusterParametersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDefaultClusterParametersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDefaultClusterParametersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3688,7 +3712,10 @@ func (c *Redshift) DescribeEventSubscriptionsPages(input *DescribeEventSubscript
 func (c *Redshift) DescribeEventSubscriptionsPagesWithContext(ctx aws.Context, input *DescribeEventSubscriptionsInput, fn func(*DescribeEventSubscriptionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventSubscriptionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventSubscriptionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3818,7 +3845,10 @@ func (c *Redshift) DescribeEventsPages(input *DescribeEventsInput, fn func(*Desc
 func (c *Redshift) DescribeEventsPagesWithContext(ctx aws.Context, input *DescribeEventsInput, fn func(*DescribeEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeEventsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeEventsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3965,7 +3995,10 @@ func (c *Redshift) DescribeHsmClientCertificatesPages(input *DescribeHsmClientCe
 func (c *Redshift) DescribeHsmClientCertificatesPagesWithContext(ctx aws.Context, input *DescribeHsmClientCertificatesInput, fn func(*DescribeHsmClientCertificatesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeHsmClientCertificatesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeHsmClientCertificatesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4112,7 +4145,10 @@ func (c *Redshift) DescribeHsmConfigurationsPages(input *DescribeHsmConfiguratio
 func (c *Redshift) DescribeHsmConfigurationsPagesWithContext(ctx aws.Context, input *DescribeHsmConfigurationsInput, fn func(*DescribeHsmConfigurationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeHsmConfigurationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeHsmConfigurationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4328,7 +4364,10 @@ func (c *Redshift) DescribeOrderableClusterOptionsPages(input *DescribeOrderable
 func (c *Redshift) DescribeOrderableClusterOptionsPagesWithContext(ctx aws.Context, input *DescribeOrderableClusterOptionsInput, fn func(*DescribeOrderableClusterOptionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeOrderableClusterOptionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeOrderableClusterOptionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4472,7 +4511,10 @@ func (c *Redshift) DescribeReservedNodeOfferingsPages(input *DescribeReservedNod
 func (c *Redshift) DescribeReservedNodeOfferingsPagesWithContext(ctx aws.Context, input *DescribeReservedNodeOfferingsInput, fn func(*DescribeReservedNodeOfferingsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReservedNodeOfferingsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReservedNodeOfferingsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4604,7 +4646,10 @@ func (c *Redshift) DescribeReservedNodesPages(input *DescribeReservedNodesInput,
 func (c *Redshift) DescribeReservedNodesPagesWithContext(ctx aws.Context, input *DescribeReservedNodesInput, fn func(*DescribeReservedNodesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeReservedNodesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeReservedNodesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/redshift/waiters.go
+++ b/service/redshift/waiters.go
@@ -49,7 +49,11 @@ func (c *Redshift) WaitUntilClusterAvailableWithContext(ctx aws.Context, input *
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeClustersRequest(input)
+			var inCpy DescribeClustersInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -100,7 +104,11 @@ func (c *Redshift) WaitUntilClusterDeletedWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeClustersRequest(input)
+			var inCpy DescribeClustersInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -146,7 +154,11 @@ func (c *Redshift) WaitUntilClusterRestoredWithContext(ctx aws.Context, input *D
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeClustersRequest(input)
+			var inCpy DescribeClustersInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeClustersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -197,7 +209,11 @@ func (c *Redshift) WaitUntilSnapshotAvailableWithContext(ctx aws.Context, input 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeClusterSnapshotsRequest(input)
+			var inCpy DescribeClusterSnapshotsInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.DescribeClusterSnapshotsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/rekognition/api.go
+++ b/service/rekognition/api.go
@@ -981,7 +981,10 @@ func (c *Rekognition) ListCollectionsPages(input *ListCollectionsInput, fn func(
 func (c *Rekognition) ListCollectionsPagesWithContext(ctx aws.Context, input *ListCollectionsInput, fn func(*ListCollectionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListCollectionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListCollectionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1136,7 +1139,10 @@ func (c *Rekognition) ListFacesPages(input *ListFacesInput, fn func(*ListFacesOu
 func (c *Rekognition) ListFacesPagesWithContext(ctx aws.Context, input *ListFacesInput, fn func(*ListFacesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListFacesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListFacesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -3240,7 +3240,10 @@ func (c *Route53) ListHealthChecksPages(input *ListHealthChecksInput, fn func(*L
 func (c *Route53) ListHealthChecksPagesWithContext(ctx aws.Context, input *ListHealthChecksInput, fn func(*ListHealthChecksOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListHealthChecksInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListHealthChecksRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3403,7 +3406,10 @@ func (c *Route53) ListHostedZonesPages(input *ListHostedZonesInput, fn func(*Lis
 func (c *Route53) ListHostedZonesPagesWithContext(ctx aws.Context, input *ListHostedZonesInput, fn func(*ListHostedZonesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListHostedZonesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListHostedZonesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3709,7 +3715,10 @@ func (c *Route53) ListResourceRecordSetsPages(input *ListResourceRecordSetsInput
 func (c *Route53) ListResourceRecordSetsPagesWithContext(ctx aws.Context, input *ListResourceRecordSetsInput, fn func(*ListResourceRecordSetsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListResourceRecordSetsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListResourceRecordSetsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/route53/waiters.go
+++ b/service/route53/waiters.go
@@ -39,7 +39,11 @@ func (c *Route53) WaitUntilResourceRecordSetsChangedWithContext(ctx aws.Context,
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetChangeRequest(input)
+			var inCpy GetChangeInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetChangeRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -1053,7 +1053,10 @@ func (c *Route53Domains) ListDomainsPages(input *ListDomainsInput, fn func(*List
 func (c *Route53Domains) ListDomainsPagesWithContext(ctx aws.Context, input *ListDomainsInput, fn func(*ListDomainsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDomainsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDomainsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1187,7 +1190,10 @@ func (c *Route53Domains) ListOperationsPages(input *ListOperationsInput, fn func
 func (c *Route53Domains) ListOperationsPagesWithContext(ctx aws.Context, input *ListOperationsInput, fn func(*ListOperationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListOperationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListOperationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -3668,7 +3668,10 @@ func (c *S3) ListMultipartUploadsPages(input *ListMultipartUploadsInput, fn func
 func (c *S3) ListMultipartUploadsPagesWithContext(ctx aws.Context, input *ListMultipartUploadsInput, fn func(*ListMultipartUploadsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListMultipartUploadsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListMultipartUploadsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3795,7 +3798,10 @@ func (c *S3) ListObjectVersionsPages(input *ListObjectVersionsInput, fn func(*Li
 func (c *S3) ListObjectVersionsPagesWithContext(ctx aws.Context, input *ListObjectVersionsInput, fn func(*ListObjectVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListObjectVersionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListObjectVersionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3929,7 +3935,10 @@ func (c *S3) ListObjectsPages(input *ListObjectsInput, fn func(*ListObjectsOutpu
 func (c *S3) ListObjectsPagesWithContext(ctx aws.Context, input *ListObjectsInput, fn func(*ListObjectsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListObjectsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListObjectsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4064,7 +4073,10 @@ func (c *S3) ListObjectsV2Pages(input *ListObjectsV2Input, fn func(*ListObjectsV
 func (c *S3) ListObjectsV2PagesWithContext(ctx aws.Context, input *ListObjectsV2Input, fn func(*ListObjectsV2Output, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListObjectsV2Input
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListObjectsV2Request(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4191,7 +4203,10 @@ func (c *S3) ListPartsPages(input *ListPartsInput, fn func(*ListPartsOutput, boo
 func (c *S3) ListPartsPagesWithContext(ctx aws.Context, input *ListPartsInput, fn func(*ListPartsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPartsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPartsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/s3/waiters.go
+++ b/service/s3/waiters.go
@@ -54,7 +54,11 @@ func (c *S3) WaitUntilBucketExistsWithContext(ctx aws.Context, input *HeadBucket
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.HeadBucketRequest(input)
+			var inCpy HeadBucketInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.HeadBucketRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -95,7 +99,11 @@ func (c *S3) WaitUntilBucketNotExistsWithContext(ctx aws.Context, input *HeadBuc
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.HeadBucketRequest(input)
+			var inCpy HeadBucketInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.HeadBucketRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -141,7 +149,11 @@ func (c *S3) WaitUntilObjectExistsWithContext(ctx aws.Context, input *HeadObject
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.HeadObjectRequest(input)
+			var inCpy HeadObjectInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.HeadObjectRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -182,7 +194,11 @@ func (c *S3) WaitUntilObjectNotExistsWithContext(ctx aws.Context, input *HeadObj
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.HeadObjectRequest(input)
+			var inCpy HeadObjectInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.HeadObjectRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -2386,7 +2386,10 @@ func (c *SES) ListIdentitiesPages(input *ListIdentitiesInput, fn func(*ListIdent
 func (c *SES) ListIdentitiesPagesWithContext(ctx aws.Context, input *ListIdentitiesInput, fn func(*ListIdentitiesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListIdentitiesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListIdentitiesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/ses/waiters.go
+++ b/service/ses/waiters.go
@@ -39,7 +39,11 @@ func (c *SES) WaitUntilIdentityExistsWithContext(ctx aws.Context, input *GetIden
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetIdentityVerificationAttributesRequest(input)
+			var inCpy GetIdentityVerificationAttributesInput
+			if input != nil {
+				inCpy = *input
+			}
+			req, _ := c.GetIdentityVerificationAttributesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/service/sfn/api.go
+++ b/service/sfn/api.go
@@ -825,7 +825,10 @@ func (c *SFN) GetExecutionHistoryPages(input *GetExecutionHistoryInput, fn func(
 func (c *SFN) GetExecutionHistoryPagesWithContext(ctx aws.Context, input *GetExecutionHistoryInput, fn func(*GetExecutionHistoryOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetExecutionHistoryInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetExecutionHistoryRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -959,7 +962,10 @@ func (c *SFN) ListActivitiesPages(input *ListActivitiesInput, fn func(*ListActiv
 func (c *SFN) ListActivitiesPagesWithContext(ctx aws.Context, input *ListActivitiesInput, fn func(*ListActivitiesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListActivitiesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListActivitiesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1099,7 +1105,10 @@ func (c *SFN) ListExecutionsPages(input *ListExecutionsInput, fn func(*ListExecu
 func (c *SFN) ListExecutionsPagesWithContext(ctx aws.Context, input *ListExecutionsInput, fn func(*ListExecutionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListExecutionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListExecutionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1233,7 +1242,10 @@ func (c *SFN) ListStateMachinesPages(input *ListStateMachinesInput, fn func(*Lis
 func (c *SFN) ListStateMachinesPagesWithContext(ctx aws.Context, input *ListStateMachinesInput, fn func(*ListStateMachinesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListStateMachinesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListStateMachinesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/simpledb/api.go
+++ b/service/simpledb/api.go
@@ -826,7 +826,10 @@ func (c *SimpleDB) ListDomainsPages(input *ListDomainsInput, fn func(*ListDomain
 func (c *SimpleDB) ListDomainsPagesWithContext(ctx aws.Context, input *ListDomainsInput, fn func(*ListDomainsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDomainsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDomainsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1117,7 +1120,10 @@ func (c *SimpleDB) SelectPages(input *SelectInput, fn func(*SelectOutput, bool) 
 func (c *SimpleDB) SelectPagesWithContext(ctx aws.Context, input *SelectInput, fn func(*SelectOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy SelectInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.SelectRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/sms/api.go
+++ b/service/sms/api.go
@@ -526,7 +526,10 @@ func (c *SMS) GetConnectorsPages(input *GetConnectorsInput, fn func(*GetConnecto
 func (c *SMS) GetConnectorsPagesWithContext(ctx aws.Context, input *GetConnectorsInput, fn func(*GetConnectorsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetConnectorsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetConnectorsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -668,7 +671,10 @@ func (c *SMS) GetReplicationJobsPages(input *GetReplicationJobsInput, fn func(*G
 func (c *SMS) GetReplicationJobsPagesWithContext(ctx aws.Context, input *GetReplicationJobsInput, fn func(*GetReplicationJobsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetReplicationJobsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetReplicationJobsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -810,7 +816,10 @@ func (c *SMS) GetReplicationRunsPages(input *GetReplicationRunsInput, fn func(*G
 func (c *SMS) GetReplicationRunsPagesWithContext(ctx aws.Context, input *GetReplicationRunsInput, fn func(*GetReplicationRunsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetReplicationRunsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetReplicationRunsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -943,7 +952,10 @@ func (c *SMS) GetServersPages(input *GetServersInput, fn func(*GetServersOutput,
 func (c *SMS) GetServersPagesWithContext(ctx aws.Context, input *GetServersInput, fn func(*GetServersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetServersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetServersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/snowball/api.go
+++ b/service/snowball/api.go
@@ -679,7 +679,10 @@ func (c *Snowball) DescribeAddressesPages(input *DescribeAddressesInput, fn func
 func (c *Snowball) DescribeAddressesPagesWithContext(ctx aws.Context, input *DescribeAddressesInput, fn func(*DescribeAddressesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeAddressesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeAddressesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1412,7 +1415,10 @@ func (c *Snowball) ListJobsPages(input *ListJobsInput, fn func(*ListJobsOutput, 
 func (c *Snowball) ListJobsPagesWithContext(ctx aws.Context, input *ListJobsInput, fn func(*ListJobsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListJobsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListJobsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -1465,7 +1465,10 @@ func (c *SNS) ListEndpointsByPlatformApplicationPages(input *ListEndpointsByPlat
 func (c *SNS) ListEndpointsByPlatformApplicationPagesWithContext(ctx aws.Context, input *ListEndpointsByPlatformApplicationInput, fn func(*ListEndpointsByPlatformApplicationOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListEndpointsByPlatformApplicationInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListEndpointsByPlatformApplicationRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1708,7 +1711,10 @@ func (c *SNS) ListPlatformApplicationsPages(input *ListPlatformApplicationsInput
 func (c *SNS) ListPlatformApplicationsPagesWithContext(ctx aws.Context, input *ListPlatformApplicationsInput, fn func(*ListPlatformApplicationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListPlatformApplicationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListPlatformApplicationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1849,7 +1855,10 @@ func (c *SNS) ListSubscriptionsPages(input *ListSubscriptionsInput, fn func(*Lis
 func (c *SNS) ListSubscriptionsPagesWithContext(ctx aws.Context, input *ListSubscriptionsInput, fn func(*ListSubscriptionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListSubscriptionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListSubscriptionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1993,7 +2002,10 @@ func (c *SNS) ListSubscriptionsByTopicPages(input *ListSubscriptionsByTopicInput
 func (c *SNS) ListSubscriptionsByTopicPagesWithContext(ctx aws.Context, input *ListSubscriptionsByTopicInput, fn func(*ListSubscriptionsByTopicOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListSubscriptionsByTopicInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListSubscriptionsByTopicRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2133,7 +2145,10 @@ func (c *SNS) ListTopicsPages(input *ListTopicsInput, fn func(*ListTopicsOutput,
 func (c *SNS) ListTopicsPagesWithContext(ctx aws.Context, input *ListTopicsInput, fn func(*ListTopicsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListTopicsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListTopicsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -1864,7 +1864,10 @@ func (c *SSM) DescribeActivationsPages(input *DescribeActivationsInput, fn func(
 func (c *SSM) DescribeActivationsPagesWithContext(ctx aws.Context, input *DescribeActivationsInput, fn func(*DescribeActivationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeActivationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeActivationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2750,7 +2753,10 @@ func (c *SSM) DescribeInstanceInformationPages(input *DescribeInstanceInformatio
 func (c *SSM) DescribeInstanceInformationPagesWithContext(ctx aws.Context, input *DescribeInstanceInformationInput, fn func(*DescribeInstanceInformationOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeInstanceInformationInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeInstanceInformationRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5193,7 +5199,10 @@ func (c *SSM) ListAssociationsPages(input *ListAssociationsInput, fn func(*ListA
 func (c *SSM) ListAssociationsPagesWithContext(ctx aws.Context, input *ListAssociationsInput, fn func(*ListAssociationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListAssociationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListAssociationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5352,7 +5361,10 @@ func (c *SSM) ListCommandInvocationsPages(input *ListCommandInvocationsInput, fn
 func (c *SSM) ListCommandInvocationsPagesWithContext(ctx aws.Context, input *ListCommandInvocationsInput, fn func(*ListCommandInvocationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListCommandInvocationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListCommandInvocationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5507,7 +5519,10 @@ func (c *SSM) ListCommandsPages(input *ListCommandsInput, fn func(*ListCommandsO
 func (c *SSM) ListCommandsPagesWithContext(ctx aws.Context, input *ListCommandsInput, fn func(*ListCommandsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListCommandsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListCommandsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -5731,7 +5746,10 @@ func (c *SSM) ListDocumentsPages(input *ListDocumentsInput, fn func(*ListDocumen
 func (c *SSM) ListDocumentsPagesWithContext(ctx aws.Context, input *ListDocumentsInput, fn func(*ListDocumentsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDocumentsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDocumentsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -2971,7 +2971,10 @@ func (c *StorageGateway) DescribeTapeArchivesPages(input *DescribeTapeArchivesIn
 func (c *StorageGateway) DescribeTapeArchivesPagesWithContext(ctx aws.Context, input *DescribeTapeArchivesInput, fn func(*DescribeTapeArchivesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeTapeArchivesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeTapeArchivesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3113,7 +3116,10 @@ func (c *StorageGateway) DescribeTapeRecoveryPointsPages(input *DescribeTapeReco
 func (c *StorageGateway) DescribeTapeRecoveryPointsPagesWithContext(ctx aws.Context, input *DescribeTapeRecoveryPointsInput, fn func(*DescribeTapeRecoveryPointsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeTapeRecoveryPointsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeTapeRecoveryPointsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3252,7 +3258,10 @@ func (c *StorageGateway) DescribeTapesPages(input *DescribeTapesInput, fn func(*
 func (c *StorageGateway) DescribeTapesPagesWithContext(ctx aws.Context, input *DescribeTapesInput, fn func(*DescribeTapesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeTapesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeTapesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3481,7 +3490,10 @@ func (c *StorageGateway) DescribeVTLDevicesPages(input *DescribeVTLDevicesInput,
 func (c *StorageGateway) DescribeVTLDevicesPagesWithContext(ctx aws.Context, input *DescribeVTLDevicesInput, fn func(*DescribeVTLDevicesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeVTLDevicesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeVTLDevicesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -3899,7 +3911,10 @@ func (c *StorageGateway) ListGatewaysPages(input *ListGatewaysInput, fn func(*Li
 func (c *StorageGateway) ListGatewaysPagesWithContext(ctx aws.Context, input *ListGatewaysInput, fn func(*ListGatewaysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListGatewaysInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListGatewaysRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -4496,7 +4511,10 @@ func (c *StorageGateway) ListVolumesPages(input *ListVolumesInput, fn func(*List
 func (c *StorageGateway) ListVolumesPagesWithContext(ctx aws.Context, input *ListVolumesInput, fn func(*ListVolumesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListVolumesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListVolumesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -567,7 +567,10 @@ func (c *Support) DescribeCasesPages(input *DescribeCasesInput, fn func(*Describ
 func (c *Support) DescribeCasesPagesWithContext(ctx aws.Context, input *DescribeCasesInput, fn func(*DescribeCasesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeCasesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeCasesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -711,7 +714,10 @@ func (c *Support) DescribeCommunicationsPages(input *DescribeCommunicationsInput
 func (c *Support) DescribeCommunicationsPagesWithContext(ctx aws.Context, input *DescribeCommunicationsInput, fn func(*DescribeCommunicationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeCommunicationsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeCommunicationsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -1321,7 +1321,10 @@ func (c *SWF) GetWorkflowExecutionHistoryPages(input *GetWorkflowExecutionHistor
 func (c *SWF) GetWorkflowExecutionHistoryPagesWithContext(ctx aws.Context, input *GetWorkflowExecutionHistoryInput, fn func(*GetWorkflowExecutionHistoryOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy GetWorkflowExecutionHistoryInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.GetWorkflowExecutionHistoryRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1477,7 +1480,10 @@ func (c *SWF) ListActivityTypesPages(input *ListActivityTypesInput, fn func(*Lis
 func (c *SWF) ListActivityTypesPagesWithContext(ctx aws.Context, input *ListActivityTypesInput, fn func(*ListActivityTypesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListActivityTypesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListActivityTypesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1637,7 +1643,10 @@ func (c *SWF) ListClosedWorkflowExecutionsPages(input *ListClosedWorkflowExecuti
 func (c *SWF) ListClosedWorkflowExecutionsPagesWithContext(ctx aws.Context, input *ListClosedWorkflowExecutionsInput, fn func(*WorkflowExecutionInfos, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListClosedWorkflowExecutionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListClosedWorkflowExecutionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1788,7 +1797,10 @@ func (c *SWF) ListDomainsPages(input *ListDomainsInput, fn func(*ListDomainsOutp
 func (c *SWF) ListDomainsPagesWithContext(ctx aws.Context, input *ListDomainsInput, fn func(*ListDomainsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListDomainsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListDomainsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1948,7 +1960,10 @@ func (c *SWF) ListOpenWorkflowExecutionsPages(input *ListOpenWorkflowExecutionsI
 func (c *SWF) ListOpenWorkflowExecutionsPagesWithContext(ctx aws.Context, input *ListOpenWorkflowExecutionsInput, fn func(*WorkflowExecutionInfos, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListOpenWorkflowExecutionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListOpenWorkflowExecutionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2102,7 +2117,10 @@ func (c *SWF) ListWorkflowTypesPages(input *ListWorkflowTypesInput, fn func(*Lis
 func (c *SWF) ListWorkflowTypesPagesWithContext(ctx aws.Context, input *ListWorkflowTypesInput, fn func(*ListWorkflowTypesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy ListWorkflowTypesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.ListWorkflowTypesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -2390,7 +2408,10 @@ func (c *SWF) PollForDecisionTaskPages(input *PollForDecisionTaskInput, fn func(
 func (c *SWF) PollForDecisionTaskPagesWithContext(ctx aws.Context, input *PollForDecisionTaskInput, fn func(*PollForDecisionTaskOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy PollForDecisionTaskInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.PollForDecisionTaskRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -1313,7 +1313,10 @@ func (c *WorkDocs) DescribeDocumentVersionsPages(input *DescribeDocumentVersions
 func (c *WorkDocs) DescribeDocumentVersionsPagesWithContext(ctx aws.Context, input *DescribeDocumentVersionsInput, fn func(*DescribeDocumentVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeDocumentVersionsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeDocumentVersionsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1468,7 +1471,10 @@ func (c *WorkDocs) DescribeFolderContentsPages(input *DescribeFolderContentsInpu
 func (c *WorkDocs) DescribeFolderContentsPagesWithContext(ctx aws.Context, input *DescribeFolderContentsInput, fn func(*DescribeFolderContentsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeFolderContentsInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeFolderContentsRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -1796,7 +1802,10 @@ func (c *WorkDocs) DescribeUsersPages(input *DescribeUsersInput, fn func(*Descri
 func (c *WorkDocs) DescribeUsersPagesWithContext(ctx aws.Context, input *DescribeUsersInput, fn func(*DescribeUsersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeUsersInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeUsersRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -472,7 +472,10 @@ func (c *WorkSpaces) DescribeWorkspaceBundlesPages(input *DescribeWorkspaceBundl
 func (c *WorkSpaces) DescribeWorkspaceBundlesPagesWithContext(ctx aws.Context, input *DescribeWorkspaceBundlesInput, fn func(*DescribeWorkspaceBundlesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeWorkspaceBundlesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeWorkspaceBundlesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -611,7 +614,10 @@ func (c *WorkSpaces) DescribeWorkspaceDirectoriesPages(input *DescribeWorkspaceD
 func (c *WorkSpaces) DescribeWorkspaceDirectoriesPagesWithContext(ctx aws.Context, input *DescribeWorkspaceDirectoriesInput, fn func(*DescribeWorkspaceDirectoriesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeWorkspaceDirectoriesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeWorkspaceDirectoriesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
@@ -754,7 +760,10 @@ func (c *WorkSpaces) DescribeWorkspacesPages(input *DescribeWorkspacesInput, fn 
 func (c *WorkSpaces) DescribeWorkspacesPagesWithContext(ctx aws.Context, input *DescribeWorkspacesInput, fn func(*DescribeWorkspacesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
+			var inCpy DescribeWorkspacesInput
+			if input != nil {
+				inCpy = *input
+			}
 			req, _ := c.DescribeWorkspacesRequest(&inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)


### PR DESCRIPTION
Corrects the code generation for Paginators and waiters that caused a
panic if nil input parameters were used with the operations.

Adds tests to verify waiters and paginators will not panic on nil input
parameters.

Fix #1156