### PR TITLE
Fix DefaultPartSize reference in s3manager docs

### DIFF
--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -31,7 +31,7 @@ const DefaultDownloadConcurrency = 5
 type Downloader struct {
 	// The buffer size (in bytes) to use when buffering data into chunks and
 	// sending them as parts to S3. The minimum allowed part size is 5MB, and
-	// if this value is set to zero, the DefaultPartSize value will be used.
+	// if this value is set to zero, the DefaultDownloadPartSize value will be used.
 	PartSize int64
 
 	// The number of goroutines to spin up in parallel when sending parts.

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -215,7 +215,7 @@ func WithUploaderRequestOptions(opts ...request.Option) func(*Uploader) {
 type Uploader struct {
 	// The buffer size (in bytes) to use when buffering data into chunks and
 	// sending them as parts to S3. The minimum allowed part size is 5MB, and
-	// if this value is set to zero, the DefaultPartSize value will be used.
+	// if this value is set to zero, the DefaultUploadPartSize value will be used.
 	PartSize int64
 
 	// The number of goroutines to spin up in parallel when sending parts.


### PR DESCRIPTION
The docs for the Downloader and Uploader struct's PartSize members refer to a default value const DefaultPartSize that does not exist. This makes grepping for the value difficult.
