### PR TITLE
example: Fixup example to have correct build tags and usage docs

### DIFF
--- a/example/aws/endpoints/customEndpoint/README.md
+++ b/example/aws/endpoints/customEndpoint/README.md
@@ -3,4 +3,12 @@ Custom Endpoint Example
 
 This example provides examples on how you can provide custom endpoints, and logic to how endpoints are resolved by the SDK.
 
-The example creates multiple clients with different endpoint configuraiton. From a custom endpoint resolver that wraps the defeault resolver so that any S3 service client created uses the custom endpoint, to how you can provide your own logic to a single service's endpoint resolving.
+The example creates multiple clients with different endpoint configuration. From a custom endpoint resolver that wraps the default resolver so that any Amazon S3 service client created uses the custom endpoint, to how you can provide your own logic to a single service's endpoint resolving.
+
+
+Usage
+---
+
+```sh
+go run -tags example customeEndpoint.go
+```

--- a/example/aws/endpoints/enumEndpoints/README.md
+++ b/example/aws/endpoints/enumEndpoints/README.md
@@ -1,7 +1,7 @@
 Enumerate Regions and Endpoints Example
 ===
 
-Demostrates how the SDK's endpoints can be enumerated over to discover regions, services, and endpoints defined by the SDK's Regions and Endpoints metadata.
+Demonstrates how the SDK's endpoints can be enumerated over to discover regions, services, and endpoints defined by the SDK's Regions and Endpoints metadata.
 
 Usage
 ---
@@ -10,7 +10,7 @@ The following parameters can be used to enumerate the SDK's partition metadata.
 
 Example:
 
-    go run enumEndpoints.go -p aws -services -r us-west-2
+    go run -tags example enumEndpoints.go -p aws -services -r us-west-2
 
 Output:
 

--- a/example/aws/request/withContext/README.md
+++ b/example/aws/request/withContext/README.md
@@ -10,4 +10,4 @@ Will default to shared config file, but can load from environment if provided.
 ## Usage:
 
     # Upload myfile.txt to myBucket/myKey. Must complete within 10 minutes or will fail
-    go run withContext.go -b mybucket -k myKey -d 10m < myfile.txt
+    go run -tags example withContext.go -b mybucket -k myKey -d 10m < myfile.txt

--- a/example/service/dynamodb/scanItems/README.md
+++ b/example/service/dynamodb/scanItems/README.md
@@ -29,7 +29,7 @@ In DynamoDB the structure of the item to be returned will be:
 
 ## Usage
 
-`scanItems.go -table "<table_name>" -region "<optional_region>"`
+`go run -tags example scanItems.go -table "<table_name>" -region "<optional_region>"`
 
 ## Output
 

--- a/example/service/dynamodb/unitTest/README.md
+++ b/example/service/dynamodb/unitTest/README.md
@@ -6,6 +6,7 @@ methods connecting to DynamoDB, or as `unitTest` demonstrates, create your own
 ## Test-compatible DynamoDB field
 If you use `*dynamodb.DynamoDB` as a field, you will be unable to unit test it,
 as documented in #88. Cast it instead as `dynamodbiface.DynamoDBAPI`:
+
 ```go
 type ItemGetter struct {
 		DynamoDB dynamodbiface.DynamoDBAPI
@@ -14,6 +15,7 @@ type ItemGetter struct {
 
 ## Querying actual DynamoDB
 You'll need an `*aws.Config` and `*session.Session` for these to work correctly:
+
 ```go
 // Setup
 var getter = new(ItemGetter)
@@ -30,6 +32,7 @@ Construct a `fakeDynamoDB` and add the necessary methods for each of those
 structs (custom ones for `ItemGetter` and [whatever methods you're using for
 DynamoDB](https://github.com/aws/aws-sdk-go/blob/master/service/dynamodb/dynamodbiface/interface.go)),
 and you're good to go!
+
 ```go
 type fakeDynamoDB struct {
 		dynamodbiface.DynamoDBAPI
@@ -42,7 +45,7 @@ getter.DynamoDB.GetItem(/* ... */)
 
 ## Output
 ```
-$ go test -cover
+$ go test -tags example -cover
 PASS
 coverage: 100.0% of statements
 ok		_/Users/shatil/workspace/aws-sdk-go/example/service/dynamodb/unitTest	0.008s

--- a/example/service/ec2/filterInstances/README.md
+++ b/example/service/ec2/filterInstances/README.md
@@ -1,11 +1,11 @@
 # Example
 
-filter_ec2_by_tag is an example using the AWS SDK for Go to list ec2 instaces that match provided tag name filter.
+This is an example using the AWS SDK for Go to list ec2 instances that match provided tag name filter.
 
 
 # Usage
 
-The example uses the the bucket name provided, and lists all object keys in a bucket.
+The example uses the bucket name provided, and lists all object keys in a bucket.
 
 ```sh
 go run -tags example filter_ec2_by_tag.go <name_filter>

--- a/example/service/s3/concatObjects/README.md
+++ b/example/service/s3/concatObjects/README.md
@@ -1,13 +1,13 @@
 # Example
 
-concatObjects is an example using the AWS SDK for Go to concatenate two objects together.
+This is an example using the AWS SDK for Go to concatenate two objects together.
 We use `UploadPartCopy` which uses an object for a part. Here in this example we have two parts, or in other words
 two objects that we want to concatenate together.
 
 
 # Usage
 
-The example uses the the bucket name provided, two keys for each object, and lastly the output key.
+The example uses the bucket name provided, two keys for each object, and lastly the output key.
 
 ```sh
 AWS_REGION=<region> go run -tags example concatenateObjects.go <bucket> <key for object 1> <key for object 2> <key for output>

--- a/example/service/s3/listObjects/README.md
+++ b/example/service/s3/listObjects/README.md
@@ -1,11 +1,11 @@
 # Example
 
-listObjects is an example using the AWS SDK for Go to list objects' key in a S3 bucket.
+This is an example using the AWS SDK for Go to list objects' key in a S3 bucket.
 
 
 # Usage
 
-The example uses the the bucket name provided, and lists all object keys in a bucket.
+The example uses the bucket name provided, and lists all object keys in a bucket.
 
 ```sh
 go run -tags example listObjects.go <bucket>

--- a/example/service/s3/listObjectsConcurrently/README.md
+++ b/example/service/s3/listObjectsConcurrently/README.md
@@ -1,6 +1,6 @@
 ## Example
 
-listObjectsConcurrentlv is an example using the AWS SDK for Go concurrently to list the encrypted objects in the S3 buckets owned by an account.
+This is an example using the AWS SDK for Go concurrently to list the encrypted objects in the S3 buckets owned by an account.
 
 ## Usage
 

--- a/example/service/s3/putObjectAcl/putObjectAcl.go
+++ b/example/service/s3/putObjectAcl/putObjectAcl.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (

--- a/example/service/sqs/mockingClientsForTests/README.md
+++ b/example/service/sqs/mockingClientsForTests/README.md
@@ -1,9 +1,9 @@
 # Example
 
-This example shows how the SDK's API interfaces can be used by your code intead of the concrete service client type directly. Using this pattern allows you to mock out your code's usage of the SDK's service client for testing.
+This example shows how the SDK's API interfaces can be used by your code instead of the concrete service client type directly. Using this pattern allows you to mock out your code's usage of the SDK's service client for testing.
 
 # Usage
 
 Use the `go test` tool to verify the `Queue` type's `GetMessages` function correctly unmarshals the SQS message responses.
 
-`go test ./`
+`go test -tags example ifaceExample.go`

--- a/example/service/sqs/mockingClientsForTests/ifaceExample.go
+++ b/example/service/sqs/mockingClientsForTests/ifaceExample.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (

--- a/example/service/sqs/mockingClientsForTests/ifaceExample_test.go
+++ b/example/service/sqs/mockingClientsForTests/ifaceExample_test.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (


### PR DESCRIPTION
Corrects various example documentation instructions and typos. Also ensures all examples have the `example` build tag, and Usage examples are correct.