### PR TITLE
aws/client: Fix clients polluting handler list

### DIFF
--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -46,7 +46,7 @@ func New(cfg aws.Config, info metadata.ClientInfo, handlers request.Handlers, op
 	svc := &Client{
 		Config:     cfg,
 		ClientInfo: info,
-		Handlers:   handlers,
+		Handlers:   handlers.Copy(),
 	}
 
 	switch retryer, ok := cfg.Retryer.(request.Retryer); {
@@ -86,8 +86,8 @@ func (c *Client) AddDebugHandlers() {
 		return
 	}
 
-	c.Handlers.Send.PushFront(logRequest)
-	c.Handlers.Send.PushBack(logResponse)
+	c.Handlers.Send.PushFrontNamed(request.NamedHandler{Name: "awssdk.client.LogRequest", Fn: logRequest})
+	c.Handlers.Send.PushBackNamed(request.NamedHandler{Name: "awssdk.client.LogResponse", Fn: logResponse})
 }
 
 const logReqMsg = `DEBUG: Request %s/%s Details:

--- a/aws/client/client_test.go
+++ b/aws/client/client_test.go
@@ -1,0 +1,78 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client/metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func pushBackTestHandler(name string, list *request.HandlerList) *bool {
+	called := false
+	(*list).PushBackNamed(request.NamedHandler{
+		Name: name,
+		Fn: func(r *request.Request) {
+			called = true
+		},
+	})
+
+	return &called
+}
+
+func pushFrontTestHandler(name string, list *request.HandlerList) *bool {
+	called := false
+	(*list).PushFrontNamed(request.NamedHandler{
+		Name: name,
+		Fn: func(r *request.Request) {
+			called = true
+		},
+	})
+
+	return &called
+}
+
+func TestNewClient_CopyHandlers(t *testing.T) {
+	handlers := request.Handlers{}
+	firstCalled := pushBackTestHandler("first", &handlers.Send)
+	secondCalled := pushBackTestHandler("second", &handlers.Send)
+
+	var clientHandlerCalled *bool
+	c := New(aws.Config{}, metadata.ClientInfo{}, handlers,
+		func(c *Client) {
+			clientHandlerCalled = pushFrontTestHandler("client handler", &c.Handlers.Send)
+		},
+	)
+
+	if e, a := 2, handlers.Send.Len(); e != a {
+		t.Errorf("expect %d original handlers, got %d", e, a)
+	}
+	if e, a := 3, c.Handlers.Send.Len(); e != a {
+		t.Errorf("expect %d client handlers, got %d", e, a)
+	}
+
+	handlers.Send.Run(nil)
+	if !*firstCalled {
+		t.Errorf("expect first handler to of been called")
+	}
+	*firstCalled = false
+	if !*secondCalled {
+		t.Errorf("expect second handler to of been called")
+	}
+	*secondCalled = false
+	if *clientHandlerCalled {
+		t.Errorf("expect client handler to not of been called, but was")
+	}
+
+	c.Handlers.Send.Run(nil)
+	if !*firstCalled {
+		t.Errorf("expect client's first handler to of been called")
+	}
+	if !*secondCalled {
+		t.Errorf("expect client's second handler to of been called")
+	}
+	if !*clientHandlerCalled {
+		t.Errorf("expect client's client handler to of been called")
+	}
+
+}


### PR DESCRIPTION
Fixes the clients potentially polluting the passed in handler list with
the client's customizations. This change ensures every client always works
with a clean copy of the request handlers and it cannot pollute the handlers
back upstream.

This issue was exposed in ec2metadata client created by the default
credentials chain. The client would inject request handlers, which would
pollute the backing handler list array. This caused service clients that
were created from a session to not have their Send request handler in
their list. This issue was not present in service clients such as S3
which were created with a Session's ClientCoinfig because the
ClientConfig would of always created a copy of the session.

Fix #1184