### PR TITLE
v1.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.8.11 (2017-04-07)
+===
+
+### Service Client Updates
+* `service/redshift`: Updates service API, documentation, and paginators
+  * This update adds the GetClusterCredentials API which is used to get temporary login credentials to the cluster. AccountWithRestoreAccess now has a new member AccountAlias, this is the identifier of the AWS support account authorized to restore the specified snapshot. This is added to support the feature where the customer can share their snapshot with the Amazon Redshift Support Account without having to manually specify the AWS Redshift Service account ID on the AWS Console/API.
+
 Release v1.8.10 (2017-04-06)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.8.10"
+const SDKVersion = "1.8.11"

--- a/models/apis/redshift/2012-12-01/api-2.json
+++ b/models/apis/redshift/2012-12-01/api-2.json
@@ -1,12 +1,12 @@
 {
   "version":"2.0",
   "metadata":{
-    "uid":"redshift-2012-12-01",
     "apiVersion":"2012-12-01",
     "endpointPrefix":"redshift",
     "protocol":"query",
     "serviceFullName":"Amazon Redshift",
     "signatureVersion":"v4",
+    "uid":"redshift-2012-12-01",
     "xmlNamespace":"http://redshift.amazonaws.com/doc/2012-12-01/"
   },
   "operations":{
@@ -632,7 +632,8 @@
       },
       "errors":[
         {"shape":"ReservedNodeOfferingNotFoundFault"},
-        {"shape":"UnsupportedOperationFault"}
+        {"shape":"UnsupportedOperationFault"},
+        {"shape":"DependentServiceUnavailableFault"}
       ]
     },
     "DescribeReservedNodes":{
@@ -647,7 +648,8 @@
         "resultWrapper":"DescribeReservedNodesResult"
       },
       "errors":[
-        {"shape":"ReservedNodeNotFoundFault"}
+        {"shape":"ReservedNodeNotFoundFault"},
+        {"shape":"DependentServiceUnavailableFault"}
       ]
     },
     "DescribeResize":{
@@ -790,6 +792,22 @@
         {"shape":"DependentServiceRequestThrottlingFault"}
       ]
     },
+    "GetClusterCredentials":{
+      "name":"GetClusterCredentials",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"GetClusterCredentialsMessage"},
+      "output":{
+        "shape":"ClusterCredentials",
+        "resultWrapper":"GetClusterCredentialsResult"
+      },
+      "errors":[
+        {"shape":"ClusterNotFoundFault"},
+        {"shape":"UnsupportedOperationFault"}
+      ]
+    },
     "ModifyCluster":{
       "name":"ModifyCluster",
       "http":{
@@ -806,6 +824,7 @@
         {"shape":"InvalidClusterSecurityGroupStateFault"},
         {"shape":"ClusterNotFoundFault"},
         {"shape":"NumberOfNodesQuotaExceededFault"},
+        {"shape":"NumberOfNodesPerClusterLimitExceededFault"},
         {"shape":"ClusterSecurityGroupNotFoundFault"},
         {"shape":"ClusterParameterGroupNotFoundFault"},
         {"shape":"InsufficientClusterCapacityFault"},
@@ -1085,7 +1104,8 @@
     "AccountWithRestoreAccess":{
       "type":"structure",
       "members":{
-        "AccountId":{"shape":"String"}
+        "AccountId":{"shape":"String"},
+        "AccountAlias":{"shape":"String"}
       }
     },
     "AccountsWithRestoreAccessList":{
@@ -1238,6 +1258,14 @@
         "senderFault":true
       },
       "exception":true
+    },
+    "ClusterCredentials":{
+      "type":"structure",
+      "members":{
+        "DbUser":{"shape":"String"},
+        "DbPassword":{"shape":"SensitiveString"},
+        "Expiration":{"shape":"TStamp"}
+      }
     },
     "ClusterIamRole":{
       "type":"structure",
@@ -1842,6 +1870,13 @@
         "Tags":{"shape":"TagList"}
       }
     },
+    "DbGroupList":{
+      "type":"list",
+      "member":{
+        "shape":"String",
+        "locationName":"DbGroup"
+      }
+    },
     "DefaultClusterParameters":{
       "type":"structure",
       "members":{
@@ -1946,6 +1981,17 @@
       },
       "error":{
         "code":"DependentServiceRequestThrottlingFault",
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "DependentServiceUnavailableFault":{
+      "type":"structure",
+      "members":{
+      },
+      "error":{
+        "code":"DependentServiceUnavailableFault",
         "httpStatusCode":400,
         "senderFault":true
       },
@@ -2349,6 +2395,21 @@
       "members":{
         "Marker":{"shape":"String"},
         "Events":{"shape":"EventList"}
+      }
+    },
+    "GetClusterCredentialsMessage":{
+      "type":"structure",
+      "required":[
+        "DbUser",
+        "ClusterIdentifier"
+      ],
+      "members":{
+        "DbUser":{"shape":"String"},
+        "DbName":{"shape":"String"},
+        "ClusterIdentifier":{"shape":"String"},
+        "DurationSeconds":{"shape":"IntegerOptional"},
+        "AutoCreate":{"shape":"BooleanOptional"},
+        "DbGroups":{"shape":"DbGroupList"}
       }
     },
     "HsmClientCertificate":{
@@ -3334,6 +3395,10 @@
         "senderFault":true
       },
       "exception":true
+    },
+    "SensitiveString":{
+      "type":"string",
+      "sensitive":true
     },
     "Snapshot":{
       "type":"structure",

--- a/models/apis/redshift/2012-12-01/docs-2.json
+++ b/models/apis/redshift/2012-12-01/docs-2.json
@@ -50,6 +50,7 @@
     "DisableSnapshotCopy": "<p>Disables the automatic copying of snapshots from one region to another region for a specified cluster.</p> <p>If your cluster and its snapshots are encrypted using a customer master key (CMK) from AWS KMS, use <a>DeleteSnapshotCopyGrant</a> to delete the grant that grants Amazon Redshift permission to the CMK in the destination region. </p>",
     "EnableLogging": "<p>Starts logging information, such as queries and connection attempts, for the specified Amazon Redshift cluster.</p>",
     "EnableSnapshotCopy": "<p>Enables the automatic copy of snapshots from one region to another region for a specified cluster.</p>",
+    "GetClusterCredentials": "<p>Returns a database user name and temporary password with temporary authorization to log in to an Amazon Redshift database. The action returns the database user name prefixed with <code>IAM:</code> if <code>AutoCreate</code> is <code>False</code> or <code>IAMA:</code> if <code>AutoCreate</code> is <code>True</code>. You can optionally specify one or more database user groups that the user will join at log in. By default, the temporary credentials expire in 900 seconds. You can optionally specify a duration between 900 seconds (15 minutes) and 3600 seconds (60 minutes). For more information, see Generating IAM Database User Credentials in the Amazon Redshift Cluster Management Guide.</p> <p>The IAM user or role that executes GetClusterCredentials must have an IAM policy attached that allows the <code>redshift:GetClusterCredentials</code> action with access to the <code>dbuser</code> resource on the cluster. The user name specified for <code>dbuser</code> in the IAM policy and the user name specified for the <code>DbUser</code> parameter must match.</p> <p>If the <code>DbGroups</code> parameter is specified, the IAM policy must allow the <code>redshift:JoinGroup</code> action with access to the listed <code>dbgroups</code>. </p> <p>In addition, if the <code>AutoCreate</code> parameter is set to <code>True</code>, then the policy must include the <code>redshift:CreateClusterUser</code> privilege.</p> <p>If the <code>DbName</code> parameter is specified, the IAM policy must allow access to the resource <code>dbname</code> for the specified database name. </p>",
     "ModifyCluster": "<p>Modifies the settings for a cluster. For example, you can add another security or parameter group, update the preferred maintenance window, or change the master user password. Resetting a cluster password or modifying the security groups associated with a cluster do not need a reboot. However, modifying a parameter group requires a reboot for parameters to take effect. For more information about managing clusters, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html\">Amazon Redshift Clusters</a> in the <i>Amazon Redshift Cluster Management Guide</i>.</p> <p>You can also change node type and the number of nodes to scale up or down the cluster. When resizing a cluster, you must specify both the number of nodes and the node type even if one of the parameters does not change.</p>",
     "ModifyClusterIamRoles": "<p>Modifies the list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services.</p> <p>A cluster can have up to 10 IAM roles associated at any time.</p>",
     "ModifyClusterParameterGroup": "<p>Modifies the parameters of a parameter group.</p> <p> For more information about parameters and parameter groups, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html\">Amazon Redshift Parameter Groups</a> in the <i>Amazon Redshift Cluster Management Guide</i>.</p>",
@@ -156,6 +157,7 @@
         "CreateClusterMessage$Encrypted": "<p>If <code>true</code>, the data in the cluster is encrypted at rest. </p> <p>Default: false</p>",
         "CreateClusterMessage$EnhancedVpcRouting": "<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>",
         "CreateEventSubscriptionMessage$Enabled": "<p>A Boolean value; set to <code>true</code> to activate the subscription, set to <code>false</code> to create the subscription but not active it. </p>",
+        "GetClusterCredentialsMessage$AutoCreate": "<p>Create a database user with the name specified for <code>DbUser</code> if one does not exist.</p>",
         "ModifyClusterMessage$AllowVersionUpgrade": "<p>If <code>true</code>, major version upgrades will be applied automatically to the cluster during the maintenance window. </p> <p>Default: <code>false</code> </p>",
         "ModifyClusterMessage$PubliclyAccessible": "<p>If <code>true</code>, the cluster can be accessed from a public network. Only clusters in VPCs can be set to be publicly available.</p>",
         "ModifyClusterMessage$EnhancedVpcRouting": "<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>",
@@ -190,6 +192,11 @@
     },
     "ClusterAlreadyExistsFault": {
       "base": "<p>The account already has a cluster with the given identifier.</p>",
+      "refs": {
+      }
+    },
+    "ClusterCredentials": {
+      "base": "<p>Temporary credentials with authorization to log in to an Amazon Redshift database. </p>",
       "refs": {
       }
     },
@@ -541,6 +548,12 @@
       "refs": {
       }
     },
+    "DbGroupList": {
+      "base": null,
+      "refs": {
+        "GetClusterCredentialsMessage$DbGroups": "<p>A list of the names of existing database groups that <code>DbUser</code> will join for the current session. If not specified, the new user is added only to PUBLIC.</p>"
+      }
+    },
     "DefaultClusterParameters": {
       "base": "<p>Describes the default cluster parameters for a parameter group family.</p>",
       "refs": {
@@ -609,6 +622,11 @@
     },
     "DependentServiceRequestThrottlingFault": {
       "base": "<p>The request cannot be completed because a dependent service is throttling requests made by Amazon Redshift on your behalf. Wait and retry the request.</p>",
+      "refs": {
+      }
+    },
+    "DependentServiceUnavailableFault": {
+      "base": "<p>Your request cannot be completed because a dependent internal service is temporarily unavailable. Wait 30 to 60 seconds and try again.</p>",
       "refs": {
       }
     },
@@ -877,6 +895,11 @@
       "refs": {
       }
     },
+    "GetClusterCredentialsMessage": {
+      "base": "<p>The request parameters to get cluster credentials.</p>",
+      "refs": {
+      }
+    },
     "HsmClientCertificate": {
       "base": "<p>Returns information about an HSM client certificate. The certificate is stored in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift cluster to encrypt data files.</p>",
       "refs": {
@@ -1048,6 +1071,7 @@
         "DescribeTableRestoreStatusMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved.</p>",
         "DescribeTagsMessage$MaxRecords": "<p>The maximum number or response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned <code>marker</code> value. </p>",
         "EnableSnapshotCopyMessage$RetentionPeriod": "<p>The number of days to retain automated snapshots in the destination region after they are copied from the source region.</p> <p>Default: 7.</p> <p>Constraints: Must be at least 1 and no more than 35.</p>",
+        "GetClusterCredentialsMessage$DurationSeconds": "<p>The number of seconds until the returned temporary password expires.</p> <p>Constraint: minimum 900, maximum 3600.</p> <p>Default: 900</p>",
         "ModifyClusterMessage$NumberOfNodes": "<p>The new number of nodes of the cluster. If you specify a new number of nodes, you must also specify the node type parameter.</p> <p>When you submit your request to resize a cluster, Amazon Redshift sets access permissions for the cluster to read-only. After Amazon Redshift provisions a new cluster according to your resize requirements, there will be a temporary outage while the old cluster is deleted and your connection is switched to the new cluster. When the new connection is complete, the original access permissions for the cluster are restored. You can use <a>DescribeResize</a> to track the progress of the resize request. </p> <p>Valid Values: Integer greater than <code>0</code>.</p>",
         "ModifyClusterMessage$AutomatedSnapshotRetentionPeriod": "<p>The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with <a>CreateClusterSnapshot</a>. </p> <p>If you decrease the automated snapshot retention period from its current value, existing automated snapshots that fall outside of the new retention period will be immediately deleted.</p> <p>Default: Uses existing setting.</p> <p>Constraints: Must be a value from 0 to 35.</p>",
         "PendingModifiedValues$NumberOfNodes": "<p>The pending or in-progress change of the number of nodes in the cluster.</p>",
@@ -1481,6 +1505,12 @@
       "refs": {
       }
     },
+    "SensitiveString": {
+      "base": null,
+      "refs": {
+        "ClusterCredentials$DbPassword": "<p>A temporary password that authorizes the user name returned by <code>DbUser</code> to log on to the database <code>DbName</code>. </p>"
+      }
+    },
     "Snapshot": {
       "base": "<p>Describes a snapshot.</p>",
       "refs": {
@@ -1575,13 +1605,14 @@
       "base": null,
       "refs": {
         "AccountWithRestoreAccess$AccountId": "<p>The identifier of an AWS customer account authorized to restore a snapshot.</p>",
+        "AccountWithRestoreAccess$AccountAlias": "<p>The identifier of an AWS support account authorized to restore a snapshot. For AWS support, the identifier is <code>amazon-redshift-support</code>. </p>",
         "AuthorizeClusterSecurityGroupIngressMessage$ClusterSecurityGroupName": "<p>The name of the security group to which the ingress rule is added.</p>",
         "AuthorizeClusterSecurityGroupIngressMessage$CIDRIP": "<p>The IP range to be added the Amazon Redshift security group.</p>",
         "AuthorizeClusterSecurityGroupIngressMessage$EC2SecurityGroupName": "<p>The EC2 security group to be added the Amazon Redshift security group.</p>",
         "AuthorizeClusterSecurityGroupIngressMessage$EC2SecurityGroupOwnerId": "<p>The AWS account number of the owner of the security group specified by the <i>EC2SecurityGroupName</i> parameter. The AWS Access Key ID is not an acceptable value. </p> <p>Example: <code>111122223333</code> </p>",
         "AuthorizeSnapshotAccessMessage$SnapshotIdentifier": "<p>The identifier of the snapshot the account is authorized to restore.</p>",
         "AuthorizeSnapshotAccessMessage$SnapshotClusterIdentifier": "<p>The identifier of the cluster the snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name.</p>",
-        "AuthorizeSnapshotAccessMessage$AccountWithRestoreAccess": "<p>The identifier of the AWS customer account authorized to restore the specified snapshot.</p>",
+        "AuthorizeSnapshotAccessMessage$AccountWithRestoreAccess": "<p>The identifier of the AWS customer account authorized to restore the specified snapshot.</p> <p>To share a snapshot with AWS support, specify amazon-redshift-support.</p>",
         "AvailabilityZone$Name": "<p>The name of the availability zone.</p>",
         "Cluster$ClusterIdentifier": "<p>The unique identifier of the cluster.</p>",
         "Cluster$NodeType": "<p>The node type for the nodes in the cluster.</p>",
@@ -1597,6 +1628,7 @@
         "Cluster$ClusterPublicKey": "<p>The public key for the cluster.</p>",
         "Cluster$ClusterRevisionNumber": "<p>The specific revision number of the database in the cluster.</p>",
         "Cluster$KmsKeyId": "<p>The AWS Key Management Service (AWS KMS) key ID of the encryption key used to encrypt data in the cluster.</p>",
+        "ClusterCredentials$DbUser": "<p>A database user name that is authorized to log on to the database <code>DbName</code> using the password <code>DbPassword</code>. If the <code>DbGroups</code> parameter is specifed, <code>DbUser</code> is added to the listed groups for the current session. The user name is prefixed with <code>IAM:</code> for an existing user name or <code>IAMA:</code> if the user was auto-created. </p>",
         "ClusterIamRole$IamRoleArn": "<p>The Amazon Resource Name (ARN) of the IAM role, for example, <code>arn:aws:iam::123456789012:role/RedshiftCopyUnload</code>. </p>",
         "ClusterIamRole$ApplyStatus": "<p>A value that describes the status of the IAM role's association with an Amazon Redshift cluster.</p> <p>The following are possible statuses and descriptions.</p> <ul> <li> <p> <code>in-sync</code>: The role is available for use by the cluster.</p> </li> <li> <p> <code>adding</code>: The role is in the process of being associated with the cluster.</p> </li> <li> <p> <code>removing</code>: The role is in the process of being disassociated with the cluster.</p> </li> </ul>",
         "ClusterNode$NodeRole": "<p>Whether the node is a leader node or a compute node.</p>",
@@ -1674,6 +1706,7 @@
         "CreateSnapshotCopyGrantMessage$SnapshotCopyGrantName": "<p>The name of the snapshot copy grant. This name must be unique in the region for the AWS account.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>Alphabetic characters must be lowercase.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must be unique for all clusters within an AWS account.</p> </li> </ul>",
         "CreateSnapshotCopyGrantMessage$KmsKeyId": "<p>The unique identifier of the customer master key (CMK) to which to grant Amazon Redshift permission. If no key is specified, the default key is used.</p>",
         "CreateTagsMessage$ResourceName": "<p>The Amazon Resource Name (ARN) to which you want to add the tag or tags. For example, <code>arn:aws:redshift:us-east-1:123456789:cluster:t1</code>. </p>",
+        "DbGroupList$member": null,
         "DefaultClusterParameters$ParameterGroupFamily": "<p>The name of the cluster parameter group family to which the engine default parameters apply.</p>",
         "DefaultClusterParameters$Marker": "<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>",
         "DeleteClusterMessage$ClusterIdentifier": "<p>The identifier of the cluster to be deleted.</p> <p>Constraints:</p> <ul> <li> <p>Must contain lowercase characters.</p> </li> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
@@ -1766,6 +1799,9 @@
         "EventSubscription$Severity": "<p>The event severity specified in the Amazon Redshift event notification subscription.</p> <p>Values: ERROR, INFO</p>",
         "EventSubscriptionsMessage$Marker": "<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>",
         "EventsMessage$Marker": "<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>",
+        "GetClusterCredentialsMessage$DbUser": "<p>The name of a database user. If a user name matching <code>DbUser</code> exists in the database, the temporary user credentials have the same permissions as the existing user. If <code>DbUser</code> doesn't exist in the database and <code>Autocreate</code> is <code>True</code>, a new user is created using the value for <code>DbUser</code> with PUBLIC permissions. If a database user matching the value for <code>DbUser</code> doesn't exist and <code>Autocreate</code> is <code>False</code>, then the command succeeds but the connection attempt will fail because the user doesn't exist in the database.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/http:/docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html\">CREATE USER</a> in the Amazon Redshift Database Developer Guide. </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 128 alphanumeric characters or hyphens</p> </li> <li> <p>Must contain only lowercase letters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Must not contain a colon ( : ) or slash ( / ). </p> </li> <li> <p>Cannot be a reserved word. A list of reserved words can be found in <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html\">Reserved Words</a> in the Amazon Redshift Database Developer Guide.</p> </li> </ul>",
+        "GetClusterCredentialsMessage$DbName": "<p>The name of a database that <code>DbUser</code> is authorized to log on to. If <code>DbName</code> is not specified, <code>DbUser</code> can log in to any existing database.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 64 alphanumeric characters or hyphens</p> </li> <li> <p>Must contain only lowercase letters.</p> </li> <li> <p>Cannot be a reserved word. A list of reserved words can be found in <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html\">Reserved Words</a> in the Amazon Redshift Database Developer Guide.</p> </li> </ul>",
+        "GetClusterCredentialsMessage$ClusterIdentifier": "<p>The unique identifier of the cluster that contains the database for which your are requesting credentials. This parameter is case sensitive.</p>",
         "HsmClientCertificate$HsmClientCertificateIdentifier": "<p>The identifier of the HSM client certificate.</p>",
         "HsmClientCertificate$HsmClientCertificatePublicKey": "<p>The public key that the Amazon Redshift cluster will use to connect to the HSM. You must register the public key in the HSM.</p>",
         "HsmClientCertificateMessage$Marker": "<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>",
@@ -1970,6 +2006,7 @@
       "base": null,
       "refs": {
         "Cluster$ClusterCreateTime": "<p>The date and time that the cluster was created.</p>",
+        "ClusterCredentials$Expiration": "<p>The date and time <code>DbPassword</code> expires.</p>",
         "DescribeClusterSnapshotsMessage$StartTime": "<p>A value that requests only snapshots created at or after the specified time. The time value is specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: <code>2012-07-16T18:00:00Z</code> </p>",
         "DescribeClusterSnapshotsMessage$EndTime": "<p>A time value that requests only snapshots created at or before the specified time. The time value is specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: <code>2012-07-16T18:00:00Z</code> </p>",
         "DescribeEventsMessage$StartTime": "<p>The beginning of the time interval to retrieve events for, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: <code>2009-07-08T18:00Z</code> </p>",

--- a/models/apis/redshift/2012-12-01/paginators-1.json
+++ b/models/apis/redshift/2012-12-01/paginators-1.json
@@ -2,92 +2,92 @@
   "pagination": {
     "DescribeClusterParameterGroups": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "ParameterGroups"
     },
     "DescribeClusterParameters": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "Parameters"
     },
     "DescribeClusterSecurityGroups": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "ClusterSecurityGroups"
     },
     "DescribeClusterSnapshots": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "Snapshots"
     },
     "DescribeClusterSubnetGroups": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "ClusterSubnetGroups"
     },
     "DescribeClusterVersions": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "ClusterVersions"
     },
     "DescribeClusters": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "Clusters"
     },
     "DescribeDefaultClusterParameters": {
       "input_token": "Marker",
-      "output_token": "DefaultClusterParameters.Marker",
       "limit_key": "MaxRecords",
+      "output_token": "DefaultClusterParameters.Marker",
       "result_key": "DefaultClusterParameters.Parameters"
     },
     "DescribeEventSubscriptions": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "EventSubscriptionsList"
     },
     "DescribeEvents": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "Events"
     },
     "DescribeHsmClientCertificates": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "HsmClientCertificates"
     },
     "DescribeHsmConfigurations": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "HsmConfigurations"
     },
     "DescribeOrderableClusterOptions": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "OrderableClusterOptions"
     },
     "DescribeReservedNodeOfferings": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "ReservedNodeOfferings"
     },
     "DescribeReservedNodes": {
       "input_token": "Marker",
-      "output_token": "Marker",
       "limit_key": "MaxRecords",
+      "output_token": "Marker",
       "result_key": "ReservedNodes"
     }
   }

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -4471,6 +4471,10 @@ func (c *Redshift) DescribeReservedNodeOfferingsRequest(input *DescribeReservedN
 //   * ErrCodeUnsupportedOperationFault "UnsupportedOperation"
 //   The requested operation isn't supported.
 //
+//   * ErrCodeDependentServiceUnavailableFault "DependentServiceUnavailableFault"
+//   Your request cannot be completed because a dependent internal service is
+//   temporarily unavailable. Wait 30 to 60 seconds and try again.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/DescribeReservedNodeOfferings
 func (c *Redshift) DescribeReservedNodeOfferings(input *DescribeReservedNodeOfferingsInput) (*DescribeReservedNodeOfferingsOutput, error) {
 	req, out := c.DescribeReservedNodeOfferingsRequest(input)
@@ -4606,6 +4610,10 @@ func (c *Redshift) DescribeReservedNodesRequest(input *DescribeReservedNodesInpu
 // Returned Error Codes:
 //   * ErrCodeReservedNodeNotFoundFault "ReservedNodeNotFound"
 //   The specified reserved compute node not found.
+//
+//   * ErrCodeDependentServiceUnavailableFault "DependentServiceUnavailableFault"
+//   Your request cannot be completed because a dependent internal service is
+//   temporarily unavailable. Wait 30 to 60 seconds and try again.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/DescribeReservedNodes
 func (c *Redshift) DescribeReservedNodes(input *DescribeReservedNodesInput) (*DescribeReservedNodesOutput, error) {
@@ -5431,6 +5439,111 @@ func (c *Redshift) EnableSnapshotCopyWithContext(ctx aws.Context, input *EnableS
 	return out, req.Send()
 }
 
+const opGetClusterCredentials = "GetClusterCredentials"
+
+// GetClusterCredentialsRequest generates a "aws/request.Request" representing the
+// client's request for the GetClusterCredentials operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetClusterCredentials for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetClusterCredentials method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetClusterCredentialsRequest method.
+//    req, resp := client.GetClusterCredentialsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/GetClusterCredentials
+func (c *Redshift) GetClusterCredentialsRequest(input *GetClusterCredentialsInput) (req *request.Request, output *GetClusterCredentialsOutput) {
+	op := &request.Operation{
+		Name:       opGetClusterCredentials,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetClusterCredentialsInput{}
+	}
+
+	output = &GetClusterCredentialsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetClusterCredentials API operation for Amazon Redshift.
+//
+// Returns a database user name and temporary password with temporary authorization
+// to log in to an Amazon Redshift database. The action returns the database
+// user name prefixed with IAM: if AutoCreate is False or IAMA: if AutoCreate
+// is True. You can optionally specify one or more database user groups that
+// the user will join at log in. By default, the temporary credentials expire
+// in 900 seconds. You can optionally specify a duration between 900 seconds
+// (15 minutes) and 3600 seconds (60 minutes). For more information, see Generating
+// IAM Database User Credentials in the Amazon Redshift Cluster Management Guide.
+//
+// The IAM user or role that executes GetClusterCredentials must have an IAM
+// policy attached that allows the redshift:GetClusterCredentials action with
+// access to the dbuser resource on the cluster. The user name specified for
+// dbuser in the IAM policy and the user name specified for the DbUser parameter
+// must match.
+//
+// If the DbGroups parameter is specified, the IAM policy must allow the redshift:JoinGroup
+// action with access to the listed dbgroups.
+//
+// In addition, if the AutoCreate parameter is set to True, then the policy
+// must include the redshift:CreateClusterUser privilege.
+//
+// If the DbName parameter is specified, the IAM policy must allow access to
+// the resource dbname for the specified database name.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Redshift's
+// API operation GetClusterCredentials for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeClusterNotFoundFault "ClusterNotFound"
+//   The ClusterIdentifier parameter does not refer to an existing cluster.
+//
+//   * ErrCodeUnsupportedOperationFault "UnsupportedOperation"
+//   The requested operation isn't supported.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/GetClusterCredentials
+func (c *Redshift) GetClusterCredentials(input *GetClusterCredentialsInput) (*GetClusterCredentialsOutput, error) {
+	req, out := c.GetClusterCredentialsRequest(input)
+	return out, req.Send()
+}
+
+// GetClusterCredentialsWithContext is the same as GetClusterCredentials with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetClusterCredentials for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Redshift) GetClusterCredentialsWithContext(ctx aws.Context, input *GetClusterCredentialsInput, opts ...request.Option) (*GetClusterCredentialsOutput, error) {
+	req, out := c.GetClusterCredentialsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opModifyCluster = "ModifyCluster"
 
 // ModifyClusterRequest generates a "aws/request.Request" representing the
@@ -5510,6 +5623,9 @@ func (c *Redshift) ModifyClusterRequest(input *ModifyClusterInput) (req *request
 //   information about increasing your quota, go to Limits in Amazon Redshift
 //   (http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html)
 //   in the Amazon Redshift Cluster Management Guide.
+//
+//   * ErrCodeNumberOfNodesPerClusterLimitExceededFault "NumberOfNodesPerClusterLimitExceeded"
+//   The operation would exceed the number of nodes allowed for a cluster.
 //
 //   * ErrCodeClusterSecurityGroupNotFoundFault "ClusterSecurityGroupNotFound"
 //   The cluster security group name does not refer to an existing cluster security
@@ -6881,6 +6997,10 @@ func (c *Redshift) RotateEncryptionKeyWithContext(ctx aws.Context, input *Rotate
 type AccountWithRestoreAccess struct {
 	_ struct{} `type:"structure"`
 
+	// The identifier of an AWS support account authorized to restore a snapshot.
+	// For AWS support, the identifier is amazon-redshift-support.
+	AccountAlias *string `type:"string"`
+
 	// The identifier of an AWS customer account authorized to restore a snapshot.
 	AccountId *string `type:"string"`
 }
@@ -6893,6 +7013,12 @@ func (s AccountWithRestoreAccess) String() string {
 // GoString returns the string representation
 func (s AccountWithRestoreAccess) GoString() string {
 	return s.String()
+}
+
+// SetAccountAlias sets the AccountAlias field's value.
+func (s *AccountWithRestoreAccess) SetAccountAlias(v string) *AccountWithRestoreAccess {
+	s.AccountAlias = &v
+	return s
 }
 
 // SetAccountId sets the AccountId field's value.
@@ -7001,6 +7127,8 @@ type AuthorizeSnapshotAccessInput struct {
 
 	// The identifier of the AWS customer account authorized to restore the specified
 	// snapshot.
+	//
+	// To share a snapshot with AWS support, specify amazon-redshift-support.
 	//
 	// AccountWithRestoreAccess is a required field
 	AccountWithRestoreAccess *string `type:"string" required:"true"`
@@ -13481,6 +13609,185 @@ func (s *EventSubscription) SetSubscriptionCreationTime(v time.Time) *EventSubsc
 // SetTags sets the Tags field's value.
 func (s *EventSubscription) SetTags(v []*Tag) *EventSubscription {
 	s.Tags = v
+	return s
+}
+
+// The request parameters to get cluster credentials.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/GetClusterCredentialsMessage
+type GetClusterCredentialsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Create a database user with the name specified for DbUser if one does not
+	// exist.
+	AutoCreate *bool `type:"boolean"`
+
+	// The unique identifier of the cluster that contains the database for which
+	// your are requesting credentials. This parameter is case sensitive.
+	//
+	// ClusterIdentifier is a required field
+	ClusterIdentifier *string `type:"string" required:"true"`
+
+	// A list of the names of existing database groups that DbUser will join for
+	// the current session. If not specified, the new user is added only to PUBLIC.
+	DbGroups []*string `locationNameList:"DbGroup" type:"list"`
+
+	// The name of a database that DbUser is authorized to log on to. If DbName
+	// is not specified, DbUser can log in to any existing database.
+	//
+	// Constraints:
+	//
+	//    * Must be 1 to 64 alphanumeric characters or hyphens
+	//
+	//    * Must contain only lowercase letters.
+	//
+	//    * Cannot be a reserved word. A list of reserved words can be found in
+	//    Reserved Words (http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html)
+	//    in the Amazon Redshift Database Developer Guide.
+	DbName *string `type:"string"`
+
+	// The name of a database user. If a user name matching DbUser exists in the
+	// database, the temporary user credentials have the same permissions as the
+	// existing user. If DbUser doesn't exist in the database and Autocreate is
+	// True, a new user is created using the value for DbUser with PUBLIC permissions.
+	// If a database user matching the value for DbUser doesn't exist and Autocreate
+	// is False, then the command succeeds but the connection attempt will fail
+	// because the user doesn't exist in the database.
+	//
+	// For more information, see CREATE USER (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html)
+	// in the Amazon Redshift Database Developer Guide.
+	//
+	// Constraints:
+	//
+	//    * Must be 1 to 128 alphanumeric characters or hyphens
+	//
+	//    * Must contain only lowercase letters.
+	//
+	//    * First character must be a letter.
+	//
+	//    * Must not contain a colon ( : ) or slash ( / ).
+	//
+	//    * Cannot be a reserved word. A list of reserved words can be found in
+	//    Reserved Words (http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html)
+	//    in the Amazon Redshift Database Developer Guide.
+	//
+	// DbUser is a required field
+	DbUser *string `type:"string" required:"true"`
+
+	// The number of seconds until the returned temporary password expires.
+	//
+	// Constraint: minimum 900, maximum 3600.
+	//
+	// Default: 900
+	DurationSeconds *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s GetClusterCredentialsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetClusterCredentialsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetClusterCredentialsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetClusterCredentialsInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.DbUser == nil {
+		invalidParams.Add(request.NewErrParamRequired("DbUser"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAutoCreate sets the AutoCreate field's value.
+func (s *GetClusterCredentialsInput) SetAutoCreate(v bool) *GetClusterCredentialsInput {
+	s.AutoCreate = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *GetClusterCredentialsInput) SetClusterIdentifier(v string) *GetClusterCredentialsInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetDbGroups sets the DbGroups field's value.
+func (s *GetClusterCredentialsInput) SetDbGroups(v []*string) *GetClusterCredentialsInput {
+	s.DbGroups = v
+	return s
+}
+
+// SetDbName sets the DbName field's value.
+func (s *GetClusterCredentialsInput) SetDbName(v string) *GetClusterCredentialsInput {
+	s.DbName = &v
+	return s
+}
+
+// SetDbUser sets the DbUser field's value.
+func (s *GetClusterCredentialsInput) SetDbUser(v string) *GetClusterCredentialsInput {
+	s.DbUser = &v
+	return s
+}
+
+// SetDurationSeconds sets the DurationSeconds field's value.
+func (s *GetClusterCredentialsInput) SetDurationSeconds(v int64) *GetClusterCredentialsInput {
+	s.DurationSeconds = &v
+	return s
+}
+
+// Temporary credentials with authorization to log in to an Amazon Redshift
+// database.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ClusterCredentials
+type GetClusterCredentialsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A temporary password that authorizes the user name returned by DbUser to
+	// log on to the database DbName.
+	DbPassword *string `type:"string"`
+
+	// A database user name that is authorized to log on to the database DbName
+	// using the password DbPassword. If the DbGroups parameter is specifed, DbUser
+	// is added to the listed groups for the current session. The user name is prefixed
+	// with IAM: for an existing user name or IAMA: if the user was auto-created.
+	DbUser *string `type:"string"`
+
+	// The date and time DbPassword expires.
+	Expiration *time.Time `type:"timestamp" timestampFormat:"iso8601"`
+}
+
+// String returns the string representation
+func (s GetClusterCredentialsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetClusterCredentialsOutput) GoString() string {
+	return s.String()
+}
+
+// SetDbPassword sets the DbPassword field's value.
+func (s *GetClusterCredentialsOutput) SetDbPassword(v string) *GetClusterCredentialsOutput {
+	s.DbPassword = &v
+	return s
+}
+
+// SetDbUser sets the DbUser field's value.
+func (s *GetClusterCredentialsOutput) SetDbUser(v string) *GetClusterCredentialsOutput {
+	s.DbUser = &v
+	return s
+}
+
+// SetExpiration sets the Expiration field's value.
+func (s *GetClusterCredentialsOutput) SetExpiration(v time.Time) *GetClusterCredentialsOutput {
+	s.Expiration = &v
 	return s
 }
 

--- a/service/redshift/errors.go
+++ b/service/redshift/errors.go
@@ -165,6 +165,13 @@ const (
 	// requests made by Amazon Redshift on your behalf. Wait and retry the request.
 	ErrCodeDependentServiceRequestThrottlingFault = "DependentServiceRequestThrottlingFault"
 
+	// ErrCodeDependentServiceUnavailableFault for service response error code
+	// "DependentServiceUnavailableFault".
+	//
+	// Your request cannot be completed because a dependent internal service is
+	// temporarily unavailable. Wait 30 to 60 seconds and try again.
+	ErrCodeDependentServiceUnavailableFault = "DependentServiceUnavailableFault"
+
 	// ErrCodeEventSubscriptionQuotaExceededFault for service response error code
 	// "EventSubscriptionQuotaExceeded".
 	//

--- a/service/redshift/examples_test.go
+++ b/service/redshift/examples_test.go
@@ -1295,6 +1295,35 @@ func ExampleRedshift_EnableSnapshotCopy() {
 	fmt.Println(resp)
 }
 
+func ExampleRedshift_GetClusterCredentials() {
+	sess := session.Must(session.NewSession())
+
+	svc := redshift.New(sess)
+
+	params := &redshift.GetClusterCredentialsInput{
+		ClusterIdentifier: aws.String("String"), // Required
+		DbUser:            aws.String("String"), // Required
+		AutoCreate:        aws.Bool(true),
+		DbGroups: []*string{
+			aws.String("String"), // Required
+			// More values...
+		},
+		DbName:          aws.String("String"),
+		DurationSeconds: aws.Int64(1),
+	}
+	resp, err := svc.GetClusterCredentials(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleRedshift_ModifyCluster() {
 	sess := session.Must(session.NewSession())
 

--- a/service/redshift/redshiftiface/interface.go
+++ b/service/redshift/redshiftiface/interface.go
@@ -297,6 +297,10 @@ type RedshiftAPI interface {
 	EnableSnapshotCopyWithContext(aws.Context, *redshift.EnableSnapshotCopyInput, ...request.Option) (*redshift.EnableSnapshotCopyOutput, error)
 	EnableSnapshotCopyRequest(*redshift.EnableSnapshotCopyInput) (*request.Request, *redshift.EnableSnapshotCopyOutput)
 
+	GetClusterCredentials(*redshift.GetClusterCredentialsInput) (*redshift.GetClusterCredentialsOutput, error)
+	GetClusterCredentialsWithContext(aws.Context, *redshift.GetClusterCredentialsInput, ...request.Option) (*redshift.GetClusterCredentialsOutput, error)
+	GetClusterCredentialsRequest(*redshift.GetClusterCredentialsInput) (*request.Request, *redshift.GetClusterCredentialsOutput)
+
 	ModifyCluster(*redshift.ModifyClusterInput) (*redshift.ModifyClusterOutput, error)
 	ModifyClusterWithContext(aws.Context, *redshift.ModifyClusterInput, ...request.Option) (*redshift.ModifyClusterOutput, error)
 	ModifyClusterRequest(*redshift.ModifyClusterInput) (*request.Request, *redshift.ModifyClusterOutput)


### PR DESCRIPTION
Release v1.8.11 (2017-04-07)
===

### Service Client Updates
* `service/redshift`: Updates service API, documentation, and paginators
  * This update adds the GetClusterCredentials API which is used to get temporary login credentials to the cluster. AccountWithRestoreAccess now has a new member AccountAlias, this is the identifier of the AWS support account authorized to restore the specified snapshot. This is added to support the feature where the customer can share their snapshot with the Amazon Redshift Support Account without having to manually specify the AWS Redshift Service account ID on the AWS Console/API.

