### PR TITLE
service/glacier: Export ComputeTreeHash

### DIFF
--- a/service/glacier/treehash.go
+++ b/service/glacier/treehash.go
@@ -15,6 +15,8 @@ type Hash struct {
 }
 
 // ComputeHashes computes the tree-hash and linear hash of a seekable reader r.
+//
+// See http://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html for more information.
 func ComputeHashes(r io.ReadSeeker) Hash {
 	r.Seek(0, 0)       // Read the whole stream
 	defer r.Seek(0, 0) // Rewind stream at end
@@ -41,12 +43,16 @@ func ComputeHashes(r io.ReadSeeker) Hash {
 
 	return Hash{
 		LinearHash: hsh.Sum(nil),
-		TreeHash:   buildHashTree(hashes),
+		TreeHash:   ComputeTreeHash(hashes),
 	}
 }
 
-// buildHashTree builds a hash tree root node given a set of hashes.
-func buildHashTree(hashes [][]byte) []byte {
+// ComputeTreeHash builds a tree hash root node given a slice of
+// hashes. Glacier tree hash to be derived from SHA256 hashes of 1MB
+// chucks of the data.
+//
+// See http://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html for more information.
+func ComputeTreeHash(hashes [][]byte) []byte {
 	if hashes == nil || len(hashes) == 0 {
 		return nil
 	}

--- a/service/glacier/treehash_test.go
+++ b/service/glacier/treehash_test.go
@@ -2,18 +2,16 @@ package glacier_test
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
+	"io"
 
 	"github.com/aws/aws-sdk-go/service/glacier"
 )
 
 func ExampleComputeHashes() {
-	buf := make([]byte, 5767168) // 5.5MB buffer
-	for i := range buf {
-		buf[i] = '0' // Fill with zero characters
-	}
+	r := testCreateReader()
 
-	r := bytes.NewReader(buf)
 	h := glacier.ComputeHashes(r)
 	n, _ := r.Seek(0, 1) // Check position after checksumming
 
@@ -25,4 +23,41 @@ func ExampleComputeHashes() {
 	// linear: 68aff0c5a91aa0491752bfb96e3fef33eb74953804f6a2f7b708d5bcefa8ff6b
 	// tree: 154e26c78fd74d0c2c9b3cc4644191619dc4f2cd539ae2a74d5fd07957a3ee6a
 	// pos: 0
+}
+
+func testCreateReader() io.ReadSeeker {
+	buf := make([]byte, 5767168) // 5.5MB buffer
+	for i := range buf {
+		buf[i] = '0' // Fill with zero characters
+	}
+
+	return bytes.NewReader(buf)
+}
+
+func ExampleComputeTreeHash() {
+	r := testCreateReader()
+
+	const chunkSize = 1024 * 1024 // 1MB
+	buf := make([]byte, chunkSize)
+	hashes := [][]byte{}
+
+	for {
+		// Reach 1MB chunks from reader to generate hashes from
+		n, err := io.ReadAtLeast(r, buf, chunkSize)
+		if n == 0 {
+			break
+		}
+
+		tmpHash := sha256.Sum256(buf[:n])
+		hashes = append(hashes, tmpHash[:])
+		if err != nil {
+			break // last chunk
+		}
+	}
+
+	treeHash := glacier.ComputeTreeHash(hashes)
+	fmt.Printf("TreeHash: %x\n", treeHash)
+
+	// Output:
+	// TreeHash: 154e26c78fd74d0c2c9b3cc4644191619dc4f2cd539ae2a74d5fd07957a3ee6a
 }


### PR DESCRIPTION
Exports the ComputeTreeHash function in the Glacier service client package. This allows you to use the SDK's built in tree hash function for multipart uploads.

Fix #1149