### PR TITLE
example/service/dynamodb: Update example documentation

### DIFF
--- a/example/service/dynamodb/scanItems/README.md
+++ b/example/service/dynamodb/scanItems/README.md
@@ -10,10 +10,10 @@ The `Item` time will be used by the example to unmarshal the DynamoDB table's it
 type Item struct {
 	Key  int
 	Desc string
-	Data map[string]interface{} `dynamodbav:"Data,omitempty"`
+	Data map[string]interface{}
 }
 ```
-Use Go tags to define what the name is of the attribute in your DynamoDB table. See https://godoc.org/github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute#Marshal for more information.
+Use Go tags to define what the name is of the attribute in your DynamoDB table. See [AWS SDK for Go API Reference: Marshal](http://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/dynamodbattribute/#Marshal) for more information.
 
 In DynamoDB the structure of the item to be returned will be:
 ```json
@@ -45,9 +45,3 @@ In DynamoDB the structure of the item to be returned will be:
 	- "Value 1": abc
 	- "Value 2": 1234567890
 ```
-
-## Credentials
-The easiest way to set the credentials and start using this example is to install the AWS cli application: http://docs.aws.amazon.com/cli/latest/userguide/installing.html
-
-and run ``aws configure`` which will ask for your Key ID, Access Key, region name and output format.
-This proceedure is documented here: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html

--- a/example/service/dynamodb/scanItems/README.md
+++ b/example/service/dynamodb/scanItems/README.md
@@ -8,11 +8,12 @@ The `Item` time will be used by the example to unmarshal the DynamoDB table's it
 
 ```go
 type Item struct {
-	Key  int
-	Desc string
-	Data map[string]interface{}
+	Key  int `dynamodb:"Key"`
+	Desc string `dynamodb:"Desc"`
+	Data map[string]interface{} `dynamodb:"Data"`
 }
 ```
+Use Go tags to define what the name is of the attribute in your DynamoDB table.
 
 In DynamoDB the structure of the item to be returned will be:
 ```json
@@ -33,7 +34,7 @@ In DynamoDB the structure of the item to be returned will be:
 ## Output
 
 ```
-0: Key: 123, Desc: An item in the DynamoDB table 
+0: Key: 123, Desc: An item in the DynamoDB table
 	Num Data Values: 0
 1: Key: 2, Desc: Second ddb item
 	Num Data Values: 2
@@ -44,3 +45,9 @@ In DynamoDB the structure of the item to be returned will be:
 	- "Value 1": abc
 	- "Value 2": 1234567890
 ```
+
+## Credentials
+The easiest way to set the credentials and start using this example is to install the AWS cli application: http://docs.aws.amazon.com/cli/latest/userguide/installing.html
+
+and run ``aws configure`` which will ask for your Key ID, Access Key, region name and output format.
+This proceedure is documented here: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html

--- a/example/service/dynamodb/scanItems/README.md
+++ b/example/service/dynamodb/scanItems/README.md
@@ -8,12 +8,12 @@ The `Item` time will be used by the example to unmarshal the DynamoDB table's it
 
 ```go
 type Item struct {
-	Key  int `dynamodb:"Key"`
-	Desc string `dynamodb:"Desc"`
-	Data map[string]interface{} `dynamodb:"Data"`
+	Key  int
+	Desc string
+	Data map[string]interface{} `dynamodbav:"Data,omitempty"`
 }
 ```
-Use Go tags to define what the name is of the attribute in your DynamoDB table.
+Use Go tags to define what the name is of the attribute in your DynamoDB table. See https://godoc.org/github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute#Marshal for more information.
 
 In DynamoDB the structure of the item to be returned will be:
 ```json


### PR DESCRIPTION
Updates the example documentation to include missing information on tags and options.

Fixup of #938