### PR TITLE
aws/request: Add support for PUT temporary redirects (307)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/request`: Add support for PUT temporary redirects (307) [#1283](https://github.com/aws/aws-sdk-go/issues/1283)
+  * Adds support for Go 1.8's GetBody function allowing the SDK's http request using PUT and POST methods to be redirected with temporary redirects with 307 status code.
+  * Fixes: [#1267](https://github.com/aws/aws-sdk-go/issues/1267)

--- a/aws/request/request_1_7.go
+++ b/aws/request/request_1_7.go
@@ -30,5 +30,5 @@ func (r *Request) ResetBody() {
 		return
 	}
 
-	r.HTTPRequest.Body = Body
+	r.HTTPRequest.Body = body
 }

--- a/aws/request/request_1_7.go
+++ b/aws/request/request_1_7.go
@@ -19,3 +19,16 @@ func (noBody) WriteTo(io.Writer) (int64, error) { return 0, nil }
 // NoBody is an empty reader that will trigger the Go HTTP client to not include
 // and body in the HTTP request.
 var NoBody = noBody{}
+
+// ResetBody rewinds the request body back to its starting position, and
+// set's the HTTP Request body reference. When the body is read prior
+// to being sent in the HTTP request it will need to be rewound.
+func (r *Request) ResetBody() {
+	body, err := r.getNextRequestBody()
+	if err != nil {
+		r.Error = err
+		return
+	}
+
+	r.HTTPRequest.Body = Body
+}

--- a/aws/request/request_1_7.go
+++ b/aws/request/request_1_7.go
@@ -23,6 +23,11 @@ var NoBody = noBody{}
 // ResetBody rewinds the request body back to its starting position, and
 // set's the HTTP Request body reference. When the body is read prior
 // to being sent in the HTTP request it will need to be rewound.
+//
+// ResetBody will automatically be called by the SDK's build handler, but if
+// the request is being used directly ResetBody must be called before the request
+// is Sent.  SetStringBody, SetBufferBody, and SetReaderBody will automatically
+// call ResetBody.
 func (r *Request) ResetBody() {
 	body, err := r.getNextRequestBody()
 	if err != nil {

--- a/aws/request/request_1_8.go
+++ b/aws/request/request_1_8.go
@@ -14,6 +14,11 @@ var NoBody = http.NoBody
 // set's the HTTP Request body reference. When the body is read prior
 // to being sent in the HTTP request it will need to be rewound.
 //
+// ResetBody will automatically be called by the SDK's build handler, but if
+// the request is being used directly ResetBody must be called before the request
+// is Sent.  SetStringBody, SetBufferBody, and SetReaderBody will automatically
+// call ResetBody.
+//
 // Will also set the Go 1.8's http.Request.GetBody member to allow retrying
 // PUT/POST redirects.
 func (r *Request) ResetBody() {

--- a/aws/request/request_1_8.go
+++ b/aws/request/request_1_8.go
@@ -9,3 +9,20 @@ import (
 // NoBody is a http.NoBody reader instructing Go HTTP client to not include
 // and body in the HTTP request.
 var NoBody = http.NoBody
+
+// ResetBody rewinds the request body back to its starting position, and
+// set's the HTTP Request body reference. When the body is read prior
+// to being sent in the HTTP request it will need to be rewound.
+//
+// Will also set the Go 1.8's http.Request.GetBody member to allow retrying
+// PUT/POST redirects.
+func (r *Request) ResetBody() {
+	body, err := r.getNextRequestBody()
+	if err != nil {
+		r.Error = err
+		return
+	}
+
+	r.HTTPRequest.Body = body
+	r.HTTPRequest.GetBody = r.getNextRequestBody
+}

--- a/aws/request/request_1_8_test.go
+++ b/aws/request/request_1_8_test.go
@@ -1,15 +1,23 @@
 // +build go1.8
 
-package request
+package request_test
 
 import (
+	"bytes"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
 )
 
 func TestResetBody_WithEmptyBody(t *testing.T) {
-	r := Request{
+	r := request.Request{
 		HTTPRequest: &http.Request{},
 	}
 
@@ -21,5 +29,57 @@ func TestResetBody_WithEmptyBody(t *testing.T) {
 	if a, e := r.HTTPRequest.Body, http.NoBody; a != e {
 		t.Errorf("expected request body to be set to reader, got %#v",
 			r.HTTPRequest.Body)
+	}
+}
+
+func TestRequest_FollowPUTRedirects(t *testing.T) {
+	const bodySize = 1024
+
+	redirectHit := 0
+	endpointHit := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/redirect-me":
+			u := *r.URL
+			u.Path = "/endpoint"
+			w.Header().Set("Location", u.String())
+			w.WriteHeader(307)
+			redirectHit++
+		case "/endpoint":
+			b := bytes.Buffer{}
+			io.Copy(&b, r.Body)
+			r.Body.Close()
+			if e, a := bodySize, b.Len(); e != a {
+				t.Fatalf("expect %d body size, got %d", e, a)
+			}
+			endpointHit++
+		default:
+			t.Fatalf("unexpected endpoint used, %q", r.URL.String())
+		}
+	}))
+
+	svc := awstesting.NewClient(&aws.Config{
+		Region:     unit.Session.Config.Region,
+		DisableSSL: aws.Bool(true),
+		Endpoint:   aws.String(server.URL),
+	})
+
+	req := svc.NewRequest(&request.Operation{
+		Name:       "Operation",
+		HTTPMethod: "PUT",
+		HTTPPath:   "/redirect-me",
+	}, &struct{}{}, &struct{}{})
+	req.SetReaderBody(bytes.NewReader(make([]byte, bodySize)))
+
+	err := req.Send()
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
+	if e, a := 1, redirectHit; e != a {
+		t.Errorf("expect %d redirect hits, got %d", e, a)
+	}
+	if e, a := 1, endpointHit; e != a {
+		t.Errorf("expect %d endpoint hits, got %d", e, a)
 	}
 }


### PR DESCRIPTION
Adds support for Go 1.8's GetBody function allowing the SDK's http
request using PUT and POST methods to be redirected with temporary
redirects with 307 status code.

Fix #1267
