### PR TITLE
aws/request: Do not treat LimitExceededException as throttle error

### DIFF
--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -38,7 +38,6 @@ var throttleCodes = map[string]struct{}{
 	"ThrottlingException":                    {},
 	"RequestLimitExceeded":                   {},
 	"RequestThrottled":                       {},
-	"LimitExceededException":                 {}, // Deleting 10+ DynamoDb tables at once
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
 }


### PR DESCRIPTION
The LimitExceededException error code should not be treated as a
throttling condition. This error code implies that resources are
exhausted or too many tasks are being attempted at once. The SDK does
not have the information it needs to distinguish between the resources
exhausted and too many tasks attempted at once.

This logic is best implemented by user applications as they will have
the most context about what is being attempted.

To add custom retry with this error code a custom implementation of the
`request.Retryer` interface should be used.

Fix #1271
