### PR TITLE
service/s3: Add utilities to make getting a bucket's region easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ integration: get-deps-tests integ-custom smoke-tests performance
 integ-custom:
 	go test -tags "integration" ./awstesting/integration/customizations/...
 
+cleanup-integ:
+	go run -tags "integration" ./awstesting/cmd/bucket_cleanup/main.go "aws-sdk-go-integration"
+
 smoke-tests: get-deps-tests
 	gucumber -go-tags "integration" ./awstesting/integration/smoke
 

--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -27,7 +27,7 @@ type lener interface {
 // or will use the HTTPRequest.Header's "Content-Length" if defined. If unable
 // to determine request body length and no "Content-Length" was specified it will panic.
 //
-// The Content-Length will only be aded to the request if the length of the body
+// The Content-Length will only be added to the request if the length of the body
 // is greater than 0. If the body is empty or the current `Content-Length`
 // header is <= 0, the header will also be stripped.
 var BuildContentLengthHandler = request.NamedHandler{Name: "core.BuildContentLengthHandler", Fn: func(r *request.Request) {
@@ -71,8 +71,8 @@ var reStatusCode = regexp.MustCompile(`^(\d{3})`)
 
 // ValidateReqSigHandler is a request handler to ensure that the request's
 // signature doesn't expire before it is sent. This can happen when a request
-// is built and signed signficantly before it is sent. Or significant delays
-// occur whne retrying requests that would cause the signature to expire.
+// is built and signed significantly before it is sent. Or significant delays
+// occur when retrying requests that would cause the signature to expire.
 var ValidateReqSigHandler = request.NamedHandler{
 	Name: "core.ValidateReqSigHandler",
 	Fn: func(r *request.Request) {
@@ -98,54 +98,79 @@ var ValidateReqSigHandler = request.NamedHandler{
 }
 
 // SendHandler is a request handler to send service request using HTTP client.
-var SendHandler = request.NamedHandler{Name: "core.SendHandler", Fn: func(r *request.Request) {
-	var err error
-	r.HTTPResponse, err = r.Config.HTTPClient.Do(r.HTTPRequest)
-	if err != nil {
-		// Prevent leaking if an HTTPResponse was returned. Clean up
-		// the body.
-		if r.HTTPResponse != nil {
-			r.HTTPResponse.Body.Close()
+var SendHandler = request.NamedHandler{
+	Name: "core.SendHandler",
+	Fn: func(r *request.Request) {
+		sender := sendFollowRedirects
+		if r.DisableFollowRedirects {
+			sender = sendWithoutFollowRedirects
 		}
-		// Capture the case where url.Error is returned for error processing
-		// response. e.g. 301 without location header comes back as string
-		// error and r.HTTPResponse is nil. Other url redirect errors will
-		// comeback in a similar method.
-		if e, ok := err.(*url.Error); ok && e.Err != nil {
-			if s := reStatusCode.FindStringSubmatch(e.Err.Error()); s != nil {
-				code, _ := strconv.ParseInt(s[1], 10, 64)
-				r.HTTPResponse = &http.Response{
-					StatusCode: int(code),
-					Status:     http.StatusText(int(code)),
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
-				}
-				return
-			}
+
+		var err error
+		r.HTTPResponse, err = sender(r)
+		if err != nil {
+			handleSendError(r, err)
 		}
-		if r.HTTPResponse == nil {
-			// Add a dummy request response object to ensure the HTTPResponse
-			// value is consistent.
+	},
+}
+
+func sendFollowRedirects(r *request.Request) (*http.Response, error) {
+	return r.Config.HTTPClient.Do(r.HTTPRequest)
+}
+
+func sendWithoutFollowRedirects(r *request.Request) (*http.Response, error) {
+	transport := r.Config.HTTPClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	return transport.RoundTrip(r.HTTPRequest)
+}
+
+func handleSendError(r *request.Request, err error) {
+	// Prevent leaking if an HTTPResponse was returned. Clean up
+	// the body.
+	if r.HTTPResponse != nil {
+		r.HTTPResponse.Body.Close()
+	}
+	// Capture the case where url.Error is returned for error processing
+	// response. e.g. 301 without location header comes back as string
+	// error and r.HTTPResponse is nil. Other URL redirect errors will
+	// comeback in a similar method.
+	if e, ok := err.(*url.Error); ok && e.Err != nil {
+		if s := reStatusCode.FindStringSubmatch(e.Err.Error()); s != nil {
+			code, _ := strconv.ParseInt(s[1], 10, 64)
 			r.HTTPResponse = &http.Response{
-				StatusCode: int(0),
-				Status:     http.StatusText(int(0)),
+				StatusCode: int(code),
+				Status:     http.StatusText(int(code)),
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
 			}
-		}
-		// Catch all other request errors.
-		r.Error = awserr.New("RequestError", "send request failed", err)
-		r.Retryable = aws.Bool(true) // network errors are retryable
-
-		// Override the error with a context canceled error, if that was canceled.
-		ctx := r.Context()
-		select {
-		case <-ctx.Done():
-			r.Error = awserr.New(request.CanceledErrorCode,
-				"request context canceled", ctx.Err())
-			r.Retryable = aws.Bool(false)
-		default:
+			return
 		}
 	}
-}}
+	if r.HTTPResponse == nil {
+		// Add a dummy request response object to ensure the HTTPResponse
+		// value is consistent.
+		r.HTTPResponse = &http.Response{
+			StatusCode: int(0),
+			Status:     http.StatusText(int(0)),
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+		}
+	}
+	// Catch all other request errors.
+	r.Error = awserr.New("RequestError", "send request failed", err)
+	r.Retryable = aws.Bool(true) // network errors are retryable
+
+	// Override the error with a context canceled error, if that was canceled.
+	ctx := r.Context()
+	select {
+	case <-ctx.Done():
+		r.Error = awserr.New(request.CanceledErrorCode,
+			"request context canceled", ctx.Err())
+		r.Retryable = aws.Bool(false)
+	default:
+	}
+}
 
 // ValidateResponseHandler is a request handler to validate service response.
 var ValidateResponseHandler = request.NamedHandler{Name: "core.ValidateResponseHandler", Fn: func(r *request.Request) {

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -41,23 +41,24 @@ type Request struct {
 	Handlers   Handlers
 
 	Retryer
-	Time             time.Time
-	ExpireTime       time.Duration
-	Operation        *Operation
-	HTTPRequest      *http.Request
-	HTTPResponse     *http.Response
-	Body             io.ReadSeeker
-	BodyStart        int64 // offset from beginning of Body that the request body starts
-	Params           interface{}
-	Error            error
-	Data             interface{}
-	RequestID        string
-	RetryCount       int
-	Retryable        *bool
-	RetryDelay       time.Duration
-	NotHoist         bool
-	SignedHeaderVals http.Header
-	LastSignedAt     time.Time
+	Time                   time.Time
+	ExpireTime             time.Duration
+	Operation              *Operation
+	HTTPRequest            *http.Request
+	HTTPResponse           *http.Response
+	Body                   io.ReadSeeker
+	BodyStart              int64 // offset from beginning of Body that the request body starts
+	Params                 interface{}
+	Error                  error
+	Data                   interface{}
+	RequestID              string
+	RetryCount             int
+	Retryable              *bool
+	RetryDelay             time.Duration
+	NotHoist               bool
+	SignedHeaderVals       http.Header
+	LastSignedAt           time.Time
+	DisableFollowRedirects bool
 
 	context aws.Context
 

--- a/awstesting/cmd/bucket_cleanup/main.go
+++ b/awstesting/cmd/bucket_cleanup/main.go
@@ -1,0 +1,94 @@
+// +build integration
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// Searches the buckets of an account that match the prefix, and deletes
+// those buckets, and all objects within. Before deleting will prompt user
+// to confirm bucket should be deleted. Positive confirmation is required.
+//
+// Usage:
+//    go run deleteBuckets.go <bucketPrefix>
+func main() {
+	sess := session.Must(session.NewSession())
+
+	svc := s3.New(sess)
+	buckets, err := svc.ListBuckets(&s3.ListBucketsInput{})
+	if err != nil {
+		panic(fmt.Sprintf("failed to list buckets, %v", err))
+	}
+
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "bucket prefix required")
+		os.Exit(1)
+	}
+	bucketPrefix := os.Args[1]
+
+	var failed bool
+	for _, b := range buckets.Buckets {
+		bucket := aws.StringValue(b.Name)
+
+		if !strings.HasPrefix(bucket, bucketPrefix) {
+			continue
+		}
+
+		fmt.Printf("Delete bucket %q? [y/N]: ", bucket)
+		var v string
+		if _, err := fmt.Scanln(&v); err != nil || !(v == "Y" || v == "y") {
+			fmt.Println("\tSkipping")
+			continue
+		}
+
+		fmt.Println("\tDeleting")
+		if err := deleteBucket(svc, bucket); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to delete bucket %q, %v", bucket, err)
+			failed = true
+		}
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+}
+
+func deleteBucket(svc *s3.S3, bucket string) error {
+	bucketName := &bucket
+
+	objs, err := svc.ListObjects(&s3.ListObjectsInput{Bucket: bucketName})
+	if err != nil {
+		return fmt.Errorf("failed to list bucket %q objects, %v", bucketName, err)
+	}
+
+	for _, o := range objs.Contents {
+		svc.DeleteObject(&s3.DeleteObjectInput{Bucket: bucketName, Key: o.Key})
+	}
+
+	uploads, err := svc.ListMultipartUploads(&s3.ListMultipartUploadsInput{Bucket: bucketName})
+	if err != nil {
+		return fmt.Errorf("failed to list bucket %q multipart objects, %v", bucketName, err)
+	}
+
+	for _, u := range uploads.Uploads {
+		svc.AbortMultipartUpload(&s3.AbortMultipartUploadInput{
+			Bucket:   bucketName,
+			Key:      u.Key,
+			UploadId: u.UploadId,
+		})
+	}
+
+	_, err = svc.DeleteBucket(&s3.DeleteBucketInput{Bucket: bucketName})
+	if err != nil {
+		return fmt.Errorf("failed to delete bucket %q, %v", bucketName, err)
+	}
+
+	return nil
+}

--- a/awstesting/integration/customizations/s3/s3manager/bucket_region_test.go
+++ b/awstesting/integration/customizations/s3/s3manager/bucket_region_test.go
@@ -1,0 +1,27 @@
+// +build integration
+
+package s3manager
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting/integration"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+func TestGetBucketRegion(t *testing.T) {
+	expectRegion := aws.StringValue(integration.Session.Config.Region)
+
+	ctx := aws.BackgroundContext()
+	region, err := s3manager.GetBucketRegion(ctx, integration.Session,
+		aws.StringValue(bucketName), expectRegion)
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if e, a := expectRegion, region; e != a {
+		t.Errorf("expect %s bucket region, got %s", e, a)
+	}
+}

--- a/service/s3/bucket_location.go
+++ b/service/s3/bucket_location.go
@@ -12,6 +12,69 @@ import (
 
 var reBucketLocation = regexp.MustCompile(`>([^<>]+)<\/Location`)
 
+// NormalizeBucketLocation is a utility function which will update the
+// passed in value to always be a region ID. Generally this would be used
+// with GetBucketLocation API operation.
+//
+// Replaces empty string with "us-east-1", and "EU" with "eu-west-1".
+//
+// See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
+// for more information on the values that can be returned.
+func NormalizeBucketLocation(loc string) string {
+	switch loc {
+	case "":
+		loc = "us-east-1"
+	case "EU":
+		loc = "eu-west-1"
+	}
+
+	return loc
+}
+
+// NormalizeBucketLocationHandler is a request handler which will update the
+// GetBucketLocation's result LocationConstraint value to always be a region ID.
+//
+// Replaces empty string with "us-east-1", and "EU" with "eu-west-1".
+//
+// See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
+// for more information on the values that can be returned.
+//
+//     req, result := svc.GetBucketLocationRequest(&s3.GetBucketLocationInput{
+//         Bucket: aws.String(bucket),
+//     })
+//     req.Handlers.Unmarshal.PushBackNamed(NormalizeBucketLocationHandler)
+//     err := req.Send()
+var NormalizeBucketLocationHandler = request.NamedHandler{
+	Name: "awssdk.s3.NormalizeBucketLocation",
+	Fn: func(req *request.Request) {
+		if req.Error != nil {
+			return
+		}
+
+		out := req.Data.(*GetBucketLocationOutput)
+		loc := NormalizeBucketLocation(aws.StringValue(out.LocationConstraint))
+		out.LocationConstraint = aws.String(loc)
+	},
+}
+
+// WithNormalizeBucketLocation is a request option which will update the
+// GetBucketLocation's result LocationConstraint value to always be a region ID.
+//
+// Replaces empty string with "us-east-1", and "EU" with "eu-west-1".
+//
+// See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
+// for more information on the values that can be returned.
+//
+//     result, err := svc.GetBucketLocationWithContext(ctx,
+//         &s3.GetBucketLocationInput{
+//             Bucket: aws.String(bucket),
+//         },
+//         WithNormalizeBucketLocation,
+//     )
+func WithNormalizeBucketLocation(r *request.Request) {
+	r.Handlers.Unmarshal.PushBackNamed(NormalizeBucketLocationHandler)
+}
+
 func buildGetBucketLocation(r *request.Request) {
 	if r.DataFilled() {
 		out := r.Data.(*GetBucketLocationOutput)
@@ -24,7 +87,7 @@ func buildGetBucketLocation(r *request.Request) {
 		match := reBucketLocation.FindSubmatch(b)
 		if len(match) > 1 {
 			loc := string(match[1])
-			out.LocationConstraint = &loc
+			out.LocationConstraint = aws.String(loc)
 		}
 	}
 }

--- a/service/s3/bucket_location_test.go
+++ b/service/s3/bucket_location_test.go
@@ -34,9 +34,57 @@ func TestGetBucketLocation(t *testing.T) {
 		resp, err := s.GetBucketLocation(&s3.GetBucketLocationInput{Bucket: aws.String("bucket")})
 		assert.NoError(t, err)
 		if test.loc == "" {
-			assert.Nil(t, resp.LocationConstraint)
+			if v := resp.LocationConstraint; v != nil {
+				t.Errorf("expect location constraint to be nil, got %s", *v)
+			}
 		} else {
-			assert.Equal(t, test.loc, *resp.LocationConstraint)
+			if e, a := test.loc, *resp.LocationConstraint; e != a {
+				t.Errorf("expect %s location constraint, got %v", e, a)
+			}
+		}
+	}
+}
+
+func TestNormalizeBucketLocation(t *testing.T) {
+	cases := []struct {
+		In, Out string
+	}{
+		{"", "us-east-1"},
+		{"EU", "eu-west-1"},
+		{"us-east-1", "us-east-1"},
+		{"something", "something"},
+	}
+
+	for i, c := range cases {
+		actual := s3.NormalizeBucketLocation(c.In)
+		if e, a := c.Out, actual; e != a {
+			t.Errorf("%d, expect %s bucket location, got %s", i, e, a)
+		}
+	}
+}
+
+func TestWithNormalizeBucketLocation(t *testing.T) {
+	req := &request.Request{}
+	req.ApplyOptions(s3.WithNormalizeBucketLocation)
+
+	cases := []struct {
+		In, Out string
+	}{
+		{"", "us-east-1"},
+		{"EU", "eu-west-1"},
+		{"us-east-1", "us-east-1"},
+		{"something", "something"},
+	}
+
+	for i, c := range cases {
+		req.Data = &s3.GetBucketLocationOutput{
+			LocationConstraint: aws.String(c.In),
+		}
+		req.Handlers.Unmarshal.Run(req)
+
+		v := req.Data.(*s3.GetBucketLocationOutput).LocationConstraint
+		if e, a := c.Out, aws.StringValue(v); e != a {
+			t.Errorf("%d, expect %s bucket location, got %s", i, e, a)
 		}
 	}
 }
@@ -47,11 +95,18 @@ func TestPopulateLocationConstraint(t *testing.T) {
 		Bucket: aws.String("bucket"),
 	}
 	req, _ := s.CreateBucketRequest(in)
-	err := req.Build()
-	assert.NoError(t, err)
+	if err := req.Build(); err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
 	v, _ := awsutil.ValuesAtPath(req.Params, "CreateBucketConfiguration.LocationConstraint")
-	assert.Equal(t, "mock-region", *(v[0].(*string)))
-	assert.Nil(t, in.CreateBucketConfiguration) // don't modify original params
+	if e, a := "mock-region", *(v[0].(*string)); e != a {
+		t.Errorf("expect %s location constraint, got %s", e, a)
+	}
+	if v := in.CreateBucketConfiguration; v != nil {
+		// don't modify original params
+		t.Errorf("expect create bucket Configuration to be nil, got %s", *v)
+	}
 }
 
 func TestNoPopulateLocationConstraintIfProvided(t *testing.T) {
@@ -60,10 +115,13 @@ func TestNoPopulateLocationConstraintIfProvided(t *testing.T) {
 		Bucket: aws.String("bucket"),
 		CreateBucketConfiguration: &s3.CreateBucketConfiguration{},
 	})
-	err := req.Build()
-	assert.NoError(t, err)
+	if err := req.Build(); err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 	v, _ := awsutil.ValuesAtPath(req.Params, "CreateBucketConfiguration.LocationConstraint")
-	assert.Equal(t, 0, len(v))
+	if v := len(v); v != 0 {
+		t.Errorf("expect no values, got %d", v)
+	}
 }
 
 func TestNoPopulateLocationConstraintIfClassic(t *testing.T) {
@@ -71,8 +129,11 @@ func TestNoPopulateLocationConstraintIfClassic(t *testing.T) {
 	req, _ := s.CreateBucketRequest(&s3.CreateBucketInput{
 		Bucket: aws.String("bucket"),
 	})
-	err := req.Build()
-	assert.NoError(t, err)
+	if err := req.Build(); err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 	v, _ := awsutil.ValuesAtPath(req.Params, "CreateBucketConfiguration.LocationConstraint")
-	assert.Equal(t, 0, len(v))
+	if v := len(v); v != 0 {
+		t.Errorf("expect no values, got %d", v)
+	}
 }

--- a/service/s3/s3manager/bucket_region.go
+++ b/service/s3/s3manager/bucket_region.go
@@ -1,0 +1,83 @@
+package s3manager
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+// GetBucketRegion will attempt to get the region for a bucket using the
+// regionHint to determine which AWS partition to perform the query on.
+//
+// The request will not be signed, and will not use your AWS credentials.
+//
+// A "NotFound" error code will be returned if the bucket does not exist in
+// the AWS partition the regionHint belongs to.
+//
+// For example to get the region of a bucket which exists in "eu-central-1"
+// you could provide a region hint of "us-west-2".
+//
+//    sess := session.Must(session.NewSession())
+//
+//    bucket := "my-bucket"
+//    region, err := s3manager.GetBucketRegion(ctx, sess, bucket, "us-west-2")
+//    if err != nil {
+//        if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
+//             fmt.Fprintf(os.Stderr, "unable to find bucket %s's region not found\n", bucket)
+//        }
+//        return err
+//    }
+//    fmt.Printf("Bucket %s is in %s region\n", bucket, region)
+//
+func GetBucketRegion(ctx aws.Context, c client.ConfigProvider, bucket, regionHint string, opts ...request.Option) (string, error) {
+	svc := s3.New(c, &aws.Config{
+		Region: aws.String(regionHint),
+	})
+	return GetBucketRegionWithClient(ctx, svc, bucket, opts...)
+}
+
+const bucketRegionHeader = "X-Amz-Bucket-Region"
+
+// GetBucketRegionWithClient is the same as GetBucketRegion with the exception
+// that it takes a S3 service client instead of a Session. The regionHint is
+// derived from the region the S3 service client was created in.
+//
+// See GetBucketRegion for more information.
+func GetBucketRegionWithClient(ctx aws.Context, svc s3iface.S3API, bucket string, opts ...request.Option) (string, error) {
+	req, _ := svc.HeadBucketRequest(&s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	req.Config.S3ForcePathStyle = aws.Bool(true)
+	req.Config.Credentials = credentials.AnonymousCredentials
+	req.SetContext(ctx)
+
+	// Disable HTTP redirects to prevent an invalid 301 from eating the response
+	// because Go's HTTP client will fail, and drop the response if an 301 is
+	// received without a location header. S3 will return a 301 without the
+	// location header for HeadObject API calls.
+	req.DisableFollowRedirects = true
+
+	var bucketRegion string
+	req.Handlers.Send.PushBack(func(r *request.Request) {
+		bucketRegion = r.HTTPResponse.Header.Get(bucketRegionHeader)
+		if len(bucketRegion) == 0 {
+			return
+		}
+		r.HTTPResponse.StatusCode = 200
+		r.HTTPResponse.Status = "OK"
+		r.Error = nil
+	})
+
+	req.ApplyOptions(opts...)
+
+	if err := req.Send(); err != nil {
+		return "", err
+	}
+
+	bucketRegion = s3.NormalizeBucketLocation(bucketRegion)
+
+	return bucketRegion, nil
+}

--- a/service/s3/s3manager/bucket_region_test.go
+++ b/service/s3/s3manager/bucket_region_test.go
@@ -1,0 +1,90 @@
+package s3manager
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func testSetupGetBucketRegionServer(region string, statusCode int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(bucketRegionHeader, region)
+		w.WriteHeader(statusCode)
+	}))
+}
+
+var testGetBucketRegionCases = []struct {
+	RespRegion string
+	StatusCode int
+}{
+	{"bucket-region", 301},
+	{"bucket-region", 403},
+	{"bucket-region", 200},
+}
+
+func TestGetBucketRegion_Exists(t *testing.T) {
+	for i, c := range testGetBucketRegionCases {
+		server := testSetupGetBucketRegionServer(c.RespRegion, c.StatusCode)
+
+		sess := unit.Session.Copy()
+		sess.Config.Endpoint = aws.String(server.URL)
+		sess.Config.DisableSSL = aws.Bool(true)
+
+		ctx := aws.BackgroundContext()
+		region, err := GetBucketRegion(ctx, sess, "bucket", "region")
+		if err != nil {
+			t.Fatalf("%d, expect no error, got %v", i, err)
+		}
+		if e, a := c.RespRegion, region; e != a {
+			t.Errorf("%d, expect %q region, got %q", i, e, a)
+		}
+	}
+}
+
+func TestGetBucketRegion_NotExists(t *testing.T) {
+	server := testSetupGetBucketRegionServer("ignore-region", 404)
+
+	sess := unit.Session.Copy()
+	sess.Config.Endpoint = aws.String(server.URL)
+	sess.Config.DisableSSL = aws.Bool(true)
+
+	ctx := aws.BackgroundContext()
+	region, err := GetBucketRegion(ctx, sess, "bucket", "region")
+	if err == nil {
+		t.Fatalf("expect error, but did not get one")
+	}
+	aerr := err.(awserr.Error)
+	if e, a := "NotFound", aerr.Code(); e != a {
+		t.Errorf("expect %s error code, got %s", e, a)
+	}
+	if len(region) != 0 {
+		t.Errorf("expect region not to be set, got %q", region)
+	}
+}
+
+func TestGetBucketRegionWithClient(t *testing.T) {
+	for i, c := range testGetBucketRegionCases {
+		server := testSetupGetBucketRegionServer(c.RespRegion, c.StatusCode)
+
+		svc := s3.New(unit.Session, &aws.Config{
+			Region:     aws.String("region"),
+			Endpoint:   aws.String(server.URL),
+			DisableSSL: aws.Bool(true),
+		})
+
+		ctx := aws.BackgroundContext()
+
+		region, err := GetBucketRegionWithClient(ctx, svc, "bucket")
+		if err != nil {
+			t.Fatalf("%d, expect no error, got %v", i, err)
+		}
+		if e, a := c.RespRegion, region; e != a {
+			t.Errorf("%d, expect %q region, got %q", i, e, a)
+		}
+	}
+}

--- a/service/s3/s3manager/bucket_region_test.go
+++ b/service/s3/s3manager/bucket_region_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-func testSetupGetBucketRegionServer(region string, statusCode int) *httptest.Server {
+func testSetupGetBucketRegionServer(region string, statusCode int, incHeader bool) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(bucketRegionHeader, region)
+		if incHeader {
+			w.Header().Set(bucketRegionHeader, region)
+		}
 		w.WriteHeader(statusCode)
 	}))
 }
@@ -29,7 +31,7 @@ var testGetBucketRegionCases = []struct {
 
 func TestGetBucketRegion_Exists(t *testing.T) {
 	for i, c := range testGetBucketRegionCases {
-		server := testSetupGetBucketRegionServer(c.RespRegion, c.StatusCode)
+		server := testSetupGetBucketRegionServer(c.RespRegion, c.StatusCode, true)
 
 		sess := unit.Session.Copy()
 		sess.Config.Endpoint = aws.String(server.URL)
@@ -47,7 +49,7 @@ func TestGetBucketRegion_Exists(t *testing.T) {
 }
 
 func TestGetBucketRegion_NotExists(t *testing.T) {
-	server := testSetupGetBucketRegionServer("ignore-region", 404)
+	server := testSetupGetBucketRegionServer("ignore-region", 404, false)
 
 	sess := unit.Session.Copy()
 	sess.Config.Endpoint = aws.String(server.URL)
@@ -69,7 +71,7 @@ func TestGetBucketRegion_NotExists(t *testing.T) {
 
 func TestGetBucketRegionWithClient(t *testing.T) {
 	for i, c := range testGetBucketRegionCases {
-		server := testSetupGetBucketRegionServer(c.RespRegion, c.StatusCode)
+		server := testSetupGetBucketRegionServer(c.RespRegion, c.StatusCode, true)
 
 		svc := s3.New(unit.Session, &aws.Config{
 			Region:     aws.String("region"),


### PR DESCRIPTION
Adds two features which make it easier to get a bucket's region, `s3.NormalizeBucketLocation` and `s3manager.GetBucketRegion`.

* `s3.NormalizeBucketLocation` function will perform logic to ensure that the value returned by `GetBucketLocation` API operation always is a region ID. This adjusts the [documented behavior](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html), where empty string and `EU` values could be returned instead of region IDs. This is available as a standalone function, request option and request handler.
  * `s3.WithNormalizeBucketLocation` - request option to always normalize `GetBucketLocation` response. Should be applied using the [`GetBucketLocationWithContext`](http://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.GetBucketLocationWithContext) API operation method, or [`Request.ApplyOptions`](http://docs.aws.amazon.com/sdk-for-go/api/aws/request/#Request.ApplyOptions).
  * `s3.NormalizeBucketLocationHandler` request handler that can be added to the `Unmarshal` request handler list.
  * `s3.NormalizeBucketLocation` - standalone function to ensure a region ID is always returned.

*  `s3manager.GetBucketRegion` - Performs a anonymous HEAD request on the bucket to determine the region the bucket is in. Uses a region `hint` to determine which AWS partition to look in. e.g. [AWS, AWS China, and AWS Gov Cloud](http://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/#pkg-constants).

