### PR TITLE
aws/defaults: Add support for generic http credential provider

### DIFF
--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -97,6 +97,27 @@ type Provider interface {
 	IsExpired() bool
 }
 
+// An ErrorProvider is a stub credentials provider that always returns an error
+// this is used by the SDK when construction a known provider is not possible
+// due to an error.
+type ErrorProvider struct {
+	// The error to be returned from Retrieve
+	Err error
+
+	// The provider name to set on the Retrieved returned Value
+	ProviderName string
+}
+
+// Retrieve will always return the error that the ErrorProvider was created with.
+func (p ErrorProvider) Retrieve() (Value, error) {
+	return Value{ProviderName: p.ProviderName}, p.Err
+}
+
+// IsExpired will always return not expired.
+func (p ErrorProvider) IsExpired() bool {
+	return false
+}
+
 // A Expiry provides shared expiration logic to be used by credentials
 // providers to implement expiry functionality.
 //

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -103,7 +103,7 @@ const (
 	ecsCredsProviderEnvVar = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
 )
 
-// RemoteCredProvider returns a credenitials provider for the default remote
+// RemoteCredProvider returns a credentials provider for the default remote
 // endpoints such as EC2 or ECS Roles.
 func RemoteCredProvider(cfg aws.Config, handlers request.Handlers) credentials.Provider {
 	if u := os.Getenv(httpProviderEnvVar); len(u) > 0 {
@@ -125,7 +125,7 @@ func localHTTPCredProvider(cfg aws.Config, handlers request.Handlers, u string) 
 	if err != nil {
 		errMsg = fmt.Sprintf("invalid URL, %v", err)
 	} else if host := aws.URLHostname(parsed); !(host == "localhost" || host == "127.0.0.1") {
-		errMsg = fmt.Sprintf("invalid host addresss, %q, only localhost and 127.0.0.1 are valid.", host)
+		errMsg = fmt.Sprintf("invalid host address, %q, only localhost and 127.0.0.1 are valid.", host)
 	}
 
 	if len(errMsg) > 0 {

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -111,7 +111,7 @@ func RemoteCredProvider(cfg aws.Config, handlers request.Handlers) credentials.P
 		if err != nil {
 			log(cfg.Logger,
 				"Ignoring,", httpProviderEnvVar, "failed to parse url", err)
-		} else if host := parsed.Hostname(); !(host == "localhost" || host == "127.0.0.1") {
+		} else if host := aws.URLHostname(parsed); !(host == "localhost" || host == "127.0.0.1") {
 			log(cfg.Logger,
 				"Ignoring,", httpProviderEnvVar, "specified URL with invalid hostname",
 				host, ", only localhost and 127.0.0.1 are valid.")

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -118,13 +118,6 @@ func RemoteCredProvider(cfg aws.Config, handlers request.Handlers) credentials.P
 	return ec2RoleProvider(cfg, handlers)
 }
 
-func log(logger aws.Logger, msg ...interface{}) {
-	if logger == nil {
-		return
-	}
-	logger.Log(msg...)
-}
-
 func localHTTPCredProvider(cfg aws.Config, handlers request.Handlers, u string) credentials.Provider {
 	var errMsg string
 

--- a/aws/defaults/defaults_test.go
+++ b/aws/defaults/defaults_test.go
@@ -9,36 +9,73 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/endpointcreds"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/stretchr/testify/assert"
 )
+
+func TestHTTPCredProvider(t *testing.T) {
+	cases := []struct {
+		Host string
+		Fail bool
+	}{
+		{"localhost", false}, {"127.0.0.1", false},
+		{"www.example.com", true}, {"169.254.170.2", true},
+	}
+
+	defer os.Clearenv()
+
+	for i, c := range cases {
+		u := fmt.Sprintf("http://%s/abc/123", c.Host)
+		os.Setenv(httpProviderEnvVar, u)
+
+		provider := RemoteCredProvider(aws.Config{}, request.Handlers{})
+		if provider == nil {
+			t.Fatalf("%d, expect provider not to be nil, but was", i)
+		}
+
+		httpProvider, ok := provider.(*endpointcreds.Provider)
+		if c.Fail {
+			if ok {
+				t.Fatalf("%d, expect http provider not to be set, but was, %#v", i, httpProvider)
+			}
+		} else {
+			if httpProvider == nil {
+				t.Fatalf("%d, expect provider not to be nil, but was", i)
+			}
+			if e, a := u, httpProvider.Client.Endpoint; e != a {
+				t.Errorf("%d, expect %q endpoint, got %q", i, e, a)
+			}
+		}
+	}
+}
 
 func TestECSCredProvider(t *testing.T) {
 	defer os.Clearenv()
-	os.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/abc/123")
+	os.Setenv(ecsCredsProviderEnvVar, "/abc/123")
 
 	provider := RemoteCredProvider(aws.Config{}, request.Handlers{})
+	if provider == nil {
+		t.Fatalf("expect provider not to be nil, but was")
+	}
 
-	assert.NotNil(t, provider)
-
-	ecsProvider, ok := provider.(*endpointcreds.Provider)
-	assert.NotNil(t, ecsProvider)
-	assert.True(t, ok)
-
-	assert.Equal(t, fmt.Sprintf("http://169.254.170.2/abc/123"),
-		ecsProvider.Client.Endpoint)
+	httpProvider := provider.(*endpointcreds.Provider)
+	if httpProvider == nil {
+		t.Fatalf("expect provider not to be nil, but was")
+	}
+	if e, a := "http://169.254.170.2/abc/123", httpProvider.Client.Endpoint; e != a {
+		t.Errorf("expect %q endpoint, got %q", e, a)
+	}
 }
 
 func TestDefaultEC2RoleProvider(t *testing.T) {
 	provider := RemoteCredProvider(aws.Config{}, request.Handlers{})
+	if provider == nil {
+		t.Fatalf("expect provider not to be nil, but was")
+	}
 
-	assert.NotNil(t, provider)
-
-	ec2Provider, ok := provider.(*ec2rolecreds.EC2RoleProvider)
-	assert.NotNil(t, ec2Provider)
-	assert.True(t, ok)
-
-	fmt.Println(ec2Provider.Client.Endpoint)
-
-	assert.Equal(t, fmt.Sprintf("http://169.254.169.254/latest"),
-		ec2Provider.Client.Endpoint)
+	ec2Provider := provider.(*ec2rolecreds.EC2RoleProvider)
+	if ec2Provider == nil {
+		t.Fatalf("expect provider not to be nil, but was")
+	}
+	if e, a := "http://169.254.169.254/latest", ec2Provider.Client.Endpoint; e != a {
+		t.Errorf("expect %q endpoint, got %q", e, a)
+	}
 }

--- a/aws/url.go
+++ b/aws/url.go
@@ -1,0 +1,12 @@
+// +build go1.8
+
+package aws
+
+import "net/url"
+
+// URLHostname will extract the Hostname without port from the URL value.
+//
+// Wrapper of net/url#URL.Hostname for backwards Go version compatibility.
+func URLHostname(url *url.URL) string {
+	return url.Hostname()
+}

--- a/aws/url_1_7.go
+++ b/aws/url_1_7.go
@@ -1,0 +1,29 @@
+// +build !go1.8
+
+package aws
+
+import (
+	"net/url"
+	"strings"
+)
+
+// URLHostname will extract the Hostname without port from the URL value.
+//
+// Copy of Go 1.8's net/url#URL.Hostname functionality.
+func URLHostname(url *url.URL) string {
+	return stripPort(url.Host)
+
+}
+
+// stripPort is copy of Go 1.8 url#URL.Hostname functionality.
+// https://golang.org/src/net/url/url.go
+func stripPort(hostport string) string {
+	colon := strings.IndexByte(hostport, ':')
+	if colon == -1 {
+		return hostport
+	}
+	if i := strings.IndexByte(hostport, ']'); i != -1 {
+		return strings.TrimPrefix(hostport[:i], "[")
+	}
+	return hostport[:colon]
+}


### PR DESCRIPTION
Adds support for the `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment
variable to the default credential chain. With the limitation that the host must be `localhost` or `127.0.0.1`.