### PR TITLE
session: add SharedConfigFiles option

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -155,6 +155,10 @@ type Options struct {
 	// and enable or disable the shared config functionality.
 	SharedConfigState SharedConfigState
 
+	// Ordered list of files the session will load configuration from.
+	// It will override environment variable AWS_SHARED_CREDENTIALS_FILE, AWS_CONFIG_FILE.
+	SharedConfigFiles []string
+
 	// When the SDK's shared config is configured to assume a role with MFA
 	// this option is required in order to provide the mechanism that will
 	// retrieve the MFA token. There is no default value for this field. If
@@ -304,13 +308,18 @@ func newSession(opts Options, envCfg envConfig, cfgs ...*aws.Config) (*Session, 
 	userCfg := &aws.Config{}
 	userCfg.MergeIn(cfgs...)
 
-	// Order config files will be loaded in with later files overwriting
+	// Ordered config files will be loaded in with later files overwriting
 	// previous config file values.
-	cfgFiles := []string{envCfg.SharedConfigFile, envCfg.SharedCredentialsFile}
-	if !envCfg.EnableSharedConfig {
-		// The shared config file (~/.aws/config) is only loaded if instructed
-		// to load via the envConfig.EnableSharedConfig (AWS_SDK_LOAD_CONFIG).
-		cfgFiles = cfgFiles[1:]
+	var cfgFiles []string
+	if opts.SharedConfigFiles != nil {
+		cfgFiles = opts.SharedConfigFiles
+	} else {
+		cfgFiles = []string{envCfg.SharedConfigFile, envCfg.SharedCredentialsFile}
+		if !envCfg.EnableSharedConfig {
+			// The shared config file (~/.aws/config) is only loaded if instructed
+			// to load via the envConfig.EnableSharedConfig (AWS_SDK_LOAD_CONFIG).
+			cfgFiles = cfgFiles[1:]
+		}
 	}
 
 	// Load additional config from file(s)

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -178,6 +178,29 @@ func TestNewSessionWithOptions_OverrideSharedConfigDisable(t *testing.T) {
 	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
 }
 
+func TestNewSessionWithOptions_OverrideSharedConfigFiles(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer popEnv(oldEnv)
+
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "config_file_load_order")
+
+	s, err := NewSessionWithOptions(Options{
+		SharedConfigFiles: []string{testConfigOtherFilename},
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, "shared_config_other_region", *s.Config.Region)
+
+	creds, err := s.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "shared_config_other_akid", creds.AccessKeyID)
+	assert.Equal(t, "shared_config_other_secret", creds.SecretAccessKey)
+	assert.Empty(t, creds.SessionToken)
+	assert.Contains(t, creds.ProviderName, "SharedConfigCredentials")
+}
+
 func TestNewSessionWithOptions_Overrides(t *testing.T) {
 	cases := []struct {
 		InEnvs    map[string]string


### PR DESCRIPTION
Add SharedConfigFiles option for users to load custom config files.
This will override any related ENV.

Fix https://github.com/aws/aws-sdk-go/issues/1258