### PR TITLE
service/s3: Fix HeadObject's incorrect documented error codes

### DIFF
--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -104,6 +104,25 @@ func s3Customizations(a *API) {
 			}
 		}
 	}
+	s3CustRemoveHeadObjectModeledErrors(a)
+}
+
+// S3 HeadObject API call incorrect models NoSuchKey as valid
+// error code that can be returned. This operation does not
+// return error codes, all error codes are derived from HTTP
+// status codes.
+//
+// aws/aws-sdk-go#1208
+func s3CustRemoveHeadObjectModeledErrors(a *API) {
+	op, ok := a.Operations["HeadObject"]
+	if !ok {
+		return
+	}
+	op.Documentation += `
+//
+// See http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#RESTErrorResponses
+// for more information on returned errors.`
+	op.ErrorRefs = []ShapeRef{}
 }
 
 // cloudfrontCustomizations customized the API generation to replace values

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -3223,17 +3223,15 @@ func (c *S3) HeadObjectRequest(input *HeadObjectInput) (req *request.Request, ou
 // object itself. This operation is useful if you're only interested in an object's
 // metadata. To use HEAD, you must have READ access to the object.
 //
+// See http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#RESTErrorResponses
+// for more information on returned errors.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
 //
 // See the AWS API reference guide for Amazon Simple Storage Service's
 // API operation HeadObject for usage and error information.
-//
-// Returned Error Codes:
-//   * ErrCodeNoSuchKey "NoSuchKey"
-//   The specified key does not exist.
-//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadObject
 func (c *S3) HeadObject(input *HeadObjectInput) (*HeadObjectOutput, error) {
 	req, out := c.HeadObjectRequest(input)


### PR DESCRIPTION
The HeadObject's model incorrectly states that the operation can return
the `NoSuchKey` error code.

Fix #1208