### PR TITLE
aws/endpoints: Add utilities improving endpoints lookup

### DIFF
--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -142,17 +142,20 @@ const (
 // DefaultResolver returns an Endpoint resolver that will be able
 // to resolve endpoints for: AWS Standard, AWS China, and AWS GovCloud (US).
 //
-// Casting the return value of this func to a EnumPartitions will
-// allow you to get a list of the partitions in the order the endpoints
-// will be resolved in.
+// Use DefaultPartitions() to get the list of the default partitions.
+func DefaultResolver() Resolver {
+	return defaultPartitions
+}
+
+// DefaultPartitions returns a list of the partitions the SDK  is bundled
+// with. The available partitions are: AWS Standard, AWS China, and AWS GovCloud (US).
 //
-//    resolver := endpoints.DefaultResolver()
-//    partitions := resolver.(endpoints.EnumPartitions).Partitions()
+//    partitions := endpoints.DefaultPartitions
 //    for _, p := range partitions {
 //        // ... inspect partitions
 //    }
-func DefaultResolver() Resolver {
-	return defaultPartitions
+func DefaultPartitions() []Partition {
+	return defaultPartitions.Partitions()
 }
 
 var defaultPartitions = partitions{

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -147,7 +147,7 @@ func DefaultResolver() Resolver {
 	return defaultPartitions
 }
 
-// DefaultPartitions returns a list of the partitions the SDK  is bundled
+// DefaultPartitions returns a list of the partitions the SDK is bundled
 // with. The available partitions are: AWS Standard, AWS China, and AWS GovCloud (US).
 //
 //    partitions := endpoints.DefaultPartitions

--- a/aws/endpoints/endpoints.go
+++ b/aws/endpoints/endpoints.go
@@ -125,28 +125,31 @@ type EnumPartitions interface {
 }
 
 // RegionsForService returns a map of regions for the partition and service.
-// If either the partition or service does not exist an empty list will be
-// returned.
+// If either the partition or service does not exist false will be returned
+// as the second parameter.
 //
 // This example shows how  to get the regions for DynamoDB in the AWS partition.
 //    rs := RegionsForService(endpoints.DefaultPartitions(), endpoints.AwsPartitionID, endpoints.DynamoDBServiceID)
 //
 // This is equivalent to using the partition directly.
 //    rs := endpoints.AwsPartition().Services()[endpoints.DynamoDBServiceID].Regions()
-func RegionsForService(ps []Partition, partitionID, serviceID string) map[string]Region {
+func RegionsForService(ps []Partition, partitionID, serviceID string) (map[string]Region, bool) {
 	for _, p := range ps {
 		if p.ID() != partitionID {
 			continue
+		}
+		if _, ok := p.p.Services[serviceID]; !ok {
+			break
 		}
 
 		s := Service{
 			id: serviceID,
 			p:  p.p,
 		}
-		return s.Regions()
+		return s.Regions(), true
 	}
 
-	return map[string]Region{}
+	return map[string]Region{}, false
 }
 
 // PartitionForRegion returns the first partition which includes the region

--- a/aws/endpoints/endpoints.go
+++ b/aws/endpoints/endpoints.go
@@ -124,6 +124,46 @@ type EnumPartitions interface {
 	Partitions() []Partition
 }
 
+// RegionsForService returns a map of regions for the partition and service.
+// If either the partition or service does not exist an empty list will be
+// returned.
+//
+// This example shows how  to get the regions for DynamoDB in the AWS partition.
+//    rs := RegionsForService(endpoints.DefaultPartitions(), endpoints.AwsPartitionID, endpoints.DynamoDBServiceID)
+//
+// This is equivalent to using the partition directly.
+//    rs := endpoints.AwsPartition().Services()[endpoints.DynamoDBServiceID].Regions()
+func RegionsForService(ps []Partition, partitionID, serviceID string) map[string]Region {
+	for _, p := range ps {
+		if p.ID() != partitionID {
+			continue
+		}
+
+		s := Service{
+			id: serviceID,
+			p:  p.p,
+		}
+		return s.Regions()
+	}
+
+	return map[string]Region{}
+}
+
+// PartitionForRegion returns the first partition which includes the region
+// passed in. This includes both known regions and regions which match
+// a pattern supported by the partition which may include regions that are
+// not explicitly known by the partition. Use the Regions method of the
+// returned Partition if explicit support is needed.
+func PartitionForRegion(ps []Partition, regionID string) (Partition, bool) {
+	for _, p := range ps {
+		if _, ok := p.p.Regions[regionID]; ok || p.p.RegionRegex.MatchString(regionID) {
+			return p, true
+		}
+	}
+
+	return Partition{}, false
+}
+
 // A Partition provides the ability to enumerate the partition's regions
 // and services.
 type Partition struct {
@@ -132,7 +172,7 @@ type Partition struct {
 }
 
 // ID returns the identifier of the partition.
-func (p *Partition) ID() string { return p.id }
+func (p Partition) ID() string { return p.id }
 
 // EndpointFor attempts to resolve the endpoint based on service and region.
 // See Options for information on configuring how the endpoint is resolved.
@@ -155,13 +195,13 @@ func (p *Partition) ID() string { return p.id }
 // Errors that can be returned.
 //   * UnknownServiceError
 //   * UnknownEndpointError
-func (p *Partition) EndpointFor(service, region string, opts ...func(*Options)) (ResolvedEndpoint, error) {
+func (p Partition) EndpointFor(service, region string, opts ...func(*Options)) (ResolvedEndpoint, error) {
 	return p.p.EndpointFor(service, region, opts...)
 }
 
 // Regions returns a map of Regions indexed by their ID. This is useful for
 // enumerating over the regions in a partition.
-func (p *Partition) Regions() map[string]Region {
+func (p Partition) Regions() map[string]Region {
 	rs := map[string]Region{}
 	for id := range p.p.Regions {
 		rs[id] = Region{
@@ -175,7 +215,7 @@ func (p *Partition) Regions() map[string]Region {
 
 // Services returns a map of Service indexed by their ID. This is useful for
 // enumerating over the services in a partition.
-func (p *Partition) Services() map[string]Service {
+func (p Partition) Services() map[string]Service {
 	ss := map[string]Service{}
 	for id := range p.p.Services {
 		ss[id] = Service{
@@ -195,16 +235,16 @@ type Region struct {
 }
 
 // ID returns the region's identifier.
-func (r *Region) ID() string { return r.id }
+func (r Region) ID() string { return r.id }
 
 // ResolveEndpoint resolves an endpoint from the context of the region given
 // a service. See Partition.EndpointFor for usage and errors that can be returned.
-func (r *Region) ResolveEndpoint(service string, opts ...func(*Options)) (ResolvedEndpoint, error) {
+func (r Region) ResolveEndpoint(service string, opts ...func(*Options)) (ResolvedEndpoint, error) {
 	return r.p.EndpointFor(service, r.id, opts...)
 }
 
 // Services returns a list of all services that are known to be in this region.
-func (r *Region) Services() map[string]Service {
+func (r Region) Services() map[string]Service {
 	ss := map[string]Service{}
 	for id, s := range r.p.Services {
 		if _, ok := s.Endpoints[r.id]; ok {
@@ -226,17 +266,38 @@ type Service struct {
 }
 
 // ID returns the identifier for the service.
-func (s *Service) ID() string { return s.id }
+func (s Service) ID() string { return s.id }
 
 // ResolveEndpoint resolves an endpoint from the context of a service given
 // a region. See Partition.EndpointFor for usage and errors that can be returned.
-func (s *Service) ResolveEndpoint(region string, opts ...func(*Options)) (ResolvedEndpoint, error) {
+func (s Service) ResolveEndpoint(region string, opts ...func(*Options)) (ResolvedEndpoint, error) {
 	return s.p.EndpointFor(s.id, region, opts...)
+}
+
+// Regions returns a map of Regions that the service is present in.
+//
+// A region is the AWS region the service exists in. Whereas a Endpoint is
+// an URL that can be resolved to a instance of a service.
+func (s Service) Regions() map[string]Region {
+	rs := map[string]Region{}
+	for id := range s.p.Services[s.id].Endpoints {
+		if _, ok := s.p.Regions[id]; ok {
+			rs[id] = Region{
+				id: id,
+				p:  s.p,
+			}
+		}
+	}
+
+	return rs
 }
 
 // Endpoints returns a map of Endpoints indexed by their ID for all known
 // endpoints for a service.
-func (s *Service) Endpoints() map[string]Endpoint {
+//
+// A region is the AWS region the service exists in. Whereas a Endpoint is
+// an URL that can be resolved to a instance of a service.
+func (s Service) Endpoints() map[string]Endpoint {
 	es := map[string]Endpoint{}
 	for id := range s.p.Services[s.id].Endpoints {
 		es[id] = Endpoint{
@@ -259,15 +320,15 @@ type Endpoint struct {
 }
 
 // ID returns the identifier for an endpoint.
-func (e *Endpoint) ID() string { return e.id }
+func (e Endpoint) ID() string { return e.id }
 
 // ServiceID returns the identifier the endpoint belongs to.
-func (e *Endpoint) ServiceID() string { return e.serviceID }
+func (e Endpoint) ServiceID() string { return e.serviceID }
 
 // ResolveEndpoint resolves an endpoint from the context of a service and
 // region the endpoint represents. See Partition.EndpointFor for usage and
 // errors that can be returned.
-func (e *Endpoint) ResolveEndpoint(opts ...func(*Options)) (ResolvedEndpoint, error) {
+func (e Endpoint) ResolveEndpoint(opts ...func(*Options)) (ResolvedEndpoint, error) {
 	return e.p.EndpointFor(e.serviceID, e.id, opts...)
 }
 
@@ -299,28 +360,6 @@ type EndpointNotFoundError struct {
 	Service   string
 	Region    string
 }
-
-//// NewEndpointNotFoundError builds and returns NewEndpointNotFoundError.
-//func NewEndpointNotFoundError(p, s, r string) EndpointNotFoundError {
-//	return EndpointNotFoundError{
-//		awsError:  awserr.New("EndpointNotFoundError", "unable to find endpoint", nil),
-//		Partition: p,
-//		Service:   s,
-//		Region:    r,
-//	}
-//}
-//
-//// Error returns string representation of the error.
-//func (e EndpointNotFoundError) Error() string {
-//	extra := fmt.Sprintf("partition: %q, service: %q, region: %q",
-//		e.Partition, e.Service, e.Region)
-//	return awserr.SprintError(e.Code(), e.Message(), extra, e.OrigErr())
-//}
-//
-//// String returns the string representation of the error.
-//func (e EndpointNotFoundError) String() string {
-//	return e.Error()
-//}
 
 // A UnknownServiceError is returned when the service does not resolve to an
 // endpoint. Includes a list of all known services for the partition. Returned

--- a/aws/endpoints/endpoints_test.go
+++ b/aws/endpoints/endpoints_test.go
@@ -84,6 +84,22 @@ func TestEnumRegionServices(t *testing.T) {
 	}
 }
 
+func TestEnumServiceRegions(t *testing.T) {
+	p := testPartitions[0].Partition()
+
+	rs := p.Services()["service1"].Regions()
+	if e, a := 2, len(rs); e != a {
+		t.Errorf("expect %d regions, got %d", e, a)
+	}
+
+	if _, ok := rs["us-east-1"]; !ok {
+		t.Errorf("expect region to be found")
+	}
+	if _, ok := rs["us-west-2"]; !ok {
+		t.Errorf("expect region to be found")
+	}
+}
+
 func TestEnumServicesEndpoints(t *testing.T) {
 	p := testPartitions[0].Partition()
 
@@ -240,5 +256,65 @@ func TestOptionsSet(t *testing.T) {
 
 	if actual != expect {
 		t.Errorf("expect %v options got %v", expect, actual)
+	}
+}
+
+func TestRegionsForService(t *testing.T) {
+	ps := DefaultPartitions()
+
+	var expect map[string]Region
+	var serviceID string
+	for _, s := range ps[0].Services() {
+		expect = s.Regions()
+		serviceID = s.ID()
+		if len(expect) > 0 {
+			break
+		}
+	}
+
+	actual := RegionsForService(ps, ps[0].ID(), serviceID)
+
+	if len(actual) == 0 {
+		t.Fatalf("expect service %s to have regions")
+	}
+	if e, a := len(expect), len(actual); e != a {
+		t.Fatalf("expect %d regions, got %d", e, a)
+	}
+
+	for id, r := range actual {
+		if e, a := id, r.ID(); e != a {
+			t.Errorf("expect %s region id, got %s", e, a)
+		}
+		if _, ok := expect[id]; !ok {
+			t.Errorf("expect %s region to be found", id)
+		}
+	}
+}
+
+func TestPartitionForRegion(t *testing.T) {
+	ps := DefaultPartitions()
+	expect := ps[len(ps)%2]
+
+	var regionID string
+	for id := range expect.Regions() {
+		regionID = id
+		break
+	}
+
+	actual, ok := PartitionForRegion(ps, regionID)
+	if !ok {
+		t.Fatalf("expect partition to be found")
+	}
+	if e, a := expect.ID(), actual.ID(); e != a {
+		t.Errorf("expect %s partition, got %s", e, a)
+	}
+}
+
+func TestPartitionForRegion_NotFound(t *testing.T) {
+	ps := DefaultPartitions()
+
+	actual, ok := PartitionForRegion(ps, "regionNotExists")
+	if ok {
+		t.Errorf("expect no partition to be found, got %v", actual)
 	}
 }

--- a/aws/endpoints/endpoints_test.go
+++ b/aws/endpoints/endpoints_test.go
@@ -275,7 +275,7 @@ func TestRegionsForService(t *testing.T) {
 	actual := RegionsForService(ps, ps[0].ID(), serviceID)
 
 	if len(actual) == 0 {
-		t.Fatalf("expect service %s to have regions")
+		t.Fatalf("expect service %s to have regions", serviceID)
 	}
 	if e, a := len(expect), len(actual); e != a {
 		t.Fatalf("expect %d regions, got %d", e, a)

--- a/aws/endpoints/endpoints_test.go
+++ b/aws/endpoints/endpoints_test.go
@@ -272,7 +272,10 @@ func TestRegionsForService(t *testing.T) {
 		}
 	}
 
-	actual := RegionsForService(ps, ps[0].ID(), serviceID)
+	actual, ok := RegionsForService(ps, ps[0].ID(), serviceID)
+	if !ok {
+		t.Fatalf("expect regions to be found, was not")
+	}
 
 	if len(actual) == 0 {
 		t.Fatalf("expect service %s to have regions", serviceID)
@@ -288,6 +291,18 @@ func TestRegionsForService(t *testing.T) {
 		if _, ok := expect[id]; !ok {
 			t.Errorf("expect %s region to be found", id)
 		}
+	}
+}
+
+func TestRegionsForService_NotFound(t *testing.T) {
+	ps := testPartitions.Partitions()
+
+	actual, ok := RegionsForService(ps, ps[0].ID(), "service-not-exists")
+	if ok {
+		t.Fatalf("expect no regions to be found, but were")
+	}
+	if len(actual) != 0 {
+		t.Errorf("expect no regions, got %v", actual)
 	}
 }
 

--- a/aws/endpoints/v3model_codegen.go
+++ b/aws/endpoints/v3model_codegen.go
@@ -209,17 +209,20 @@ import (
 	// DefaultResolver returns an Endpoint resolver that will be able
 	// to resolve endpoints for: {{ ListPartitionNames . }}.
 	//
-	// Casting the return value of this func to a EnumPartitions will
-	// allow you to get a list of the partitions in the order the endpoints
-	// will be resolved in.
+	// Use DefaultPartitions() to get the list of the default partitions.
+	func DefaultResolver() Resolver {
+		return defaultPartitions
+	}
+
+	// DefaultPartitions returns a list of the partitions the SDK  is bundled
+	// with. The available partitions are: {{ ListPartitionNames . }}.
 	//
-	//    resolver := endpoints.DefaultResolver()
-	//    partitions := resolver.(endpoints.EnumPartitions).Partitions()
+	//    partitions := endpoints.DefaultPartitions
 	//    for _, p := range partitions {
 	//        // ... inspect partitions
 	//    }
-	func DefaultResolver() Resolver {
-		return defaultPartitions
+	func DefaultPartitions() []Partition {
+		return defaultPartitions.Partitions()
 	}
 
 	var defaultPartitions = partitions{

--- a/aws/endpoints/v3model_codegen.go
+++ b/aws/endpoints/v3model_codegen.go
@@ -214,7 +214,7 @@ import (
 		return defaultPartitions
 	}
 
-	// DefaultPartitions returns a list of the partitions the SDK  is bundled
+	// DefaultPartitions returns a list of the partitions the SDK is bundled
 	// with. The available partitions are: {{ ListPartitionNames . }}.
 	//
 	//    partitions := endpoints.DefaultPartitions


### PR DESCRIPTION
Adds several utilities to the endpoints packages to make looking up
partitions, regions, and services easier.

* `DefaultPartitions` - returns a list of Partitions. Removing the need
to cast the DefaultResolver to EnumPartitions interface.

* `RegionsForService` - returns the regions a service is in given the
partition list, partition id and service id.

* `PartitionForRegion` - returns the first partition that matches a given region.

* `Service.Regions` - returns a list of regions for a service. Excluding
additional meta endpoints such as `aws-global`

This change also changes the Partition, Region, Service and Endpoint
receiver methods to be value instead of pointer. This change improves
the usage of the AwsPartition functions allowing the methods calls to be
used without taking the address of the returned Partition.

Fix #994