### PR TITLE
aws/client: logging on response will do any body manipulation or error handling

### DIFF
--- a/aws/client/logger.go
+++ b/aws/client/logger.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http/httputil"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+const logReqMsg = `DEBUG: Request %s/%s Details:
+---[ REQUEST POST-SIGN ]-----------------------------
+%s
+-----------------------------------------------------`
+
+const logReqErrMsg = `DEBUG ERROR: Request %s/%s:
+---[ REQUEST DUMP ERROR ]-----------------------------
+%s
+------------------------------------------------------`
+
+type logWriter struct {
+	// Logger is what we will use to log the payload of a response.
+	Logger aws.Logger
+	// buf stores the contents of what has been read
+	buf *bytes.Buffer
+}
+
+func (logger *logWriter) Write(b []byte) (int, error) {
+	return logger.buf.Write(b)
+}
+
+type teeReaderCloser struct {
+	// io.Reader will be a tee reader that is used during logging.
+	// This structure will read from a body and write the contents to a logger.
+	io.Reader
+	// Source is used just to close when we are done reading.
+	Source io.ReadCloser
+}
+
+func (reader *teeReaderCloser) Close() error {
+	return reader.Source.Close()
+}
+
+func logRequest(r *request.Request) {
+	logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
+	dumpedBody, err := httputil.DumpRequestOut(r.HTTPRequest, logBody)
+	if err != nil {
+		r.Config.Logger.Log(fmt.Sprintf(logReqErrMsg, r.ClientInfo.ServiceName, r.Operation.Name, err))
+		return
+	}
+
+	if logBody {
+		// Reset the request body because dumpRequest will re-wrap the r.HTTPRequest's
+		// Body as a NoOpCloser and will not be reset after read by the HTTP
+		// client reader.
+		r.ResetBody()
+	}
+
+	r.Config.Logger.Log(fmt.Sprintf(logReqMsg, r.ClientInfo.ServiceName, r.Operation.Name, string(dumpedBody)))
+}
+
+const logRespMsg = `DEBUG: Response %s/%s Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespErrMsg = `DEBUG ERROR: Response %s/%s:
+---[ RESPONSE DUMP ERROR ]-----------------------------
+%s
+-----------------------------------------------------`
+
+func logResponse(r *request.Request) {
+	lw := &logWriter{r.Config.Logger, bytes.NewBuffer(nil)}
+	r.HTTPResponse.Body = &teeReaderCloser{
+		Reader: io.TeeReader(r.HTTPResponse.Body, lw),
+		Source: r.HTTPResponse.Body,
+	}
+
+	handlerFn := func(req *request.Request) {
+		body, err := httputil.DumpResponse(req.HTTPResponse, false)
+		if err != nil {
+			lw.Logger.Log(fmt.Sprintf(logRespErrMsg, req.ClientInfo.ServiceName, req.Operation.Name, err))
+			return
+		}
+
+		b, err := ioutil.ReadAll(lw.buf)
+		if err != nil {
+			lw.Logger.Log(fmt.Sprintf(logRespErrMsg, req.ClientInfo.ServiceName, req.Operation.Name, err))
+			return
+		}
+		lw.Logger.Log(fmt.Sprintf(logRespMsg, req.ClientInfo.ServiceName, req.Operation.Name, string(body)))
+		if req.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody) {
+			lw.Logger.Log(string(b))
+		}
+	}
+
+	r.Handlers.Unmarshal.PushBack(handlerFn)
+	r.Handlers.UnmarshalError.PushBack(handlerFn)
+}

--- a/aws/client/logger_test.go
+++ b/aws/client/logger_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+type mockCloser struct {
+	closed bool
+}
+
+func (closer *mockCloser) Read(b []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (closer *mockCloser) Close() error {
+	closer.closed = true
+	return nil
+}
+
+func TestTeeReaderCloser(t *testing.T) {
+	expected := "FOO"
+	buf := bytes.NewBuffer([]byte(expected))
+	lw := bytes.NewBuffer(nil)
+	c := &mockCloser{}
+	closer := teeReaderCloser{
+		io.TeeReader(buf, lw),
+		c,
+	}
+
+	b := make([]byte, len(expected))
+	_, err := closer.Read(b)
+	closer.Close()
+
+	if expected != lw.String() {
+		t.Errorf("Expected %q, but received %q", expected, lw.String())
+	}
+
+	if err != nil {
+		t.Errorf("Expected 'nil', but received %v", err)
+	}
+
+	if !c.closed {
+		t.Error("Expected 'true', but received 'false'")
+	}
+}
+
+func TestLogWriter(t *testing.T) {
+	expected := "FOO"
+	lw := &logWriter{nil, bytes.NewBuffer(nil)}
+	lw.Write([]byte(expected))
+
+	if expected != lw.buf.String() {
+		t.Errorf("Expected %q, but received %q", expected, lw.buf.String())
+	}
+}

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -3,7 +3,6 @@ package request_test
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -760,33 +759,4 @@ func (reader *errReader) Read(b []byte) (int, error) {
 
 func (reader *errReader) Close() error {
 	return nil
-}
-
-func TestLoggerNotIgnoringErrors(t *testing.T) {
-	s := awstesting.NewClient(&aws.Config{
-		Region:     aws.String("mock-region"),
-		MaxRetries: aws.Int(0),
-		DisableSSL: aws.Bool(true),
-		LogLevel:   aws.LogLevel(aws.LogDebugWithHTTPBody),
-	})
-
-	s.Handlers.Validate.Clear()
-	s.Handlers.Send.Clear()
-	s.Handlers.Send.PushBack(func(r *request.Request) {
-		r.HTTPResponse = &http.Response{StatusCode: 200, Body: &errReader{errors.New("Foo error")}}
-	})
-	s.AddDebugHandlers()
-
-	out := &testData{}
-	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
-	err := r.Send()
-	if err == nil {
-		t.Error("expected error, but got nil")
-	}
-
-	if aerr, ok := err.(awserr.Error); !ok {
-		t.Errorf("expected awserr.Error, but got different error, %v", err)
-	} else if aerr.Code() != request.ErrCodeRead {
-		t.Errorf("expected %q, but received %q", request.ErrCodeRead, aerr.Code())
-	}
 }


### PR DESCRIPTION
Logging responses will now only log when the body is being read. This moves error handling from the logging to the protocol unmarshalers.