### PR TITLE
Pulling default shared credential filename from correct environment v…

### DIFF
--- a/aws/credentials/shared_credentials_provider.go
+++ b/aws/credentials/shared_credentials_provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/go-ini/ini"
 
@@ -122,10 +123,13 @@ func (p *SharedCredentialsProvider) filename() (string, error) {
 			return p.Filename, nil
 		}
 
-		homeDir := os.Getenv("HOME") // *nix
-		if homeDir == "" {           // Windows
+		homeDir := ""
+		if runtime.GOOS == "windows" { // Windows
 			homeDir = os.Getenv("USERPROFILE")
+		} else { // *nix
+			homeDir = os.Getenv("HOME")
 		}
+
 		if homeDir == "" {
 			return "", ErrSharedCredentialsHomeNotFound
 		}

--- a/aws/credentials/shared_credentials_provider_linux_test.go
+++ b/aws/credentials/shared_credentials_provider_linux_test.go
@@ -1,0 +1,25 @@
+package credentials
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSharedCredentialsProviderFromHomeDirectory(t *testing.T) {
+	os.Clearenv()
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	os.Setenv("HOME", filepath.Join(wd, "testhomedir"))
+	os.Setenv("USERPROFILE", filepath.Join(wd, "whatwouldbetesthomedironwindows"))
+	p := SharedCredentialsProvider{}
+	creds, err := p.Retrieve()
+
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "homeDirAccessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "homeDirSecret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Equal(t, "homeDirToken", creds.SessionToken, "Expect session token to match")
+}

--- a/aws/credentials/shared_credentials_provider_windows_test.go
+++ b/aws/credentials/shared_credentials_provider_windows_test.go
@@ -1,0 +1,25 @@
+package credentials
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSharedCredentialsProviderFromHomeDirectory(t *testing.T) {
+	os.Clearenv()
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	os.Setenv("USERPROFILE", filepath.Join(wd, "testhomedir"))
+	os.Setenv("HOME", filepath.Join(wd, "whatwouldbetesthomedironlinux"))
+	p := SharedCredentialsProvider{}
+	creds, err := p.Retrieve()
+
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "homeDirAccessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "homeDirSecret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Equal(t, "homeDirToken", creds.SessionToken, "Expect session token to match")
+}

--- a/aws/credentials/testhomedir/.aws/credentials
+++ b/aws/credentials/testhomedir/.aws/credentials
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id = homeDirAccessKey
+aws_secret_access_key = homeDirSecret
+aws_session_token = homeDirToken


### PR DESCRIPTION
On Windows, if I have my HOME environment variable set, the default shared credentials file path created relative to the HOME variable, not the USERPROFILE per the [documentation](https://github.com/aws/aws-sdk-go/blob/301ea4de9fcd6f424fd15d5b01e5516d14acec35/aws/credentials/shared_credentials_provider.go#L34).

I'd be glad to unit test this if you have any suggestions for mocking runtime.GOOS. I've run this code manually locally and seen it hit the windows branch.

Got the idea to use runtime.GOOS from [this StackOverflow post](https://stackoverflow.com/questions/19847594/how-to-reliably-detect-os-platform-in-go)