### PR TITLE
Update contributing guide for models

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Please be aware of the following notes prior to opening a pull request:
    been added.
 
 5. The JSON files under the SDK's `models` folder are sourced from outside the SDK.
-   Such as `models/apis/ec2/2016-11-15/api.json`. We cannot accept pull requests
+   Such as `models/apis/ec2/2016-11-15/api.json`. We will not accept pull requests
    directly on these models. If you discover an issue with the models please
    create a Github [issue](issues) describing the issue.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,11 @@ Please be aware of the following notes prior to opening a pull request:
    SDK's test coverage percentage are unlikely to be merged until tests have
    been added.
 
+5. The JSON files under the SDK's `models` folder are sourced from outside the SDK.
+   Such as `models/apis/ec2/2016-11-15/api.json`. We cannot accept pull requests
+   directly on these models. If you discover an issue with the models please
+   create a Github [issue](issues) describing the issue.
+
 ### Testing
 
 To run the tests locally, running the `make unit` command will `go get` the 


### PR DESCRIPTION
Updates the contributing guide highlighting that the SDK is unable to take model change PRs directly, but to create an issue instead.