### PR TITLE
aws/session: Fix Shared Config Load Error

### DIFF
--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -113,7 +113,7 @@ func loadSharedConfigIniFiles(filenames []string) ([]sharedConfigFile, error) {
 
 		f, err := ini.Load(b)
 		if err != nil {
-			return nil, SharedConfigLoadError{Filename: filename}
+			return nil, SharedConfigLoadError{Filename: filename, Err: err}
 		}
 
 		files = append(files, sharedConfigFile{


### PR DESCRIPTION
Fixes the SharedConfigLoadError not including the underlying error
message if there was one when the SDK loads the config file, and the ini
parser fails to parse the file.