### PR TITLE
service/dynamodb/dynamodbattribute: Fix typo in the comment of type Marshaler

### DIFF
--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -57,10 +57,9 @@ func (e *UnixTime) UnmarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) 
 //		type ExampleMarshaler struct {
 //			Value int
 //		}
-//		type (m *ExampleMarshaler) 	MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
+//		func (m *ExampleMarshaler) 	MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
 //			n := fmt.Sprintf("%v", m.Value)
 //			av.N = &n
-//
 //			return nil
 //		}
 //


### PR DESCRIPTION
There is a typo in the comment which cause the official documentation to be inaccurate:

```go
type (m *ExampleMarshaler) 	MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
	n := fmt.Sprintf("%v", m.Value)
	av.N = &n
	return nil
}
```

should be

```go
func (m *ExampleMarshaler) 	MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
	n := fmt.Sprintf("%v", m.Value)
	av.N = &n
	return nil
}
```
