### PR TITLE
service/s3/s3manager: Fix download hang on connection error

### DIFF
--- a/service/s3/s3manager/download_test.go
+++ b/service/s3/s3manager/download_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -431,6 +432,63 @@ func TestDownloadWithContextCanceled(t *testing.T) {
 	}
 	if e, a := "canceled", aerr.Message(); !strings.Contains(a, e) {
 		t.Errorf("expected error message to contain %q, but did not %q", e, a)
+	}
+}
+
+func TestDownload_WithFailure(t *testing.T) {
+	svc := s3.New(unit.Session)
+	svc.Handlers.Send.Clear()
+
+	first := true
+	svc.Handlers.Send.PushBack(func(r *request.Request) {
+		if first {
+			first = false
+			body := bytes.NewReader(make([]byte, s3manager.DefaultDownloadPartSize))
+			r.HTTPResponse = &http.Response{
+				StatusCode:    http.StatusOK,
+				Status:        http.StatusText(http.StatusOK),
+				ContentLength: int64(body.Len()),
+				Body:          ioutil.NopCloser(body),
+				Header:        http.Header{},
+			}
+			r.HTTPResponse.Header.Set("Content-Length", strconv.Itoa(body.Len()))
+			r.HTTPResponse.Header.Set("Content-Range",
+				fmt.Sprintf("bytes 0-%d/%d", body.Len()-1, body.Len()*10))
+			return
+		}
+
+		// Give a chance for the multipart chunks to be queued up
+		time.Sleep(1 * time.Second)
+
+		r.HTTPResponse = &http.Response{
+			Header: http.Header{},
+			Body:   ioutil.NopCloser(&bytes.Buffer{}),
+		}
+		r.Error = awserr.New("ConnectionError", "some connection error", nil)
+		r.Retryable = aws.Bool(false)
+	})
+
+	start := time.Now()
+	d := s3manager.NewDownloaderWithClient(svc, func(d *s3manager.Downloader) {
+		d.Concurrency = 2
+	})
+
+	w := &aws.WriteAtBuffer{}
+	params := s3.GetObjectInput{
+		Bucket: aws.String("Bucket"),
+		Key:    aws.String("Key"),
+	}
+
+	// Expect this request to exit quickly after failure
+	_, err := d.Download(w, &params)
+	if err == nil {
+		t.Fatalf("expect error, got none")
+	}
+
+	limit := start.Add(5 * time.Second)
+	dur := time.Now().Sub(start)
+	if time.Now().After(limit) {
+		t.Errorf("expect time to be less than %v, took %v", limit, dur)
 	}
 }
 


### PR DESCRIPTION
Fixes an edge case in the S3 Download Manager that will hang for ever if
the connection errors out on all workers, and the download manager is
blocked on pushing additional items to the queue. The bug occurred
because the download workers where existing.

Fix #1227