### PR TITLE
aws/request: Minor perf improvement for HandlerList copy, push, and clear

### DIFF
--- a/aws/request/handlers.go
+++ b/aws/request/handlers.go
@@ -88,13 +88,17 @@ func (l *HandlerList) copy() HandlerList {
 	n := HandlerList{
 		AfterEachFn: l.AfterEachFn,
 	}
+	if len(l.list) == 0 {
+		return n
+	}
+
 	n.list = append(make([]NamedHandler, 0, len(l.list)), l.list...)
 	return n
 }
 
 // Clear clears the handler list.
 func (l *HandlerList) Clear() {
-	l.list = []NamedHandler{}
+	l.list = l.list[0:0]
 }
 
 // Len returns the number of handlers in the list.
@@ -104,33 +108,49 @@ func (l *HandlerList) Len() int {
 
 // PushBack pushes handler f to the back of the handler list.
 func (l *HandlerList) PushBack(f func(*Request)) {
-	l.list = append(l.list, NamedHandler{"__anonymous", f})
-}
-
-// PushFront pushes handler f to the front of the handler list.
-func (l *HandlerList) PushFront(f func(*Request)) {
-	l.list = append([]NamedHandler{{"__anonymous", f}}, l.list...)
+	l.PushBackNamed(NamedHandler{"__anonymous", f})
 }
 
 // PushBackNamed pushes named handler f to the back of the handler list.
 func (l *HandlerList) PushBackNamed(n NamedHandler) {
+	if cap(l.list) == 0 {
+		l.list = make([]NamedHandler, 0, 5)
+	}
 	l.list = append(l.list, n)
+}
+
+// PushFront pushes handler f to the front of the handler list.
+func (l *HandlerList) PushFront(f func(*Request)) {
+	l.PushFrontNamed(NamedHandler{"__anonymous", f})
 }
 
 // PushFrontNamed pushes named handler f to the front of the handler list.
 func (l *HandlerList) PushFrontNamed(n NamedHandler) {
-	l.list = append([]NamedHandler{n}, l.list...)
+	if cap(l.list) == len(l.list) {
+		// Allocating new list required
+		l.list = append([]NamedHandler{n}, l.list...)
+	} else {
+		// Enough room to prepend into list.
+		l.list = append(l.list, NamedHandler{})
+		copy(l.list[1:], l.list)
+		l.list[0] = n
+	}
 }
 
 // Remove removes a NamedHandler n
 func (l *HandlerList) Remove(n NamedHandler) {
-	newlist := []NamedHandler{}
-	for _, m := range l.list {
-		if m.Name != n.Name {
-			newlist = append(newlist, m)
+	for i := 0; i < len(l.list); i++ {
+		m := l.list[i]
+		if m.Name == n.Name {
+			// Shift array preventing creating new arrays
+			copy(l.list[i:], l.list[i+1:])
+			l.list[len(l.list)-1] = NamedHandler{}
+			l.list = l.list[:len(l.list)-1]
+
+			// decrement list so next check to length is correct
+			i--
 		}
 	}
-	l.list = newlist
 }
 
 // Run executes all handlers in the list with a given request object.

--- a/aws/request/request_internal_test.go
+++ b/aws/request/request_internal_test.go
@@ -2,8 +2,6 @@ package request
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCopy(t *testing.T) {
@@ -15,6 +13,15 @@ func TestCopy(t *testing.T) {
 	req.Handlers = handlers
 
 	r := req.copy()
-	assert.NotEqual(t, req, r)
-	assert.Equal(t, req.Operation.HTTPMethod, r.Operation.HTTPMethod)
+
+	if r == req {
+		t.Fatal("expect request pointer copy to be different")
+	}
+	if r.Operation == req.Operation {
+		t.Errorf("expect request operation pointer to be different")
+	}
+
+	if e, a := req.Operation.HTTPMethod, r.Operation.HTTPMethod; e != a {
+		t.Errorf("expect %q http method, got %q", e, a)
+	}
 }


### PR DESCRIPTION
Minor optimization to the handler list's handling of copying and pushing
request handlers to the handler list.

    benchmark                        old ns/op     new ns/op     delta
    BenchmarkOffsetReader-4          54.7          55.4          +1.28%
    BenchmarkBytesReader-4           0.76          0.74          -2.63%
    BenchmarkNewRequest-4            2629          2682          +2.02%
    BenchmarkHandlersCopy-4          462           366           -20.78%
    BenchmarkHandlersPushBack-4      439           160           -63.55%
    BenchmarkHandlersPushFront-4     633           515           -18.64%
    BenchmarkHandlersClear-4         688           516           -25.00%
    BenchmarkCodegenIterator-4       746562        750308        +0.50%
    BenchmarkEachPageIterator-4      746546        766297        +2.65%

    benchmark                        old allocs     new allocs     delta
    BenchmarkOffsetReader-4          0              0              +0.00%
    BenchmarkBytesReader-4           0              0              +0.00%
    BenchmarkNewRequest-4            22             22             +0.00%
    BenchmarkHandlersCopy-4          4              4              +0.00%
    BenchmarkHandlersPushBack-4      3              1              -66.67%
    BenchmarkHandlersPushFront-4     7              7              +0.00%
    BenchmarkHandlersClear-4         7              7              +0.00%
    BenchmarkCodegenIterator-4       4247           4247           +0.00%
    BenchmarkEachPageIterator-4      4247           4247           +0.00%

    benchmark                        old bytes     new bytes     delta
    BenchmarkOffsetReader-4          3             3             +0.00%
    BenchmarkBytesReader-4           0             0             +0.00%
    BenchmarkNewRequest-4            2688          2688          +0.00%
    BenchmarkHandlersCopy-4          192           192           +0.00%
    BenchmarkHandlersPushBack-4      176           128           -27.27%
    BenchmarkHandlersPushFront-4     352           352           +0.00%
    BenchmarkHandlersClear-4         352           352           +0.00%
    BenchmarkCodegenIterator-4       819700        819723        +0.00%
    BenchmarkEachPageIterator-4      819691        819713        +0.00%