### PR TITLE
Treat SnapshotCreationPerVolumeRateExceeded as retryable code

### DIFF
--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -40,6 +40,7 @@ var throttleCodes = map[string]struct{}{
 	"RequestThrottled":                       {},
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
+	"SnapshotCreationPerVolumeRateExceeded":  {}, // EBS volume snapshots
 }
 
 // credsExpiredCodes is a collection of error codes which signify the credentials


### PR DESCRIPTION
I believe the below error message should be treated as retryable
```
SnapshotCreationPerVolumeRateExceeded: The maximum per volume CreateSnapshot request rate has been exceeded. Use an increasing or variable sleep interval between requests.
            status code: 400, request id: 6dd8c250-d69a-45d8-8f81-48ff52fe0c28
```
