### PR TITLE
 aws/request: Fix for syscall pkg not available on plan9

### DIFF
--- a/aws/request/connection_reset_error.go
+++ b/aws/request/connection_reset_error.go
@@ -1,4 +1,4 @@
-// +build !appengine
+// +build !appengine,!plan9
 
 package request
 

--- a/aws/request/connection_reset_error_other.go
+++ b/aws/request/connection_reset_error_other.go
@@ -1,4 +1,4 @@
-// +build appengine
+// +build appengine plan9
 
 package request
 

--- a/aws/request/connection_reset_error_other_test.go
+++ b/aws/request/connection_reset_error_other_test.go
@@ -1,4 +1,4 @@
-// +build appengine
+// +build appengine plan9
 
 package request_test
 

--- a/aws/request/connection_reset_error_test.go
+++ b/aws/request/connection_reset_error_test.go
@@ -1,4 +1,4 @@
-// +build !appengine
+// +build !appengine,!plan9
 
 package request_test
 


### PR DESCRIPTION
Plan9 doesn't have the syscall.ECONNRESET symbol so work around in the
same way as appengine.