### PR TITLE
aws/corehandlers: Ensure that ShouldRetry is being utlized

### DIFF
--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -54,6 +54,12 @@ func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 
 // ShouldRetry returns true if the request should be retried.
 func (d DefaultRetryer) ShouldRetry(r *request.Request) bool {
+	// If one of the other handlers already set the retry state
+	// we don't want to override it based on the service's state
+	if r.Retryable != nil {
+		return *r.Retryable
+	}
+
 	if r.HTTPResponse.StatusCode >= 500 {
 		return true
 	}

--- a/aws/config.go
+++ b/aws/config.go
@@ -53,6 +53,12 @@ type Config struct {
 	// to use based on region.
 	EndpointResolver endpoints.Resolver
 
+	// EnforceShouldRetryCheck is used in the AfterRetryHandler to always call
+	// ShouldRetry. If this is set and ShouldRetry is called, then the request's
+	// Retryable field can be either nil or set. Proper handling of the Retryable
+	// field is important when setting this field.
+	EnforceShouldRetryCheck *bool
+
 	// The region to send requests to. This parameter is required and must
 	// be configured globally or on a per-client basis unless otherwise
 	// noted. A full list of regions is found in the "Regions and Endpoints"
@@ -442,6 +448,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.DisableRestProtocolURICleaning != nil {
 		dst.DisableRestProtocolURICleaning = other.DisableRestProtocolURICleaning
+	}
+
+	if other.EnforceShouldRetryCheck != nil {
+		dst.EnforceShouldRetryCheck = other.EnforceShouldRetryCheck
 	}
 }
 

--- a/aws/config.go
+++ b/aws/config.go
@@ -54,9 +54,10 @@ type Config struct {
 	EndpointResolver endpoints.Resolver
 
 	// EnforceShouldRetryCheck is used in the AfterRetryHandler to always call
-	// ShouldRetry. If this is set and ShouldRetry is called, then the request's
-	// Retryable field can be either nil or set. Proper handling of the Retryable
-	// field is important when setting this field.
+	// ShouldRetry regardless of whether or not if request.Retryable is set.
+	// This will utilize ShouldRetry method of custom retryers. If EnforceShouldRetryCheck
+	// is not set, then ShouldRetry will only be called if request.Retryable is nil.
+	// Proper handling of the request.Retryable field is important when setting this field.
 	EnforceShouldRetryCheck *bool
 
 	// The region to send requests to. This parameter is required and must

--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -160,7 +160,7 @@ var ValidateResponseHandler = request.NamedHandler{Name: "core.ValidateResponseH
 var AfterRetryHandler = request.NamedHandler{Name: "core.AfterRetryHandler", Fn: func(r *request.Request) {
 	// If one of the other handlers already set the retry state
 	// we don't want to override it based on the service's state
-	if r.Retryable == nil {
+	if r.Retryable == nil || aws.BoolValue(r.Config.EnforceShouldRetryCheck) {
 		r.Retryable = aws.Bool(r.ShouldRetry(r))
 	}
 


### PR DESCRIPTION
Fixes #1203 

Prior to this fix, requests that experience network issues would not call `ShouldRetry`. However, now we will call `ShouldRetry` if `EnforceShouldRetryCheck` is set. Additionally, the default retryer will check to see if the `Retryable` field is set. If it is, we will return that. 