### PR TITLE
aws/request: Fix waiter error match condition

### DIFF
--- a/aws/request/waiter.go
+++ b/aws/request/waiter.go
@@ -178,13 +178,8 @@ func (w Waiter) WaitWithContext(ctx aws.Context) error {
 
 		// See if any of the acceptors match the request's response, or error
 		for _, a := range w.Acceptors {
-			matched, matchErr := a.match(w.Name, w.Logger, req, err)
-			if matchErr != nil {
-				// Error occurred during current waiter call
+			if matched, matchErr := a.match(w.Name, w.Logger, req, err); matched {
 				return matchErr
-			} else if matched {
-				// Match was found can stop here and return
-				return nil
 			}
 		}
 
@@ -273,7 +268,7 @@ func (a *WaiterAcceptor) match(name string, l aws.Logger, req *Request, err erro
 		return true, nil
 	case FailureWaiterState:
 		// Waiter failure state triggered
-		return false, awserr.New("ResourceNotReady",
+		return true, awserr.New(WaiterResourceNotReadyErrorCode,
 			"failed waiting for successful resource state", err)
 	case RetryWaiterState:
 		// clear the error and retry the operation

--- a/aws/request/waiter.go
+++ b/aws/request/waiter.go
@@ -178,11 +178,10 @@ func (w Waiter) WaitWithContext(ctx aws.Context) error {
 
 		// See if any of the acceptors match the request's response, or error
 		for _, a := range w.Acceptors {
-			var matched bool
-			matched, err = a.match(w.Name, w.Logger, req, err)
-			if err != nil {
+			matched, matchErr := a.match(w.Name, w.Logger, req, err)
+			if matchErr != nil {
 				// Error occurred during current waiter call
-				return err
+				return matchErr
 			} else if matched {
 				// Match was found can stop here and return
 				return nil


### PR DESCRIPTION
Fixes the waiters's matching overwriting the request's `err`, effectively ignoring the error condition. This broke waiters with the `FailureWaiterState` matcher state.

Updated waiter tests to verify error failure condition correctly, not just error retry.

Fix #1193