### PR TITLE
aws/request: Fix logging from reporting wrong retry request errors

### DIFF
--- a/aws/client/logger.go
+++ b/aws/client/logger.go
@@ -97,6 +97,12 @@ func logResponse(r *request.Request) {
 		}
 	}
 
-	r.Handlers.Unmarshal.PushBack(handlerFn)
-	r.Handlers.UnmarshalError.PushBack(handlerFn)
+	const handlerName = "awsdk.client.LogResponse.ResponseBody"
+
+	r.Handlers.Unmarshal.SetBackNamed(request.NamedHandler{
+		Name: handlerName, Fn: handlerFn,
+	})
+	r.Handlers.UnmarshalError.SetBackNamed(request.NamedHandler{
+		Name: handlerName, Fn: handlerFn,
+	})
 }

--- a/aws/request/handlers.go
+++ b/aws/request/handlers.go
@@ -158,6 +158,37 @@ func (l *HandlerList) RemoveByName(name string) {
 	}
 }
 
+// SwapNamed will swap out any existing handlers with the same name as the
+// passed in NamedHandler returning true if handlers were swapped. False is
+// returned otherwise.
+func (l *HandlerList) SwapNamed(n NamedHandler) (swapped bool) {
+	for i := 0; i < len(l.list); i++ {
+		if l.list[i].Name == n.Name {
+			l.list[i].Fn = n.Fn
+			swapped = true
+		}
+	}
+
+	return swapped
+}
+
+// SetBackNamed will replace the named handler if it exists in the handler list.
+// If the handler does not exist the handler will be added to the end of the list.
+func (l *HandlerList) SetBackNamed(n NamedHandler) {
+	if !l.SwapNamed(n) {
+		l.PushBackNamed(n)
+	}
+}
+
+// SetFrontNamed will replace the named handler if it exists in the handler list.
+// If the handler does not exist the handler will be added to the beginning of
+// the list.
+func (l *HandlerList) SetFrontNamed(n NamedHandler) {
+	if !l.SwapNamed(n) {
+		l.PushFrontNamed(n)
+	}
+}
+
 // Run executes all handlers in the list with a given request object.
 func (l *HandlerList) Run(r *Request) {
 	for i, h := range l.list {

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -488,7 +488,7 @@ func (r *Request) Send() error {
 			r.Handlers.Retry.Run(r)
 			r.Handlers.AfterRetry.Run(r)
 			if r.Error != nil {
-				debugLogReqError(r, "Send Request", false, r.Error)
+				debugLogReqError(r, "Send Request", false, err)
 				return r.Error
 			}
 			debugLogReqError(r, "Send Request", true, err)
@@ -497,12 +497,13 @@ func (r *Request) Send() error {
 		r.Handlers.UnmarshalMeta.Run(r)
 		r.Handlers.ValidateResponse.Run(r)
 		if r.Error != nil {
-			err := r.Error
 			r.Handlers.UnmarshalError.Run(r)
+			err := r.Error
+
 			r.Handlers.Retry.Run(r)
 			r.Handlers.AfterRetry.Run(r)
 			if r.Error != nil {
-				debugLogReqError(r, "Validate Response", false, r.Error)
+				debugLogReqError(r, "Validate Response", false, err)
 				return r.Error
 			}
 			debugLogReqError(r, "Validate Response", true, err)
@@ -515,7 +516,7 @@ func (r *Request) Send() error {
 			r.Handlers.Retry.Run(r)
 			r.Handlers.AfterRetry.Run(r)
 			if r.Error != nil {
-				debugLogReqError(r, "Unmarshal Response", false, r.Error)
+				debugLogReqError(r, "Unmarshal Response", false, err)
 				return r.Error
 			}
 			debugLogReqError(r, "Unmarshal Response", true, err)


### PR DESCRIPTION
Fixes the SDK's retry request logging to report the the actual error
that occurred, not a stubbed Unknown error message.

Fixes the SDK's response logger to not output the response log multiple
times per retry.