### PR TITLE
v1.8.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.8.28 (2017-05-23)
+===
+
+### Service Client Updates
+* `service/databasemigrationservice`: Updates service API, documentation, paginators, and examples
+  * This release adds support for using Amazon S3 and Amazon DynamoDB as targets for database migration, and using MongoDB as a source for database migration. For more information, see the AWS Database Migration Service documentation.
+
 Release v1.8.27 (2017-05-22)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.8.27"
+const SDKVersion = "1.8.28"

--- a/models/apis/dms/2016-01-01/api-2.json
+++ b/models/apis/dms/2016-01-01/api-2.json
@@ -40,6 +40,22 @@
         {"shape":"AccessDeniedFault"}
       ]
     },
+    "CreateEventSubscription":{
+      "name":"CreateEventSubscription",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CreateEventSubscriptionMessage"},
+      "output":{"shape":"CreateEventSubscriptionResponse"},
+      "errors":[
+        {"shape":"ResourceQuotaExceededFault"},
+        {"shape":"ResourceAlreadyExistsFault"},
+        {"shape":"SNSInvalidTopicFault"},
+        {"shape":"SNSNoAuthorizationFault"},
+        {"shape":"ResourceNotFoundFault"}
+      ]
+    },
     "CreateReplicationInstance":{
       "name":"CreateReplicationInstance",
       "http":{
@@ -115,6 +131,19 @@
       },
       "input":{"shape":"DeleteEndpointMessage"},
       "output":{"shape":"DeleteEndpointResponse"},
+      "errors":[
+        {"shape":"ResourceNotFoundFault"},
+        {"shape":"InvalidResourceStateFault"}
+      ]
+    },
+    "DeleteEventSubscription":{
+      "name":"DeleteEventSubscription",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteEventSubscriptionMessage"},
+      "output":{"shape":"DeleteEventSubscriptionResponse"},
       "errors":[
         {"shape":"ResourceNotFoundFault"},
         {"shape":"InvalidResourceStateFault"}
@@ -212,6 +241,36 @@
       "errors":[
         {"shape":"ResourceNotFoundFault"}
       ]
+    },
+    "DescribeEventCategories":{
+      "name":"DescribeEventCategories",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeEventCategoriesMessage"},
+      "output":{"shape":"DescribeEventCategoriesResponse"}
+    },
+    "DescribeEventSubscriptions":{
+      "name":"DescribeEventSubscriptions",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeEventSubscriptionsMessage"},
+      "output":{"shape":"DescribeEventSubscriptionsResponse"},
+      "errors":[
+        {"shape":"ResourceNotFoundFault"}
+      ]
+    },
+    "DescribeEvents":{
+      "name":"DescribeEvents",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeEventsMessage"},
+      "output":{"shape":"DescribeEventsResponse"}
     },
     "DescribeOrderableReplicationInstances":{
       "name":"DescribeOrderableReplicationInstances",
@@ -334,7 +393,23 @@
         {"shape":"InvalidResourceStateFault"},
         {"shape":"ResourceNotFoundFault"},
         {"shape":"ResourceAlreadyExistsFault"},
-        {"shape":"KMSKeyNotAccessibleFault"}
+        {"shape":"KMSKeyNotAccessibleFault"},
+        {"shape":"AccessDeniedFault"}
+      ]
+    },
+    "ModifyEventSubscription":{
+      "name":"ModifyEventSubscription",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ModifyEventSubscriptionMessage"},
+      "output":{"shape":"ModifyEventSubscriptionResponse"},
+      "errors":[
+        {"shape":"ResourceQuotaExceededFault"},
+        {"shape":"ResourceNotFoundFault"},
+        {"shape":"SNSInvalidTopicFault"},
+        {"shape":"SNSNoAuthorizationFault"}
       ]
     },
     "ModifyReplicationInstance":{
@@ -399,6 +474,19 @@
         {"shape":"ResourceNotFoundFault"},
         {"shape":"KMSKeyNotAccessibleFault"},
         {"shape":"ResourceQuotaExceededFault"}
+      ]
+    },
+    "ReloadTables":{
+      "name":"ReloadTables",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ReloadTablesMessage"},
+      "output":{"shape":"ReloadTablesResponse"},
+      "errors":[
+        {"shape":"ResourceNotFoundFault"},
+        {"shape":"InvalidResourceStateFault"}
       ]
     },
     "RemoveTagsFromResource":{
@@ -494,6 +582,21 @@
       "members":{
       }
     },
+    "AuthMechanismValue":{
+      "type":"string",
+      "enum":[
+        "default",
+        "mongodb_cr",
+        "scram_sha_1"
+      ]
+    },
+    "AuthTypeValue":{
+      "type":"string",
+      "enum":[
+        "no",
+        "password"
+      ]
+    },
     "AvailabilityZone":{
       "type":"structure",
       "members":{
@@ -525,6 +628,13 @@
       }
     },
     "CertificateWallet":{"type":"blob"},
+    "CompressionTypeValue":{
+      "type":"string",
+      "enum":[
+        "none",
+        "gzip"
+      ]
+    },
     "Connection":{
       "type":"structure",
       "members":{
@@ -563,13 +673,38 @@
         "KmsKeyId":{"shape":"String"},
         "Tags":{"shape":"TagList"},
         "CertificateArn":{"shape":"String"},
-        "SslMode":{"shape":"DmsSslModeValue"}
+        "SslMode":{"shape":"DmsSslModeValue"},
+        "DynamoDbSettings":{"shape":"DynamoDbSettings"},
+        "S3Settings":{"shape":"S3Settings"},
+        "MongoDbSettings":{"shape":"MongoDbSettings"}
       }
     },
     "CreateEndpointResponse":{
       "type":"structure",
       "members":{
         "Endpoint":{"shape":"Endpoint"}
+      }
+    },
+    "CreateEventSubscriptionMessage":{
+      "type":"structure",
+      "required":[
+        "SubscriptionName",
+        "SnsTopicArn"
+      ],
+      "members":{
+        "SubscriptionName":{"shape":"String"},
+        "SnsTopicArn":{"shape":"String"},
+        "SourceType":{"shape":"String"},
+        "EventCategories":{"shape":"EventCategoriesList"},
+        "SourceIds":{"shape":"SourceIdsList"},
+        "Enabled":{"shape":"BooleanOptional"},
+        "Tags":{"shape":"TagList"}
+      }
+    },
+    "CreateEventSubscriptionResponse":{
+      "type":"structure",
+      "members":{
+        "EventSubscription":{"shape":"EventSubscription"}
       }
     },
     "CreateReplicationInstanceMessage":{
@@ -672,6 +807,19 @@
       "type":"structure",
       "members":{
         "Endpoint":{"shape":"Endpoint"}
+      }
+    },
+    "DeleteEventSubscriptionMessage":{
+      "type":"structure",
+      "required":["SubscriptionName"],
+      "members":{
+        "SubscriptionName":{"shape":"String"}
+      }
+    },
+    "DeleteEventSubscriptionResponse":{
+      "type":"structure",
+      "members":{
+        "EventSubscription":{"shape":"EventSubscription"}
       }
     },
     "DeleteReplicationInstanceMessage":{
@@ -781,6 +929,56 @@
       "members":{
         "Marker":{"shape":"String"},
         "Endpoints":{"shape":"EndpointList"}
+      }
+    },
+    "DescribeEventCategoriesMessage":{
+      "type":"structure",
+      "members":{
+        "SourceType":{"shape":"String"},
+        "Filters":{"shape":"FilterList"}
+      }
+    },
+    "DescribeEventCategoriesResponse":{
+      "type":"structure",
+      "members":{
+        "EventCategoryGroupList":{"shape":"EventCategoryGroupList"}
+      }
+    },
+    "DescribeEventSubscriptionsMessage":{
+      "type":"structure",
+      "members":{
+        "SubscriptionName":{"shape":"String"},
+        "Filters":{"shape":"FilterList"},
+        "MaxRecords":{"shape":"IntegerOptional"},
+        "Marker":{"shape":"String"}
+      }
+    },
+    "DescribeEventSubscriptionsResponse":{
+      "type":"structure",
+      "members":{
+        "Marker":{"shape":"String"},
+        "EventSubscriptionsList":{"shape":"EventSubscriptionsList"}
+      }
+    },
+    "DescribeEventsMessage":{
+      "type":"structure",
+      "members":{
+        "SourceIdentifier":{"shape":"String"},
+        "SourceType":{"shape":"SourceType"},
+        "StartTime":{"shape":"TStamp"},
+        "EndTime":{"shape":"TStamp"},
+        "Duration":{"shape":"IntegerOptional"},
+        "EventCategories":{"shape":"EventCategoriesList"},
+        "Filters":{"shape":"FilterList"},
+        "MaxRecords":{"shape":"IntegerOptional"},
+        "Marker":{"shape":"String"}
+      }
+    },
+    "DescribeEventsResponse":{
+      "type":"structure",
+      "members":{
+        "Marker":{"shape":"String"},
+        "Events":{"shape":"EventList"}
       }
     },
     "DescribeOrderableReplicationInstancesMessage":{
@@ -897,6 +1095,13 @@
         "verify-full"
       ]
     },
+    "DynamoDbSettings":{
+      "type":"structure",
+      "required":["ServiceAccessRoleArn"],
+      "members":{
+        "ServiceAccessRoleArn":{"shape":"String"}
+      }
+    },
     "Endpoint":{
       "type":"structure",
       "members":{
@@ -912,7 +1117,11 @@
         "KmsKeyId":{"shape":"String"},
         "EndpointArn":{"shape":"String"},
         "CertificateArn":{"shape":"String"},
-        "SslMode":{"shape":"DmsSslModeValue"}
+        "SslMode":{"shape":"DmsSslModeValue"},
+        "ExternalId":{"shape":"String"},
+        "DynamoDbSettings":{"shape":"DynamoDbSettings"},
+        "S3Settings":{"shape":"S3Settings"},
+        "MongoDbSettings":{"shape":"MongoDbSettings"}
       }
     },
     "EndpointList":{
@@ -920,6 +1129,65 @@
       "member":{
         "shape":"Endpoint",
         "locationName":"Endpoint"
+      }
+    },
+    "Event":{
+      "type":"structure",
+      "members":{
+        "SourceIdentifier":{"shape":"String"},
+        "SourceType":{"shape":"SourceType"},
+        "Message":{"shape":"String"},
+        "EventCategories":{"shape":"EventCategoriesList"},
+        "Date":{"shape":"TStamp"}
+      }
+    },
+    "EventCategoriesList":{
+      "type":"list",
+      "member":{
+        "shape":"String",
+        "locationName":"EventCategory"
+      }
+    },
+    "EventCategoryGroup":{
+      "type":"structure",
+      "members":{
+        "SourceType":{"shape":"String"},
+        "EventCategories":{"shape":"EventCategoriesList"}
+      }
+    },
+    "EventCategoryGroupList":{
+      "type":"list",
+      "member":{
+        "shape":"EventCategoryGroup",
+        "locationName":"EventCategoryGroup"
+      }
+    },
+    "EventList":{
+      "type":"list",
+      "member":{
+        "shape":"Event",
+        "locationName":"Event"
+      }
+    },
+    "EventSubscription":{
+      "type":"structure",
+      "members":{
+        "CustomerAwsId":{"shape":"String"},
+        "CustSubscriptionId":{"shape":"String"},
+        "SnsTopicArn":{"shape":"String"},
+        "Status":{"shape":"String"},
+        "SubscriptionCreationTime":{"shape":"String"},
+        "SourceType":{"shape":"String"},
+        "SourceIdsList":{"shape":"SourceIdsList"},
+        "EventCategoriesList":{"shape":"EventCategoriesList"},
+        "Enabled":{"shape":"Boolean"}
+      }
+    },
+    "EventSubscriptionsList":{
+      "type":"list",
+      "member":{
+        "shape":"EventSubscription",
+        "locationName":"EventSubscription"
       }
     },
     "ExceptionMessage":{"type":"string"},
@@ -1041,13 +1309,33 @@
         "DatabaseName":{"shape":"String"},
         "ExtraConnectionAttributes":{"shape":"String"},
         "CertificateArn":{"shape":"String"},
-        "SslMode":{"shape":"DmsSslModeValue"}
+        "SslMode":{"shape":"DmsSslModeValue"},
+        "DynamoDbSettings":{"shape":"DynamoDbSettings"},
+        "S3Settings":{"shape":"S3Settings"},
+        "MongoDbSettings":{"shape":"MongoDbSettings"}
       }
     },
     "ModifyEndpointResponse":{
       "type":"structure",
       "members":{
         "Endpoint":{"shape":"Endpoint"}
+      }
+    },
+    "ModifyEventSubscriptionMessage":{
+      "type":"structure",
+      "required":["SubscriptionName"],
+      "members":{
+        "SubscriptionName":{"shape":"String"},
+        "SnsTopicArn":{"shape":"String"},
+        "SourceType":{"shape":"String"},
+        "EventCategories":{"shape":"EventCategoriesList"},
+        "Enabled":{"shape":"BooleanOptional"}
+      }
+    },
+    "ModifyEventSubscriptionResponse":{
+      "type":"structure",
+      "members":{
+        "EventSubscription":{"shape":"EventSubscription"}
       }
     },
     "ModifyReplicationInstanceMessage":{
@@ -1109,6 +1397,29 @@
         "ReplicationTask":{"shape":"ReplicationTask"}
       }
     },
+    "MongoDbSettings":{
+      "type":"structure",
+      "members":{
+        "Username":{"shape":"String"},
+        "Password":{"shape":"SecretString"},
+        "ServerName":{"shape":"String"},
+        "Port":{"shape":"IntegerOptional"},
+        "DatabaseName":{"shape":"String"},
+        "AuthType":{"shape":"AuthTypeValue"},
+        "AuthMechanism":{"shape":"AuthMechanismValue"},
+        "NestingLevel":{"shape":"NestingLevelValue"},
+        "ExtractDocId":{"shape":"String"},
+        "DocsToInvestigate":{"shape":"String"},
+        "AuthSource":{"shape":"String"}
+      }
+    },
+    "NestingLevelValue":{
+      "type":"string",
+      "enum":[
+        "none",
+        "one"
+      ]
+    },
     "OrderableReplicationInstance":{
       "type":"structure",
       "members":{
@@ -1162,6 +1473,23 @@
         "failed",
         "refreshing"
       ]
+    },
+    "ReloadTablesMessage":{
+      "type":"structure",
+      "required":[
+        "ReplicationTaskArn",
+        "TablesToReload"
+      ],
+      "members":{
+        "ReplicationTaskArn":{"shape":"String"},
+        "TablesToReload":{"shape":"TableListToReload"}
+      }
+    },
+    "ReloadTablesResponse":{
+      "type":"structure",
+      "members":{
+        "ReplicationTaskArn":{"shape":"String"}
+      }
     },
     "RemoveTagsFromResourceMessage":{
       "type":"structure",
@@ -1324,6 +1652,32 @@
       },
       "exception":true
     },
+    "S3Settings":{
+      "type":"structure",
+      "members":{
+        "ServiceAccessRoleArn":{"shape":"String"},
+        "ExternalTableDefinition":{"shape":"String"},
+        "CsvRowDelimiter":{"shape":"String"},
+        "CsvDelimiter":{"shape":"String"},
+        "BucketFolder":{"shape":"String"},
+        "BucketName":{"shape":"String"},
+        "CompressionType":{"shape":"CompressionTypeValue"}
+      }
+    },
+    "SNSInvalidTopicFault":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
+    "SNSNoAuthorizationFault":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ExceptionMessage"}
+      },
+      "exception":true
+    },
     "SchemaList":{
       "type":"list",
       "member":{"shape":"String"}
@@ -1331,6 +1685,17 @@
     "SecretString":{
       "type":"string",
       "sensitive":true
+    },
+    "SourceIdsList":{
+      "type":"list",
+      "member":{
+        "shape":"String",
+        "locationName":"SourceId"
+      }
+    },
+    "SourceType":{
+      "type":"string",
+      "enum":["replication-instance"]
     },
     "StartReplicationTaskMessage":{
       "type":"structure",
@@ -1424,6 +1789,10 @@
       }
     },
     "TStamp":{"type":"timestamp"},
+    "TableListToReload":{
+      "type":"list",
+      "member":{"shape":"TableToReload"}
+    },
     "TableStatistics":{
       "type":"structure",
       "members":{
@@ -1441,6 +1810,13 @@
     "TableStatisticsList":{
       "type":"list",
       "member":{"shape":"TableStatistics"}
+    },
+    "TableToReload":{
+      "type":"structure",
+      "members":{
+        "SchemaName":{"shape":"String"},
+        "TableName":{"shape":"String"}
+      }
     },
     "Tag":{
       "type":"structure",

--- a/models/apis/dms/2016-01-01/docs-2.json
+++ b/models/apis/dms/2016-01-01/docs-2.json
@@ -1,14 +1,16 @@
 {
   "version": "2.0",
-  "service": "<fullname>AWS Database Migration Service</fullname> <p>AWS Database Migration Service (AWS DMS) can migrate your data to and from the most widely used commercial and open-source databases such as Oracle, PostgreSQL, Microsoft SQL Server, Amazon Redshift, MariaDB, Amazon Aurora, MySQL, and SAP Adaptive Server Enterprise (ASE). The service supports homogeneous migrations such as Oracle to Oracle, as well as heterogeneous migrations between different database platforms, such as Oracle to MySQL or SQL Server to PostgreSQL.</p>",
+  "service": "<fullname>AWS Database Migration Service</fullname> <p>AWS Database Migration Service (AWS DMS) can migrate your data to and from the most widely used commercial and open-source databases such as Oracle, PostgreSQL, Microsoft SQL Server, Amazon Redshift, MariaDB, Amazon Aurora, MySQL, and SAP Adaptive Server Enterprise (ASE). The service supports homogeneous migrations such as Oracle to Oracle, as well as heterogeneous migrations between different database platforms, such as Oracle to MySQL or SQL Server to PostgreSQL.</p> <p>For more information about AWS DMS, see the AWS DMS user guide at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/Welcome.html\"> What Is AWS Database Migration Service? </a> </p>",
   "operations": {
     "AddTagsToResource": "<p>Adds metadata tags to a DMS resource, including replication instance, endpoint, security group, and migration task. These tags can also be used with cost allocation reporting to track cost associated with DMS resources, or used in a Condition statement in an IAM policy for DMS.</p>",
     "CreateEndpoint": "<p>Creates an endpoint using the provided settings.</p>",
+    "CreateEventSubscription": "<p> Creates an AWS DMS event notification subscription. </p> <p>You can specify the type of source (<code>SourceType</code>) you want to be notified of, provide a list of AWS DMS source IDs (<code>SourceIds</code>) that triggers the events, and provide a list of event categories (<code>EventCategories</code>) for events you want to be notified of. If you specify both the <code>SourceType</code> and <code>SourceIds</code>, such as <code>SourceType = replication-instance</code> and <code>SourceIdentifier = my-replinstance</code>, you will be notified of all the replication instance events for the specified source. If you specify a <code>SourceType</code> but don't specify a <code>SourceIdentifier</code>, you receive notice of the events for that source type for all your AWS DMS sources. If you don't specify either <code>SourceType</code> nor <code>SourceIdentifier</code>, you will be notified of events generated from all AWS DMS sources belonging to your customer account.</p> <p>For more information about AWS DMS events, see <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html\"> Working with Events and Notifications </a> in the AWS Database MIgration Service User Guide.</p>",
     "CreateReplicationInstance": "<p>Creates the replication instance using the specified parameters.</p>",
     "CreateReplicationSubnetGroup": "<p>Creates a replication subnet group given a list of the subnet IDs in a VPC.</p>",
     "CreateReplicationTask": "<p>Creates a replication task using the specified parameters.</p>",
     "DeleteCertificate": "<p>Deletes the specified certificate. </p>",
     "DeleteEndpoint": "<p>Deletes the specified endpoint.</p> <note> <p>All tasks associated with the endpoint must be deleted before you can delete the endpoint.</p> </note> <p/>",
+    "DeleteEventSubscription": "<p> Deletes an AWS DMS event subscription. </p>",
     "DeleteReplicationInstance": "<p>Deletes the specified replication instance.</p> <note> <p>You must delete any migration tasks that are associated with the replication instance before you can delete it.</p> </note> <p/>",
     "DeleteReplicationSubnetGroup": "<p>Deletes a subnet group.</p>",
     "DeleteReplicationTask": "<p>Deletes the specified replication task.</p>",
@@ -17,6 +19,9 @@
     "DescribeConnections": "<p>Describes the status of the connections that have been made between the replication instance and an endpoint. Connections are created when you test an endpoint.</p>",
     "DescribeEndpointTypes": "<p>Returns information about the type of endpoints available.</p>",
     "DescribeEndpoints": "<p>Returns information about the endpoints for your account in the current region.</p>",
+    "DescribeEventCategories": "<p>Lists categories for all event source types, or, if specified, for a specified source type. You can see a list of the event categories and source types in <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html\"> Working with Events and Notifications </a> in the AWS Database Migration Service User Guide. </p>",
+    "DescribeEventSubscriptions": "<p>Lists all the event subscriptions for a customer account. The description of a subscription includes <code>SubscriptionName</code>, <code>SNSTopicARN</code>, <code>CustomerID</code>, <code>SourceType</code>, <code>SourceID</code>, <code>CreationTime</code>, and <code>Status</code>. </p> <p>If you specify <code>SubscriptionName</code>, this action lists the description for that subscription.</p>",
+    "DescribeEvents": "<p> Lists events for a given source identifier and source type. You can also specify a start and end time. For more information on AWS DMS events, see <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html\"> Working with Events and Notifications </a>. </p>",
     "DescribeOrderableReplicationInstances": "<p>Returns information about the replication instance types that can be created in the specified region.</p>",
     "DescribeRefreshSchemasStatus": "<p>Returns the status of the RefreshSchemas operation.</p>",
     "DescribeReplicationInstances": "<p>Returns information about replication instances for your account in the current region.</p>",
@@ -27,12 +32,14 @@
     "ImportCertificate": "<p>Uploads the specified certificate.</p>",
     "ListTagsForResource": "<p>Lists all tags for an AWS DMS resource.</p>",
     "ModifyEndpoint": "<p>Modifies the specified endpoint.</p>",
+    "ModifyEventSubscription": "<p>Modifies an existing AWS DMS event notification subscription. </p>",
     "ModifyReplicationInstance": "<p>Modifies the replication instance to apply new settings. You can change one or more parameters by specifying these parameters and the new values in the request.</p> <p>Some settings are applied during the maintenance window.</p> <p/>",
     "ModifyReplicationSubnetGroup": "<p>Modifies the settings for the specified replication subnet group.</p>",
-    "ModifyReplicationTask": "<p>Modifies the specified replication task.</p> <p>You can't modify the task endpoints. The task must be stopped before you can modify it. </p>",
+    "ModifyReplicationTask": "<p>Modifies the specified replication task.</p> <p>You can't modify the task endpoints. The task must be stopped before you can modify it. </p> <p>For more information about AWS DMS tasks, see the AWS DMS user guide at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.html\"> Working with Migration Tasks </a> </p>",
     "RefreshSchemas": "<p>Populates the schema for the specified endpoint. This is an asynchronous operation and can take several minutes. You can check the status of this operation by calling the DescribeRefreshSchemasStatus operation.</p>",
+    "ReloadTables": "<p>Reloads the target database table with the source data. </p>",
     "RemoveTagsFromResource": "<p>Removes metadata tags from a DMS resource.</p>",
-    "StartReplicationTask": "<p>Starts the replication task.</p>",
+    "StartReplicationTask": "<p>Starts the replication task.</p> <p>For more information about AWS DMS tasks, see the AWS DMS user guide at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.html\"> Working with Migration Tasks </a> </p>",
     "StopReplicationTask": "<p>Stops the replication task.</p> <p/>",
     "TestConnection": "<p>Tests the connection between the replication instance and the endpoint.</p>"
   },
@@ -64,6 +71,18 @@
       "refs": {
       }
     },
+    "AuthMechanismValue": {
+      "base": null,
+      "refs": {
+        "MongoDbSettings$AuthMechanism": "<p> The authentication mechanism you use to access the MongoDB source endpoint.</p> <p>Valid values: DEFAULT, MONGODB_CR, SCRAM_SHA_1 </p> <p>DEFAULT – For MongoDB version 2.x, use MONGODB_CR. For MongoDB version 3.x, use SCRAM_SHA_1. This attribute is not used when authType=No.</p>"
+      }
+    },
+    "AuthTypeValue": {
+      "base": null,
+      "refs": {
+        "MongoDbSettings$AuthType": "<p> The authentication type you use to access the MongoDB source endpoint.</p> <p>Valid values: NO, PASSWORD </p> <p>When NO is selected, user name and password parameters are not used and can be empty. </p>"
+      }
+    },
     "AvailabilityZone": {
       "base": "<p/>",
       "refs": {
@@ -73,6 +92,7 @@
     "Boolean": {
       "base": null,
       "refs": {
+        "EventSubscription$Enabled": "<p>Boolean value that indicates if the event subscription is enabled.</p>",
         "ModifyReplicationInstanceMessage$ApplyImmediately": "<p>Indicates whether the changes should be applied immediately or during the next maintenance window.</p>",
         "ModifyReplicationInstanceMessage$AllowMajorVersionUpgrade": "<p>Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.</p> <p>Constraints: This parameter must be set to true when specifying a value for the <code>EngineVersion</code> parameter that is a different major version than the replication instance's current version.</p>",
         "ReplicationInstance$MultiAZ": "<p> Specifies if the replication instance is a Multi-AZ deployment. You cannot set the <code>AvailabilityZone</code> parameter if the Multi-AZ parameter is set to <code>true</code>. </p>",
@@ -84,9 +104,11 @@
     "BooleanOptional": {
       "base": null,
       "refs": {
+        "CreateEventSubscriptionMessage$Enabled": "<p> A Boolean value; set to <b>true</b> to activate the subscription, or set to <b>false</b> to create the subscription but not activate it. </p>",
         "CreateReplicationInstanceMessage$MultiAZ": "<p> Specifies if the replication instance is a Multi-AZ deployment. You cannot set the <code>AvailabilityZone</code> parameter if the Multi-AZ parameter is set to <code>true</code>. </p>",
         "CreateReplicationInstanceMessage$AutoMinorVersionUpgrade": "<p>Indicates that minor engine upgrades will be applied automatically to the replication instance during the maintenance window.</p> <p>Default: <code>true</code> </p>",
         "CreateReplicationInstanceMessage$PubliclyAccessible": "<p> Specifies the accessibility options for the replication instance. A value of <code>true</code> represents an instance with a public IP address. A value of <code>false</code> represents an instance with a private IP address. The default value is <code>true</code>. </p>",
+        "ModifyEventSubscriptionMessage$Enabled": "<p> A Boolean value; set to <b>true</b> to activate the subscription. </p>",
         "ModifyReplicationInstanceMessage$MultiAZ": "<p> Specifies if the replication instance is a Multi-AZ deployment. You cannot set the <code>AvailabilityZone</code> parameter if the Multi-AZ parameter is set to <code>true</code>. </p>",
         "ModifyReplicationInstanceMessage$AutoMinorVersionUpgrade": "<p> Indicates that minor version upgrades will be applied automatically to the replication instance during the maintenance window. Changing this parameter does not result in an outage except in the following case and the change is asynchronously applied as soon as possible. An outage will result if this parameter is set to <code>true</code> during the maintenance window, and a newer minor version is available, and AWS DMS has enabled auto patching for that engine version. </p>",
         "ReplicationPendingModifiedValues$MultiAZ": "<p> Specifies if the replication instance is a Multi-AZ deployment. You cannot set the <code>AvailabilityZone</code> parameter if the Multi-AZ parameter is set to <code>true</code>. </p>"
@@ -113,6 +135,12 @@
         "ImportCertificateMessage$CertificateWallet": "<p>The location of the imported Oracle Wallet certificate for use with SSL.</p>"
       }
     },
+    "CompressionTypeValue": {
+      "base": null,
+      "refs": {
+        "S3Settings$CompressionType": "<p> An optional parameter to use GZIP to compress the target files. Set to GZIP to compress the target files. Set to NONE (the default) or do not use to leave the files uncompressed. </p>"
+      }
+    },
     "Connection": {
       "base": "<p/>",
       "refs": {
@@ -132,6 +160,16 @@
       }
     },
     "CreateEndpointResponse": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "CreateEventSubscriptionMessage": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "CreateEventSubscriptionResponse": {
       "base": "<p/>",
       "refs": {
       }
@@ -182,6 +220,16 @@
       }
     },
     "DeleteEndpointResponse": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "DeleteEventSubscriptionMessage": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "DeleteEventSubscriptionResponse": {
       "base": "<p/>",
       "refs": {
       }
@@ -266,6 +314,36 @@
       "refs": {
       }
     },
+    "DescribeEventCategoriesMessage": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "DescribeEventCategoriesResponse": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "DescribeEventSubscriptionsMessage": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "DescribeEventSubscriptionsResponse": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "DescribeEventsMessage": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "DescribeEventsResponse": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
     "DescribeOrderableReplicationInstancesMessage": {
       "base": "<p/>",
       "refs": {
@@ -344,6 +422,14 @@
         "ModifyEndpointMessage$SslMode": "<p>The SSL mode to be used.</p> <p>SSL mode can be one of four values: none, require, verify-ca, verify-full. </p> <p>The default value is none.</p>"
       }
     },
+    "DynamoDbSettings": {
+      "base": "<p/>",
+      "refs": {
+        "CreateEndpointMessage$DynamoDbSettings": "<p>Settings in JSON format for the target Amazon DynamoDB endpoint. For more information about the available settings, see the <b>Using Object Mapping to Migrate Data to DynamoDB</b> section at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.DynamoDB.html\"> Using an Amazon DynamoDB Database as a Target for AWS Database Migration Service</a>. </p>",
+        "Endpoint$DynamoDbSettings": "<p>The settings for the target DynamoDB database. For more information, see the <code>DynamoDBSettings</code> structure.</p>",
+        "ModifyEndpointMessage$DynamoDbSettings": "<p>Settings in JSON format for the target Amazon DynamoDB endpoint. For more information about the available settings, see the <b>Using Object Mapping to Migrate Data to DynamoDB</b> section at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.DynamoDB.html\"> Using an Amazon DynamoDB Database as a Target for AWS Database Migration Service</a>. </p>"
+      }
+    },
     "Endpoint": {
       "base": "<p/>",
       "refs": {
@@ -359,6 +445,56 @@
         "DescribeEndpointsResponse$Endpoints": "<p>Endpoint description.</p>"
       }
     },
+    "Event": {
+      "base": "<p/>",
+      "refs": {
+        "EventList$member": null
+      }
+    },
+    "EventCategoriesList": {
+      "base": null,
+      "refs": {
+        "CreateEventSubscriptionMessage$EventCategories": "<p> A list of event categories for a source type that you want to subscribe to. You can see a list of the categories for a given source type by calling the <b>DescribeEventCategories</b> action or in the topic <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html\"> Working with Events and Notifications</a> in the AWS Database Migration Service User Guide. </p>",
+        "DescribeEventsMessage$EventCategories": "<p>A list of event categories for a source type that you want to subscribe to.</p>",
+        "Event$EventCategories": "<p>The event categories available for the specified source type.</p>",
+        "EventCategoryGroup$EventCategories": "<p> A list of event categories for a <code>SourceType</code> that you want to subscribe to. </p>",
+        "EventSubscription$EventCategoriesList": "<p>A lists of event categories.</p>",
+        "ModifyEventSubscriptionMessage$EventCategories": "<p> A list of event categories for a source type that you want to subscribe to. Use the <code>DescribeEventCategories</code> action to see a list of event categories. </p>"
+      }
+    },
+    "EventCategoryGroup": {
+      "base": "<p/>",
+      "refs": {
+        "EventCategoryGroupList$member": null
+      }
+    },
+    "EventCategoryGroupList": {
+      "base": null,
+      "refs": {
+        "DescribeEventCategoriesResponse$EventCategoryGroupList": "<p>A list of event categories.</p>"
+      }
+    },
+    "EventList": {
+      "base": null,
+      "refs": {
+        "DescribeEventsResponse$Events": "<p>The events described.</p>"
+      }
+    },
+    "EventSubscription": {
+      "base": "<p/>",
+      "refs": {
+        "CreateEventSubscriptionResponse$EventSubscription": "<p>The event subscription that was created.</p>",
+        "DeleteEventSubscriptionResponse$EventSubscription": "<p>The event subscription that was deleted.</p>",
+        "EventSubscriptionsList$member": null,
+        "ModifyEventSubscriptionResponse$EventSubscription": "<p>The modified event subscription.</p>"
+      }
+    },
+    "EventSubscriptionsList": {
+      "base": null,
+      "refs": {
+        "DescribeEventSubscriptionsResponse$EventSubscriptionsList": "<p>A list of event subscriptions.</p>"
+      }
+    },
     "ExceptionMessage": {
       "base": null,
       "refs": {
@@ -372,6 +508,8 @@
         "ResourceAlreadyExistsFault$message": "<p/>",
         "ResourceNotFoundFault$message": "<p/>",
         "ResourceQuotaExceededFault$message": "<p/>",
+        "SNSInvalidTopicFault$message": "<p/>",
+        "SNSNoAuthorizationFault$message": "<p/>",
         "StorageQuotaExceededFault$message": "<p/>",
         "SubnetAlreadyInUse$message": "<p/>",
         "UpgradeDependencyFailureFault$message": "<p/>"
@@ -390,6 +528,9 @@
         "DescribeConnectionsMessage$Filters": "<p>The filters applied to the connection.</p> <p>Valid filter names: endpoint-arn | replication-instance-arn</p>",
         "DescribeEndpointTypesMessage$Filters": "<p>Filters applied to the describe action.</p> <p>Valid filter names: engine-name | endpoint-type</p>",
         "DescribeEndpointsMessage$Filters": "<p>Filters applied to the describe action.</p> <p>Valid filter names: endpoint-arn | endpoint-type | endpoint-id | engine-name</p>",
+        "DescribeEventCategoriesMessage$Filters": "<p>Filters applied to the action.</p>",
+        "DescribeEventSubscriptionsMessage$Filters": "<p>Filters applied to the action.</p>",
+        "DescribeEventsMessage$Filters": "<p>Filters applied to the action.</p>",
         "DescribeReplicationInstancesMessage$Filters": "<p>Filters applied to the describe action.</p> <p>Valid filter names: replication-instance-arn | replication-instance-id | replication-instance-class | engine-version</p>",
         "DescribeReplicationSubnetGroupsMessage$Filters": "<p>Filters applied to the describe action.</p>",
         "DescribeReplicationTasksMessage$Filters": "<p>Filters applied to the describe action.</p> <p>Valid filter names: replication-task-arn | replication-task-id | migration-type | endpoint-arn | replication-instance-arn</p>"
@@ -441,6 +582,9 @@
         "DescribeConnectionsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
         "DescribeEndpointTypesMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
         "DescribeEndpointsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeEventSubscriptionsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeEventsMessage$Duration": "<p>The duration of the events to be listed.</p>",
+        "DescribeEventsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
         "DescribeOrderableReplicationInstancesMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
         "DescribeReplicationInstancesMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
         "DescribeReplicationSubnetGroupsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
@@ -450,6 +594,7 @@
         "Endpoint$Port": "<p>The port value used to access the endpoint.</p>",
         "ModifyEndpointMessage$Port": "<p>The port used by the endpoint database.</p>",
         "ModifyReplicationInstanceMessage$AllocatedStorage": "<p>The amount of storage (in gigabytes) to be allocated for the replication instance.</p>",
+        "MongoDbSettings$Port": "<p> The port value for the MongoDB source endpoint. </p>",
         "ReplicationPendingModifiedValues$AllocatedStorage": "<p>The amount of storage (in gigabytes) that is allocated for the replication instance.</p>"
       }
     },
@@ -520,6 +665,16 @@
       "refs": {
       }
     },
+    "ModifyEventSubscriptionMessage": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "ModifyEventSubscriptionResponse": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
     "ModifyReplicationInstanceMessage": {
       "base": "<p/>",
       "refs": {
@@ -548,6 +703,20 @@
     "ModifyReplicationTaskResponse": {
       "base": "<p/>",
       "refs": {
+      }
+    },
+    "MongoDbSettings": {
+      "base": "<p/>",
+      "refs": {
+        "CreateEndpointMessage$MongoDbSettings": "<p>Settings in JSON format for the source MongoDB endpoint. For more information about the available settings, see the <b>Configuration Properties When Using MongoDB as a Source for AWS Database Migration Service</b> section at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html\"> Using Amazon S3 as a Target for AWS Database Migration Service</a>. </p>",
+        "Endpoint$MongoDbSettings": "<p>The settings for the MongoDB source endpoint. For more information, see the <code>MongoDbSettings</code> structure.</p>",
+        "ModifyEndpointMessage$MongoDbSettings": "<p>Settings in JSON format for the source MongoDB endpoint. For more information about the available settings, see the <b>Configuration Properties When Using MongoDB as a Source for AWS Database Migration Service</b> section at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html\"> Using Amazon S3 as a Target for AWS Database Migration Service</a>. </p>"
+      }
+    },
+    "NestingLevelValue": {
+      "base": null,
+      "refs": {
+        "MongoDbSettings$NestingLevel": "<p> Specifies either document or table mode. </p> <p>Valid values: NONE, ONE</p> <p>Default value is NONE. Specify NONE to use document mode. Specify ONE to use table mode.</p>"
       }
     },
     "OrderableReplicationInstance": {
@@ -583,6 +752,16 @@
       "base": null,
       "refs": {
         "RefreshSchemasStatus$Status": "<p>The status of the schema.</p>"
+      }
+    },
+    "ReloadTablesMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ReloadTablesResponse": {
+      "base": null,
+      "refs": {
       }
     },
     "RemoveTagsFromResourceMessage": {
@@ -695,6 +874,24 @@
       "refs": {
       }
     },
+    "S3Settings": {
+      "base": "<p/>",
+      "refs": {
+        "CreateEndpointMessage$S3Settings": "<p>Settings in JSON format for the target S3 endpoint. For more information about the available settings, see the <b>Extra Connection Attributes</b> section at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html\"> Using Amazon S3 as a Target for AWS Database Migration Service</a>. </p>",
+        "Endpoint$S3Settings": "<p>The settings for the S3 target endpoint. For more information, see the <code>S3Settings</code> structure.</p>",
+        "ModifyEndpointMessage$S3Settings": "<p>Settings in JSON format for the target S3 endpoint. For more information about the available settings, see the <b>Extra Connection Attributes</b> section at <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html\"> Using Amazon S3 as a Target for AWS Database Migration Service</a>. </p>"
+      }
+    },
+    "SNSInvalidTopicFault": {
+      "base": "<p>The SNS topic is invalid.</p>",
+      "refs": {
+      }
+    },
+    "SNSNoAuthorizationFault": {
+      "base": "<p>You are not authorized for the SNS subscription.</p>",
+      "refs": {
+      }
+    },
     "SchemaList": {
       "base": null,
       "refs": {
@@ -705,7 +902,22 @@
       "base": null,
       "refs": {
         "CreateEndpointMessage$Password": "<p>The password to be used to login to the endpoint database.</p>",
-        "ModifyEndpointMessage$Password": "<p>The password to be used to login to the endpoint database.</p>"
+        "ModifyEndpointMessage$Password": "<p>The password to be used to login to the endpoint database.</p>",
+        "MongoDbSettings$Password": "<p> The password for the user account you use to access the MongoDB source endpoint. </p>"
+      }
+    },
+    "SourceIdsList": {
+      "base": null,
+      "refs": {
+        "CreateEventSubscriptionMessage$SourceIds": "<p> The list of identifiers of the event sources for which events will be returned. If not specified, then all sources are included in the response. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens; it cannot end with a hyphen or contain two consecutive hyphens. </p>",
+        "EventSubscription$SourceIdsList": "<p>A list of source Ids for the event subscription.</p>"
+      }
+    },
+    "SourceType": {
+      "base": null,
+      "refs": {
+        "DescribeEventsMessage$SourceType": "<p>The type of AWS DMS resource that generates events.</p> <p>Valid values: replication-instance | migration-task</p>",
+        "Event$SourceType": "<p> The type of AWS DMS resource that generates events. </p> <p>Valid values: replication-instance | endpoint | migration-task</p>"
       }
     },
     "StartReplicationTaskMessage": {
@@ -757,13 +969,16 @@
         "Connection$EndpointIdentifier": "<p>The identifier of the endpoint. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.</p>",
         "Connection$ReplicationInstanceIdentifier": "<p>The replication instance identifier. This parameter is stored as a lowercase string.</p>",
         "CreateEndpointMessage$EndpointIdentifier": "<p>The database endpoint identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.</p>",
-        "CreateEndpointMessage$EngineName": "<p>The type of engine for the endpoint. Valid values include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, SYBASE, and SQLSERVER.</p>",
+        "CreateEndpointMessage$EngineName": "<p>The type of engine for the endpoint. Valid values, depending on the EndPointType, include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB, MONGODB, and SQLSERVER.</p>",
         "CreateEndpointMessage$Username": "<p>The user name to be used to login to the endpoint database.</p>",
         "CreateEndpointMessage$ServerName": "<p>The name of the server where the endpoint database resides.</p>",
         "CreateEndpointMessage$DatabaseName": "<p>The name of the endpoint database.</p>",
         "CreateEndpointMessage$ExtraConnectionAttributes": "<p>Additional attributes associated with the connection.</p>",
         "CreateEndpointMessage$KmsKeyId": "<p>The KMS key identifier that will be used to encrypt the connection parameters. If you do not specify a value for the KmsKeyId parameter, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.</p>",
         "CreateEndpointMessage$CertificateArn": "<p>The Amazon Resource Number (ARN) for the certificate.</p>",
+        "CreateEventSubscriptionMessage$SubscriptionName": "<p>The name of the DMS event notification subscription. </p> <p>Constraints: The name must be less than 255 characters. </p>",
+        "CreateEventSubscriptionMessage$SnsTopicArn": "<p> The Amazon Resource Name (ARN) of the Amazon SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it. </p>",
+        "CreateEventSubscriptionMessage$SourceType": "<p> The type of AWS DMS resource that generates the events. For example, if you want to be notified of events generated by a replication instance, you set this parameter to <code>replication-instance</code>. If this value is not specified, all events are returned. </p> <p>Valid values: replication-instance | migration-task</p>",
         "CreateReplicationInstanceMessage$ReplicationInstanceIdentifier": "<p>The replication instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>myrepinstance</code> </p>",
         "CreateReplicationInstanceMessage$ReplicationInstanceClass": "<p>The compute and memory capacity of the replication instance as specified by the replication instance class.</p> <p> Valid Values: <code>dms.t2.micro | dms.t2.small | dms.t2.medium | dms.t2.large | dms.c4.large | dms.c4.xlarge | dms.c4.2xlarge | dms.c4.4xlarge </code> </p>",
         "CreateReplicationInstanceMessage$AvailabilityZone": "<p>The EC2 Availability Zone that the replication instance will be created in.</p> <p>Default: A random, system-chosen Availability Zone in the endpoint's region.</p> <p> Example: <code>us-east-1d</code> </p>",
@@ -773,14 +988,15 @@
         "CreateReplicationInstanceMessage$KmsKeyId": "<p>The KMS key identifier that will be used to encrypt the content on the replication instance. If you do not specify a value for the KmsKeyId parameter, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.</p>",
         "CreateReplicationSubnetGroupMessage$ReplicationSubnetGroupIdentifier": "<p>The name for the replication subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, spaces, underscores, or hyphens. Must not be \"default\".</p> <p>Example: <code>mySubnetgroup</code> </p>",
         "CreateReplicationSubnetGroupMessage$ReplicationSubnetGroupDescription": "<p>The description for the subnet group.</p>",
-        "CreateReplicationTaskMessage$ReplicationTaskIdentifier": "<p>The replication task identifier.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
+        "CreateReplicationTaskMessage$ReplicationTaskIdentifier": "<p>The replication task identifier.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
         "CreateReplicationTaskMessage$SourceEndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
         "CreateReplicationTaskMessage$TargetEndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
         "CreateReplicationTaskMessage$ReplicationInstanceArn": "<p>The Amazon Resource Name (ARN) of the replication instance.</p>",
-        "CreateReplicationTaskMessage$TableMappings": "<p>The path of the JSON file that contains the table mappings. Preceed the path with \"file://\".</p> <p>For example, --table-mappings file://mappingfile.json</p>",
+        "CreateReplicationTaskMessage$TableMappings": "<p>When using the AWS CLI or boto3, provide the path of the JSON file that contains the table mappings. Precede the path with \"file://\". When working with the DMS API, provide the JSON as the parameter value.</p> <p>For example, --table-mappings file://mappingfile.json</p>",
         "CreateReplicationTaskMessage$ReplicationTaskSettings": "<p>Settings for the task, such as target metadata settings. For a complete list of task settings, see <a href=\"http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TaskSettings.html\">Task Settings for AWS Database Migration Service Tasks</a>.</p>",
         "DeleteCertificateMessage$CertificateArn": "<p>The Amazon Resource Name (ARN) of the deleted certificate.</p>",
         "DeleteEndpointMessage$EndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
+        "DeleteEventSubscriptionMessage$SubscriptionName": "<p>The name of the DMS event notification subscription to be deleted.</p>",
         "DeleteReplicationInstanceMessage$ReplicationInstanceArn": "<p>The Amazon Resource Name (ARN) of the replication instance to be deleted.</p>",
         "DeleteReplicationSubnetGroupMessage$ReplicationSubnetGroupIdentifier": "<p>The subnet group name of the replication instance.</p>",
         "DeleteReplicationTaskMessage$ReplicationTaskArn": "<p>The Amazon Resource Name (ARN) of the replication task to be deleted.</p>",
@@ -792,6 +1008,13 @@
         "DescribeEndpointTypesResponse$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
         "DescribeEndpointsMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
         "DescribeEndpointsResponse$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeEventCategoriesMessage$SourceType": "<p> The type of AWS DMS resource that generates events. </p> <p>Valid values: replication-instance | migration-task</p>",
+        "DescribeEventSubscriptionsMessage$SubscriptionName": "<p>The name of the AWS DMS event subscription to be described.</p>",
+        "DescribeEventSubscriptionsMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeEventSubscriptionsResponse$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeEventsMessage$SourceIdentifier": "<p> The identifier of the event source. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens. It cannot end with a hyphen or contain two consecutive hyphens. </p>",
+        "DescribeEventsMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeEventsResponse$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
         "DescribeOrderableReplicationInstancesMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
         "DescribeOrderableReplicationInstancesResponse$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
         "DescribeRefreshSchemasStatusMessage$EndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
@@ -808,8 +1031,9 @@
         "DescribeTableStatisticsMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
         "DescribeTableStatisticsResponse$ReplicationTaskArn": "<p>The Amazon Resource Name (ARN) of the replication task.</p>",
         "DescribeTableStatisticsResponse$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DynamoDbSettings$ServiceAccessRoleArn": "<p> The Amazon Resource Name (ARN) used by the service access IAM role. </p>",
         "Endpoint$EndpointIdentifier": "<p>The database endpoint identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.</p>",
-        "Endpoint$EngineName": "<p>The database engine name. Valid values include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, SYBASE, and SQLSERVER.</p>",
+        "Endpoint$EngineName": "<p>The database engine name. Valid values, depending on the EndPointType, include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB, MONGODB, and SQLSERVER.</p>",
         "Endpoint$Username": "<p>The user name used to connect to the endpoint.</p>",
         "Endpoint$ServerName": "<p>The name of the server at the endpoint.</p>",
         "Endpoint$DatabaseName": "<p>The name of the database at the endpoint.</p>",
@@ -818,6 +1042,17 @@
         "Endpoint$KmsKeyId": "<p>The KMS key identifier that will be used to encrypt the connection parameters. If you do not specify a value for the KmsKeyId parameter, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.</p>",
         "Endpoint$EndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
         "Endpoint$CertificateArn": "<p>The Amazon Resource Name (ARN) used for SSL connection to the endpoint.</p>",
+        "Endpoint$ExternalId": "<p> Value returned by a call to CreateEndpoint that can be used for cross-account validation. Use it on a subsequent call to CreateEndpoint to create the endpoint with a cross-account. </p>",
+        "Event$SourceIdentifier": "<p> The identifier of the event source. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens; it cannot end with a hyphen or contain two consecutive hyphens. </p> <p>Constraints:replication instance, endpoint, migration task</p>",
+        "Event$Message": "<p>The event message.</p>",
+        "EventCategoriesList$member": null,
+        "EventCategoryGroup$SourceType": "<p> The type of AWS DMS resource that generates events. </p> <p>Valid values: replication-instance | replication-server | security-group | migration-task</p>",
+        "EventSubscription$CustomerAwsId": "<p>The AWS customer account associated with the AWS DMS event notification subscription.</p>",
+        "EventSubscription$CustSubscriptionId": "<p>The AWS DMS event notification subscription Id.</p>",
+        "EventSubscription$SnsTopicArn": "<p>The topic ARN of the AWS DMS event notification subscription.</p>",
+        "EventSubscription$Status": "<p>The status of the AWS DMS event notification subscription.</p> <p>Constraints:</p> <p>Can be one of the following: creating | modifying | deleting | active | no-permission | topic-not-exist</p> <p>The status \"no-permission\" indicates that AWS DMS no longer has permission to post to the SNS topic. The status \"topic-not-exist\" indicates that the topic was deleted after the subscription was created.</p>",
+        "EventSubscription$SubscriptionCreationTime": "<p>The time the RDS event notification subscription was created.</p>",
+        "EventSubscription$SourceType": "<p> The type of AWS DMS resource that generates events. </p> <p>Valid values: replication-instance | replication-server | security-group | migration-task</p>",
         "Filter$Name": "<p>The name of the filter.</p>",
         "FilterValueList$member": null,
         "ImportCertificateMessage$CertificateIdentifier": "<p>The customer-assigned name of the certificate. Valid characters are A-z and 0-9.</p>",
@@ -826,12 +1061,15 @@
         "ListTagsForResourceMessage$ResourceArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the AWS DMS resource.</p>",
         "ModifyEndpointMessage$EndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
         "ModifyEndpointMessage$EndpointIdentifier": "<p>The database endpoint identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.</p>",
-        "ModifyEndpointMessage$EngineName": "<p>The type of engine for the endpoint. Valid values include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, SYBASE, and SQLSERVER.</p>",
+        "ModifyEndpointMessage$EngineName": "<p>The type of engine for the endpoint. Valid values, depending on the EndPointType, include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, DYNAMODB, MONGODB, SYBASE, and SQLSERVER.</p>",
         "ModifyEndpointMessage$Username": "<p>The user name to be used to login to the endpoint database.</p>",
         "ModifyEndpointMessage$ServerName": "<p>The name of the server where the endpoint database resides.</p>",
         "ModifyEndpointMessage$DatabaseName": "<p>The name of the endpoint database.</p>",
         "ModifyEndpointMessage$ExtraConnectionAttributes": "<p>Additional attributes associated with the connection.</p>",
         "ModifyEndpointMessage$CertificateArn": "<p>The Amazon Resource Name (ARN) of the certificate used for SSL connection.</p>",
+        "ModifyEventSubscriptionMessage$SubscriptionName": "<p>The name of the AWS DMS event notification subscription to be modified.</p>",
+        "ModifyEventSubscriptionMessage$SnsTopicArn": "<p> The Amazon Resource Name (ARN) of the Amazon SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it.</p>",
+        "ModifyEventSubscriptionMessage$SourceType": "<p> The type of AWS DMS resource that generates the events you want to subscribe to. </p> <p>Valid values: replication-instance | migration-task</p>",
         "ModifyReplicationInstanceMessage$ReplicationInstanceArn": "<p>The Amazon Resource Name (ARN) of the replication instance.</p>",
         "ModifyReplicationInstanceMessage$ReplicationInstanceClass": "<p>The compute and memory capacity of the replication instance.</p> <p> Valid Values: <code>dms.t2.micro | dms.t2.small | dms.t2.medium | dms.t2.large | dms.c4.large | dms.c4.xlarge | dms.c4.2xlarge | dms.c4.4xlarge </code> </p>",
         "ModifyReplicationInstanceMessage$PreferredMaintenanceWindow": "<p>The weekly time range (in UTC) during which system maintenance can occur, which might result in an outage. Changing this parameter does not result in an outage, except in the following situation, and the change is asynchronously applied as soon as possible. If moving this window to the current time, there must be at least 30 minutes between the current time and end of the window to ensure pending changes are applied.</p> <p>Default: Uses existing setting</p> <p>Format: ddd:hh24:mi-ddd:hh24:mi</p> <p>Valid Days: Mon | Tue | Wed | Thu | Fri | Sat | Sun</p> <p>Constraints: Must be at least 30 minutes</p>",
@@ -840,9 +1078,15 @@
         "ModifyReplicationSubnetGroupMessage$ReplicationSubnetGroupIdentifier": "<p>The name of the replication instance subnet group.</p>",
         "ModifyReplicationSubnetGroupMessage$ReplicationSubnetGroupDescription": "<p>The description of the replication instance subnet group.</p>",
         "ModifyReplicationTaskMessage$ReplicationTaskArn": "<p>The Amazon Resource Name (ARN) of the replication task.</p>",
-        "ModifyReplicationTaskMessage$ReplicationTaskIdentifier": "<p>The replication task identifier.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
-        "ModifyReplicationTaskMessage$TableMappings": "<p>The path of the JSON file that contains the table mappings. Preceed the path with \"file://\".</p> <p>For example, --table-mappings file://mappingfile.json</p>",
+        "ModifyReplicationTaskMessage$ReplicationTaskIdentifier": "<p>The replication task identifier.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
+        "ModifyReplicationTaskMessage$TableMappings": "<p>When using the AWS CLI or boto3, provide the path of the JSON file that contains the table mappings. Precede the path with \"file://\". When working with the DMS API, provide the JSON as the parameter value.</p> <p>For example, --table-mappings file://mappingfile.json</p>",
         "ModifyReplicationTaskMessage$ReplicationTaskSettings": "<p>JSON file that contains settings for the task, such as target metadata settings.</p>",
+        "MongoDbSettings$Username": "<p>The user name you use to access the MongoDB source endpoint. </p>",
+        "MongoDbSettings$ServerName": "<p> The name of the server on the MongoDB source endpoint. </p>",
+        "MongoDbSettings$DatabaseName": "<p> The database name on the MongoDB source endpoint. </p>",
+        "MongoDbSettings$ExtractDocId": "<p> Specifies the document ID. Use this attribute when <code>NestingLevel</code> is set to NONE. </p> <p>Default value is false. </p>",
+        "MongoDbSettings$DocsToInvestigate": "<p> Indicates the number of documents to preview to determine the document organization. Use this attribute when <code>NestingLevel</code> is set to ONE. </p> <p>Must be a positive value greater than 0. Default value is 1000.</p>",
+        "MongoDbSettings$AuthSource": "<p> The MongoDB database name. This attribute is not used when <code>authType=NO</code>. </p> <p>The default is admin.</p>",
         "OrderableReplicationInstance$EngineVersion": "<p>The version of the replication engine.</p>",
         "OrderableReplicationInstance$ReplicationInstanceClass": "<p>The compute and memory capacity of the replication instance.</p> <p> Valid Values: <code>dms.t2.micro | dms.t2.small | dms.t2.medium | dms.t2.large | dms.c4.large | dms.c4.xlarge | dms.c4.2xlarge | dms.c4.4xlarge </code> </p>",
         "OrderableReplicationInstance$StorageType": "<p>The type of storage used by the replication instance.</p>",
@@ -851,6 +1095,8 @@
         "RefreshSchemasStatus$EndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
         "RefreshSchemasStatus$ReplicationInstanceArn": "<p>The Amazon Resource Name (ARN) of the replication instance.</p>",
         "RefreshSchemasStatus$LastFailureMessage": "<p>The last failure message for the schema.</p>",
+        "ReloadTablesMessage$ReplicationTaskArn": "<p>The Amazon Resource Name (ARN) of the replication instance. </p>",
+        "ReloadTablesResponse$ReplicationTaskArn": "<p>The Amazon Resource Name (ARN) of the replication task. </p>",
         "RemoveTagsFromResourceMessage$ResourceArn": "<p>&gt;The Amazon Resource Name (ARN) of the AWS DMS resource the tag is to be removed from.</p>",
         "ReplicationInstance$ReplicationInstanceIdentifier": "<p>The replication instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>myrepinstance</code> </p>",
         "ReplicationInstance$ReplicationInstanceClass": "<p>The compute and memory capacity of the replication instance.</p> <p> Valid Values: <code>dms.t2.micro | dms.t2.small | dms.t2.medium | dms.t2.large | dms.c4.large | dms.c4.xlarge | dms.c4.2xlarge | dms.c4.4xlarge </code> </p>",
@@ -871,7 +1117,7 @@
         "ReplicationSubnetGroup$ReplicationSubnetGroupDescription": "<p>The description of the replication subnet group.</p>",
         "ReplicationSubnetGroup$VpcId": "<p>The ID of the VPC.</p>",
         "ReplicationSubnetGroup$SubnetGroupStatus": "<p>The status of the subnet group.</p>",
-        "ReplicationTask$ReplicationTaskIdentifier": "<p>The replication task identifier.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
+        "ReplicationTask$ReplicationTaskIdentifier": "<p>The replication task identifier.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
         "ReplicationTask$SourceEndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
         "ReplicationTask$TargetEndpointArn": "<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>",
         "ReplicationTask$ReplicationInstanceArn": "<p>The Amazon Resource Name (ARN) of the replication instance.</p>",
@@ -881,16 +1127,25 @@
         "ReplicationTask$LastFailureMessage": "<p>The last error (failure) message generated for the replication instance.</p>",
         "ReplicationTask$StopReason": "<p>The reason the replication task was stopped.</p>",
         "ReplicationTask$ReplicationTaskArn": "<p>The Amazon Resource Name (ARN) of the replication task.</p>",
+        "S3Settings$ServiceAccessRoleArn": "<p> The Amazon Resource Name (ARN) used by the service access IAM role. </p>",
+        "S3Settings$ExternalTableDefinition": "<p> </p>",
+        "S3Settings$CsvRowDelimiter": "<p> The delimiter used to separate rows in the source files. The default is a carriage return (\\n). </p>",
+        "S3Settings$CsvDelimiter": "<p> The delimiter used to separate columns in the source files. The default is a comma. </p>",
+        "S3Settings$BucketFolder": "<p> An optional parameter to set a folder name in the S3 bucket. If provided, tables are created in the path &lt;bucketFolder&gt;/&lt;schema_name&gt;/&lt;table_name&gt;/. If this parameter is not specified, then the path used is &lt;schema_name&gt;/&lt;table_name&gt;/. </p>",
+        "S3Settings$BucketName": "<p> The name of the S3 bucket. </p>",
         "SchemaList$member": null,
+        "SourceIdsList$member": null,
         "StartReplicationTaskMessage$ReplicationTaskArn": "<p>The Amazon Resource Number (ARN) of the replication task to be started.</p>",
         "StopReplicationTaskMessage$ReplicationTaskArn": "<p>The Amazon Resource Number(ARN) of the replication task to be stopped.</p>",
         "Subnet$SubnetIdentifier": "<p>The subnet identifier.</p>",
         "Subnet$SubnetStatus": "<p>The status of the subnet.</p>",
         "SubnetIdentifierList$member": null,
-        "SupportedEndpointType$EngineName": "<p>The database engine name. Valid values include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, SYBASE, and SQLSERVER.</p>",
+        "SupportedEndpointType$EngineName": "<p>The database engine name. Valid values, depending on the EndPointType, include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB, MONGODB, and SQLSERVER.</p>",
         "TableStatistics$SchemaName": "<p>The schema name.</p>",
         "TableStatistics$TableName": "<p>The name of the table.</p>",
         "TableStatistics$TableState": "<p>The state of the table.</p>",
+        "TableToReload$SchemaName": "<p>The schema name of the table to be reloaded.</p>",
+        "TableToReload$TableName": "<p>The table name of the table to be reloaded.</p>",
         "Tag$Key": "<p>A key is the required name of the tag. The string value can be from 1 to 128 Unicode characters in length and cannot be prefixed with \"aws:\" or \"dms:\". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>",
         "Tag$Value": "<p>A value is the optional value of the tag. The string value can be from 1 to 256 Unicode characters in length and cannot be prefixed with \"aws:\" or \"dms:\". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>",
         "TestConnectionMessage$ReplicationInstanceArn": "<p>The Amazon Resource Name (ARN) of the replication instance.</p>",
@@ -943,6 +1198,9 @@
         "Certificate$ValidFromDate": "<p>The beginning date that the certificate is valid.</p>",
         "Certificate$ValidToDate": "<p>The final date that the certificate is valid.</p>",
         "CreateReplicationTaskMessage$CdcStartTime": "<p>The start time for the Change Data Capture (CDC) operation.</p>",
+        "DescribeEventsMessage$StartTime": "<p>The start time for the events to be listed.</p>",
+        "DescribeEventsMessage$EndTime": "<p>The end time for the events to be listed.</p>",
+        "Event$Date": "<p>The date of the event.</p>",
         "ModifyReplicationTaskMessage$CdcStartTime": "<p>The start time for the Change Data Capture (CDC) operation.</p>",
         "RefreshSchemasStatus$LastRefreshDate": "<p>The date the schema was last refreshed.</p>",
         "ReplicationInstance$InstanceCreateTime": "<p>The time the replication instance was created.</p>",
@@ -950,6 +1208,12 @@
         "ReplicationTask$ReplicationTaskStartDate": "<p>The date the replication task is scheduled to start.</p>",
         "StartReplicationTaskMessage$CdcStartTime": "<p>The start time for the Change Data Capture (CDC) operation.</p>",
         "TableStatistics$LastUpdateTime": "<p>The last time the table was updated.</p>"
+      }
+    },
+    "TableListToReload": {
+      "base": null,
+      "refs": {
+        "ReloadTablesMessage$TablesToReload": "<p>The name and schema of the table to be reloaded. </p>"
       }
     },
     "TableStatistics": {
@@ -964,6 +1228,12 @@
         "DescribeTableStatisticsResponse$TableStatistics": "<p>The table statistics.</p>"
       }
     },
+    "TableToReload": {
+      "base": "<p/>",
+      "refs": {
+        "TableListToReload$member": null
+      }
+    },
     "Tag": {
       "base": "<p/>",
       "refs": {
@@ -975,6 +1245,7 @@
       "refs": {
         "AddTagsToResourceMessage$Tags": "<p>The tag to be assigned to the DMS resource.</p>",
         "CreateEndpointMessage$Tags": "<p>Tags to be added to the endpoint.</p>",
+        "CreateEventSubscriptionMessage$Tags": "<p>A tag to be attached to the event subscription.</p>",
         "CreateReplicationInstanceMessage$Tags": "<p>Tags to be associated with the replication instance.</p>",
         "CreateReplicationSubnetGroupMessage$Tags": "<p>The tag to be assigned to the subnet group.</p>",
         "CreateReplicationTaskMessage$Tags": "<p>Tags to be added to the replication instance.</p>",

--- a/models/apis/dms/2016-01-01/examples-1.json
+++ b/models/apis/dms/2016-01-01/examples-1.json
@@ -1,5 +1,1053 @@
 {
   "version": "1.0",
   "examples": {
+    "AddTagsToResource": [
+      {
+        "input": {
+          "ResourceArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E",
+          "Tags": [
+            {
+              "Key": "Acount",
+              "Value": "1633456"
+            }
+          ]
+        },
+        "output": {
+        },
+        "comments": {
+          "input": {
+            "ResourceArn": "Required. Use the ARN of the resource you want to tag.",
+            "Tags": "Required. Use the Key/Value pair format."
+          },
+          "output": {
+          }
+        },
+        "description": "Adds metadata tags to an AWS DMS resource, including replication instance, endpoint, security group, and migration task. These tags can also be used with cost allocation reporting to track cost associated with AWS DMS resources, or used in a Condition statement in an IAM policy for AWS DMS.",
+        "id": "add-tags-to-resource-1481744141435",
+        "title": "Add tags to resource"
+      }
+    ],
+    "CreateEndpoint": [
+      {
+        "input": {
+          "CertificateArn": "",
+          "DatabaseName": "testdb",
+          "EndpointIdentifier": "test-endpoint-1",
+          "EndpointType": "source",
+          "EngineName": "mysql",
+          "ExtraConnectionAttributes": "",
+          "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/4c1731d6-5435-ed4d-be13-d53411a7cfbd",
+          "Password": "pasword",
+          "Port": 3306,
+          "ServerName": "mydb.cx1llnox7iyx.us-west-2.rds.amazonaws.com",
+          "SslMode": "require",
+          "Tags": [
+            {
+              "Key": "Acount",
+              "Value": "143327655"
+            }
+          ],
+          "Username": "username"
+        },
+        "output": {
+          "Endpoint": {
+            "EndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:RAAR3R22XSH46S3PWLC3NJAWKM",
+            "EndpointIdentifier": "test-endpoint-1",
+            "EndpointType": "source",
+            "EngineName": "mysql",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/4c1731d6-5435-ed4d-be13-d53411a7cfbd",
+            "Port": 3306,
+            "ServerName": "mydb.cx1llnox7iyx.us-west-2.rds.amazonaws.com",
+            "Status": "active",
+            "Username": "username"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Creates an endpoint using the provided settings.",
+        "id": "create-endpoint-1481746254348",
+        "title": "Create endpoint"
+      }
+    ],
+    "CreateReplicationInstance": [
+      {
+        "input": {
+          "AllocatedStorage": 123,
+          "AutoMinorVersionUpgrade": true,
+          "AvailabilityZone": "",
+          "EngineVersion": "",
+          "KmsKeyId": "",
+          "MultiAZ": true,
+          "PreferredMaintenanceWindow": "",
+          "PubliclyAccessible": true,
+          "ReplicationInstanceClass": "",
+          "ReplicationInstanceIdentifier": "",
+          "ReplicationSubnetGroupIdentifier": "",
+          "Tags": [
+            {
+              "Key": "string",
+              "Value": "string"
+            }
+          ],
+          "VpcSecurityGroupIds": [
+
+          ]
+        },
+        "output": {
+          "ReplicationInstance": {
+            "AllocatedStorage": 5,
+            "AutoMinorVersionUpgrade": true,
+            "EngineVersion": "1.5.0",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/4c1731d6-5435-ed4d-be13-d53411a7cfbd",
+            "PendingModifiedValues": {
+            },
+            "PreferredMaintenanceWindow": "sun:06:00-sun:14:00",
+            "PubliclyAccessible": true,
+            "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+            "ReplicationInstanceClass": "dms.t2.micro",
+            "ReplicationInstanceIdentifier": "test-rep-1",
+            "ReplicationInstanceStatus": "creating",
+            "ReplicationSubnetGroup": {
+              "ReplicationSubnetGroupDescription": "default",
+              "ReplicationSubnetGroupIdentifier": "default",
+              "SubnetGroupStatus": "Complete",
+              "Subnets": [
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1d"
+                  },
+                  "SubnetIdentifier": "subnet-f6dd91af",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1b"
+                  },
+                  "SubnetIdentifier": "subnet-3605751d",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1c"
+                  },
+                  "SubnetIdentifier": "subnet-c2daefb5",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1e"
+                  },
+                  "SubnetIdentifier": "subnet-85e90cb8",
+                  "SubnetStatus": "Active"
+                }
+              ],
+              "VpcId": "vpc-6741a603"
+            }
+          }
+        },
+        "comments": {
+          "output": {
+          }
+        },
+        "description": "Creates the replication instance using the specified parameters.",
+        "id": "create-replication-instance-1481746705295",
+        "title": "Create replication instance"
+      }
+    ],
+    "CreateReplicationSubnetGroup": [
+      {
+        "input": {
+          "ReplicationSubnetGroupDescription": "US West subnet group",
+          "ReplicationSubnetGroupIdentifier": "us-west-2ab-vpc-215ds366",
+          "SubnetIds": [
+            "subnet-e145356n",
+            "subnet-58f79200"
+          ],
+          "Tags": [
+            {
+              "Key": "Acount",
+              "Value": "145235"
+            }
+          ]
+        },
+        "output": {
+          "ReplicationSubnetGroup": {
+          }
+        },
+        "comments": {
+          "output": {
+          }
+        },
+        "description": "Creates a replication subnet group given a list of the subnet IDs in a VPC.",
+        "id": "create-replication-subnet-group-1481747297930",
+        "title": "Create replication subnet group"
+      }
+    ],
+    "CreateReplicationTask": [
+      {
+        "input": {
+          "CdcStartTime": "2016-12-14T18:25:43Z",
+          "MigrationType": "full-load",
+          "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+          "ReplicationTaskIdentifier": "task1",
+          "ReplicationTaskSettings": "",
+          "SourceEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ZW5UAN6P4E77EC7YWHK4RZZ3BE",
+          "TableMappings": "file://mappingfile.json",
+          "Tags": [
+            {
+              "Key": "Acount",
+              "Value": "24352226"
+            }
+          ],
+          "TargetEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"
+        },
+        "output": {
+          "ReplicationTask": {
+            "MigrationType": "full-load",
+            "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+            "ReplicationTaskArn": "arn:aws:dms:us-east-1:123456789012:task:OEAMB3NXSTZ6LFYZFEPPBBXPYM",
+            "ReplicationTaskCreationDate": "2016-12-14T18:25:43Z",
+            "ReplicationTaskIdentifier": "task1",
+            "ReplicationTaskSettings": "{\"TargetMetadata\":{\"TargetSchema\":\"\",\"SupportLobs\":true,\"FullLobMode\":true,\"LobChunkSize\":64,\"LimitedSizeLobMode\":false,\"LobMaxSize\":0},\"FullLoadSettings\":{\"FullLoadEnabled\":true,\"ApplyChangesEnabled\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"CreatePkAfterFullLoad\":false,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"ResumeEnabled\":false,\"ResumeMinTableSize\":100000,\"ResumeOnlyClusteredPKTables\":true,\"MaxFullLoadSubTasks\":8,\"TransactionConsistencyTimeout\":600,\"CommitRate\":10000},\"Logging\":{\"EnableLogging\":false}}",
+            "SourceEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ZW5UAN6P4E77EC7YWHK4RZZ3BE",
+            "Status": "creating",
+            "TableMappings": "file://mappingfile.json",
+            "TargetEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Creates a replication task using the specified parameters.",
+        "id": "create-replication-task-1481747646288",
+        "title": "Create replication task"
+      }
+    ],
+    "DeleteCertificate": [
+      {
+        "input": {
+          "CertificateArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUSM457DE6XFJCJQ"
+        },
+        "output": {
+          "Certificate": {
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Deletes the specified certificate.",
+        "id": "delete-certificate-1481751957981",
+        "title": "Delete Certificate"
+      }
+    ],
+    "DeleteEndpoint": [
+      {
+        "input": {
+          "EndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:RAAR3R22XSH46S3PWLC3NJAWKM"
+        },
+        "output": {
+          "Endpoint": {
+            "EndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:RAAR3R22XSH46S3PWLC3NJAWKM",
+            "EndpointIdentifier": "test-endpoint-1",
+            "EndpointType": "source",
+            "EngineName": "mysql",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/4c1731d6-5435-ed4d-be13-d53411a7cfbd",
+            "Port": 3306,
+            "ServerName": "mydb.cx1llnox7iyx.us-west-2.rds.amazonaws.com",
+            "Status": "active",
+            "Username": "username"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Deletes the specified endpoint. All tasks associated with the endpoint must be deleted before you can delete the endpoint.\n",
+        "id": "delete-endpoint-1481752425530",
+        "title": "Delete Endpoint"
+      }
+    ],
+    "DeleteReplicationInstance": [
+      {
+        "input": {
+          "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ"
+        },
+        "output": {
+          "ReplicationInstance": {
+            "AllocatedStorage": 5,
+            "AutoMinorVersionUpgrade": true,
+            "EngineVersion": "1.5.0",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/4c1731d6-5435-ed4d-be13-d53411a7cfbd",
+            "PendingModifiedValues": {
+            },
+            "PreferredMaintenanceWindow": "sun:06:00-sun:14:00",
+            "PubliclyAccessible": true,
+            "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+            "ReplicationInstanceClass": "dms.t2.micro",
+            "ReplicationInstanceIdentifier": "test-rep-1",
+            "ReplicationInstanceStatus": "creating",
+            "ReplicationSubnetGroup": {
+              "ReplicationSubnetGroupDescription": "default",
+              "ReplicationSubnetGroupIdentifier": "default",
+              "SubnetGroupStatus": "Complete",
+              "Subnets": [
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1d"
+                  },
+                  "SubnetIdentifier": "subnet-f6dd91af",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1b"
+                  },
+                  "SubnetIdentifier": "subnet-3605751d",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1c"
+                  },
+                  "SubnetIdentifier": "subnet-c2daefb5",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1e"
+                  },
+                  "SubnetIdentifier": "subnet-85e90cb8",
+                  "SubnetStatus": "Active"
+                }
+              ],
+              "VpcId": "vpc-6741a603"
+            }
+          }
+        },
+        "comments": {
+          "output": {
+          }
+        },
+        "description": "Deletes the specified replication instance. You must delete any migration tasks that are associated with the replication instance before you can delete it.\n\n",
+        "id": "delete-replication-instance-1481752552839",
+        "title": "Delete Replication Instance"
+      }
+    ],
+    "DeleteReplicationSubnetGroup": [
+      {
+        "input": {
+          "ReplicationSubnetGroupIdentifier": "us-west-2ab-vpc-215ds366"
+        },
+        "output": {
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Deletes a replication subnet group.",
+        "id": "delete-replication-subnet-group-1481752728597",
+        "title": "Delete Replication Subnet Group"
+      }
+    ],
+    "DeleteReplicationTask": [
+      {
+        "input": {
+          "ReplicationTaskArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ"
+        },
+        "output": {
+          "ReplicationTask": {
+            "MigrationType": "full-load",
+            "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+            "ReplicationTaskArn": "arn:aws:dms:us-east-1:123456789012:task:OEAMB3NXSTZ6LFYZFEPPBBXPYM",
+            "ReplicationTaskCreationDate": "2016-12-14T18:25:43Z",
+            "ReplicationTaskIdentifier": "task1",
+            "ReplicationTaskSettings": "{\"TargetMetadata\":{\"TargetSchema\":\"\",\"SupportLobs\":true,\"FullLobMode\":true,\"LobChunkSize\":64,\"LimitedSizeLobMode\":false,\"LobMaxSize\":0},\"FullLoadSettings\":{\"FullLoadEnabled\":true,\"ApplyChangesEnabled\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"CreatePkAfterFullLoad\":false,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"ResumeEnabled\":false,\"ResumeMinTableSize\":100000,\"ResumeOnlyClusteredPKTables\":true,\"MaxFullLoadSubTasks\":8,\"TransactionConsistencyTimeout\":600,\"CommitRate\":10000},\"Logging\":{\"EnableLogging\":false}}",
+            "SourceEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ZW5UAN6P4E77EC7YWHK4RZZ3BE",
+            "Status": "creating",
+            "TableMappings": "file://mappingfile.json",
+            "TargetEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Deletes the specified replication task.",
+        "id": "delete-replication-task-1481752903506",
+        "title": "Delete Replication Task"
+      }
+    ],
+    "DescribeAccountAttributes": [
+      {
+        "input": {
+        },
+        "output": {
+          "AccountQuotas": [
+            {
+              "AccountQuotaName": "ReplicationInstances",
+              "Max": 20,
+              "Used": 0
+            },
+            {
+              "AccountQuotaName": "AllocatedStorage",
+              "Max": 20,
+              "Used": 0
+            },
+            {
+              "AccountQuotaName": "Endpoints",
+              "Max": 20,
+              "Used": 0
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Lists all of the AWS DMS attributes for a customer account. The attributes include AWS DMS quotas for the account, such as the number of replication instances allowed. The description for a quota includes the quota name, current usage toward that quota, and the quota's maximum value. This operation does not take any parameters.",
+        "id": "describe-acount-attributes-1481753085663",
+        "title": "Describe acount attributes"
+      }
+    ],
+    "DescribeCertificates": [
+      {
+        "input": {
+          "Filters": [
+            {
+              "Name": "string",
+              "Values": [
+                "string",
+                "string"
+              ]
+            }
+          ],
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Certificates": [
+
+          ],
+          "Marker": ""
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Provides a description of the certificate.",
+        "id": "describe-certificates-1481753186244",
+        "title": "Describe certificates"
+      }
+    ],
+    "DescribeConnections": [
+      {
+        "input": {
+          "Filters": [
+            {
+              "Name": "string",
+              "Values": [
+                "string",
+                "string"
+              ]
+            }
+          ],
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Connections": [
+            {
+              "EndpointArn": "arn:aws:dms:us-east-arn:aws:dms:us-east-1:123456789012:endpoint:ZW5UAN6P4E77EC7YWHK4RZZ3BE",
+              "EndpointIdentifier": "testsrc1",
+              "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+              "ReplicationInstanceIdentifier": "test",
+              "Status": "successful"
+            }
+          ],
+          "Marker": ""
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Describes the status of the connections that have been made between the replication instance and an endpoint. Connections are created when you test an endpoint.",
+        "id": "describe-connections-1481754477953",
+        "title": "Describe connections"
+      }
+    ],
+    "DescribeEndpointTypes": [
+      {
+        "input": {
+          "Filters": [
+            {
+              "Name": "string",
+              "Values": [
+                "string",
+                "string"
+              ]
+            }
+          ],
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Marker": "",
+          "SupportedEndpointTypes": [
+
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns information about the type of endpoints available.",
+        "id": "describe-endpoint-types-1481754742591",
+        "title": "Describe endpoint types"
+      }
+    ],
+    "DescribeEndpoints": [
+      {
+        "input": {
+          "Filters": [
+            {
+              "Name": "string",
+              "Values": [
+                "string",
+                "string"
+              ]
+            }
+          ],
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Endpoints": [
+
+          ],
+          "Marker": ""
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns information about the endpoints for your account in the current region.",
+        "id": "describe-endpoints-1481754926060",
+        "title": "Describe endpoints"
+      }
+    ],
+    "DescribeOrderableReplicationInstances": [
+      {
+        "input": {
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Marker": "",
+          "OrderableReplicationInstances": [
+
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns information about the replication instance types that can be created in the specified region.",
+        "id": "describe-orderable-replication-instances-1481755123669",
+        "title": "Describe orderable replication instances"
+      }
+    ],
+    "DescribeRefreshSchemasStatus": [
+      {
+        "input": {
+          "EndpointArn": ""
+        },
+        "output": {
+          "RefreshSchemasStatus": {
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns the status of the refresh-schemas operation.",
+        "id": "describe-refresh-schema-status-1481755303497",
+        "title": "Describe refresh schema status"
+      }
+    ],
+    "DescribeReplicationInstances": [
+      {
+        "input": {
+          "Filters": [
+            {
+              "Name": "string",
+              "Values": [
+                "string",
+                "string"
+              ]
+            }
+          ],
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Marker": "",
+          "ReplicationInstances": [
+
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns the status of the refresh-schemas operation.",
+        "id": "describe-replication-instances-1481755443952",
+        "title": "Describe replication instances"
+      }
+    ],
+    "DescribeReplicationSubnetGroups": [
+      {
+        "input": {
+          "Filters": [
+            {
+              "Name": "string",
+              "Values": [
+                "string",
+                "string"
+              ]
+            }
+          ],
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Marker": "",
+          "ReplicationSubnetGroups": [
+
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns information about the replication subnet groups.",
+        "id": "describe-replication-subnet-groups-1481755621284",
+        "title": "Describe replication subnet groups"
+      }
+    ],
+    "DescribeReplicationTasks": [
+      {
+        "input": {
+          "Filters": [
+            {
+              "Name": "string",
+              "Values": [
+                "string",
+                "string"
+              ]
+            }
+          ],
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Marker": "",
+          "ReplicationTasks": [
+
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns information about replication tasks for your account in the current region.",
+        "id": "describe-replication-tasks-1481755777563",
+        "title": "Describe replication tasks"
+      }
+    ],
+    "DescribeSchemas": [
+      {
+        "input": {
+          "EndpointArn": "",
+          "Marker": "",
+          "MaxRecords": 123
+        },
+        "output": {
+          "Marker": "",
+          "Schemas": [
+
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns information about the schema for the specified endpoint.",
+        "id": "describe-schemas-1481755933924",
+        "title": "Describe schemas"
+      }
+    ],
+    "DescribeTableStatistics": [
+      {
+        "input": {
+          "Marker": "",
+          "MaxRecords": 123,
+          "ReplicationTaskArn": ""
+        },
+        "output": {
+          "Marker": "",
+          "ReplicationTaskArn": "",
+          "TableStatistics": [
+
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Returns table statistics on the database migration task, including table name, rows inserted, rows updated, and rows deleted.",
+        "id": "describe-table-statistics-1481756071890",
+        "title": "Describe table statistics"
+      }
+    ],
+    "ImportCertificate": [
+      {
+        "input": {
+          "CertificateIdentifier": "",
+          "CertificatePem": ""
+        },
+        "output": {
+          "Certificate": {
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Uploads the specified certificate.",
+        "id": "import-certificate-1481756197206",
+        "title": "Import certificate"
+      }
+    ],
+    "ListTagsForResource": [
+      {
+        "input": {
+          "ResourceArn": ""
+        },
+        "output": {
+          "TagList": [
+
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Lists all tags for an AWS DMS resource.",
+        "id": "list-tags-for-resource-1481761095501",
+        "title": "List tags for resource"
+      }
+    ],
+    "ModifyEndpoint": [
+      {
+        "input": {
+          "CertificateArn": "",
+          "DatabaseName": "",
+          "EndpointArn": "",
+          "EndpointIdentifier": "",
+          "EndpointType": "source",
+          "EngineName": "",
+          "ExtraConnectionAttributes": "",
+          "Password": "",
+          "Port": 123,
+          "ServerName": "",
+          "SslMode": "require",
+          "Username": ""
+        },
+        "output": {
+          "Endpoint": {
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Modifies the specified endpoint.",
+        "id": "modify-endpoint-1481761649937",
+        "title": "Modify endpoint"
+      }
+    ],
+    "ModifyReplicationInstance": [
+      {
+        "input": {
+          "AllocatedStorage": 123,
+          "AllowMajorVersionUpgrade": true,
+          "ApplyImmediately": true,
+          "AutoMinorVersionUpgrade": true,
+          "EngineVersion": "1.5.0",
+          "MultiAZ": true,
+          "PreferredMaintenanceWindow": "sun:06:00-sun:14:00",
+          "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+          "ReplicationInstanceClass": "dms.t2.micro",
+          "ReplicationInstanceIdentifier": "test-rep-1",
+          "VpcSecurityGroupIds": [
+
+          ]
+        },
+        "output": {
+          "ReplicationInstance": {
+            "AllocatedStorage": 5,
+            "AutoMinorVersionUpgrade": true,
+            "EngineVersion": "1.5.0",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/4c1731d6-5435-ed4d-be13-d53411a7cfbd",
+            "PendingModifiedValues": {
+            },
+            "PreferredMaintenanceWindow": "sun:06:00-sun:14:00",
+            "PubliclyAccessible": true,
+            "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+            "ReplicationInstanceClass": "dms.t2.micro",
+            "ReplicationInstanceIdentifier": "test-rep-1",
+            "ReplicationInstanceStatus": "available",
+            "ReplicationSubnetGroup": {
+              "ReplicationSubnetGroupDescription": "default",
+              "ReplicationSubnetGroupIdentifier": "default",
+              "SubnetGroupStatus": "Complete",
+              "Subnets": [
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1d"
+                  },
+                  "SubnetIdentifier": "subnet-f6dd91af",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1b"
+                  },
+                  "SubnetIdentifier": "subnet-3605751d",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1c"
+                  },
+                  "SubnetIdentifier": "subnet-c2daefb5",
+                  "SubnetStatus": "Active"
+                },
+                {
+                  "SubnetAvailabilityZone": {
+                    "Name": "us-east-1e"
+                  },
+                  "SubnetIdentifier": "subnet-85e90cb8",
+                  "SubnetStatus": "Active"
+                }
+              ],
+              "VpcId": "vpc-6741a603"
+            }
+          }
+        },
+        "comments": {
+          "output": {
+          }
+        },
+        "description": "Modifies the replication instance to apply new settings. You can change one or more parameters by specifying these parameters and the new values in the request. Some settings are applied during the maintenance window.",
+        "id": "modify-replication-instance-1481761784746",
+        "title": "Modify replication instance"
+      }
+    ],
+    "ModifyReplicationSubnetGroup": [
+      {
+        "input": {
+          "ReplicationSubnetGroupDescription": "",
+          "ReplicationSubnetGroupIdentifier": "",
+          "SubnetIds": [
+
+          ]
+        },
+        "output": {
+          "ReplicationSubnetGroup": {
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Modifies the settings for the specified replication subnet group.",
+        "id": "modify-replication-subnet-group-1481762275392",
+        "title": "Modify replication subnet group"
+      }
+    ],
+    "RefreshSchemas": [
+      {
+        "input": {
+          "EndpointArn": "",
+          "ReplicationInstanceArn": ""
+        },
+        "output": {
+          "RefreshSchemasStatus": {
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Populates the schema for the specified endpoint. This is an asynchronous operation and can take several minutes. You can check the status of this operation by calling the describe-refresh-schemas-status operation.",
+        "id": "refresh-schema-1481762399111",
+        "title": "Refresh schema"
+      }
+    ],
+    "RemoveTagsFromResource": [
+      {
+        "input": {
+          "ResourceArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E",
+          "TagKeys": [
+
+          ]
+        },
+        "output": {
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Removes metadata tags from an AWS DMS resource.",
+        "id": "remove-tags-from-resource-1481762571330",
+        "title": "Remove tags from resource"
+      }
+    ],
+    "StartReplicationTask": [
+      {
+        "input": {
+          "CdcStartTime": "2016-12-14T13:33:20Z",
+          "ReplicationTaskArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+          "StartReplicationTaskType": "start-replication"
+        },
+        "output": {
+          "ReplicationTask": {
+            "MigrationType": "full-load",
+            "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+            "ReplicationTaskArn": "arn:aws:dms:us-east-1:123456789012:task:OEAMB3NXSTZ6LFYZFEPPBBXPYM",
+            "ReplicationTaskCreationDate": "2016-12-14T18:25:43Z",
+            "ReplicationTaskIdentifier": "task1",
+            "ReplicationTaskSettings": "{\"TargetMetadata\":{\"TargetSchema\":\"\",\"SupportLobs\":true,\"FullLobMode\":true,\"LobChunkSize\":64,\"LimitedSizeLobMode\":false,\"LobMaxSize\":0},\"FullLoadSettings\":{\"FullLoadEnabled\":true,\"ApplyChangesEnabled\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"CreatePkAfterFullLoad\":false,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"ResumeEnabled\":false,\"ResumeMinTableSize\":100000,\"ResumeOnlyClusteredPKTables\":true,\"MaxFullLoadSubTasks\":8,\"TransactionConsistencyTimeout\":600,\"CommitRate\":10000},\"Logging\":{\"EnableLogging\":false}}",
+            "SourceEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ZW5UAN6P4E77EC7YWHK4RZZ3BE",
+            "Status": "creating",
+            "TableMappings": "file://mappingfile.json",
+            "TargetEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Starts the replication task.",
+        "id": "start-replication-task-1481762706778",
+        "title": "Start replication task"
+      }
+    ],
+    "StopReplicationTask": [
+      {
+        "input": {
+          "ReplicationTaskArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"
+        },
+        "output": {
+          "ReplicationTask": {
+            "MigrationType": "full-load",
+            "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ",
+            "ReplicationTaskArn": "arn:aws:dms:us-east-1:123456789012:task:OEAMB3NXSTZ6LFYZFEPPBBXPYM",
+            "ReplicationTaskCreationDate": "2016-12-14T18:25:43Z",
+            "ReplicationTaskIdentifier": "task1",
+            "ReplicationTaskSettings": "{\"TargetMetadata\":{\"TargetSchema\":\"\",\"SupportLobs\":true,\"FullLobMode\":true,\"LobChunkSize\":64,\"LimitedSizeLobMode\":false,\"LobMaxSize\":0},\"FullLoadSettings\":{\"FullLoadEnabled\":true,\"ApplyChangesEnabled\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"CreatePkAfterFullLoad\":false,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"ResumeEnabled\":false,\"ResumeMinTableSize\":100000,\"ResumeOnlyClusteredPKTables\":true,\"MaxFullLoadSubTasks\":8,\"TransactionConsistencyTimeout\":600,\"CommitRate\":10000},\"Logging\":{\"EnableLogging\":false}}",
+            "SourceEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ZW5UAN6P4E77EC7YWHK4RZZ3BE",
+            "Status": "creating",
+            "TableMappings": "file://mappingfile.json",
+            "TargetEndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Stops the replication task.",
+        "id": "stop-replication-task-1481762924947",
+        "title": "Stop replication task"
+      }
+    ],
+    "TestConnection": [
+      {
+        "input": {
+          "EndpointArn": "arn:aws:dms:us-east-1:123456789012:endpoint:RAAR3R22XSH46S3PWLC3NJAWKM",
+          "ReplicationInstanceArn": "arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ"
+        },
+        "output": {
+          "Connection": {
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "Tests the connection between the replication instance and the endpoint.",
+        "id": "test-conection-1481763017636",
+        "title": "Test conection"
+      }
+    ]
   }
 }

--- a/models/apis/dms/2016-01-01/paginators-1.json
+++ b/models/apis/dms/2016-01-01/paginators-1.json
@@ -1,0 +1,64 @@
+{
+  "pagination": {
+    "DescribeCertificates": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeConnections": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeEndpointTypes": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeEndpoints": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeEventSubscriptions": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeEvents": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeOrderableReplicationInstances": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeReplicationInstances": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeReplicationSubnetGroups": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeReplicationTasks": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeSchemas": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    },
+    "DescribeTableStatistics": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "MaxRecords"
+    }
+  }
+}

--- a/service/databasemigrationservice/api.go
+++ b/service/databasemigrationservice/api.go
@@ -190,6 +190,114 @@ func (c *DatabaseMigrationService) CreateEndpointWithContext(ctx aws.Context, in
 	return out, req.Send()
 }
 
+const opCreateEventSubscription = "CreateEventSubscription"
+
+// CreateEventSubscriptionRequest generates a "aws/request.Request" representing the
+// client's request for the CreateEventSubscription operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See CreateEventSubscription for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the CreateEventSubscription method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the CreateEventSubscriptionRequest method.
+//    req, resp := client.CreateEventSubscriptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/CreateEventSubscription
+func (c *DatabaseMigrationService) CreateEventSubscriptionRequest(input *CreateEventSubscriptionInput) (req *request.Request, output *CreateEventSubscriptionOutput) {
+	op := &request.Operation{
+		Name:       opCreateEventSubscription,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateEventSubscriptionInput{}
+	}
+
+	output = &CreateEventSubscriptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateEventSubscription API operation for AWS Database Migration Service.
+//
+// Creates an AWS DMS event notification subscription.
+//
+// You can specify the type of source (SourceType) you want to be notified of,
+// provide a list of AWS DMS source IDs (SourceIds) that triggers the events,
+// and provide a list of event categories (EventCategories) for events you want
+// to be notified of. If you specify both the SourceType and SourceIds, such
+// as SourceType = replication-instance and SourceIdentifier = my-replinstance,
+// you will be notified of all the replication instance events for the specified
+// source. If you specify a SourceType but don't specify a SourceIdentifier,
+// you receive notice of the events for that source type for all your AWS DMS
+// sources. If you don't specify either SourceType nor SourceIdentifier, you
+// will be notified of events generated from all AWS DMS sources belonging to
+// your customer account.
+//
+// For more information about AWS DMS events, see  Working with Events and Notifications
+//  (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html) in the
+// AWS Database MIgration Service User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation CreateEventSubscription for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceQuotaExceededFault "ResourceQuotaExceededFault"
+//   The quota for this resource quota has been exceeded.
+//
+//   * ErrCodeResourceAlreadyExistsFault "ResourceAlreadyExistsFault"
+//   The resource you are attempting to create already exists.
+//
+//   * ErrCodeSNSInvalidTopicFault "SNSInvalidTopicFault"
+//   The SNS topic is invalid.
+//
+//   * ErrCodeSNSNoAuthorizationFault "SNSNoAuthorizationFault"
+//   You are not authorized for the SNS subscription.
+//
+//   * ErrCodeResourceNotFoundFault "ResourceNotFoundFault"
+//   The resource could not be found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/CreateEventSubscription
+func (c *DatabaseMigrationService) CreateEventSubscription(input *CreateEventSubscriptionInput) (*CreateEventSubscriptionOutput, error) {
+	req, out := c.CreateEventSubscriptionRequest(input)
+	return out, req.Send()
+}
+
+// CreateEventSubscriptionWithContext is the same as CreateEventSubscription with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateEventSubscription for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) CreateEventSubscriptionWithContext(ctx aws.Context, input *CreateEventSubscriptionInput, opts ...request.Option) (*CreateEventSubscriptionOutput, error) {
+	req, out := c.CreateEventSubscriptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateReplicationInstance = "CreateReplicationInstance"
 
 // CreateReplicationInstanceRequest generates a "aws/request.Request" representing the
@@ -659,6 +767,90 @@ func (c *DatabaseMigrationService) DeleteEndpointWithContext(ctx aws.Context, in
 	return out, req.Send()
 }
 
+const opDeleteEventSubscription = "DeleteEventSubscription"
+
+// DeleteEventSubscriptionRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteEventSubscription operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DeleteEventSubscription for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DeleteEventSubscription method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DeleteEventSubscriptionRequest method.
+//    req, resp := client.DeleteEventSubscriptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DeleteEventSubscription
+func (c *DatabaseMigrationService) DeleteEventSubscriptionRequest(input *DeleteEventSubscriptionInput) (req *request.Request, output *DeleteEventSubscriptionOutput) {
+	op := &request.Operation{
+		Name:       opDeleteEventSubscription,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteEventSubscriptionInput{}
+	}
+
+	output = &DeleteEventSubscriptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteEventSubscription API operation for AWS Database Migration Service.
+//
+// Deletes an AWS DMS event subscription.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation DeleteEventSubscription for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundFault "ResourceNotFoundFault"
+//   The resource could not be found.
+//
+//   * ErrCodeInvalidResourceStateFault "InvalidResourceStateFault"
+//   The resource is in a state that prevents it from being used for database
+//   migration.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DeleteEventSubscription
+func (c *DatabaseMigrationService) DeleteEventSubscription(input *DeleteEventSubscriptionInput) (*DeleteEventSubscriptionOutput, error) {
+	req, out := c.DeleteEventSubscriptionRequest(input)
+	return out, req.Send()
+}
+
+// DeleteEventSubscriptionWithContext is the same as DeleteEventSubscription with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteEventSubscription for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DeleteEventSubscriptionWithContext(ctx aws.Context, input *DeleteEventSubscriptionInput, opts ...request.Option) (*DeleteEventSubscriptionOutput, error) {
+	req, out := c.DeleteEventSubscriptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteReplicationInstance = "DeleteReplicationInstance"
 
 // DeleteReplicationInstanceRequest generates a "aws/request.Request" representing the
@@ -1026,6 +1218,12 @@ func (c *DatabaseMigrationService) DescribeCertificatesRequest(input *DescribeCe
 		Name:       opDescribeCertificates,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1074,6 +1272,56 @@ func (c *DatabaseMigrationService) DescribeCertificatesWithContext(ctx aws.Conte
 	return out, req.Send()
 }
 
+// DescribeCertificatesPages iterates over the pages of a DescribeCertificates operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeCertificates method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeCertificates operation.
+//    pageNum := 0
+//    err := client.DescribeCertificatesPages(params,
+//        func(page *DescribeCertificatesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeCertificatesPages(input *DescribeCertificatesInput, fn func(*DescribeCertificatesOutput, bool) bool) error {
+	return c.DescribeCertificatesPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeCertificatesPagesWithContext same as DescribeCertificatesPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeCertificatesPagesWithContext(ctx aws.Context, input *DescribeCertificatesInput, fn func(*DescribeCertificatesOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeCertificatesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeCertificatesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeCertificatesOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeConnections = "DescribeConnections"
 
 // DescribeConnectionsRequest generates a "aws/request.Request" representing the
@@ -1106,6 +1354,12 @@ func (c *DatabaseMigrationService) DescribeConnectionsRequest(input *DescribeCon
 		Name:       opDescribeConnections,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1155,6 +1409,56 @@ func (c *DatabaseMigrationService) DescribeConnectionsWithContext(ctx aws.Contex
 	return out, req.Send()
 }
 
+// DescribeConnectionsPages iterates over the pages of a DescribeConnections operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeConnections method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeConnections operation.
+//    pageNum := 0
+//    err := client.DescribeConnectionsPages(params,
+//        func(page *DescribeConnectionsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeConnectionsPages(input *DescribeConnectionsInput, fn func(*DescribeConnectionsOutput, bool) bool) error {
+	return c.DescribeConnectionsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeConnectionsPagesWithContext same as DescribeConnectionsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeConnectionsPagesWithContext(ctx aws.Context, input *DescribeConnectionsInput, fn func(*DescribeConnectionsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeConnectionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeConnectionsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeConnectionsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeEndpointTypes = "DescribeEndpointTypes"
 
 // DescribeEndpointTypesRequest generates a "aws/request.Request" representing the
@@ -1187,6 +1491,12 @@ func (c *DatabaseMigrationService) DescribeEndpointTypesRequest(input *DescribeE
 		Name:       opDescribeEndpointTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1230,6 +1540,56 @@ func (c *DatabaseMigrationService) DescribeEndpointTypesWithContext(ctx aws.Cont
 	return out, req.Send()
 }
 
+// DescribeEndpointTypesPages iterates over the pages of a DescribeEndpointTypes operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeEndpointTypes method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeEndpointTypes operation.
+//    pageNum := 0
+//    err := client.DescribeEndpointTypesPages(params,
+//        func(page *DescribeEndpointTypesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeEndpointTypesPages(input *DescribeEndpointTypesInput, fn func(*DescribeEndpointTypesOutput, bool) bool) error {
+	return c.DescribeEndpointTypesPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeEndpointTypesPagesWithContext same as DescribeEndpointTypesPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeEndpointTypesPagesWithContext(ctx aws.Context, input *DescribeEndpointTypesInput, fn func(*DescribeEndpointTypesOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeEndpointTypesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeEndpointTypesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeEndpointTypesOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeEndpoints = "DescribeEndpoints"
 
 // DescribeEndpointsRequest generates a "aws/request.Request" representing the
@@ -1262,6 +1622,12 @@ func (c *DatabaseMigrationService) DescribeEndpointsRequest(input *DescribeEndpo
 		Name:       opDescribeEndpoints,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1310,6 +1676,408 @@ func (c *DatabaseMigrationService) DescribeEndpointsWithContext(ctx aws.Context,
 	return out, req.Send()
 }
 
+// DescribeEndpointsPages iterates over the pages of a DescribeEndpoints operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeEndpoints method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeEndpoints operation.
+//    pageNum := 0
+//    err := client.DescribeEndpointsPages(params,
+//        func(page *DescribeEndpointsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeEndpointsPages(input *DescribeEndpointsInput, fn func(*DescribeEndpointsOutput, bool) bool) error {
+	return c.DescribeEndpointsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeEndpointsPagesWithContext same as DescribeEndpointsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeEndpointsPagesWithContext(ctx aws.Context, input *DescribeEndpointsInput, fn func(*DescribeEndpointsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeEndpointsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeEndpointsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeEndpointsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opDescribeEventCategories = "DescribeEventCategories"
+
+// DescribeEventCategoriesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeEventCategories operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeEventCategories for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeEventCategories method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeEventCategoriesRequest method.
+//    req, resp := client.DescribeEventCategoriesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventCategories
+func (c *DatabaseMigrationService) DescribeEventCategoriesRequest(input *DescribeEventCategoriesInput) (req *request.Request, output *DescribeEventCategoriesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeEventCategories,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeEventCategoriesInput{}
+	}
+
+	output = &DescribeEventCategoriesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeEventCategories API operation for AWS Database Migration Service.
+//
+// Lists categories for all event source types, or, if specified, for a specified
+// source type. You can see a list of the event categories and source types
+// in  Working with Events and Notifications  (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html)
+// in the AWS Database Migration Service User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation DescribeEventCategories for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventCategories
+func (c *DatabaseMigrationService) DescribeEventCategories(input *DescribeEventCategoriesInput) (*DescribeEventCategoriesOutput, error) {
+	req, out := c.DescribeEventCategoriesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeEventCategoriesWithContext is the same as DescribeEventCategories with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeEventCategories for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeEventCategoriesWithContext(ctx aws.Context, input *DescribeEventCategoriesInput, opts ...request.Option) (*DescribeEventCategoriesOutput, error) {
+	req, out := c.DescribeEventCategoriesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeEventSubscriptions = "DescribeEventSubscriptions"
+
+// DescribeEventSubscriptionsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeEventSubscriptions operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeEventSubscriptions for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeEventSubscriptions method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeEventSubscriptionsRequest method.
+//    req, resp := client.DescribeEventSubscriptionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventSubscriptions
+func (c *DatabaseMigrationService) DescribeEventSubscriptionsRequest(input *DescribeEventSubscriptionsInput) (req *request.Request, output *DescribeEventSubscriptionsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeEventSubscriptions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeEventSubscriptionsInput{}
+	}
+
+	output = &DescribeEventSubscriptionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeEventSubscriptions API operation for AWS Database Migration Service.
+//
+// Lists all the event subscriptions for a customer account. The description
+// of a subscription includes SubscriptionName, SNSTopicARN, CustomerID, SourceType,
+// SourceID, CreationTime, and Status.
+//
+// If you specify SubscriptionName, this action lists the description for that
+// subscription.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation DescribeEventSubscriptions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundFault "ResourceNotFoundFault"
+//   The resource could not be found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventSubscriptions
+func (c *DatabaseMigrationService) DescribeEventSubscriptions(input *DescribeEventSubscriptionsInput) (*DescribeEventSubscriptionsOutput, error) {
+	req, out := c.DescribeEventSubscriptionsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeEventSubscriptionsWithContext is the same as DescribeEventSubscriptions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeEventSubscriptions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeEventSubscriptionsWithContext(ctx aws.Context, input *DescribeEventSubscriptionsInput, opts ...request.Option) (*DescribeEventSubscriptionsOutput, error) {
+	req, out := c.DescribeEventSubscriptionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeEventSubscriptionsPages iterates over the pages of a DescribeEventSubscriptions operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeEventSubscriptions method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeEventSubscriptions operation.
+//    pageNum := 0
+//    err := client.DescribeEventSubscriptionsPages(params,
+//        func(page *DescribeEventSubscriptionsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeEventSubscriptionsPages(input *DescribeEventSubscriptionsInput, fn func(*DescribeEventSubscriptionsOutput, bool) bool) error {
+	return c.DescribeEventSubscriptionsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeEventSubscriptionsPagesWithContext same as DescribeEventSubscriptionsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeEventSubscriptionsPagesWithContext(ctx aws.Context, input *DescribeEventSubscriptionsInput, fn func(*DescribeEventSubscriptionsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeEventSubscriptionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeEventSubscriptionsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeEventSubscriptionsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opDescribeEvents = "DescribeEvents"
+
+// DescribeEventsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeEvents operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeEvents for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeEvents method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeEventsRequest method.
+//    req, resp := client.DescribeEventsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEvents
+func (c *DatabaseMigrationService) DescribeEventsRequest(input *DescribeEventsInput) (req *request.Request, output *DescribeEventsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeEvents,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeEventsInput{}
+	}
+
+	output = &DescribeEventsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeEvents API operation for AWS Database Migration Service.
+//
+// Lists events for a given source identifier and source type. You can also
+// specify a start and end time. For more information on AWS DMS events, see
+//  Working with Events and Notifications  (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation DescribeEvents for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEvents
+func (c *DatabaseMigrationService) DescribeEvents(input *DescribeEventsInput) (*DescribeEventsOutput, error) {
+	req, out := c.DescribeEventsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeEventsWithContext is the same as DescribeEvents with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeEvents for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeEventsWithContext(ctx aws.Context, input *DescribeEventsInput, opts ...request.Option) (*DescribeEventsOutput, error) {
+	req, out := c.DescribeEventsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeEventsPages iterates over the pages of a DescribeEvents operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeEvents method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeEvents operation.
+//    pageNum := 0
+//    err := client.DescribeEventsPages(params,
+//        func(page *DescribeEventsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeEventsPages(input *DescribeEventsInput, fn func(*DescribeEventsOutput, bool) bool) error {
+	return c.DescribeEventsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeEventsPagesWithContext same as DescribeEventsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeEventsPagesWithContext(ctx aws.Context, input *DescribeEventsInput, fn func(*DescribeEventsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeEventsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeEventsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeEventsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeOrderableReplicationInstances = "DescribeOrderableReplicationInstances"
 
 // DescribeOrderableReplicationInstancesRequest generates a "aws/request.Request" representing the
@@ -1342,6 +2110,12 @@ func (c *DatabaseMigrationService) DescribeOrderableReplicationInstancesRequest(
 		Name:       opDescribeOrderableReplicationInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1384,6 +2158,56 @@ func (c *DatabaseMigrationService) DescribeOrderableReplicationInstancesWithCont
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+// DescribeOrderableReplicationInstancesPages iterates over the pages of a DescribeOrderableReplicationInstances operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeOrderableReplicationInstances method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeOrderableReplicationInstances operation.
+//    pageNum := 0
+//    err := client.DescribeOrderableReplicationInstancesPages(params,
+//        func(page *DescribeOrderableReplicationInstancesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeOrderableReplicationInstancesPages(input *DescribeOrderableReplicationInstancesInput, fn func(*DescribeOrderableReplicationInstancesOutput, bool) bool) error {
+	return c.DescribeOrderableReplicationInstancesPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeOrderableReplicationInstancesPagesWithContext same as DescribeOrderableReplicationInstancesPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeOrderableReplicationInstancesPagesWithContext(ctx aws.Context, input *DescribeOrderableReplicationInstancesInput, fn func(*DescribeOrderableReplicationInstancesOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeOrderableReplicationInstancesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeOrderableReplicationInstancesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeOrderableReplicationInstancesOutput), !p.HasNextPage())
+	}
+	return p.Err()
 }
 
 const opDescribeRefreshSchemasStatus = "DescribeRefreshSchemasStatus"
@@ -1502,6 +2326,12 @@ func (c *DatabaseMigrationService) DescribeReplicationInstancesRequest(input *De
 		Name:       opDescribeReplicationInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1551,6 +2381,56 @@ func (c *DatabaseMigrationService) DescribeReplicationInstancesWithContext(ctx a
 	return out, req.Send()
 }
 
+// DescribeReplicationInstancesPages iterates over the pages of a DescribeReplicationInstances operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeReplicationInstances method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeReplicationInstances operation.
+//    pageNum := 0
+//    err := client.DescribeReplicationInstancesPages(params,
+//        func(page *DescribeReplicationInstancesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeReplicationInstancesPages(input *DescribeReplicationInstancesInput, fn func(*DescribeReplicationInstancesOutput, bool) bool) error {
+	return c.DescribeReplicationInstancesPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeReplicationInstancesPagesWithContext same as DescribeReplicationInstancesPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeReplicationInstancesPagesWithContext(ctx aws.Context, input *DescribeReplicationInstancesInput, fn func(*DescribeReplicationInstancesOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeReplicationInstancesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeReplicationInstancesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeReplicationInstancesOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeReplicationSubnetGroups = "DescribeReplicationSubnetGroups"
 
 // DescribeReplicationSubnetGroupsRequest generates a "aws/request.Request" representing the
@@ -1583,6 +2463,12 @@ func (c *DatabaseMigrationService) DescribeReplicationSubnetGroupsRequest(input 
 		Name:       opDescribeReplicationSubnetGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1631,6 +2517,56 @@ func (c *DatabaseMigrationService) DescribeReplicationSubnetGroupsWithContext(ct
 	return out, req.Send()
 }
 
+// DescribeReplicationSubnetGroupsPages iterates over the pages of a DescribeReplicationSubnetGroups operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeReplicationSubnetGroups method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeReplicationSubnetGroups operation.
+//    pageNum := 0
+//    err := client.DescribeReplicationSubnetGroupsPages(params,
+//        func(page *DescribeReplicationSubnetGroupsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeReplicationSubnetGroupsPages(input *DescribeReplicationSubnetGroupsInput, fn func(*DescribeReplicationSubnetGroupsOutput, bool) bool) error {
+	return c.DescribeReplicationSubnetGroupsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeReplicationSubnetGroupsPagesWithContext same as DescribeReplicationSubnetGroupsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeReplicationSubnetGroupsPagesWithContext(ctx aws.Context, input *DescribeReplicationSubnetGroupsInput, fn func(*DescribeReplicationSubnetGroupsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeReplicationSubnetGroupsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeReplicationSubnetGroupsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeReplicationSubnetGroupsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeReplicationTasks = "DescribeReplicationTasks"
 
 // DescribeReplicationTasksRequest generates a "aws/request.Request" representing the
@@ -1663,6 +2599,12 @@ func (c *DatabaseMigrationService) DescribeReplicationTasksRequest(input *Descri
 		Name:       opDescribeReplicationTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1712,6 +2654,56 @@ func (c *DatabaseMigrationService) DescribeReplicationTasksWithContext(ctx aws.C
 	return out, req.Send()
 }
 
+// DescribeReplicationTasksPages iterates over the pages of a DescribeReplicationTasks operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeReplicationTasks method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeReplicationTasks operation.
+//    pageNum := 0
+//    err := client.DescribeReplicationTasksPages(params,
+//        func(page *DescribeReplicationTasksOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeReplicationTasksPages(input *DescribeReplicationTasksInput, fn func(*DescribeReplicationTasksOutput, bool) bool) error {
+	return c.DescribeReplicationTasksPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeReplicationTasksPagesWithContext same as DescribeReplicationTasksPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeReplicationTasksPagesWithContext(ctx aws.Context, input *DescribeReplicationTasksInput, fn func(*DescribeReplicationTasksOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeReplicationTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeReplicationTasksRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeReplicationTasksOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeSchemas = "DescribeSchemas"
 
 // DescribeSchemasRequest generates a "aws/request.Request" representing the
@@ -1744,6 +2736,12 @@ func (c *DatabaseMigrationService) DescribeSchemasRequest(input *DescribeSchemas
 		Name:       opDescribeSchemas,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1796,6 +2794,56 @@ func (c *DatabaseMigrationService) DescribeSchemasWithContext(ctx aws.Context, i
 	return out, req.Send()
 }
 
+// DescribeSchemasPages iterates over the pages of a DescribeSchemas operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeSchemas method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeSchemas operation.
+//    pageNum := 0
+//    err := client.DescribeSchemasPages(params,
+//        func(page *DescribeSchemasOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeSchemasPages(input *DescribeSchemasInput, fn func(*DescribeSchemasOutput, bool) bool) error {
+	return c.DescribeSchemasPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeSchemasPagesWithContext same as DescribeSchemasPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeSchemasPagesWithContext(ctx aws.Context, input *DescribeSchemasInput, fn func(*DescribeSchemasOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeSchemasInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeSchemasRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeSchemasOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeTableStatistics = "DescribeTableStatistics"
 
 // DescribeTableStatisticsRequest generates a "aws/request.Request" representing the
@@ -1828,6 +2876,12 @@ func (c *DatabaseMigrationService) DescribeTableStatisticsRequest(input *Describ
 		Name:       opDescribeTableStatistics,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1879,6 +2933,56 @@ func (c *DatabaseMigrationService) DescribeTableStatisticsWithContext(ctx aws.Co
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+// DescribeTableStatisticsPages iterates over the pages of a DescribeTableStatistics operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeTableStatistics method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeTableStatistics operation.
+//    pageNum := 0
+//    err := client.DescribeTableStatisticsPages(params,
+//        func(page *DescribeTableStatisticsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeTableStatisticsPages(input *DescribeTableStatisticsInput, fn func(*DescribeTableStatisticsOutput, bool) bool) error {
+	return c.DescribeTableStatisticsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeTableStatisticsPagesWithContext same as DescribeTableStatisticsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeTableStatisticsPagesWithContext(ctx aws.Context, input *DescribeTableStatisticsInput, fn func(*DescribeTableStatisticsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeTableStatisticsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeTableStatisticsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeTableStatisticsOutput), !p.HasNextPage())
+	}
+	return p.Err()
 }
 
 const opImportCertificate = "ImportCertificate"
@@ -2112,6 +3216,9 @@ func (c *DatabaseMigrationService) ModifyEndpointRequest(input *ModifyEndpointIn
 //   * ErrCodeKMSKeyNotAccessibleFault "KMSKeyNotAccessibleFault"
 //   AWS DMS cannot access the KMS key.
 //
+//   * ErrCodeAccessDeniedFault "AccessDeniedFault"
+//   AWS DMS was denied access to the endpoint.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ModifyEndpoint
 func (c *DatabaseMigrationService) ModifyEndpoint(input *ModifyEndpointInput) (*ModifyEndpointOutput, error) {
 	req, out := c.ModifyEndpointRequest(input)
@@ -2129,6 +3236,95 @@ func (c *DatabaseMigrationService) ModifyEndpoint(input *ModifyEndpointInput) (*
 // for more information on using Contexts.
 func (c *DatabaseMigrationService) ModifyEndpointWithContext(ctx aws.Context, input *ModifyEndpointInput, opts ...request.Option) (*ModifyEndpointOutput, error) {
 	req, out := c.ModifyEndpointRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opModifyEventSubscription = "ModifyEventSubscription"
+
+// ModifyEventSubscriptionRequest generates a "aws/request.Request" representing the
+// client's request for the ModifyEventSubscription operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ModifyEventSubscription for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ModifyEventSubscription method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ModifyEventSubscriptionRequest method.
+//    req, resp := client.ModifyEventSubscriptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ModifyEventSubscription
+func (c *DatabaseMigrationService) ModifyEventSubscriptionRequest(input *ModifyEventSubscriptionInput) (req *request.Request, output *ModifyEventSubscriptionOutput) {
+	op := &request.Operation{
+		Name:       opModifyEventSubscription,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ModifyEventSubscriptionInput{}
+	}
+
+	output = &ModifyEventSubscriptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ModifyEventSubscription API operation for AWS Database Migration Service.
+//
+// Modifies an existing AWS DMS event notification subscription.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation ModifyEventSubscription for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceQuotaExceededFault "ResourceQuotaExceededFault"
+//   The quota for this resource quota has been exceeded.
+//
+//   * ErrCodeResourceNotFoundFault "ResourceNotFoundFault"
+//   The resource could not be found.
+//
+//   * ErrCodeSNSInvalidTopicFault "SNSInvalidTopicFault"
+//   The SNS topic is invalid.
+//
+//   * ErrCodeSNSNoAuthorizationFault "SNSNoAuthorizationFault"
+//   You are not authorized for the SNS subscription.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ModifyEventSubscription
+func (c *DatabaseMigrationService) ModifyEventSubscription(input *ModifyEventSubscriptionInput) (*ModifyEventSubscriptionOutput, error) {
+	req, out := c.ModifyEventSubscriptionRequest(input)
+	return out, req.Send()
+}
+
+// ModifyEventSubscriptionWithContext is the same as ModifyEventSubscription with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ModifyEventSubscription for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) ModifyEventSubscriptionWithContext(ctx aws.Context, input *ModifyEventSubscriptionInput, opts ...request.Option) (*ModifyEventSubscriptionOutput, error) {
+	req, out := c.ModifyEventSubscriptionRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2380,6 +3576,9 @@ func (c *DatabaseMigrationService) ModifyReplicationTaskRequest(input *ModifyRep
 // You can't modify the task endpoints. The task must be stopped before you
 // can modify it.
 //
+// For more information about AWS DMS tasks, see the AWS DMS user guide at
+// Working with Migration Tasks  (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.html)
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -2515,6 +3714,90 @@ func (c *DatabaseMigrationService) RefreshSchemasWithContext(ctx aws.Context, in
 	return out, req.Send()
 }
 
+const opReloadTables = "ReloadTables"
+
+// ReloadTablesRequest generates a "aws/request.Request" representing the
+// client's request for the ReloadTables operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ReloadTables for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ReloadTables method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ReloadTablesRequest method.
+//    req, resp := client.ReloadTablesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ReloadTables
+func (c *DatabaseMigrationService) ReloadTablesRequest(input *ReloadTablesInput) (req *request.Request, output *ReloadTablesOutput) {
+	op := &request.Operation{
+		Name:       opReloadTables,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ReloadTablesInput{}
+	}
+
+	output = &ReloadTablesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ReloadTables API operation for AWS Database Migration Service.
+//
+// Reloads the target database table with the source data.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation ReloadTables for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundFault "ResourceNotFoundFault"
+//   The resource could not be found.
+//
+//   * ErrCodeInvalidResourceStateFault "InvalidResourceStateFault"
+//   The resource is in a state that prevents it from being used for database
+//   migration.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ReloadTables
+func (c *DatabaseMigrationService) ReloadTables(input *ReloadTablesInput) (*ReloadTablesOutput, error) {
+	req, out := c.ReloadTablesRequest(input)
+	return out, req.Send()
+}
+
+// ReloadTablesWithContext is the same as ReloadTables with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ReloadTables for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) ReloadTablesWithContext(ctx aws.Context, input *ReloadTablesInput, opts ...request.Option) (*ReloadTablesOutput, error) {
+	req, out := c.ReloadTablesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opRemoveTagsFromResource = "RemoveTagsFromResource"
 
 // RemoveTagsFromResourceRequest generates a "aws/request.Request" representing the
@@ -2641,6 +3924,9 @@ func (c *DatabaseMigrationService) StartReplicationTaskRequest(input *StartRepli
 // StartReplicationTask API operation for AWS Database Migration Service.
 //
 // Starts the replication task.
+//
+// For more information about AWS DMS tasks, see the AWS DMS user guide at
+// Working with Migration Tasks  (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.html)
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3183,6 +4469,12 @@ type CreateEndpointInput struct {
 	// The name of the endpoint database.
 	DatabaseName *string `type:"string"`
 
+	// Settings in JSON format for the target Amazon DynamoDB endpoint. For more
+	// information about the available settings, see the Using Object Mapping to
+	// Migrate Data to DynamoDB section at  Using an Amazon DynamoDB Database as
+	// a Target for AWS Database Migration Service (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.DynamoDB.html).
+	DynamoDbSettings *DynamoDbSettings `type:"structure"`
+
 	// The database endpoint identifier. Identifiers must begin with a letter; must
 	// contain only ASCII letters, digits, and hyphens; and must not end with a
 	// hyphen or contain two consecutive hyphens.
@@ -3195,8 +4487,9 @@ type CreateEndpointInput struct {
 	// EndpointType is a required field
 	EndpointType *string `type:"string" required:"true" enum:"ReplicationEndpointTypeValue"`
 
-	// The type of engine for the endpoint. Valid values include MYSQL, ORACLE,
-	// POSTGRES, MARIADB, AURORA, REDSHIFT, SYBASE, and SQLSERVER.
+	// The type of engine for the endpoint. Valid values, depending on the EndPointType,
+	// include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB,
+	// MONGODB, and SQLSERVER.
 	//
 	// EngineName is a required field
 	EngineName *string `type:"string" required:"true"`
@@ -3211,11 +4504,22 @@ type CreateEndpointInput struct {
 	// key for each AWS region.
 	KmsKeyId *string `type:"string"`
 
+	// Settings in JSON format for the source MongoDB endpoint. For more information
+	// about the available settings, see the Configuration Properties When Using
+	// MongoDB as a Source for AWS Database Migration Service section at  Using
+	// Amazon S3 as a Target for AWS Database Migration Service (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html).
+	MongoDbSettings *MongoDbSettings `type:"structure"`
+
 	// The password to be used to login to the endpoint database.
 	Password *string `type:"string"`
 
 	// The port used by the endpoint database.
 	Port *int64 `type:"integer"`
+
+	// Settings in JSON format for the target S3 endpoint. For more information
+	// about the available settings, see the Extra Connection Attributes section
+	// at  Using Amazon S3 as a Target for AWS Database Migration Service (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html).
+	S3Settings *S3Settings `type:"structure"`
 
 	// The name of the server where the endpoint database resides.
 	ServerName *string `type:"string"`
@@ -3256,6 +4560,11 @@ func (s *CreateEndpointInput) Validate() error {
 	if s.EngineName == nil {
 		invalidParams.Add(request.NewErrParamRequired("EngineName"))
 	}
+	if s.DynamoDbSettings != nil {
+		if err := s.DynamoDbSettings.Validate(); err != nil {
+			invalidParams.AddNested("DynamoDbSettings", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3272,6 +4581,12 @@ func (s *CreateEndpointInput) SetCertificateArn(v string) *CreateEndpointInput {
 // SetDatabaseName sets the DatabaseName field's value.
 func (s *CreateEndpointInput) SetDatabaseName(v string) *CreateEndpointInput {
 	s.DatabaseName = &v
+	return s
+}
+
+// SetDynamoDbSettings sets the DynamoDbSettings field's value.
+func (s *CreateEndpointInput) SetDynamoDbSettings(v *DynamoDbSettings) *CreateEndpointInput {
+	s.DynamoDbSettings = v
 	return s
 }
 
@@ -3305,6 +4620,12 @@ func (s *CreateEndpointInput) SetKmsKeyId(v string) *CreateEndpointInput {
 	return s
 }
 
+// SetMongoDbSettings sets the MongoDbSettings field's value.
+func (s *CreateEndpointInput) SetMongoDbSettings(v *MongoDbSettings) *CreateEndpointInput {
+	s.MongoDbSettings = v
+	return s
+}
+
 // SetPassword sets the Password field's value.
 func (s *CreateEndpointInput) SetPassword(v string) *CreateEndpointInput {
 	s.Password = &v
@@ -3314,6 +4635,12 @@ func (s *CreateEndpointInput) SetPassword(v string) *CreateEndpointInput {
 // SetPort sets the Port field's value.
 func (s *CreateEndpointInput) SetPort(v int64) *CreateEndpointInput {
 	s.Port = &v
+	return s
+}
+
+// SetS3Settings sets the S3Settings field's value.
+func (s *CreateEndpointInput) SetS3Settings(v *S3Settings) *CreateEndpointInput {
+	s.S3Settings = v
 	return s
 }
 
@@ -3362,6 +4689,145 @@ func (s CreateEndpointOutput) GoString() string {
 // SetEndpoint sets the Endpoint field's value.
 func (s *CreateEndpointOutput) SetEndpoint(v *Endpoint) *CreateEndpointOutput {
 	s.Endpoint = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/CreateEventSubscriptionMessage
+type CreateEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// A Boolean value; set to true to activate the subscription, or set to false
+	// to create the subscription but not activate it.
+	Enabled *bool `type:"boolean"`
+
+	// A list of event categories for a source type that you want to subscribe to.
+	// You can see a list of the categories for a given source type by calling the
+	// DescribeEventCategories action or in the topic  Working with Events and Notifications
+	// (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Events.html) in the
+	// AWS Database Migration Service User Guide.
+	EventCategories []*string `locationNameList:"EventCategory" type:"list"`
+
+	// The Amazon Resource Name (ARN) of the Amazon SNS topic created for event
+	// notification. The ARN is created by Amazon SNS when you create a topic and
+	// subscribe to it.
+	//
+	// SnsTopicArn is a required field
+	SnsTopicArn *string `type:"string" required:"true"`
+
+	// The list of identifiers of the event sources for which events will be returned.
+	// If not specified, then all sources are included in the response. An identifier
+	// must begin with a letter and must contain only ASCII letters, digits, and
+	// hyphens; it cannot end with a hyphen or contain two consecutive hyphens.
+	SourceIds []*string `locationNameList:"SourceId" type:"list"`
+
+	// The type of AWS DMS resource that generates the events. For example, if you
+	// want to be notified of events generated by a replication instance, you set
+	// this parameter to replication-instance. If this value is not specified, all
+	// events are returned.
+	//
+	// Valid values: replication-instance | migration-task
+	SourceType *string `type:"string"`
+
+	// The name of the DMS event notification subscription.
+	//
+	// Constraints: The name must be less than 255 characters.
+	//
+	// SubscriptionName is a required field
+	SubscriptionName *string `type:"string" required:"true"`
+
+	// A tag to be attached to the event subscription.
+	Tags []*Tag `locationNameList:"Tag" type:"list"`
+}
+
+// String returns the string representation
+func (s CreateEventSubscriptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateEventSubscriptionInput"}
+	if s.SnsTopicArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SnsTopicArn"))
+	}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *CreateEventSubscriptionInput) SetEnabled(v bool) *CreateEventSubscriptionInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *CreateEventSubscriptionInput) SetEventCategories(v []*string) *CreateEventSubscriptionInput {
+	s.EventCategories = v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *CreateEventSubscriptionInput) SetSnsTopicArn(v string) *CreateEventSubscriptionInput {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceIds sets the SourceIds field's value.
+func (s *CreateEventSubscriptionInput) SetSourceIds(v []*string) *CreateEventSubscriptionInput {
+	s.SourceIds = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *CreateEventSubscriptionInput) SetSourceType(v string) *CreateEventSubscriptionInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *CreateEventSubscriptionInput) SetSubscriptionName(v string) *CreateEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateEventSubscriptionInput) SetTags(v []*Tag) *CreateEventSubscriptionInput {
+	s.Tags = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/CreateEventSubscriptionResponse
+type CreateEventSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The event subscription that was created.
+	EventSubscription *EventSubscription `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateEventSubscriptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateEventSubscriptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *CreateEventSubscriptionOutput) SetEventSubscription(v *EventSubscription) *CreateEventSubscriptionOutput {
+	s.EventSubscription = v
 	return s
 }
 
@@ -3710,7 +5176,7 @@ type CreateReplicationTaskInput struct {
 	//
 	// Constraints:
 	//
-	//    * Must contain from 1 to 63 alphanumeric characters or hyphens.
+	//    * Must contain from 1 to 255 alphanumeric characters or hyphens.
 	//
 	//    * First character must be a letter.
 	//
@@ -3729,8 +5195,9 @@ type CreateReplicationTaskInput struct {
 	// SourceEndpointArn is a required field
 	SourceEndpointArn *string `type:"string" required:"true"`
 
-	// The path of the JSON file that contains the table mappings. Preceed the path
-	// with "file://".
+	// When using the AWS CLI or boto3, provide the path of the JSON file that contains
+	// the table mappings. Precede the path with "file://". When working with the
+	// DMS API, provide the JSON as the parameter value.
 	//
 	// For example, --table-mappings file://mappingfile.json
 	//
@@ -3985,6 +5452,69 @@ func (s DeleteEndpointOutput) GoString() string {
 // SetEndpoint sets the Endpoint field's value.
 func (s *DeleteEndpointOutput) SetEndpoint(v *Endpoint) *DeleteEndpointOutput {
 	s.Endpoint = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DeleteEventSubscriptionMessage
+type DeleteEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the DMS event notification subscription to be deleted.
+	//
+	// SubscriptionName is a required field
+	SubscriptionName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteEventSubscriptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEventSubscriptionInput"}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *DeleteEventSubscriptionInput) SetSubscriptionName(v string) *DeleteEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DeleteEventSubscriptionResponse
+type DeleteEventSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The event subscription that was deleted.
+	EventSubscription *EventSubscription `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteEventSubscriptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEventSubscriptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *DeleteEventSubscriptionOutput) SetEventSubscription(v *EventSubscription) *DeleteEventSubscriptionOutput {
+	s.EventSubscription = v
 	return s
 }
 
@@ -4626,6 +6156,362 @@ func (s *DescribeEndpointsOutput) SetEndpoints(v []*Endpoint) *DescribeEndpoints
 
 // SetMarker sets the Marker field's value.
 func (s *DescribeEndpointsOutput) SetMarker(v string) *DescribeEndpointsOutput {
+	s.Marker = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventCategoriesMessage
+type DescribeEventCategoriesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Filters applied to the action.
+	Filters []*Filter `locationNameList:"Filter" type:"list"`
+
+	// The type of AWS DMS resource that generates events.
+	//
+	// Valid values: replication-instance | migration-task
+	SourceType *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeEventCategoriesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventCategoriesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEventCategoriesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEventCategoriesInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeEventCategoriesInput) SetFilters(v []*Filter) *DescribeEventCategoriesInput {
+	s.Filters = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *DescribeEventCategoriesInput) SetSourceType(v string) *DescribeEventCategoriesInput {
+	s.SourceType = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventCategoriesResponse
+type DescribeEventCategoriesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of event categories.
+	EventCategoryGroupList []*EventCategoryGroup `locationNameList:"EventCategoryGroup" type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeEventCategoriesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventCategoriesOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventCategoryGroupList sets the EventCategoryGroupList field's value.
+func (s *DescribeEventCategoriesOutput) SetEventCategoryGroupList(v []*EventCategoryGroup) *DescribeEventCategoriesOutput {
+	s.EventCategoryGroupList = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventSubscriptionsMessage
+type DescribeEventSubscriptionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Filters applied to the action.
+	Filters []*Filter `locationNameList:"Filter" type:"list"`
+
+	// An optional pagination token provided by a previous request. If this parameter
+	// is specified, the response includes only records beyond the marker, up to
+	// the value specified by MaxRecords.
+	Marker *string `type:"string"`
+
+	// The maximum number of records to include in the response. If more records
+	// exist than the specified MaxRecords value, a pagination token called a marker
+	// is included in the response so that the remaining results can be retrieved.
+	//
+	// Default: 100
+	//
+	// Constraints: Minimum 20, maximum 100.
+	MaxRecords *int64 `type:"integer"`
+
+	// The name of the AWS DMS event subscription to be described.
+	SubscriptionName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeEventSubscriptionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventSubscriptionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEventSubscriptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEventSubscriptionsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeEventSubscriptionsInput) SetFilters(v []*Filter) *DescribeEventSubscriptionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventSubscriptionsInput) SetMarker(v string) *DescribeEventSubscriptionsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEventSubscriptionsInput) SetMaxRecords(v int64) *DescribeEventSubscriptionsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *DescribeEventSubscriptionsInput) SetSubscriptionName(v string) *DescribeEventSubscriptionsInput {
+	s.SubscriptionName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventSubscriptionsResponse
+type DescribeEventSubscriptionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of event subscriptions.
+	EventSubscriptionsList []*EventSubscription `locationNameList:"EventSubscription" type:"list"`
+
+	// An optional pagination token provided by a previous request. If this parameter
+	// is specified, the response includes only records beyond the marker, up to
+	// the value specified by MaxRecords.
+	Marker *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeEventSubscriptionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventSubscriptionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventSubscriptionsList sets the EventSubscriptionsList field's value.
+func (s *DescribeEventSubscriptionsOutput) SetEventSubscriptionsList(v []*EventSubscription) *DescribeEventSubscriptionsOutput {
+	s.EventSubscriptionsList = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventSubscriptionsOutput) SetMarker(v string) *DescribeEventSubscriptionsOutput {
+	s.Marker = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventsMessage
+type DescribeEventsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The duration of the events to be listed.
+	Duration *int64 `type:"integer"`
+
+	// The end time for the events to be listed.
+	EndTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// A list of event categories for a source type that you want to subscribe to.
+	EventCategories []*string `locationNameList:"EventCategory" type:"list"`
+
+	// Filters applied to the action.
+	Filters []*Filter `locationNameList:"Filter" type:"list"`
+
+	// An optional pagination token provided by a previous request. If this parameter
+	// is specified, the response includes only records beyond the marker, up to
+	// the value specified by MaxRecords.
+	Marker *string `type:"string"`
+
+	// The maximum number of records to include in the response. If more records
+	// exist than the specified MaxRecords value, a pagination token called a marker
+	// is included in the response so that the remaining results can be retrieved.
+	//
+	// Default: 100
+	//
+	// Constraints: Minimum 20, maximum 100.
+	MaxRecords *int64 `type:"integer"`
+
+	// The identifier of the event source. An identifier must begin with a letter
+	// and must contain only ASCII letters, digits, and hyphens. It cannot end with
+	// a hyphen or contain two consecutive hyphens.
+	SourceIdentifier *string `type:"string"`
+
+	// The type of AWS DMS resource that generates events.
+	//
+	// Valid values: replication-instance | migration-task
+	SourceType *string `type:"string" enum:"SourceType"`
+
+	// The start time for the events to be listed.
+	StartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+}
+
+// String returns the string representation
+func (s DescribeEventsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEventsInput"}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDuration sets the Duration field's value.
+func (s *DescribeEventsInput) SetDuration(v int64) *DescribeEventsInput {
+	s.Duration = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeEventsInput) SetEndTime(v time.Time) *DescribeEventsInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *DescribeEventsInput) SetEventCategories(v []*string) *DescribeEventsInput {
+	s.EventCategories = v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeEventsInput) SetFilters(v []*Filter) *DescribeEventsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventsInput) SetMarker(v string) *DescribeEventsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeEventsInput) SetMaxRecords(v int64) *DescribeEventsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *DescribeEventsInput) SetSourceIdentifier(v string) *DescribeEventsInput {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *DescribeEventsInput) SetSourceType(v string) *DescribeEventsInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeEventsInput) SetStartTime(v time.Time) *DescribeEventsInput {
+	s.StartTime = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeEventsResponse
+type DescribeEventsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The events described.
+	Events []*Event `locationNameList:"Event" type:"list"`
+
+	// An optional pagination token provided by a previous request. If this parameter
+	// is specified, the response includes only records beyond the marker, up to
+	// the value specified by MaxRecords.
+	Marker *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeEventsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsOutput) GoString() string {
+	return s.String()
+}
+
+// SetEvents sets the Events field's value.
+func (s *DescribeEventsOutput) SetEvents(v []*Event) *DescribeEventsOutput {
+	s.Events = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeEventsOutput) SetMarker(v string) *DescribeEventsOutput {
 	s.Marker = &v
 	return s
 }
@@ -5299,6 +7185,45 @@ func (s *DescribeTableStatisticsOutput) SetTableStatistics(v []*TableStatistics)
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DynamoDbSettings
+type DynamoDbSettings struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) used by the service access IAM role.
+	//
+	// ServiceAccessRoleArn is a required field
+	ServiceAccessRoleArn *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DynamoDbSettings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DynamoDbSettings) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DynamoDbSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DynamoDbSettings"}
+	if s.ServiceAccessRoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServiceAccessRoleArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetServiceAccessRoleArn sets the ServiceAccessRoleArn field's value.
+func (s *DynamoDbSettings) SetServiceAccessRoleArn(v string) *DynamoDbSettings {
+	s.ServiceAccessRoleArn = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/Endpoint
 type Endpoint struct {
 	_ struct{} `type:"structure"`
@@ -5308,6 +7233,10 @@ type Endpoint struct {
 
 	// The name of the database at the endpoint.
 	DatabaseName *string `type:"string"`
+
+	// The settings for the target DynamoDB database. For more information, see
+	// the DynamoDBSettings structure.
+	DynamoDbSettings *DynamoDbSettings `type:"structure"`
 
 	// The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.
 	EndpointArn *string `type:"string"`
@@ -5320,9 +7249,15 @@ type Endpoint struct {
 	// The type of endpoint.
 	EndpointType *string `type:"string" enum:"ReplicationEndpointTypeValue"`
 
-	// The database engine name. Valid values include MYSQL, ORACLE, POSTGRES, MARIADB,
-	// AURORA, REDSHIFT, SYBASE, and SQLSERVER.
+	// The database engine name. Valid values, depending on the EndPointType, include
+	// MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB,
+	// MONGODB, and SQLSERVER.
 	EngineName *string `type:"string"`
+
+	// Value returned by a call to CreateEndpoint that can be used for cross-account
+	// validation. Use it on a subsequent call to CreateEndpoint to create the endpoint
+	// with a cross-account.
+	ExternalId *string `type:"string"`
 
 	// Additional connection attributes used to connect to the endpoint.
 	ExtraConnectionAttributes *string `type:"string"`
@@ -5334,8 +7269,16 @@ type Endpoint struct {
 	// key for each AWS region.
 	KmsKeyId *string `type:"string"`
 
+	// The settings for the MongoDB source endpoint. For more information, see the
+	// MongoDbSettings structure.
+	MongoDbSettings *MongoDbSettings `type:"structure"`
+
 	// The port value used to access the endpoint.
 	Port *int64 `type:"integer"`
+
+	// The settings for the S3 target endpoint. For more information, see the S3Settings
+	// structure.
+	S3Settings *S3Settings `type:"structure"`
 
 	// The name of the server at the endpoint.
 	ServerName *string `type:"string"`
@@ -5376,6 +7319,12 @@ func (s *Endpoint) SetDatabaseName(v string) *Endpoint {
 	return s
 }
 
+// SetDynamoDbSettings sets the DynamoDbSettings field's value.
+func (s *Endpoint) SetDynamoDbSettings(v *DynamoDbSettings) *Endpoint {
+	s.DynamoDbSettings = v
+	return s
+}
+
 // SetEndpointArn sets the EndpointArn field's value.
 func (s *Endpoint) SetEndpointArn(v string) *Endpoint {
 	s.EndpointArn = &v
@@ -5400,6 +7349,12 @@ func (s *Endpoint) SetEngineName(v string) *Endpoint {
 	return s
 }
 
+// SetExternalId sets the ExternalId field's value.
+func (s *Endpoint) SetExternalId(v string) *Endpoint {
+	s.ExternalId = &v
+	return s
+}
+
 // SetExtraConnectionAttributes sets the ExtraConnectionAttributes field's value.
 func (s *Endpoint) SetExtraConnectionAttributes(v string) *Endpoint {
 	s.ExtraConnectionAttributes = &v
@@ -5412,9 +7367,21 @@ func (s *Endpoint) SetKmsKeyId(v string) *Endpoint {
 	return s
 }
 
+// SetMongoDbSettings sets the MongoDbSettings field's value.
+func (s *Endpoint) SetMongoDbSettings(v *MongoDbSettings) *Endpoint {
+	s.MongoDbSettings = v
+	return s
+}
+
 // SetPort sets the Port field's value.
 func (s *Endpoint) SetPort(v int64) *Endpoint {
 	s.Port = &v
+	return s
+}
+
+// SetS3Settings sets the S3Settings field's value.
+func (s *Endpoint) SetS3Settings(v *S3Settings) *Endpoint {
+	s.S3Settings = v
 	return s
 }
 
@@ -5439,6 +7406,216 @@ func (s *Endpoint) SetStatus(v string) *Endpoint {
 // SetUsername sets the Username field's value.
 func (s *Endpoint) SetUsername(v string) *Endpoint {
 	s.Username = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/Event
+type Event struct {
+	_ struct{} `type:"structure"`
+
+	// The date of the event.
+	Date *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The event categories available for the specified source type.
+	EventCategories []*string `locationNameList:"EventCategory" type:"list"`
+
+	// The event message.
+	Message *string `type:"string"`
+
+	// The identifier of the event source. An identifier must begin with a letter
+	// and must contain only ASCII letters, digits, and hyphens; it cannot end with
+	// a hyphen or contain two consecutive hyphens.
+	//
+	// Constraints:replication instance, endpoint, migration task
+	SourceIdentifier *string `type:"string"`
+
+	// The type of AWS DMS resource that generates events.
+	//
+	// Valid values: replication-instance | endpoint | migration-task
+	SourceType *string `type:"string" enum:"SourceType"`
+}
+
+// String returns the string representation
+func (s Event) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Event) GoString() string {
+	return s.String()
+}
+
+// SetDate sets the Date field's value.
+func (s *Event) SetDate(v time.Time) *Event {
+	s.Date = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *Event) SetEventCategories(v []*string) *Event {
+	s.EventCategories = v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *Event) SetMessage(v string) *Event {
+	s.Message = &v
+	return s
+}
+
+// SetSourceIdentifier sets the SourceIdentifier field's value.
+func (s *Event) SetSourceIdentifier(v string) *Event {
+	s.SourceIdentifier = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *Event) SetSourceType(v string) *Event {
+	s.SourceType = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/EventCategoryGroup
+type EventCategoryGroup struct {
+	_ struct{} `type:"structure"`
+
+	// A list of event categories for a SourceType that you want to subscribe to.
+	EventCategories []*string `locationNameList:"EventCategory" type:"list"`
+
+	// The type of AWS DMS resource that generates events.
+	//
+	// Valid values: replication-instance | replication-server | security-group
+	// | migration-task
+	SourceType *string `type:"string"`
+}
+
+// String returns the string representation
+func (s EventCategoryGroup) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EventCategoryGroup) GoString() string {
+	return s.String()
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *EventCategoryGroup) SetEventCategories(v []*string) *EventCategoryGroup {
+	s.EventCategories = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *EventCategoryGroup) SetSourceType(v string) *EventCategoryGroup {
+	s.SourceType = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/EventSubscription
+type EventSubscription struct {
+	_ struct{} `type:"structure"`
+
+	// The AWS DMS event notification subscription Id.
+	CustSubscriptionId *string `type:"string"`
+
+	// The AWS customer account associated with the AWS DMS event notification subscription.
+	CustomerAwsId *string `type:"string"`
+
+	// Boolean value that indicates if the event subscription is enabled.
+	Enabled *bool `type:"boolean"`
+
+	// A lists of event categories.
+	EventCategoriesList []*string `locationNameList:"EventCategory" type:"list"`
+
+	// The topic ARN of the AWS DMS event notification subscription.
+	SnsTopicArn *string `type:"string"`
+
+	// A list of source Ids for the event subscription.
+	SourceIdsList []*string `locationNameList:"SourceId" type:"list"`
+
+	// The type of AWS DMS resource that generates events.
+	//
+	// Valid values: replication-instance | replication-server | security-group
+	// | migration-task
+	SourceType *string `type:"string"`
+
+	// The status of the AWS DMS event notification subscription.
+	//
+	// Constraints:
+	//
+	// Can be one of the following: creating | modifying | deleting | active | no-permission
+	// | topic-not-exist
+	//
+	// The status "no-permission" indicates that AWS DMS no longer has permission
+	// to post to the SNS topic. The status "topic-not-exist" indicates that the
+	// topic was deleted after the subscription was created.
+	Status *string `type:"string"`
+
+	// The time the RDS event notification subscription was created.
+	SubscriptionCreationTime *string `type:"string"`
+}
+
+// String returns the string representation
+func (s EventSubscription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EventSubscription) GoString() string {
+	return s.String()
+}
+
+// SetCustSubscriptionId sets the CustSubscriptionId field's value.
+func (s *EventSubscription) SetCustSubscriptionId(v string) *EventSubscription {
+	s.CustSubscriptionId = &v
+	return s
+}
+
+// SetCustomerAwsId sets the CustomerAwsId field's value.
+func (s *EventSubscription) SetCustomerAwsId(v string) *EventSubscription {
+	s.CustomerAwsId = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *EventSubscription) SetEnabled(v bool) *EventSubscription {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategoriesList sets the EventCategoriesList field's value.
+func (s *EventSubscription) SetEventCategoriesList(v []*string) *EventSubscription {
+	s.EventCategoriesList = v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *EventSubscription) SetSnsTopicArn(v string) *EventSubscription {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceIdsList sets the SourceIdsList field's value.
+func (s *EventSubscription) SetSourceIdsList(v []*string) *EventSubscription {
+	s.SourceIdsList = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *EventSubscription) SetSourceType(v string) *EventSubscription {
+	s.SourceType = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *EventSubscription) SetStatus(v string) *EventSubscription {
+	s.Status = &v
+	return s
+}
+
+// SetSubscriptionCreationTime sets the SubscriptionCreationTime field's value.
+func (s *EventSubscription) SetSubscriptionCreationTime(v string) *EventSubscription {
+	s.SubscriptionCreationTime = &v
 	return s
 }
 
@@ -5653,6 +7830,12 @@ type ModifyEndpointInput struct {
 	// The name of the endpoint database.
 	DatabaseName *string `type:"string"`
 
+	// Settings in JSON format for the target Amazon DynamoDB endpoint. For more
+	// information about the available settings, see the Using Object Mapping to
+	// Migrate Data to DynamoDB section at  Using an Amazon DynamoDB Database as
+	// a Target for AWS Database Migration Service (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.DynamoDB.html).
+	DynamoDbSettings *DynamoDbSettings `type:"structure"`
+
 	// The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.
 	//
 	// EndpointArn is a required field
@@ -5666,18 +7849,30 @@ type ModifyEndpointInput struct {
 	// The type of endpoint.
 	EndpointType *string `type:"string" enum:"ReplicationEndpointTypeValue"`
 
-	// The type of engine for the endpoint. Valid values include MYSQL, ORACLE,
-	// POSTGRES, MARIADB, AURORA, REDSHIFT, SYBASE, and SQLSERVER.
+	// The type of engine for the endpoint. Valid values, depending on the EndPointType,
+	// include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, DYNAMODB,
+	// MONGODB, SYBASE, and SQLSERVER.
 	EngineName *string `type:"string"`
 
 	// Additional attributes associated with the connection.
 	ExtraConnectionAttributes *string `type:"string"`
+
+	// Settings in JSON format for the source MongoDB endpoint. For more information
+	// about the available settings, see the Configuration Properties When Using
+	// MongoDB as a Source for AWS Database Migration Service section at  Using
+	// Amazon S3 as a Target for AWS Database Migration Service (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html).
+	MongoDbSettings *MongoDbSettings `type:"structure"`
 
 	// The password to be used to login to the endpoint database.
 	Password *string `type:"string"`
 
 	// The port used by the endpoint database.
 	Port *int64 `type:"integer"`
+
+	// Settings in JSON format for the target S3 endpoint. For more information
+	// about the available settings, see the Extra Connection Attributes section
+	// at  Using Amazon S3 as a Target for AWS Database Migration Service (http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html).
+	S3Settings *S3Settings `type:"structure"`
 
 	// The name of the server where the endpoint database resides.
 	ServerName *string `type:"string"`
@@ -5709,6 +7904,11 @@ func (s *ModifyEndpointInput) Validate() error {
 	if s.EndpointArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("EndpointArn"))
 	}
+	if s.DynamoDbSettings != nil {
+		if err := s.DynamoDbSettings.Validate(); err != nil {
+			invalidParams.AddNested("DynamoDbSettings", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5725,6 +7925,12 @@ func (s *ModifyEndpointInput) SetCertificateArn(v string) *ModifyEndpointInput {
 // SetDatabaseName sets the DatabaseName field's value.
 func (s *ModifyEndpointInput) SetDatabaseName(v string) *ModifyEndpointInput {
 	s.DatabaseName = &v
+	return s
+}
+
+// SetDynamoDbSettings sets the DynamoDbSettings field's value.
+func (s *ModifyEndpointInput) SetDynamoDbSettings(v *DynamoDbSettings) *ModifyEndpointInput {
+	s.DynamoDbSettings = v
 	return s
 }
 
@@ -5758,6 +7964,12 @@ func (s *ModifyEndpointInput) SetExtraConnectionAttributes(v string) *ModifyEndp
 	return s
 }
 
+// SetMongoDbSettings sets the MongoDbSettings field's value.
+func (s *ModifyEndpointInput) SetMongoDbSettings(v *MongoDbSettings) *ModifyEndpointInput {
+	s.MongoDbSettings = v
+	return s
+}
+
 // SetPassword sets the Password field's value.
 func (s *ModifyEndpointInput) SetPassword(v string) *ModifyEndpointInput {
 	s.Password = &v
@@ -5767,6 +7979,12 @@ func (s *ModifyEndpointInput) SetPassword(v string) *ModifyEndpointInput {
 // SetPort sets the Port field's value.
 func (s *ModifyEndpointInput) SetPort(v int64) *ModifyEndpointInput {
 	s.Port = &v
+	return s
+}
+
+// SetS3Settings sets the S3Settings field's value.
+func (s *ModifyEndpointInput) SetS3Settings(v *S3Settings) *ModifyEndpointInput {
+	s.S3Settings = v
 	return s
 }
 
@@ -5809,6 +8027,111 @@ func (s ModifyEndpointOutput) GoString() string {
 // SetEndpoint sets the Endpoint field's value.
 func (s *ModifyEndpointOutput) SetEndpoint(v *Endpoint) *ModifyEndpointOutput {
 	s.Endpoint = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ModifyEventSubscriptionMessage
+type ModifyEventSubscriptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// A Boolean value; set to true to activate the subscription.
+	Enabled *bool `type:"boolean"`
+
+	// A list of event categories for a source type that you want to subscribe to.
+	// Use the DescribeEventCategories action to see a list of event categories.
+	EventCategories []*string `locationNameList:"EventCategory" type:"list"`
+
+	// The Amazon Resource Name (ARN) of the Amazon SNS topic created for event
+	// notification. The ARN is created by Amazon SNS when you create a topic and
+	// subscribe to it.
+	SnsTopicArn *string `type:"string"`
+
+	// The type of AWS DMS resource that generates the events you want to subscribe
+	// to.
+	//
+	// Valid values: replication-instance | migration-task
+	SourceType *string `type:"string"`
+
+	// The name of the AWS DMS event notification subscription to be modified.
+	//
+	// SubscriptionName is a required field
+	SubscriptionName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ModifyEventSubscriptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyEventSubscriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyEventSubscriptionInput"}
+	if s.SubscriptionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SubscriptionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *ModifyEventSubscriptionInput) SetEnabled(v bool) *ModifyEventSubscriptionInput {
+	s.Enabled = &v
+	return s
+}
+
+// SetEventCategories sets the EventCategories field's value.
+func (s *ModifyEventSubscriptionInput) SetEventCategories(v []*string) *ModifyEventSubscriptionInput {
+	s.EventCategories = v
+	return s
+}
+
+// SetSnsTopicArn sets the SnsTopicArn field's value.
+func (s *ModifyEventSubscriptionInput) SetSnsTopicArn(v string) *ModifyEventSubscriptionInput {
+	s.SnsTopicArn = &v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *ModifyEventSubscriptionInput) SetSourceType(v string) *ModifyEventSubscriptionInput {
+	s.SourceType = &v
+	return s
+}
+
+// SetSubscriptionName sets the SubscriptionName field's value.
+func (s *ModifyEventSubscriptionInput) SetSubscriptionName(v string) *ModifyEventSubscriptionInput {
+	s.SubscriptionName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ModifyEventSubscriptionResponse
+type ModifyEventSubscriptionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The modified event subscription.
+	EventSubscription *EventSubscription `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyEventSubscriptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyEventSubscriptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventSubscription sets the EventSubscription field's value.
+func (s *ModifyEventSubscriptionOutput) SetEventSubscription(v *EventSubscription) *ModifyEventSubscriptionOutput {
+	s.EventSubscription = v
 	return s
 }
 
@@ -6106,7 +8429,7 @@ type ModifyReplicationTaskInput struct {
 	//
 	// Constraints:
 	//
-	//    * Must contain from 1 to 63 alphanumeric characters or hyphens.
+	//    * Must contain from 1 to 255 alphanumeric characters or hyphens.
 	//
 	//    * First character must be a letter.
 	//
@@ -6116,8 +8439,9 @@ type ModifyReplicationTaskInput struct {
 	// JSON file that contains settings for the task, such as target metadata settings.
 	ReplicationTaskSettings *string `type:"string"`
 
-	// The path of the JSON file that contains the table mappings. Preceed the path
-	// with "file://".
+	// When using the AWS CLI or boto3, provide the path of the JSON file that contains
+	// the table mappings. Precede the path with "file://". When working with the
+	// DMS API, provide the JSON as the parameter value.
 	//
 	// For example, --table-mappings file://mappingfile.json
 	TableMappings *string `type:"string"`
@@ -6203,6 +8527,143 @@ func (s ModifyReplicationTaskOutput) GoString() string {
 // SetReplicationTask sets the ReplicationTask field's value.
 func (s *ModifyReplicationTaskOutput) SetReplicationTask(v *ReplicationTask) *ModifyReplicationTaskOutput {
 	s.ReplicationTask = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/MongoDbSettings
+type MongoDbSettings struct {
+	_ struct{} `type:"structure"`
+
+	// The authentication mechanism you use to access the MongoDB source endpoint.
+	//
+	// Valid values: DEFAULT, MONGODB_CR, SCRAM_SHA_1
+	//
+	// DEFAULT – For MongoDB version 2.x, use MONGODB_CR. For MongoDB version 3.x,
+	// use SCRAM_SHA_1. This attribute is not used when authType=No.
+	AuthMechanism *string `type:"string" enum:"AuthMechanismValue"`
+
+	// The MongoDB database name. This attribute is not used when authType=NO.
+	//
+	// The default is admin.
+	AuthSource *string `type:"string"`
+
+	// The authentication type you use to access the MongoDB source endpoint.
+	//
+	// Valid values: NO, PASSWORD
+	//
+	// When NO is selected, user name and password parameters are not used and can
+	// be empty.
+	AuthType *string `type:"string" enum:"AuthTypeValue"`
+
+	// The database name on the MongoDB source endpoint.
+	DatabaseName *string `type:"string"`
+
+	// Indicates the number of documents to preview to determine the document organization.
+	// Use this attribute when NestingLevel is set to ONE.
+	//
+	// Must be a positive value greater than 0. Default value is 1000.
+	DocsToInvestigate *string `type:"string"`
+
+	// Specifies the document ID. Use this attribute when NestingLevel is set to
+	// NONE.
+	//
+	// Default value is false.
+	ExtractDocId *string `type:"string"`
+
+	// Specifies either document or table mode.
+	//
+	// Valid values: NONE, ONE
+	//
+	// Default value is NONE. Specify NONE to use document mode. Specify ONE to
+	// use table mode.
+	NestingLevel *string `type:"string" enum:"NestingLevelValue"`
+
+	// The password for the user account you use to access the MongoDB source endpoint.
+	Password *string `type:"string"`
+
+	// The port value for the MongoDB source endpoint.
+	Port *int64 `type:"integer"`
+
+	// The name of the server on the MongoDB source endpoint.
+	ServerName *string `type:"string"`
+
+	// The user name you use to access the MongoDB source endpoint.
+	Username *string `type:"string"`
+}
+
+// String returns the string representation
+func (s MongoDbSettings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MongoDbSettings) GoString() string {
+	return s.String()
+}
+
+// SetAuthMechanism sets the AuthMechanism field's value.
+func (s *MongoDbSettings) SetAuthMechanism(v string) *MongoDbSettings {
+	s.AuthMechanism = &v
+	return s
+}
+
+// SetAuthSource sets the AuthSource field's value.
+func (s *MongoDbSettings) SetAuthSource(v string) *MongoDbSettings {
+	s.AuthSource = &v
+	return s
+}
+
+// SetAuthType sets the AuthType field's value.
+func (s *MongoDbSettings) SetAuthType(v string) *MongoDbSettings {
+	s.AuthType = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *MongoDbSettings) SetDatabaseName(v string) *MongoDbSettings {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetDocsToInvestigate sets the DocsToInvestigate field's value.
+func (s *MongoDbSettings) SetDocsToInvestigate(v string) *MongoDbSettings {
+	s.DocsToInvestigate = &v
+	return s
+}
+
+// SetExtractDocId sets the ExtractDocId field's value.
+func (s *MongoDbSettings) SetExtractDocId(v string) *MongoDbSettings {
+	s.ExtractDocId = &v
+	return s
+}
+
+// SetNestingLevel sets the NestingLevel field's value.
+func (s *MongoDbSettings) SetNestingLevel(v string) *MongoDbSettings {
+	s.NestingLevel = &v
+	return s
+}
+
+// SetPassword sets the Password field's value.
+func (s *MongoDbSettings) SetPassword(v string) *MongoDbSettings {
+	s.Password = &v
+	return s
+}
+
+// SetPort sets the Port field's value.
+func (s *MongoDbSettings) SetPort(v int64) *MongoDbSettings {
+	s.Port = &v
+	return s
+}
+
+// SetServerName sets the ServerName field's value.
+func (s *MongoDbSettings) SetServerName(v string) *MongoDbSettings {
+	s.ServerName = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *MongoDbSettings) SetUsername(v string) *MongoDbSettings {
+	s.Username = &v
 	return s
 }
 
@@ -6425,6 +8886,83 @@ func (s *RefreshSchemasStatus) SetReplicationInstanceArn(v string) *RefreshSchem
 // SetStatus sets the Status field's value.
 func (s *RefreshSchemasStatus) SetStatus(v string) *RefreshSchemasStatus {
 	s.Status = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ReloadTablesMessage
+type ReloadTablesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the replication instance.
+	//
+	// ReplicationTaskArn is a required field
+	ReplicationTaskArn *string `type:"string" required:"true"`
+
+	// The name and schema of the table to be reloaded.
+	//
+	// TablesToReload is a required field
+	TablesToReload []*TableToReload `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s ReloadTablesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ReloadTablesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReloadTablesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReloadTablesInput"}
+	if s.ReplicationTaskArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationTaskArn"))
+	}
+	if s.TablesToReload == nil {
+		invalidParams.Add(request.NewErrParamRequired("TablesToReload"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *ReloadTablesInput) SetReplicationTaskArn(v string) *ReloadTablesInput {
+	s.ReplicationTaskArn = &v
+	return s
+}
+
+// SetTablesToReload sets the TablesToReload field's value.
+func (s *ReloadTablesInput) SetTablesToReload(v []*TableToReload) *ReloadTablesInput {
+	s.TablesToReload = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ReloadTablesResponse
+type ReloadTablesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the replication task.
+	ReplicationTaskArn *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ReloadTablesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ReloadTablesOutput) GoString() string {
+	return s.String()
+}
+
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *ReloadTablesOutput) SetReplicationTaskArn(v string) *ReloadTablesOutput {
+	s.ReplicationTaskArn = &v
 	return s
 }
 
@@ -6863,7 +9401,7 @@ type ReplicationTask struct {
 	//
 	// Constraints:
 	//
-	//    * Must contain from 1 to 63 alphanumeric characters or hyphens.
+	//    * Must contain from 1 to 255 alphanumeric characters or hyphens.
 	//
 	//    * First character must be a letter.
 	//
@@ -7056,6 +9594,89 @@ func (s *ReplicationTaskStats) SetTablesLoading(v int64) *ReplicationTaskStats {
 // SetTablesQueued sets the TablesQueued field's value.
 func (s *ReplicationTaskStats) SetTablesQueued(v int64) *ReplicationTaskStats {
 	s.TablesQueued = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/S3Settings
+type S3Settings struct {
+	_ struct{} `type:"structure"`
+
+	// An optional parameter to set a folder name in the S3 bucket. If provided,
+	// tables are created in the path <bucketFolder>/<schema_name>/<table_name>/.
+	// If this parameter is not specified, then the path used is <schema_name>/<table_name>/.
+	BucketFolder *string `type:"string"`
+
+	// The name of the S3 bucket.
+	BucketName *string `type:"string"`
+
+	// An optional parameter to use GZIP to compress the target files. Set to GZIP
+	// to compress the target files. Set to NONE (the default) or do not use to
+	// leave the files uncompressed.
+	CompressionType *string `type:"string" enum:"CompressionTypeValue"`
+
+	// The delimiter used to separate columns in the source files. The default is
+	// a comma.
+	CsvDelimiter *string `type:"string"`
+
+	// The delimiter used to separate rows in the source files. The default is a
+	// carriage return (\n).
+	CsvRowDelimiter *string `type:"string"`
+
+	ExternalTableDefinition *string `type:"string"`
+
+	// The Amazon Resource Name (ARN) used by the service access IAM role.
+	ServiceAccessRoleArn *string `type:"string"`
+}
+
+// String returns the string representation
+func (s S3Settings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s S3Settings) GoString() string {
+	return s.String()
+}
+
+// SetBucketFolder sets the BucketFolder field's value.
+func (s *S3Settings) SetBucketFolder(v string) *S3Settings {
+	s.BucketFolder = &v
+	return s
+}
+
+// SetBucketName sets the BucketName field's value.
+func (s *S3Settings) SetBucketName(v string) *S3Settings {
+	s.BucketName = &v
+	return s
+}
+
+// SetCompressionType sets the CompressionType field's value.
+func (s *S3Settings) SetCompressionType(v string) *S3Settings {
+	s.CompressionType = &v
+	return s
+}
+
+// SetCsvDelimiter sets the CsvDelimiter field's value.
+func (s *S3Settings) SetCsvDelimiter(v string) *S3Settings {
+	s.CsvDelimiter = &v
+	return s
+}
+
+// SetCsvRowDelimiter sets the CsvRowDelimiter field's value.
+func (s *S3Settings) SetCsvRowDelimiter(v string) *S3Settings {
+	s.CsvRowDelimiter = &v
+	return s
+}
+
+// SetExternalTableDefinition sets the ExternalTableDefinition field's value.
+func (s *S3Settings) SetExternalTableDefinition(v string) *S3Settings {
+	s.ExternalTableDefinition = &v
+	return s
+}
+
+// SetServiceAccessRoleArn sets the ServiceAccessRoleArn field's value.
+func (s *S3Settings) SetServiceAccessRoleArn(v string) *S3Settings {
+	s.ServiceAccessRoleArn = &v
 	return s
 }
 
@@ -7257,8 +9878,9 @@ type SupportedEndpointType struct {
 	// The type of endpoint.
 	EndpointType *string `type:"string" enum:"ReplicationEndpointTypeValue"`
 
-	// The database engine name. Valid values include MYSQL, ORACLE, POSTGRES, MARIADB,
-	// AURORA, REDSHIFT, SYBASE, and SQLSERVER.
+	// The database engine name. Valid values, depending on the EndPointType, include
+	// MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB,
+	// MONGODB, and SQLSERVER.
 	EngineName *string `type:"string"`
 
 	// Indicates if Change Data Capture (CDC) is supported.
@@ -7387,6 +10009,39 @@ func (s *TableStatistics) SetTableState(v string) *TableStatistics {
 // SetUpdates sets the Updates field's value.
 func (s *TableStatistics) SetUpdates(v int64) *TableStatistics {
 	s.Updates = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/TableToReload
+type TableToReload struct {
+	_ struct{} `type:"structure"`
+
+	// The schema name of the table to be reloaded.
+	SchemaName *string `type:"string"`
+
+	// The table name of the table to be reloaded.
+	TableName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s TableToReload) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TableToReload) GoString() string {
+	return s.String()
+}
+
+// SetSchemaName sets the SchemaName field's value.
+func (s *TableToReload) SetSchemaName(v string) *TableToReload {
+	s.SchemaName = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *TableToReload) SetTableName(v string) *TableToReload {
+	s.TableName = &v
 	return s
 }
 
@@ -7540,6 +10195,33 @@ func (s *VpcSecurityGroupMembership) SetVpcSecurityGroupId(v string) *VpcSecurit
 }
 
 const (
+	// AuthMechanismValueDefault is a AuthMechanismValue enum value
+	AuthMechanismValueDefault = "default"
+
+	// AuthMechanismValueMongodbCr is a AuthMechanismValue enum value
+	AuthMechanismValueMongodbCr = "mongodb_cr"
+
+	// AuthMechanismValueScramSha1 is a AuthMechanismValue enum value
+	AuthMechanismValueScramSha1 = "scram_sha_1"
+)
+
+const (
+	// AuthTypeValueNo is a AuthTypeValue enum value
+	AuthTypeValueNo = "no"
+
+	// AuthTypeValuePassword is a AuthTypeValue enum value
+	AuthTypeValuePassword = "password"
+)
+
+const (
+	// CompressionTypeValueNone is a CompressionTypeValue enum value
+	CompressionTypeValueNone = "none"
+
+	// CompressionTypeValueGzip is a CompressionTypeValue enum value
+	CompressionTypeValueGzip = "gzip"
+)
+
+const (
 	// DmsSslModeValueNone is a DmsSslModeValue enum value
 	DmsSslModeValueNone = "none"
 
@@ -7565,6 +10247,14 @@ const (
 )
 
 const (
+	// NestingLevelValueNone is a NestingLevelValue enum value
+	NestingLevelValueNone = "none"
+
+	// NestingLevelValueOne is a NestingLevelValue enum value
+	NestingLevelValueOne = "one"
+)
+
+const (
 	// RefreshSchemasStatusTypeValueSuccessful is a RefreshSchemasStatusTypeValue enum value
 	RefreshSchemasStatusTypeValueSuccessful = "successful"
 
@@ -7581,6 +10271,11 @@ const (
 
 	// ReplicationEndpointTypeValueTarget is a ReplicationEndpointTypeValue enum value
 	ReplicationEndpointTypeValueTarget = "target"
+)
+
+const (
+	// SourceTypeReplicationInstance is a SourceType enum value
+	SourceTypeReplicationInstance = "replication-instance"
 )
 
 const (

--- a/service/databasemigrationservice/databasemigrationserviceiface/interface.go
+++ b/service/databasemigrationservice/databasemigrationserviceiface/interface.go
@@ -68,6 +68,10 @@ type DatabaseMigrationServiceAPI interface {
 	CreateEndpointWithContext(aws.Context, *databasemigrationservice.CreateEndpointInput, ...request.Option) (*databasemigrationservice.CreateEndpointOutput, error)
 	CreateEndpointRequest(*databasemigrationservice.CreateEndpointInput) (*request.Request, *databasemigrationservice.CreateEndpointOutput)
 
+	CreateEventSubscription(*databasemigrationservice.CreateEventSubscriptionInput) (*databasemigrationservice.CreateEventSubscriptionOutput, error)
+	CreateEventSubscriptionWithContext(aws.Context, *databasemigrationservice.CreateEventSubscriptionInput, ...request.Option) (*databasemigrationservice.CreateEventSubscriptionOutput, error)
+	CreateEventSubscriptionRequest(*databasemigrationservice.CreateEventSubscriptionInput) (*request.Request, *databasemigrationservice.CreateEventSubscriptionOutput)
+
 	CreateReplicationInstance(*databasemigrationservice.CreateReplicationInstanceInput) (*databasemigrationservice.CreateReplicationInstanceOutput, error)
 	CreateReplicationInstanceWithContext(aws.Context, *databasemigrationservice.CreateReplicationInstanceInput, ...request.Option) (*databasemigrationservice.CreateReplicationInstanceOutput, error)
 	CreateReplicationInstanceRequest(*databasemigrationservice.CreateReplicationInstanceInput) (*request.Request, *databasemigrationservice.CreateReplicationInstanceOutput)
@@ -87,6 +91,10 @@ type DatabaseMigrationServiceAPI interface {
 	DeleteEndpoint(*databasemigrationservice.DeleteEndpointInput) (*databasemigrationservice.DeleteEndpointOutput, error)
 	DeleteEndpointWithContext(aws.Context, *databasemigrationservice.DeleteEndpointInput, ...request.Option) (*databasemigrationservice.DeleteEndpointOutput, error)
 	DeleteEndpointRequest(*databasemigrationservice.DeleteEndpointInput) (*request.Request, *databasemigrationservice.DeleteEndpointOutput)
+
+	DeleteEventSubscription(*databasemigrationservice.DeleteEventSubscriptionInput) (*databasemigrationservice.DeleteEventSubscriptionOutput, error)
+	DeleteEventSubscriptionWithContext(aws.Context, *databasemigrationservice.DeleteEventSubscriptionInput, ...request.Option) (*databasemigrationservice.DeleteEventSubscriptionOutput, error)
+	DeleteEventSubscriptionRequest(*databasemigrationservice.DeleteEventSubscriptionInput) (*request.Request, *databasemigrationservice.DeleteEventSubscriptionOutput)
 
 	DeleteReplicationInstance(*databasemigrationservice.DeleteReplicationInstanceInput) (*databasemigrationservice.DeleteReplicationInstanceOutput, error)
 	DeleteReplicationInstanceWithContext(aws.Context, *databasemigrationservice.DeleteReplicationInstanceInput, ...request.Option) (*databasemigrationservice.DeleteReplicationInstanceOutput, error)
@@ -108,21 +116,54 @@ type DatabaseMigrationServiceAPI interface {
 	DescribeCertificatesWithContext(aws.Context, *databasemigrationservice.DescribeCertificatesInput, ...request.Option) (*databasemigrationservice.DescribeCertificatesOutput, error)
 	DescribeCertificatesRequest(*databasemigrationservice.DescribeCertificatesInput) (*request.Request, *databasemigrationservice.DescribeCertificatesOutput)
 
+	DescribeCertificatesPages(*databasemigrationservice.DescribeCertificatesInput, func(*databasemigrationservice.DescribeCertificatesOutput, bool) bool) error
+	DescribeCertificatesPagesWithContext(aws.Context, *databasemigrationservice.DescribeCertificatesInput, func(*databasemigrationservice.DescribeCertificatesOutput, bool) bool, ...request.Option) error
+
 	DescribeConnections(*databasemigrationservice.DescribeConnectionsInput) (*databasemigrationservice.DescribeConnectionsOutput, error)
 	DescribeConnectionsWithContext(aws.Context, *databasemigrationservice.DescribeConnectionsInput, ...request.Option) (*databasemigrationservice.DescribeConnectionsOutput, error)
 	DescribeConnectionsRequest(*databasemigrationservice.DescribeConnectionsInput) (*request.Request, *databasemigrationservice.DescribeConnectionsOutput)
+
+	DescribeConnectionsPages(*databasemigrationservice.DescribeConnectionsInput, func(*databasemigrationservice.DescribeConnectionsOutput, bool) bool) error
+	DescribeConnectionsPagesWithContext(aws.Context, *databasemigrationservice.DescribeConnectionsInput, func(*databasemigrationservice.DescribeConnectionsOutput, bool) bool, ...request.Option) error
 
 	DescribeEndpointTypes(*databasemigrationservice.DescribeEndpointTypesInput) (*databasemigrationservice.DescribeEndpointTypesOutput, error)
 	DescribeEndpointTypesWithContext(aws.Context, *databasemigrationservice.DescribeEndpointTypesInput, ...request.Option) (*databasemigrationservice.DescribeEndpointTypesOutput, error)
 	DescribeEndpointTypesRequest(*databasemigrationservice.DescribeEndpointTypesInput) (*request.Request, *databasemigrationservice.DescribeEndpointTypesOutput)
 
+	DescribeEndpointTypesPages(*databasemigrationservice.DescribeEndpointTypesInput, func(*databasemigrationservice.DescribeEndpointTypesOutput, bool) bool) error
+	DescribeEndpointTypesPagesWithContext(aws.Context, *databasemigrationservice.DescribeEndpointTypesInput, func(*databasemigrationservice.DescribeEndpointTypesOutput, bool) bool, ...request.Option) error
+
 	DescribeEndpoints(*databasemigrationservice.DescribeEndpointsInput) (*databasemigrationservice.DescribeEndpointsOutput, error)
 	DescribeEndpointsWithContext(aws.Context, *databasemigrationservice.DescribeEndpointsInput, ...request.Option) (*databasemigrationservice.DescribeEndpointsOutput, error)
 	DescribeEndpointsRequest(*databasemigrationservice.DescribeEndpointsInput) (*request.Request, *databasemigrationservice.DescribeEndpointsOutput)
 
+	DescribeEndpointsPages(*databasemigrationservice.DescribeEndpointsInput, func(*databasemigrationservice.DescribeEndpointsOutput, bool) bool) error
+	DescribeEndpointsPagesWithContext(aws.Context, *databasemigrationservice.DescribeEndpointsInput, func(*databasemigrationservice.DescribeEndpointsOutput, bool) bool, ...request.Option) error
+
+	DescribeEventCategories(*databasemigrationservice.DescribeEventCategoriesInput) (*databasemigrationservice.DescribeEventCategoriesOutput, error)
+	DescribeEventCategoriesWithContext(aws.Context, *databasemigrationservice.DescribeEventCategoriesInput, ...request.Option) (*databasemigrationservice.DescribeEventCategoriesOutput, error)
+	DescribeEventCategoriesRequest(*databasemigrationservice.DescribeEventCategoriesInput) (*request.Request, *databasemigrationservice.DescribeEventCategoriesOutput)
+
+	DescribeEventSubscriptions(*databasemigrationservice.DescribeEventSubscriptionsInput) (*databasemigrationservice.DescribeEventSubscriptionsOutput, error)
+	DescribeEventSubscriptionsWithContext(aws.Context, *databasemigrationservice.DescribeEventSubscriptionsInput, ...request.Option) (*databasemigrationservice.DescribeEventSubscriptionsOutput, error)
+	DescribeEventSubscriptionsRequest(*databasemigrationservice.DescribeEventSubscriptionsInput) (*request.Request, *databasemigrationservice.DescribeEventSubscriptionsOutput)
+
+	DescribeEventSubscriptionsPages(*databasemigrationservice.DescribeEventSubscriptionsInput, func(*databasemigrationservice.DescribeEventSubscriptionsOutput, bool) bool) error
+	DescribeEventSubscriptionsPagesWithContext(aws.Context, *databasemigrationservice.DescribeEventSubscriptionsInput, func(*databasemigrationservice.DescribeEventSubscriptionsOutput, bool) bool, ...request.Option) error
+
+	DescribeEvents(*databasemigrationservice.DescribeEventsInput) (*databasemigrationservice.DescribeEventsOutput, error)
+	DescribeEventsWithContext(aws.Context, *databasemigrationservice.DescribeEventsInput, ...request.Option) (*databasemigrationservice.DescribeEventsOutput, error)
+	DescribeEventsRequest(*databasemigrationservice.DescribeEventsInput) (*request.Request, *databasemigrationservice.DescribeEventsOutput)
+
+	DescribeEventsPages(*databasemigrationservice.DescribeEventsInput, func(*databasemigrationservice.DescribeEventsOutput, bool) bool) error
+	DescribeEventsPagesWithContext(aws.Context, *databasemigrationservice.DescribeEventsInput, func(*databasemigrationservice.DescribeEventsOutput, bool) bool, ...request.Option) error
+
 	DescribeOrderableReplicationInstances(*databasemigrationservice.DescribeOrderableReplicationInstancesInput) (*databasemigrationservice.DescribeOrderableReplicationInstancesOutput, error)
 	DescribeOrderableReplicationInstancesWithContext(aws.Context, *databasemigrationservice.DescribeOrderableReplicationInstancesInput, ...request.Option) (*databasemigrationservice.DescribeOrderableReplicationInstancesOutput, error)
 	DescribeOrderableReplicationInstancesRequest(*databasemigrationservice.DescribeOrderableReplicationInstancesInput) (*request.Request, *databasemigrationservice.DescribeOrderableReplicationInstancesOutput)
+
+	DescribeOrderableReplicationInstancesPages(*databasemigrationservice.DescribeOrderableReplicationInstancesInput, func(*databasemigrationservice.DescribeOrderableReplicationInstancesOutput, bool) bool) error
+	DescribeOrderableReplicationInstancesPagesWithContext(aws.Context, *databasemigrationservice.DescribeOrderableReplicationInstancesInput, func(*databasemigrationservice.DescribeOrderableReplicationInstancesOutput, bool) bool, ...request.Option) error
 
 	DescribeRefreshSchemasStatus(*databasemigrationservice.DescribeRefreshSchemasStatusInput) (*databasemigrationservice.DescribeRefreshSchemasStatusOutput, error)
 	DescribeRefreshSchemasStatusWithContext(aws.Context, *databasemigrationservice.DescribeRefreshSchemasStatusInput, ...request.Option) (*databasemigrationservice.DescribeRefreshSchemasStatusOutput, error)
@@ -132,21 +173,36 @@ type DatabaseMigrationServiceAPI interface {
 	DescribeReplicationInstancesWithContext(aws.Context, *databasemigrationservice.DescribeReplicationInstancesInput, ...request.Option) (*databasemigrationservice.DescribeReplicationInstancesOutput, error)
 	DescribeReplicationInstancesRequest(*databasemigrationservice.DescribeReplicationInstancesInput) (*request.Request, *databasemigrationservice.DescribeReplicationInstancesOutput)
 
+	DescribeReplicationInstancesPages(*databasemigrationservice.DescribeReplicationInstancesInput, func(*databasemigrationservice.DescribeReplicationInstancesOutput, bool) bool) error
+	DescribeReplicationInstancesPagesWithContext(aws.Context, *databasemigrationservice.DescribeReplicationInstancesInput, func(*databasemigrationservice.DescribeReplicationInstancesOutput, bool) bool, ...request.Option) error
+
 	DescribeReplicationSubnetGroups(*databasemigrationservice.DescribeReplicationSubnetGroupsInput) (*databasemigrationservice.DescribeReplicationSubnetGroupsOutput, error)
 	DescribeReplicationSubnetGroupsWithContext(aws.Context, *databasemigrationservice.DescribeReplicationSubnetGroupsInput, ...request.Option) (*databasemigrationservice.DescribeReplicationSubnetGroupsOutput, error)
 	DescribeReplicationSubnetGroupsRequest(*databasemigrationservice.DescribeReplicationSubnetGroupsInput) (*request.Request, *databasemigrationservice.DescribeReplicationSubnetGroupsOutput)
+
+	DescribeReplicationSubnetGroupsPages(*databasemigrationservice.DescribeReplicationSubnetGroupsInput, func(*databasemigrationservice.DescribeReplicationSubnetGroupsOutput, bool) bool) error
+	DescribeReplicationSubnetGroupsPagesWithContext(aws.Context, *databasemigrationservice.DescribeReplicationSubnetGroupsInput, func(*databasemigrationservice.DescribeReplicationSubnetGroupsOutput, bool) bool, ...request.Option) error
 
 	DescribeReplicationTasks(*databasemigrationservice.DescribeReplicationTasksInput) (*databasemigrationservice.DescribeReplicationTasksOutput, error)
 	DescribeReplicationTasksWithContext(aws.Context, *databasemigrationservice.DescribeReplicationTasksInput, ...request.Option) (*databasemigrationservice.DescribeReplicationTasksOutput, error)
 	DescribeReplicationTasksRequest(*databasemigrationservice.DescribeReplicationTasksInput) (*request.Request, *databasemigrationservice.DescribeReplicationTasksOutput)
 
+	DescribeReplicationTasksPages(*databasemigrationservice.DescribeReplicationTasksInput, func(*databasemigrationservice.DescribeReplicationTasksOutput, bool) bool) error
+	DescribeReplicationTasksPagesWithContext(aws.Context, *databasemigrationservice.DescribeReplicationTasksInput, func(*databasemigrationservice.DescribeReplicationTasksOutput, bool) bool, ...request.Option) error
+
 	DescribeSchemas(*databasemigrationservice.DescribeSchemasInput) (*databasemigrationservice.DescribeSchemasOutput, error)
 	DescribeSchemasWithContext(aws.Context, *databasemigrationservice.DescribeSchemasInput, ...request.Option) (*databasemigrationservice.DescribeSchemasOutput, error)
 	DescribeSchemasRequest(*databasemigrationservice.DescribeSchemasInput) (*request.Request, *databasemigrationservice.DescribeSchemasOutput)
 
+	DescribeSchemasPages(*databasemigrationservice.DescribeSchemasInput, func(*databasemigrationservice.DescribeSchemasOutput, bool) bool) error
+	DescribeSchemasPagesWithContext(aws.Context, *databasemigrationservice.DescribeSchemasInput, func(*databasemigrationservice.DescribeSchemasOutput, bool) bool, ...request.Option) error
+
 	DescribeTableStatistics(*databasemigrationservice.DescribeTableStatisticsInput) (*databasemigrationservice.DescribeTableStatisticsOutput, error)
 	DescribeTableStatisticsWithContext(aws.Context, *databasemigrationservice.DescribeTableStatisticsInput, ...request.Option) (*databasemigrationservice.DescribeTableStatisticsOutput, error)
 	DescribeTableStatisticsRequest(*databasemigrationservice.DescribeTableStatisticsInput) (*request.Request, *databasemigrationservice.DescribeTableStatisticsOutput)
+
+	DescribeTableStatisticsPages(*databasemigrationservice.DescribeTableStatisticsInput, func(*databasemigrationservice.DescribeTableStatisticsOutput, bool) bool) error
+	DescribeTableStatisticsPagesWithContext(aws.Context, *databasemigrationservice.DescribeTableStatisticsInput, func(*databasemigrationservice.DescribeTableStatisticsOutput, bool) bool, ...request.Option) error
 
 	ImportCertificate(*databasemigrationservice.ImportCertificateInput) (*databasemigrationservice.ImportCertificateOutput, error)
 	ImportCertificateWithContext(aws.Context, *databasemigrationservice.ImportCertificateInput, ...request.Option) (*databasemigrationservice.ImportCertificateOutput, error)
@@ -159,6 +215,10 @@ type DatabaseMigrationServiceAPI interface {
 	ModifyEndpoint(*databasemigrationservice.ModifyEndpointInput) (*databasemigrationservice.ModifyEndpointOutput, error)
 	ModifyEndpointWithContext(aws.Context, *databasemigrationservice.ModifyEndpointInput, ...request.Option) (*databasemigrationservice.ModifyEndpointOutput, error)
 	ModifyEndpointRequest(*databasemigrationservice.ModifyEndpointInput) (*request.Request, *databasemigrationservice.ModifyEndpointOutput)
+
+	ModifyEventSubscription(*databasemigrationservice.ModifyEventSubscriptionInput) (*databasemigrationservice.ModifyEventSubscriptionOutput, error)
+	ModifyEventSubscriptionWithContext(aws.Context, *databasemigrationservice.ModifyEventSubscriptionInput, ...request.Option) (*databasemigrationservice.ModifyEventSubscriptionOutput, error)
+	ModifyEventSubscriptionRequest(*databasemigrationservice.ModifyEventSubscriptionInput) (*request.Request, *databasemigrationservice.ModifyEventSubscriptionOutput)
 
 	ModifyReplicationInstance(*databasemigrationservice.ModifyReplicationInstanceInput) (*databasemigrationservice.ModifyReplicationInstanceOutput, error)
 	ModifyReplicationInstanceWithContext(aws.Context, *databasemigrationservice.ModifyReplicationInstanceInput, ...request.Option) (*databasemigrationservice.ModifyReplicationInstanceOutput, error)
@@ -175,6 +235,10 @@ type DatabaseMigrationServiceAPI interface {
 	RefreshSchemas(*databasemigrationservice.RefreshSchemasInput) (*databasemigrationservice.RefreshSchemasOutput, error)
 	RefreshSchemasWithContext(aws.Context, *databasemigrationservice.RefreshSchemasInput, ...request.Option) (*databasemigrationservice.RefreshSchemasOutput, error)
 	RefreshSchemasRequest(*databasemigrationservice.RefreshSchemasInput) (*request.Request, *databasemigrationservice.RefreshSchemasOutput)
+
+	ReloadTables(*databasemigrationservice.ReloadTablesInput) (*databasemigrationservice.ReloadTablesOutput, error)
+	ReloadTablesWithContext(aws.Context, *databasemigrationservice.ReloadTablesInput, ...request.Option) (*databasemigrationservice.ReloadTablesOutput, error)
+	ReloadTablesRequest(*databasemigrationservice.ReloadTablesInput) (*request.Request, *databasemigrationservice.ReloadTablesOutput)
 
 	RemoveTagsFromResource(*databasemigrationservice.RemoveTagsFromResourceInput) (*databasemigrationservice.RemoveTagsFromResourceOutput, error)
 	RemoveTagsFromResourceWithContext(aws.Context, *databasemigrationservice.RemoveTagsFromResourceInput, ...request.Option) (*databasemigrationservice.RemoveTagsFromResourceOutput, error)

--- a/service/databasemigrationservice/doc.go
+++ b/service/databasemigrationservice/doc.go
@@ -11,6 +11,9 @@
 // between different database platforms, such as Oracle to MySQL or SQL Server
 // to PostgreSQL.
 //
+// For more information about AWS DMS, see the AWS DMS user guide at  What Is
+// AWS Database Migration Service?  (http://docs.aws.amazon.com/dms/latest/userguide/Welcome.html)
+//
 // See https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01 for more information on this service.
 //
 // See databasemigrationservice package documentation for more information.

--- a/service/databasemigrationservice/errors.go
+++ b/service/databasemigrationservice/errors.go
@@ -66,6 +66,18 @@ const (
 	// The quota for this resource quota has been exceeded.
 	ErrCodeResourceQuotaExceededFault = "ResourceQuotaExceededFault"
 
+	// ErrCodeSNSInvalidTopicFault for service response error code
+	// "SNSInvalidTopicFault".
+	//
+	// The SNS topic is invalid.
+	ErrCodeSNSInvalidTopicFault = "SNSInvalidTopicFault"
+
+	// ErrCodeSNSNoAuthorizationFault for service response error code
+	// "SNSNoAuthorizationFault".
+	//
+	// You are not authorized for the SNS subscription.
+	ErrCodeSNSNoAuthorizationFault = "SNSNoAuthorizationFault"
+
 	// ErrCodeStorageQuotaExceededFault for service response error code
 	// "StorageQuotaExceededFault".
 	//

--- a/service/databasemigrationservice/examples_test.go
+++ b/service/databasemigrationservice/examples_test.go
@@ -49,17 +49,42 @@ func ExampleDatabaseMigrationService_CreateEndpoint() {
 	svc := databasemigrationservice.New(sess)
 
 	params := &databasemigrationservice.CreateEndpointInput{
-		EndpointIdentifier:        aws.String("String"),                       // Required
-		EndpointType:              aws.String("ReplicationEndpointTypeValue"), // Required
-		EngineName:                aws.String("String"),                       // Required
-		CertificateArn:            aws.String("String"),
-		DatabaseName:              aws.String("String"),
+		EndpointIdentifier: aws.String("String"),                       // Required
+		EndpointType:       aws.String("ReplicationEndpointTypeValue"), // Required
+		EngineName:         aws.String("String"),                       // Required
+		CertificateArn:     aws.String("String"),
+		DatabaseName:       aws.String("String"),
+		DynamoDbSettings: &databasemigrationservice.DynamoDbSettings{
+			ServiceAccessRoleArn: aws.String("String"), // Required
+		},
 		ExtraConnectionAttributes: aws.String("String"),
 		KmsKeyId:                  aws.String("String"),
-		Password:                  aws.String("SecretString"),
-		Port:                      aws.Int64(1),
-		ServerName:                aws.String("String"),
-		SslMode:                   aws.String("DmsSslModeValue"),
+		MongoDbSettings: &databasemigrationservice.MongoDbSettings{
+			AuthMechanism:     aws.String("AuthMechanismValue"),
+			AuthSource:        aws.String("String"),
+			AuthType:          aws.String("AuthTypeValue"),
+			DatabaseName:      aws.String("String"),
+			DocsToInvestigate: aws.String("String"),
+			ExtractDocId:      aws.String("String"),
+			NestingLevel:      aws.String("NestingLevelValue"),
+			Password:          aws.String("SecretString"),
+			Port:              aws.Int64(1),
+			ServerName:        aws.String("String"),
+			Username:          aws.String("String"),
+		},
+		Password: aws.String("SecretString"),
+		Port:     aws.Int64(1),
+		S3Settings: &databasemigrationservice.S3Settings{
+			BucketFolder:            aws.String("String"),
+			BucketName:              aws.String("String"),
+			CompressionType:         aws.String("CompressionTypeValue"),
+			CsvDelimiter:            aws.String("String"),
+			CsvRowDelimiter:         aws.String("String"),
+			ExternalTableDefinition: aws.String("String"),
+			ServiceAccessRoleArn:    aws.String("String"),
+		},
+		ServerName: aws.String("String"),
+		SslMode:    aws.String("DmsSslModeValue"),
 		Tags: []*databasemigrationservice.Tag{
 			{ // Required
 				Key:   aws.String("String"),
@@ -70,6 +95,45 @@ func ExampleDatabaseMigrationService_CreateEndpoint() {
 		Username: aws.String("String"),
 	}
 	resp, err := svc.CreateEndpoint(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleDatabaseMigrationService_CreateEventSubscription() {
+	sess := session.Must(session.NewSession())
+
+	svc := databasemigrationservice.New(sess)
+
+	params := &databasemigrationservice.CreateEventSubscriptionInput{
+		SnsTopicArn:      aws.String("String"), // Required
+		SubscriptionName: aws.String("String"), // Required
+		Enabled:          aws.Bool(true),
+		EventCategories: []*string{
+			aws.String("String"), // Required
+			// More values...
+		},
+		SourceIds: []*string{
+			aws.String("String"), // Required
+			// More values...
+		},
+		SourceType: aws.String("String"),
+		Tags: []*databasemigrationservice.Tag{
+			{ // Required
+				Key:   aws.String("String"),
+				Value: aws.String("String"),
+			},
+			// More values...
+		},
+	}
+	resp, err := svc.CreateEventSubscription(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and
@@ -222,6 +286,27 @@ func ExampleDatabaseMigrationService_DeleteEndpoint() {
 		EndpointArn: aws.String("String"), // Required
 	}
 	resp, err := svc.DeleteEndpoint(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleDatabaseMigrationService_DeleteEventSubscription() {
+	sess := session.Must(session.NewSession())
+
+	svc := databasemigrationservice.New(sess)
+
+	params := &databasemigrationservice.DeleteEventSubscriptionInput{
+		SubscriptionName: aws.String("String"), // Required
+	}
+	resp, err := svc.DeleteEventSubscription(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and
@@ -432,6 +517,111 @@ func ExampleDatabaseMigrationService_DescribeEndpoints() {
 		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeEndpoints(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleDatabaseMigrationService_DescribeEventCategories() {
+	sess := session.Must(session.NewSession())
+
+	svc := databasemigrationservice.New(sess)
+
+	params := &databasemigrationservice.DescribeEventCategoriesInput{
+		Filters: []*databasemigrationservice.Filter{
+			{ // Required
+				Name: aws.String("String"), // Required
+				Values: []*string{ // Required
+					aws.String("String"), // Required
+					// More values...
+				},
+			},
+			// More values...
+		},
+		SourceType: aws.String("String"),
+	}
+	resp, err := svc.DescribeEventCategories(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleDatabaseMigrationService_DescribeEventSubscriptions() {
+	sess := session.Must(session.NewSession())
+
+	svc := databasemigrationservice.New(sess)
+
+	params := &databasemigrationservice.DescribeEventSubscriptionsInput{
+		Filters: []*databasemigrationservice.Filter{
+			{ // Required
+				Name: aws.String("String"), // Required
+				Values: []*string{ // Required
+					aws.String("String"), // Required
+					// More values...
+				},
+			},
+			// More values...
+		},
+		Marker:           aws.String("String"),
+		MaxRecords:       aws.Int64(1),
+		SubscriptionName: aws.String("String"),
+	}
+	resp, err := svc.DescribeEventSubscriptions(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleDatabaseMigrationService_DescribeEvents() {
+	sess := session.Must(session.NewSession())
+
+	svc := databasemigrationservice.New(sess)
+
+	params := &databasemigrationservice.DescribeEventsInput{
+		Duration: aws.Int64(1),
+		EndTime:  aws.Time(time.Now()),
+		EventCategories: []*string{
+			aws.String("String"), // Required
+			// More values...
+		},
+		Filters: []*databasemigrationservice.Filter{
+			{ // Required
+				Name: aws.String("String"), // Required
+				Values: []*string{ // Required
+					aws.String("String"), // Required
+					// More values...
+				},
+			},
+			// More values...
+		},
+		Marker:           aws.String("String"),
+		MaxRecords:       aws.Int64(1),
+		SourceIdentifier: aws.String("String"),
+		SourceType:       aws.String("SourceType"),
+		StartTime:        aws.Time(time.Now()),
+	}
+	resp, err := svc.DescribeEvents(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and
@@ -679,20 +869,73 @@ func ExampleDatabaseMigrationService_ModifyEndpoint() {
 	svc := databasemigrationservice.New(sess)
 
 	params := &databasemigrationservice.ModifyEndpointInput{
-		EndpointArn:               aws.String("String"), // Required
-		CertificateArn:            aws.String("String"),
-		DatabaseName:              aws.String("String"),
+		EndpointArn:    aws.String("String"), // Required
+		CertificateArn: aws.String("String"),
+		DatabaseName:   aws.String("String"),
+		DynamoDbSettings: &databasemigrationservice.DynamoDbSettings{
+			ServiceAccessRoleArn: aws.String("String"), // Required
+		},
 		EndpointIdentifier:        aws.String("String"),
 		EndpointType:              aws.String("ReplicationEndpointTypeValue"),
 		EngineName:                aws.String("String"),
 		ExtraConnectionAttributes: aws.String("String"),
-		Password:                  aws.String("SecretString"),
-		Port:                      aws.Int64(1),
-		ServerName:                aws.String("String"),
-		SslMode:                   aws.String("DmsSslModeValue"),
-		Username:                  aws.String("String"),
+		MongoDbSettings: &databasemigrationservice.MongoDbSettings{
+			AuthMechanism:     aws.String("AuthMechanismValue"),
+			AuthSource:        aws.String("String"),
+			AuthType:          aws.String("AuthTypeValue"),
+			DatabaseName:      aws.String("String"),
+			DocsToInvestigate: aws.String("String"),
+			ExtractDocId:      aws.String("String"),
+			NestingLevel:      aws.String("NestingLevelValue"),
+			Password:          aws.String("SecretString"),
+			Port:              aws.Int64(1),
+			ServerName:        aws.String("String"),
+			Username:          aws.String("String"),
+		},
+		Password: aws.String("SecretString"),
+		Port:     aws.Int64(1),
+		S3Settings: &databasemigrationservice.S3Settings{
+			BucketFolder:            aws.String("String"),
+			BucketName:              aws.String("String"),
+			CompressionType:         aws.String("CompressionTypeValue"),
+			CsvDelimiter:            aws.String("String"),
+			CsvRowDelimiter:         aws.String("String"),
+			ExternalTableDefinition: aws.String("String"),
+			ServiceAccessRoleArn:    aws.String("String"),
+		},
+		ServerName: aws.String("String"),
+		SslMode:    aws.String("DmsSslModeValue"),
+		Username:   aws.String("String"),
 	}
 	resp, err := svc.ModifyEndpoint(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleDatabaseMigrationService_ModifyEventSubscription() {
+	sess := session.Must(session.NewSession())
+
+	svc := databasemigrationservice.New(sess)
+
+	params := &databasemigrationservice.ModifyEventSubscriptionInput{
+		SubscriptionName: aws.String("String"), // Required
+		Enabled:          aws.Bool(true),
+		EventCategories: []*string{
+			aws.String("String"), // Required
+			// More values...
+		},
+		SnsTopicArn: aws.String("String"),
+		SourceType:  aws.String("String"),
+	}
+	resp, err := svc.ModifyEventSubscription(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and
@@ -801,6 +1044,34 @@ func ExampleDatabaseMigrationService_RefreshSchemas() {
 		ReplicationInstanceArn: aws.String("String"), // Required
 	}
 	resp, err := svc.RefreshSchemas(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleDatabaseMigrationService_ReloadTables() {
+	sess := session.Must(session.NewSession())
+
+	svc := databasemigrationservice.New(sess)
+
+	params := &databasemigrationservice.ReloadTablesInput{
+		ReplicationTaskArn: aws.String("String"), // Required
+		TablesToReload: []*databasemigrationservice.TableToReload{ // Required
+			{ // Required
+				SchemaName: aws.String("String"),
+				TableName:  aws.String("String"),
+			},
+			// More values...
+		},
+	}
+	resp, err := svc.ReloadTables(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and


### PR DESCRIPTION
Release v1.8.28 (2017-05-23)
===

### Service Client Updates
* `service/databasemigrationservice`: Updates service API, documentation, paginators, and examples
  * This release adds support for using Amazon S3 and Amazon DynamoDB as targets for database migration, and using MongoDB as a source for database migration. For more information, see the AWS Database Migration Service documentation.

