### PR TITLE
aws/corehandlers: Do request with nil Body if was NoBody value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ get-deps-tests:
 	go get github.com/stretchr/testify
 	go get github.com/smartystreets/goconvey
 	go get golang.org/x/net/html
+	go get golang.org/x/net/http2
 
 get-deps-verify:
 	@echo "go get SDK verification utilities"

--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -106,6 +106,18 @@ var SendHandler = request.NamedHandler{
 			sender = sendWithoutFollowRedirects
 		}
 
+		if request.NoBody == r.HTTPRequest.Body {
+			// Strip off the request body if the NoBody reader was used as a
+			// place holder for a request body. This prevents the SDK from
+			// making requests with a request body when it would be invalid
+			// to do so.
+			var origBody io.ReadCloser
+			origBody, r.HTTPRequest.Body = r.HTTPRequest.Body, nil
+			defer func() {
+				r.HTTPRequest.Body = origBody
+			}()
+		}
+
 		var err error
 		r.HTTPResponse, err = sender(r)
 		if err != nil {

--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -111,10 +111,14 @@ var SendHandler = request.NamedHandler{
 			// place holder for a request body. This prevents the SDK from
 			// making requests with a request body when it would be invalid
 			// to do so.
-			var origBody io.ReadCloser
-			origBody, r.HTTPRequest.Body = r.HTTPRequest.Body, nil
+			//
+			// Use a shallow copy of the http.Request to ensure the race condition
+			// of transport on Body will not trigger
+			reqOrig, reqCopy := r.HTTPRequest, *r.HTTPRequest
+			reqCopy.Body = nil
+			r.HTTPRequest = &reqCopy
 			defer func() {
-				r.HTTPRequest.Body = origBody
+				r.HTTPRequest = reqOrig
 			}()
 		}
 

--- a/aws/corehandlers/handlers_1_8_test.go
+++ b/aws/corehandlers/handlers_1_8_test.go
@@ -1,0 +1,64 @@
+// +build go1.8
+
+package corehandlers_test
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/awstesting"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"golang.org/x/net/http2"
+)
+
+func TestSendHandler_HEADNoBody(t *testing.T) {
+	TLSBundleCertFile, TLSBundleKeyFile, TLSBundleCAFile, err := awstesting.CreateTLSBundleFiles()
+	if err != nil {
+		panic(err)
+	}
+	defer awstesting.CleanupTLSBundleFiles(TLSBundleCertFile, TLSBundleKeyFile, TLSBundleCAFile)
+
+	endpoint, err := awstesting.CreateTLSServer(TLSBundleCertFile, TLSBundleKeyFile, nil)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	transport := http.DefaultTransport.(*http.Transport)
+	// test server's certificate is self-signed certificate
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	http2.ConfigureTransport(transport)
+
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			HTTPClient:       &http.Client{},
+			Endpoint:         aws.String(endpoint),
+			Region:           aws.String("mock-region"),
+			Credentials:      credentials.AnonymousCredentials,
+			S3ForcePathStyle: aws.Bool(true),
+		},
+	})
+
+	svc := s3.New(sess)
+
+	req, _ := svc.HeadObjectRequest(&s3.HeadObjectInput{
+		Bucket: aws.String("bucketname"),
+		Key:    aws.String("keyname"),
+	})
+
+	if e, a := request.NoBody, req.HTTPRequest.Body; e != a {
+		t.Fatalf("expect %T request body, got %T", e, a)
+	}
+
+	err = req.Send()
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := http.StatusOK, req.HTTPResponse.StatusCode; e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
+}

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -368,7 +368,7 @@ func (r *Request) ResetBody() {
 	}
 
 	if l == 0 {
-		r.HTTPRequest.Body = noBodyReader
+		r.HTTPRequest.Body = NoBody
 	} else if l > 0 {
 		r.HTTPRequest.Body = r.safeBody
 	} else {
@@ -382,7 +382,7 @@ func (r *Request) ResetBody() {
 		// a io.Reader that was not also an io.Seeker.
 		switch r.Operation.HTTPMethod {
 		case "GET", "HEAD", "DELETE":
-			r.HTTPRequest.Body = noBodyReader
+			r.HTTPRequest.Body = NoBody
 		default:
 			r.HTTPRequest.Body = r.safeBody
 		}

--- a/aws/request/request_1_7.go
+++ b/aws/request/request_1_7.go
@@ -16,6 +16,6 @@ func (noBody) Read([]byte) (int, error)         { return 0, io.EOF }
 func (noBody) Close() error                     { return nil }
 func (noBody) WriteTo(io.Writer) (int64, error) { return 0, nil }
 
-// Is an empty reader that will trigger the Go HTTP client to not include
+// NoBody is an empty reader that will trigger the Go HTTP client to not include
 // and body in the HTTP request.
-var noBodyReader = noBody{}
+var NoBody = noBody{}

--- a/aws/request/request_1_8.go
+++ b/aws/request/request_1_8.go
@@ -2,8 +2,10 @@
 
 package request
 
-import "net/http"
+import (
+	"net/http"
+)
 
-// Is a http.NoBody reader instructing Go HTTP client to not include
+// NoBody is a http.NoBody reader instructing Go HTTP client to not include
 // and body in the HTTP request.
-var noBodyReader = http.NoBody
+var NoBody = http.NoBody

--- a/aws/request/request_resetbody_test.go
+++ b/aws/request/request_resetbody_test.go
@@ -50,7 +50,7 @@ func TestResetBody_ExcludeUnseekableBodyByMethod(t *testing.T) {
 
 		r.SetReaderBody(reader)
 
-		if a, e := r.HTTPRequest.Body == noBodyReader, c.IsNoBody; a != e {
+		if a, e := r.HTTPRequest.Body == NoBody, c.IsNoBody; a != e {
 			t.Errorf("%d, expect body to be set to noBody(%t), but was %t", i, e, a)
 		}
 	}

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -760,3 +760,21 @@ func (reader *errReader) Read(b []byte) (int, error) {
 func (reader *errReader) Close() error {
 	return nil
 }
+
+func TestIsNoBodyReader(t *testing.T) {
+	cases := []struct {
+		reader io.ReadCloser
+		expect bool
+	}{
+		{ioutil.NopCloser(bytes.NewReader([]byte("abc"))), false},
+		{ioutil.NopCloser(bytes.NewReader(nil)), false},
+		{nil, false},
+		{request.NoBody, true},
+	}
+
+	for i, c := range cases {
+		if e, a := c.expect, request.NoBody == c.reader; e != a {
+			t.Errorf("%d, expect %t match, but was %t", i, e, a)
+		}
+	}
+}

--- a/aws/session/custom_ca_bundle_test.go
+++ b/aws/session/custom_ca_bundle_test.go
@@ -2,90 +2,76 @@ package session
 
 import (
 	"bytes"
-	"crypto/tls"
-	"io/ioutil"
+	"fmt"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/stretchr/testify/assert"
+	"github.com/aws/aws-sdk-go/awstesting"
 )
 
-func createTLSServer(cert, key []byte, done <-chan struct{}) (*httptest.Server, error) {
-	c, err := tls.X509KeyPair(cert, key)
+var TLSBundleCertFile string
+var TLSBundleKeyFile string
+var TLSBundleCAFile string
+
+func TestMain(m *testing.M) {
+	var err error
+
+	TLSBundleCertFile, TLSBundleKeyFile, TLSBundleCAFile, err = awstesting.CreateTLSBundleFiles()
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
-	s := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	s.TLS = &tls.Config{
-		Certificates: []tls.Certificate{c},
-	}
-	s.TLS.BuildNameToCertificate()
-	s.StartTLS()
+	fmt.Println("TestMain", TLSBundleCertFile, TLSBundleKeyFile)
 
-	go func() {
-		<-done
-		s.Close()
-	}()
+	code := m.Run()
 
-	return s, nil
-}
-
-func setupTestCAFile(b []byte) (string, error) {
-	bundleFile, err := ioutil.TempFile(os.TempDir(), "aws-sdk-go-session-test")
+	err = awstesting.CleanupTLSBundleFiles(TLSBundleCertFile, TLSBundleKeyFile, TLSBundleCAFile)
 	if err != nil {
-		return "", err
+		panic(err)
 	}
 
-	_, err = bundleFile.Write(b)
-	if err != nil {
-		return "", err
-	}
-
-	defer bundleFile.Close()
-	return bundleFile.Name(), nil
+	os.Exit(code)
 }
 
 func TestNewSession_WithCustomCABundle_Env(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	done := make(chan struct{})
-	server, err := createTLSServer(testTLSBundleCert, testTLSBundleKey, done)
-	assert.NoError(t, err)
+	endpoint, err := awstesting.CreateTLSServer(TLSBundleCertFile, TLSBundleKeyFile, nil)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
-	// Write bundle to file
-	caFilename, err := setupTestCAFile(testTLSBundleCA)
-	defer func() {
-		os.Remove(caFilename)
-	}()
-	assert.NoError(t, err)
-
-	os.Setenv("AWS_CA_BUNDLE", caFilename)
+	os.Setenv("AWS_CA_BUNDLE", TLSBundleCAFile)
 
 	s, err := NewSession(&aws.Config{
 		HTTPClient:  &http.Client{},
-		Endpoint:    aws.String(server.URL),
+		Endpoint:    aws.String(endpoint),
 		Region:      aws.String("mock-region"),
 		Credentials: credentials.AnonymousCredentials,
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, s)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if s == nil {
+		t.Fatalf("expect session to be created, got none")
+	}
 
 	req, _ := http.NewRequest("GET", *s.Config.Endpoint, nil)
 	resp, err := s.Config.HTTPClient.Do(req)
-	assert.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := http.StatusOK, resp.StatusCode; e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
 }
 
 func TestNewSession_WithCustomCABundle_EnvNotExists(t *testing.T) {
@@ -95,65 +81,87 @@ func TestNewSession_WithCustomCABundle_EnvNotExists(t *testing.T) {
 	os.Setenv("AWS_CA_BUNDLE", "file-not-exists")
 
 	s, err := NewSession()
-	assert.Error(t, err)
-	assert.Equal(t, "LoadCustomCABundleError", err.(awserr.Error).Code())
-	assert.Nil(t, s)
+	if err == nil {
+		t.Fatalf("expect error, got none")
+	}
+	if e, a := "LoadCustomCABundleError", err.(awserr.Error).Code(); e != a {
+		t.Errorf("expect %s error code, got %s", e, a)
+	}
+	if s != nil {
+		t.Errorf("expect nil session, got %v", s)
+	}
 }
 
 func TestNewSession_WithCustomCABundle_Option(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	done := make(chan struct{})
-	server, err := createTLSServer(testTLSBundleCert, testTLSBundleKey, done)
-	assert.NoError(t, err)
+	endpoint, err := awstesting.CreateTLSServer(TLSBundleCertFile, TLSBundleKeyFile, nil)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
 	s, err := NewSessionWithOptions(Options{
 		Config: aws.Config{
 			HTTPClient:  &http.Client{},
-			Endpoint:    aws.String(server.URL),
+			Endpoint:    aws.String(endpoint),
 			Region:      aws.String("mock-region"),
 			Credentials: credentials.AnonymousCredentials,
 		},
-		CustomCABundle: bytes.NewReader(testTLSBundleCA),
+		CustomCABundle: bytes.NewReader(awstesting.TLSBundleCA),
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, s)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if s == nil {
+		t.Fatalf("expect session to be created, got none")
+	}
 
 	req, _ := http.NewRequest("GET", *s.Config.Endpoint, nil)
 	resp, err := s.Config.HTTPClient.Do(req)
-	assert.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := http.StatusOK, resp.StatusCode; e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
 }
 
 func TestNewSession_WithCustomCABundle_OptionPriority(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	done := make(chan struct{})
-	server, err := createTLSServer(testTLSBundleCert, testTLSBundleKey, done)
-	assert.NoError(t, err)
+	endpoint, err := awstesting.CreateTLSServer(TLSBundleCertFile, TLSBundleKeyFile, nil)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
 	os.Setenv("AWS_CA_BUNDLE", "file-not-exists")
 
 	s, err := NewSessionWithOptions(Options{
 		Config: aws.Config{
 			HTTPClient:  &http.Client{},
-			Endpoint:    aws.String(server.URL),
+			Endpoint:    aws.String(endpoint),
 			Region:      aws.String("mock-region"),
 			Credentials: credentials.AnonymousCredentials,
 		},
-		CustomCABundle: bytes.NewReader(testTLSBundleCA),
+		CustomCABundle: bytes.NewReader(awstesting.TLSBundleCA),
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, s)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if s == nil {
+		t.Fatalf("expect session to be created, got none")
+	}
 
 	req, _ := http.NewRequest("GET", *s.Config.Endpoint, nil)
 	resp, err := s.Config.HTTPClient.Do(req)
-	assert.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := http.StatusOK, resp.StatusCode; e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
 }
 
 type mockRoundTripper struct{}
@@ -172,25 +180,35 @@ func TestNewSession_WithCustomCABundle_UnsupportedTransport(t *testing.T) {
 				Transport: &mockRoundTripper{},
 			},
 		},
-		CustomCABundle: bytes.NewReader(testTLSBundleCA),
+		CustomCABundle: bytes.NewReader(awstesting.TLSBundleCA),
 	})
-	assert.Error(t, err)
-	assert.Equal(t, "LoadCustomCABundleError", err.(awserr.Error).Code())
-	assert.Contains(t, err.(awserr.Error).Message(), "transport unsupported type")
-	assert.Nil(t, s)
+	if err == nil {
+		t.Fatalf("expect error, got none")
+	}
+	if e, a := "LoadCustomCABundleError", err.(awserr.Error).Code(); e != a {
+		t.Errorf("expect %s error code, got %s", e, a)
+	}
+	if s != nil {
+		t.Errorf("expect nil session, got %v", s)
+	}
+	aerrMsg := err.(awserr.Error).Message()
+	if e, a := "transport unsupported type", aerrMsg; !strings.Contains(a, e) {
+		t.Errorf("expect %s to be in %s", e, a)
+	}
 }
 
 func TestNewSession_WithCustomCABundle_TransportSet(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer popEnv(oldEnv)
 
-	done := make(chan struct{})
-	server, err := createTLSServer(testTLSBundleCert, testTLSBundleKey, done)
-	assert.NoError(t, err)
+	endpoint, err := awstesting.CreateTLSServer(TLSBundleCertFile, TLSBundleKeyFile, nil)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
 	s, err := NewSessionWithOptions(Options{
 		Config: aws.Config{
-			Endpoint:    aws.String(server.URL),
+			Endpoint:    aws.String(endpoint),
 			Region:      aws.String("mock-region"),
 			Credentials: credentials.AnonymousCredentials,
 			HTTPClient: &http.Client{
@@ -205,115 +223,21 @@ func TestNewSession_WithCustomCABundle_TransportSet(t *testing.T) {
 				},
 			},
 		},
-		CustomCABundle: bytes.NewReader(testTLSBundleCA),
+		CustomCABundle: bytes.NewReader(awstesting.TLSBundleCA),
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, s)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if s == nil {
+		t.Fatalf("expect session to be created, got none")
+	}
 
 	req, _ := http.NewRequest("GET", *s.Config.Endpoint, nil)
 	resp, err := s.Config.HTTPClient.Do(req)
-	assert.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := http.StatusOK, resp.StatusCode; e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
 }
-
-/* Cert generation steps
-# Create the CA key
-openssl genrsa -des3 -out ca.key 1024
-
-# Create the CA Cert
-openssl req -new -sha256 -x509 -days 3650 \
-    -subj "/C=GO/ST=Gopher/O=Testing ROOT CA" \
-    -key ca.key -out ca.crt
-
-# Create config
-cat > csr_details.txt <<-EOF
-
-[req]
-default_bits = 1024
-prompt = no
-default_md = sha256
-req_extensions = SAN
-distinguished_name = dn
-
-[ dn ]
-C=GO
-ST=Gopher
-O=Testing Certificate
-OU=Testing IP
-
-[SAN]
-subjectAltName = IP:127.0.0.1
-EOF
-
-# Create certificate signing request
-openssl req -new -sha256 -nodes -newkey rsa:1024 \
-    -config <( cat csr_details.txt ) \
-    -keyout ia.key -out ia.csr
-
-# Create a signed certificate
-openssl x509 -req -days 3650 \
-    -CAcreateserial \
-    -extfile <( cat csr_details.txt ) \
-    -extensions SAN \
-    -CA ca.crt -CAkey ca.key -in ia.csr -out ia.crt
-
-# Verify
-openssl req -noout -text -in ia.csr
-openssl x509 -noout -text -in ia.crt
-*/
-var (
-	// ca.crt
-	testTLSBundleCA = []byte(`-----BEGIN CERTIFICATE-----
-MIICiTCCAfKgAwIBAgIJAJ5X1olt05XjMA0GCSqGSIb3DQEBCwUAMDgxCzAJBgNV
-BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
-QTAeFw0xNzAzMDkwMDAyMDZaFw0yNzAzMDcwMDAyMDZaMDgxCzAJBgNVBAYTAkdP
-MQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBDQTCBnzAN
-BgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAw/8DN+t9XQR60jx42rsQ2WE2Dx85rb3n
-GQxnKZZLNddsT8rDyxJNP18aFalbRbFlyln5fxWxZIblu9Xkm/HRhOpbSimSqo1y
-uDx21NVZ1YsOvXpHby71jx3gPrrhSc/t/zikhi++6D/C6m1CiIGuiJ0GBiJxtrub
-UBMXT0QtI2ECAwEAAaOBmjCBlzAdBgNVHQ4EFgQU8XG3X/YHBA6T04kdEkq6+4GV
-YykwaAYDVR0jBGEwX4AU8XG3X/YHBA6T04kdEkq6+4GVYymhPKQ6MDgxCzAJBgNV
-BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
-QYIJAJ5X1olt05XjMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADgYEAeILv
-z49+uxmPcfOZzonuOloRcpdvyjiXblYxbzz6ch8GsE7Q886FTZbvwbgLhzdwSVgG
-G8WHkodDUsymVepdqAamS3f8PdCUk8xIk9mop8LgaB9Ns0/TssxDvMr3sOD2Grb3
-xyWymTWMcj6uCiEBKtnUp4rPiefcvCRYZ17/hLE=
------END CERTIFICATE-----
-`)
-
-	// ai.crt
-	testTLSBundleCert = []byte(`-----BEGIN CERTIFICATE-----
-MIICGjCCAYOgAwIBAgIJAIIu+NOoxxM0MA0GCSqGSIb3DQEBBQUAMDgxCzAJBgNV
-BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
-QTAeFw0xNzAzMDkwMDAzMTRaFw0yNzAzMDcwMDAzMTRaMFExCzAJBgNVBAYTAkdP
-MQ8wDQYDVQQIDAZHb3BoZXIxHDAaBgNVBAoME1Rlc3RpbmcgQ2VydGlmaWNhdGUx
-EzARBgNVBAsMClRlc3RpbmcgSVAwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-AN1hWHeioo/nASvbrjwCQzXCiWiEzGkw353NxsAB54/NqDL3LXNATtiSJu8kJBrm
-Ah12IFLtWLGXjGjjYlHbQWnOR6awveeXnQZukJyRWh7m/Qlt9Ho0CgZE1U+832ac
-5GWVldNxW1Lz4I+W9/ehzqe8I80RS6eLEKfUFXGiW+9RAgMBAAGjEzARMA8GA1Ud
-EQQIMAaHBH8AAAEwDQYJKoZIhvcNAQEFBQADgYEAdF4WQHfVdPCbgv9sxgJjcR1H
-Hgw9rZ47gO1IiIhzglnLXQ6QuemRiHeYFg4kjcYBk1DJguxzDTGnUwhUXOibAB+S
-zssmrkdYYvn9aUhjc3XK3tjAoDpsPpeBeTBamuUKDHoH/dNRXxerZ8vu6uPR3Pgs
-5v/KCV6IAEcvNyOXMPo=
------END CERTIFICATE-----
-`)
-
-	// ai.key
-	testTLSBundleKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQDdYVh3oqKP5wEr2648AkM1wolohMxpMN+dzcbAAeePzagy9y1z
-QE7YkibvJCQa5gIddiBS7Vixl4xo42JR20FpzkemsL3nl50GbpCckVoe5v0JbfR6
-NAoGRNVPvN9mnORllZXTcVtS8+CPlvf3oc6nvCPNEUunixCn1BVxolvvUQIDAQAB
-AoGBAMISrcirddGrlLZLLrKC1ULS2T0cdkqdQtwHYn4+7S5+/z42vMx1iumHLsSk
-rVY7X41OWkX4trFxhvEIrc/O48bo2zw78P7flTxHy14uxXnllU8cLThE29SlUU7j
-AVBNxJZMsXMlS/DowwD4CjFe+x4Pu9wZcReF2Z9ntzMpySABAkEA+iWoJCPE2JpS
-y78q3HYYgpNY3gF3JqQ0SI/zTNkb3YyEIUffEYq0Y9pK13HjKtdsSuX4osTIhQkS
-+UgRp6tCAQJBAOKPYTfQ2FX8ijgUpHZRuEAVaxASAS0UATiLgzXxLvOh/VC2at5x
-wjOX6sD65pPz/0D8Qj52Cq6Q1TQ+377SDVECQAIy0od+yPweXxvrUjUd1JlRMjbB
-TIrKZqs8mKbUQapw0bh5KTy+O1elU4MRPS3jNtBxtP25PQnuSnxmZcFTgAECQFzg
-DiiFcsn9FuRagfkHExMiNJuH5feGxeFaP9WzI144v9GAllrOI6Bm3JNzx2ZLlg4b
-20Qju8lIEj6yr6JYFaECQHM1VSojGRKpOl9Ox/R4yYSA9RV5Gyn00/aJNxVYyPD5
-i3acL2joQm2kLD/LO8paJ4+iQdRXCOMMIpjxSNjGQjQ=
------END RSA PRIVATE KEY-----
-`)
-)

--- a/awstesting/custom_ca_bundle.go
+++ b/awstesting/custom_ca_bundle.go
@@ -1,0 +1,191 @@
+package awstesting
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+func availableLocalAddr(ip string) (string, error) {
+	l, err := net.Listen("tcp", ip+":0")
+	if err != nil {
+		return "", err
+	}
+	defer l.Close()
+
+	return l.Addr().String(), nil
+}
+
+// CreateTLSServer will create the TLS server on an open port using the
+// certificate and key. The address will be returned that the server is running on.
+func CreateTLSServer(cert, key string, mux *http.ServeMux) (string, error) {
+	addr, err := availableLocalAddr("127.0.0.1")
+	if err != nil {
+		return "", err
+	}
+
+	if mux == nil {
+		mux = http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
+	}
+
+	go func() {
+		if err := http.ListenAndServeTLS(addr, cert, key, mux); err != nil {
+			panic(err)
+		}
+	}()
+	time.Sleep(1 * time.Second)
+
+	return "https://" + addr, nil
+}
+
+// CreateTLSBundleFiles returns the temporary filenames for the certificate
+// key, and CA PEM content. These files should be deleted when no longer
+// needed. CleanupTLSBundleFiles can be used for this cleanup.
+func CreateTLSBundleFiles() (cert, key, ca string, err error) {
+	cert, err = createTmpFile(TLSBundleCert)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	key, err = createTmpFile(TLSBundleKey)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	ca, err = createTmpFile(TLSBundleCA)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return cert, key, ca, nil
+}
+
+// CleanupTLSBundleFiles takes variadic list of files to be deleted.
+func CleanupTLSBundleFiles(files ...string) error {
+	for _, file := range files {
+		if err := os.Remove(file); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createTmpFile(b []byte) (string, error) {
+	bundleFile, err := ioutil.TempFile(os.TempDir(), "aws-sdk-go-session-test")
+	if err != nil {
+		return "", err
+	}
+
+	_, err = bundleFile.Write(b)
+	if err != nil {
+		return "", err
+	}
+
+	defer bundleFile.Close()
+	return bundleFile.Name(), nil
+}
+
+/* Cert generation steps
+# Create the CA key
+openssl genrsa -des3 -out ca.key 1024
+
+# Create the CA Cert
+openssl req -new -sha256 -x509 -days 3650 \
+    -subj "/C=GO/ST=Gopher/O=Testing ROOT CA" \
+    -key ca.key -out ca.crt
+
+# Create config
+cat > csr_details.txt <<-EOF
+
+[req]
+default_bits = 1024
+prompt = no
+default_md = sha256
+req_extensions = SAN
+distinguished_name = dn
+
+[ dn ]
+C=GO
+ST=Gopher
+O=Testing Certificate
+OU=Testing IP
+
+[SAN]
+subjectAltName = IP:127.0.0.1
+EOF
+
+# Create certificate signing request
+openssl req -new -sha256 -nodes -newkey rsa:1024 \
+    -config <( cat csr_details.txt ) \
+    -keyout ia.key -out ia.csr
+
+# Create a signed certificate
+openssl x509 -req -days 3650 \
+    -CAcreateserial \
+    -extfile <( cat csr_details.txt ) \
+    -extensions SAN \
+    -CA ca.crt -CAkey ca.key -in ia.csr -out ia.crt
+
+# Verify
+openssl req -noout -text -in ia.csr
+openssl x509 -noout -text -in ia.crt
+*/
+var (
+	// TLSBundleCA ca.crt
+	TLSBundleCA = []byte(`-----BEGIN CERTIFICATE-----
+MIICiTCCAfKgAwIBAgIJAJ5X1olt05XjMA0GCSqGSIb3DQEBCwUAMDgxCzAJBgNV
+BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
+QTAeFw0xNzAzMDkwMDAyMDZaFw0yNzAzMDcwMDAyMDZaMDgxCzAJBgNVBAYTAkdP
+MQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBDQTCBnzAN
+BgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAw/8DN+t9XQR60jx42rsQ2WE2Dx85rb3n
+GQxnKZZLNddsT8rDyxJNP18aFalbRbFlyln5fxWxZIblu9Xkm/HRhOpbSimSqo1y
+uDx21NVZ1YsOvXpHby71jx3gPrrhSc/t/zikhi++6D/C6m1CiIGuiJ0GBiJxtrub
+UBMXT0QtI2ECAwEAAaOBmjCBlzAdBgNVHQ4EFgQU8XG3X/YHBA6T04kdEkq6+4GV
+YykwaAYDVR0jBGEwX4AU8XG3X/YHBA6T04kdEkq6+4GVYymhPKQ6MDgxCzAJBgNV
+BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
+QYIJAJ5X1olt05XjMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADgYEAeILv
+z49+uxmPcfOZzonuOloRcpdvyjiXblYxbzz6ch8GsE7Q886FTZbvwbgLhzdwSVgG
+G8WHkodDUsymVepdqAamS3f8PdCUk8xIk9mop8LgaB9Ns0/TssxDvMr3sOD2Grb3
+xyWymTWMcj6uCiEBKtnUp4rPiefcvCRYZ17/hLE=
+-----END CERTIFICATE-----
+`)
+
+	// TLSBundleCert ai.crt
+	TLSBundleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIICGjCCAYOgAwIBAgIJAIIu+NOoxxM0MA0GCSqGSIb3DQEBBQUAMDgxCzAJBgNV
+BAYTAkdPMQ8wDQYDVQQIEwZHb3BoZXIxGDAWBgNVBAoTD1Rlc3RpbmcgUk9PVCBD
+QTAeFw0xNzAzMDkwMDAzMTRaFw0yNzAzMDcwMDAzMTRaMFExCzAJBgNVBAYTAkdP
+MQ8wDQYDVQQIDAZHb3BoZXIxHDAaBgNVBAoME1Rlc3RpbmcgQ2VydGlmaWNhdGUx
+EzARBgNVBAsMClRlc3RpbmcgSVAwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
+AN1hWHeioo/nASvbrjwCQzXCiWiEzGkw353NxsAB54/NqDL3LXNATtiSJu8kJBrm
+Ah12IFLtWLGXjGjjYlHbQWnOR6awveeXnQZukJyRWh7m/Qlt9Ho0CgZE1U+832ac
+5GWVldNxW1Lz4I+W9/ehzqe8I80RS6eLEKfUFXGiW+9RAgMBAAGjEzARMA8GA1Ud
+EQQIMAaHBH8AAAEwDQYJKoZIhvcNAQEFBQADgYEAdF4WQHfVdPCbgv9sxgJjcR1H
+Hgw9rZ47gO1IiIhzglnLXQ6QuemRiHeYFg4kjcYBk1DJguxzDTGnUwhUXOibAB+S
+zssmrkdYYvn9aUhjc3XK3tjAoDpsPpeBeTBamuUKDHoH/dNRXxerZ8vu6uPR3Pgs
+5v/KCV6IAEcvNyOXMPo=
+-----END CERTIFICATE-----
+`)
+
+	// TLSBundleKey ai.key
+	TLSBundleKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDdYVh3oqKP5wEr2648AkM1wolohMxpMN+dzcbAAeePzagy9y1z
+QE7YkibvJCQa5gIddiBS7Vixl4xo42JR20FpzkemsL3nl50GbpCckVoe5v0JbfR6
+NAoGRNVPvN9mnORllZXTcVtS8+CPlvf3oc6nvCPNEUunixCn1BVxolvvUQIDAQAB
+AoGBAMISrcirddGrlLZLLrKC1ULS2T0cdkqdQtwHYn4+7S5+/z42vMx1iumHLsSk
+rVY7X41OWkX4trFxhvEIrc/O48bo2zw78P7flTxHy14uxXnllU8cLThE29SlUU7j
+AVBNxJZMsXMlS/DowwD4CjFe+x4Pu9wZcReF2Z9ntzMpySABAkEA+iWoJCPE2JpS
+y78q3HYYgpNY3gF3JqQ0SI/zTNkb3YyEIUffEYq0Y9pK13HjKtdsSuX4osTIhQkS
++UgRp6tCAQJBAOKPYTfQ2FX8ijgUpHZRuEAVaxASAS0UATiLgzXxLvOh/VC2at5x
+wjOX6sD65pPz/0D8Qj52Cq6Q1TQ+377SDVECQAIy0od+yPweXxvrUjUd1JlRMjbB
+TIrKZqs8mKbUQapw0bh5KTy+O1elU4MRPS3jNtBxtP25PQnuSnxmZcFTgAECQFzg
+DiiFcsn9FuRagfkHExMiNJuH5feGxeFaP9WzI144v9GAllrOI6Bm3JNzx2ZLlg4b
+20Qju8lIEj6yr6JYFaECQHM1VSojGRKpOl9Ox/R4yYSA9RV5Gyn00/aJNxVYyPD5
+i3acL2joQm2kLD/LO8paJ4+iQdRXCOMMIpjxSNjGQjQ=
+-----END RSA PRIVATE KEY-----
+`)
+)


### PR DESCRIPTION
Updates the SDK's usage of NoBody so that HTTP requests substitute nil
for http.NoBody. Once the request is sent the Body value will be reset
back to NoBody. This ensures that the SDK sends requests will a nil Body
when no request body is intended to be sent, and the usage of
Request's HTTPRequest.Body will not be a breaking change.

Also moves the aws/session's custom CA bundle test to awstesting to make the bundle and server reusable for other SDK tests.

Fix #1264