### PR TITLE
private/protocol/xml/xmlutil: Fix unmarshaling dropping errors

### DIFF
--- a/private/protocol/protocol_test.go
+++ b/private/protocol/protocol_test.go
@@ -1,7 +1,6 @@
 package protocol_test
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -21,11 +20,13 @@ import (
 )
 
 func xmlData(set bool, b []byte, size, delta int) {
+	const openingTags = "<B><A>"
+	const closingTags = "</A></B>"
 	if !set {
-		copy(b, []byte("<B><A>"))
+		copy(b, []byte(openingTags))
 	}
 	if size == 0 {
-		copy(b[delta-len("</B></A>"):], []byte("</B></A>"))
+		copy(b[delta-len(closingTags):], []byte(closingTags))
 	}
 }
 
@@ -118,7 +119,6 @@ func checkForLeak(data interface{}, build, fn func(*request.Request), t *testing
 	if result.errExists {
 		assert.NotNil(t, req.Error)
 	} else {
-		fmt.Println(req.Error)
 		assert.Nil(t, req.Error)
 	}
 

--- a/private/protocol/xml/xmlutil/unmarshal.go
+++ b/private/protocol/xml/xmlutil/unmarshal.go
@@ -15,7 +15,10 @@ import (
 // needs to match the shape of the XML expected to be decoded.
 // If the shape doesn't match unmarshaling will fail.
 func UnmarshalXML(v interface{}, d *xml.Decoder, wrapper string) error {
-	n, _ := XMLToStruct(d, nil)
+	n, err := XMLToStruct(d, nil)
+	if err != nil {
+		return err
+	}
 	if n.Children != nil {
 		for _, root := range n.Children {
 			for _, c := range root {
@@ -23,7 +26,7 @@ func UnmarshalXML(v interface{}, d *xml.Decoder, wrapper string) error {
 					c = wrappedChild[0] // pull out wrapped element
 				}
 
-				err := parse(reflect.ValueOf(v), c, "")
+				err = parse(reflect.ValueOf(v), c, "")
 				if err != nil {
 					if err == io.EOF {
 						return nil

--- a/private/protocol/xml/xmlutil/unmarshal_test.go
+++ b/private/protocol/xml/xmlutil/unmarshal_test.go
@@ -4,10 +4,12 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 type mockBody struct {
@@ -24,7 +26,90 @@ func (m *mockBody) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func TestUnmarshalXML_UnexpectedEOF(t *testing.T) {
+type mockOutput struct {
+	_       struct{}          `type:"structure"`
+	String  *string           `type:"string"`
+	Integer *int64            `type:"integer"`
+	Nested  *mockNestedStruct `type:"structure"`
+	List    []*mockListElem   `locationName:"List" locationNameList:"Elem" type:"list"`
+	Closed  *mockClosedTags   `type:"structure"`
+}
+type mockNestedStruct struct {
+	_            struct{} `type:"structure"`
+	NestedString *string  `type:"string"`
+	NestedInt    *int64   `type:"integer"`
+}
+type mockClosedTags struct {
+	_    struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+	Attr *string  `locationName:"xsi:attrval" type:"string" xmlAttribute:"true"`
+}
+type mockListElem struct {
+	_          struct{}            `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+	String     *string             `type:"string"`
+	NestedElem *mockNestedListElem `type:"structure"`
+}
+type mockNestedListElem struct {
+	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+
+	String *string `type:"string"`
+	Type   *string `locationName:"xsi:type" type:"string" xmlAttribute:"true"`
+}
+
+func TestUnmarshal(t *testing.T) {
+	const xmlBodyStr = `<?xml version="1.0" encoding="UTF-8"?>
+<MockResponse xmlns="http://xmlns.example.com">
+	<String>string value</String>
+	<Integer>123</Integer>
+	<Closed xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:attrval="attr value"/>
+	<Nested>
+		<NestedString>nested string value</NestedString>
+		<NestedInt>321</NestedInt>
+	</Nested>
+	<List>
+		<Elem>
+			<NestedElem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="type">
+				<String>nested elem string value</String>
+			</NestedElem>
+			<String>elem string value</String>
+		</Elem>
+	</List>
+</MockResponse>`
+
+	expect := mockOutput{
+		String:  aws.String("string value"),
+		Integer: aws.Int64(123),
+		Closed: &mockClosedTags{
+			Attr: aws.String("attr value"),
+		},
+		Nested: &mockNestedStruct{
+			NestedString: aws.String("nested string value"),
+			NestedInt:    aws.Int64(321),
+		},
+		List: []*mockListElem{
+			{
+				String: aws.String("elem string value"),
+				NestedElem: &mockNestedListElem{
+					String: aws.String("nested elem string value"),
+					Type:   aws.String("type"),
+				},
+			},
+		},
+	}
+
+	actual := mockOutput{}
+	decoder := xml.NewDecoder(strings.NewReader(xmlBodyStr))
+	err := UnmarshalXML(&actual, decoder, "")
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(expect, actual) {
+		t.Errorf("expect unmarshal to match\nExpect: %s\nActual: %s",
+			awsutil.Prettify(expect), awsutil.Prettify(actual))
+	}
+}
+
+func TestUnmarshal_UnexpectedEOF(t *testing.T) {
 	const partialXMLBody = `<?xml version="1.0" encoding="UTF-8"?>
 	<First>first value</First>
 	<Second>Second val`

--- a/private/protocol/xml/xmlutil/unmarshal_test.go
+++ b/private/protocol/xml/xmlutil/unmarshal_test.go
@@ -1,0 +1,57 @@
+package xmlutil
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+type mockBody struct {
+	DoneErr error
+	Body    io.Reader
+}
+
+func (m *mockBody) Read(p []byte) (int, error) {
+	n, err := m.Body.Read(p)
+	if (n == 0 || err == io.EOF) && m.DoneErr != nil {
+		return n, m.DoneErr
+	}
+
+	return n, err
+}
+
+func TestUnmarshalXML_UnexpectedEOF(t *testing.T) {
+	const partialXMLBody = `<?xml version="1.0" encoding="UTF-8"?>
+	<First>first value</First>
+	<Second>Second val`
+
+	out := struct {
+		First  *string `locationName:"First" type:"string"`
+		Second *string `locationName:"Second" type:"string"`
+	}{}
+
+	expect := out
+	expect.First = aws.String("first")
+	expect.Second = aws.String("second")
+
+	expectErr := fmt.Errorf("expected read error")
+
+	body := &mockBody{
+		DoneErr: expectErr,
+		Body:    strings.NewReader(partialXMLBody),
+	}
+
+	decoder := xml.NewDecoder(body)
+	err := UnmarshalXML(&out, decoder, "")
+
+	if err == nil {
+		t.Fatalf("expect error, got none")
+	}
+	if e, a := expectErr, err; e != a {
+		t.Errorf("expect %v error in %v, but was not", e, a)
+	}
+}

--- a/private/protocol/xml/xmlutil/xml_to_struct.go
+++ b/private/protocol/xml/xmlutil/xml_to_struct.go
@@ -40,11 +40,16 @@ func XMLToStruct(d *xml.Decoder, s *xml.StartElement) (*XMLNode, error) {
 	out := &XMLNode{}
 	for {
 		tok, err := d.Token()
-		if tok == nil || err == io.EOF {
-			break
-		}
 		if err != nil {
-			return out, err
+			if err == io.EOF {
+				break
+			} else {
+				return out, err
+			}
+		}
+
+		if tok == nil {
+			break
 		}
 
 		switch typed := tok.(type) {

--- a/private/protocol/xml/xmlutil/xml_to_struct_test.go
+++ b/private/protocol/xml/xmlutil/xml_to_struct_test.go
@@ -14,8 +14,21 @@ import (
 
 func TestUnmarshal(t *testing.T) {
 	xmlVal := []byte(`<?xml version="1.0" encoding="UTF-8"?>
-	<AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>foo-id</ID><DisplayName>user</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="type"><ID>foo-id</ID><DisplayName>user</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList><
-	/AccessControlPolicy>`)
+<AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+	<Owner>
+		<ID>foo-id</ID>
+		<DisplayName>user</DisplayName>
+	</Owner>
+	<AccessControlList>
+		<Grant>
+		<Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="type">
+			<ID>foo-id</ID>
+			<DisplayName>user</DisplayName>
+		</Grantee>
+		<Permission>FULL_CONTROL</Permission>
+		</Grant>
+	</AccessControlList>
+</AccessControlPolicy>`)
 
 	var server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(xmlVal)

--- a/service/s3/statusok_error_test.go
+++ b/service/s3/statusok_error_test.go
@@ -54,7 +54,7 @@ func TestCopyObjectError(t *testing.T) {
 func TestUploadPartCopySuccess(t *testing.T) {
 	const successMsg = `
 <?xml version="1.0" encoding="UTF-8"?>
-<UploadPartCopyResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2009-11-23T0:00:00Z</LastModified><ETag>&quot;1da64c7f13d1e8dbeaea40b905fd586c&quot;</ETag></CopyObjectResult>`
+<UploadPartCopyResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2009-11-23T0:00:00Z</LastModified><ETag>&quot;1da64c7f13d1e8dbeaea40b905fd586c&quot;</ETag></UploadPartCopyResult>`
 
 	res, err := newCopyTestSvc(successMsg).UploadPartCopy(&s3.UploadPartCopyInput{
 		Bucket:     aws.String("bucketname"),


### PR DESCRIPTION
The XML unmarshaler would drop any serialization or body read error
that occurred on the floor effectively hiding any errors that would
occur.

This corrects the issue of TCP connection reset with XML services such as S3 
only partially unmarshal the response. Leaving some fields unset.

Fix #1205