### PR TITLE
v1.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.8.9 (2017-04-05)
+===
+
+### Service Client Updates
+* `service/elasticache`: Updates service API, documentation, paginators, and examples
+  * ElastiCache added support for testing the Elasticache Multi-AZ feature with Automatic Failover.
+
 Release v1.8.8 (2017-04-04)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,4 +2,4 @@
 
 ### SDK Enhancements
 
-### SDK Bugs 
+### SDK Bugs

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.8.8"
+const SDKVersion = "1.8.9"

--- a/models/apis/elasticache/2015-02-02/api-2.json
+++ b/models/apis/elasticache/2015-02-02/api-2.json
@@ -710,9 +710,42 @@
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidParameterCombinationException"}
       ]
+    },
+    "TestFailover":{
+      "name":"TestFailover",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"TestFailoverMessage"},
+      "output":{
+        "shape":"TestFailoverResult",
+        "resultWrapper":"TestFailoverResult"
+      },
+      "errors":[
+        {"shape":"APICallRateForCustomerExceededFault"},
+        {"shape":"InvalidCacheClusterStateFault"},
+        {"shape":"InvalidReplicationGroupStateFault"},
+        {"shape":"NodeGroupNotFoundFault"},
+        {"shape":"ReplicationGroupNotFoundFault"},
+        {"shape":"TestFailoverNotAvailableFault"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"InvalidParameterCombinationException"}
+      ]
     }
   },
   "shapes":{
+    "APICallRateForCustomerExceededFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"APICallRateForCustomerExceeded",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
     "AZMode":{
       "type":"string",
       "enum":[
@@ -1446,7 +1479,8 @@
         "CacheClusterId":{"shape":"String"},
         "MaxRecords":{"shape":"IntegerOptional"},
         "Marker":{"shape":"String"},
-        "ShowCacheNodeInfo":{"shape":"BooleanOptional"}
+        "ShowCacheNodeInfo":{"shape":"BooleanOptional"},
+        "ShowCacheClustersNotInReplicationGroups":{"shape":"BooleanOptional"}
       }
     },
     "DescribeCacheEngineVersionsMessage":{
@@ -1847,7 +1881,8 @@
         "AutoMinorVersionUpgrade":{"shape":"BooleanOptional"},
         "SnapshotRetentionLimit":{"shape":"IntegerOptional"},
         "SnapshotWindow":{"shape":"String"},
-        "CacheNodeType":{"shape":"String"}
+        "CacheNodeType":{"shape":"String"},
+        "NodeGroupId":{"shape":"String"}
       }
     },
     "ModifyReplicationGroupResult":{
@@ -1905,6 +1940,17 @@
         "shape":"NodeGroupMember",
         "locationName":"NodeGroupMember"
       }
+    },
+    "NodeGroupNotFoundFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"NodeGroupNotFoundFault",
+        "httpStatusCode":404,
+        "senderFault":true
+      },
+      "exception":true
     },
     "NodeGroupsPerReplicationGroupQuotaExceededFault":{
       "type":"structure",
@@ -2099,7 +2145,9 @@
         "AutomaticFailover":{"shape":"AutomaticFailoverStatus"},
         "ConfigurationEndpoint":{"shape":"Endpoint"},
         "SnapshotRetentionLimit":{"shape":"IntegerOptional"},
-        "SnapshotWindow":{"shape":"String"}
+        "SnapshotWindow":{"shape":"String"},
+        "ClusterEnabled":{"shape":"BooleanOptional"},
+        "CacheNodeType":{"shape":"String"}
       },
       "wrapper":true
     },
@@ -2469,6 +2517,34 @@
         "senderFault":true
       },
       "exception":true
+    },
+    "TestFailoverMessage":{
+      "type":"structure",
+      "required":[
+        "ReplicationGroupId",
+        "NodeGroupId"
+      ],
+      "members":{
+        "ReplicationGroupId":{"shape":"String"},
+        "NodeGroupId":{"shape":"String"}
+      }
+    },
+    "TestFailoverNotAvailableFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"TestFailoverNotAvailableFault",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "TestFailoverResult":{
+      "type":"structure",
+      "members":{
+        "ReplicationGroup":{"shape":"ReplicationGroup"}
+      }
     }
   }
 }

--- a/models/apis/elasticache/2015-02-02/docs-2.json
+++ b/models/apis/elasticache/2015-02-02/docs-2.json
@@ -2,14 +2,14 @@
   "version": "2.0",
   "service": "<fullname>Amazon ElastiCache</fullname> <p>Amazon ElastiCache is a web service that makes it easier to set up, operate, and scale a distributed cache in the cloud.</p> <p>With ElastiCache, customers get all of the benefits of a high-performance, in-memory cache with less of the administrative burden involved in launching and managing a distributed cache. The service makes setup, scaling, and cluster failure handling much simpler than in a self-managed cache deployment.</p> <p>In addition, through integration with Amazon CloudWatch, customers get enhanced visibility into the key performance statistics associated with their cache and can receive alarms if a part of their cache runs hot.</p>",
   "operations": {
-    "AddTagsToResource": "<p>Adds up to 10 cost allocation tags to the named resource. A cost allocation tag is a key-value pair where the key and value are case-sensitive. You can use cost allocation tags to categorize and track your AWS costs.</p> <p> When you apply tags to your ElastiCache resources, AWS generates a cost allocation report as a comma-separated value (CSV) file with your usage and costs aggregated by your tags. You can apply tags that represent business categories (such as cost centers, application names, or owners) to organize your costs across multiple services. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Tagging.html\">Using Cost Allocation Tags in Amazon ElastiCache</a> in the <i>ElastiCache User Guide</i>.</p>",
+    "AddTagsToResource": "<p>Adds up to 50 cost allocation tags to the named resource. A cost allocation tag is a key-value pair where the key and value are case-sensitive. You can use cost allocation tags to categorize and track your AWS costs.</p> <p> When you apply tags to your ElastiCache resources, AWS generates a cost allocation report as a comma-separated value (CSV) file with your usage and costs aggregated by your tags. You can apply tags that represent business categories (such as cost centers, application names, or owners) to organize your costs across multiple services. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Tagging.html\">Using Cost Allocation Tags in Amazon ElastiCache</a> in the <i>ElastiCache User Guide</i>.</p>",
     "AuthorizeCacheSecurityGroupIngress": "<p>Allows network ingress to a cache security group. Applications using ElastiCache must be running on Amazon EC2, and Amazon EC2 security groups are used as the authorization mechanism.</p> <note> <p>You cannot authorize ingress from an Amazon EC2 security group in one region to an ElastiCache cluster in another region.</p> </note>",
     "CopySnapshot": "<p>Makes a copy of an existing snapshot.</p> <note> <p>This operation is valid for Redis only.</p> </note> <important> <p>Users or groups that have permissions to use the <code>CopySnapshot</code> operation can create their own Amazon S3 buckets and copy snapshots to it. To control access to your snapshots, use an IAM policy to control who has the ability to use the <code>CopySnapshot</code> operation. For more information about using IAM to control the use of ElastiCache operations, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html\">Exporting Snapshots</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/IAM.html\">Authentication &amp; Access Control</a>.</p> </important> <p>You could receive the following error messages.</p> <p class=\"title\"> <b>Error Messages</b> </p> <ul> <li> <p> <b>Error Message:</b> The S3 bucket %s is outside of the region.</p> <p> <b>Solution:</b> Create an Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s does not exist.</p> <p> <b>Solution:</b> Create an Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s is not owned by the authenticated user.</p> <p> <b>Solution:</b> Create an Amazon S3 bucket in the same region as your snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.CreateBucket\">Step 1: Create an Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message:</b> The authenticated user does not have sufficient permissions to perform the desired activity.</p> <p> <b>Solution:</b> Contact your system administrator to get the needed permissions.</p> </li> <li> <p> <b>Error Message:</b> The S3 bucket %s already contains an object with key %s.</p> <p> <b>Solution:</b> Give the <code>TargetSnapshotName</code> a new and unique value. If exporting a snapshot, you could alternatively create a new Amazon S3 bucket and use this same value for <code>TargetSnapshotName</code>.</p> </li> <li> <p> <b>Error Message: </b> ElastiCache has not been granted READ permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add List and Read permissions on the bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message: </b> ElastiCache has not been granted WRITE permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add Upload/Delete permissions on the bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> <li> <p> <b>Error Message: </b> ElastiCache has not been granted READ_ACP permissions %s on the S3 Bucket.</p> <p> <b>Solution:</b> Add View Permissions on the bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the ElastiCache User Guide.</p> </li> </ul>",
     "CreateCacheCluster": "<p>Creates a cache cluster. All nodes in the cache cluster run the same protocol-compliant cache engine software, either Memcached or Redis.</p> <important> <p>Due to current limitations on Redis (cluster mode disabled), this operation or parameter is not supported on Redis (cluster mode enabled) replication groups.</p> </important>",
-    "CreateCacheParameterGroup": "<p>Creates a new cache parameter group. A cache parameter group is a collection of parameters that you apply to all of the nodes in a cache cluster.</p>",
+    "CreateCacheParameterGroup": "<p>Creates a new Amazon ElastiCache cache parameter group. An ElastiCache cache parameter group is a collection of parameters and their values that are applied to all of the nodes in any cache cluster or replication group using the CacheParameterGroup.</p> <p>A newly created CacheParameterGroup is an exact duplicate of the default parameter group for the CacheParameterGroupFamily. To customize the newly created CacheParameterGroup you can change the values of specific parameters. For more information, see:</p> <ul> <li> <p> <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheParameterGroup.html\">ModifyCacheParameterGroup</a> in the ElastiCache API Reference.</p> </li> <li> <p> <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ParameterGroups.html\">Parameters and Parameter Groups</a> in the ElastiCache User Guide.</p> </li> </ul>",
     "CreateCacheSecurityGroup": "<p>Creates a new cache security group. Use a cache security group to control access to one or more cache clusters.</p> <p>Cache security groups are only used when you are creating a cache cluster outside of an Amazon Virtual Private Cloud (Amazon VPC). If you are creating a cache cluster inside of a VPC, use a cache subnet group instead. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheSubnetGroup.html\">CreateCacheSubnetGroup</a>.</p>",
     "CreateCacheSubnetGroup": "<p>Creates a new cache subnet group.</p> <p>Use this parameter only when you are creating a cluster in an Amazon Virtual Private Cloud (Amazon VPC).</p>",
-    "CreateReplicationGroup": "<p>Creates a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group.</p> <p>A Redis (cluster mode disabled) replication group is a collection of cache clusters, where one of the cache clusters is a read/write primary and the others are read-only replicas. Writes to the primary are asynchronously propagated to the replicas.</p> <p>A Redis (cluster mode enabled) replication group is a collection of 1 to 15 node groups (shards). Each node group (shard) has one read/write primary node and up to 5 read-only replica nodes. Writes to the primary are asynchronously propagated to the replicas. Redis (cluster mode enabled) replication groups partition the data across node groups (shards).</p> <p>When a Redis (cluster mode disabled) replication group has been successfully created, you can add one or more read replicas to it, up to a total of 5 read replicas. You cannot alter a Redis (cluster mode enabled) replication group after it has been created.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
+    "CreateReplicationGroup": "<p>Creates a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group.</p> <p>A Redis (cluster mode disabled) replication group is a collection of cache clusters, where one of the cache clusters is a read/write primary and the others are read-only replicas. Writes to the primary are asynchronously propagated to the replicas.</p> <p>A Redis (cluster mode enabled) replication group is a collection of 1 to 15 node groups (shards). Each node group (shard) has one read/write primary node and up to 5 read-only replica nodes. Writes to the primary are asynchronously propagated to the replicas. Redis (cluster mode enabled) replication groups partition the data across node groups (shards).</p> <p>When a Redis (cluster mode disabled) replication group has been successfully created, you can add one or more read replicas to it, up to a total of 5 read replicas. You cannot alter a Redis (cluster mode enabled) replication group after it has been created. However, if you need to increase or decrease the number of node groups (console: shards), you can avail yourself of ElastiCache for Redis' enhanced backup and restore. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/backups-restoring.html\">Restoring From a Backup with Cluster Resizing</a> in the <i>ElastiCache User Guide</i>.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
     "CreateSnapshot": "<p>Creates a copy of an entire cache cluster or replication group at a specific moment in time.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
     "DeleteCacheCluster": "<p>Deletes a previously provisioned cache cluster. <code>DeleteCacheCluster</code> deletes all associated cache nodes, node endpoints and the cache cluster itself. When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the cache cluster; you cannot cancel or revert this operation.</p> <p>This operation cannot be used to delete a cache cluster that is the last read replica of a replication group or node group (shard) that has Multi-AZ mode enabled or a cache cluster from a Redis (cluster mode enabled) replication group.</p> <important> <p>Due to current limitations on Redis (cluster mode disabled), this operation or parameter is not supported on Redis (cluster mode enabled) replication groups.</p> </important>",
     "DeleteCacheParameterGroup": "<p>Deletes the specified cache parameter group. You cannot delete a cache parameter group if it is associated with any cache clusters.</p>",
@@ -17,7 +17,7 @@
     "DeleteCacheSubnetGroup": "<p>Deletes a cache subnet group.</p> <note> <p>You cannot delete a cache subnet group if it is associated with any cache clusters.</p> </note>",
     "DeleteReplicationGroup": "<p>Deletes an existing replication group. By default, this operation deletes the entire replication group, including the primary/primaries and all of the read replicas. If the replication group has only one primary, you can optionally delete only the read replicas, while retaining the primary by setting <code>RetainPrimaryCluster=true</code>.</p> <p>When you receive a successful response from this operation, Amazon ElastiCache immediately begins deleting the selected resources; you cannot cancel or revert this operation.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
     "DeleteSnapshot": "<p>Deletes an existing snapshot. When you receive a successful response from this operation, ElastiCache immediately begins deleting the snapshot; you cannot cancel or revert this operation.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
-    "DescribeCacheClusters": "<p>Returns information about all provisioned cache clusters if no cache cluster identifier is specified, or about a specific cache cluster if a cache cluster identifier is supplied.</p> <p>By default, abbreviated information about the cache clusters are returned. You can use the optional <code>ShowDetails</code> flag to retrieve detailed information about the cache nodes associated with the cache clusters. These details include the DNS address and port for the cache node endpoint.</p> <p>If the cluster is in the CREATING state, only cluster-level information is displayed until all of the nodes are successfully provisioned.</p> <p>If the cluster is in the DELETING state, only cluster-level information is displayed.</p> <p>If cache nodes are currently being added to the cache cluster, node endpoint information and creation time for the additional nodes are not displayed until they are completely provisioned. When the cache cluster state is <code>available</code>, the cluster is ready for use.</p> <p>If cache nodes are currently being removed from the cache cluster, no endpoint information for the removed nodes is displayed.</p>",
+    "DescribeCacheClusters": "<p>Returns information about all provisioned cache clusters if no cache cluster identifier is specified, or about a specific cache cluster if a cache cluster identifier is supplied.</p> <p>By default, abbreviated information about the cache clusters is returned. You can use the optional <i>ShowCacheNodeInfo</i> flag to retrieve detailed information about the cache nodes associated with the cache clusters. These details include the DNS address and port for the cache node endpoint.</p> <p>If the cluster is in the <i>creating</i> state, only cluster-level information is displayed until all of the nodes are successfully provisioned.</p> <p>If the cluster is in the <i>deleting</i> state, only cluster-level information is displayed.</p> <p>If cache nodes are currently being added to the cache cluster, node endpoint information and creation time for the additional nodes are not displayed until they are completely provisioned. When the cache cluster state is <i>available</i>, the cluster is ready for use.</p> <p>If cache nodes are currently being removed from the cache cluster, no endpoint information for the removed nodes is displayed.</p>",
     "DescribeCacheEngineVersions": "<p>Returns a list of the available cache engines and their versions.</p>",
     "DescribeCacheParameterGroups": "<p>Returns a list of cache parameter group descriptions. If a cache parameter group name is specified, the list contains only the descriptions for that group.</p>",
     "DescribeCacheParameters": "<p>Returns the detailed parameter list for a particular cache parameter group.</p>",
@@ -30,7 +30,7 @@
     "DescribeReservedCacheNodesOfferings": "<p>Lists available reserved cache node offerings.</p>",
     "DescribeSnapshots": "<p>Returns information about cache cluster or replication group snapshots. By default, <code>DescribeSnapshots</code> lists all of your snapshots; it can optionally describe a single snapshot, or just the snapshots associated with a particular cache cluster.</p> <note> <p>This operation is valid for Redis only.</p> </note>",
     "ListAllowedNodeTypeModifications": "<p>Lists all available node types that you can scale your Redis cluster's or replication group's current node type up to.</p> <p>When you use the <code>ModifyCacheCluster</code> or <code>ModifyReplicationGroup</code> operations to scale up your cluster or replication group, the value of the <code>CacheNodeType</code> parameter must be one of the node types returned by this operation.</p>",
-    "ListTagsForResource": "<p>Lists all cost allocation tags currently on the named resource. A <code>cost allocation tag</code> is a key-value pair where the key is case-sensitive and the value is optional. You can use cost allocation tags to categorize and track your AWS costs.</p> <p>You can have a maximum of 10 cost allocation tags on an ElastiCache resource. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/BestPractices.html\">Using Cost Allocation Tags in Amazon ElastiCache</a>.</p>",
+    "ListTagsForResource": "<p>Lists all cost allocation tags currently on the named resource. A <code>cost allocation tag</code> is a key-value pair where the key is case-sensitive and the value is optional. You can use cost allocation tags to categorize and track your AWS costs.</p> <p>You can have a maximum of 50 cost allocation tags on an ElastiCache resource. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/BestPractices.html\">Using Cost Allocation Tags in Amazon ElastiCache</a>.</p>",
     "ModifyCacheCluster": "<p>Modifies the settings for a cache cluster. You can use this operation to change one or more cluster configuration parameters by specifying the parameters and the new values.</p>",
     "ModifyCacheParameterGroup": "<p>Modifies the parameters of a cache parameter group. You can modify up to 20 parameters in a single request by submitting a list parameter name and value pairs.</p>",
     "ModifyCacheSubnetGroup": "<p>Modifies an existing cache subnet group.</p>",
@@ -39,9 +39,15 @@
     "RebootCacheCluster": "<p>Reboots some, or all, of the cache nodes within a provisioned cache cluster. This operation applies any modified cache parameter groups to the cache cluster. The reboot operation takes place as soon as possible, and results in a momentary outage to the cache cluster. During the reboot, the cache cluster status is set to REBOOTING.</p> <p>The reboot causes the contents of the cache (for each cache node being rebooted) to be lost.</p> <p>When the reboot is complete, a cache cluster event is created.</p>",
     "RemoveTagsFromResource": "<p>Removes the tags identified by the <code>TagKeys</code> list from the named resource.</p>",
     "ResetCacheParameterGroup": "<p>Modifies the parameters of a cache parameter group to the engine or system default value. You can reset specific parameters by submitting a list of parameter names. To reset the entire cache parameter group, specify the <code>ResetAllParameters</code> and <code>CacheParameterGroupName</code> parameters.</p>",
-    "RevokeCacheSecurityGroupIngress": "<p>Revokes ingress from a cache security group. Use this operation to disallow access from an Amazon EC2 security group that had been previously authorized.</p>"
+    "RevokeCacheSecurityGroupIngress": "<p>Revokes ingress from a cache security group. Use this operation to disallow access from an Amazon EC2 security group that had been previously authorized.</p>",
+    "TestFailover": "<p>Represents the input of a <code>TestFailover</code> operation which test automatic failover on a specified node group (called shard in the console) in a replication group (called cluster in the console).</p> <p class=\"title\"> <b>Note the following</b> </p> <ul> <li> <p>A customer can use this operation to test automatic failover on up to 5 shards (called node groups in the ElastiCache API and AWS CLI) in any rolling 24-hour period.</p> </li> <li> <p>If calling this operation on shards in different clusters (called replication groups in the API and CLI), the calls can be made concurrently.</p> <p> </p> </li> <li> <p>If calling this operation multiple times on different shards in the same Redis (cluster mode enabled) replication group, the first node replacement must complete before a subsequent call can be made.</p> </li> <li> <p>To determine whether the node replacement is complete you can check Events using the Amazon ElastiCache console, the AWS CLI, or the ElastiCache API. Look for the following automatic failover related events, listed here in order of occurrance:</p> <ol> <li> <p>Replication group message: <code>Test Failover API called for node group &lt;node-group-id&gt;</code> </p> </li> <li> <p>Cache cluster message: <code>Failover from master node &lt;primary-node-id&gt; to replica node &lt;node-id&gt; completed</code> </p> </li> <li> <p>Replication group message: <code>Failover from master node &lt;primary-node-id&gt; to replica node &lt;node-id&gt; completed</code> </p> </li> <li> <p>Cache cluster message: <code>Recovering cache nodes &lt;node-id&gt;</code> </p> </li> <li> <p>Cache cluster message: <code>Finished recovery for cache nodes &lt;node-id&gt;</code> </p> </li> </ol> <p>For more information see:</p> <ul> <li> <p> <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ECEvents.Viewing.html\">Viewing ElastiCache Events</a> in the <i>ElastiCache User Guide</i> </p> </li> <li> <p> <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DescribeEvents.html\">DescribeEvents</a> in the ElastiCache API Reference</p> </li> </ul> </li> </ul> <p>Also see, <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoFailover.html#auto-failover-test\">Testing Multi-AZ with Automatic Failover</a> in the <i>ElastiCache User Guide</i>.</p>"
   },
   "shapes": {
+    "APICallRateForCustomerExceededFault": {
+      "base": "<p>The customer has exceeded the allowed rate of API calls.</p>",
+      "refs": {
+      }
+    },
     "AZMode": {
       "base": null,
       "refs": {
@@ -55,7 +61,7 @@
       }
     },
     "AllowedNodeTypeModificationsMessage": {
-      "base": null,
+      "base": "<p>Represents the allowed node types you can use to modify your cache cluster or replication group.</p>",
       "refs": {
       }
     },
@@ -126,11 +132,13 @@
         "CreateReplicationGroupMessage$AutomaticFailoverEnabled": "<p>Specifies whether a read-only replica is automatically promoted to read/write primary if the existing primary fails.</p> <p>If <code>true</code>, Multi-AZ is enabled for this replication group. If <code>false</code>, Multi-AZ is disabled for this replication group.</p> <p> <code>AutomaticFailoverEnabled</code> must be enabled for Redis (cluster mode enabled) replication groups.</p> <p>Default: false</p> <note> <p>ElastiCache Multi-AZ replication groups is not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled): T1 and T2 node types.</p> <p>Redis (cluster mode enabled): T2 node types.</p> </li> </ul> </note>",
         "CreateReplicationGroupMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
         "DeleteReplicationGroupMessage$RetainPrimaryCluster": "<p>If set to <code>true</code>, all of the read replicas are deleted, but the primary node is retained.</p>",
-        "DescribeCacheClustersMessage$ShowCacheNodeInfo": "<p>An optional flag that can be included in the DescribeCacheCluster request to retrieve information about the individual cache nodes.</p>",
+        "DescribeCacheClustersMessage$ShowCacheNodeInfo": "<p>An optional flag that can be included in the <code>DescribeCacheCluster</code> request to retrieve information about the individual cache nodes.</p>",
+        "DescribeCacheClustersMessage$ShowCacheClustersNotInReplicationGroups": "<p>An optional flag that can be included in the <code>DescribeCacheCluster</code> request to show only nodes (API/CLI: clusters) that are not members of a replication group. In practice, this mean Memcached and single node Redis clusters.</p>",
         "DescribeSnapshotsMessage$ShowNodeGroupConfig": "<p>A Boolean value which if true, the node group (shard) configuration is included in the snapshot description.</p>",
         "ModifyCacheClusterMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
         "ModifyReplicationGroupMessage$AutomaticFailoverEnabled": "<p>Determines whether a read replica is automatically promoted to read/write primary if the existing primary encounters a failure.</p> <p>Valid values: <code>true</code> | <code>false</code> </p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>",
-        "ModifyReplicationGroupMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>"
+        "ModifyReplicationGroupMessage$AutoMinorVersionUpgrade": "<p>This parameter is currently disabled.</p>",
+        "ReplicationGroup$ClusterEnabled": "<p>A flag indicating whether or not this replication group is cluster enabled; i.e., whether its data can be partitioned across multiple shards (API/CLI: node groups).</p> <p>Valid values: <code>true</code> | <code>false</code> </p>"
       }
     },
     "CacheCluster": {
@@ -604,7 +612,7 @@
     "Endpoint": {
       "base": "<p>Represents the information required for client programs to connect to a cache node.</p>",
       "refs": {
-        "CacheCluster$ConfigurationEndpoint": null,
+        "CacheCluster$ConfigurationEndpoint": "<p>Represents a Memcached cluster endpoint which, if Automatic Discovery is enabled on the cluster, can be used by an application to connect to any node in the cluster. The configuration endpoint will always have <code>.cfg</code> in it.</p> <p>Example: <code>mem-3.9dvc4r<u>.cfg</u>.usw2.cache.amazonaws.com:11211</code> </p>",
         "CacheNode$Endpoint": "<p>The hostname for connecting to this cache node.</p>",
         "NodeGroup$PrimaryEndpoint": "<p>The endpoint of the primary node in this node group (shard).</p>",
         "NodeGroupMember$ReadEndpoint": null,
@@ -656,7 +664,7 @@
         "CreateCacheClusterMessage$NumCacheNodes": "<p>The initial number of cache nodes that the cache cluster has.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <p>If you need more than 20 nodes for your Memcached cluster, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\">http://aws.amazon.com/contact-us/elasticache-node-limit-request/</a>.</p>",
         "CreateCacheClusterMessage$Port": "<p>The port number on which each of the cache nodes accepts connections.</p>",
         "CreateCacheClusterMessage$SnapshotRetentionLimit": "<p>The number of days for which ElastiCache retains automatic snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot taken today is retained for 5 days before being deleted.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Default: 0 (i.e., automatic backups are disabled for this cache cluster).</p>",
-        "CreateReplicationGroupMessage$NumCacheClusters": "<p>The number of clusters this replication group initially has.</p> <p>This parameter is not used if there is more than one node group (shard). You should use <code>ReplicasPerNodeGroup</code> instead.</p> <p>If <code>Multi-AZ</code> is <code>enabled</code>, the value of this parameter must be at least 2.</p> <p>The maximum permitted value for <code>NumCacheClusters</code> is 6 (primary plus 5 replicas).</p>",
+        "CreateReplicationGroupMessage$NumCacheClusters": "<p>The number of clusters this replication group initially has.</p> <p>This parameter is not used if there is more than one node group (shard). You should use <code>ReplicasPerNodeGroup</code> instead.</p> <p>If <code>AutomaticFailoverEnabled</code> is <code>true</code>, the value of this parameter must be at least 2. If <code>AutomaticFailoverEnabled</code> is <code>false</code> you can omit this parameter (it will default to 1), or you can explicitly set it to a value between 2 and 6.</p> <p>The maximum permitted value for <code>NumCacheClusters</code> is 6 (primary plus 5 replicas).</p>",
         "CreateReplicationGroupMessage$NumNodeGroups": "<p>An optional parameter that specifies the number of node groups (shards) for this Redis (cluster mode enabled) replication group. For Redis (cluster mode disabled) either omit this parameter or set it to 1.</p> <p>Default: 1</p>",
         "CreateReplicationGroupMessage$ReplicasPerNodeGroup": "<p>An optional parameter that specifies the number of replica nodes in each node group (shard). Valid values are 0 to 5.</p>",
         "CreateReplicationGroupMessage$Port": "<p>The port number on which each member of the replication group accepts connections.</p>",
@@ -668,7 +676,7 @@
         "DescribeCacheSecurityGroupsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeCacheSubnetGroupsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeEngineDefaultParametersMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
-        "DescribeEventsMessage$Duration": "<p>The number of minutes' worth of events to retrieve.</p>",
+        "DescribeEventsMessage$Duration": "<p>The number of minutes worth of events to retrieve.</p>",
         "DescribeEventsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeReplicationGroupsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
         "DescribeReservedCacheNodesMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>",
@@ -804,7 +812,7 @@
     "NodeGroupConfigurationList": {
       "base": null,
       "refs": {
-        "CreateReplicationGroupMessage$NodeGroupConfiguration": "<p>A list of node group (shard) configuration options. Each node group (shard) configuration has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones, ReplicaCount.</p> <p>If you're creating a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group, you can use this parameter to configure one node group (shard) or you can omit this parameter.</p>"
+        "CreateReplicationGroupMessage$NodeGroupConfiguration": "<p>A list of node group (shard) configuration options. Each node group (shard) configuration has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones, ReplicaCount.</p> <p>If you're creating a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group, you can use this parameter to individually configure each node group (shard), or you can omit this parameter.</p>"
       }
     },
     "NodeGroupList": {
@@ -823,6 +831,11 @@
       "base": null,
       "refs": {
         "NodeGroup$NodeGroupMembers": "<p>A list containing information about individual nodes within the node group (shard).</p>"
+      }
+    },
+    "NodeGroupNotFoundFault": {
+      "base": "<p>The node group specified by the <code>NodeGroupId</code> parameter could not be found. Please verify that the node group exists and that you spelled the <code>NodeGroupId</code> value correctly.</p>",
+      "refs": {
       }
     },
     "NodeGroupsPerReplicationGroupQuotaExceededFault": {
@@ -855,7 +868,7 @@
     "NodeTypeList": {
       "base": null,
       "refs": {
-        "AllowedNodeTypeModificationsMessage$ScaleUpModifications": null
+        "AllowedNodeTypeModificationsMessage$ScaleUpModifications": "<p>A string list, each element of which specifies a cache node type which you can use to scale your cache cluster or replication group.</p> <p>When scaling up a Redis cluster or replication group using <code>ModifyCacheCluster</code> or <code>ModifyReplicationGroup</code>, use a value from this list for the <code>CacheNodeType</code> parameter.</p>"
       }
     },
     "NotificationConfiguration": {
@@ -953,7 +966,8 @@
         "CreateReplicationGroupResult$ReplicationGroup": null,
         "DeleteReplicationGroupResult$ReplicationGroup": null,
         "ModifyReplicationGroupResult$ReplicationGroup": null,
-        "ReplicationGroupList$member": null
+        "ReplicationGroupList$member": null,
+        "TestFailoverResult$ReplicationGroup": null
       }
     },
     "ReplicationGroupAlreadyExistsFault": {
@@ -1092,7 +1106,7 @@
       "base": null,
       "refs": {
         "CreateCacheClusterMessage$SnapshotArns": "<p>A single-element string list containing an Amazon Resource Name (ARN) that uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot file is used to populate the node group (shard). The Amazon S3 object name in the ARN cannot contain any commas.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>",
-        "CreateReplicationGroupMessage$SnapshotArns": "<p>A list of Amazon Resource Names (ARN) that uniquely identify the Redis RDB snapshot files stored in Amazon S3. The snapshot files are used to populate the replication group. The Amazon S3 object name in the ARN cannot contain any commas. The list must match the number of node groups (shards) in the replication group, which means you cannot repartition.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>"
+        "CreateReplicationGroupMessage$SnapshotArns": "<p>A list of Amazon Resource Names (ARN) that uniquely identify the Redis RDB snapshot files stored in Amazon S3. The snapshot files are used to populate the new replication group. The Amazon S3 object name in the ARN cannot contain any commas. The new replication group will have the number of node groups (console: shards) specified by the parameter <i>NumNodeGroups</i> or the number of node groups configured by <i>NodeGroupConfiguration</i> regardless of the number of ARNs specified here.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>"
       }
     },
     "SnapshotFeatureNotSupportedFault": {
@@ -1306,10 +1320,11 @@
         "ModifyReplicationGroupMessage$EngineVersion": "<p>The upgraded version of the cache engine to be run on the cache clusters in the replication group.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing replication group and create it anew with the earlier engine version. </p>",
         "ModifyReplicationGroupMessage$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of the node group (shard) specified by <code>SnapshottingClusterId</code>.</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p>",
         "ModifyReplicationGroupMessage$CacheNodeType": "<p>A valid cache node type that you want to scale this replication group to.</p>",
+        "ModifyReplicationGroupMessage$NodeGroupId": "<p>The name of the Node Group (called shard in the console).</p>",
         "NodeGroup$NodeGroupId": "<p>The identifier for the node group (shard). A Redis (cluster mode disabled) replication group contains only 1 node group; therefore, the node group ID is 0001. A Redis (cluster mode enabled) replication group contains 1 to 15 node groups numbered 0001 to 0015. </p>",
         "NodeGroup$Status": "<p>The current state of this replication group - <code>creating</code>, <code>available</code>, etc.</p>",
         "NodeGroup$Slots": "<p>The keyspace for this node group (shard).</p>",
-        "NodeGroupConfiguration$Slots": "<p>A string that specifies the keyspaces as a series of comma separated values. Keyspaces are 0 to 16,383. The string is in the format <code>startkey-endkey</code>.</p> <p>Example: <code>\"0-3999\"</code> </p>",
+        "NodeGroupConfiguration$Slots": "<p>A string that specifies the keyspace for a particular node group. Keyspaces range from 0 to 16,383. The string is in the format <code>startkey-endkey</code>.</p> <p>Example: <code>\"0-3999\"</code> </p>",
         "NodeGroupConfiguration$PrimaryAvailabilityZone": "<p>The Availability Zone where the primary node of this node group (shard) is launched.</p>",
         "NodeGroupMember$CacheClusterId": "<p>The ID of the cache cluster to which the node belongs.</p>",
         "NodeGroupMember$CacheNodeId": "<p>The ID of the node within its cache cluster. A node ID is a numeric identifier (0001, 0002, etc.).</p>",
@@ -1344,6 +1359,7 @@
         "ReplicationGroup$Status": "<p>The current state of this replication group - <code>creating</code>, <code>available</code>, <code>modifying</code>, <code>deleting</code>, <code>create-failed</code>, <code>snapshotting</code>.</p>",
         "ReplicationGroup$SnapshottingClusterId": "<p>The cache cluster ID that is used as the daily snapshot source for the replication group.</p>",
         "ReplicationGroup$SnapshotWindow": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p> <p> <b>Note:</b> This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p>",
+        "ReplicationGroup$CacheNodeType": "<p>The name of the compute and memory capacity node type for each node in the replication group.</p>",
         "ReplicationGroupMessage$Marker": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "ReplicationGroupPendingModifiedValues$PrimaryClusterId": "<p>The primary cluster ID that is applied immediately (if <code>--apply-immediately</code> was specified), or during the next maintenance window.</p>",
         "ReservedCacheNode$ReservedCacheNodeId": "<p>The unique identifier for the reservation.</p>",
@@ -1384,8 +1400,10 @@
         "SnapshotArnsList$member": null,
         "Subnet$SubnetIdentifier": "<p>The unique identifier for the subnet.</p>",
         "SubnetIdentifierList$member": null,
-        "Tag$Key": "<p>The key for the tag.</p>",
-        "Tag$Value": "<p>The tag's value. May not be null.</p>"
+        "Tag$Key": "<p>The key for the tag. May not be null.</p>",
+        "Tag$Value": "<p>The tag's value. May be null.</p>",
+        "TestFailoverMessage$ReplicationGroupId": "<p>The name of the replication group (console: cluster) whose automatic failover is being tested by this operation.</p>",
+        "TestFailoverMessage$NodeGroupId": "<p>The name of the node group (called shard in the console) in this replication group on which automatic failover is to be tested. You may test automatic failover on up to 5 node groups in any rolling 24-hour period.</p>"
       }
     },
     "Subnet": {
@@ -1417,8 +1435,8 @@
       "refs": {
         "CacheCluster$CacheClusterCreateTime": "<p>The date and time when the cache cluster was created.</p>",
         "CacheNode$CacheNodeCreateTime": "<p>The date and time when the cache node was created.</p>",
-        "DescribeEventsMessage$StartTime": "<p>The beginning of the time interval to retrieve events for, specified in ISO 8601 format.</p>",
-        "DescribeEventsMessage$EndTime": "<p>The end of the time interval for which to retrieve events, specified in ISO 8601 format.</p>",
+        "DescribeEventsMessage$StartTime": "<p>The beginning of the time interval to retrieve events for, specified in ISO 8601 format.</p> <p> <b>Example:</b> 2017-03-30T07:03:49.555Z</p>",
+        "DescribeEventsMessage$EndTime": "<p>The end of the time interval for which to retrieve events, specified in ISO 8601 format.</p> <p> <b>Example:</b> 2017-03-30T07:03:49.555Z</p>",
         "Event$Date": "<p>The date and time when the event occurred.</p>",
         "NodeSnapshot$CacheNodeCreateTime": "<p>The date and time when the cache node was created in the source cache cluster.</p>",
         "NodeSnapshot$SnapshotCreateTime": "<p>The date and time when the source node's metadata and cache data set was obtained for the snapshot.</p>",
@@ -1442,7 +1460,7 @@
       }
     },
     "TagListMessage": {
-      "base": "<p>Represents the output from the <code>AddTagsToResource</code>, <code>ListTagsOnResource</code>, and <code>RemoveTagsFromResource</code> operations.</p>",
+      "base": "<p>Represents the output from the <code>AddTagsToResource</code>, <code>ListTagsForResource</code>, and <code>RemoveTagsFromResource</code> operations.</p>",
       "refs": {
       }
     },
@@ -1452,7 +1470,22 @@
       }
     },
     "TagQuotaPerResourceExceeded": {
-      "base": "<p>The request cannot be processed because it would cause the resource to have more than the allowed number of tags. The maximum number of tags permitted on a resource is 10.</p>",
+      "base": "<p>The request cannot be processed because it would cause the resource to have more than the allowed number of tags. The maximum number of tags permitted on a resource is 50.</p>",
+      "refs": {
+      }
+    },
+    "TestFailoverMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "TestFailoverNotAvailableFault": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "TestFailoverResult": {
+      "base": null,
       "refs": {
       }
     }

--- a/models/apis/elasticache/2015-02-02/examples-1.json
+++ b/models/apis/elasticache/2015-02-02/examples-1.json
@@ -65,32 +65,34 @@
           "TargetSnapshotName": "my-snapshot-copy"
         },
         "output": {
-          "AutoMinorVersionUpgrade": true,
-          "CacheClusterCreateTime": "2016-12-21T22:24:04.955Z",
-          "CacheClusterId": "my-redis4",
-          "CacheNodeType": "cache.m3.large",
-          "CacheParameterGroupName": "default.redis3.2",
-          "CacheSubnetGroupName": "default",
-          "Engine": "redis",
-          "EngineVersion": "3.2.4",
-          "NodeSnapshots": [
-            {
-              "CacheNodeCreateTime": "2016-12-21T22:24:04.955Z",
-              "CacheNodeId": "0001",
-              "CacheSize": "3 MB",
-              "SnapshotCreateTime": "2016-12-28T07:00:52Z"
-            }
-          ],
-          "NumCacheNodes": 1,
-          "Port": 6379,
-          "PreferredAvailabilityZone": "us-east-1c",
-          "PreferredMaintenanceWindow": "tue:09:30-tue:10:30",
-          "SnapshotName": "my-snapshot-copy",
-          "SnapshotRetentionLimit": 7,
-          "SnapshotSource": "manual",
-          "SnapshotStatus": "creating",
-          "SnapshotWindow": "07:00-08:00",
-          "VpcId": "vpc-3820329f3"
+          "Snapshot": {
+            "AutoMinorVersionUpgrade": true,
+            "CacheClusterCreateTime": "2016-12-21T22:24:04.955Z",
+            "CacheClusterId": "my-redis4",
+            "CacheNodeType": "cache.m3.large",
+            "CacheParameterGroupName": "default.redis3.2",
+            "CacheSubnetGroupName": "default",
+            "Engine": "redis",
+            "EngineVersion": "3.2.4",
+            "NodeSnapshots": [
+              {
+                "CacheNodeCreateTime": "2016-12-21T22:24:04.955Z",
+                "CacheNodeId": "0001",
+                "CacheSize": "3 MB",
+                "SnapshotCreateTime": "2016-12-28T07:00:52Z"
+              }
+            ],
+            "NumCacheNodes": 1,
+            "Port": 6379,
+            "PreferredAvailabilityZone": "us-east-1c",
+            "PreferredMaintenanceWindow": "tue:09:30-tue:10:30",
+            "SnapshotName": "my-snapshot-copy",
+            "SnapshotRetentionLimit": 7,
+            "SnapshotSource": "manual",
+            "SnapshotStatus": "creating",
+            "SnapshotWindow": "07:00-08:00",
+            "VpcId": "vpc-3820329f3"
+          }
         },
         "comments": {
           "input": {
@@ -116,29 +118,31 @@
           "Port": 11211
         },
         "output": {
-          "AutoMinorVersionUpgrade": true,
-          "CacheClusterId": "my-memcached-cluster",
-          "CacheClusterStatus": "creating",
-          "CacheNodeType": "cache.r3.large",
-          "CacheParameterGroup": {
-            "CacheNodeIdsToReboot": [
+          "CacheCluster": {
+            "AutoMinorVersionUpgrade": true,
+            "CacheClusterId": "my-memcached-cluster",
+            "CacheClusterStatus": "creating",
+            "CacheNodeType": "cache.r3.large",
+            "CacheParameterGroup": {
+              "CacheNodeIdsToReboot": [
+
+              ],
+              "CacheParameterGroupName": "default.memcached1.4",
+              "ParameterApplyStatus": "in-sync"
+            },
+            "CacheSecurityGroups": [
 
             ],
-            "CacheParameterGroupName": "default.memcached1.4",
-            "ParameterApplyStatus": "in-sync"
-          },
-          "CacheSecurityGroups": [
-
-          ],
-          "CacheSubnetGroupName": "default",
-          "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
-          "Engine": "memcached",
-          "EngineVersion": "1.4.24",
-          "NumCacheNodes": 2,
-          "PendingModifiedValues": {
-          },
-          "PreferredAvailabilityZone": "Multiple",
-          "PreferredMaintenanceWindow": "wed:09:00-wed:10:00"
+            "CacheSubnetGroupName": "default",
+            "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
+            "Engine": "memcached",
+            "EngineVersion": "1.4.24",
+            "NumCacheNodes": 2,
+            "PendingModifiedValues": {
+            },
+            "PreferredAvailabilityZone": "Multiple",
+            "PreferredMaintenanceWindow": "wed:09:00-wed:10:00"
+          }
         },
         "comments": {
           "input": {
@@ -164,31 +168,33 @@
           "SnapshotRetentionLimit": 7
         },
         "output": {
-          "AutoMinorVersionUpgrade": true,
-          "CacheClusterId": "my-redis",
-          "CacheClusterStatus": "creating",
-          "CacheNodeType": "cache.m3.large",
-          "CacheParameterGroup": {
-            "CacheNodeIdsToReboot": [
+          "CacheCluster": {
+            "AutoMinorVersionUpgrade": true,
+            "CacheClusterId": "my-redis",
+            "CacheClusterStatus": "creating",
+            "CacheNodeType": "cache.m3.large",
+            "CacheParameterGroup": {
+              "CacheNodeIdsToReboot": [
+
+              ],
+              "CacheParameterGroupName": "default.redis3.2",
+              "ParameterApplyStatus": "in-sync"
+            },
+            "CacheSecurityGroups": [
 
             ],
-            "CacheParameterGroupName": "default.redis3.2",
-            "ParameterApplyStatus": "in-sync"
-          },
-          "CacheSecurityGroups": [
-
-          ],
-          "CacheSubnetGroupName": "default",
-          "ClientDownloadLandingPage": "https: //console.aws.amazon.com/elasticache/home#client-download: ",
-          "Engine": "redis",
-          "EngineVersion": "3.2.4",
-          "NumCacheNodes": 1,
-          "PendingModifiedValues": {
-          },
-          "PreferredAvailabilityZone": "us-east-1c",
-          "PreferredMaintenanceWindow": "fri: 05: 30-fri: 06: 30",
-          "SnapshotRetentionLimit": 7,
-          "SnapshotWindow": "10: 00-11: 00"
+            "CacheSubnetGroupName": "default",
+            "ClientDownloadLandingPage": "https: //console.aws.amazon.com/elasticache/home#client-download: ",
+            "Engine": "redis",
+            "EngineVersion": "3.2.4",
+            "NumCacheNodes": 1,
+            "PendingModifiedValues": {
+            },
+            "PreferredAvailabilityZone": "us-east-1c",
+            "PreferredMaintenanceWindow": "fri: 05: 30-fri: 06: 30",
+            "SnapshotRetentionLimit": 7,
+            "SnapshotWindow": "10: 00-11: 00"
+          }
         },
         "comments": {
           "input": {
@@ -206,12 +212,14 @@
         "input": {
           "CacheParameterGroupFamily": "redis2.8",
           "CacheParameterGroupName": "custom-redis2-8",
-          "Description": "Redis 2.8 parameter group that limits maxmemory to half of available memory."
+          "Description": "Custom Redis 2.8 parameter group."
         },
         "output": {
-          "CacheParameterGroupFamily": "redis2.8",
-          "CacheParameterGroupName": "custom-redis2-8",
-          "Description": "Redis 2.8 parame3ter group that limits maxmemory to half of available memory."
+          "CacheParameterGroup": {
+            "CacheParameterGroupFamily": "redis2.8",
+            "CacheParameterGroupName": "custom-redis2-8",
+            "Description": "Custom Redis 2.8 parameter group."
+          }
         },
         "comments": {
           "input": {
@@ -253,29 +261,31 @@
           ]
         },
         "output": {
-          "CacheSubnetGroupDescription": "My subnet group.",
-          "CacheSubnetGroupName": "my-sn-grp",
-          "Subnets": [
-            {
-              "SubnetAvailabilityZone": {
-                "Name": "us-east-1a"
+          "CacheSubnetGroup": {
+            "CacheSubnetGroupDescription": "My subnet group.",
+            "CacheSubnetGroupName": "my-sn-grp",
+            "Subnets": [
+              {
+                "SubnetAvailabilityZone": {
+                  "Name": "us-east-1a"
+                },
+                "SubnetIdentifier": "subnet-6f28c982"
               },
-              "SubnetIdentifier": "subnet-6f28c982"
-            },
-            {
-              "SubnetAvailabilityZone": {
-                "Name": "us-east-1c"
+              {
+                "SubnetAvailabilityZone": {
+                  "Name": "us-east-1c"
+                },
+                "SubnetIdentifier": "subnet-bcd382f3"
               },
-              "SubnetIdentifier": "subnet-bcd382f3"
-            },
-            {
-              "SubnetAvailabilityZone": {
-                "Name": "us-east-1b"
-              },
-              "SubnetIdentifier": "subnet-845b3e7c0"
-            }
-          ],
-          "VpcId": "vpc-91280df6"
+              {
+                "SubnetAvailabilityZone": {
+                  "Name": "us-east-1b"
+                },
+                "SubnetIdentifier": "subnet-845b3e7c0"
+              }
+            ],
+            "VpcId": "vpc-91280df6"
+          }
         },
         "comments": {
           "input": {
@@ -301,18 +311,20 @@
           "SnapshotRetentionLimit": 30
         },
         "output": {
-          "AutomaticFailover": "enabling",
-          "Description": "A Redis replication group.",
-          "MemberClusters": [
-            "my-redis-rg-001",
-            "my-redis-rg-002",
-            "my-redis-rg-003"
-          ],
-          "PendingModifiedValues": {
-          },
-          "ReplicationGroupId": "my-redis-rg",
-          "SnapshottingClusterId": "my-redis-rg-002",
-          "Status": "creating"
+          "ReplicationGroup": {
+            "AutomaticFailover": "enabling",
+            "Description": "A Redis replication group.",
+            "MemberClusters": [
+              "my-redis-rg-001",
+              "my-redis-rg-002",
+              "my-redis-rg-003"
+            ],
+            "PendingModifiedValues": {
+            },
+            "ReplicationGroupId": "my-redis-rg",
+            "SnapshottingClusterId": "my-redis-rg-002",
+            "Status": "creating"
+          }
         },
         "comments": {
           "input": {
@@ -323,40 +335,56 @@
         "description": "Creates a Redis replication group with 3 nodes.",
         "id": "createcachereplicationgroup-1474998730655",
         "title": "CreateCacheReplicationGroup"
-      }
-    ],
-    "CreateSnapshot": [
+      },
       {
         "input": {
-          "CacheClusterId": "my-redis",
-          "SnapshotName": "snapshot-20161221"
-        },
-        "output": {
           "AutoMinorVersionUpgrade": true,
-          "CacheClusterCreateTime": "2016-12-21T22:27:12.543Z",
-          "CacheClusterId": "my-redis",
-          "CacheNodeType": "cache.m3.large",
-          "CacheParameterGroupName": "default.redis3.2",
-          "CacheSubnetGroupName": "default",
+          "CacheNodeType": "cache.m3.medium",
+          "CacheParameterGroupName": "default.redis3.2.cluster.on",
           "Engine": "redis",
           "EngineVersion": "3.2.4",
-          "NodeSnapshots": [
+          "NodeGroupConfiguration": [
             {
-              "CacheNodeCreateTime": "2016-12-21T22:27:12.543Z",
-              "CacheNodeId": "0001",
-              "CacheSize": ""
+              "PrimaryAvailabilityZone": "us-east-1c",
+              "ReplicaAvailabilityZones": [
+                "us-east-1b"
+              ],
+              "ReplicaCount": 1,
+              "Slots": "0-8999"
+            },
+            {
+              "PrimaryAvailabilityZone": "us-east-1a",
+              "ReplicaAvailabilityZones": [
+                "us-east-1a",
+                "us-east-1c"
+              ],
+              "ReplicaCount": 2,
+              "Slots": "9000-16383"
             }
           ],
-          "NumCacheNodes": 1,
-          "Port": 6379,
-          "PreferredAvailabilityZone": "us-east-1c",
-          "PreferredMaintenanceWindow": "fri:05:30-fri:06:30",
-          "SnapshotName": "snapshot-20161221",
-          "SnapshotRetentionLimit": 7,
-          "SnapshotSource": "manual",
-          "SnapshotStatus": "creating",
-          "SnapshotWindow": "10:00-11:00",
-          "VpcId": "vpc-91280df6"
+          "NumNodeGroups": 2,
+          "ReplicationGroupDescription": "A multi-sharded replication group",
+          "ReplicationGroupId": "clustered-redis-rg",
+          "SnapshotRetentionLimit": 8
+        },
+        "output": {
+          "ReplicationGroup": {
+            "AutomaticFailover": "enabled",
+            "Description": "Sharded replication group",
+            "MemberClusters": [
+              "rc-rg3-0001-001",
+              "rc-rg3-0001-002",
+              "rc-rg3-0002-001",
+              "rc-rg3-0002-002",
+              "rc-rg3-0002-003"
+            ],
+            "PendingModifiedValues": {
+            },
+            "ReplicationGroupId": "clustered-redis-rg",
+            "SnapshotRetentionLimit": 8,
+            "SnapshotWindow": "05:30-06:30",
+            "Status": "creating"
+          }
         },
         "comments": {
           "input": {
@@ -364,9 +392,142 @@
           "output": {
           }
         },
-        "description": "Creates a Redis snapshot.",
+        "description": "Creates a Redis (cluster mode enabled) replication group with two shards. One shard has one read replica node and the other shard has two read replicas.",
+        "id": "createreplicationgroup-1483657035585",
+        "title": "CreateReplicationGroup"
+      }
+    ],
+    "CreateSnapshot": [
+      {
+        "input": {
+          "CacheClusterId": "onenoderedis",
+          "SnapshotName": "snapshot-1"
+        },
+        "output": {
+          "Snapshot": {
+            "AutoMinorVersionUpgrade": true,
+            "CacheClusterCreateTime": "2017-02-03T15:43:36.278Z",
+            "CacheClusterId": "onenoderedis",
+            "CacheNodeType": "cache.m3.medium",
+            "CacheParameterGroupName": "default.redis3.2",
+            "CacheSubnetGroupName": "default",
+            "Engine": "redis",
+            "EngineVersion": "3.2.4",
+            "NodeSnapshots": [
+              {
+                "CacheNodeCreateTime": "2017-02-03T15:43:36.278Z",
+                "CacheNodeId": "0001",
+                "CacheSize": ""
+              }
+            ],
+            "NumCacheNodes": 1,
+            "Port": 6379,
+            "PreferredAvailabilityZone": "us-west-2c",
+            "PreferredMaintenanceWindow": "sat:08:00-sat:09:00",
+            "SnapshotName": "snapshot-1",
+            "SnapshotRetentionLimit": 1,
+            "SnapshotSource": "manual",
+            "SnapshotStatus": "creating",
+            "SnapshotWindow": "00:00-01:00",
+            "VpcId": "vpc-73c3cd17"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Creates a snapshot of a non-clustered Redis cluster that has only one node.",
         "id": "createsnapshot-1474999681024",
-        "title": "CreateSnapshot"
+        "title": "CreateSnapshot - NonClustered Redis, no read-replicas"
+      },
+      {
+        "input": {
+          "CacheClusterId": "threenoderedis-001",
+          "SnapshotName": "snapshot-2"
+        },
+        "output": {
+          "AutoMinorVersionUpgrade": true,
+          "CacheClusterCreateTime": "2017-02-03T15:43:36.278Z",
+          "CacheClusterId": "threenoderedis-001",
+          "CacheNodeType": "cache.m3.medium",
+          "CacheParameterGroupName": "default.redis3.2",
+          "CacheSubnetGroupName": "default",
+          "Engine": "redis",
+          "EngineVersion": "3.2.4",
+          "NodeSnapshots": [
+            {
+              "CacheNodeCreateTime": "2017-02-03T15:43:36.278Z",
+              "CacheNodeId": "0001",
+              "CacheSize": ""
+            }
+          ],
+          "NumCacheNodes": 1,
+          "Port": 6379,
+          "PreferredAvailabilityZone": "us-west-2c",
+          "PreferredMaintenanceWindow": "sat:08:00-sat:09:00",
+          "SnapshotName": "snapshot-2",
+          "SnapshotRetentionLimit": 1,
+          "SnapshotSource": "manual",
+          "SnapshotStatus": "creating",
+          "SnapshotWindow": "00:00-01:00",
+          "VpcId": "vpc-73c3cd17"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Creates a snapshot of a non-clustered Redis cluster that has only three nodes, primary and two read-replicas. CacheClusterId must be a specific node in the cluster.",
+        "id": "createsnapshot-1474999681024",
+        "title": "CreateSnapshot - NonClustered Redis, 2 read-replicas"
+      },
+      {
+        "input": {
+          "ReplicationGroupId": "clusteredredis",
+          "SnapshotName": "snapshot-2x5"
+        },
+        "output": {
+          "AutoMinorVersionUpgrade": true,
+          "AutomaticFailover": "enabled",
+          "CacheNodeType": "cache.m3.medium",
+          "CacheParameterGroupName": "default.redis3.2.cluster.on",
+          "CacheSubnetGroupName": "default",
+          "Engine": "redis",
+          "EngineVersion": "3.2.4",
+          "NodeSnapshots": [
+            {
+              "CacheSize": "",
+              "NodeGroupId": "0001"
+            },
+            {
+              "CacheSize": "",
+              "NodeGroupId": "0002"
+            }
+          ],
+          "NumNodeGroups": 2,
+          "Port": 6379,
+          "PreferredMaintenanceWindow": "mon:09:30-mon:10:30",
+          "ReplicationGroupDescription": "Redis cluster with 2 shards.",
+          "ReplicationGroupId": "clusteredredis",
+          "SnapshotName": "snapshot-2x5",
+          "SnapshotRetentionLimit": 1,
+          "SnapshotSource": "manual",
+          "SnapshotStatus": "creating",
+          "SnapshotWindow": "12:00-13:00",
+          "VpcId": "vpc-73c3cd17"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Creates a snapshot of a clustered Redis cluster that has 2 shards, each with a primary and 4 read-replicas.",
+        "id": "createsnapshot-clustered-redis-1486144841758",
+        "title": "CreateSnapshot-clustered Redis"
       }
     ],
     "DeleteCacheCluster": [
@@ -375,34 +536,36 @@
           "CacheClusterId": "my-memcached"
         },
         "output": {
-          "AutoMinorVersionUpgrade": true,
-          "CacheClusterCreateTime": "2016-12-22T16:05:17.314Z",
-          "CacheClusterId": "my-memcached",
-          "CacheClusterStatus": "deleting",
-          "CacheNodeType": "cache.r3.large",
-          "CacheParameterGroup": {
-            "CacheNodeIdsToReboot": [
+          "CacheCluster": {
+            "AutoMinorVersionUpgrade": true,
+            "CacheClusterCreateTime": "2016-12-22T16:05:17.314Z",
+            "CacheClusterId": "my-memcached",
+            "CacheClusterStatus": "deleting",
+            "CacheNodeType": "cache.r3.large",
+            "CacheParameterGroup": {
+              "CacheNodeIdsToReboot": [
+
+              ],
+              "CacheParameterGroupName": "default.memcached1.4",
+              "ParameterApplyStatus": "in-sync"
+            },
+            "CacheSecurityGroups": [
 
             ],
-            "CacheParameterGroupName": "default.memcached1.4",
-            "ParameterApplyStatus": "in-sync"
-          },
-          "CacheSecurityGroups": [
-
-          ],
-          "CacheSubnetGroupName": "default",
-          "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
-          "ConfigurationEndpoint": {
-            "Address": "my-memcached2.ameaqx.cfg.use1.cache.amazonaws.com",
-            "Port": 11211
-          },
-          "Engine": "memcached",
-          "EngineVersion": "1.4.24",
-          "NumCacheNodes": 2,
-          "PendingModifiedValues": {
-          },
-          "PreferredAvailabilityZone": "Multiple",
-          "PreferredMaintenanceWindow": "tue:07:30-tue:08:30"
+            "CacheSubnetGroupName": "default",
+            "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
+            "ConfigurationEndpoint": {
+              "Address": "my-memcached2.ameaqx.cfg.use1.cache.amazonaws.com",
+              "Port": 11211
+            },
+            "Engine": "memcached",
+            "EngineVersion": "1.4.24",
+            "NumCacheNodes": 2,
+            "PendingModifiedValues": {
+            },
+            "PreferredAvailabilityZone": "Multiple",
+            "PreferredMaintenanceWindow": "tue:07:30-tue:08:30"
+          }
         },
         "comments": {
           "input": {
@@ -470,12 +633,14 @@
           "RetainPrimaryCluster": false
         },
         "output": {
-          "AutomaticFailover": "disabled",
-          "Description": "simple redis cluster",
-          "PendingModifiedValues": {
-          },
-          "ReplicationGroupId": "my-redis-rg",
-          "Status": "deleting"
+          "ReplicationGroup": {
+            "AutomaticFailover": "disabled",
+            "Description": "simple redis cluster",
+            "PendingModifiedValues": {
+            },
+            "ReplicationGroupId": "my-redis-rg",
+            "Status": "deleting"
+          }
         },
         "comments": {
           "input": {
@@ -494,32 +659,34 @@
           "SnapshotName": "snapshot-20161212"
         },
         "output": {
-          "AutoMinorVersionUpgrade": true,
-          "CacheClusterCreateTime": "2016-12-21T22:27:12.543Z",
-          "CacheClusterId": "my-redis5",
-          "CacheNodeType": "cache.m3.large",
-          "CacheParameterGroupName": "default.redis3.2",
-          "CacheSubnetGroupName": "default",
-          "Engine": "redis",
-          "EngineVersion": "3.2.4",
-          "NodeSnapshots": [
-            {
-              "CacheNodeCreateTime": "2016-12-21T22:27:12.543Z",
-              "CacheNodeId": "0001",
-              "CacheSize": "3 MB",
-              "SnapshotCreateTime": "2016-12-21T22:30:26Z"
-            }
-          ],
-          "NumCacheNodes": 1,
-          "Port": 6379,
-          "PreferredAvailabilityZone": "us-east-1c",
-          "PreferredMaintenanceWindow": "fri:05:30-fri:06:30",
-          "SnapshotName": "snapshot-20161212",
-          "SnapshotRetentionLimit": 7,
-          "SnapshotSource": "manual",
-          "SnapshotStatus": "deleting",
-          "SnapshotWindow": "10:00-11:00",
-          "VpcId": "vpc-91280df6"
+          "Snapshot": {
+            "AutoMinorVersionUpgrade": true,
+            "CacheClusterCreateTime": "2016-12-21T22:27:12.543Z",
+            "CacheClusterId": "my-redis5",
+            "CacheNodeType": "cache.m3.large",
+            "CacheParameterGroupName": "default.redis3.2",
+            "CacheSubnetGroupName": "default",
+            "Engine": "redis",
+            "EngineVersion": "3.2.4",
+            "NodeSnapshots": [
+              {
+                "CacheNodeCreateTime": "2016-12-21T22:27:12.543Z",
+                "CacheNodeId": "0001",
+                "CacheSize": "3 MB",
+                "SnapshotCreateTime": "2016-12-21T22:30:26Z"
+              }
+            ],
+            "NumCacheNodes": 1,
+            "Port": 6379,
+            "PreferredAvailabilityZone": "us-east-1c",
+            "PreferredMaintenanceWindow": "fri:05:30-fri:06:30",
+            "SnapshotName": "snapshot-20161212",
+            "SnapshotRetentionLimit": 7,
+            "SnapshotSource": "manual",
+            "SnapshotStatus": "deleting",
+            "SnapshotWindow": "10:00-11:00",
+            "VpcId": "vpc-91280df6"
+          }
         },
         "comments": {
           "input": {
@@ -1341,602 +1508,604 @@
           "MaxRecords": 25
         },
         "output": {
-          "CacheNodeTypeSpecificParameters": [
-            {
-              "AllowedValues": "0-",
-              "CacheNodeTypeSpecificValues": [
-                {
-                  "CacheNodeType": "cache.c1.xlarge",
-                  "Value": "650117120"
-                },
-                {
-                  "CacheNodeType": "cache.m1.large",
-                  "Value": "702545920"
-                },
-                {
-                  "CacheNodeType": "cache.m1.medium",
-                  "Value": "309329920"
-                },
-                {
-                  "CacheNodeType": "cache.m1.small",
-                  "Value": "94371840"
-                },
-                {
-                  "CacheNodeType": "cache.m1.xlarge",
-                  "Value": "1488977920"
-                },
-                {
-                  "CacheNodeType": "cache.m2.2xlarge",
-                  "Value": "3502243840"
-                },
-                {
-                  "CacheNodeType": "cache.m2.4xlarge",
-                  "Value": "7088373760"
-                },
-                {
-                  "CacheNodeType": "cache.m2.xlarge",
-                  "Value": "1709178880"
-                },
-                {
-                  "CacheNodeType": "cache.m3.2xlarge",
-                  "Value": "2998927360"
-                },
-                {
-                  "CacheNodeType": "cache.m3.large",
-                  "Value": "650117120"
-                },
-                {
-                  "CacheNodeType": "cache.m3.medium",
-                  "Value": "309329920"
-                },
-                {
-                  "CacheNodeType": "cache.m3.xlarge",
-                  "Value": "1426063360"
-                },
-                {
-                  "CacheNodeType": "cache.m4.10xlarge",
-                  "Value": "16604761424"
-                },
-                {
-                  "CacheNodeType": "cache.m4.2xlarge",
-                  "Value": "3188912636"
-                },
-                {
-                  "CacheNodeType": "cache.m4.4xlarge",
-                  "Value": "6525729063"
-                },
-                {
-                  "CacheNodeType": "cache.m4.large",
-                  "Value": "689259315"
-                },
-                {
-                  "CacheNodeType": "cache.m4.xlarge",
-                  "Value": "1532850176"
-                },
-                {
-                  "CacheNodeType": "cache.r3.2xlarge",
-                  "Value": "6081740800"
-                },
-                {
-                  "CacheNodeType": "cache.r3.4xlarge",
-                  "Value": "12268339200"
-                },
-                {
-                  "CacheNodeType": "cache.r3.8xlarge",
-                  "Value": "24536678400"
-                },
-                {
-                  "CacheNodeType": "cache.r3.large",
-                  "Value": "1468006400"
-                },
-                {
-                  "CacheNodeType": "cache.r3.xlarge",
-                  "Value": "3040870400"
-                },
-                {
-                  "CacheNodeType": "cache.t1.micro",
-                  "Value": "14260633"
-                },
-                {
-                  "CacheNodeType": "cache.t2.medium",
-                  "Value": "346134937"
-                },
-                {
-                  "CacheNodeType": "cache.t2.micro",
-                  "Value": "58195968"
-                },
-                {
-                  "CacheNodeType": "cache.t2.small",
-                  "Value": "166513868"
-                }
-              ],
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Slave client output buffer hard limit in bytes.",
-              "IsModifiable": false,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-slave-hard-limit",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "CacheNodeTypeSpecificValues": [
-                {
-                  "CacheNodeType": "cache.c1.xlarge",
-                  "Value": "650117120"
-                },
-                {
-                  "CacheNodeType": "cache.m1.large",
-                  "Value": "702545920"
-                },
-                {
-                  "CacheNodeType": "cache.m1.medium",
-                  "Value": "309329920"
-                },
-                {
-                  "CacheNodeType": "cache.m1.small",
-                  "Value": "94371840"
-                },
-                {
-                  "CacheNodeType": "cache.m1.xlarge",
-                  "Value": "1488977920"
-                },
-                {
-                  "CacheNodeType": "cache.m2.2xlarge",
-                  "Value": "3502243840"
-                },
-                {
-                  "CacheNodeType": "cache.m2.4xlarge",
-                  "Value": "7088373760"
-                },
-                {
-                  "CacheNodeType": "cache.m2.xlarge",
-                  "Value": "1709178880"
-                },
-                {
-                  "CacheNodeType": "cache.m3.2xlarge",
-                  "Value": "2998927360"
-                },
-                {
-                  "CacheNodeType": "cache.m3.large",
-                  "Value": "650117120"
-                },
-                {
-                  "CacheNodeType": "cache.m3.medium",
-                  "Value": "309329920"
-                },
-                {
-                  "CacheNodeType": "cache.m3.xlarge",
-                  "Value": "1426063360"
-                },
-                {
-                  "CacheNodeType": "cache.m4.10xlarge",
-                  "Value": "16604761424"
-                },
-                {
-                  "CacheNodeType": "cache.m4.2xlarge",
-                  "Value": "3188912636"
-                },
-                {
-                  "CacheNodeType": "cache.m4.4xlarge",
-                  "Value": "6525729063"
-                },
-                {
-                  "CacheNodeType": "cache.m4.large",
-                  "Value": "689259315"
-                },
-                {
-                  "CacheNodeType": "cache.m4.xlarge",
-                  "Value": "1532850176"
-                },
-                {
-                  "CacheNodeType": "cache.r3.2xlarge",
-                  "Value": "6081740800"
-                },
-                {
-                  "CacheNodeType": "cache.r3.4xlarge",
-                  "Value": "12268339200"
-                },
-                {
-                  "CacheNodeType": "cache.r3.8xlarge",
-                  "Value": "24536678400"
-                },
-                {
-                  "CacheNodeType": "cache.r3.large",
-                  "Value": "1468006400"
-                },
-                {
-                  "CacheNodeType": "cache.r3.xlarge",
-                  "Value": "3040870400"
-                },
-                {
-                  "CacheNodeType": "cache.t1.micro",
-                  "Value": "14260633"
-                },
-                {
-                  "CacheNodeType": "cache.t2.medium",
-                  "Value": "346134937"
-                },
-                {
-                  "CacheNodeType": "cache.t2.micro",
-                  "Value": "58195968"
-                },
-                {
-                  "CacheNodeType": "cache.t2.small",
-                  "Value": "166513868"
-                }
-              ],
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Slave client output buffer soft limit in bytes.",
-              "IsModifiable": false,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-slave-soft-limit",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "CacheNodeTypeSpecificValues": [
-                {
-                  "CacheNodeType": "cache.c1.xlarge",
-                  "Value": "6501171200"
-                },
-                {
-                  "CacheNodeType": "cache.m1.large",
-                  "Value": "7025459200"
-                },
-                {
-                  "CacheNodeType": "cache.m1.medium",
-                  "Value": "3093299200"
-                },
-                {
-                  "CacheNodeType": "cache.m1.small",
-                  "Value": "943718400"
-                },
-                {
-                  "CacheNodeType": "cache.m1.xlarge",
-                  "Value": "14889779200"
-                },
-                {
-                  "CacheNodeType": "cache.m2.2xlarge",
-                  "Value": "35022438400"
-                },
-                {
-                  "CacheNodeType": "cache.m2.4xlarge",
-                  "Value": "70883737600"
-                },
-                {
-                  "CacheNodeType": "cache.m2.xlarge",
-                  "Value": "17091788800"
-                },
-                {
-                  "CacheNodeType": "cache.m3.2xlarge",
-                  "Value": "29989273600"
-                },
-                {
-                  "CacheNodeType": "cache.m3.large",
-                  "Value": "6501171200"
-                },
-                {
-                  "CacheNodeType": "cache.m3.medium",
-                  "Value": "2988441600"
-                },
-                {
-                  "CacheNodeType": "cache.m3.xlarge",
-                  "Value": "14260633600"
-                },
-                {
-                  "CacheNodeType": "cache.m4.10xlarge",
-                  "Value": "166047614239"
-                },
-                {
-                  "CacheNodeType": "cache.m4.2xlarge",
-                  "Value": "31889126359"
-                },
-                {
-                  "CacheNodeType": "cache.m4.4xlarge",
-                  "Value": "65257290629"
-                },
-                {
-                  "CacheNodeType": "cache.m4.large",
-                  "Value": "6892593152"
-                },
-                {
-                  "CacheNodeType": "cache.m4.xlarge",
-                  "Value": "15328501760"
-                },
-                {
-                  "CacheNodeType": "cache.r3.2xlarge",
-                  "Value": "62495129600"
-                },
-                {
-                  "CacheNodeType": "cache.r3.4xlarge",
-                  "Value": "126458265600"
-                },
-                {
-                  "CacheNodeType": "cache.r3.8xlarge",
-                  "Value": "254384537600"
-                },
-                {
-                  "CacheNodeType": "cache.r3.large",
-                  "Value": "14470348800"
-                },
-                {
-                  "CacheNodeType": "cache.r3.xlarge",
-                  "Value": "30513561600"
-                },
-                {
-                  "CacheNodeType": "cache.t1.micro",
-                  "Value": "142606336"
-                },
-                {
-                  "CacheNodeType": "cache.t2.medium",
-                  "Value": "3461349376"
-                },
-                {
-                  "CacheNodeType": "cache.t2.micro",
-                  "Value": "581959680"
-                },
-                {
-                  "CacheNodeType": "cache.t2.small",
-                  "Value": "1665138688"
-                }
-              ],
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "The maximum configurable amount of memory to use to store items, in bytes.",
-              "IsModifiable": false,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "maxmemory",
-              "Source": "system"
-            }
-          ],
-          "CacheParameterGroupFamily": "redis2.8",
-          "Marker": "bWluLXNsYXZlcy10by13cml0ZQ==",
-          "Parameters": [
-            {
-              "AllowedValues": "yes,no",
-              "ChangeType": "requires-reboot",
-              "DataType": "string",
-              "Description": "Apply rehashing or not.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "activerehashing",
-              "ParameterValue": "yes",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "always,everysec,no",
-              "ChangeType": "immediate",
-              "DataType": "string",
-              "Description": "fsync policy for AOF persistence",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "appendfsync",
-              "ParameterValue": "everysec",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "yes,no",
-              "ChangeType": "immediate",
-              "DataType": "string",
-              "Description": "Enable Redis persistence.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "appendonly",
-              "ParameterValue": "no",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Normal client output buffer hard limit in bytes.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-normal-hard-limit",
-              "ParameterValue": "0",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Normal client output buffer soft limit in bytes.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-normal-soft-limit",
-              "ParameterValue": "0",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Normal client output buffer soft limit in seconds.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-normal-soft-seconds",
-              "ParameterValue": "0",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Pubsub client output buffer hard limit in bytes.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-pubsub-hard-limit",
-              "ParameterValue": "33554432",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Pubsub client output buffer soft limit in bytes.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-pubsub-soft-limit",
-              "ParameterValue": "8388608",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Pubsub client output buffer soft limit in seconds.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-pubsub-soft-seconds",
-              "ParameterValue": "60",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Slave client output buffer soft limit in seconds.",
-              "IsModifiable": false,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "client-output-buffer-limit-slave-soft-seconds",
-              "ParameterValue": "60",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "yes,no",
-              "ChangeType": "immediate",
-              "DataType": "string",
-              "Description": "If enabled, clients who attempt to write to a read-only slave will be disconnected. Applicable to 2.8.23 and higher.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.23",
-              "ParameterName": "close-on-slave-write",
-              "ParameterValue": "yes",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "1-1200000",
-              "ChangeType": "requires-reboot",
-              "DataType": "integer",
-              "Description": "Set the number of databases.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "databases",
-              "ParameterValue": "16",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "The maximum number of hash entries in order for the dataset to be compressed.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "hash-max-ziplist-entries",
-              "ParameterValue": "512",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "The threshold of biggest hash entries in order for the dataset to be compressed.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "hash-max-ziplist-value",
-              "ParameterValue": "64",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "The maximum number of list entries in order for the dataset to be compressed.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "list-max-ziplist-entries",
-              "ParameterValue": "512",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "The threshold of biggest list entries in order for the dataset to be compressed.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "list-max-ziplist-value",
-              "ParameterValue": "64",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "5000",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Max execution time of a Lua script in milliseconds. 0 for unlimited execution without warnings.",
-              "IsModifiable": false,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "lua-time-limit",
-              "ParameterValue": "5000",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "1-65000",
-              "ChangeType": "requires-reboot",
-              "DataType": "integer",
-              "Description": "The maximum number of Redis clients.",
-              "IsModifiable": false,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "maxclients",
-              "ParameterValue": "65000",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "volatile-lru,allkeys-lru,volatile-random,allkeys-random,volatile-ttl,noeviction",
-              "ChangeType": "immediate",
-              "DataType": "string",
-              "Description": "Max memory policy.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "maxmemory-policy",
-              "ParameterValue": "volatile-lru",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "1-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Max memory samples.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "maxmemory-samples",
-              "ParameterValue": "3",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Maximum number of seconds within which the master must receive a ping from a slave to take writes. Use this parameter together with min-slaves-to-write to regulate when the master stops accepting writes. Setting this value to 0 means the master always takes writes.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "min-slaves-max-lag",
-              "ParameterValue": "10",
-              "Source": "system"
-            },
-            {
-              "AllowedValues": "0-",
-              "ChangeType": "immediate",
-              "DataType": "integer",
-              "Description": "Number of slaves that must be connected in order for master to take writes. Use this parameter together with min-slaves-max-lag to regulate when the master stops accepting writes. Setting this to 0 means the master always takes writes.",
-              "IsModifiable": true,
-              "MinimumEngineVersion": "2.8.6",
-              "ParameterName": "min-slaves-to-write",
-              "ParameterValue": "0",
-              "Source": "system"
-            }
-          ]
+          "EngineDefaults": {
+            "CacheNodeTypeSpecificParameters": [
+              {
+                "AllowedValues": "0-",
+                "CacheNodeTypeSpecificValues": [
+                  {
+                    "CacheNodeType": "cache.c1.xlarge",
+                    "Value": "650117120"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.large",
+                    "Value": "702545920"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.medium",
+                    "Value": "309329920"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.small",
+                    "Value": "94371840"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.xlarge",
+                    "Value": "1488977920"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.2xlarge",
+                    "Value": "3502243840"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.4xlarge",
+                    "Value": "7088373760"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.xlarge",
+                    "Value": "1709178880"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.2xlarge",
+                    "Value": "2998927360"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.large",
+                    "Value": "650117120"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.medium",
+                    "Value": "309329920"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.xlarge",
+                    "Value": "1426063360"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.10xlarge",
+                    "Value": "16604761424"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.2xlarge",
+                    "Value": "3188912636"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.4xlarge",
+                    "Value": "6525729063"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.large",
+                    "Value": "689259315"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.xlarge",
+                    "Value": "1532850176"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.2xlarge",
+                    "Value": "6081740800"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.4xlarge",
+                    "Value": "12268339200"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.8xlarge",
+                    "Value": "24536678400"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.large",
+                    "Value": "1468006400"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.xlarge",
+                    "Value": "3040870400"
+                  },
+                  {
+                    "CacheNodeType": "cache.t1.micro",
+                    "Value": "14260633"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.medium",
+                    "Value": "346134937"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.micro",
+                    "Value": "58195968"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.small",
+                    "Value": "166513868"
+                  }
+                ],
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Slave client output buffer hard limit in bytes.",
+                "IsModifiable": false,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-slave-hard-limit",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "CacheNodeTypeSpecificValues": [
+                  {
+                    "CacheNodeType": "cache.c1.xlarge",
+                    "Value": "650117120"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.large",
+                    "Value": "702545920"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.medium",
+                    "Value": "309329920"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.small",
+                    "Value": "94371840"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.xlarge",
+                    "Value": "1488977920"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.2xlarge",
+                    "Value": "3502243840"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.4xlarge",
+                    "Value": "7088373760"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.xlarge",
+                    "Value": "1709178880"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.2xlarge",
+                    "Value": "2998927360"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.large",
+                    "Value": "650117120"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.medium",
+                    "Value": "309329920"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.xlarge",
+                    "Value": "1426063360"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.10xlarge",
+                    "Value": "16604761424"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.2xlarge",
+                    "Value": "3188912636"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.4xlarge",
+                    "Value": "6525729063"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.large",
+                    "Value": "689259315"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.xlarge",
+                    "Value": "1532850176"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.2xlarge",
+                    "Value": "6081740800"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.4xlarge",
+                    "Value": "12268339200"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.8xlarge",
+                    "Value": "24536678400"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.large",
+                    "Value": "1468006400"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.xlarge",
+                    "Value": "3040870400"
+                  },
+                  {
+                    "CacheNodeType": "cache.t1.micro",
+                    "Value": "14260633"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.medium",
+                    "Value": "346134937"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.micro",
+                    "Value": "58195968"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.small",
+                    "Value": "166513868"
+                  }
+                ],
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Slave client output buffer soft limit in bytes.",
+                "IsModifiable": false,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-slave-soft-limit",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "CacheNodeTypeSpecificValues": [
+                  {
+                    "CacheNodeType": "cache.c1.xlarge",
+                    "Value": "6501171200"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.large",
+                    "Value": "7025459200"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.medium",
+                    "Value": "3093299200"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.small",
+                    "Value": "943718400"
+                  },
+                  {
+                    "CacheNodeType": "cache.m1.xlarge",
+                    "Value": "14889779200"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.2xlarge",
+                    "Value": "35022438400"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.4xlarge",
+                    "Value": "70883737600"
+                  },
+                  {
+                    "CacheNodeType": "cache.m2.xlarge",
+                    "Value": "17091788800"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.2xlarge",
+                    "Value": "29989273600"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.large",
+                    "Value": "6501171200"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.medium",
+                    "Value": "2988441600"
+                  },
+                  {
+                    "CacheNodeType": "cache.m3.xlarge",
+                    "Value": "14260633600"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.10xlarge",
+                    "Value": "166047614239"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.2xlarge",
+                    "Value": "31889126359"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.4xlarge",
+                    "Value": "65257290629"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.large",
+                    "Value": "6892593152"
+                  },
+                  {
+                    "CacheNodeType": "cache.m4.xlarge",
+                    "Value": "15328501760"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.2xlarge",
+                    "Value": "62495129600"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.4xlarge",
+                    "Value": "126458265600"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.8xlarge",
+                    "Value": "254384537600"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.large",
+                    "Value": "14470348800"
+                  },
+                  {
+                    "CacheNodeType": "cache.r3.xlarge",
+                    "Value": "30513561600"
+                  },
+                  {
+                    "CacheNodeType": "cache.t1.micro",
+                    "Value": "142606336"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.medium",
+                    "Value": "3461349376"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.micro",
+                    "Value": "581959680"
+                  },
+                  {
+                    "CacheNodeType": "cache.t2.small",
+                    "Value": "1665138688"
+                  }
+                ],
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "The maximum configurable amount of memory to use to store items, in bytes.",
+                "IsModifiable": false,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "maxmemory",
+                "Source": "system"
+              }
+            ],
+            "CacheParameterGroupFamily": "redis2.8",
+            "Marker": "bWluLXNsYXZlcy10by13cml0ZQ==",
+            "Parameters": [
+              {
+                "AllowedValues": "yes,no",
+                "ChangeType": "requires-reboot",
+                "DataType": "string",
+                "Description": "Apply rehashing or not.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "activerehashing",
+                "ParameterValue": "yes",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "always,everysec,no",
+                "ChangeType": "immediate",
+                "DataType": "string",
+                "Description": "fsync policy for AOF persistence",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "appendfsync",
+                "ParameterValue": "everysec",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "yes,no",
+                "ChangeType": "immediate",
+                "DataType": "string",
+                "Description": "Enable Redis persistence.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "appendonly",
+                "ParameterValue": "no",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Normal client output buffer hard limit in bytes.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-normal-hard-limit",
+                "ParameterValue": "0",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Normal client output buffer soft limit in bytes.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-normal-soft-limit",
+                "ParameterValue": "0",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Normal client output buffer soft limit in seconds.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-normal-soft-seconds",
+                "ParameterValue": "0",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Pubsub client output buffer hard limit in bytes.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-pubsub-hard-limit",
+                "ParameterValue": "33554432",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Pubsub client output buffer soft limit in bytes.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-pubsub-soft-limit",
+                "ParameterValue": "8388608",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Pubsub client output buffer soft limit in seconds.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-pubsub-soft-seconds",
+                "ParameterValue": "60",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Slave client output buffer soft limit in seconds.",
+                "IsModifiable": false,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "client-output-buffer-limit-slave-soft-seconds",
+                "ParameterValue": "60",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "yes,no",
+                "ChangeType": "immediate",
+                "DataType": "string",
+                "Description": "If enabled, clients who attempt to write to a read-only slave will be disconnected. Applicable to 2.8.23 and higher.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.23",
+                "ParameterName": "close-on-slave-write",
+                "ParameterValue": "yes",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "1-1200000",
+                "ChangeType": "requires-reboot",
+                "DataType": "integer",
+                "Description": "Set the number of databases.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "databases",
+                "ParameterValue": "16",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "The maximum number of hash entries in order for the dataset to be compressed.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "hash-max-ziplist-entries",
+                "ParameterValue": "512",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "The threshold of biggest hash entries in order for the dataset to be compressed.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "hash-max-ziplist-value",
+                "ParameterValue": "64",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "The maximum number of list entries in order for the dataset to be compressed.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "list-max-ziplist-entries",
+                "ParameterValue": "512",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "The threshold of biggest list entries in order for the dataset to be compressed.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "list-max-ziplist-value",
+                "ParameterValue": "64",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "5000",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Max execution time of a Lua script in milliseconds. 0 for unlimited execution without warnings.",
+                "IsModifiable": false,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "lua-time-limit",
+                "ParameterValue": "5000",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "1-65000",
+                "ChangeType": "requires-reboot",
+                "DataType": "integer",
+                "Description": "The maximum number of Redis clients.",
+                "IsModifiable": false,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "maxclients",
+                "ParameterValue": "65000",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "volatile-lru,allkeys-lru,volatile-random,allkeys-random,volatile-ttl,noeviction",
+                "ChangeType": "immediate",
+                "DataType": "string",
+                "Description": "Max memory policy.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "maxmemory-policy",
+                "ParameterValue": "volatile-lru",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "1-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Max memory samples.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "maxmemory-samples",
+                "ParameterValue": "3",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Maximum number of seconds within which the master must receive a ping from a slave to take writes. Use this parameter together with min-slaves-to-write to regulate when the master stops accepting writes. Setting this value to 0 means the master always takes writes.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "min-slaves-max-lag",
+                "ParameterValue": "10",
+                "Source": "system"
+              },
+              {
+                "AllowedValues": "0-",
+                "ChangeType": "immediate",
+                "DataType": "integer",
+                "Description": "Number of slaves that must be connected in order for master to take writes. Use this parameter together with min-slaves-max-lag to regulate when the master stops accepting writes. Setting this to 0 means the master always takes writes.",
+                "IsModifiable": true,
+                "MinimumEngineVersion": "2.8.6",
+                "ParameterName": "min-slaves-to-write",
+                "ParameterValue": "0",
+                "Source": "system"
+              }
+            ]
+          }
         },
         "comments": {
           "input": {
@@ -2616,32 +2785,34 @@
           "SnapshotRetentionLimit": 14
         },
         "output": {
-          "AutoMinorVersionUpgrade": true,
-          "CacheClusterCreateTime": "2016-12-22T16:27:56.078Z",
-          "CacheClusterId": "redis-cluster",
-          "CacheClusterStatus": "available",
-          "CacheNodeType": "cache.r3.large",
-          "CacheParameterGroup": {
-            "CacheNodeIdsToReboot": [
+          "CacheCluster": {
+            "AutoMinorVersionUpgrade": true,
+            "CacheClusterCreateTime": "2016-12-22T16:27:56.078Z",
+            "CacheClusterId": "redis-cluster",
+            "CacheClusterStatus": "available",
+            "CacheNodeType": "cache.r3.large",
+            "CacheParameterGroup": {
+              "CacheNodeIdsToReboot": [
+
+              ],
+              "CacheParameterGroupName": "default.redis3.2",
+              "ParameterApplyStatus": "in-sync"
+            },
+            "CacheSecurityGroups": [
 
             ],
-            "CacheParameterGroupName": "default.redis3.2",
-            "ParameterApplyStatus": "in-sync"
-          },
-          "CacheSecurityGroups": [
-
-          ],
-          "CacheSubnetGroupName": "default",
-          "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
-          "Engine": "redis",
-          "EngineVersion": "3.2.4",
-          "NumCacheNodes": 1,
-          "PendingModifiedValues": {
-          },
-          "PreferredAvailabilityZone": "us-east-1e",
-          "PreferredMaintenanceWindow": "fri:09:00-fri:10:00",
-          "SnapshotRetentionLimit": 14,
-          "SnapshotWindow": "07:00-08:00"
+            "CacheSubnetGroupName": "default",
+            "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
+            "Engine": "redis",
+            "EngineVersion": "3.2.4",
+            "NumCacheNodes": 1,
+            "PendingModifiedValues": {
+            },
+            "PreferredAvailabilityZone": "us-east-1e",
+            "PreferredMaintenanceWindow": "fri:09:00-fri:10:00",
+            "SnapshotRetentionLimit": 14,
+            "SnapshotWindow": "07:00-08:00"
+          }
         },
         "comments": {
           "input": {
@@ -2692,41 +2863,43 @@
           ]
         },
         "output": {
-          "CacheSubnetGroupDescription": "My subnet group.",
-          "CacheSubnetGroupName": "my-sn-grp",
-          "Subnets": [
-            {
-              "SubnetAvailabilityZone": {
-                "Name": "us-east-1c"
+          "CacheSubnetGroup": {
+            "CacheSubnetGroupDescription": "My subnet group.",
+            "CacheSubnetGroupName": "my-sn-grp",
+            "Subnets": [
+              {
+                "SubnetAvailabilityZone": {
+                  "Name": "us-east-1c"
+                },
+                "SubnetIdentifier": "subnet-a1b2c3d4"
               },
-              "SubnetIdentifier": "subnet-a1b2c3d4"
-            },
-            {
-              "SubnetAvailabilityZone": {
-                "Name": "us-east-1e"
+              {
+                "SubnetAvailabilityZone": {
+                  "Name": "us-east-1e"
+                },
+                "SubnetIdentifier": "subnet-1a2b3c4d"
               },
-              "SubnetIdentifier": "subnet-1a2b3c4d"
-            },
-            {
-              "SubnetAvailabilityZone": {
-                "Name": "us-east-1e"
+              {
+                "SubnetAvailabilityZone": {
+                  "Name": "us-east-1e"
+                },
+                "SubnetIdentifier": "subnet-bcde2345"
               },
-              "SubnetIdentifier": "subnet-bcde2345"
-            },
-            {
-              "SubnetAvailabilityZone": {
-                "Name": "us-east-1c"
+              {
+                "SubnetAvailabilityZone": {
+                  "Name": "us-east-1c"
+                },
+                "SubnetIdentifier": "subnet-1234abcd"
               },
-              "SubnetIdentifier": "subnet-1234abcd"
-            },
-            {
-              "SubnetAvailabilityZone": {
-                "Name": "us-east-1b"
-              },
-              "SubnetIdentifier": "subnet-abcd1234"
-            }
-          ],
-          "VpcId": "vpc-91280df6"
+              {
+                "SubnetAvailabilityZone": {
+                  "Name": "us-east-1b"
+                },
+                "SubnetIdentifier": "subnet-abcd1234"
+              }
+            ],
+            "VpcId": "vpc-91280df6"
+          }
         },
         "comments": {
           "input": {
@@ -2749,60 +2922,62 @@
           "SnapshottingClusterId": "my-redis-rg-001"
         },
         "output": {
-          "AutomaticFailover": "enabled",
-          "Description": "Modified replication group",
-          "MemberClusters": [
-            "my-redis-rg-001",
-            "my-redis-rg-002",
-            "my-redis-rg-003"
-          ],
-          "NodeGroups": [
-            {
-              "NodeGroupId": "0001",
-              "NodeGroupMembers": [
-                {
-                  "CacheClusterId": "my-redis-rg-001",
-                  "CacheNodeId": "0001",
-                  "CurrentRole": "primary",
-                  "PreferredAvailabilityZone": "us-east-1b",
-                  "ReadEndpoint": {
-                    "Address": "my-redis-rg-001.abcdef.0001.use1.cache.amazonaws.com",
-                    "Port": 6379
+          "ReplicationGroup": {
+            "AutomaticFailover": "enabled",
+            "Description": "Modified replication group",
+            "MemberClusters": [
+              "my-redis-rg-001",
+              "my-redis-rg-002",
+              "my-redis-rg-003"
+            ],
+            "NodeGroups": [
+              {
+                "NodeGroupId": "0001",
+                "NodeGroupMembers": [
+                  {
+                    "CacheClusterId": "my-redis-rg-001",
+                    "CacheNodeId": "0001",
+                    "CurrentRole": "primary",
+                    "PreferredAvailabilityZone": "us-east-1b",
+                    "ReadEndpoint": {
+                      "Address": "my-redis-rg-001.abcdef.0001.use1.cache.amazonaws.com",
+                      "Port": 6379
+                    }
+                  },
+                  {
+                    "CacheClusterId": "my-redis-rg-002",
+                    "CacheNodeId": "0001",
+                    "CurrentRole": "replica",
+                    "PreferredAvailabilityZone": "us-east-1a",
+                    "ReadEndpoint": {
+                      "Address": "my-redis-rg-002.abcdef.0001.use1.cache.amazonaws.com",
+                      "Port": 6379
+                    }
+                  },
+                  {
+                    "CacheClusterId": "my-redis-rg-003",
+                    "CacheNodeId": "0001",
+                    "CurrentRole": "replica",
+                    "PreferredAvailabilityZone": "us-east-1c",
+                    "ReadEndpoint": {
+                      "Address": "my-redis-rg-003.abcdef.0001.use1.cache.amazonaws.com",
+                      "Port": 6379
+                    }
                   }
+                ],
+                "PrimaryEndpoint": {
+                  "Address": "my-redis-rg.abcdef.ng.0001.use1.cache.amazonaws.com",
+                  "Port": 6379
                 },
-                {
-                  "CacheClusterId": "my-redis-rg-002",
-                  "CacheNodeId": "0001",
-                  "CurrentRole": "replica",
-                  "PreferredAvailabilityZone": "us-east-1a",
-                  "ReadEndpoint": {
-                    "Address": "my-redis-rg-002.abcdef.0001.use1.cache.amazonaws.com",
-                    "Port": 6379
-                  }
-                },
-                {
-                  "CacheClusterId": "my-redis-rg-003",
-                  "CacheNodeId": "0001",
-                  "CurrentRole": "replica",
-                  "PreferredAvailabilityZone": "us-east-1c",
-                  "ReadEndpoint": {
-                    "Address": "my-redis-rg-003.abcdef.0001.use1.cache.amazonaws.com",
-                    "Port": 6379
-                  }
-                }
-              ],
-              "PrimaryEndpoint": {
-                "Address": "my-redis-rg.abcdef.ng.0001.use1.cache.amazonaws.com",
-                "Port": 6379
-              },
-              "Status": "available"
-            }
-          ],
-          "PendingModifiedValues": {
-          },
-          "ReplicationGroupId": "my-redis-rg",
-          "SnapshottingClusterId": "my-redis-rg-002",
-          "Status": "available"
+                "Status": "available"
+              }
+            ],
+            "PendingModifiedValues": {
+            },
+            "ReplicationGroupId": "my-redis-rg",
+            "SnapshottingClusterId": "my-redis-rg-002",
+            "Status": "available"
+          }
         },
         "comments": {
           "input": {
@@ -2841,34 +3016,36 @@
           ]
         },
         "output": {
-          "AutoMinorVersionUpgrade": true,
-          "CacheClusterCreateTime": "2016-12-21T21:59:43.794Z",
-          "CacheClusterId": "my-mem-cluster",
-          "CacheClusterStatus": "rebooting cache cluster nodes",
-          "CacheNodeType": "cache.t2.medium",
-          "CacheParameterGroup": {
-            "CacheNodeIdsToReboot": [
+          "CacheCluster": {
+            "AutoMinorVersionUpgrade": true,
+            "CacheClusterCreateTime": "2016-12-21T21:59:43.794Z",
+            "CacheClusterId": "my-mem-cluster",
+            "CacheClusterStatus": "rebooting cache cluster nodes",
+            "CacheNodeType": "cache.t2.medium",
+            "CacheParameterGroup": {
+              "CacheNodeIdsToReboot": [
+
+              ],
+              "CacheParameterGroupName": "default.memcached1.4",
+              "ParameterApplyStatus": "in-sync"
+            },
+            "CacheSecurityGroups": [
 
             ],
-            "CacheParameterGroupName": "default.memcached1.4",
-            "ParameterApplyStatus": "in-sync"
-          },
-          "CacheSecurityGroups": [
-
-          ],
-          "CacheSubnetGroupName": "default",
-          "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
-          "ConfigurationEndpoint": {
-            "Address": "my-mem-cluster.abcdef.cfg.use1.cache.amazonaws.com",
-            "Port": 11211
-          },
-          "Engine": "memcached",
-          "EngineVersion": "1.4.24",
-          "NumCacheNodes": 2,
-          "PendingModifiedValues": {
-          },
-          "PreferredAvailabilityZone": "Multiple",
-          "PreferredMaintenanceWindow": "wed:06:00-wed:07:00"
+            "CacheSubnetGroupName": "default",
+            "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
+            "ConfigurationEndpoint": {
+              "Address": "my-mem-cluster.abcdef.cfg.use1.cache.amazonaws.com",
+              "Port": 11211
+            },
+            "Engine": "memcached",
+            "EngineVersion": "1.4.24",
+            "NumCacheNodes": 2,
+            "PendingModifiedValues": {
+            },
+            "PreferredAvailabilityZone": "Multiple",
+            "PreferredMaintenanceWindow": "wed:06:00-wed:07:00"
+          }
         },
         "comments": {
           "input": {

--- a/models/apis/elasticache/2015-02-02/paginators-1.json
+++ b/models/apis/elasticache/2015-02-02/paginators-1.json
@@ -2,74 +2,74 @@
   "pagination": {
     "DescribeCacheClusters": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "CacheClusters"
     },
     "DescribeCacheEngineVersions": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "CacheEngineVersions"
     },
     "DescribeCacheParameterGroups": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "CacheParameterGroups"
     },
     "DescribeCacheParameters": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "Parameters"
     },
     "DescribeCacheSecurityGroups": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "CacheSecurityGroups"
     },
     "DescribeCacheSubnetGroups": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "CacheSubnetGroups"
     },
     "DescribeEngineDefaultParameters": {
       "input_token": "Marker",
-      "output_token": "EngineDefaults.Marker",
       "limit_key": "MaxRecords",
+      "output_token": "EngineDefaults.Marker",
       "result_key": "EngineDefaults.Parameters"
     },
     "DescribeEvents": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "Events"
+    },
+    "DescribeReplicationGroups": {
+      "input_token": "Marker",
+      "limit_key": "MaxRecords",
+      "output_token": "Marker",
+      "result_key": "ReplicationGroups"
     },
     "DescribeReservedCacheNodes": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "ReservedCacheNodes"
     },
     "DescribeReservedCacheNodesOfferings": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "ReservedCacheNodesOfferings"
-    },
-    "DescribeReplicationGroups": {
-      "input_token": "Marker",
-      "output_token": "Marker",
-      "limit_key": "MaxRecords",
-      "result_key": "ReplicationGroups"
     },
     "DescribeSnapshots": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "Snapshots"
     }
   }

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -789,14 +789,14 @@ const opInputService5TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation4Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputService5TestCaseOperation1Input{}
+		input = &InputService5TestShapeInputService5TestCaseOperation4Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation1Output{}
@@ -814,7 +814,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation1 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *InputService5TestShapeInputService5TestCaseOperation1Input) (*InputService5TestShapeInputService5TestCaseOperation1Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *InputService5TestShapeInputService5TestCaseOperation4Input) (*InputService5TestShapeInputService5TestCaseOperation1Output, error) {
 	req, out := c.InputService5TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -828,7 +828,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation1Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation1Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation4Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation1Output, error) {
 	req, out := c.InputService5TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -860,14 +860,14 @@ const opInputService5TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputService5TestCaseOperation4Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputService5TestCaseOperation1Input{}
+		input = &InputService5TestShapeInputService5TestCaseOperation4Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation2Output{}
@@ -885,7 +885,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation2 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *InputService5TestShapeInputService5TestCaseOperation1Input) (*InputService5TestShapeInputService5TestCaseOperation2Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *InputService5TestShapeInputService5TestCaseOperation4Input) (*InputService5TestShapeInputService5TestCaseOperation2Output, error) {
 	req, out := c.InputService5TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -899,7 +899,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation1Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation2Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation4Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation2Output, error) {
 	req, out := c.InputService5TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -931,14 +931,14 @@ const opInputService5TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation3Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation3Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation3Request(input *InputService5TestShapeInputService5TestCaseOperation4Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation3,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputService5TestCaseOperation1Input{}
+		input = &InputService5TestShapeInputService5TestCaseOperation4Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation3Output{}
@@ -956,7 +956,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation3Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation3 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation3(input *InputService5TestShapeInputService5TestCaseOperation1Input) (*InputService5TestShapeInputService5TestCaseOperation3Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation3(input *InputService5TestShapeInputService5TestCaseOperation4Input) (*InputService5TestShapeInputService5TestCaseOperation3Output, error) {
 	req, out := c.InputService5TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -970,7 +970,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation3(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation3WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation1Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation3Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation3WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation4Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation3Output, error) {
 	req, out := c.InputService5TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1002,14 +1002,14 @@ const opInputService5TestCaseOperation4 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation4Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation4Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation4Request(input *InputService5TestShapeInputService5TestCaseOperation4Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation4Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation4,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputService5TestCaseOperation1Input{}
+		input = &InputService5TestShapeInputService5TestCaseOperation4Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation4Output{}
@@ -1027,7 +1027,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation4Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation4 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation4(input *InputService5TestShapeInputService5TestCaseOperation1Input) (*InputService5TestShapeInputService5TestCaseOperation4Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation4(input *InputService5TestShapeInputService5TestCaseOperation4Input) (*InputService5TestShapeInputService5TestCaseOperation4Output, error) {
 	req, out := c.InputService5TestCaseOperation4Request(input)
 	return out, req.Send()
 }
@@ -1041,7 +1041,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation4(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation4WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation1Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation4Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation4WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation4Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation4Output, error) {
 	req, out := c.InputService5TestCaseOperation4Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1073,14 +1073,14 @@ const opInputService5TestCaseOperation5 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation5Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation5Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation5Request(input *InputService5TestShapeInputService5TestCaseOperation4Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation5Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation5,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputService5TestCaseOperation1Input{}
+		input = &InputService5TestShapeInputService5TestCaseOperation4Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation5Output{}
@@ -1098,7 +1098,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation5Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation5 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *InputService5TestShapeInputService5TestCaseOperation1Input) (*InputService5TestShapeInputService5TestCaseOperation5Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *InputService5TestShapeInputService5TestCaseOperation4Input) (*InputService5TestShapeInputService5TestCaseOperation5Output, error) {
 	req, out := c.InputService5TestCaseOperation5Request(input)
 	return out, req.Send()
 }
@@ -1112,7 +1112,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation5WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation1Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation5Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation5WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation4Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation5Output, error) {
 	req, out := c.InputService5TestCaseOperation5Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1144,14 +1144,14 @@ const opInputService5TestCaseOperation6 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation6Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputService5TestCaseOperation4Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation6Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation6,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputService5TestCaseOperation1Input{}
+		input = &InputService5TestShapeInputService5TestCaseOperation4Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation6Output{}
@@ -1169,7 +1169,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation6 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *InputService5TestShapeInputService5TestCaseOperation1Input) (*InputService5TestShapeInputService5TestCaseOperation6Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *InputService5TestShapeInputService5TestCaseOperation4Input) (*InputService5TestShapeInputService5TestCaseOperation6Output, error) {
 	req, out := c.InputService5TestCaseOperation6Request(input)
 	return out, req.Send()
 }
@@ -1183,23 +1183,11 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation1Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation6Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation4Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation6Output, error) {
 	req, out := c.InputService5TestCaseOperation6Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
-}
-
-type InputService5TestShapeInputService5TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
-
-	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
-}
-
-// SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetRecursiveStruct(v *InputService5TestShapeRecursiveStructType) *InputService5TestShapeInputService5TestCaseOperation1Input {
-	s.RecursiveStruct = v
-	return s
 }
 
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
@@ -1212,6 +1200,18 @@ type InputService5TestShapeInputService5TestCaseOperation2Output struct {
 
 type InputService5TestShapeInputService5TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService5TestShapeInputService5TestCaseOperation4Input struct {
+	_ struct{} `type:"structure"`
+
+	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService5TestShapeInputService5TestCaseOperation4Input) SetRecursiveStruct(v *InputService5TestShapeRecursiveStructType) *InputService5TestShapeInputService5TestCaseOperation4Input {
+	s.RecursiveStruct = v
+	return s
 }
 
 type InputService5TestShapeInputService5TestCaseOperation4Output struct {
@@ -1768,7 +1768,7 @@ func TestInputService4ProtocolTestNestedBlobsCase1(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputService5TestCaseOperation1Input{
+	input := &InputService5TestShapeInputService5TestCaseOperation4Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
@@ -1796,7 +1796,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputService5TestCaseOperation1Input{
+	input := &InputService5TestShapeInputService5TestCaseOperation4Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
@@ -1826,7 +1826,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputService5TestCaseOperation1Input{
+	input := &InputService5TestShapeInputService5TestCaseOperation4Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 				RecursiveStruct: &InputService5TestShapeRecursiveStructType{
@@ -1860,7 +1860,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputService5TestCaseOperation1Input{
+	input := &InputService5TestShapeInputService5TestCaseOperation4Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveList: []*InputService5TestShapeRecursiveStructType{
 				{
@@ -1895,7 +1895,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputService5TestCaseOperation1Input{
+	input := &InputService5TestShapeInputService5TestCaseOperation4Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveList: []*InputService5TestShapeRecursiveStructType{
 				{
@@ -1932,7 +1932,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputService5TestCaseOperation1Input{
+	input := &InputService5TestShapeInputService5TestCaseOperation4Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveMap: map[string]*InputService5TestShapeRecursiveStructType{
 				"bar": {

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -643,7 +643,7 @@ const opOutputService4TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation2Output) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opOutputService4TestCaseOperation1,
 		HTTPPath: "/",
@@ -653,7 +653,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(inp
 		input = &OutputService4TestShapeOutputService4TestCaseOperation1Input{}
 	}
 
-	output = &OutputService4TestShapeOutputService4TestCaseOperation2Output{}
+	output = &OutputService4TestShapeOutputService4TestCaseOperation1Output{}
 	req = c.newRequest(op, input, output)
 	return
 }
@@ -666,7 +666,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation OutputService4TestCaseOperation1 for usage and error information.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (*OutputService4TestShapeOutputService4TestCaseOperation2Output, error) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (*OutputService4TestShapeOutputService4TestCaseOperation1Output, error) {
 	req, out := c.OutputService4TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -680,7 +680,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1WithContext(ctx aws.Context, input *OutputService4TestShapeOutputService4TestCaseOperation1Input, opts ...request.Option) (*OutputService4TestShapeOutputService4TestCaseOperation2Output, error) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1WithContext(ctx aws.Context, input *OutputService4TestShapeOutputService4TestCaseOperation1Input, opts ...request.Option) (*OutputService4TestShapeOutputService4TestCaseOperation1Output, error) {
 	req, out := c.OutputService4TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -712,7 +712,7 @@ const opOutputService4TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2Request(input *OutputService4TestShapeOutputService4TestCaseOperation2Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation2Output) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2Request(input *OutputService4TestShapeOutputService4TestCaseOperation2Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opOutputService4TestCaseOperation2,
 		HTTPPath: "/",
@@ -722,7 +722,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2Request(inp
 		input = &OutputService4TestShapeOutputService4TestCaseOperation2Input{}
 	}
 
-	output = &OutputService4TestShapeOutputService4TestCaseOperation2Output{}
+	output = &OutputService4TestShapeOutputService4TestCaseOperation1Output{}
 	req = c.newRequest(op, input, output)
 	return
 }
@@ -735,7 +735,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation OutputService4TestCaseOperation2 for usage and error information.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2(input *OutputService4TestShapeOutputService4TestCaseOperation2Input) (*OutputService4TestShapeOutputService4TestCaseOperation2Output, error) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2(input *OutputService4TestShapeOutputService4TestCaseOperation2Input) (*OutputService4TestShapeOutputService4TestCaseOperation1Output, error) {
 	req, out := c.OutputService4TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -749,7 +749,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2(input *Out
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2WithContext(ctx aws.Context, input *OutputService4TestShapeOutputService4TestCaseOperation2Input, opts ...request.Option) (*OutputService4TestShapeOutputService4TestCaseOperation2Output, error) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2WithContext(ctx aws.Context, input *OutputService4TestShapeOutputService4TestCaseOperation2Input, opts ...request.Option) (*OutputService4TestShapeOutputService4TestCaseOperation1Output, error) {
 	req, out := c.OutputService4TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -760,11 +760,7 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
-type OutputService4TestShapeOutputService4TestCaseOperation2Input struct {
-	_ struct{} `type:"structure"`
-}
-
-type OutputService4TestShapeOutputService4TestCaseOperation2Output struct {
+type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
 	ListMember []*string `type:"list"`
@@ -775,21 +771,25 @@ type OutputService4TestShapeOutputService4TestCaseOperation2Output struct {
 }
 
 // SetListMember sets the ListMember field's value.
-func (s *OutputService4TestShapeOutputService4TestCaseOperation2Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation2Output {
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
 	s.ListMember = v
 	return s
 }
 
 // SetListMemberMap sets the ListMemberMap field's value.
-func (s *OutputService4TestShapeOutputService4TestCaseOperation2Output) SetListMemberMap(v []map[string]*string) *OutputService4TestShapeOutputService4TestCaseOperation2Output {
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMemberMap(v []map[string]*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
 	s.ListMemberMap = v
 	return s
 }
 
 // SetListMemberStruct sets the ListMemberStruct field's value.
-func (s *OutputService4TestShapeOutputService4TestCaseOperation2Output) SetListMemberStruct(v []*OutputService4TestShapeStructType) *OutputService4TestShapeOutputService4TestCaseOperation2Output {
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMemberStruct(v []*OutputService4TestShapeStructType) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
 	s.ListMemberStruct = v
 	return s
+}
+
+type OutputService4TestShapeOutputService4TestCaseOperation2Input struct {
+	_ struct{} `type:"structure"`
 }
 
 type OutputService4TestShapeStructType struct {

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -804,14 +804,14 @@ const opInputService4TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation2Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService4TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService4TestShapeInputService4TestCaseOperation1Input{}
+		input = &InputService4TestShapeInputService4TestCaseOperation2Input{}
 	}
 
 	output = &InputService4TestShapeInputService4TestCaseOperation1Output{}
@@ -829,7 +829,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService4TestCaseOperation1 for usage and error information.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *InputService4TestShapeInputService4TestCaseOperation1Input) (*InputService4TestShapeInputService4TestCaseOperation1Output, error) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *InputService4TestShapeInputService4TestCaseOperation2Input) (*InputService4TestShapeInputService4TestCaseOperation1Output, error) {
 	req, out := c.InputService4TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -843,7 +843,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1WithContext(ctx aws.Context, input *InputService4TestShapeInputService4TestCaseOperation1Input, opts ...request.Option) (*InputService4TestShapeInputService4TestCaseOperation1Output, error) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1WithContext(ctx aws.Context, input *InputService4TestShapeInputService4TestCaseOperation2Input, opts ...request.Option) (*InputService4TestShapeInputService4TestCaseOperation1Output, error) {
 	req, out := c.InputService4TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -875,14 +875,14 @@ const opInputService4TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation2Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation2Output) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation2Request(input *InputService4TestShapeInputService4TestCaseOperation2Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService4TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService4TestShapeInputService4TestCaseOperation1Input{}
+		input = &InputService4TestShapeInputService4TestCaseOperation2Input{}
 	}
 
 	output = &InputService4TestShapeInputService4TestCaseOperation2Output{}
@@ -900,7 +900,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService4TestCaseOperation2 for usage and error information.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation2(input *InputService4TestShapeInputService4TestCaseOperation1Input) (*InputService4TestShapeInputService4TestCaseOperation2Output, error) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation2(input *InputService4TestShapeInputService4TestCaseOperation2Input) (*InputService4TestShapeInputService4TestCaseOperation2Output, error) {
 	req, out := c.InputService4TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -914,14 +914,18 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation2WithContext(ctx aws.Context, input *InputService4TestShapeInputService4TestCaseOperation1Input, opts ...request.Option) (*InputService4TestShapeInputService4TestCaseOperation2Output, error) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation2WithContext(ctx aws.Context, input *InputService4TestShapeInputService4TestCaseOperation2Input, opts ...request.Option) (*InputService4TestShapeInputService4TestCaseOperation2Output, error) {
 	req, out := c.InputService4TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 
-type InputService4TestShapeInputService4TestCaseOperation1Input struct {
+type InputService4TestShapeInputService4TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService4TestShapeInputService4TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
 	ListArg []*string `type:"list" flattened:"true"`
@@ -932,25 +936,21 @@ type InputService4TestShapeInputService4TestCaseOperation1Input struct {
 }
 
 // SetListArg sets the ListArg field's value.
-func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetListArg(v []*string) *InputService4TestShapeInputService4TestCaseOperation1Input {
+func (s *InputService4TestShapeInputService4TestCaseOperation2Input) SetListArg(v []*string) *InputService4TestShapeInputService4TestCaseOperation2Input {
 	s.ListArg = v
 	return s
 }
 
 // SetNamedListArg sets the NamedListArg field's value.
-func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetNamedListArg(v []*string) *InputService4TestShapeInputService4TestCaseOperation1Input {
+func (s *InputService4TestShapeInputService4TestCaseOperation2Input) SetNamedListArg(v []*string) *InputService4TestShapeInputService4TestCaseOperation2Input {
 	s.NamedListArg = v
 	return s
 }
 
 // SetScalarArg sets the ScalarArg field's value.
-func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetScalarArg(v string) *InputService4TestShapeInputService4TestCaseOperation1Input {
+func (s *InputService4TestShapeInputService4TestCaseOperation2Input) SetScalarArg(v string) *InputService4TestShapeInputService4TestCaseOperation2Input {
 	s.ScalarArg = &v
 	return s
-}
-
-type InputService4TestShapeInputService4TestCaseOperation1Output struct {
-	_ struct{} `type:"structure"`
 }
 
 type InputService4TestShapeInputService4TestCaseOperation2Output struct {
@@ -2040,14 +2040,14 @@ const opInputService12TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(input *InputService12TestShapeInputService12TestCaseOperation4Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation1Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(input *InputService12TestShapeInputService12TestCaseOperation5Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputService12TestCaseOperation4Input{}
+		input = &InputService12TestShapeInputService12TestCaseOperation5Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation1Output{}
@@ -2065,7 +2065,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation1 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *InputService12TestShapeInputService12TestCaseOperation4Input) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *InputService12TestShapeInputService12TestCaseOperation5Input) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
 	req, out := c.InputService12TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -2079,7 +2079,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation4Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation5Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
 	req, out := c.InputService12TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2111,14 +2111,14 @@ const opInputService12TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation2Request(input *InputService12TestShapeInputService12TestCaseOperation4Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation2Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation2Request(input *InputService12TestShapeInputService12TestCaseOperation5Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputService12TestCaseOperation4Input{}
+		input = &InputService12TestShapeInputService12TestCaseOperation5Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation2Output{}
@@ -2136,7 +2136,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation2 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation2(input *InputService12TestShapeInputService12TestCaseOperation4Input) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation2(input *InputService12TestShapeInputService12TestCaseOperation5Input) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
 	req, out := c.InputService12TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -2150,7 +2150,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation2WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation4Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation2WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation5Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
 	req, out := c.InputService12TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2182,14 +2182,14 @@ const opInputService12TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation3Request(input *InputService12TestShapeInputService12TestCaseOperation4Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation3Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation3Request(input *InputService12TestShapeInputService12TestCaseOperation5Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation3,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputService12TestCaseOperation4Input{}
+		input = &InputService12TestShapeInputService12TestCaseOperation5Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation3Output{}
@@ -2207,7 +2207,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation3Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation3 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation3(input *InputService12TestShapeInputService12TestCaseOperation4Input) (*InputService12TestShapeInputService12TestCaseOperation3Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation3(input *InputService12TestShapeInputService12TestCaseOperation5Input) (*InputService12TestShapeInputService12TestCaseOperation3Output, error) {
 	req, out := c.InputService12TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -2221,7 +2221,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation3(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation3WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation4Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation3Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation3WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation5Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation3Output, error) {
 	req, out := c.InputService12TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2253,14 +2253,14 @@ const opInputService12TestCaseOperation4 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation4Request(input *InputService12TestShapeInputService12TestCaseOperation4Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation4Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation4Request(input *InputService12TestShapeInputService12TestCaseOperation5Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation4Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation4,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputService12TestCaseOperation4Input{}
+		input = &InputService12TestShapeInputService12TestCaseOperation5Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation4Output{}
@@ -2278,7 +2278,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation4Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation4 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation4(input *InputService12TestShapeInputService12TestCaseOperation4Input) (*InputService12TestShapeInputService12TestCaseOperation4Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation4(input *InputService12TestShapeInputService12TestCaseOperation5Input) (*InputService12TestShapeInputService12TestCaseOperation4Output, error) {
 	req, out := c.InputService12TestCaseOperation4Request(input)
 	return out, req.Send()
 }
@@ -2292,7 +2292,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation4(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation4WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation4Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation4Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation4WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation5Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation4Output, error) {
 	req, out := c.InputService12TestCaseOperation4Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2324,14 +2324,14 @@ const opInputService12TestCaseOperation5 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation5Request(input *InputService12TestShapeInputService12TestCaseOperation4Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation5Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation5Request(input *InputService12TestShapeInputService12TestCaseOperation5Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation5Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation5,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputService12TestCaseOperation4Input{}
+		input = &InputService12TestShapeInputService12TestCaseOperation5Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation5Output{}
@@ -2349,7 +2349,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation5Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation5 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation5(input *InputService12TestShapeInputService12TestCaseOperation4Input) (*InputService12TestShapeInputService12TestCaseOperation5Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation5(input *InputService12TestShapeInputService12TestCaseOperation5Input) (*InputService12TestShapeInputService12TestCaseOperation5Output, error) {
 	req, out := c.InputService12TestCaseOperation5Request(input)
 	return out, req.Send()
 }
@@ -2363,7 +2363,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation5(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation5WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation4Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation5Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation5WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation5Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation5Output, error) {
 	req, out := c.InputService12TestCaseOperation5Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2395,14 +2395,14 @@ const opInputService12TestCaseOperation6 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation6Request(input *InputService12TestShapeInputService12TestCaseOperation4Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation6Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation6Request(input *InputService12TestShapeInputService12TestCaseOperation5Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation6Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation6,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputService12TestCaseOperation4Input{}
+		input = &InputService12TestShapeInputService12TestCaseOperation5Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation6Output{}
@@ -2420,7 +2420,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation6Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation6 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation6(input *InputService12TestShapeInputService12TestCaseOperation4Input) (*InputService12TestShapeInputService12TestCaseOperation6Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation6(input *InputService12TestShapeInputService12TestCaseOperation5Input) (*InputService12TestShapeInputService12TestCaseOperation6Output, error) {
 	req, out := c.InputService12TestCaseOperation6Request(input)
 	return out, req.Send()
 }
@@ -2434,7 +2434,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation6(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation6WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation4Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation6Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation6WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation5Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation6Output, error) {
 	req, out := c.InputService12TestCaseOperation6Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2453,20 +2453,20 @@ type InputService12TestShapeInputService12TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService12TestShapeInputService12TestCaseOperation4Input struct {
+type InputService12TestShapeInputService12TestCaseOperation4Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService12TestShapeInputService12TestCaseOperation5Input struct {
 	_ struct{} `type:"structure"`
 
 	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
 }
 
 // SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService12TestShapeInputService12TestCaseOperation4Input) SetRecursiveStruct(v *InputService12TestShapeRecursiveStructType) *InputService12TestShapeInputService12TestCaseOperation4Input {
+func (s *InputService12TestShapeInputService12TestCaseOperation5Input) SetRecursiveStruct(v *InputService12TestShapeRecursiveStructType) *InputService12TestShapeInputService12TestCaseOperation5Input {
 	s.RecursiveStruct = v
 	return s
-}
-
-type InputService12TestShapeInputService12TestCaseOperation4Output struct {
-	_ struct{} `type:"structure"`
 }
 
 type InputService12TestShapeInputService12TestCaseOperation5Output struct {
@@ -2889,7 +2889,7 @@ func TestInputService3ProtocolTestListTypesCase2(t *testing.T) {
 
 func TestInputService4ProtocolTestFlattenedListCase1(t *testing.T) {
 	svc := NewInputService4ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService4TestShapeInputService4TestCaseOperation1Input{
+	input := &InputService4TestShapeInputService4TestCaseOperation2Input{
 		ListArg: []*string{
 			aws.String("a"),
 			aws.String("b"),
@@ -2918,7 +2918,7 @@ func TestInputService4ProtocolTestFlattenedListCase1(t *testing.T) {
 
 func TestInputService4ProtocolTestFlattenedListCase2(t *testing.T) {
 	svc := NewInputService4ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService4TestShapeInputService4TestCaseOperation1Input{
+	input := &InputService4TestShapeInputService4TestCaseOperation2Input{
 		NamedListArg: []*string{
 			aws.String("a"),
 		},
@@ -3130,7 +3130,7 @@ func TestInputService11ProtocolTestTimestampValuesCase1(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputService12TestCaseOperation4Input{
+	input := &InputService12TestShapeInputService12TestCaseOperation5Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
@@ -3156,7 +3156,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputService12TestCaseOperation4Input{
+	input := &InputService12TestShapeInputService12TestCaseOperation5Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
@@ -3184,7 +3184,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputService12TestCaseOperation4Input{
+	input := &InputService12TestShapeInputService12TestCaseOperation5Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 				RecursiveStruct: &InputService12TestShapeRecursiveStructType{
@@ -3216,7 +3216,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputService12TestCaseOperation4Input{
+	input := &InputService12TestShapeInputService12TestCaseOperation5Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveList: []*InputService12TestShapeRecursiveStructType{
 				{
@@ -3249,7 +3249,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputService12TestCaseOperation4Input{
+	input := &InputService12TestShapeInputService12TestCaseOperation5Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveList: []*InputService12TestShapeRecursiveStructType{
 				{
@@ -3284,7 +3284,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputService12TestCaseOperation4Input{
+	input := &InputService12TestShapeInputService12TestCaseOperation5Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveMap: map[string]*InputService12TestShapeRecursiveStructType{
 				"bar": {

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -2090,7 +2090,7 @@ const opInputService13TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(input *InputService13TestShapeInputService13TestCaseOperation2Input) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation1Output) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(input *InputService13TestShapeInputService13TestCaseOperation1Input) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService13TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -2098,7 +2098,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService13TestShapeInputService13TestCaseOperation2Input{}
+		input = &InputService13TestShapeInputService13TestCaseOperation1Input{}
 	}
 
 	output = &InputService13TestShapeInputService13TestCaseOperation1Output{}
@@ -2116,7 +2116,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService13TestCaseOperation1 for usage and error information.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation1(input *InputService13TestShapeInputService13TestCaseOperation2Input) (*InputService13TestShapeInputService13TestCaseOperation1Output, error) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation1(input *InputService13TestShapeInputService13TestCaseOperation1Input) (*InputService13TestShapeInputService13TestCaseOperation1Output, error) {
 	req, out := c.InputService13TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -2130,7 +2130,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation1WithContext(ctx aws.Context, input *InputService13TestShapeInputService13TestCaseOperation2Input, opts ...request.Option) (*InputService13TestShapeInputService13TestCaseOperation1Output, error) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation1WithContext(ctx aws.Context, input *InputService13TestShapeInputService13TestCaseOperation1Input, opts ...request.Option) (*InputService13TestShapeInputService13TestCaseOperation1Output, error) {
 	req, out := c.InputService13TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2162,7 +2162,7 @@ const opInputService13TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(input *InputService13TestShapeInputService13TestCaseOperation2Input) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation2Output) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(input *InputService13TestShapeInputService13TestCaseOperation1Input) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService13TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -2170,7 +2170,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService13TestShapeInputService13TestCaseOperation2Input{}
+		input = &InputService13TestShapeInputService13TestCaseOperation1Input{}
 	}
 
 	output = &InputService13TestShapeInputService13TestCaseOperation2Output{}
@@ -2188,7 +2188,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService13TestCaseOperation2 for usage and error information.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation2(input *InputService13TestShapeInputService13TestCaseOperation2Input) (*InputService13TestShapeInputService13TestCaseOperation2Output, error) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation2(input *InputService13TestShapeInputService13TestCaseOperation1Input) (*InputService13TestShapeInputService13TestCaseOperation2Output, error) {
 	req, out := c.InputService13TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -2202,27 +2202,27 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation2WithContext(ctx aws.Context, input *InputService13TestShapeInputService13TestCaseOperation2Input, opts ...request.Option) (*InputService13TestShapeInputService13TestCaseOperation2Output, error) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation2WithContext(ctx aws.Context, input *InputService13TestShapeInputService13TestCaseOperation1Input, opts ...request.Option) (*InputService13TestShapeInputService13TestCaseOperation2Output, error) {
 	req, out := c.InputService13TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 
-type InputService13TestShapeInputService13TestCaseOperation1Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService13TestShapeInputService13TestCaseOperation2Input struct {
+type InputService13TestShapeInputService13TestCaseOperation1Input struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
 	Foo []byte `locationName:"foo" type:"blob"`
 }
 
 // SetFoo sets the Foo field's value.
-func (s *InputService13TestShapeInputService13TestCaseOperation2Input) SetFoo(v []byte) *InputService13TestShapeInputService13TestCaseOperation2Input {
+func (s *InputService13TestShapeInputService13TestCaseOperation1Input) SetFoo(v []byte) *InputService13TestShapeInputService13TestCaseOperation1Input {
 	s.Foo = v
 	return s
+}
+
+type InputService13TestShapeInputService13TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
 }
 
 type InputService13TestShapeInputService13TestCaseOperation2Output struct {
@@ -2759,7 +2759,7 @@ const opInputService16TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(input *InputService16TestShapeInputService16TestCaseOperation2Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation1Output) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(input *InputService16TestShapeInputService16TestCaseOperation6Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService16TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -2767,7 +2767,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService16TestShapeInputService16TestCaseOperation2Input{}
+		input = &InputService16TestShapeInputService16TestCaseOperation6Input{}
 	}
 
 	output = &InputService16TestShapeInputService16TestCaseOperation1Output{}
@@ -2785,7 +2785,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService16TestCaseOperation1 for usage and error information.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation1(input *InputService16TestShapeInputService16TestCaseOperation2Input) (*InputService16TestShapeInputService16TestCaseOperation1Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation1(input *InputService16TestShapeInputService16TestCaseOperation6Input) (*InputService16TestShapeInputService16TestCaseOperation1Output, error) {
 	req, out := c.InputService16TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -2799,7 +2799,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation1WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation2Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation1Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation1WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation6Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation1Output, error) {
 	req, out := c.InputService16TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2831,7 +2831,7 @@ const opInputService16TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation2Request(input *InputService16TestShapeInputService16TestCaseOperation2Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation2Output) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation2Request(input *InputService16TestShapeInputService16TestCaseOperation6Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService16TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -2839,7 +2839,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService16TestShapeInputService16TestCaseOperation2Input{}
+		input = &InputService16TestShapeInputService16TestCaseOperation6Input{}
 	}
 
 	output = &InputService16TestShapeInputService16TestCaseOperation2Output{}
@@ -2857,7 +2857,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService16TestCaseOperation2 for usage and error information.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation2(input *InputService16TestShapeInputService16TestCaseOperation2Input) (*InputService16TestShapeInputService16TestCaseOperation2Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation2(input *InputService16TestShapeInputService16TestCaseOperation6Input) (*InputService16TestShapeInputService16TestCaseOperation2Output, error) {
 	req, out := c.InputService16TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -2871,7 +2871,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation2WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation2Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation2Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation2WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation6Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation2Output, error) {
 	req, out := c.InputService16TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2903,7 +2903,7 @@ const opInputService16TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation3Request(input *InputService16TestShapeInputService16TestCaseOperation2Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation3Output) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation3Request(input *InputService16TestShapeInputService16TestCaseOperation6Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:       opInputService16TestCaseOperation3,
 		HTTPMethod: "POST",
@@ -2911,7 +2911,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation3Request(inp
 	}
 
 	if input == nil {
-		input = &InputService16TestShapeInputService16TestCaseOperation2Input{}
+		input = &InputService16TestShapeInputService16TestCaseOperation6Input{}
 	}
 
 	output = &InputService16TestShapeInputService16TestCaseOperation3Output{}
@@ -2929,7 +2929,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation3Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService16TestCaseOperation3 for usage and error information.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation3(input *InputService16TestShapeInputService16TestCaseOperation2Input) (*InputService16TestShapeInputService16TestCaseOperation3Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation3(input *InputService16TestShapeInputService16TestCaseOperation6Input) (*InputService16TestShapeInputService16TestCaseOperation3Output, error) {
 	req, out := c.InputService16TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -2943,7 +2943,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation3(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation3WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation2Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation3Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation3WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation6Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation3Output, error) {
 	req, out := c.InputService16TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2975,7 +2975,7 @@ const opInputService16TestCaseOperation4 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation4Request(input *InputService16TestShapeInputService16TestCaseOperation2Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation4Output) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation4Request(input *InputService16TestShapeInputService16TestCaseOperation6Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation4Output) {
 	op := &request.Operation{
 		Name:       opInputService16TestCaseOperation4,
 		HTTPMethod: "POST",
@@ -2983,7 +2983,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation4Request(inp
 	}
 
 	if input == nil {
-		input = &InputService16TestShapeInputService16TestCaseOperation2Input{}
+		input = &InputService16TestShapeInputService16TestCaseOperation6Input{}
 	}
 
 	output = &InputService16TestShapeInputService16TestCaseOperation4Output{}
@@ -3001,7 +3001,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation4Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService16TestCaseOperation4 for usage and error information.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation4(input *InputService16TestShapeInputService16TestCaseOperation2Input) (*InputService16TestShapeInputService16TestCaseOperation4Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation4(input *InputService16TestShapeInputService16TestCaseOperation6Input) (*InputService16TestShapeInputService16TestCaseOperation4Output, error) {
 	req, out := c.InputService16TestCaseOperation4Request(input)
 	return out, req.Send()
 }
@@ -3015,7 +3015,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation4(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation4WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation2Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation4Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation4WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation6Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation4Output, error) {
 	req, out := c.InputService16TestCaseOperation4Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3047,7 +3047,7 @@ const opInputService16TestCaseOperation5 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation5Request(input *InputService16TestShapeInputService16TestCaseOperation2Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation5Output) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation5Request(input *InputService16TestShapeInputService16TestCaseOperation6Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation5Output) {
 	op := &request.Operation{
 		Name:       opInputService16TestCaseOperation5,
 		HTTPMethod: "POST",
@@ -3055,7 +3055,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation5Request(inp
 	}
 
 	if input == nil {
-		input = &InputService16TestShapeInputService16TestCaseOperation2Input{}
+		input = &InputService16TestShapeInputService16TestCaseOperation6Input{}
 	}
 
 	output = &InputService16TestShapeInputService16TestCaseOperation5Output{}
@@ -3073,7 +3073,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation5Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService16TestCaseOperation5 for usage and error information.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation5(input *InputService16TestShapeInputService16TestCaseOperation2Input) (*InputService16TestShapeInputService16TestCaseOperation5Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation5(input *InputService16TestShapeInputService16TestCaseOperation6Input) (*InputService16TestShapeInputService16TestCaseOperation5Output, error) {
 	req, out := c.InputService16TestCaseOperation5Request(input)
 	return out, req.Send()
 }
@@ -3087,7 +3087,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation5(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation5WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation2Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation5Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation5WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation6Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation5Output, error) {
 	req, out := c.InputService16TestCaseOperation5Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3119,7 +3119,7 @@ const opInputService16TestCaseOperation6 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation6Request(input *InputService16TestShapeInputService16TestCaseOperation2Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation6Output) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation6Request(input *InputService16TestShapeInputService16TestCaseOperation6Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation6Output) {
 	op := &request.Operation{
 		Name:       opInputService16TestCaseOperation6,
 		HTTPMethod: "POST",
@@ -3127,7 +3127,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation6Request(inp
 	}
 
 	if input == nil {
-		input = &InputService16TestShapeInputService16TestCaseOperation2Input{}
+		input = &InputService16TestShapeInputService16TestCaseOperation6Input{}
 	}
 
 	output = &InputService16TestShapeInputService16TestCaseOperation6Output{}
@@ -3145,7 +3145,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation6Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService16TestCaseOperation6 for usage and error information.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation6(input *InputService16TestShapeInputService16TestCaseOperation2Input) (*InputService16TestShapeInputService16TestCaseOperation6Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation6(input *InputService16TestShapeInputService16TestCaseOperation6Input) (*InputService16TestShapeInputService16TestCaseOperation6Output, error) {
 	req, out := c.InputService16TestCaseOperation6Request(input)
 	return out, req.Send()
 }
@@ -3159,7 +3159,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation6(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation6WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation2Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation6Output, error) {
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation6WithContext(ctx aws.Context, input *InputService16TestShapeInputService16TestCaseOperation6Input, opts ...request.Option) (*InputService16TestShapeInputService16TestCaseOperation6Output, error) {
 	req, out := c.InputService16TestCaseOperation6Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3168,18 +3168,6 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation6WithContext
 
 type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService16TestShapeInputService16TestCaseOperation2Input struct {
-	_ struct{} `type:"structure"`
-
-	RecursiveStruct *InputService16TestShapeRecursiveStructType `type:"structure"`
-}
-
-// SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService16TestShapeInputService16TestCaseOperation2Input) SetRecursiveStruct(v *InputService16TestShapeRecursiveStructType) *InputService16TestShapeInputService16TestCaseOperation2Input {
-	s.RecursiveStruct = v
-	return s
 }
 
 type InputService16TestShapeInputService16TestCaseOperation2Output struct {
@@ -3196,6 +3184,18 @@ type InputService16TestShapeInputService16TestCaseOperation4Output struct {
 
 type InputService16TestShapeInputService16TestCaseOperation5Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService16TestShapeInputService16TestCaseOperation6Input struct {
+	_ struct{} `type:"structure"`
+
+	RecursiveStruct *InputService16TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService16TestShapeInputService16TestCaseOperation6Input) SetRecursiveStruct(v *InputService16TestShapeRecursiveStructType) *InputService16TestShapeInputService16TestCaseOperation6Input {
+	s.RecursiveStruct = v
+	return s
 }
 
 type InputService16TestShapeInputService16TestCaseOperation6Output struct {
@@ -4496,7 +4496,7 @@ func TestInputService12ProtocolTestSerializeBlobsInBodyCase1(t *testing.T) {
 
 func TestInputService13ProtocolTestBlobPayloadCase1(t *testing.T) {
 	svc := NewInputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService13TestShapeInputService13TestCaseOperation2Input{
+	input := &InputService13TestShapeInputService13TestCaseOperation1Input{
 		Foo: []byte("bar"),
 	}
 	req, _ := svc.InputService13TestCaseOperation1Request(input)
@@ -4520,7 +4520,7 @@ func TestInputService13ProtocolTestBlobPayloadCase1(t *testing.T) {
 
 func TestInputService13ProtocolTestBlobPayloadCase2(t *testing.T) {
 	svc := NewInputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService13TestShapeInputService13TestCaseOperation2Input{}
+	input := &InputService13TestShapeInputService13TestCaseOperation1Input{}
 	req, _ := svc.InputService13TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
@@ -4616,7 +4616,7 @@ func TestInputService15ProtocolTestOmitsNullQueryParamsButSerializesEmptyStrings
 
 func TestInputService16ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputService16TestCaseOperation2Input{
+	input := &InputService16TestShapeInputService16TestCaseOperation6Input{
 		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
@@ -4642,7 +4642,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 func TestInputService16ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputService16TestCaseOperation2Input{
+	input := &InputService16TestShapeInputService16TestCaseOperation6Input{
 		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
@@ -4670,7 +4670,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 func TestInputService16ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputService16TestCaseOperation2Input{
+	input := &InputService16TestShapeInputService16TestCaseOperation6Input{
 		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 				RecursiveStruct: &InputService16TestShapeRecursiveStructType{
@@ -4702,7 +4702,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 func TestInputService16ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputService16TestCaseOperation2Input{
+	input := &InputService16TestShapeInputService16TestCaseOperation6Input{
 		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 			RecursiveList: []*InputService16TestShapeRecursiveStructType{
 				{
@@ -4735,7 +4735,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 func TestInputService16ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputService16TestCaseOperation2Input{
+	input := &InputService16TestShapeInputService16TestCaseOperation6Input{
 		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 			RecursiveList: []*InputService16TestShapeRecursiveStructType{
 				{
@@ -4770,7 +4770,7 @@ func TestInputService16ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 func TestInputService16ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc := NewInputService16ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService16TestShapeInputService16TestCaseOperation2Input{
+	input := &InputService16TestShapeInputService16TestCaseOperation6Input{
 		RecursiveStruct: &InputService16TestShapeRecursiveStructType{
 			RecursiveMap: map[string]*InputService16TestShapeRecursiveStructType{
 				"bar": {

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -2496,7 +2496,7 @@ const opInputService15TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(input *InputService15TestShapeInputService15TestCaseOperation2Input) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation1Output) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(input *InputService15TestShapeInputService15TestCaseOperation1Input) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService15TestCaseOperation1,
 		HTTPMethod: "GET",
@@ -2504,7 +2504,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService15TestShapeInputService15TestCaseOperation2Input{}
+		input = &InputService15TestShapeInputService15TestCaseOperation1Input{}
 	}
 
 	output = &InputService15TestShapeInputService15TestCaseOperation1Output{}
@@ -2522,7 +2522,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService15TestCaseOperation1 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1(input *InputService15TestShapeInputService15TestCaseOperation2Input) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1(input *InputService15TestShapeInputService15TestCaseOperation1Input) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
 	req, out := c.InputService15TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -2536,7 +2536,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1WithContext(ctx aws.Context, input *InputService15TestShapeInputService15TestCaseOperation2Input, opts ...request.Option) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1WithContext(ctx aws.Context, input *InputService15TestShapeInputService15TestCaseOperation1Input, opts ...request.Option) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
 	req, out := c.InputService15TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2568,7 +2568,7 @@ const opInputService15TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(input *InputService15TestShapeInputService15TestCaseOperation2Input) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation2Output) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(input *InputService15TestShapeInputService15TestCaseOperation1Input) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService15TestCaseOperation2,
 		HTTPMethod: "GET",
@@ -2576,7 +2576,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService15TestShapeInputService15TestCaseOperation2Input{}
+		input = &InputService15TestShapeInputService15TestCaseOperation1Input{}
 	}
 
 	output = &InputService15TestShapeInputService15TestCaseOperation2Output{}
@@ -2594,7 +2594,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService15TestCaseOperation2 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *InputService15TestShapeInputService15TestCaseOperation2Input) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *InputService15TestShapeInputService15TestCaseOperation1Input) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
 	req, out := c.InputService15TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -2608,27 +2608,27 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation2WithContext(ctx aws.Context, input *InputService15TestShapeInputService15TestCaseOperation2Input, opts ...request.Option) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation2WithContext(ctx aws.Context, input *InputService15TestShapeInputService15TestCaseOperation1Input, opts ...request.Option) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
 	req, out := c.InputService15TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 
-type InputService15TestShapeInputService15TestCaseOperation1Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService15TestShapeInputService15TestCaseOperation2Input struct {
+type InputService15TestShapeInputService15TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	BoolQuery *bool `location:"querystring" locationName:"bool-query" type:"boolean"`
 }
 
 // SetBoolQuery sets the BoolQuery field's value.
-func (s *InputService15TestShapeInputService15TestCaseOperation2Input) SetBoolQuery(v bool) *InputService15TestShapeInputService15TestCaseOperation2Input {
+func (s *InputService15TestShapeInputService15TestCaseOperation1Input) SetBoolQuery(v bool) *InputService15TestShapeInputService15TestCaseOperation1Input {
 	s.BoolQuery = &v
 	return s
+}
+
+type InputService15TestShapeInputService15TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
 }
 
 type InputService15TestShapeInputService15TestCaseOperation2Output struct {
@@ -3077,7 +3077,7 @@ const opInputService18TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(input *InputService18TestShapeInputService18TestCaseOperation3Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation1Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(input *InputService18TestShapeInputService18TestCaseOperation4Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -3085,7 +3085,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputService18TestCaseOperation3Input{}
+		input = &InputService18TestShapeInputService18TestCaseOperation4Input{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation1Output{}
@@ -3103,7 +3103,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation1 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *InputService18TestShapeInputService18TestCaseOperation3Input) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *InputService18TestShapeInputService18TestCaseOperation4Input) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
 	req, out := c.InputService18TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -3117,7 +3117,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation3Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation4Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
 	req, out := c.InputService18TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3149,7 +3149,7 @@ const opInputService18TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(input *InputService18TestShapeInputService18TestCaseOperation3Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation2Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(input *InputService18TestShapeInputService18TestCaseOperation4Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -3157,7 +3157,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputService18TestCaseOperation3Input{}
+		input = &InputService18TestShapeInputService18TestCaseOperation4Input{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation2Output{}
@@ -3175,7 +3175,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation2 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *InputService18TestShapeInputService18TestCaseOperation3Input) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *InputService18TestShapeInputService18TestCaseOperation4Input) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
 	req, out := c.InputService18TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -3189,7 +3189,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation2WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation3Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation4Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
 	req, out := c.InputService18TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3221,7 +3221,7 @@ const opInputService18TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputService18TestCaseOperation3Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation3Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputService18TestCaseOperation4Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation3,
 		HTTPMethod: "POST",
@@ -3229,7 +3229,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputService18TestCaseOperation3Input{}
+		input = &InputService18TestShapeInputService18TestCaseOperation4Input{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation3Output{}
@@ -3247,7 +3247,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation3 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *InputService18TestShapeInputService18TestCaseOperation3Input) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *InputService18TestShapeInputService18TestCaseOperation4Input) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
 	req, out := c.InputService18TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -3261,7 +3261,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation3Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation4Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
 	req, out := c.InputService18TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3293,7 +3293,7 @@ const opInputService18TestCaseOperation4 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputService18TestCaseOperation3Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation4Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputService18TestCaseOperation4Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation4Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation4,
 		HTTPMethod: "POST",
@@ -3301,7 +3301,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputService18TestCaseOperation3Input{}
+		input = &InputService18TestShapeInputService18TestCaseOperation4Input{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation4Output{}
@@ -3319,7 +3319,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation4 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *InputService18TestShapeInputService18TestCaseOperation3Input) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *InputService18TestShapeInputService18TestCaseOperation4Input) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
 	req, out := c.InputService18TestCaseOperation4Request(input)
 	return out, req.Send()
 }
@@ -3333,7 +3333,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation3Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation4Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
 	req, out := c.InputService18TestCaseOperation4Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3360,20 +3360,20 @@ type InputService18TestShapeInputService18TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService18TestShapeInputService18TestCaseOperation3Input struct {
+type InputService18TestShapeInputService18TestCaseOperation3Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService18TestShapeInputService18TestCaseOperation4Input struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
 	Foo *InputService18TestShapeFooShape `locationName:"foo" type:"structure"`
 }
 
 // SetFoo sets the Foo field's value.
-func (s *InputService18TestShapeInputService18TestCaseOperation3Input) SetFoo(v *InputService18TestShapeFooShape) *InputService18TestShapeInputService18TestCaseOperation3Input {
+func (s *InputService18TestShapeInputService18TestCaseOperation4Input) SetFoo(v *InputService18TestShapeFooShape) *InputService18TestShapeInputService18TestCaseOperation4Input {
 	s.Foo = v
 	return s
-}
-
-type InputService18TestShapeInputService18TestCaseOperation3Output struct {
-	_ struct{} `type:"structure"`
 }
 
 type InputService18TestShapeInputService18TestCaseOperation4Output struct {
@@ -5297,7 +5297,7 @@ func TestInputService14ProtocolTestStringToStringListMapsInQuerystringCase1(t *t
 
 func TestInputService15ProtocolTestBooleanInQuerystringCase1(t *testing.T) {
 	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputService15TestCaseOperation2Input{
+	input := &InputService15TestShapeInputService15TestCaseOperation1Input{
 		BoolQuery: aws.Bool(true),
 	}
 	req, _ := svc.InputService15TestCaseOperation1Request(input)
@@ -5316,7 +5316,7 @@ func TestInputService15ProtocolTestBooleanInQuerystringCase1(t *testing.T) {
 
 func TestInputService15ProtocolTestBooleanInQuerystringCase2(t *testing.T) {
 	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputService15TestCaseOperation2Input{
+	input := &InputService15TestShapeInputService15TestCaseOperation1Input{
 		BoolQuery: aws.Bool(false),
 	}
 	req, _ := svc.InputService15TestCaseOperation2Request(input)
@@ -5400,7 +5400,7 @@ func TestInputService17ProtocolTestBlobPayloadCase2(t *testing.T) {
 
 func TestInputService18ProtocolTestStructurePayloadCase1(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputService18TestCaseOperation3Input{
+	input := &InputService18TestShapeInputService18TestCaseOperation4Input{
 		Foo: &InputService18TestShapeFooShape{
 			Baz: aws.String("bar"),
 		},
@@ -5415,7 +5415,7 @@ func TestInputService18ProtocolTestStructurePayloadCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)), InputService18TestShapeInputService18TestCaseOperation3Input{})
+	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)), InputService18TestShapeInputService18TestCaseOperation4Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -5426,7 +5426,7 @@ func TestInputService18ProtocolTestStructurePayloadCase1(t *testing.T) {
 
 func TestInputService18ProtocolTestStructurePayloadCase2(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputService18TestCaseOperation3Input{}
+	input := &InputService18TestShapeInputService18TestCaseOperation4Input{}
 	req, _ := svc.InputService18TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
@@ -5443,7 +5443,7 @@ func TestInputService18ProtocolTestStructurePayloadCase2(t *testing.T) {
 
 func TestInputService18ProtocolTestStructurePayloadCase3(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputService18TestCaseOperation3Input{
+	input := &InputService18TestShapeInputService18TestCaseOperation4Input{
 		Foo: &InputService18TestShapeFooShape{},
 	}
 	req, _ := svc.InputService18TestCaseOperation3Request(input)
@@ -5456,7 +5456,7 @@ func TestInputService18ProtocolTestStructurePayloadCase3(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<foo></foo>`, util.Trim(string(body)), InputService18TestShapeInputService18TestCaseOperation3Input{})
+	awstesting.AssertXML(t, `<foo></foo>`, util.Trim(string(body)), InputService18TestShapeInputService18TestCaseOperation4Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -5467,7 +5467,7 @@ func TestInputService18ProtocolTestStructurePayloadCase3(t *testing.T) {
 
 func TestInputService18ProtocolTestStructurePayloadCase4(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputService18TestCaseOperation3Input{}
+	input := &InputService18TestShapeInputService18TestCaseOperation4Input{}
 	req, _ := svc.InputService18TestCaseOperation4Request(input)
 	r := req.HTTPRequest
 

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -125,7 +125,7 @@ const opOutputService1TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opOutputService1TestCaseOperation1,
 		HTTPPath: "/",
@@ -135,7 +135,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(inp
 		input = &OutputService1TestShapeOutputService1TestCaseOperation1Input{}
 	}
 
-	output = &OutputService1TestShapeOutputService1TestCaseOperation1Output{}
+	output = &OutputService1TestShapeOutputService1TestCaseOperation2Output{}
 	req = c.newRequest(op, input, output)
 	return
 }
@@ -148,7 +148,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation OutputService1TestCaseOperation1 for usage and error information.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (*OutputService1TestShapeOutputService1TestCaseOperation1Output, error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (*OutputService1TestShapeOutputService1TestCaseOperation2Output, error) {
 	req, out := c.OutputService1TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -162,7 +162,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1WithContext(ctx aws.Context, input *OutputService1TestShapeOutputService1TestCaseOperation1Input, opts ...request.Option) (*OutputService1TestShapeOutputService1TestCaseOperation1Output, error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1WithContext(ctx aws.Context, input *OutputService1TestShapeOutputService1TestCaseOperation1Input, opts ...request.Option) (*OutputService1TestShapeOutputService1TestCaseOperation2Output, error) {
 	req, out := c.OutputService1TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -194,7 +194,7 @@ const opOutputService1TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opOutputService1TestCaseOperation2,
 		HTTPPath: "/",
@@ -204,7 +204,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(inp
 		input = &OutputService1TestShapeOutputService1TestCaseOperation2Input{}
 	}
 
-	output = &OutputService1TestShapeOutputService1TestCaseOperation1Output{}
+	output = &OutputService1TestShapeOutputService1TestCaseOperation2Output{}
 	req = c.newRequest(op, input, output)
 	return
 }
@@ -217,7 +217,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation OutputService1TestCaseOperation2 for usage and error information.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (*OutputService1TestShapeOutputService1TestCaseOperation1Output, error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (*OutputService1TestShapeOutputService1TestCaseOperation2Output, error) {
 	req, out := c.OutputService1TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -231,7 +231,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2(input *Out
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2WithContext(ctx aws.Context, input *OutputService1TestShapeOutputService1TestCaseOperation2Input, opts ...request.Option) (*OutputService1TestShapeOutputService1TestCaseOperation1Output, error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2WithContext(ctx aws.Context, input *OutputService1TestShapeOutputService1TestCaseOperation2Input, opts ...request.Option) (*OutputService1TestShapeOutputService1TestCaseOperation2Output, error) {
 	req, out := c.OutputService1TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -242,7 +242,11 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
-type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
+type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
+	_ struct{} `type:"structure"`
+}
+
+type OutputService1TestShapeOutputService1TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 
 	Char *string `type:"character"`
@@ -269,73 +273,69 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 }
 
 // SetChar sets the Char field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetChar(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetChar(v string) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Char = &v
 	return s
 }
 
 // SetDouble sets the Double field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetDouble(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetDouble(v float64) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Double = &v
 	return s
 }
 
 // SetFalseBool sets the FalseBool field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFalseBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetFalseBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.FalseBool = &v
 	return s
 }
 
 // SetFloat sets the Float field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetFloat(v float64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetFloat(v float64) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Float = &v
 	return s
 }
 
 // SetImaHeader sets the ImaHeader field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetImaHeader(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetImaHeader(v string) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.ImaHeader = &v
 	return s
 }
 
 // SetImaHeaderLocation sets the ImaHeaderLocation field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetImaHeaderLocation(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetImaHeaderLocation(v string) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.ImaHeaderLocation = &v
 	return s
 }
 
 // SetLong sets the Long field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetLong(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetLong(v int64) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Long = &v
 	return s
 }
 
 // SetNum sets the Num field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetNum(v int64) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetNum(v int64) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Num = &v
 	return s
 }
 
 // SetStr sets the Str field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetStr(v string) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetStr(v string) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Str = &v
 	return s
 }
 
 // SetTimestamp sets the Timestamp field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTimestamp(v time.Time) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetTimestamp(v time.Time) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Timestamp = &v
 	return s
 }
 
 // SetTrueBool sets the TrueBool field's value.
-func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.TrueBool = &v
 	return s
-}
-
-type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
-	_ struct{} `type:"structure"`
 }
 
 // The service client's operations are safe to be used concurrently.

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -58,7 +58,7 @@ func (c *ElastiCache) AddTagsToResourceRequest(input *AddTagsToResourceInput) (r
 
 // AddTagsToResource API operation for Amazon ElastiCache.
 //
-// Adds up to 10 cost allocation tags to the named resource. A cost allocation
+// Adds up to 50 cost allocation tags to the named resource. A cost allocation
 // tag is a key-value pair where the key and value are case-sensitive. You can
 // use cost allocation tags to categorize and track your AWS costs.
 //
@@ -87,7 +87,7 @@ func (c *ElastiCache) AddTagsToResourceRequest(input *AddTagsToResourceInput) (r
 //   * ErrCodeTagQuotaPerResourceExceeded "TagQuotaPerResourceExceeded"
 //   The request cannot be processed because it would cause the resource to have
 //   more than the allowed number of tags. The maximum number of tags permitted
-//   on a resource is 10.
+//   on a resource is 50.
 //
 //   * ErrCodeInvalidARNFault "InvalidARN"
 //   The requested Amazon Resource Name (ARN) does not refer to an existing resource.
@@ -477,7 +477,7 @@ func (c *ElastiCache) CreateCacheClusterRequest(input *CreateCacheClusterInput) 
 //   * ErrCodeTagQuotaPerResourceExceeded "TagQuotaPerResourceExceeded"
 //   The request cannot be processed because it would cause the resource to have
 //   more than the allowed number of tags. The maximum number of tags permitted
-//   on a resource is 10.
+//   on a resource is 50.
 //
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValue"
 //   The value for a parameter is invalid.
@@ -552,8 +552,20 @@ func (c *ElastiCache) CreateCacheParameterGroupRequest(input *CreateCacheParamet
 
 // CreateCacheParameterGroup API operation for Amazon ElastiCache.
 //
-// Creates a new cache parameter group. A cache parameter group is a collection
-// of parameters that you apply to all of the nodes in a cache cluster.
+// Creates a new Amazon ElastiCache cache parameter group. An ElastiCache cache
+// parameter group is a collection of parameters and their values that are applied
+// to all of the nodes in any cache cluster or replication group using the CacheParameterGroup.
+//
+// A newly created CacheParameterGroup is an exact duplicate of the default
+// parameter group for the CacheParameterGroupFamily. To customize the newly
+// created CacheParameterGroup you can change the values of specific parameters.
+// For more information, see:
+//
+//    * ModifyCacheParameterGroup (http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheParameterGroup.html)
+//    in the ElastiCache API Reference.
+//
+//    * Parameters and Parameter Groups (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ParameterGroups.html)
+//    in the ElastiCache User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -855,7 +867,11 @@ func (c *ElastiCache) CreateReplicationGroupRequest(input *CreateReplicationGrou
 // When a Redis (cluster mode disabled) replication group has been successfully
 // created, you can add one or more read replicas to it, up to a total of 5
 // read replicas. You cannot alter a Redis (cluster mode enabled) replication
-// group after it has been created.
+// group after it has been created. However, if you need to increase or decrease
+// the number of node groups (console: shards), you can avail yourself of ElastiCache
+// for Redis' enhanced backup and restore. For more information, see Restoring
+// From a Backup with Cluster Resizing (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/backups-restoring.html)
+// in the ElastiCache User Guide.
 //
 // This operation is valid for Redis only.
 //
@@ -910,7 +926,7 @@ func (c *ElastiCache) CreateReplicationGroupRequest(input *CreateReplicationGrou
 //   * ErrCodeTagQuotaPerResourceExceeded "TagQuotaPerResourceExceeded"
 //   The request cannot be processed because it would cause the resource to have
 //   more than the allowed number of tags. The maximum number of tags permitted
-//   on a resource is 10.
+//   on a resource is 50.
 //
 //   * ErrCodeNodeGroupsPerReplicationGroupQuotaExceededFault "NodeGroupsPerReplicationGroupQuotaExceeded"
 //   The request cannot be processed because it would exceed the maximum of 15
@@ -1724,15 +1740,15 @@ func (c *ElastiCache) DescribeCacheClustersRequest(input *DescribeCacheClustersI
 // identifier is specified, or about a specific cache cluster if a cache cluster
 // identifier is supplied.
 //
-// By default, abbreviated information about the cache clusters are returned.
-// You can use the optional ShowDetails flag to retrieve detailed information
+// By default, abbreviated information about the cache clusters is returned.
+// You can use the optional ShowCacheNodeInfo flag to retrieve detailed information
 // about the cache nodes associated with the cache clusters. These details include
 // the DNS address and port for the cache node endpoint.
 //
-// If the cluster is in the CREATING state, only cluster-level information is
+// If the cluster is in the creating state, only cluster-level information is
 // displayed until all of the nodes are successfully provisioned.
 //
-// If the cluster is in the DELETING state, only cluster-level information is
+// If the cluster is in the deleting state, only cluster-level information is
 // displayed.
 //
 // If cache nodes are currently being added to the cache cluster, node endpoint
@@ -3543,7 +3559,7 @@ func (c *ElastiCache) ListTagsForResourceRequest(input *ListTagsForResourceInput
 // optional. You can use cost allocation tags to categorize and track your AWS
 // costs.
 //
-// You can have a maximum of 10 cost allocation tags on an ElastiCache resource.
+// You can have a maximum of 50 cost allocation tags on an ElastiCache resource.
 // For more information, see Using Cost Allocation Tags in Amazon ElastiCache
 // (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/BestPractices.html).
 //
@@ -4477,6 +4493,151 @@ func (c *ElastiCache) RevokeCacheSecurityGroupIngressWithContext(ctx aws.Context
 	return out, req.Send()
 }
 
+const opTestFailover = "TestFailover"
+
+// TestFailoverRequest generates a "aws/request.Request" representing the
+// client's request for the TestFailover operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See TestFailover for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the TestFailover method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the TestFailoverRequest method.
+//    req, resp := client.TestFailoverRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/TestFailover
+func (c *ElastiCache) TestFailoverRequest(input *TestFailoverInput) (req *request.Request, output *TestFailoverOutput) {
+	op := &request.Operation{
+		Name:       opTestFailover,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &TestFailoverInput{}
+	}
+
+	output = &TestFailoverOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// TestFailover API operation for Amazon ElastiCache.
+//
+// Represents the input of a TestFailover operation which test automatic failover
+// on a specified node group (called shard in the console) in a replication
+// group (called cluster in the console).
+//
+// Note the following
+//
+//    * A customer can use this operation to test automatic failover on up to
+//    5 shards (called node groups in the ElastiCache API and AWS CLI) in any
+//    rolling 24-hour period.
+//
+//    * If calling this operation on shards in different clusters (called replication
+//    groups in the API and CLI), the calls can be made concurrently.
+//
+//    * If calling this operation multiple times on different shards in the
+//    same Redis (cluster mode enabled) replication group, the first node replacement
+//    must complete before a subsequent call can be made.
+//
+//    * To determine whether the node replacement is complete you can check
+//    Events using the Amazon ElastiCache console, the AWS CLI, or the ElastiCache
+//    API. Look for the following automatic failover related events, listed
+//    here in order of occurrance:
+//
+// Replication group message: Test Failover API called for node group <node-group-id>
+//
+// Cache cluster message: Failover from master node <primary-node-id> to replica
+//    node <node-id> completed
+//
+// Replication group message: Failover from master node <primary-node-id> to
+//    replica node <node-id> completed
+//
+// Cache cluster message: Recovering cache nodes <node-id>
+//
+// Cache cluster message: Finished recovery for cache nodes <node-id>
+//
+// For more information see:
+//
+// Viewing ElastiCache Events (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ECEvents.Viewing.html)
+//    in the ElastiCache User Guide
+//
+// DescribeEvents (http://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DescribeEvents.html)
+//    in the ElastiCache API Reference
+//
+// Also see, Testing Multi-AZ with Automatic Failover (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoFailover.html#auto-failover-test)
+// in the ElastiCache User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon ElastiCache's
+// API operation TestFailover for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeAPICallRateForCustomerExceededFault "APICallRateForCustomerExceeded"
+//   The customer has exceeded the allowed rate of API calls.
+//
+//   * ErrCodeInvalidCacheClusterStateFault "InvalidCacheClusterState"
+//   The requested cache cluster is not in the available state.
+//
+//   * ErrCodeInvalidReplicationGroupStateFault "InvalidReplicationGroupState"
+//   The requested replication group is not in the available state.
+//
+//   * ErrCodeNodeGroupNotFoundFault "NodeGroupNotFoundFault"
+//   The node group specified by the NodeGroupId parameter could not be found.
+//   Please verify that the node group exists and that you spelled the NodeGroupId
+//   value correctly.
+//
+//   * ErrCodeReplicationGroupNotFoundFault "ReplicationGroupNotFoundFault"
+//   The specified replication group does not exist.
+//
+//   * ErrCodeTestFailoverNotAvailableFault "TestFailoverNotAvailableFault"
+//
+//   * ErrCodeInvalidParameterValueException "InvalidParameterValue"
+//   The value for a parameter is invalid.
+//
+//   * ErrCodeInvalidParameterCombinationException "InvalidParameterCombination"
+//   Two or more incompatible parameters were specified.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/TestFailover
+func (c *ElastiCache) TestFailover(input *TestFailoverInput) (*TestFailoverOutput, error) {
+	req, out := c.TestFailoverRequest(input)
+	return out, req.Send()
+}
+
+// TestFailoverWithContext is the same as TestFailover with the addition of
+// the ability to pass a context and additional request options.
+//
+// See TestFailover for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElastiCache) TestFailoverWithContext(ctx aws.Context, input *TestFailoverInput, opts ...request.Option) (*TestFailoverOutput, error) {
+	req, out := c.TestFailoverRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 // Represents the input of an AddTagsToResource operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/AddTagsToResourceMessage
 type AddTagsToResourceInput struct {
@@ -4739,8 +4900,11 @@ type CacheCluster struct {
 	// library.
 	ClientDownloadLandingPage *string `type:"string"`
 
-	// Represents the information required for client programs to connect to a cache
-	// node.
+	// Represents a Memcached cluster endpoint which, if Automatic Discovery is
+	// enabled on the cluster, can be used by an application to connect to any node
+	// in the cluster. The configuration endpoint will always have .cfg in it.
+	//
+	// Example: mem-3.9dvc4r.cfg.usw2.cache.amazonaws.com:11211
 	ConfigurationEndpoint *Endpoint `type:"structure"`
 
 	// The name of the cache engine (memcached or redis) to be used for this cache
@@ -6507,8 +6671,8 @@ type CreateReplicationGroupInput struct {
 	// ReplicaCount.
 	//
 	// If you're creating a Redis (cluster mode disabled) or a Redis (cluster mode
-	// enabled) replication group, you can use this parameter to configure one node
-	// group (shard) or you can omit this parameter.
+	// enabled) replication group, you can use this parameter to individually configure
+	// each node group (shard), or you can omit this parameter.
 	NodeGroupConfiguration []*NodeGroupConfiguration `locationNameList:"NodeGroupConfiguration" type:"list"`
 
 	// The Amazon Resource Name (ARN) of the Amazon Simple Notification Service
@@ -6522,7 +6686,10 @@ type CreateReplicationGroupInput struct {
 	// This parameter is not used if there is more than one node group (shard).
 	// You should use ReplicasPerNodeGroup instead.
 	//
-	// If Multi-AZ is enabled, the value of this parameter must be at least 2.
+	// If AutomaticFailoverEnabled is true, the value of this parameter must be
+	// at least 2. If AutomaticFailoverEnabled is false you can omit this parameter
+	// (it will default to 1), or you can explicitly set it to a value between 2
+	// and 6.
 	//
 	// The maximum permitted value for NumCacheClusters is 6 (primary plus 5 replicas).
 	NumCacheClusters *int64 `type:"integer"`
@@ -6620,9 +6787,11 @@ type CreateReplicationGroupInput struct {
 
 	// A list of Amazon Resource Names (ARN) that uniquely identify the Redis RDB
 	// snapshot files stored in Amazon S3. The snapshot files are used to populate
-	// the replication group. The Amazon S3 object name in the ARN cannot contain
-	// any commas. The list must match the number of node groups (shards) in the
-	// replication group, which means you cannot repartition.
+	// the new replication group. The Amazon S3 object name in the ARN cannot contain
+	// any commas. The new replication group will have the number of node groups
+	// (console: shards) specified by the parameter NumNodeGroups or the number
+	// of node groups configured by NodeGroupConfiguration regardless of the number
+	// of ARNs specified here.
 	//
 	// This parameter is only valid if the Engine parameter is redis.
 	//
@@ -7377,6 +7546,11 @@ type DescribeCacheClustersInput struct {
 	MaxRecords *int64 `type:"integer"`
 
 	// An optional flag that can be included in the DescribeCacheCluster request
+	// to show only nodes (API/CLI: clusters) that are not members of a replication
+	// group. In practice, this mean Memcached and single node Redis clusters.
+	ShowCacheClustersNotInReplicationGroups *bool `type:"boolean"`
+
+	// An optional flag that can be included in the DescribeCacheCluster request
 	// to retrieve information about the individual cache nodes.
 	ShowCacheNodeInfo *bool `type:"boolean"`
 }
@@ -7406,6 +7580,12 @@ func (s *DescribeCacheClustersInput) SetMarker(v string) *DescribeCacheClustersI
 // SetMaxRecords sets the MaxRecords field's value.
 func (s *DescribeCacheClustersInput) SetMaxRecords(v int64) *DescribeCacheClustersInput {
 	s.MaxRecords = &v
+	return s
+}
+
+// SetShowCacheClustersNotInReplicationGroups sets the ShowCacheClustersNotInReplicationGroups field's value.
+func (s *DescribeCacheClustersInput) SetShowCacheClustersNotInReplicationGroups(v bool) *DescribeCacheClustersInput {
+	s.ShowCacheClustersNotInReplicationGroups = &v
 	return s
 }
 
@@ -8052,11 +8232,13 @@ func (s *DescribeEngineDefaultParametersOutput) SetEngineDefaults(v *EngineDefau
 type DescribeEventsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The number of minutes' worth of events to retrieve.
+	// The number of minutes worth of events to retrieve.
 	Duration *int64 `type:"integer"`
 
 	// The end of the time interval for which to retrieve events, specified in ISO
 	// 8601 format.
+	//
+	// Example: 2017-03-30T07:03:49.555Z
 	EndTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
 	// An optional marker returned from a prior request. Use this marker for pagination
@@ -8083,6 +8265,8 @@ type DescribeEventsInput struct {
 
 	// The beginning of the time interval to retrieve events for, specified in ISO
 	// 8601 format.
+	//
+	// Example: 2017-03-30T07:03:49.555Z
 	StartTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 }
 
@@ -8977,10 +9161,18 @@ func (s *ListAllowedNodeTypeModificationsInput) SetReplicationGroupId(v string) 
 	return s
 }
 
+// Represents the allowed node types you can use to modify your cache cluster
+// or replication group.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/AllowedNodeTypeModificationsMessage
 type ListAllowedNodeTypeModificationsOutput struct {
 	_ struct{} `type:"structure"`
 
+	// A string list, each element of which specifies a cache node type which you
+	// can use to scale your cache cluster or replication group.
+	//
+	// When scaling up a Redis cluster or replication group using ModifyCacheCluster
+	// or ModifyReplicationGroup, use a value from this list for the CacheNodeType
+	// parameter.
 	ScaleUpModifications []*string `type:"list"`
 }
 
@@ -9649,6 +9841,9 @@ type ModifyReplicationGroupInput struct {
 	// and create it anew with the earlier engine version.
 	EngineVersion *string `type:"string"`
 
+	// The name of the Node Group (called shard in the console).
+	NodeGroupId *string `type:"string"`
+
 	// The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications
 	// are sent.
 	//
@@ -9791,6 +9986,12 @@ func (s *ModifyReplicationGroupInput) SetCacheSecurityGroupNames(v []*string) *M
 // SetEngineVersion sets the EngineVersion field's value.
 func (s *ModifyReplicationGroupInput) SetEngineVersion(v string) *ModifyReplicationGroupInput {
 	s.EngineVersion = &v
+	return s
+}
+
+// SetNodeGroupId sets the NodeGroupId field's value.
+func (s *ModifyReplicationGroupInput) SetNodeGroupId(v string) *ModifyReplicationGroupInput {
+	s.NodeGroupId = &v
 	return s
 }
 
@@ -9964,8 +10165,8 @@ type NodeGroupConfiguration struct {
 	// The number of read replica nodes in this node group (shard).
 	ReplicaCount *int64 `type:"integer"`
 
-	// A string that specifies the keyspaces as a series of comma separated values.
-	// Keyspaces are 0 to 16,383. The string is in the format startkey-endkey.
+	// A string that specifies the keyspace for a particular node group. Keyspaces
+	// range from 0 to 16,383. The string is in the format startkey-endkey.
 	//
 	// Example: "0-3999"
 	Slots *string `type:"string"`
@@ -10661,6 +10862,17 @@ type ReplicationGroup struct {
 	// Redis (cluster mode enabled): T1 node types.
 	AutomaticFailover *string `type:"string" enum:"AutomaticFailoverStatus"`
 
+	// The name of the compute and memory capacity node type for each node in the
+	// replication group.
+	CacheNodeType *string `type:"string"`
+
+	// A flag indicating whether or not this replication group is cluster enabled;
+	// i.e., whether its data can be partitioned across multiple shards (API/CLI:
+	// node groups).
+	//
+	// Valid values: true | false
+	ClusterEnabled *bool `type:"boolean"`
+
 	// The configuration endpoint for this replicaiton group. Use the configuration
 	// endpoint to connect to this replication group.
 	ConfigurationEndpoint *Endpoint `type:"structure"`
@@ -10724,6 +10936,18 @@ func (s ReplicationGroup) GoString() string {
 // SetAutomaticFailover sets the AutomaticFailover field's value.
 func (s *ReplicationGroup) SetAutomaticFailover(v string) *ReplicationGroup {
 	s.AutomaticFailover = &v
+	return s
+}
+
+// SetCacheNodeType sets the CacheNodeType field's value.
+func (s *ReplicationGroup) SetCacheNodeType(v string) *ReplicationGroup {
+	s.CacheNodeType = &v
+	return s
+}
+
+// SetClusterEnabled sets the ClusterEnabled field's value.
+func (s *ReplicationGroup) SetClusterEnabled(v bool) *ReplicationGroup {
+	s.ClusterEnabled = &v
 	return s
 }
 
@@ -11681,10 +11905,10 @@ func (s *Subnet) SetSubnetIdentifier(v string) *Subnet {
 type Tag struct {
 	_ struct{} `type:"structure"`
 
-	// The key for the tag.
+	// The key for the tag. May not be null.
 	Key *string `type:"string"`
 
-	// The tag's value. May not be null.
+	// The tag's value. May be null.
 	Value *string `type:"string"`
 }
 
@@ -11710,7 +11934,7 @@ func (s *Tag) SetValue(v string) *Tag {
 	return s
 }
 
-// Represents the output from the AddTagsToResource, ListTagsOnResource, and
+// Represents the output from the AddTagsToResource, ListTagsForResource, and
 // RemoveTagsFromResource operations.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/TagListMessage
 type TagListMessage struct {
@@ -11733,6 +11957,86 @@ func (s TagListMessage) GoString() string {
 // SetTagList sets the TagList field's value.
 func (s *TagListMessage) SetTagList(v []*Tag) *TagListMessage {
 	s.TagList = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/TestFailoverMessage
+type TestFailoverInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the node group (called shard in the console) in this replication
+	// group on which automatic failover is to be tested. You may test automatic
+	// failover on up to 5 node groups in any rolling 24-hour period.
+	//
+	// NodeGroupId is a required field
+	NodeGroupId *string `type:"string" required:"true"`
+
+	// The name of the replication group (console: cluster) whose automatic failover
+	// is being tested by this operation.
+	//
+	// ReplicationGroupId is a required field
+	ReplicationGroupId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s TestFailoverInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TestFailoverInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestFailoverInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestFailoverInput"}
+	if s.NodeGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("NodeGroupId"))
+	}
+	if s.ReplicationGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationGroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetNodeGroupId sets the NodeGroupId field's value.
+func (s *TestFailoverInput) SetNodeGroupId(v string) *TestFailoverInput {
+	s.NodeGroupId = &v
+	return s
+}
+
+// SetReplicationGroupId sets the ReplicationGroupId field's value.
+func (s *TestFailoverInput) SetReplicationGroupId(v string) *TestFailoverInput {
+	s.ReplicationGroupId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/TestFailoverResult
+type TestFailoverOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Contains all of the attributes of a specific Redis replication group.
+	ReplicationGroup *ReplicationGroup `type:"structure"`
+}
+
+// String returns the string representation
+func (s TestFailoverOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TestFailoverOutput) GoString() string {
+	return s.String()
+}
+
+// SetReplicationGroup sets the ReplicationGroup field's value.
+func (s *TestFailoverOutput) SetReplicationGroup(v *ReplicationGroup) *TestFailoverOutput {
+	s.ReplicationGroup = v
 	return s
 }
 

--- a/service/elasticache/elasticacheiface/interface.go
+++ b/service/elasticache/elasticacheiface/interface.go
@@ -248,6 +248,10 @@ type ElastiCacheAPI interface {
 	RevokeCacheSecurityGroupIngressWithContext(aws.Context, *elasticache.RevokeCacheSecurityGroupIngressInput, ...request.Option) (*elasticache.RevokeCacheSecurityGroupIngressOutput, error)
 	RevokeCacheSecurityGroupIngressRequest(*elasticache.RevokeCacheSecurityGroupIngressInput) (*request.Request, *elasticache.RevokeCacheSecurityGroupIngressOutput)
 
+	TestFailover(*elasticache.TestFailoverInput) (*elasticache.TestFailoverOutput, error)
+	TestFailoverWithContext(aws.Context, *elasticache.TestFailoverInput, ...request.Option) (*elasticache.TestFailoverOutput, error)
+	TestFailoverRequest(*elasticache.TestFailoverInput) (*request.Request, *elasticache.TestFailoverOutput)
+
 	WaitUntilCacheClusterAvailable(*elasticache.DescribeCacheClustersInput) error
 	WaitUntilCacheClusterAvailableWithContext(aws.Context, *elasticache.DescribeCacheClustersInput, ...request.WaiterOption) error
 

--- a/service/elasticache/errors.go
+++ b/service/elasticache/errors.go
@@ -4,6 +4,12 @@ package elasticache
 
 const (
 
+	// ErrCodeAPICallRateForCustomerExceededFault for service response error code
+	// "APICallRateForCustomerExceeded".
+	//
+	// The customer has exceeded the allowed rate of API calls.
+	ErrCodeAPICallRateForCustomerExceededFault = "APICallRateForCustomerExceeded"
+
 	// ErrCodeAuthorizationAlreadyExistsFault for service response error code
 	// "AuthorizationAlreadyExists".
 	//
@@ -180,6 +186,14 @@ const (
 	// The VPC network is in an invalid state.
 	ErrCodeInvalidVPCNetworkStateFault = "InvalidVPCNetworkStateFault"
 
+	// ErrCodeNodeGroupNotFoundFault for service response error code
+	// "NodeGroupNotFoundFault".
+	//
+	// The node group specified by the NodeGroupId parameter could not be found.
+	// Please verify that the node group exists and that you spelled the NodeGroupId
+	// value correctly.
+	ErrCodeNodeGroupNotFoundFault = "NodeGroupNotFoundFault"
+
 	// ErrCodeNodeGroupsPerReplicationGroupQuotaExceededFault for service response error code
 	// "NodeGroupsPerReplicationGroupQuotaExceeded".
 	//
@@ -288,6 +302,10 @@ const (
 	//
 	// The request cannot be processed because it would cause the resource to have
 	// more than the allowed number of tags. The maximum number of tags permitted
-	// on a resource is 10.
+	// on a resource is 50.
 	ErrCodeTagQuotaPerResourceExceeded = "TagQuotaPerResourceExceeded"
+
+	// ErrCodeTestFailoverNotAvailableFault for service response error code
+	// "TestFailoverNotAvailableFault".
+	ErrCodeTestFailoverNotAvailableFault = "TestFailoverNotAvailableFault"
 )

--- a/service/elasticache/examples_test.go
+++ b/service/elasticache/examples_test.go
@@ -454,10 +454,11 @@ func ExampleElastiCache_DescribeCacheClusters() {
 	svc := elasticache.New(sess)
 
 	params := &elasticache.DescribeCacheClustersInput{
-		CacheClusterId:    aws.String("String"),
-		Marker:            aws.String("String"),
-		MaxRecords:        aws.Int64(1),
-		ShowCacheNodeInfo: aws.Bool(true),
+		CacheClusterId:                          aws.String("String"),
+		Marker:                                  aws.String("String"),
+		MaxRecords:                              aws.Int64(1),
+		ShowCacheClustersNotInReplicationGroups: aws.Bool(true),
+		ShowCacheNodeInfo:                       aws.Bool(true),
 	}
 	resp, err := svc.DescribeCacheClusters(params)
 
@@ -909,6 +910,7 @@ func ExampleElastiCache_ModifyReplicationGroup() {
 			// More values...
 		},
 		EngineVersion:               aws.String("String"),
+		NodeGroupId:                 aws.String("String"),
 		NotificationTopicArn:        aws.String("String"),
 		NotificationTopicStatus:     aws.String("String"),
 		PreferredMaintenanceWindow:  aws.String("String"),
@@ -1048,6 +1050,28 @@ func ExampleElastiCache_RevokeCacheSecurityGroupIngress() {
 		EC2SecurityGroupOwnerId: aws.String("String"), // Required
 	}
 	resp, err := svc.RevokeCacheSecurityGroupIngress(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleElastiCache_TestFailover() {
+	sess := session.Must(session.NewSession())
+
+	svc := elasticache.New(sess)
+
+	params := &elasticache.TestFailoverInput{
+		NodeGroupId:        aws.String("String"), // Required
+		ReplicationGroupId: aws.String("String"), // Required
+	}
+	resp, err := svc.TestFailover(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and


### PR DESCRIPTION
Release v1.8.9 (2017-04-05)
===

### Service Client Updates
* `service/elasticache`: Updates service API, documentation, paginators, and examples
  * ElastiCache added support for testing the Elasticache Multi-AZ feature with Automatic Failover.

