### PR TITLE
aws/request: Fix HTTP/2 protocol error on HEAD request.

### DIFF
--- a/aws/request/request_1_8.go
+++ b/aws/request/request_1_8.go
@@ -2,8 +2,8 @@
 
 package request
 
-import "net/http"
+import "io"
 
-// Is a http.NoBody reader instructing Go HTTP client to not include
+// Is a nil instructing Go HTTP client to not include
 // and body in the HTTP request.
-var noBodyReader = http.NoBody
+var noBodyReader io.ReadCloser

--- a/aws/request/request_1_8_test.go
+++ b/aws/request/request_1_8_test.go
@@ -18,7 +18,7 @@ func TestResetBody_WithEmptyBody(t *testing.T) {
 
 	r.ResetBody()
 
-	if a, e := r.HTTPRequest.Body, http.NoBody; a != e {
+	if a := r.HTTPRequest.Body; a != nil {
 		t.Errorf("expected request body to be set to reader, got %#v",
 			r.HTTPRequest.Body)
 	}


### PR DESCRIPTION
## Bug report

I'm using S3 mock server written in Go to develop. I was faced with a problem that HEAD request sending by aws-sdk-go is interpreted as HTTP/2 protocol error by server written in Go. Server written in Go return HTTP/2 protocol error, when received HEAD request from Go http client with non-nil body (e.g. http.NoBody) using HTTP/2. Code to reproduce is follow.

### Client's code to reproduce

```
package main

import (
    "crypto/tls"
    "fmt"
    "net/http"

    "golang.org/x/net/http2"

    "github.com/aws/aws-sdk-go/aws"
    "github.com/aws/aws-sdk-go/aws/credentials"
    "github.com/aws/aws-sdk-go/aws/session"
    "github.com/aws/aws-sdk-go/service/s3"
)

func main() {
    region := "local"
    bucket := "test-bucket"
    key := "test-key"
    t := http.DefaultTransport.(*http.Transport)
    // test server's certificate is self-signed certificate
    t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
    http2.ConfigureTransport(t)
    cli := s3.New(session.New(&aws.Config{
        Credentials:      credentials.NewStaticCredentials("****", "****", "token"),
        Region:           &region,
        Endpoint:         aws.String("localhost:8080"),
        S3ForcePathStyle: aws.Bool(true),
    }))
    resp, err := cli.HeadObject(&s3.HeadObjectInput{Bucket: &bucket, Key: &key})
    fmt.Print(resp, err)
}

```

### Server's code to reproduce

```
package main

import (
  "fmt"
  "net/http"
)

func main() {
  http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, "OK") })
  // cert.pem and key.pem produced by /src/crypto/tls/generate_cert.go
  fmt.Println(http.ListenAndServeTLS(":8080", "./cert.pem", "./key.pem", nil))
}
```

### Result

```
HEAD {

} RequestError: send request failed
caused by: Head https://localhost:8080/test-bucket/test-key: stream error: stream ID 7; PROTOCOL_ERROR
```

### Environment

* aws-sdk-go: v1.8.13
* Go: go1.8.1 linux/amd64 
* OS: CentOS release 6.8


## Bug fix

Set `nil` to `noBodyReader` instead of `http.NoBody` to avoid HTTP/2 protocol error on HEAD request.
