### PR TITLE
Change dup. mention of "credentials" to "config"

### DIFF
--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -124,9 +124,8 @@ file (~/.aws/config) and shared credentials file (~/.aws/credentials). Both
 files have the same format.
 
 If both config files are present the configuration from both files will be
-read. The Session will be created from  configuration values from the shared
-credentials file (~/.aws/credentials) over those in the shared credentials
-file (~/.aws/config).
+read. The Session will be created from configuration values from the shared
+credentials file (~/.aws/credentials) over those in the shared config file (~/.aws/config).
 
 Credentials are the values the SDK should use for authenticating requests with
 AWS Services. They arfrom a configuration file will need to include both


### PR DESCRIPTION
There are several places in a row in the `session` doc that mention the
credentials file (`~/.aws/credentials`) and the config file
(`~/.aws/config`) file back to back. In one case they were both called
the "shared credentials" file so I changed the appropriate one to
"config file."