### PR TITLE
aws/request: Add request option helpers for response headers

### DIFF
--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -114,6 +114,40 @@ func New(cfg aws.Config, clientInfo metadata.ClientInfo, handlers Handlers,
 // using a WithContext API operation method.
 type Option func(*Request)
 
+// WithGetResponseHeader builds a request Option which will retrieve a single
+// header value from the HTTP Response. If there are multiple values for the
+// header key use WithGetResponseHeaders instead to access the http.Header
+// map directly. The passed in val pointer must be non-nil.
+//
+// This Option can be used multiple times with a single API operation.
+//
+//    var id2, versionID string
+//    svc.PutObjectWithContext(ctx, params,
+//        request.WithGetResponseHeader("x-amz-id-2", &id2),
+//        request.WithGetResponseHeader("x-amz-version-id", &versionID),
+//    )
+func WithGetResponseHeader(key string, val *string) Option {
+	return func(r *Request) {
+		r.Handlers.Complete.PushBack(func(req *Request) {
+			*val = req.HTTPResponse.Header.Get(key)
+		})
+	}
+}
+
+// WithGetResponseHeaders builds a request Option which will retrieve the
+// headers from the HTTP response and assign them to the passed in headers
+// variable. The passed in headers pointer must be non-nil.
+//
+//    var headers http.Header
+//    svc.PutObjectWithContext(ctx, params, request.WithGetResponseHeaders(&headers))
+func WithGetResponseHeaders(headers *http.Header) Option {
+	return func(r *Request) {
+		r.Handlers.Complete.PushBack(func(req *Request) {
+			*headers = req.HTTPResponse.Header
+		})
+	}
+}
+
 // WithLogLevel is a request option that will set the request to use a specific
 // log level when the request is made.
 //

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -91,9 +89,15 @@ func TestRequestRecoverRetry5xx(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
-	assert.Equal(t, 2, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 2, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q")
+	}
 }
 
 // test that retries occur for 4xx status codes with a response type that can be retried - see `shouldRetry`
@@ -117,9 +121,15 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
-	assert.Equal(t, 2, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 2, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q")
+	}
 }
 
 // test that retries don't occur for 4xx status codes with a response type that can't be retried
@@ -135,15 +145,22 @@ func TestRequest4xxUnretryable(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.NotNil(t, err)
-	if e, ok := err.(awserr.RequestFailure); ok {
-		assert.Equal(t, 401, e.StatusCode())
-	} else {
-		assert.Fail(t, "Expected error to be a service failure")
+	if err == nil {
+		t.Fatalf("expect error, but did not get one")
 	}
-	assert.Equal(t, "SignatureDoesNotMatch", err.(awserr.Error).Code())
-	assert.Equal(t, "Signature does not match.", err.(awserr.Error).Message())
-	assert.Equal(t, 0, int(r.RetryCount))
+	aerr := err.(awserr.RequestFailure)
+	if e, a := 401, aerr.StatusCode(); e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
+	if e, a := "SignatureDoesNotMatch", aerr.Code(); e != a {
+		t.Errorf("expect %q error code, got %q", e, a)
+	}
+	if e, a := "Signature does not match.", aerr.Message(); e != a {
+		t.Errorf("expect %q error message, got %q", e, a)
+	}
+	if e, a := 0, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
 }
 
 func TestRequestExhaustRetries(t *testing.T) {
@@ -171,22 +188,31 @@ func TestRequestExhaustRetries(t *testing.T) {
 	})
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := r.Send()
-	assert.NotNil(t, err)
-	if e, ok := err.(awserr.RequestFailure); ok {
-		assert.Equal(t, 500, e.StatusCode())
-	} else {
-		assert.Fail(t, "Expected error to be a service failure")
+	if err == nil {
+		t.Fatalf("expect error, but did not get one")
 	}
-	assert.Equal(t, "UnknownError", err.(awserr.Error).Code())
-	assert.Equal(t, "An error occurred.", err.(awserr.Error).Message())
-	assert.Equal(t, 3, int(r.RetryCount))
+	aerr := err.(awserr.RequestFailure)
+	if e, a := 500, aerr.StatusCode(); e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
+	if e, a := "UnknownError", aerr.Code(); e != a {
+		t.Errorf("expect %q error code, got %q", e, a)
+	}
+	if e, a := "An error occurred.", aerr.Message(); e != a {
+		t.Errorf("expect %q error message, got %q", e, a)
+	}
+	if e, a := 3, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
 
 	expectDelays := []struct{ min, max time.Duration }{{30, 59}, {60, 118}, {120, 236}}
 	for i, v := range delays {
 		min := expectDelays[i].min * time.Millisecond
 		max := expectDelays[i].max * time.Millisecond
-		assert.True(t, min <= v && v <= max,
-			"Expect delay to be within range, i:%d, v:%s, min:%s, max:%s", i, v, min, max)
+		if !(min <= v && v <= max) {
+			t.Errorf("Expect delay to be within range, i:%d, v:%s, min:%s, max:%s",
+				i, v, min, max)
+		}
 	}
 }
 
@@ -222,14 +248,26 @@ func TestRequestRecoverExpiredCreds(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
-	assert.False(t, credExpiredBeforeRetry, "Expect valid creds before retry check")
-	assert.True(t, credExpiredAfterRetry, "Expect expired creds after retry check")
-	assert.False(t, s.Config.Credentials.IsExpired(), "Expect valid creds after cred expired recovery")
+	if credExpiredBeforeRetry {
+		t.Errorf("Expect valid creds before retry check")
+	}
+	if !credExpiredAfterRetry {
+		t.Errorf("Expect expired creds after retry check")
+	}
+	if s.Config.Credentials.IsExpired() {
+		t.Errorf("Expect valid creds after cred expired recovery")
+	}
 
-	assert.Equal(t, 1, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if e, a := 1, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q")
+	}
 }
 
 func TestMakeAddtoUserAgentHandler(t *testing.T) {
@@ -238,7 +276,9 @@ func TestMakeAddtoUserAgentHandler(t *testing.T) {
 	r.HTTPRequest.Header.Set("User-Agent", "foo/bar")
 	fn(r)
 
-	assert.Equal(t, "foo/bar name/version (extra1; extra2)", r.HTTPRequest.Header.Get("User-Agent"))
+	if e, a := "foo/bar name/version (extra1; extra2)", r.HTTPRequest.Header.Get("User-Agent"); e != a {
+		t.Errorf("expect %q user agent, got %q", e, a)
+	}
 }
 
 func TestMakeAddtoUserAgentFreeFormHandler(t *testing.T) {
@@ -247,7 +287,9 @@ func TestMakeAddtoUserAgentFreeFormHandler(t *testing.T) {
 	r.HTTPRequest.Header.Set("User-Agent", "foo/bar")
 	fn(r)
 
-	assert.Equal(t, "foo/bar name/version (extra1; extra2)", r.HTTPRequest.Header.Get("User-Agent"))
+	if e, a := "foo/bar name/version (extra1; extra2)", r.HTTPRequest.Header.Get("User-Agent"); e != a {
+		t.Errorf("expect %q user agent, got %q", e, a)
+	}
 }
 
 func TestRequestUserAgent(t *testing.T) {
@@ -256,11 +298,15 @@ func TestRequestUserAgent(t *testing.T) {
 
 	req := s.NewRequest(&request.Operation{Name: "Operation"}, nil, &testData{})
 	req.HTTPRequest.Header.Set("User-Agent", "foo/bar")
-	assert.NoError(t, req.Build())
+	if err := req.Build(); err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
 	expectUA := fmt.Sprintf("foo/bar %s/%s (%s; %s; %s)",
 		aws.SDKName, aws.SDKVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
-	assert.Equal(t, expectUA, req.HTTPRequest.Header.Get("User-Agent"))
+	if e, a := expectUA, req.HTTPRequest.Header.Get("User-Agent"); e != a {
+		t.Errorf("expect %q user agent, got %q", e, a)
+	}
 }
 
 func TestRequestThrottleRetries(t *testing.T) {
@@ -288,22 +334,31 @@ func TestRequestThrottleRetries(t *testing.T) {
 	})
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := r.Send()
-	assert.NotNil(t, err)
-	if e, ok := err.(awserr.RequestFailure); ok {
-		assert.Equal(t, 500, e.StatusCode())
-	} else {
-		assert.Fail(t, "Expected error to be a service failure")
+	if err == nil {
+		t.Fatalf("expect error, but did not get one")
 	}
-	assert.Equal(t, "Throttling", err.(awserr.Error).Code())
-	assert.Equal(t, "An error occurred.", err.(awserr.Error).Message())
-	assert.Equal(t, 3, int(r.RetryCount))
+	aerr := err.(awserr.RequestFailure)
+	if e, a := 500, aerr.StatusCode(); e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
+	if e, a := "Throttling", aerr.Code(); e != a {
+		t.Errorf("expect %q error code, got %q", e, a)
+	}
+	if e, a := "An error occurred.", aerr.Message(); e != a {
+		t.Errorf("expect %q error message, got %q", e, a)
+	}
+	if e, a := 3, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
 
 	expectDelays := []struct{ min, max time.Duration }{{500, 999}, {1000, 1998}, {2000, 3996}}
 	for i, v := range delays {
 		min := expectDelays[i].min * time.Millisecond
 		max := expectDelays[i].max * time.Millisecond
-		assert.True(t, min <= v && v <= max,
-			"Expect delay to be within range, i:%d, v:%s, min:%s, max:%s", i, v, min, max)
+		if !(min <= v && v <= max) {
+			t.Errorf("Expect delay to be within range, i:%d, v:%s, min:%s, max:%s",
+				i, v, min, max)
+		}
 	}
 }
 
@@ -339,9 +394,15 @@ func TestRequestRecoverTimeoutWithNilBody(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
-	assert.Equal(t, 1, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 1, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q")
+	}
 }
 
 func TestRequestRecoverTimeoutWithNilResponse(t *testing.T) {
@@ -376,9 +437,15 @@ func TestRequestRecoverTimeoutWithNilResponse(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
-	assert.Equal(t, 1, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 1, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q")
+	}
 }
 
 func TestRequest_NoBody(t *testing.T) {

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -96,7 +96,7 @@ func TestRequestRecoverRetry5xx(t *testing.T) {
 		t.Errorf("expect %d retry count, got %d", e, a)
 	}
 	if e, a := "valid", out.Data; e != a {
-		t.Errorf("expect %q output got %q")
+		t.Errorf("expect %q output got %q", e, a)
 	}
 }
 
@@ -128,7 +128,7 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 		t.Errorf("expect %d retry count, got %d", e, a)
 	}
 	if e, a := "valid", out.Data; e != a {
-		t.Errorf("expect %q output got %q")
+		t.Errorf("expect %q output got %q", e, a)
 	}
 }
 
@@ -266,7 +266,7 @@ func TestRequestRecoverExpiredCreds(t *testing.T) {
 		t.Errorf("expect %d retry count, got %d", e, a)
 	}
 	if e, a := "valid", out.Data; e != a {
-		t.Errorf("expect %q output got %q")
+		t.Errorf("expect %q output got %q", e, a)
 	}
 }
 
@@ -401,7 +401,7 @@ func TestRequestRecoverTimeoutWithNilBody(t *testing.T) {
 		t.Errorf("expect %d retry count, got %d", e, a)
 	}
 	if e, a := "valid", out.Data; e != a {
-		t.Errorf("expect %q output got %q")
+		t.Errorf("expect %q output got %q", e, a)
 	}
 }
 
@@ -444,7 +444,7 @@ func TestRequestRecoverTimeoutWithNilResponse(t *testing.T) {
 		t.Errorf("expect %d retry count, got %d", e, a)
 	}
 	if e, a := "valid", out.Data; e != a {
-		t.Errorf("expect %q output got %q")
+		t.Errorf("expect %q output got %q", e, a)
 	}
 }
 


### PR DESCRIPTION
Adds two request options to make retrieving API response headers easier
to the request package.
* WithGetResponseHeader - For a single header value
* WithGetResponseHeaders - For all response headers

Related #1162 