### PR TITLE
v1.8.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Release v1.8.31 (2017-05-30)
+===
+
+### Service Client Updates
+* `service/clouddirectory`: Updates service API, documentation, and paginators
+  * Cloud Directory has launched support for Typed Links, enabling customers to create object-to-object relationships that are not hierarchical in nature. Typed Links enable customers to quickly query for data along these relationships. Customers can also enforce referential integrity using Typed Links, ensuring data in use is not inadvertently deleted.
+* `service/s3`: Updates service paginators and examples
+  * New example snippets for Amazon S3.
+
 Release v1.8.30 (2017-05-25)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.8.30"
+const SDKVersion = "1.8.31"

--- a/models/apis/clouddirectory/2016-05-10/api-2.json
+++ b/models/apis/clouddirectory/2016-05-10/api-2.json
@@ -120,6 +120,28 @@
         {"shape":"NotIndexException"}
       ]
     },
+    "AttachTypedLink":{
+      "name":"AttachTypedLink",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/attach",
+        "responseCode":200
+      },
+      "input":{"shape":"AttachTypedLinkRequest"},
+      "output":{"shape":"AttachTypedLinkResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidAttachmentException"},
+        {"shape":"ValidationException"},
+        {"shape":"FacetValidationException"}
+      ]
+    },
     "BatchRead":{
       "name":"BatchRead",
       "http":{
@@ -198,7 +220,8 @@
         {"shape":"AccessDeniedException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"FacetAlreadyExistsException"},
-        {"shape":"InvalidRuleException"}
+        {"shape":"InvalidRuleException"},
+        {"shape":"FacetValidationException"}
       ]
     },
     "CreateIndex":{
@@ -268,6 +291,28 @@
         {"shape":"AccessDeniedException"}
       ]
     },
+    "CreateTypedLinkFacet":{
+      "name":"CreateTypedLinkFacet",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/facet/create",
+        "responseCode":200
+      },
+      "input":{"shape":"CreateTypedLinkFacetRequest"},
+      "output":{"shape":"CreateTypedLinkFacetResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"FacetAlreadyExistsException"},
+        {"shape":"InvalidRuleException"},
+        {"shape":"FacetValidationException"}
+      ]
+    },
     "DeleteDirectory":{
       "name":"DeleteDirectory",
       "http":{
@@ -285,7 +330,8 @@
         {"shape":"LimitExceededException"},
         {"shape":"AccessDeniedException"},
         {"shape":"DirectoryDeletedException"},
-        {"shape":"RetryableConflictException"}
+        {"shape":"RetryableConflictException"},
+        {"shape":"InvalidArnException"}
       ]
     },
     "DeleteFacet":{
@@ -348,6 +394,26 @@
         {"shape":"AccessDeniedException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"StillContainsLinksException"}
+      ]
+    },
+    "DeleteTypedLinkFacet":{
+      "name":"DeleteTypedLinkFacet",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/facet/delete",
+        "responseCode":200
+      },
+      "input":{"shape":"DeleteTypedLinkFacetRequest"},
+      "output":{"shape":"DeleteTypedLinkFacetResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"FacetNotFoundException"}
       ]
     },
     "DetachFromIndex":{
@@ -414,6 +480,25 @@
         {"shape":"NotPolicyException"}
       ]
     },
+    "DetachTypedLink":{
+      "name":"DetachTypedLink",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/detach",
+        "responseCode":200
+      },
+      "input":{"shape":"DetachTypedLinkRequest"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"FacetValidationException"}
+      ]
+    },
     "DisableDirectory":{
       "name":"DisableDirectory",
       "http":{
@@ -430,7 +515,8 @@
         {"shape":"ValidationException"},
         {"shape":"LimitExceededException"},
         {"shape":"AccessDeniedException"},
-        {"shape":"RetryableConflictException"}
+        {"shape":"RetryableConflictException"},
+        {"shape":"InvalidArnException"}
       ]
     },
     "EnableDirectory":{
@@ -449,7 +535,8 @@
         {"shape":"ValidationException"},
         {"shape":"LimitExceededException"},
         {"shape":"AccessDeniedException"},
-        {"shape":"RetryableConflictException"}
+        {"shape":"RetryableConflictException"},
+        {"shape":"InvalidArnException"}
       ]
     },
     "GetDirectory":{
@@ -528,6 +615,27 @@
         {"shape":"AccessDeniedException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"ValidationException"}
+      ]
+    },
+    "GetTypedLinkFacetInformation":{
+      "name":"GetTypedLinkFacetInformation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/facet/get",
+        "responseCode":200
+      },
+      "input":{"shape":"GetTypedLinkFacetInformationRequest"},
+      "output":{"shape":"GetTypedLinkFacetInformationResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidNextTokenException"},
+        {"shape":"FacetNotFoundException"}
       ]
     },
     "ListAppliedSchemaArns":{
@@ -648,6 +756,27 @@
         {"shape":"AccessDeniedException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"InvalidNextTokenException"}
+      ]
+    },
+    "ListIncomingTypedLinks":{
+      "name":"ListIncomingTypedLinks",
+      "http":{
+        "method":"POST",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/incoming",
+        "responseCode":200
+      },
+      "input":{"shape":"ListIncomingTypedLinksRequest"},
+      "output":{"shape":"ListIncomingTypedLinksResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidNextTokenException"},
+        {"shape":"FacetValidationException"}
       ]
     },
     "ListIndex":{
@@ -782,6 +911,27 @@
         {"shape":"InvalidNextTokenException"}
       ]
     },
+    "ListOutgoingTypedLinks":{
+      "name":"ListOutgoingTypedLinks",
+      "http":{
+        "method":"POST",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/outgoing",
+        "responseCode":200
+      },
+      "input":{"shape":"ListOutgoingTypedLinksRequest"},
+      "output":{"shape":"ListOutgoingTypedLinksResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidNextTokenException"},
+        {"shape":"FacetValidationException"}
+      ]
+    },
     "ListPolicyAttachments":{
       "name":"ListPolicyAttachments",
       "http":{
@@ -843,6 +993,47 @@
         {"shape":"AccessDeniedException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"InvalidTaggingRequestException"}
+      ]
+    },
+    "ListTypedLinkFacetAttributes":{
+      "name":"ListTypedLinkFacetAttributes",
+      "http":{
+        "method":"POST",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/facet/attributes",
+        "responseCode":200
+      },
+      "input":{"shape":"ListTypedLinkFacetAttributesRequest"},
+      "output":{"shape":"ListTypedLinkFacetAttributesResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"FacetNotFoundException"},
+        {"shape":"InvalidNextTokenException"}
+      ]
+    },
+    "ListTypedLinkFacetNames":{
+      "name":"ListTypedLinkFacetNames",
+      "http":{
+        "method":"POST",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/facet/list",
+        "responseCode":200
+      },
+      "input":{"shape":"ListTypedLinkFacetNamesRequest"},
+      "output":{"shape":"ListTypedLinkFacetNamesResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidNextTokenException"}
       ]
     },
     "LookupPolicy":{
@@ -1029,6 +1220,29 @@
         {"shape":"AccessDeniedException"},
         {"shape":"ResourceNotFoundException"}
       ]
+    },
+    "UpdateTypedLinkFacet":{
+      "name":"UpdateTypedLinkFacet",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/amazonclouddirectory/2017-01-11/typedlink/facet",
+        "responseCode":200
+      },
+      "input":{"shape":"UpdateTypedLinkFacetRequest"},
+      "output":{"shape":"UpdateTypedLinkFacetResponse"},
+      "errors":[
+        {"shape":"InternalServiceException"},
+        {"shape":"InvalidArnException"},
+        {"shape":"RetryableConflictException"},
+        {"shape":"ValidationException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"AccessDeniedException"},
+        {"shape":"FacetValidationException"},
+        {"shape":"InvalidFacetUpdateException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"FacetNotFoundException"},
+        {"shape":"InvalidRuleException"}
+      ]
     }
   },
   "shapes":{
@@ -1159,6 +1373,33 @@
         "AttachedObjectIdentifier":{"shape":"ObjectIdentifier"}
       }
     },
+    "AttachTypedLinkRequest":{
+      "type":"structure",
+      "required":[
+        "DirectoryArn",
+        "SourceObjectReference",
+        "TargetObjectReference",
+        "TypedLinkFacet",
+        "Attributes"
+      ],
+      "members":{
+        "DirectoryArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "SourceObjectReference":{"shape":"ObjectReference"},
+        "TargetObjectReference":{"shape":"ObjectReference"},
+        "TypedLinkFacet":{"shape":"TypedLinkSchemaAndFacetName"},
+        "Attributes":{"shape":"AttributeNameAndValueList"}
+      }
+    },
+    "AttachTypedLinkResponse":{
+      "type":"structure",
+      "members":{
+        "TypedLinkSpecifier":{"shape":"TypedLinkSpecifier"}
+      }
+    },
     "AttributeKey":{
       "type":"structure",
       "required":[
@@ -1196,6 +1437,25 @@
       "max":64,
       "min":1,
       "pattern":"^[a-zA-Z0-9._-]*$"
+    },
+    "AttributeNameAndValue":{
+      "type":"structure",
+      "required":[
+        "AttributeName",
+        "Value"
+      ],
+      "members":{
+        "AttributeName":{"shape":"AttributeName"},
+        "Value":{"shape":"TypedAttributeValue"}
+      }
+    },
+    "AttributeNameAndValueList":{
+      "type":"list",
+      "member":{"shape":"AttributeNameAndValue"}
+    },
+    "AttributeNameList":{
+      "type":"list",
+      "member":{"shape":"AttributeName"}
     },
     "BatchAddFacetToObject":{
       "type":"structure",
@@ -1638,6 +1898,26 @@
         "SchemaArn":{"shape":"Arn"}
       }
     },
+    "CreateTypedLinkFacetRequest":{
+      "type":"structure",
+      "required":[
+        "SchemaArn",
+        "Facet"
+      ],
+      "members":{
+        "SchemaArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "Facet":{"shape":"TypedLinkFacet"}
+      }
+    },
+    "CreateTypedLinkFacetResponse":{
+      "type":"structure",
+      "members":{
+      }
+    },
     "Date":{"type":"timestamp"},
     "DatetimeAttributeValue":{"type":"timestamp"},
     "DeleteDirectoryRequest":{
@@ -1715,6 +1995,26 @@
         "SchemaArn":{"shape":"Arn"}
       }
     },
+    "DeleteTypedLinkFacetRequest":{
+      "type":"structure",
+      "required":[
+        "SchemaArn",
+        "Name"
+      ],
+      "members":{
+        "SchemaArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "Name":{"shape":"TypedLinkName"}
+      }
+    },
+    "DeleteTypedLinkFacetResponse":{
+      "type":"structure",
+      "members":{
+      }
+    },
     "DetachFromIndexRequest":{
       "type":"structure",
       "required":[
@@ -1781,6 +2081,21 @@
     "DetachPolicyResponse":{
       "type":"structure",
       "members":{
+      }
+    },
+    "DetachTypedLinkRequest":{
+      "type":"structure",
+      "required":[
+        "DirectoryArn",
+        "TypedLinkSpecifier"
+      ],
+      "members":{
+        "DirectoryArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "TypedLinkSpecifier":{"shape":"TypedLinkSpecifier"}
       }
     },
     "Directory":{
@@ -2069,6 +2384,27 @@
         "Document":{"shape":"SchemaJsonDocument"}
       }
     },
+    "GetTypedLinkFacetInformationRequest":{
+      "type":"structure",
+      "required":[
+        "SchemaArn",
+        "Name"
+      ],
+      "members":{
+        "SchemaArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "Name":{"shape":"TypedLinkName"}
+      }
+    },
+    "GetTypedLinkFacetInformationResponse":{
+      "type":"structure",
+      "members":{
+        "IdentityAttributeOrder":{"shape":"AttributeNameList"}
+      }
+    },
     "IndexAttachment":{
       "type":"structure",
       "members":{
@@ -2162,7 +2498,9 @@
     },
     "LinkName":{
       "type":"string",
-      "max":64
+      "max":64,
+      "min":1,
+      "pattern":"[^\\/\\[\\]\\(\\):\\{\\}#@!?\\s\\\\;]+"
     },
     "LinkNameAlreadyInUseException":{
       "type":"structure",
@@ -2293,6 +2631,33 @@
       "type":"structure",
       "members":{
         "FacetNames":{"shape":"FacetNameList"},
+        "NextToken":{"shape":"NextToken"}
+      }
+    },
+    "ListIncomingTypedLinksRequest":{
+      "type":"structure",
+      "required":[
+        "DirectoryArn",
+        "ObjectReference"
+      ],
+      "members":{
+        "DirectoryArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "ObjectReference":{"shape":"ObjectReference"},
+        "FilterAttributeRanges":{"shape":"TypedLinkAttributeRangeList"},
+        "FilterTypedLink":{"shape":"TypedLinkSchemaAndFacetName"},
+        "NextToken":{"shape":"NextToken"},
+        "MaxResults":{"shape":"NumberResults"},
+        "ConsistencyLevel":{"shape":"ConsistencyLevel"}
+      }
+    },
+    "ListIncomingTypedLinksResponse":{
+      "type":"structure",
+      "members":{
+        "LinkSpecifiers":{"shape":"TypedLinkSpecifierList"},
         "NextToken":{"shape":"NextToken"}
       }
     },
@@ -2467,6 +2832,33 @@
         "NextToken":{"shape":"NextToken"}
       }
     },
+    "ListOutgoingTypedLinksRequest":{
+      "type":"structure",
+      "required":[
+        "DirectoryArn",
+        "ObjectReference"
+      ],
+      "members":{
+        "DirectoryArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "ObjectReference":{"shape":"ObjectReference"},
+        "FilterAttributeRanges":{"shape":"TypedLinkAttributeRangeList"},
+        "FilterTypedLink":{"shape":"TypedLinkSchemaAndFacetName"},
+        "NextToken":{"shape":"NextToken"},
+        "MaxResults":{"shape":"NumberResults"},
+        "ConsistencyLevel":{"shape":"ConsistencyLevel"}
+      }
+    },
+    "ListOutgoingTypedLinksResponse":{
+      "type":"structure",
+      "members":{
+        "TypedLinkSpecifiers":{"shape":"TypedLinkSpecifierList"},
+        "NextToken":{"shape":"NextToken"}
+      }
+    },
     "ListPolicyAttachmentsRequest":{
       "type":"structure",
       "required":[
@@ -2523,6 +2915,50 @@
       "type":"structure",
       "members":{
         "Tags":{"shape":"TagList"},
+        "NextToken":{"shape":"NextToken"}
+      }
+    },
+    "ListTypedLinkFacetAttributesRequest":{
+      "type":"structure",
+      "required":[
+        "SchemaArn",
+        "Name"
+      ],
+      "members":{
+        "SchemaArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "Name":{"shape":"TypedLinkName"},
+        "NextToken":{"shape":"NextToken"},
+        "MaxResults":{"shape":"NumberResults"}
+      }
+    },
+    "ListTypedLinkFacetAttributesResponse":{
+      "type":"structure",
+      "members":{
+        "Attributes":{"shape":"TypedLinkAttributeDefinitionList"},
+        "NextToken":{"shape":"NextToken"}
+      }
+    },
+    "ListTypedLinkFacetNamesRequest":{
+      "type":"structure",
+      "required":["SchemaArn"],
+      "members":{
+        "SchemaArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "NextToken":{"shape":"NextToken"},
+        "MaxResults":{"shape":"NumberResults"}
+      }
+    },
+    "ListTypedLinkFacetNamesResponse":{
+      "type":"structure",
+      "members":{
+        "FacetNames":{"shape":"TypedLinkNameList"},
         "NextToken":{"shape":"NextToken"}
       }
     },
@@ -2922,6 +3358,104 @@
         "EndValue":{"shape":"TypedAttributeValue"}
       }
     },
+    "TypedLinkAttributeDefinition":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "Type",
+        "RequiredBehavior"
+      ],
+      "members":{
+        "Name":{"shape":"AttributeName"},
+        "Type":{"shape":"FacetAttributeType"},
+        "DefaultValue":{"shape":"TypedAttributeValue"},
+        "IsImmutable":{"shape":"Bool"},
+        "Rules":{"shape":"RuleMap"},
+        "RequiredBehavior":{"shape":"RequiredAttributeBehavior"}
+      }
+    },
+    "TypedLinkAttributeDefinitionList":{
+      "type":"list",
+      "member":{"shape":"TypedLinkAttributeDefinition"}
+    },
+    "TypedLinkAttributeRange":{
+      "type":"structure",
+      "required":["Range"],
+      "members":{
+        "AttributeName":{"shape":"AttributeName"},
+        "Range":{"shape":"TypedAttributeValueRange"}
+      }
+    },
+    "TypedLinkAttributeRangeList":{
+      "type":"list",
+      "member":{"shape":"TypedLinkAttributeRange"}
+    },
+    "TypedLinkFacet":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "Attributes",
+        "IdentityAttributeOrder"
+      ],
+      "members":{
+        "Name":{"shape":"TypedLinkName"},
+        "Attributes":{"shape":"TypedLinkAttributeDefinitionList"},
+        "IdentityAttributeOrder":{"shape":"AttributeNameList"}
+      }
+    },
+    "TypedLinkFacetAttributeUpdate":{
+      "type":"structure",
+      "required":[
+        "Attribute",
+        "Action"
+      ],
+      "members":{
+        "Attribute":{"shape":"TypedLinkAttributeDefinition"},
+        "Action":{"shape":"UpdateActionType"}
+      }
+    },
+    "TypedLinkFacetAttributeUpdateList":{
+      "type":"list",
+      "member":{"shape":"TypedLinkFacetAttributeUpdate"}
+    },
+    "TypedLinkName":{
+      "type":"string",
+      "pattern":"^[a-zA-Z0-9._-]*$"
+    },
+    "TypedLinkNameList":{
+      "type":"list",
+      "member":{"shape":"TypedLinkName"}
+    },
+    "TypedLinkSchemaAndFacetName":{
+      "type":"structure",
+      "required":[
+        "SchemaArn",
+        "TypedLinkName"
+      ],
+      "members":{
+        "SchemaArn":{"shape":"Arn"},
+        "TypedLinkName":{"shape":"TypedLinkName"}
+      }
+    },
+    "TypedLinkSpecifier":{
+      "type":"structure",
+      "required":[
+        "TypedLinkFacet",
+        "SourceObjectReference",
+        "TargetObjectReference",
+        "IdentityAttributeValues"
+      ],
+      "members":{
+        "TypedLinkFacet":{"shape":"TypedLinkSchemaAndFacetName"},
+        "SourceObjectReference":{"shape":"ObjectReference"},
+        "TargetObjectReference":{"shape":"ObjectReference"},
+        "IdentityAttributeValues":{"shape":"AttributeNameAndValueList"}
+      }
+    },
+    "TypedLinkSpecifierList":{
+      "type":"list",
+      "member":{"shape":"TypedLinkSpecifier"}
+    },
     "UnsupportedIndexTypeException":{
       "type":"structure",
       "members":{
@@ -3017,6 +3551,30 @@
       "type":"structure",
       "members":{
         "SchemaArn":{"shape":"Arn"}
+      }
+    },
+    "UpdateTypedLinkFacetRequest":{
+      "type":"structure",
+      "required":[
+        "SchemaArn",
+        "Name",
+        "AttributeUpdates",
+        "IdentityAttributeOrder"
+      ],
+      "members":{
+        "SchemaArn":{
+          "shape":"Arn",
+          "location":"header",
+          "locationName":"x-amz-data-partition"
+        },
+        "Name":{"shape":"TypedLinkName"},
+        "AttributeUpdates":{"shape":"TypedLinkFacetAttributeUpdateList"},
+        "IdentityAttributeOrder":{"shape":"AttributeNameList"}
+      }
+    },
+    "UpdateTypedLinkFacetResponse":{
+      "type":"structure",
+      "members":{
       }
     },
     "ValidationException":{

--- a/models/apis/clouddirectory/2016-05-10/docs-2.json
+++ b/models/apis/clouddirectory/2016-05-10/docs-2.json
@@ -1,56 +1,66 @@
 {
   "version": "2.0",
-  "service": "<fullname>Amazon Cloud Directory</fullname> <p>Amazon Cloud Directory is a component of the AWS Directory Service that simplifies the development and management of cloud-scale web, mobile and IoT applications. This guide describes the Cloud Directory operations that you can call programatically and includes detailed information on data types and errors. For information about AWS Directory Services features, see <a href=\"https://aws.amazon.com/directoryservice/\">AWS Directory Service</a> and the <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/what_is.html\">AWS Directory Service Administration Guide</a>.</p>",
+  "service": "<fullname>Amazon Cloud Directory</fullname> <p>Amazon Cloud Directory is a component of the AWS Directory Service that simplifies the development and management of cloud-scale web, mobile, and IoT applications. This guide describes the Cloud Directory operations that you can call programmatically and includes detailed information on data types and errors. For information about AWS Directory Services features, see <a href=\"https://aws.amazon.com/directoryservice/\">AWS Directory Service</a> and the <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/what_is.html\">AWS Directory Service Administration Guide</a>.</p>",
   "operations": {
     "AddFacetToObject": "<p>Adds a new <a>Facet</a> to an object.</p>",
-    "ApplySchema": "<p>Copies input published schema into <a>Directory</a> with same name and version as that of published schema .</p>",
+    "ApplySchema": "<p>Copies the input published schema into the <a>Directory</a> with the same name and version as that of the published schema .</p>",
     "AttachObject": "<p>Attaches an existing object to another object. An object can be accessed in two ways:</p> <ol> <li> <p>Using the path</p> </li> <li> <p>Using <code>ObjectIdentifier</code> </p> </li> </ol>",
     "AttachPolicy": "<p>Attaches a policy object to a regular object. An object can have a limited number of attached policies.</p>",
     "AttachToIndex": "<p>Attaches the specified object to the specified index.</p>",
+    "AttachTypedLink": "<p>Attaches a typed link to a specified source and target object. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
     "BatchRead": "<p>Performs all the read operations in a batch. </p>",
     "BatchWrite": "<p>Performs all the write operations in a batch. Either all the operations succeed or none. Batch writes supports only object-related operations.</p>",
     "CreateDirectory": "<p>Creates a <a>Directory</a> by copying the published schema into the directory. A directory cannot be created without a schema.</p>",
     "CreateFacet": "<p>Creates a new <a>Facet</a> in a schema. Facet creation is allowed only in development or applied schemas.</p>",
     "CreateIndex": "<p>Creates an index object. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_indexing.html\">Indexing</a> for more information.</p>",
-    "CreateObject": "<p>Creates an object in a <a>Directory</a>. Additionally attaches the object to a parent, if a parent reference and LinkName is specified. An object is simply a collection of <a>Facet</a> attributes. You can also use this API call to create a policy object, if the facet from which you create the object is a policy facet. </p>",
+    "CreateObject": "<p>Creates an object in a <a>Directory</a>. Additionally attaches the object to a parent, if a parent reference and <code>LinkName</code> is specified. An object is simply a collection of <a>Facet</a> attributes. You can also use this API call to create a policy object, if the facet from which you create the object is a policy facet. </p>",
     "CreateSchema": "<p>Creates a new schema in a development state. A schema can exist in three phases:</p> <ul> <li> <p> <i>Development:</i> This is a mutable phase of the schema. All new schemas are in the development phase. Once the schema is finalized, it can be published.</p> </li> <li> <p> <i>Published:</i> Published schemas are immutable and have a version associated with them.</p> </li> <li> <p> <i>Applied:</i> Applied schemas are mutable in a way that allows you to add new schema facets. You can also add new, nonrequired attributes to existing schema facets. You can apply only published schemas to directories. </p> </li> </ul>",
+    "CreateTypedLinkFacet": "<p>Creates a <a>TypedLinkFacet</a>. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
     "DeleteDirectory": "<p>Deletes a directory. Only disabled directories can be deleted. A deleted directory cannot be undone. Exercise extreme caution when deleting directories.</p>",
-    "DeleteFacet": "<p>Deletes a given <a>Facet</a>. All attributes and <a>Rule</a>s associated with the facet will be deleted. Only development schema facets are allowed deletion.</p>",
+    "DeleteFacet": "<p>Deletes a given <a>Facet</a>. All attributes and <a>Rule</a>s that are associated with the facet will be deleted. Only development schema facets are allowed deletion.</p>",
     "DeleteObject": "<p>Deletes an object and its associated attributes. Only objects with no children and no parents can be deleted.</p>",
     "DeleteSchema": "<p>Deletes a given schema. Schemas in a development and published state can only be deleted. </p>",
+    "DeleteTypedLinkFacet": "<p>Deletes a <a>TypedLinkFacet</a>. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
     "DetachFromIndex": "<p>Detaches the specified object from the specified index.</p>",
     "DetachObject": "<p>Detaches a given object from the parent object. The object that is to be detached from the parent is specified by the link name.</p>",
     "DetachPolicy": "<p>Detaches a policy from an object.</p>",
+    "DetachTypedLink": "<p>Detaches a typed link from a specified source and target object. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
     "DisableDirectory": "<p>Disables the specified directory. Disabled directories cannot be read or written to. Only enabled directories can be disabled. Disabled directories may be reenabled.</p>",
     "EnableDirectory": "<p>Enables the specified directory. Only disabled directories can be enabled. Once enabled, the directory can then be read and written to.</p>",
     "GetDirectory": "<p>Retrieves metadata about a directory.</p>",
-    "GetFacet": "<p>Gets details of the <a>Facet</a>, such as Facet Name, Attributes, <a>Rule</a>s, or ObjectType. You can call this on all kinds of schema facets -- published, development, or applied.</p>",
+    "GetFacet": "<p>Gets details of the <a>Facet</a>, such as facet name, attributes, <a>Rule</a>s, or <code>ObjectType</code>. You can call this on all kinds of schema facets -- published, development, or applied.</p>",
     "GetObjectInformation": "<p>Retrieves metadata about an object.</p>",
     "GetSchemaAsJson": "<p>Retrieves a JSON representation of the schema. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_schemas.html#jsonformat\">JSON Schema Format</a> for more information.</p>",
+    "GetTypedLinkFacetInformation": "<p>Returns the identity attribute order for a specific <a>TypedLinkFacet</a>. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
     "ListAppliedSchemaArns": "<p>Lists schemas applied to a directory.</p>",
     "ListAttachedIndices": "<p>Lists indices attached to an object.</p>",
-    "ListDevelopmentSchemaArns": "<p>Retrieves the ARNs of schemas in the development state.</p>",
+    "ListDevelopmentSchemaArns": "<p>Retrieves each Amazon Resource Name (ARN) of schemas in the development state.</p>",
     "ListDirectories": "<p>Lists directories created within an account.</p>",
     "ListFacetAttributes": "<p>Retrieves attributes attached to the facet.</p>",
     "ListFacetNames": "<p>Retrieves the names of facets that exist in a schema.</p>",
+    "ListIncomingTypedLinks": "<p>Returns a paginated list of all the incoming <a>TypedLinkSpecifier</a> information for an object. It also supports filtering by typed link facet and identity attributes. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
     "ListIndex": "<p>Lists objects attached to the specified index.</p>",
-    "ListObjectAttributes": "<p>Lists all attributes associated with an object. </p>",
-    "ListObjectChildren": "<p>Returns a paginated list of child objects associated with a given object.</p>",
-    "ListObjectParentPaths": "<p>Retrieves all available parent paths for any object type such as node, leaf node, policy node, and index node objects. For more information about objects, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#dirstructure\">Directory Structure</a>.</p> <p>Use this API to evaluate all parents for an object. The call returns all objects from the root of the directory up to the requested object. The API returns the number of paths based on user-defined <code>MaxResults</code>, in case there are multiple paths to the parent. The order of the paths and nodes returned is consistent among multiple API calls unless the objects are deleted or moved. Paths not leading to directory root are ignored from the target object.</p>",
-    "ListObjectParents": "<p>Lists parent objects associated with a given object in pagination fashion.</p>",
+    "ListObjectAttributes": "<p>Lists all attributes that are associated with an object. </p>",
+    "ListObjectChildren": "<p>Returns a paginated list of child objects that are associated with a given object.</p>",
+    "ListObjectParentPaths": "<p>Retrieves all available parent paths for any object type such as node, leaf node, policy node, and index node objects. For more information about objects, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#dirstructure\">Directory Structure</a>.</p> <p>Use this API to evaluate all parents for an object. The call returns all objects from the root of the directory up to the requested object. The API returns the number of paths based on user-defined <code>MaxResults</code>, in case there are multiple paths to the parent. The order of the paths and nodes returned is consistent among multiple API calls unless the objects are deleted or moved. Paths not leading to the directory root are ignored from the target object.</p>",
+    "ListObjectParents": "<p>Lists parent objects that are associated with a given object in pagination fashion.</p>",
     "ListObjectPolicies": "<p>Returns policies attached to an object in pagination fashion.</p>",
+    "ListOutgoingTypedLinks": "<p>Returns a paginated list of all the outgoing <a>TypedLinkSpecifier</a> information for an object. It also supports filtering by typed link facet and identity attributes. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
     "ListPolicyAttachments": "<p>Returns all of the <code>ObjectIdentifiers</code> to which a given policy is attached.</p>",
-    "ListPublishedSchemaArns": "<p>Retrieves published schema ARNs.</p>",
+    "ListPublishedSchemaArns": "<p>Retrieves each published schema Amazon Resource Name (ARN).</p>",
     "ListTagsForResource": "<p>Returns tags for a resource. Tagging is currently supported only for directories with a limit of 50 tags per directory. All 50 tags are returned for a given directory with this API call.</p>",
-    "LookupPolicy": "<p>Lists all policies from the root of the <a>Directory</a> to the object specified. If there are no policies present, an empty list is returned. If policies are present, and if some objects don't have the policies attached, it returns the <code>ObjectIdentifier</code> for such objects. If policies are present, it returns <code>ObjectIdentifier</code>, <code>policyId</code>, and <code>policyType</code>. Paths that don't lead to the root from the target object are ignored.</p>",
-    "PublishSchema": "<p>Publishes a development schema with a version. If description and attributes are specified, PublishSchema overrides the development schema description and attributes. If not, the development schema description and attributes are used.</p>",
+    "ListTypedLinkFacetAttributes": "<p>Returns a paginated list of all attribute definitions for a particular <a>TypedLinkFacet</a>. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
+    "ListTypedLinkFacetNames": "<p>Returns a paginated list of <code>TypedLink</code> facet names for a particular schema. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>",
+    "LookupPolicy": "<p>Lists all policies from the root of the <a>Directory</a> to the object specified. If there are no policies present, an empty list is returned. If policies are present, and if some objects don't have the policies attached, it returns the <code>ObjectIdentifier</code> for such objects. If policies are present, it returns <code>ObjectIdentifier</code>, <code>policyId</code>, and <code>policyType</code>. Paths that don't lead to the root from the target object are ignored. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies\">Policies</a>.</p>",
+    "PublishSchema": "<p>Publishes a development schema with a version. If description and attributes are specified, <code>PublishSchema</code> overrides the development schema description and attributes. If not, the development schema description and attributes are used.</p>",
     "PutSchemaFromJson": "<p>Allows a schema to be updated using JSON upload. Only available for development schemas. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_schemas.html#jsonformat\">JSON Schema Format</a> for more information.</p>",
     "RemoveFacetFromObject": "<p>Removes the specified facet from the specified object.</p>",
-    "TagResource": "<p>API for adding tags to a resource.</p>",
-    "UntagResource": "<p>API for removing tags from a resource.</p>",
+    "TagResource": "<p>An API operation for adding tags to a resource.</p>",
+    "UntagResource": "<p>An API operation for removing tags from a resource.</p>",
     "UpdateFacet": "<p>Does the following:</p> <ol> <li> <p>Adds new <code>Attributes</code>, <code>Rules</code>, or <code>ObjectTypes</code>.</p> </li> <li> <p>Updates existing <code>Attributes</code>, <code>Rules</code>, or <code>ObjectTypes</code>.</p> </li> <li> <p>Deletes existing <code>Attributes</code>, <code>Rules</code>, or <code>ObjectTypes</code>.</p> </li> </ol>",
     "UpdateObjectAttributes": "<p>Updates a given object's attributes.</p>",
-    "UpdateSchema": "<p>Updates the schema name with a new name. Only development schema names can be updated.</p>"
+    "UpdateSchema": "<p>Updates the schema name with a new name. Only development schema names can be updated.</p>",
+    "UpdateTypedLinkFacet": "<p>Updates a <a>TypedLinkFacet</a>. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>"
   },
   "shapes": {
     "AccessDeniedException": {
@@ -81,65 +91,76 @@
     "Arn": {
       "base": null,
       "refs": {
-        "AddFacetToObjectRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
-        "ApplySchemaRequest$PublishedSchemaArn": "<p>Published schema ARN that needs to be copied. For more information, see <a>arns</a>.</p>",
-        "ApplySchemaRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> into which the schema is copied. For more information, see <a>arns</a>.</p>",
-        "ApplySchemaResponse$AppliedSchemaArn": "<p>Applied schema ARN associated with the copied schema in the <a>Directory</a>. You can use this ARN to describe the schema information applied on this directory. For more information, see <a>arns</a>.</p>",
-        "ApplySchemaResponse$DirectoryArn": "<p>ARN associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
+        "AddFacetToObjectRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
+        "ApplySchemaRequest$PublishedSchemaArn": "<p>Published schema Amazon Resource Name (ARN) that needs to be copied. For more information, see <a>arns</a>.</p>",
+        "ApplySchemaRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> into which the schema is copied. For more information, see <a>arns</a>.</p>",
+        "ApplySchemaResponse$AppliedSchemaArn": "<p>The applied schema ARN that is associated with the copied schema in the <a>Directory</a>. You can use this ARN to describe the schema information applied on this directory. For more information, see <a>arns</a>.</p>",
+        "ApplySchemaResponse$DirectoryArn": "<p>The ARN that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
         "Arns$member": null,
-        "AttachObjectRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>",
-        "AttachPolicyRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>",
-        "AttachToIndexRequest$DirectoryArn": "<p>The ARN of the directory where the object and index exist.</p>",
-        "AttributeKey$SchemaArn": "<p>The ARN of the schema that contains the facet and attribute.</p>",
-        "BatchReadRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
-        "BatchWriteRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
-        "CreateDirectoryRequest$SchemaArn": "<p>ARN of the published schema that will be copied into the data <a>Directory</a>. For more information, see <a>arns</a>.</p>",
-        "CreateDirectoryResponse$AppliedSchemaArn": "<p>ARN of the published schema in the <a>Directory</a>. Once a published schema is copied into the directory, it has its own ARN which is referred to applied schema ARN. For more information, see <a>arns</a>.</p>",
-        "CreateFacetRequest$SchemaArn": "<p>Schema ARN in which the new <a>Facet</a> will be created. For more information, see <a>arns</a>.</p>",
+        "AttachObjectRequest$DirectoryArn": "<p>Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>",
+        "AttachPolicyRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>",
+        "AttachToIndexRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) of the directory where the object and index exist.</p>",
+        "AttachTypedLinkRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) of the directory where you want to attach the typed link.</p>",
+        "AttributeKey$SchemaArn": "<p>The Amazon Resource Name (ARN) of the schema that contains the facet and attribute.</p>",
+        "BatchReadRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
+        "BatchWriteRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
+        "CreateDirectoryRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) of the published schema that will be copied into the data <a>Directory</a>. For more information, see <a>arns</a>.</p>",
+        "CreateDirectoryResponse$AppliedSchemaArn": "<p>The ARN of the published schema in the <a>Directory</a>. Once a published schema is copied into the directory, it has its own ARN, which is referred to applied schema ARN. For more information, see <a>arns</a>.</p>",
+        "CreateFacetRequest$SchemaArn": "<p>The schema ARN in which the new <a>Facet</a> will be created. For more information, see <a>arns</a>.</p>",
         "CreateIndexRequest$DirectoryArn": "<p>The ARN of the directory where the index should be created.</p>",
-        "CreateObjectRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> in which the object will be created. For more information, see <a>arns</a>.</p>",
-        "CreateSchemaResponse$SchemaArn": "<p>ARN associated with the schema. For more information, see <a>arns</a>.</p>",
+        "CreateObjectRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> in which the object will be created. For more information, see <a>arns</a>.</p>",
+        "CreateSchemaResponse$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>",
+        "CreateTypedLinkFacetRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>",
         "DeleteDirectoryRequest$DirectoryArn": "<p>The ARN of the directory to delete.</p>",
         "DeleteDirectoryResponse$DirectoryArn": "<p>The ARN of the deleted directory.</p>",
-        "DeleteFacetRequest$SchemaArn": "<p>ARN associated with the <a>Facet</a>. For more information, see <a>arns</a>.</p>",
-        "DeleteObjectRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
-        "DeleteSchemaRequest$SchemaArn": "<p>ARN of the development schema. For more information, see <a>arns</a>.</p>",
-        "DeleteSchemaResponse$SchemaArn": "<p>Input ARN that is returned as part of the response. For more information, see <a>arns</a>.</p>",
-        "DetachFromIndexRequest$DirectoryArn": "<p>The ARN of the directory the index and object exist in.</p>",
-        "DetachObjectRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where objects reside. For more information, see <a>arns</a>.</p>",
-        "DetachPolicyRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>",
+        "DeleteFacetRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Facet</a>. For more information, see <a>arns</a>.</p>",
+        "DeleteObjectRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
+        "DeleteSchemaRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) of the development schema. For more information, see <a>arns</a>.</p>",
+        "DeleteSchemaResponse$SchemaArn": "<p>The input ARN that is returned as part of the response. For more information, see <a>arns</a>.</p>",
+        "DeleteTypedLinkFacetRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>",
+        "DetachFromIndexRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) of the directory the index and object exist in.</p>",
+        "DetachObjectRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where objects reside. For more information, see <a>arns</a>.</p>",
+        "DetachPolicyRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>",
+        "DetachTypedLinkRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) of the directory where you want to detach the typed link.</p>",
         "DisableDirectoryRequest$DirectoryArn": "<p>The ARN of the directory to disable.</p>",
         "DisableDirectoryResponse$DirectoryArn": "<p>The ARN of the directory that has been disabled.</p>",
         "EnableDirectoryRequest$DirectoryArn": "<p>The ARN of the directory to enable.</p>",
         "EnableDirectoryResponse$DirectoryArn": "<p>The ARN of the enabled directory.</p>",
-        "GetFacetRequest$SchemaArn": "<p>ARN associated with the <a>Facet</a>. For more information, see <a>arns</a>.</p>",
+        "GetFacetRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Facet</a>. For more information, see <a>arns</a>.</p>",
         "GetObjectInformationRequest$DirectoryArn": "<p>The ARN of the directory being retrieved.</p>",
         "GetSchemaAsJsonRequest$SchemaArn": "<p>The ARN of the schema to retrieve.</p>",
+        "GetTypedLinkFacetInformationRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>",
         "ListAppliedSchemaArnsRequest$DirectoryArn": "<p>The ARN of the directory you are listing.</p>",
         "ListAttachedIndicesRequest$DirectoryArn": "<p>The ARN of the directory.</p>",
         "ListFacetAttributesRequest$SchemaArn": "<p>The ARN of the schema where the facet resides.</p>",
-        "ListFacetNamesRequest$SchemaArn": "<p>The ARN to retrieve facet names from.</p>",
+        "ListFacetNamesRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) to retrieve facet names from.</p>",
+        "ListIncomingTypedLinksRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) of the directory where you want to list the typed links.</p>",
         "ListIndexRequest$DirectoryArn": "<p>The ARN of the directory that the index exists in.</p>",
-        "ListObjectAttributesRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
-        "ListObjectChildrenRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
+        "ListObjectAttributesRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
+        "ListObjectChildrenRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
         "ListObjectParentPathsRequest$DirectoryArn": "<p>The ARN of the directory to which the parent path applies.</p>",
-        "ListObjectParentsRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
-        "ListObjectPoliciesRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where objects reside. For more information, see <a>arns</a>.</p>",
-        "ListPolicyAttachmentsRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where objects reside. For more information, see <a>arns</a>.</p>",
-        "ListTagsForResourceRequest$ResourceArn": "<p>ARN of the resource. Tagging is only supported for directories.</p>",
-        "LookupPolicyRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
-        "PublishSchemaRequest$DevelopmentSchemaArn": "<p>ARN associated with the development schema. For more information, see <a>arns</a>.</p>",
-        "PublishSchemaResponse$PublishedSchemaArn": "<p>ARN associated with the published schema. For more information, see <a>arns</a>.</p>",
+        "ListObjectParentsRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
+        "ListObjectPoliciesRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where objects reside. For more information, see <a>arns</a>.</p>",
+        "ListOutgoingTypedLinksRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) of the directory where you want to list the typed links.</p>",
+        "ListPolicyAttachmentsRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where objects reside. For more information, see <a>arns</a>.</p>",
+        "ListTagsForResourceRequest$ResourceArn": "<p>The Amazon Resource Name (ARN) of the resource. Tagging is only supported for directories.</p>",
+        "ListTypedLinkFacetAttributesRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>",
+        "ListTypedLinkFacetNamesRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>",
+        "LookupPolicyRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
+        "PublishSchemaRequest$DevelopmentSchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the development schema. For more information, see <a>arns</a>.</p>",
+        "PublishSchemaResponse$PublishedSchemaArn": "<p>The ARN that is associated with the published schema. For more information, see <a>arns</a>.</p>",
         "PutSchemaFromJsonRequest$SchemaArn": "<p>The ARN of the schema to update.</p>",
         "PutSchemaFromJsonResponse$Arn": "<p>The ARN of the schema to update.</p>",
         "RemoveFacetFromObjectRequest$DirectoryArn": "<p>The ARN of the directory in which the object resides.</p>",
         "SchemaFacet$SchemaArn": "<p>The ARN of the schema that contains the facet.</p>",
-        "TagResourceRequest$ResourceArn": "<p>ARN of the resource. Tagging is only supported for directories.</p>",
-        "UntagResourceRequest$ResourceArn": "<p>ARN of the resource. Tagging is only supported for directories.</p>",
-        "UpdateFacetRequest$SchemaArn": "<p>ARN associated with the <a>Facet</a>. For more information, see <a>arns</a>.</p>",
-        "UpdateObjectAttributesRequest$DirectoryArn": "<p>ARN associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
-        "UpdateSchemaRequest$SchemaArn": "<p>ARN of the development schema. For more information, see <a>arns</a>.</p>",
-        "UpdateSchemaResponse$SchemaArn": "<p>ARN associated with the updated schema. For more information, see <a>arns</a>.</p>"
+        "TagResourceRequest$ResourceArn": "<p>The Amazon Resource Name (ARN) of the resource. Tagging is only supported for directories.</p>",
+        "TypedLinkSchemaAndFacetName$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>",
+        "UntagResourceRequest$ResourceArn": "<p>The Amazon Resource Name (ARN) of the resource. Tagging is only supported for directories.</p>",
+        "UpdateFacetRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Facet</a>. For more information, see <a>arns</a>.</p>",
+        "UpdateObjectAttributesRequest$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>",
+        "UpdateSchemaRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) of the development schema. For more information, see <a>arns</a>.</p>",
+        "UpdateSchemaResponse$SchemaArn": "<p>The ARN that is associated with the updated schema. For more information, see <a>arns</a>.</p>",
+        "UpdateTypedLinkFacetRequest$SchemaArn": "<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>"
       }
     },
     "Arns": {
@@ -180,12 +201,22 @@
       "refs": {
       }
     },
+    "AttachTypedLinkRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "AttachTypedLinkResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "AttributeKey": {
       "base": "<p>A unique identifier for an attribute.</p>",
       "refs": {
         "AttributeKeyAndValue$Key": "<p>The key of the attribute.</p>",
         "AttributeKeyList$member": null,
-        "ObjectAttributeRange$AttributeKey": "<p>The key of the attribute the attribute range covers.</p>",
+        "ObjectAttributeRange$AttributeKey": "<p>The key of the attribute that the attribute range covers.</p>",
         "ObjectAttributeUpdate$ObjectAttributeKey": "<p>The key of the attribute being updated.</p>"
       }
     },
@@ -198,55 +229,80 @@
     "AttributeKeyAndValueList": {
       "base": null,
       "refs": {
-        "AddFacetToObjectRequest$ObjectAttributeList": "<p>Attributes on the facet you are adding to the object.</p>",
+        "AddFacetToObjectRequest$ObjectAttributeList": "<p>Attributes on the facet that you are adding to the object.</p>",
         "BatchAddFacetToObject$ObjectAttributeList": "<p>The attributes to set on the object.</p>",
-        "BatchCreateObject$ObjectAttributeList": "<p>Attribute map, which contains an attribute ARN as the key and attribute value as the map value.</p>",
-        "BatchListObjectAttributesResponse$Attributes": "<p>Attributes map associated with the object. <code>AttributeArn</code> is the key; attribute value is the value.</p>",
-        "CreateObjectRequest$ObjectAttributeList": "<p>Attribute map whose attribute ARN contains the key and attribute value as the map value.</p>",
+        "BatchCreateObject$ObjectAttributeList": "<p>An attribute map, which contains an attribute ARN as the key and attribute value as the map value.</p>",
+        "BatchListObjectAttributesResponse$Attributes": "<p>The attributes map that is associated with the object. <code>AttributeArn</code> is the key; attribute value is the value.</p>",
+        "CreateObjectRequest$ObjectAttributeList": "<p>The attribute map whose attribute ARN contains the key and attribute value as the map value.</p>",
         "IndexAttachment$IndexedAttributes": "<p>The indexed attribute values.</p>",
-        "ListObjectAttributesResponse$Attributes": "<p>Attributes map associated with the object. AttributeArn is the key, and attribute value is the value.</p>"
+        "ListObjectAttributesResponse$Attributes": "<p>Attributes map that is associated with the object. <code>AttributeArn</code> is the key, and attribute value is the value.</p>"
       }
     },
     "AttributeKeyList": {
       "base": null,
       "refs": {
-        "CreateIndexRequest$OrderedIndexedAttributeList": "<p>Specifies the Attributes that should be indexed on. Currently only a single attribute is supported.</p>"
+        "CreateIndexRequest$OrderedIndexedAttributeList": "<p>Specifies the attributes that should be indexed on. Currently only a single attribute is supported.</p>"
       }
     },
     "AttributeName": {
       "base": null,
       "refs": {
         "AttributeKey$Name": "<p>The name of the attribute.</p>",
+        "AttributeNameAndValue$AttributeName": "<p>The attribute name of the typed link.</p>",
+        "AttributeNameList$member": null,
         "FacetAttribute$Name": "<p>The name of the facet attribute.</p>",
-        "FacetAttributeReference$TargetAttributeName": "<p>Target attribute name associated with the facet reference. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences\">Attribute References</a> for more information.</p>"
+        "FacetAttributeReference$TargetAttributeName": "<p>The target attribute name that is associated with the facet reference. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences\">Attribute References</a> for more information.</p>",
+        "TypedLinkAttributeDefinition$Name": "<p>The unique name of the typed link attribute.</p>",
+        "TypedLinkAttributeRange$AttributeName": "<p>The unique name of the typed link attribute.</p>"
+      }
+    },
+    "AttributeNameAndValue": {
+      "base": "<p>Identifies the attribute name and value for a typed link.</p>",
+      "refs": {
+        "AttributeNameAndValueList$member": null
+      }
+    },
+    "AttributeNameAndValueList": {
+      "base": null,
+      "refs": {
+        "AttachTypedLinkRequest$Attributes": "<p>An ordered set of attributes that are associated with the typed link.</p>",
+        "TypedLinkSpecifier$IdentityAttributeValues": "<p>Identifies the attribute value to update.</p>"
+      }
+    },
+    "AttributeNameList": {
+      "base": null,
+      "refs": {
+        "GetTypedLinkFacetInformationResponse$IdentityAttributeOrder": "<p>A range filter that you provide for multiple attributes. The ability to filter typed links considers the order that the attributes are defined on the typed link facet. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range. Filters are interpreted in the order of the attributes on the typed link facet, not the order in which they are supplied to any API calls.</p>",
+        "TypedLinkFacet$IdentityAttributeOrder": "<p>A range filter that you provide for multiple attributes. The ability to filter typed links considers the order that the attributes are defined on the typed link facet. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range. Filters are interpreted in the order of the attributes on the typed link facet, not the order in which they are supplied to any API calls.</p>",
+        "UpdateTypedLinkFacetRequest$IdentityAttributeOrder": "<p>A range filter that you provide for multiple attributes. The ability to filter typed links considers the order that the attributes are defined on the typed link facet. When providing ranges to a typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range. Filters are interpreted in the order of the attributes on the typed link facet, not the order in which they are supplied to any API calls.</p>"
       }
     },
     "BatchAddFacetToObject": {
       "base": "<p>Represents the output of a batch add facet to object operation.</p>",
       "refs": {
-        "BatchWriteOperation$AddFacetToObject": "<p>Batch operation adding a facet to an object.</p>"
+        "BatchWriteOperation$AddFacetToObject": "<p>A batch operation that adds a facet to an object.</p>"
       }
     },
     "BatchAddFacetToObjectResponse": {
       "base": "<p>The result of a batch add facet to object operation.</p>",
       "refs": {
-        "BatchWriteOperationResponse$AddFacetToObject": "<p>Result of an add facet to object batch operation.</p>"
+        "BatchWriteOperationResponse$AddFacetToObject": "<p>The result of an add facet to object batch operation.</p>"
       }
     },
     "BatchAttachObject": {
-      "base": "<p>Represents the output of an AttachObject operation.</p>",
+      "base": "<p>Represents the output of an <code>AttachObject</code> operation.</p>",
       "refs": {
         "BatchWriteOperation$AttachObject": "<p>Attaches an object to a <a>Directory</a>.</p>"
       }
     },
     "BatchAttachObjectResponse": {
-      "base": "<p>Represents the output batch AttachObject response operation.</p>",
+      "base": "<p>Represents the output batch <code>AttachObject</code> response operation.</p>",
       "refs": {
         "BatchWriteOperationResponse$AttachObject": "<p>Attaches an object to a <a>Directory</a>.</p>"
       }
     },
     "BatchCreateObject": {
-      "base": "<p>Represents the output of a CreateObject operation.</p>",
+      "base": "<p>Represents the output of a <code>CreateObject</code> operation.</p>",
       "refs": {
         "BatchWriteOperation$CreateObject": "<p>Creates an object.</p>"
       }
@@ -284,13 +340,13 @@
     "BatchListObjectAttributes": {
       "base": "<p>Represents the output of a <code>ListObjectAttributes</code> operation.</p>",
       "refs": {
-        "BatchReadOperation$ListObjectAttributes": "<p>Lists all attributes associated with an object.</p>"
+        "BatchReadOperation$ListObjectAttributes": "<p>Lists all attributes that are associated with an object.</p>"
       }
     },
     "BatchListObjectAttributesResponse": {
       "base": "<p>Represents the output of a <code>ListObjectAttributes</code> response operation.</p>",
       "refs": {
-        "BatchReadSuccessfulResponse$ListObjectAttributes": "<p>Lists all attributes associated with an object.</p>"
+        "BatchReadSuccessfulResponse$ListObjectAttributes": "<p>Lists all attributes that are associated with an object.</p>"
       }
     },
     "BatchListObjectChildren": {
@@ -302,7 +358,7 @@
     "BatchListObjectChildrenResponse": {
       "base": "<p>Represents the output of a <code>ListObjectChildren</code> response operation.</p>",
       "refs": {
-        "BatchReadSuccessfulResponse$ListObjectChildren": "<p>Returns a paginated list of child objects associated with a given object.</p>"
+        "BatchReadSuccessfulResponse$ListObjectChildren": "<p>Returns a paginated list of child objects that are associated with a given object.</p>"
       }
     },
     "BatchOperationIndex": {
@@ -312,7 +368,7 @@
       }
     },
     "BatchReadException": {
-      "base": "<p>Batch Read Exception structure, which contains exception type and message.</p>",
+      "base": "<p>The batch read exception structure, which contains the exception type and message.</p>",
       "refs": {
         "BatchReadOperationResponse$ExceptionResponse": "<p>Identifies which operation in a batch has failed.</p>"
       }
@@ -320,7 +376,7 @@
     "BatchReadExceptionType": {
       "base": null,
       "refs": {
-        "BatchReadException$Type": "<p>Type of exception, such as <code>InvalidArnException</code>.</p>"
+        "BatchReadException$Type": "<p>A type of exception, such as <code>InvalidArnException</code>.</p>"
       }
     },
     "BatchReadOperation": {
@@ -332,7 +388,7 @@
     "BatchReadOperationList": {
       "base": null,
       "refs": {
-        "BatchReadRequest$Operations": "<p>List of operations that are part of the batch.</p>"
+        "BatchReadRequest$Operations": "<p>A list of operations that are part of the batch.</p>"
       }
     },
     "BatchReadOperationResponse": {
@@ -344,7 +400,7 @@
     "BatchReadOperationResponseList": {
       "base": null,
       "refs": {
-        "BatchReadResponse$Responses": "<p>List of all the responses for each batch read.</p>"
+        "BatchReadResponse$Responses": "<p>A list of all the responses for each batch read.</p>"
       }
     },
     "BatchReadRequest": {
@@ -371,21 +427,21 @@
       }
     },
     "BatchRemoveFacetFromObject": {
-      "base": "<p>Batch operation to remove a facet from an object.</p>",
+      "base": "<p>A batch operation to remove a facet from an object.</p>",
       "refs": {
-        "BatchWriteOperation$RemoveFacetFromObject": "<p>Batch operation removing a facet from an object.</p>"
+        "BatchWriteOperation$RemoveFacetFromObject": "<p>A batch operation that removes a facet from an object.</p>"
       }
     },
     "BatchRemoveFacetFromObjectResponse": {
-      "base": "<p>Empty result representing success.</p>",
+      "base": "<p>An empty result that represents success.</p>",
       "refs": {
-        "BatchWriteOperationResponse$RemoveFacetFromObject": "<p>Result of a batch remove facet from object operation.</p>"
+        "BatchWriteOperationResponse$RemoveFacetFromObject": "<p>The result of a batch remove facet from object operation.</p>"
       }
     },
     "BatchUpdateObjectAttributes": {
       "base": "<p>Represents the output of a <code>BatchUpdate</code> operation. </p>",
       "refs": {
-        "BatchWriteOperation$UpdateObjectAttributes": "<p>Update a given object's attributes.</p>"
+        "BatchWriteOperation$UpdateObjectAttributes": "<p>Updates a given object's attributes.</p>"
       }
     },
     "BatchUpdateObjectAttributesResponse": {
@@ -414,7 +470,7 @@
     "BatchWriteOperationList": {
       "base": null,
       "refs": {
-        "BatchWriteRequest$Operations": "<p>List of operations that are part of the batch.</p>"
+        "BatchWriteRequest$Operations": "<p>A list of operations that are part of the batch.</p>"
       }
     },
     "BatchWriteOperationResponse": {
@@ -426,7 +482,7 @@
     "BatchWriteOperationResponseList": {
       "base": null,
       "refs": {
-        "BatchWriteResponse$Responses": "<p>List of all the responses for each batch write.</p>"
+        "BatchWriteResponse$Responses": "<p>A list of all the responses for each batch write.</p>"
       }
     },
     "BatchWriteRequest": {
@@ -448,8 +504,9 @@
     "Bool": {
       "base": null,
       "refs": {
-        "CreateIndexRequest$IsUnique": "<p>Indicates whether objects with the same indexed attribute value can be added to the index.</p>",
-        "FacetAttributeDefinition$IsImmutable": "<p>Whether the attribute is mutable or not.</p>"
+        "CreateIndexRequest$IsUnique": "<p>Indicates whether the attribute that is being indexed has unique values or not.</p>",
+        "FacetAttributeDefinition$IsImmutable": "<p>Whether the attribute is mutable or not.</p>",
+        "TypedLinkAttributeDefinition$IsImmutable": "<p>Whether the attribute is mutable or not.</p>"
       }
     },
     "BooleanAttributeValue": {
@@ -469,11 +526,13 @@
         "BatchReadRequest$ConsistencyLevel": "<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>",
         "GetObjectInformationRequest$ConsistencyLevel": "<p>The consistency level at which to retrieve the object information.</p>",
         "ListAttachedIndicesRequest$ConsistencyLevel": "<p>The consistency level to use for this operation.</p>",
+        "ListIncomingTypedLinksRequest$ConsistencyLevel": "<p>The consistency level to execute the request at.</p>",
         "ListIndexRequest$ConsistencyLevel": "<p>The consistency level to execute the request at.</p>",
         "ListObjectAttributesRequest$ConsistencyLevel": "<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>",
         "ListObjectChildrenRequest$ConsistencyLevel": "<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>",
         "ListObjectParentsRequest$ConsistencyLevel": "<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>",
         "ListObjectPoliciesRequest$ConsistencyLevel": "<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>",
+        "ListOutgoingTypedLinksRequest$ConsistencyLevel": "<p>The consistency level to execute the request at.</p>",
         "ListPolicyAttachmentsRequest$ConsistencyLevel": "<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>"
       }
     },
@@ -523,6 +582,16 @@
       }
     },
     "CreateSchemaResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "CreateTypedLinkFacetRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "CreateTypedLinkFacetResponse": {
       "base": null,
       "refs": {
       }
@@ -579,6 +648,16 @@
       "refs": {
       }
     },
+    "DeleteTypedLinkFacetRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DeleteTypedLinkFacetResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "DetachFromIndexRequest": {
       "base": null,
       "refs": {
@@ -609,6 +688,11 @@
       "refs": {
       }
     },
+    "DetachTypedLinkRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
     "Directory": {
       "base": "<p>Directory structure that includes the directory name and directory ARN.</p>",
       "refs": {
@@ -624,27 +708,27 @@
     "DirectoryArn": {
       "base": null,
       "refs": {
-        "CreateDirectoryResponse$DirectoryArn": "<p>ARN associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
-        "Directory$DirectoryArn": "<p>ARN associated with the directory. For more information, see <a>arns</a>.</p>",
+        "CreateDirectoryResponse$DirectoryArn": "<p>The ARN that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>",
+        "Directory$DirectoryArn": "<p>The Amazon Resource Name (ARN) that is associated with the directory. For more information, see <a>arns</a>.</p>",
         "GetDirectoryRequest$DirectoryArn": "<p>The ARN of the directory.</p>"
       }
     },
     "DirectoryDeletedException": {
-      "base": "<p>A directory that has been deleted has been attempted to be accessed. Note: The requested resource will eventually cease to exist.</p>",
+      "base": "<p>A directory that has been deleted and to which access has been attempted. Note: The requested resource will eventually cease to exist.</p>",
       "refs": {
       }
     },
     "DirectoryList": {
       "base": null,
       "refs": {
-        "ListDirectoriesResponse$Directories": "<p>Lists all directories associated with your account in pagination fashion.</p>"
+        "ListDirectoriesResponse$Directories": "<p>Lists all directories that are associated with your account in pagination fashion.</p>"
       }
     },
     "DirectoryName": {
       "base": null,
       "refs": {
-        "CreateDirectoryRequest$Name": "<p>Name of the <a>Directory</a>. Should be unique per account, per region.</p>",
-        "CreateDirectoryResponse$Name": "<p>Name of the <a>Directory</a>.</p>",
+        "CreateDirectoryRequest$Name": "<p>The name of the <a>Directory</a>. Should be unique per account, per region.</p>",
+        "CreateDirectoryResponse$Name": "<p>The name of the <a>Directory</a>.</p>",
         "Directory$Name": "<p>The name of the directory.</p>"
       }
     },
@@ -689,7 +773,7 @@
       "base": null,
       "refs": {
         "AccessDeniedException$Message": null,
-        "BatchReadException$Message": "<p>Exception message associated with the failure.</p>",
+        "BatchReadException$Message": "<p>An exception message that is associated with the failure.</p>",
         "BatchWriteException$Message": null,
         "CannotListParentOfRootException$Message": null,
         "DirectoryAlreadyExistsException$Message": null,
@@ -728,7 +812,7 @@
     "Facet": {
       "base": "<p>A structure that contains <code>Name</code>, <code>ARN</code>, <code>Attributes</code>, <a>Rule</a>s, and <code>ObjectTypes</code>.</p>",
       "refs": {
-        "GetFacetResponse$Facet": "<p> <a>Facet</a> structure associated with the facet.</p>"
+        "GetFacetResponse$Facet": "<p>The <a>Facet</a> structure that is associated with the facet.</p>"
       }
     },
     "FacetAlreadyExistsException": {
@@ -737,7 +821,7 @@
       }
     },
     "FacetAttribute": {
-      "base": "<p>Attribute associated with the <a>Facet</a>.</p>",
+      "base": "<p>An attribute that is associated with the <a>Facet</a>.</p>",
       "refs": {
         "FacetAttributeList$member": null,
         "FacetAttributeUpdate$Attribute": "<p>The attribute to update.</p>"
@@ -752,20 +836,21 @@
     "FacetAttributeList": {
       "base": null,
       "refs": {
-        "CreateFacetRequest$Attributes": "<p>Attributes associated with the <a>Facet</a>.e</p>",
+        "CreateFacetRequest$Attributes": "<p>The attributes that are associated with the <a>Facet</a>.</p>",
         "ListFacetAttributesResponse$Attributes": "<p>The attributes attached to the facet.</p>"
       }
     },
     "FacetAttributeReference": {
-      "base": "<p>Facet attribute reference that specifies the attribute definition which contains attribute facet name and attribute name.</p>",
+      "base": "<p>The facet attribute reference that specifies the attribute definition that contains the attribute facet name and attribute name.</p>",
       "refs": {
-        "FacetAttribute$AttributeReference": "<p>Attribute reference associated with the attribute. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences\">Attribute References</a> for more information.</p>"
+        "FacetAttribute$AttributeReference": "<p>An attribute reference that is associated with the attribute. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences\">Attribute References</a> for more information.</p>"
       }
     },
     "FacetAttributeType": {
       "base": null,
       "refs": {
-        "FacetAttributeDefinition$Type": "<p>The type of the attribute.</p>"
+        "FacetAttributeDefinition$Type": "<p>The type of the attribute.</p>",
+        "TypedLinkAttributeDefinition$Type": "<p>The type of the attribute.</p>"
       }
     },
     "FacetAttributeUpdate": {
@@ -777,27 +862,27 @@
     "FacetAttributeUpdateList": {
       "base": null,
       "refs": {
-        "UpdateFacetRequest$AttributeUpdates": "<p>List of attributes that need to be updated in a given schema <a>Facet</a>. Each attribute is followed by AttributeAction, which specifies the type of update operation to perform. </p>"
+        "UpdateFacetRequest$AttributeUpdates": "<p>List of attributes that need to be updated in a given schema <a>Facet</a>. Each attribute is followed by <code>AttributeAction</code>, which specifies the type of update operation to perform. </p>"
       }
     },
     "FacetInUseException": {
-      "base": "<p>Occurs when deleting a facet that contains an attribute which is a target to an attribute reference in a different facet.</p>",
+      "base": "<p>Occurs when deleting a facet that contains an attribute that is a target to an attribute reference in a different facet.</p>",
       "refs": {
       }
     },
     "FacetName": {
       "base": null,
       "refs": {
-        "AttributeKey$FacetName": "<p>The name of the facet the attribute exists within.</p>",
-        "CreateFacetRequest$Name": "<p>Name of the <a>Facet</a>, which is unique for a given schema.</p>",
+        "AttributeKey$FacetName": "<p>The name of the facet that the attribute exists within.</p>",
+        "CreateFacetRequest$Name": "<p>The name of the <a>Facet</a>, which is unique for a given schema.</p>",
         "DeleteFacetRequest$Name": "<p>The name of the facet to delete.</p>",
         "Facet$Name": "<p>The name of the <a>Facet</a>.</p>",
-        "FacetAttributeReference$TargetFacetName": "<p>Target facet name associated with the facet reference. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences\">Attribute References</a> for more information.</p>",
+        "FacetAttributeReference$TargetFacetName": "<p>The target facet name that is associated with the facet reference. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences\">Attribute References</a> for more information.</p>",
         "FacetNameList$member": null,
         "GetFacetRequest$Name": "<p>The name of the facet to retrieve.</p>",
         "ListFacetAttributesRequest$Name": "<p>The name of the facet whose attributes will be retrieved.</p>",
         "SchemaFacet$FacetName": "<p>The name of the facet.</p>",
-        "UpdateFacetRequest$Name": "<p> </p>"
+        "UpdateFacetRequest$Name": "<p>The name of the facet.</p>"
       }
     },
     "FacetNameList": {
@@ -812,7 +897,7 @@
       }
     },
     "FacetValidationException": {
-      "base": "<p>The <a>Facet</a> you provided was not well formed or could not be validated with the schema.</p>",
+      "base": "<p>The <a>Facet</a> that you provided was not well formed or could not be validated with the schema.</p>",
       "refs": {
       }
     },
@@ -856,6 +941,16 @@
       "refs": {
       }
     },
+    "GetTypedLinkFacetInformationRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "GetTypedLinkFacetInformationResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "IndexAttachment": {
       "base": "<p>Represents an index and an attached object.</p>",
       "refs": {
@@ -885,7 +980,7 @@
       }
     },
     "InvalidAttachmentException": {
-      "base": "<p>Indicates that an attempt to attach an object with the same link name or to apply a schema with same name has occurred. Rename the link or the schema and then try again.</p>",
+      "base": "<p>Indicates that an attempt to attach an object with the same link name or to apply a schema with the same name has occurred. Rename the link or the schema and then try again.</p>",
       "refs": {
       }
     },
@@ -915,20 +1010,20 @@
       }
     },
     "LimitExceededException": {
-      "base": "<p>Indicates limits are exceeded. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html\">Limits</a> for more information.</p>",
+      "base": "<p>Indicates that limits are exceeded. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html\">Limits</a> for more information.</p>",
       "refs": {
       }
     },
     "LinkName": {
       "base": null,
       "refs": {
-        "AttachObjectRequest$LinkName": "<p>Link name with which the child object is attached to the parent.</p>",
+        "AttachObjectRequest$LinkName": "<p>The link name with which the child object is attached to the parent.</p>",
         "BatchAttachObject$LinkName": "<p>The name of the link.</p>",
         "BatchCreateObject$LinkName": "<p>The name of the link.</p>",
         "BatchDetachObject$LinkName": "<p>The name of the link.</p>",
         "CreateIndexRequest$LinkName": "<p>The name of the link between the parent object and the index object.</p>",
         "CreateObjectRequest$LinkName": "<p>The name of link that is used to attach this object to a parent.</p>",
-        "DetachObjectRequest$LinkName": "<p>Link name associated with the object that needs to be detached.</p>",
+        "DetachObjectRequest$LinkName": "<p>The link name associated with the object that needs to be detached.</p>",
         "LinkNameToObjectIdentifierMap$key": null,
         "ObjectIdentifierToLinkNameMap$value": null
       }
@@ -941,8 +1036,8 @@
     "LinkNameToObjectIdentifierMap": {
       "base": null,
       "refs": {
-        "BatchListObjectChildrenResponse$Children": "<p>Children structure, which is a map with key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>",
-        "ListObjectChildrenResponse$Children": "<p>Children structure, which is a map with key as the LinkName and <code>ObjectIdentifier</code> as the value.</p>"
+        "BatchListObjectChildrenResponse$Children": "<p>The children structure, which is a map with the key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>",
+        "ListObjectChildrenResponse$Children": "<p>Children structure, which is a map with key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>"
       }
     },
     "ListAppliedSchemaArnsRequest": {
@@ -1001,6 +1096,16 @@
       }
     },
     "ListFacetNamesResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListIncomingTypedLinksRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListIncomingTypedLinksResponse": {
       "base": null,
       "refs": {
       }
@@ -1065,6 +1170,16 @@
       "refs": {
       }
     },
+    "ListOutgoingTypedLinksRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListOutgoingTypedLinksResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "ListPolicyAttachmentsRequest": {
       "base": null,
       "refs": {
@@ -1091,6 +1206,26 @@
       }
     },
     "ListTagsForResourceResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTypedLinkFacetAttributesRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTypedLinkFacetAttributesResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTypedLinkFacetNamesRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTypedLinkFacetNamesResponse": {
       "base": null,
       "refs": {
       }
@@ -1124,6 +1259,8 @@
         "ListFacetAttributesResponse$NextToken": "<p>The pagination token.</p>",
         "ListFacetNamesRequest$NextToken": "<p>The pagination token.</p>",
         "ListFacetNamesResponse$NextToken": "<p>The pagination token.</p>",
+        "ListIncomingTypedLinksRequest$NextToken": "<p>The pagination token.</p>",
+        "ListIncomingTypedLinksResponse$NextToken": "<p>The pagination token.</p>",
         "ListIndexRequest$NextToken": "<p>The pagination token.</p>",
         "ListIndexResponse$NextToken": "<p>The pagination token.</p>",
         "ListObjectAttributesRequest$NextToken": "<p>The pagination token.</p>",
@@ -1136,28 +1273,34 @@
         "ListObjectParentsResponse$NextToken": "<p>The pagination token.</p>",
         "ListObjectPoliciesRequest$NextToken": "<p>The pagination token.</p>",
         "ListObjectPoliciesResponse$NextToken": "<p>The pagination token.</p>",
+        "ListOutgoingTypedLinksRequest$NextToken": "<p>The pagination token.</p>",
+        "ListOutgoingTypedLinksResponse$NextToken": "<p>The pagination token.</p>",
         "ListPolicyAttachmentsRequest$NextToken": "<p>The pagination token.</p>",
         "ListPolicyAttachmentsResponse$NextToken": "<p>The pagination token.</p>",
         "ListPublishedSchemaArnsRequest$NextToken": "<p>The pagination token.</p>",
         "ListPublishedSchemaArnsResponse$NextToken": "<p>The pagination token.</p>",
         "ListTagsForResourceRequest$NextToken": "<p>The pagination token. This is for future use. Currently pagination is not supported for tagging.</p>",
         "ListTagsForResourceResponse$NextToken": "<p>The token to use to retrieve the next page of results. This value is null when there are no more results to return.</p>",
+        "ListTypedLinkFacetAttributesRequest$NextToken": "<p>The pagination token.</p>",
+        "ListTypedLinkFacetAttributesResponse$NextToken": "<p>The pagination token.</p>",
+        "ListTypedLinkFacetNamesRequest$NextToken": "<p>The pagination token.</p>",
+        "ListTypedLinkFacetNamesResponse$NextToken": "<p>The pagination token.</p>",
         "LookupPolicyRequest$NextToken": "<p>The token to request the next page of results.</p>",
         "LookupPolicyResponse$NextToken": "<p>The pagination token.</p>"
       }
     },
     "NotIndexException": {
-      "base": "<p>Indicates the requested operation can only operate on index objects.</p>",
+      "base": "<p>Indicates that the requested operation can only operate on index objects.</p>",
       "refs": {
       }
     },
     "NotNodeException": {
-      "base": "<p>Occurs when any invalid operations are performed on an object which is not a node, such as calling <code>ListObjectChildren</code> for a leaf node object.</p>",
+      "base": "<p>Occurs when any invalid operations are performed on an object that is not a node, such as calling <code>ListObjectChildren</code> for a leaf node object.</p>",
       "refs": {
       }
     },
     "NotPolicyException": {
-      "base": "<p>Indicates the requested operation can only operate on policy objects.</p>",
+      "base": "<p>Indicates that the requested operation can only operate on policy objects.</p>",
       "refs": {
       }
     },
@@ -1170,27 +1313,31 @@
     "NumberResults": {
       "base": null,
       "refs": {
-        "BatchListObjectAttributes$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
+        "BatchListObjectAttributes$MaxResults": "<p>The maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
         "BatchListObjectChildren$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
         "ListAppliedSchemaArnsRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
         "ListAttachedIndicesRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
         "ListDevelopmentSchemaArnsRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
         "ListDirectoriesRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
         "ListFacetAttributesRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
-        "ListFacetNamesRequest$MaxResults": "<p>The maximum number of results to retrieve</p>",
+        "ListFacetNamesRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
+        "ListIncomingTypedLinksRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
         "ListIndexRequest$MaxResults": "<p>The maximum number of results to retrieve from the index.</p>",
-        "ListObjectAttributesRequest$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
-        "ListObjectChildrenRequest$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
-        "ListObjectParentPathsRequest$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
-        "ListObjectParentsRequest$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
-        "ListObjectPoliciesRequest$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
-        "ListPolicyAttachmentsRequest$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
+        "ListObjectAttributesRequest$MaxResults": "<p>The maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
+        "ListObjectChildrenRequest$MaxResults": "<p>The maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
+        "ListObjectParentPathsRequest$MaxResults": "<p>The maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
+        "ListObjectParentsRequest$MaxResults": "<p>The maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
+        "ListObjectPoliciesRequest$MaxResults": "<p>The maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
+        "ListOutgoingTypedLinksRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
+        "ListPolicyAttachmentsRequest$MaxResults": "<p>The maximum number of items to be retrieved in a single call. This is an approximate number.</p>",
         "ListPublishedSchemaArnsRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
-        "LookupPolicyRequest$MaxResults": "<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>"
+        "ListTypedLinkFacetAttributesRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
+        "ListTypedLinkFacetNamesRequest$MaxResults": "<p>The maximum number of results to retrieve.</p>",
+        "LookupPolicyRequest$MaxResults": "<p>The maximum number of items to be retrieved in a single call. This is an approximate number.</p>"
       }
     },
     "ObjectAlreadyDetachedException": {
-      "base": "<p>Indicates the object is not attached to the index.</p>",
+      "base": "<p>Indicates that the object is not attached to the index.</p>",
       "refs": {
       }
     },
@@ -1222,21 +1369,21 @@
       "base": null,
       "refs": {
         "BatchUpdateObjectAttributes$AttributeUpdates": "<p>Attributes update structure.</p>",
-        "UpdateObjectAttributesRequest$AttributeUpdates": "<p>Attributes update structure.</p>"
+        "UpdateObjectAttributesRequest$AttributeUpdates": "<p>The attributes update structure.</p>"
       }
     },
     "ObjectIdentifier": {
       "base": null,
       "refs": {
-        "AttachObjectResponse$AttachedObjectIdentifier": "<p>Attached <code>ObjectIdentifier</code>, which is the child <code>ObjectIdentifier</code>.</p>",
+        "AttachObjectResponse$AttachedObjectIdentifier": "<p>The attached <code>ObjectIdentifier</code>, which is the child <code>ObjectIdentifier</code>.</p>",
         "AttachToIndexResponse$AttachedObjectIdentifier": "<p>The <code>ObjectIdentifier</code> of the object that was attached to the index.</p>",
         "BatchAttachObjectResponse$attachedObjectIdentifier": "<p>The <code>ObjectIdentifier</code> of the object that has been attached.</p>",
-        "BatchCreateObjectResponse$ObjectIdentifier": "<p>ID associated with the object.</p>",
+        "BatchCreateObjectResponse$ObjectIdentifier": "<p>The ID that is associated with the object.</p>",
         "BatchDetachObjectResponse$detachedObjectIdentifier": "<p>The <code>ObjectIdentifier</code> of the detached object.</p>",
-        "BatchUpdateObjectAttributesResponse$ObjectIdentifier": "<p>ID associated with the object.</p>",
+        "BatchUpdateObjectAttributesResponse$ObjectIdentifier": "<p>ID that is associated with the object.</p>",
         "CreateDirectoryResponse$ObjectIdentifier": "<p>The root object node of the created directory.</p>",
         "CreateIndexResponse$ObjectIdentifier": "<p>The <code>ObjectIdentifier</code> of the index created by this operation.</p>",
-        "CreateObjectResponse$ObjectIdentifier": "<p>Identifier associated with the object.</p>",
+        "CreateObjectResponse$ObjectIdentifier": "<p>The identifier that is associated with the object.</p>",
         "DetachFromIndexResponse$DetachedObjectIdentifier": "<p>The <code>ObjectIdentifier</code> of the object that was detached from the index.</p>",
         "DetachObjectResponse$DetachedObjectIdentifier": "<p>The <code>ObjectIdentifier</code> that was detached from the object.</p>",
         "GetObjectInformationResponse$ObjectIdentifier": "<p>The <code>ObjectIdentifier</code> of the specified object.</p>",
@@ -1245,44 +1392,46 @@
         "ObjectIdentifierList$member": null,
         "ObjectIdentifierToLinkNameMap$key": null,
         "PolicyAttachment$PolicyId": "<p>The ID of <code>PolicyAttachment</code>.</p>",
-        "PolicyAttachment$ObjectIdentifier": "<p>The <code>ObjectIdentifier</code> associated with <code>PolicyAttachment</code>.</p>",
-        "UpdateObjectAttributesResponse$ObjectIdentifier": "<p> <code>ObjectIdentifier</code> of the updated object.</p>"
+        "PolicyAttachment$ObjectIdentifier": "<p>The <code>ObjectIdentifier</code> that is associated with <code>PolicyAttachment</code>.</p>",
+        "UpdateObjectAttributesResponse$ObjectIdentifier": "<p>The <code>ObjectIdentifier</code> of the updated object.</p>"
       }
     },
     "ObjectIdentifierList": {
       "base": null,
       "refs": {
-        "ListObjectPoliciesResponse$AttachedPolicyIds": "<p>List of policy <code>ObjectIdentifiers</code>, that are attached to the object.</p>",
-        "ListPolicyAttachmentsResponse$ObjectIdentifiers": "<p>List of <code>ObjectIdentifiers</code> to which the policy is attached.</p>",
+        "ListObjectPoliciesResponse$AttachedPolicyIds": "<p>A list of policy <code>ObjectIdentifiers</code>, that are attached to the object.</p>",
+        "ListPolicyAttachmentsResponse$ObjectIdentifiers": "<p>A list of <code>ObjectIdentifiers</code> to which the policy is attached.</p>",
         "PathToObjectIdentifiers$ObjectIdentifiers": "<p>Lists <code>ObjectIdentifiers</code> starting from directory root to the object in the request.</p>"
       }
     },
     "ObjectIdentifierToLinkNameMap": {
       "base": null,
       "refs": {
-        "ListObjectParentsResponse$Parents": "<p>Parent structure, which is a map with key as the <code>ObjectIdentifier</code> and LinkName as the value.</p>"
+        "ListObjectParentsResponse$Parents": "<p>The parent structure, which is a map with key as the <code>ObjectIdentifier</code> and LinkName as the value.</p>"
       }
     },
     "ObjectNotDetachedException": {
-      "base": "<p>Indicates the requested operation cannot be completed because the object has not been detached from the tree.</p>",
+      "base": "<p>Indicates that the requested operation cannot be completed because the object has not been detached from the tree.</p>",
       "refs": {
       }
     },
     "ObjectReference": {
-      "base": "<p>Reference that identifies an object.</p>",
+      "base": "<p>The reference that identifies an object.</p>",
       "refs": {
         "AddFacetToObjectRequest$ObjectReference": "<p>A reference to the object you are adding the specified facet to.</p>",
-        "AttachObjectRequest$ParentReference": "<p>Parent object reference.</p>",
-        "AttachObjectRequest$ChildReference": "<p>Child object reference to be attached to the object.</p>",
-        "AttachPolicyRequest$PolicyReference": "<p>Reference associated with the policy object.</p>",
-        "AttachPolicyRequest$ObjectReference": "<p>Reference that identifies the object to which the policy will be attached.</p>",
+        "AttachObjectRequest$ParentReference": "<p>The parent object reference.</p>",
+        "AttachObjectRequest$ChildReference": "<p>The child object reference to be attached to the object.</p>",
+        "AttachPolicyRequest$PolicyReference": "<p>The reference that is associated with the policy object.</p>",
+        "AttachPolicyRequest$ObjectReference": "<p>The reference that identifies the object to which the policy will be attached.</p>",
         "AttachToIndexRequest$IndexReference": "<p>A reference to the index that you are attaching the object to.</p>",
         "AttachToIndexRequest$TargetReference": "<p>A reference to the object that you are attaching to the index.</p>",
+        "AttachTypedLinkRequest$SourceObjectReference": "<p>Identifies the source object that the typed link will attach to.</p>",
+        "AttachTypedLinkRequest$TargetObjectReference": "<p>Identifies the target object that the typed link will attach to.</p>",
         "BatchAddFacetToObject$ObjectReference": "<p>A reference to the object being mutated.</p>",
-        "BatchAttachObject$ParentReference": "<p>Parent object reference.</p>",
-        "BatchAttachObject$ChildReference": "<p>Child object reference to be attached to the object.</p>",
+        "BatchAttachObject$ParentReference": "<p>The parent object reference.</p>",
+        "BatchAttachObject$ChildReference": "<p>The child object reference that is to be attached to the object.</p>",
         "BatchCreateObject$ParentReference": "<p>If specified, the parent reference to which this object will be attached.</p>",
-        "BatchDeleteObject$ObjectReference": "<p>Reference that identifies the object.</p>",
+        "BatchDeleteObject$ObjectReference": "<p>The reference that identifies the object.</p>",
         "BatchDetachObject$ParentReference": "<p>Parent reference from which the object with the specified link name is detached.</p>",
         "BatchListObjectAttributes$ObjectReference": "<p>Reference of the object whose attributes need to be listed.</p>",
         "BatchListObjectChildren$ObjectReference": "<p>Reference of the object for which child objects are being listed.</p>",
@@ -1290,43 +1439,47 @@
         "BatchUpdateObjectAttributes$ObjectReference": "<p>Reference that identifies the object.</p>",
         "CreateIndexRequest$ParentReference": "<p>A reference to the parent object that contains the index object.</p>",
         "CreateObjectRequest$ParentReference": "<p>If specified, the parent reference to which this object will be attached.</p>",
-        "DeleteObjectRequest$ObjectReference": "<p>Reference that identifies the object.</p>",
+        "DeleteObjectRequest$ObjectReference": "<p>A reference that identifies the object.</p>",
         "DetachFromIndexRequest$IndexReference": "<p>A reference to the index object.</p>",
         "DetachFromIndexRequest$TargetReference": "<p>A reference to the object being detached from the index.</p>",
-        "DetachObjectRequest$ParentReference": "<p>Parent reference from which the object with the specified link name is detached.</p>",
+        "DetachObjectRequest$ParentReference": "<p>The parent reference from which the object with the specified link name is detached.</p>",
         "DetachPolicyRequest$PolicyReference": "<p>Reference that identifies the policy object.</p>",
         "DetachPolicyRequest$ObjectReference": "<p>Reference that identifies the object whose policy object will be detached.</p>",
         "GetObjectInformationRequest$ObjectReference": "<p>A reference to the object.</p>",
         "ListAttachedIndicesRequest$TargetReference": "<p>A reference to the object to that has indices attached.</p>",
+        "ListIncomingTypedLinksRequest$ObjectReference": "<p>Reference that identifies the object whose attributes will be listed.</p>",
         "ListIndexRequest$IndexReference": "<p>The reference to the index to list.</p>",
-        "ListObjectAttributesRequest$ObjectReference": "<p>Reference that identifies the object whose attributes will be listed.</p>",
-        "ListObjectChildrenRequest$ObjectReference": "<p>Reference that identifies the object for which child objects are being listed.</p>",
-        "ListObjectParentPathsRequest$ObjectReference": "<p>Reference that identifies the object whose parent paths are listed.</p>",
-        "ListObjectParentsRequest$ObjectReference": "<p>Reference that identifies the object for which parent objects are being listed.</p>",
+        "ListObjectAttributesRequest$ObjectReference": "<p>The reference that identifies the object whose attributes will be listed.</p>",
+        "ListObjectChildrenRequest$ObjectReference": "<p>The reference that identifies the object for which child objects are being listed.</p>",
+        "ListObjectParentPathsRequest$ObjectReference": "<p>The reference that identifies the object whose parent paths are listed.</p>",
+        "ListObjectParentsRequest$ObjectReference": "<p>The reference that identifies the object for which parent objects are being listed.</p>",
         "ListObjectPoliciesRequest$ObjectReference": "<p>Reference that identifies the object for which policies will be listed.</p>",
-        "ListPolicyAttachmentsRequest$PolicyReference": "<p>Reference that identifies the policy object.</p>",
+        "ListOutgoingTypedLinksRequest$ObjectReference": "<p>A reference that identifies the object whose attributes will be listed.</p>",
+        "ListPolicyAttachmentsRequest$PolicyReference": "<p>The reference that identifies the policy object.</p>",
         "LookupPolicyRequest$ObjectReference": "<p>Reference that identifies the object whose policies will be looked up.</p>",
         "RemoveFacetFromObjectRequest$ObjectReference": "<p>A reference to the object to remove the facet from.</p>",
-        "UpdateObjectAttributesRequest$ObjectReference": "<p>Reference that identifies the object.</p>"
+        "TypedLinkSpecifier$SourceObjectReference": "<p>Identifies the source object that the typed link will attach to.</p>",
+        "TypedLinkSpecifier$TargetObjectReference": "<p>Identifies the target object that the typed link will attach to.</p>",
+        "UpdateObjectAttributesRequest$ObjectReference": "<p>The reference that identifies the object.</p>"
       }
     },
     "ObjectType": {
       "base": null,
       "refs": {
-        "CreateFacetRequest$ObjectType": "<p>Specifies whether a given object created from this facet is of type Node, Leaf Node, Policy or Index.</p> <ul> <li> <p>Node: Can have multiple children but one parent.</p> </li> </ul> <ul> <li> <p>Leaf Node: Cannot have children but can have multiple parents.</p> </li> </ul> <ul> <li> <p>Policy: Allows you to store a policy document and policy type. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies\">Policies</a>.</p> </li> </ul> <ul> <li> <p>Index: Can be created with the Index API.</p> </li> </ul>",
-        "Facet$ObjectType": "<p>Object type associated with the facet. See <a>CreateFacetRequest$ObjectType</a> for more details.</p>",
-        "UpdateFacetRequest$ObjectType": "<p>Object type associated with the facet. See <a>CreateFacetRequest$ObjectType</a> for more details.</p>"
+        "CreateFacetRequest$ObjectType": "<p>Specifies whether a given object created from this facet is of type node, leaf node, policy or index.</p> <ul> <li> <p>Node: Can have multiple children but one parent.</p> </li> </ul> <ul> <li> <p>Leaf node: Cannot have children but can have multiple parents.</p> </li> </ul> <ul> <li> <p>Policy: Allows you to store a policy document and policy type. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies\">Policies</a>.</p> </li> </ul> <ul> <li> <p>Index: Can be created with the Index API.</p> </li> </ul>",
+        "Facet$ObjectType": "<p>The object type that is associated with the facet. See <a>CreateFacetRequest$ObjectType</a> for more details.</p>",
+        "UpdateFacetRequest$ObjectType": "<p>The object type that is associated with the facet. See <a>CreateFacetRequest$ObjectType</a> for more details.</p>"
       }
     },
     "PathString": {
       "base": null,
       "refs": {
-        "PathToObjectIdentifiers$Path": "<p>The path used to identify the object starting from directory root.</p>",
+        "PathToObjectIdentifiers$Path": "<p>The path that is used to identify the object starting from directory root.</p>",
         "PolicyToPath$Path": "<p>The path that is referenced from the root.</p>"
       }
     },
     "PathToObjectIdentifiers": {
-      "base": "<p>Returns the path to the <code>ObjectIdentifiers</code> associated with the directory.</p>",
+      "base": "<p>Returns the path to the <code>ObjectIdentifiers</code> that is associated with the directory.</p>",
       "refs": {
         "PathToObjectIdentifiersList$member": null
       }
@@ -1334,11 +1487,11 @@
     "PathToObjectIdentifiersList": {
       "base": null,
       "refs": {
-        "ListObjectParentPathsResponse$PathToObjectIdentifiersList": "<p>Returns the path to the <code>ObjectIdentifiers</code> associated with the directory.</p>"
+        "ListObjectParentPathsResponse$PathToObjectIdentifiersList": "<p>Returns the path to the <code>ObjectIdentifiers</code> that are associated with the directory.</p>"
       }
     },
     "PolicyAttachment": {
-      "base": "<p>Contains the <code>PolicyType</code>, <code>PolicyId</code>, and the <code>ObjectIdentifier</code> to which it is attached.</p>",
+      "base": "<p>Contains the <code>PolicyType</code>, <code>PolicyId</code>, and the <code>ObjectIdentifier</code> to which it is attached. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies\">Policies</a>.</p>",
       "refs": {
         "PolicyAttachmentList$member": null
       }
@@ -1350,7 +1503,7 @@
       }
     },
     "PolicyToPath": {
-      "base": "<p>Used when a regular object exists in a <a>Directory</a> and you want to find all of the policies associated with that object and the parent to that object.</p>",
+      "base": "<p>Used when a regular object exists in a <a>Directory</a> and you want to find all of the policies that are associated with that object and the parent to that object.</p>",
       "refs": {
         "PolicyToPathList$member": null
       }
@@ -1358,7 +1511,7 @@
     "PolicyToPathList": {
       "base": null,
       "refs": {
-        "LookupPolicyResponse$PolicyToPathList": "<p>Provides list of path to policies. Policies contain <code>PolicyId</code>, <code>ObjectIdentifier</code>, and <code>PolicyType</code>.</p>"
+        "LookupPolicyResponse$PolicyToPathList": "<p>Provides list of path to policies. Policies contain <code>PolicyId</code>, <code>ObjectIdentifier</code>, and <code>PolicyType</code>. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies\">Policies</a>.</p>"
       }
     },
     "PolicyType": {
@@ -1390,8 +1543,8 @@
     "RangeMode": {
       "base": null,
       "refs": {
-        "TypedAttributeValueRange$StartMode": "<p>Inclusive or exclusive range start.</p>",
-        "TypedAttributeValueRange$EndMode": "<p>Inclusive or exclusive range end.</p>"
+        "TypedAttributeValueRange$StartMode": "<p>The inclusive or exclusive range start.</p>",
+        "TypedAttributeValueRange$EndMode": "<p>The inclusive or exclusive range end.</p>"
       }
     },
     "RemoveFacetFromObjectRequest": {
@@ -1407,7 +1560,8 @@
     "RequiredAttributeBehavior": {
       "base": null,
       "refs": {
-        "FacetAttribute$RequiredBehavior": "<p>The required behavior of the <code>FacetAttribute</code>.</p>"
+        "FacetAttribute$RequiredBehavior": "<p>The required behavior of the <code>FacetAttribute</code>.</p>",
+        "TypedLinkAttributeDefinition$RequiredBehavior": "<p>The required behavior of the <code>TypedLinkAttributeDefinition</code>.</p>"
       }
     },
     "ResourceNotFoundException": {
@@ -1421,7 +1575,7 @@
       }
     },
     "Rule": {
-      "base": "<p>Contains an ARN and parameters associated with the rule.</p>",
+      "base": "<p>Contains an Amazon Resource Name (ARN) and parameters that are associated with the rule.</p>",
       "refs": {
         "RuleMap$value": null
       }
@@ -1435,7 +1589,8 @@
     "RuleMap": {
       "base": null,
       "refs": {
-        "FacetAttributeDefinition$Rules": "<p>Validation rules attached to the attribute definition.</p>"
+        "FacetAttributeDefinition$Rules": "<p>Validation rules attached to the attribute definition.</p>",
+        "TypedLinkAttributeDefinition$Rules": "<p>Validation rules that are attached to the attribute definition.</p>"
       }
     },
     "RuleParameterKey": {
@@ -1447,7 +1602,7 @@
     "RuleParameterMap": {
       "base": null,
       "refs": {
-        "Rule$Parameters": "<p>Min and max parameters associated with the rule.</p>"
+        "Rule$Parameters": "<p>The minimum and maximum parameters that are associated with the rule.</p>"
       }
     },
     "RuleParameterValue": {
@@ -1468,7 +1623,7 @@
       }
     },
     "SchemaAlreadyPublishedException": {
-      "base": "<p>Indicates a schema is already published.</p>",
+      "base": "<p>Indicates that a schema is already published.</p>",
       "refs": {
       }
     },
@@ -1477,9 +1632,9 @@
       "refs": {
         "AddFacetToObjectRequest$SchemaFacet": "<p>Identifiers for the facet that you are adding to the object.</p>",
         "BatchAddFacetToObject$SchemaFacet": "<p>Represents the facet being added to the object.</p>",
-        "BatchListObjectAttributes$FacetFilter": "<p>Used to filter the list of object attributes associated with a certain facet.</p>",
+        "BatchListObjectAttributes$FacetFilter": "<p>Used to filter the list of object attributes that are associated with a certain facet.</p>",
         "BatchRemoveFacetFromObject$SchemaFacet": "<p>The facet to remove from the object.</p>",
-        "ListObjectAttributesRequest$FacetFilter": "<p>Used to filter the list of object attributes associated with a certain facet.</p>",
+        "ListObjectAttributesRequest$FacetFilter": "<p>Used to filter the list of object attributes that are associated with a certain facet.</p>",
         "RemoveFacetFromObjectRequest$SchemaFacet": "<p>The facet to remove.</p>",
         "SchemaFacetList$member": null
       }
@@ -1487,8 +1642,8 @@
     "SchemaFacetList": {
       "base": null,
       "refs": {
-        "BatchCreateObject$SchemaFacet": "<p>List of FacetArns that will be associated with the object. For more information, see <a>arns</a>.</p>",
-        "CreateObjectRequest$SchemaFacets": "<p>List of facet ARNs to be associated with the object. For more information, see <a>arns</a>.</p>",
+        "BatchCreateObject$SchemaFacet": "<p>A list of <code>FacetArns</code> that will be associated with the object. For more information, see <a>arns</a>.</p>",
+        "CreateObjectRequest$SchemaFacets": "<p>A list of schema facets to be associated with the object that contains <code>SchemaArn</code> and facet name. For more information, see <a>arns</a>.</p>",
         "GetObjectInformationResponse$SchemaFacets": "<p>The facets attached to the specified object.</p>"
       }
     },
@@ -1502,16 +1657,16 @@
     "SchemaName": {
       "base": null,
       "refs": {
-        "CreateSchemaRequest$Name": "<p>Name associated with the schema. This is unique to each account and in each region.</p>",
+        "CreateSchemaRequest$Name": "<p>The name that is associated with the schema. This is unique to each account and in each region.</p>",
         "GetSchemaAsJsonResponse$Name": "<p>The name of the retrieved schema.</p>",
-        "PublishSchemaRequest$Name": "<p>New name under which the schema will be published. If this is not provided, the development schema is considered.</p>",
-        "UpdateSchemaRequest$Name": "<p>Name of the schema.</p>"
+        "PublishSchemaRequest$Name": "<p>The new name under which the schema will be published. If this is not provided, the development schema is considered.</p>",
+        "UpdateSchemaRequest$Name": "<p>The name of the schema.</p>"
       }
     },
     "SelectorObjectReference": {
       "base": null,
       "refs": {
-        "ObjectReference$Selector": "<p>Allows you to specify an object. You can identify an object in one of the following ways:</p> <ul> <li> <p> <i>$ObjectIdentifier</i> - Identifies the object by <code>ObjectIdentifier</code> </p> </li> <li> <p> <i>/some/path</i> - Identifies the object based on path</p> </li> <li> <p> <i>#SomeBatchReference</i> - Identifies the object in a batch call</p> </li> </ul>"
+        "ObjectReference$Selector": "<p>A path selector supports easy selection of an object by the parent/child links leading to it from the directory root. Use the link names from each parent/child link to construct the path. Path selectors start with a slash (/) and link names are separated by slashes. For more information about paths, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#accessingobjects\">Accessing Objects</a>. You can identify an object in one of the following ways:</p> <ul> <li> <p> <i>$ObjectIdentifier</i> - An object identifier is an opaque string provided by Amazon Cloud Directory. When creating objects, the system will provide you with the identifier of the created object. An object’s identifier is immutable and no two objects will ever share the same object identifier</p> </li> <li> <p> <i>/some/path</i> - Identifies the object based on path</p> </li> <li> <p> <i>#SomeBatchReference</i> - Identifies the object in a batch call</p> </li> </ul>"
       }
     },
     "StillContainsLinksException": {
@@ -1526,7 +1681,7 @@
       }
     },
     "Tag": {
-      "base": "<p>Tag structure which contains tag key and value.</p>",
+      "base": "<p>The tag structure that contains a tag key and value.</p>",
       "refs": {
         "TagList$member": null
       }
@@ -1534,21 +1689,21 @@
     "TagKey": {
       "base": null,
       "refs": {
-        "Tag$Key": "<p>Key associated with the tag.</p>",
+        "Tag$Key": "<p>The key that is associated with the tag.</p>",
         "TagKeyList$member": null
       }
     },
     "TagKeyList": {
       "base": null,
       "refs": {
-        "UntagResourceRequest$TagKeys": "<p>Keys of the tag that needs to be removed from the resource.</p>"
+        "UntagResourceRequest$TagKeys": "<p>Keys of the tag that need to be removed from the resource.</p>"
       }
     },
     "TagList": {
       "base": null,
       "refs": {
-        "ListTagsForResourceResponse$Tags": "<p>List of tag key value pairs associated with the response.</p>",
-        "TagResourceRequest$Tags": "<p>List of tag key value pairs.</p>"
+        "ListTagsForResourceResponse$Tags": "<p>A list of tag key value pairs that are associated with the response.</p>",
+        "TagResourceRequest$Tags": "<p>A list of tag key-value pairs.</p>"
       }
     },
     "TagResourceRequest": {
@@ -1564,33 +1719,123 @@
     "TagValue": {
       "base": null,
       "refs": {
-        "Tag$Value": "<p>Value associated with the tag.</p>"
+        "Tag$Value": "<p>The value that is associated with the tag.</p>"
       }
     },
     "TagsNumberResults": {
       "base": null,
       "refs": {
-        "ListTagsForResourceRequest$MaxResults": "<p>The MaxResults parameter sets the maximum number of results returned in a single page. This is for future use and is not supported currently.</p>"
+        "ListTagsForResourceRequest$MaxResults": "<p>The <code>MaxResults</code> parameter sets the maximum number of results returned in a single page. This is for future use and is not supported currently.</p>"
       }
     },
     "TypedAttributeValue": {
       "base": "<p>Represents the data for a typed attribute. You can set one, and only one, of the elements. Each attribute in an item is a name-value pair. Attributes have a single value.</p>",
       "refs": {
         "AttributeKeyAndValue$Value": "<p>The value of the attribute.</p>",
+        "AttributeNameAndValue$Value": "<p>The value for the typed link.</p>",
         "FacetAttributeDefinition$DefaultValue": "<p>The default value of the attribute (if configured).</p>",
         "ObjectAttributeAction$ObjectAttributeUpdateValue": "<p>The value that you want to update to.</p>",
         "TypedAttributeValueRange$StartValue": "<p>The value to start the range at.</p>",
-        "TypedAttributeValueRange$EndValue": "<p>The attribute value to terminate the range at.</p>"
+        "TypedAttributeValueRange$EndValue": "<p>The attribute value to terminate the range at.</p>",
+        "TypedLinkAttributeDefinition$DefaultValue": "<p>The default value of the attribute (if configured).</p>"
       }
     },
     "TypedAttributeValueRange": {
       "base": "<p>A range of attribute values.</p>",
       "refs": {
-        "ObjectAttributeRange$Range": "<p>The range of attribute values being selected.</p>"
+        "ObjectAttributeRange$Range": "<p>The range of attribute values being selected.</p>",
+        "TypedLinkAttributeRange$Range": "<p>The range of attribute values that are being selected.</p>"
+      }
+    },
+    "TypedLinkAttributeDefinition": {
+      "base": "<p>A typed link attribute definition.</p>",
+      "refs": {
+        "TypedLinkAttributeDefinitionList$member": null,
+        "TypedLinkFacetAttributeUpdate$Attribute": "<p>The attribute to update.</p>"
+      }
+    },
+    "TypedLinkAttributeDefinitionList": {
+      "base": null,
+      "refs": {
+        "ListTypedLinkFacetAttributesResponse$Attributes": "<p>An ordered set of attributes associate with the typed link.</p>",
+        "TypedLinkFacet$Attributes": "<p>An ordered set of attributes that are associate with the typed link. You can use typed link attributes when you need to represent the relationship between two objects or allow for quick filtering of incoming or outgoing typed links.</p>"
+      }
+    },
+    "TypedLinkAttributeRange": {
+      "base": "<p>Identifies the range of attributes that are used by a specified filter.</p>",
+      "refs": {
+        "TypedLinkAttributeRangeList$member": null
+      }
+    },
+    "TypedLinkAttributeRangeList": {
+      "base": null,
+      "refs": {
+        "ListIncomingTypedLinksRequest$FilterAttributeRanges": "<p>Provides range filters for multiple attributes. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range.</p>",
+        "ListOutgoingTypedLinksRequest$FilterAttributeRanges": "<p>Provides range filters for multiple attributes. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range.</p>"
+      }
+    },
+    "TypedLinkFacet": {
+      "base": "<p>Defines the typed links structure and its attributes. To create a typed link facet, use the <a>CreateTypedLinkFacet</a> API.</p>",
+      "refs": {
+        "CreateTypedLinkFacetRequest$Facet": "<p> <a>Facet</a> structure that is associated with the typed link facet.</p>"
+      }
+    },
+    "TypedLinkFacetAttributeUpdate": {
+      "base": "<p>A typed link facet attribute update.</p>",
+      "refs": {
+        "TypedLinkFacetAttributeUpdateList$member": null
+      }
+    },
+    "TypedLinkFacetAttributeUpdateList": {
+      "base": null,
+      "refs": {
+        "UpdateTypedLinkFacetRequest$AttributeUpdates": "<p>Attributes update structure.</p>"
+      }
+    },
+    "TypedLinkName": {
+      "base": null,
+      "refs": {
+        "DeleteTypedLinkFacetRequest$Name": "<p>The unique name of the typed link facet.</p>",
+        "GetTypedLinkFacetInformationRequest$Name": "<p>The unique name of the typed link facet.</p>",
+        "ListTypedLinkFacetAttributesRequest$Name": "<p>The unique name of the typed link facet.</p>",
+        "TypedLinkFacet$Name": "<p>The unique name of the typed link facet.</p>",
+        "TypedLinkNameList$member": null,
+        "TypedLinkSchemaAndFacetName$TypedLinkName": "<p>The unique name of the typed link facet.</p>",
+        "UpdateTypedLinkFacetRequest$Name": "<p>The unique name of the typed link facet.</p>"
+      }
+    },
+    "TypedLinkNameList": {
+      "base": null,
+      "refs": {
+        "ListTypedLinkFacetNamesResponse$FacetNames": "<p>The names of typed link facets that exist within the schema.</p>"
+      }
+    },
+    "TypedLinkSchemaAndFacetName": {
+      "base": "<p>Identifies the schema Amazon Resource Name (ARN) and facet name for the typed link.</p>",
+      "refs": {
+        "AttachTypedLinkRequest$TypedLinkFacet": "<p>Identifies the typed link facet that is associated with the typed link.</p>",
+        "ListIncomingTypedLinksRequest$FilterTypedLink": "<p>Filters are interpreted in the order of the attributes on the typed link facet, not the order in which they are supplied to any API calls.</p>",
+        "ListOutgoingTypedLinksRequest$FilterTypedLink": "<p>Filters are interpreted in the order of the attributes defined on the typed link facet, not the order they are supplied to any API calls.</p>",
+        "TypedLinkSpecifier$TypedLinkFacet": "<p>Identifies the typed link facet that is associated with the typed link.</p>"
+      }
+    },
+    "TypedLinkSpecifier": {
+      "base": "<p>Contains all the information that is used to uniquely identify a typed link. The parameters discussed in this topic are used to uniquely specify the typed link being operated on. The <a>AttachTypedLink</a> API returns a typed link specifier while the <a>DetachTypedLink</a> API accepts one as input. Similarly, the <a>ListIncomingTypedLinks</a> and <a>ListOutgoingTypedLinks</a> API operations provide typed link specifiers as output. You can also construct a typed link specifier from scratch.</p>",
+      "refs": {
+        "AttachTypedLinkResponse$TypedLinkSpecifier": "<p>Returns a typed link specifier as output.</p>",
+        "DetachTypedLinkRequest$TypedLinkSpecifier": "<p>Used to accept a typed link specifier as input.</p>",
+        "TypedLinkSpecifierList$member": null
+      }
+    },
+    "TypedLinkSpecifierList": {
+      "base": null,
+      "refs": {
+        "ListIncomingTypedLinksResponse$LinkSpecifiers": "<p>Returns a typed link specifier as output.</p>",
+        "ListOutgoingTypedLinksResponse$TypedLinkSpecifiers": "<p>Returns a typed link specifier as output.</p>"
       }
     },
     "UnsupportedIndexTypeException": {
-      "base": "<p>Indicates the requested index type is not supported.</p>",
+      "base": "<p>Indicates that the requested index type is not supported.</p>",
       "refs": {
       }
     },
@@ -1608,7 +1853,8 @@
       "base": null,
       "refs": {
         "FacetAttributeUpdate$Action": "<p>The action to perform when updating the attribute.</p>",
-        "ObjectAttributeAction$ObjectAttributeActionType": "<p>Type can be either Update or Delete.</p>"
+        "ObjectAttributeAction$ObjectAttributeActionType": "<p>A type that can be either <code>Update</code> or <code>Delete</code>.</p>",
+        "TypedLinkFacetAttributeUpdate$Action": "<p>The action to perform when updating the attribute.</p>"
       }
     },
     "UpdateFacetRequest": {
@@ -1641,15 +1887,25 @@
       "refs": {
       }
     },
+    "UpdateTypedLinkFacetRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "UpdateTypedLinkFacetResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "ValidationException": {
-      "base": "<p>Indicates your request is malformed in some manner. See the exception message.</p>",
+      "base": "<p>Indicates that your request is malformed in some manner. See the exception message.</p>",
       "refs": {
       }
     },
     "Version": {
       "base": null,
       "refs": {
-        "PublishSchemaRequest$Version": "<p>Version under which the schema will be published.</p>"
+        "PublishSchemaRequest$Version": "<p>The version under which the schema will be published.</p>"
       }
     }
   }

--- a/models/apis/clouddirectory/2016-05-10/paginators-1.json
+++ b/models/apis/clouddirectory/2016-05-10/paginators-1.json
@@ -75,6 +75,16 @@
       "output_token": "NextToken",
       "limit_key": "MaxResults"
     },
+    "ListTypedLinkFacetAttributes": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "ListTypedLinkFacetNames": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
     "LookupPolicy": {
       "input_token": "NextToken",
       "output_token": "NextToken",

--- a/models/apis/s3/2006-03-01/examples-1.json
+++ b/models/apis/s3/2006-03-01/examples-1.json
@@ -1,5 +1,1876 @@
 {
   "version": "1.0",
   "examples": {
+    "AbortMultipartUpload": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "bigobject",
+          "UploadId": "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP3WA60CEg--"
+        },
+        "output": {
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example aborts a multipart upload.",
+        "id": "to-abort-a-multipart-upload-1481853354987",
+        "title": "To abort a multipart upload"
+      }
+    ],
+    "CompleteMultipartUpload": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "bigobject",
+          "MultipartUpload": {
+            "Parts": [
+              {
+                "ETag": "\"d8c2eafd90c266e19ab9dcacc479f8af\"",
+                "PartNumber": "1"
+              },
+              {
+                "ETag": "\"d8c2eafd90c266e19ab9dcacc479f8af\"",
+                "PartNumber": "2"
+              }
+            ]
+          },
+          "UploadId": "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP3WA60CEg--"
+        },
+        "output": {
+          "Bucket": "acexamplebucket",
+          "ETag": "\"4d9031c7644d8081c2829f4ea23c55f7-2\"",
+          "Key": "bigobject",
+          "Location": "https://examplebucket.s3.amazonaws.com/bigobject"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example completes a multipart upload.",
+        "id": "to-complete-multipart-upload-1481851590483",
+        "title": "To complete multipart upload"
+      }
+    ],
+    "CopyObject": [
+      {
+        "input": {
+          "Bucket": "destinationbucket",
+          "CopySource": "/sourcebucket/HappyFacejpg",
+          "Key": "HappyFaceCopyjpg"
+        },
+        "output": {
+          "CopyObjectResult": {
+            "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+            "LastModified": "2016-12-15T17:38:53.000Z"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example copies an object from one bucket to another.",
+        "id": "to-copy-an-object-1481823186878",
+        "title": "To copy an object"
+      }
+    ],
+    "CreateBucket": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "CreateBucketConfiguration": {
+            "LocationConstraint": "eu-west-1"
+          }
+        },
+        "output": {
+          "Location": "http://examplebucket.s3.amazonaws.com/"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example creates a bucket. The request specifies an AWS region where to create the bucket.",
+        "id": "to-create-a-bucket-in-a-specific-region-1483399072992",
+        "title": "To create a bucket in a specific region"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "Location": "/examplebucket"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example creates a bucket.",
+        "id": "to-create-a-bucket--1472851826060",
+        "title": "To create a bucket "
+      }
+    ],
+    "CreateMultipartUpload": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "largeobject"
+        },
+        "output": {
+          "Bucket": "examplebucket",
+          "Key": "largeobject",
+          "UploadId": "ibZBv_75gd9r8lH_gqXatLdxMVpAlj6ZQjEs.OwyF3953YdwbcQnMA2BLGn8Lx12fQNICtMw5KyteFeHw.Sjng--"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example initiates a multipart upload.",
+        "id": "to-initiate-a-multipart-upload-1481836794513",
+        "title": "To initiate a multipart upload"
+      }
+    ],
+    "DeleteBucket": [
+      {
+        "input": {
+          "Bucket": "forrandall2"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes the specified bucket.",
+        "id": "to-delete-a-bucket-1473108514262",
+        "title": "To delete a bucket"
+      }
+    ],
+    "DeleteBucketCors": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes CORS configuration on a bucket.",
+        "id": "to-delete-cors-configuration-on-a-bucket-1483042856112",
+        "title": "To delete cors configuration on a bucket."
+      }
+    ],
+    "DeleteBucketLifecycle": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes lifecycle configuration on a bucket.",
+        "id": "to-delete-lifecycle-configuration-on-a-bucket-1483043310583",
+        "title": "To delete lifecycle configuration on a bucket."
+      }
+    ],
+    "DeleteBucketPolicy": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes bucket policy on the specified bucket.",
+        "id": "to-delete-bucket-policy-1483043406577",
+        "title": "To delete bucket policy"
+      }
+    ],
+    "DeleteBucketReplication": [
+      {
+        "input": {
+          "Bucket": "example"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes replication configuration set on bucket.",
+        "id": "to-delete-bucket-replication-configuration-1483043684668",
+        "title": "To delete bucket replication configuration"
+      }
+    ],
+    "DeleteBucketTagging": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes bucket tags.",
+        "id": "to-delete-bucket-tags-1483043846509",
+        "title": "To delete bucket tags"
+      }
+    ],
+    "DeleteBucketWebsite": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes bucket website configuration.",
+        "id": "to-delete-bucket-website-configuration-1483043937825",
+        "title": "To delete bucket website configuration"
+      }
+    ],
+    "DeleteObject": [
+      {
+        "input": {
+          "Bucket": "ExampleBucket",
+          "Key": "HappyFace.jpg"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes an object from a non-versioned bucket.",
+        "id": "to-delete-an-object-from-a-non-versioned-bucket-1481588533089",
+        "title": "To delete an object (from a non-versioned bucket)"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "objectkey.jpg"
+        },
+        "output": {
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes an object from an S3 bucket.",
+        "id": "to-delete-an-object-1472850136595",
+        "title": "To delete an object"
+      }
+    ],
+    "DeleteObjectTagging": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg",
+          "VersionId": "ydlaNkwWm0SfKJR.T1b1fIdPRbldTYRI"
+        },
+        "output": {
+          "VersionId": "ydlaNkwWm0SfKJR.T1b1fIdPRbldTYRI"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example removes tag set associated with the specified object version. The request specifies both the object key and object version.",
+        "id": "to-remove-tag-set-from-an-object-version-1483145285913",
+        "title": "To remove tag set from an object version"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg"
+        },
+        "output": {
+          "VersionId": "null"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example removes tag set associated with the specified object. If the bucket is versioning enabled, the operation removes tag set from the latest object version.",
+        "id": "to-remove-tag-set-from-an-object-1483145342862",
+        "title": "To remove tag set from an object"
+      }
+    ],
+    "DeleteObjects": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Delete": {
+            "Objects": [
+              {
+                "Key": "HappyFace.jpg",
+                "VersionId": "2LWg7lQLnY41.maGB5Z6SWW.dcq0vx7b"
+              },
+              {
+                "Key": "HappyFace.jpg",
+                "VersionId": "yoz3HB.ZhCS_tKVEmIOr7qYyyAaZSKVd"
+              }
+            ],
+            "Quiet": false
+          }
+        },
+        "output": {
+          "Deleted": [
+            {
+              "Key": "HappyFace.jpg",
+              "VersionId": "yoz3HB.ZhCS_tKVEmIOr7qYyyAaZSKVd"
+            },
+            {
+              "Key": "HappyFace.jpg",
+              "VersionId": "2LWg7lQLnY41.maGB5Z6SWW.dcq0vx7b"
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes objects from a bucket. The request specifies object versions. S3 deletes specific object versions and returns the key and versions of deleted objects in the response.",
+        "id": "to-delete-multiple-object-versions-from-a-versioned-bucket-1483147087737",
+        "title": "To delete multiple object versions from a versioned bucket"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Delete": {
+            "Objects": [
+              {
+                "Key": "objectkey1"
+              },
+              {
+                "Key": "objectkey2"
+              }
+            ],
+            "Quiet": false
+          }
+        },
+        "output": {
+          "Deleted": [
+            {
+              "DeleteMarker": "true",
+              "DeleteMarkerVersionId": "A._w1z6EFiCF5uhtQMDal9JDkID9tQ7F",
+              "Key": "objectkey1"
+            },
+            {
+              "DeleteMarker": "true",
+              "DeleteMarkerVersionId": "iOd_ORxhkKe_e8G8_oSGxt2PjsCZKlkt",
+              "Key": "objectkey2"
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example deletes objects from a bucket. The bucket is versioned, and the request does not specify the object version to delete. In this case, all versions remain in the bucket and S3 adds a delete marker.",
+        "id": "to-delete-multiple-objects-from-a-versioned-bucket-1483146248805",
+        "title": "To delete multiple objects from a versioned bucket"
+      }
+    ],
+    "GetBucketCors": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "CORSRules": [
+            {
+              "AllowedHeaders": [
+                "Authorization"
+              ],
+              "AllowedMethods": [
+                "GET"
+              ],
+              "AllowedOrigins": [
+                "*"
+              ],
+              "MaxAgeSeconds": 3000
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example returns cross-origin resource sharing (CORS) configuration set on a bucket.",
+        "id": "to-get-cors-configuration-set-on-a-bucket-1481596855475",
+        "title": "To get cors configuration set on a bucket"
+      }
+    ],
+    "GetBucketLifecycle": [
+      {
+        "input": {
+          "Bucket": "acl1"
+        },
+        "output": {
+          "Rules": [
+            {
+              "Expiration": {
+                "Days": 1
+              },
+              "ID": "delete logs",
+              "Prefix": "123/",
+              "Status": "Enabled"
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example gets ACL on the specified bucket.",
+        "id": "to-get-a-bucket-acl-1474413606503",
+        "title": "To get a bucket acl"
+      }
+    ],
+    "GetBucketLifecycleConfiguration": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "Rules": [
+            {
+              "ID": "Rule for TaxDocs/",
+              "Prefix": "TaxDocs",
+              "Status": "Enabled",
+              "Transitions": [
+                {
+                  "Days": 365,
+                  "StorageClass": "STANDARD_IA"
+                }
+              ]
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves lifecycle configuration on set on a bucket. ",
+        "id": "to-get-lifecycle-configuration-on-a-bucket-1481666063200",
+        "title": "To get lifecycle configuration on a bucket"
+      }
+    ],
+    "GetBucketLocation": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "LocationConstraint": "us-west-2"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example returns bucket location.",
+        "id": "to-get-bucket-location-1481594573609",
+        "title": "To get bucket location"
+      }
+    ],
+    "GetBucketNotification": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "QueueConfiguration": {
+            "Event": "s3:ObjectCreated:Put",
+            "Events": [
+              "s3:ObjectCreated:Put"
+            ],
+            "Id": "MDQ2OGQ4NDEtOTBmNi00YTM4LTk0NzYtZDIwN2I3NWQ1NjIx",
+            "Queue": "arn:aws:sqs:us-east-1:acct-id:S3ObjectCreatedEventQueue"
+          },
+          "TopicConfiguration": {
+            "Event": "s3:ObjectCreated:Copy",
+            "Events": [
+              "s3:ObjectCreated:Copy"
+            ],
+            "Id": "YTVkMWEzZGUtNTY1NS00ZmE2LWJjYjktMmRlY2QwODFkNTJi",
+            "Topic": "arn:aws:sns:us-east-1:acct-id:S3ObjectCreatedEventTopic"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example returns notification configuration set on a bucket.",
+        "id": "to-get-notification-configuration-set-on-a-bucket-1481594028667",
+        "title": "To get notification configuration set on a bucket"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "QueueConfiguration": {
+            "Event": "s3:ObjectCreated:Put",
+            "Events": [
+              "s3:ObjectCreated:Put"
+            ],
+            "Id": "MDQ2OGQ4NDEtOTBmNi00YTM4LTk0NzYtZDIwN2I3NWQ1NjIx",
+            "Queue": "arn:aws:sqs:us-east-1:acct-id:S3ObjectCreatedEventQueue"
+          },
+          "TopicConfiguration": {
+            "Event": "s3:ObjectCreated:Copy",
+            "Events": [
+              "s3:ObjectCreated:Copy"
+            ],
+            "Id": "YTVkMWEzZGUtNTY1NS00ZmE2LWJjYjktMmRlY2QwODFkNTJi",
+            "Topic": "arn:aws:sns:us-east-1:acct-id:S3ObjectCreatedEventTopic"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example returns notification configuration set on a bucket.",
+        "id": "to-get-notification-configuration-set-on-a-bucket-1481594028667",
+        "title": "To get notification configuration set on a bucket"
+      }
+    ],
+    "GetBucketPolicy": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"LogPolicy\",\"Statement\":[{\"Sid\":\"Enables the log delivery group to publish logs to your bucket \",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"111122223333\"},\"Action\":[\"s3:GetBucketAcl\",\"s3:GetObjectAcl\",\"s3:PutObject\"],\"Resource\":[\"arn:aws:s3:::policytest1/*\",\"arn:aws:s3:::policytest1\"]}]}"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example returns bucket policy associated with a bucket.",
+        "id": "to-get-bucket-policy-1481595098424",
+        "title": "To get bucket policy"
+      }
+    ],
+    "GetBucketReplication": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "ReplicationConfiguration": {
+            "Role": "arn:aws:iam::acct-id:role/example-role",
+            "Rules": [
+              {
+                "Destination": {
+                  "Bucket": "arn:aws:s3:::destination-bucket"
+                },
+                "ID": "MWIwNTkwZmItMTE3MS00ZTc3LWJkZDEtNzRmODQwYzc1OTQy",
+                "Prefix": "Tax",
+                "Status": "Enabled"
+              }
+            ]
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example returns replication configuration set on a bucket.",
+        "id": "to-get-replication-configuration-set-on-a-bucket-1481593597175",
+        "title": "To get replication configuration set on a bucket"
+      }
+    ],
+    "GetBucketRequestPayment": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "Payer": "BucketOwner"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves bucket versioning configuration.",
+        "id": "to-get-bucket-versioning-configuration-1483037183929",
+        "title": "To get bucket versioning configuration"
+      }
+    ],
+    "GetBucketTagging": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "TagSet": [
+            {
+              "Key": "key1",
+              "Value": "value1"
+            },
+            {
+              "Key": "key2",
+              "Value": "value2"
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example returns tag set associated with a bucket",
+        "id": "to-get-tag-set-associated-with-a-bucket-1481593232107",
+        "title": "To get tag set associated with a bucket"
+      }
+    ],
+    "GetBucketVersioning": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "MFADelete": "Disabled",
+          "Status": "Enabled"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves bucket versioning configuration.",
+        "id": "to-get-bucket-versioning-configuration-1483037183929",
+        "title": "To get bucket versioning configuration"
+      }
+    ],
+    "GetBucketWebsite": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "ErrorDocument": {
+            "Key": "error.html"
+          },
+          "IndexDocument": {
+            "Suffix": "index.html"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves website configuration of a bucket.",
+        "id": "to-get-bucket-website-configuration-1483037016926",
+        "title": "To get bucket website configuration"
+      }
+    ],
+    "GetObject": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg"
+        },
+        "output": {
+          "AcceptRanges": "bytes",
+          "ContentLength": "3191",
+          "ContentType": "image/jpeg",
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "LastModified": "Thu, 15 Dec 2016 01:19:41 GMT",
+          "Metadata": {
+          },
+          "TagCount": 2,
+          "VersionId": "null"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves an object for an S3 bucket.",
+        "id": "to-retrieve-an-object-1481827837012",
+        "title": "To retrieve an object"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "SampleFile.txt",
+          "Range": "bytes=0-9"
+        },
+        "output": {
+          "AcceptRanges": "bytes",
+          "ContentLength": "10",
+          "ContentRange": "bytes 0-9/43",
+          "ContentType": "text/plain",
+          "ETag": "\"0d94420ffd0bc68cd3d152506b97a9cc\"",
+          "LastModified": "Thu, 09 Oct 2014 22:57:28 GMT",
+          "Metadata": {
+          },
+          "VersionId": "null"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves an object for an S3 bucket. The request specifies the range header to retrieve a specific byte range.",
+        "id": "to-retrieve-a-byte-range-of-an-object--1481832674603",
+        "title": "To retrieve a byte range of an object "
+      }
+    ],
+    "GetObjectAcl": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg"
+        },
+        "output": {
+          "Grants": [
+            {
+              "Grantee": {
+                "DisplayName": "owner-display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc",
+                "Type": "CanonicalUser"
+              },
+              "Permission": "WRITE"
+            },
+            {
+              "Grantee": {
+                "DisplayName": "owner-display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc",
+                "Type": "CanonicalUser"
+              },
+              "Permission": "WRITE_ACP"
+            },
+            {
+              "Grantee": {
+                "DisplayName": "owner-display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc",
+                "Type": "CanonicalUser"
+              },
+              "Permission": "READ"
+            },
+            {
+              "Grantee": {
+                "DisplayName": "owner-display-name",
+                "ID": "852b113eexamplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc",
+                "Type": "CanonicalUser"
+              },
+              "Permission": "READ_ACP"
+            }
+          ],
+          "Owner": {
+            "DisplayName": "owner-display-name",
+            "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves access control list (ACL) of an object.",
+        "id": "to-retrieve-object-acl-1481833557740",
+        "title": "To retrieve object ACL"
+      }
+    ],
+    "GetObjectTagging": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg"
+        },
+        "output": {
+          "TagSet": [
+            {
+              "Key": "Key4",
+              "Value": "Value4"
+            },
+            {
+              "Key": "Key3",
+              "Value": "Value3"
+            }
+          ],
+          "VersionId": "null"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves tag set of an object.",
+        "id": "to-retrieve-tag-set-of-an-object-1481833847896",
+        "title": "To retrieve tag set of an object"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "exampleobject",
+          "VersionId": "ydlaNkwWm0SfKJR.T1b1fIdPRbldTYRI"
+        },
+        "output": {
+          "TagSet": [
+            {
+              "Key": "Key1",
+              "Value": "Value1"
+            }
+          ],
+          "VersionId": "ydlaNkwWm0SfKJR.T1b1fIdPRbldTYRI"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves tag set of an object. The request specifies object version.",
+        "id": "to-retrieve-tag-set-of-a-specific-object-version-1483400283663",
+        "title": "To retrieve tag set of a specific object version"
+      }
+    ],
+    "GetObjectTorrent": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg"
+        },
+        "output": {
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves torrent files of an object.",
+        "id": "to-retrieve-torrent-files-for-an-object-1481834115959",
+        "title": "To retrieve torrent files for an object"
+      }
+    ],
+    "HeadBucket": [
+      {
+        "input": {
+          "Bucket": "acl1"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "This operation checks to see if a bucket exists.",
+        "id": "to-determine-if-bucket-exists-1473110292262",
+        "title": "To determine if bucket exists"
+      }
+    ],
+    "HeadObject": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg"
+        },
+        "output": {
+          "AcceptRanges": "bytes",
+          "ContentLength": "3191",
+          "ContentType": "image/jpeg",
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "LastModified": "Thu, 15 Dec 2016 01:19:41 GMT",
+          "Metadata": {
+          },
+          "VersionId": "null"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves an object metadata.",
+        "id": "to-retrieve-metadata-of-an-object-without-returning-the-object-itself-1481834820480",
+        "title": "To retrieve metadata of an object without returning the object itself"
+      }
+    ],
+    "ListBuckets": [
+      {
+        "output": {
+          "Buckets": [
+            {
+              "CreationDate": "2012-02-15T21: 03: 02.000Z",
+              "Name": "examplebucket"
+            },
+            {
+              "CreationDate": "2011-07-24T19: 33: 50.000Z",
+              "Name": "examplebucket2"
+            },
+            {
+              "CreationDate": "2010-12-17T00: 56: 49.000Z",
+              "Name": "examplebucket3"
+            }
+          ],
+          "Owner": {
+            "DisplayName": "own-display-name",
+            "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example return versions of an object with specific key name prefix. The request limits the number of items returned to two. If there are are more than two object version, S3 returns NextToken in the response. You can specify this token value in your next request to fetch next set of object versions.",
+        "id": "to-list-object-versions-1481910996058",
+        "title": "To list object versions"
+      }
+    ],
+    "ListMultipartUploads": [
+      {
+        "input": {
+          "Bucket": "examplebucket"
+        },
+        "output": {
+          "Uploads": [
+            {
+              "Initiated": "2014-05-01T05:40:58.000Z",
+              "Initiator": {
+                "DisplayName": "display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "Key": "JavaFile",
+              "Owner": {
+                "DisplayName": "display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "StorageClass": "STANDARD",
+              "UploadId": "examplelUa.CInXklLQtSMJITdUnoZ1Y5GACB5UckOtspm5zbDMCkPF_qkfZzMiFZ6dksmcnqxJyIBvQMG9X9Q--"
+            },
+            {
+              "Initiated": "2014-05-01T05:41:27.000Z",
+              "Initiator": {
+                "DisplayName": "display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "Key": "JavaFile",
+              "Owner": {
+                "DisplayName": "display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "StorageClass": "STANDARD",
+              "UploadId": "examplelo91lv1iwvWpvCiJWugw2xXLPAD7Z8cJyX9.WiIRgNrdG6Ldsn.9FtS63TCl1Uf5faTB.1U5Ckcbmdw--"
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example lists in-progress multipart uploads on a specific bucket.",
+        "id": "to-list-in-progress-multipart-uploads-on-a-bucket-1481852775260",
+        "title": "To list in-progress multipart uploads on a bucket"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "KeyMarker": "nextkeyfrompreviousresponse",
+          "MaxUploads": "2",
+          "UploadIdMarker": "valuefrompreviousresponse"
+        },
+        "output": {
+          "Bucket": "acl1",
+          "IsTruncated": true,
+          "KeyMarker": "",
+          "MaxUploads": "2",
+          "NextKeyMarker": "someobjectkey",
+          "NextUploadIdMarker": "examplelo91lv1iwvWpvCiJWugw2xXLPAD7Z8cJyX9.WiIRgNrdG6Ldsn.9FtS63TCl1Uf5faTB.1U5Ckcbmdw--",
+          "UploadIdMarker": "",
+          "Uploads": [
+            {
+              "Initiated": "2014-05-01T05:40:58.000Z",
+              "Initiator": {
+                "DisplayName": "ownder-display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "Key": "JavaFile",
+              "Owner": {
+                "DisplayName": "mohanataws",
+                "ID": "852b113e7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "StorageClass": "STANDARD",
+              "UploadId": "gZ30jIqlUa.CInXklLQtSMJITdUnoZ1Y5GACB5UckOtspm5zbDMCkPF_qkfZzMiFZ6dksmcnqxJyIBvQMG9X9Q--"
+            },
+            {
+              "Initiated": "2014-05-01T05:41:27.000Z",
+              "Initiator": {
+                "DisplayName": "ownder-display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "Key": "JavaFile",
+              "Owner": {
+                "DisplayName": "ownder-display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "StorageClass": "STANDARD",
+              "UploadId": "b7tZSqIlo91lv1iwvWpvCiJWugw2xXLPAD7Z8cJyX9.WiIRgNrdG6Ldsn.9FtS63TCl1Uf5faTB.1U5Ckcbmdw--"
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example specifies the upload-id-marker and key-marker from previous truncated response to retrieve next setup of multipart uploads.",
+        "id": "list-next-set-of-multipart-uploads-when-previous-result-is-truncated-1482428106748",
+        "title": "List next set of multipart uploads when previous result is truncated"
+      }
+    ],
+    "ListObjectVersions": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Prefix": "HappyFace.jpg"
+        },
+        "output": {
+          "Versions": [
+            {
+              "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+              "IsLatest": true,
+              "Key": "HappyFace.jpg",
+              "LastModified": "2016-12-15T01:19:41.000Z",
+              "Owner": {
+                "DisplayName": "owner-display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "Size": 3191,
+              "StorageClass": "STANDARD",
+              "VersionId": "null"
+            },
+            {
+              "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+              "IsLatest": false,
+              "Key": "HappyFace.jpg",
+              "LastModified": "2016-12-13T00:58:26.000Z",
+              "Owner": {
+                "DisplayName": "owner-display-name",
+                "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "Size": 3191,
+              "StorageClass": "STANDARD",
+              "VersionId": "PHtexPGjH2y.zBgT8LmB7wwLI2mpbz.k"
+            }
+          ]
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example return versions of an object with specific key name prefix. The request limits the number of items returned to two. If there are are more than two object version, S3 returns NextToken in the response. You can specify this token value in your next request to fetch next set of object versions.",
+        "id": "to-list-object-versions-1481910996058",
+        "title": "To list object versions"
+      }
+    ],
+    "ListObjects": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "MaxKeys": "2"
+        },
+        "output": {
+          "Contents": [
+            {
+              "ETag": "\"70ee1738b6b21e2c8a43f3a5ab0eee71\"",
+              "Key": "example1.jpg",
+              "LastModified": "2014-11-21T19:40:05.000Z",
+              "Owner": {
+                "DisplayName": "myname",
+                "ID": "12345example25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "Size": 11,
+              "StorageClass": "STANDARD"
+            },
+            {
+              "ETag": "\"9c8af9a76df052144598c115ef33e511\"",
+              "Key": "example2.jpg",
+              "LastModified": "2013-11-15T01:10:49.000Z",
+              "Owner": {
+                "DisplayName": "myname",
+                "ID": "12345example25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+              },
+              "Size": 713193,
+              "StorageClass": "STANDARD"
+            }
+          ],
+          "NextMarker": "eyJNYXJrZXIiOiBudWxsLCAiYm90b190cnVuY2F0ZV9hbW91bnQiOiAyfQ=="
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example list two objects in a bucket.",
+        "id": "to-list-objects-in-a-bucket-1473447646507",
+        "title": "To list objects in a bucket"
+      }
+    ],
+    "ListObjectsV2": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "MaxKeys": "2"
+        },
+        "output": {
+          "Contents": [
+            {
+              "ETag": "\"70ee1738b6b21e2c8a43f3a5ab0eee71\"",
+              "Key": "happyface.jpg",
+              "LastModified": "2014-11-21T19:40:05.000Z",
+              "Size": 11,
+              "StorageClass": "STANDARD"
+            },
+            {
+              "ETag": "\"becf17f89c30367a9a44495d62ed521a-1\"",
+              "Key": "test.jpg",
+              "LastModified": "2014-05-02T04:51:50.000Z",
+              "Size": 4192256,
+              "StorageClass": "STANDARD"
+            }
+          ],
+          "IsTruncated": true,
+          "KeyCount": "2",
+          "MaxKeys": "2",
+          "Name": "examplebucket",
+          "NextContinuationToken": "1w41l63U0xa8q7smH50vCxyTQqdxo69O3EmK28Bi5PcROI4wI/EyIJg==",
+          "Prefix": ""
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example retrieves object list. The request specifies max keys to limit response to include only 2 object keys. ",
+        "id": "to-get-object-list",
+        "title": "To get object list"
+      }
+    ],
+    "ListParts": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "bigobject",
+          "UploadId": "example7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP3WA60CEg--"
+        },
+        "output": {
+          "Initiator": {
+            "DisplayName": "owner-display-name",
+            "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+          },
+          "Owner": {
+            "DisplayName": "owner-display-name",
+            "ID": "examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484be31bebcc"
+          },
+          "Parts": [
+            {
+              "ETag": "\"d8c2eafd90c266e19ab9dcacc479f8af\"",
+              "LastModified": "2016-12-16T00:11:42.000Z",
+              "PartNumber": "1",
+              "Size": 26246026
+            },
+            {
+              "ETag": "\"d8c2eafd90c266e19ab9dcacc479f8af\"",
+              "LastModified": "2016-12-16T00:15:01.000Z",
+              "PartNumber": "2",
+              "Size": 26246026
+            }
+          ],
+          "StorageClass": "STANDARD"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example lists parts uploaded for a specific multipart upload.",
+        "id": "to-list-parts-of-a-multipart-upload-1481852006923",
+        "title": "To list parts of a multipart upload."
+      }
+    ],
+    "PutBucketAcl": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "GrantFullControl": "id=examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484",
+          "GrantWrite": "uri=http://acs.amazonaws.com/groups/s3/LogDelivery"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example replaces existing ACL on a bucket. The ACL grants the bucket owner (specified using the owner ID) and write permission to the LogDelivery group. Because this is a replace operation, you must specify all the grants in your request. To incrementally add or remove ACL grants, you might use the console.",
+        "id": "put-bucket-acl-1482260397033",
+        "title": "Put bucket acl"
+      }
+    ],
+    "PutBucketCors": [
+      {
+        "input": {
+          "Bucket": "",
+          "CORSConfiguration": {
+            "CORSRules": [
+              {
+                "AllowedHeaders": [
+                  "*"
+                ],
+                "AllowedMethods": [
+                  "PUT",
+                  "POST",
+                  "DELETE"
+                ],
+                "AllowedOrigins": [
+                  "http://www.example.com"
+                ],
+                "ExposeHeaders": [
+                  "x-amz-server-side-encryption"
+                ],
+                "MaxAgeSeconds": 3000
+              },
+              {
+                "AllowedHeaders": [
+                  "Authorization"
+                ],
+                "AllowedMethods": [
+                  "GET"
+                ],
+                "AllowedOrigins": [
+                  "*"
+                ],
+                "MaxAgeSeconds": 3000
+              }
+            ]
+          },
+          "ContentMD5": ""
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example enables PUT, POST, and DELETE requests from www.example.com, and enables GET requests from any domain.",
+        "id": "to-set-cors-configuration-on-a-bucket-1483037818805",
+        "title": "To set cors configuration on a bucket."
+      }
+    ],
+    "PutBucketLifecycleConfiguration": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "LifecycleConfiguration": {
+            "Rules": [
+              {
+                "Expiration": {
+                  "Days": 3650
+                },
+                "Filter": {
+                  "Prefix": "documents/"
+                },
+                "ID": "TestOnly",
+                "Status": "Enabled",
+                "Transitions": [
+                  {
+                    "Days": 365,
+                    "StorageClass": "GLACIER"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example replaces existing lifecycle configuration, if any, on the specified bucket. ",
+        "id": "put-bucket-lifecycle-1482264533092",
+        "title": "Put bucket lifecycle"
+      }
+    ],
+    "PutBucketLogging": [
+      {
+        "input": {
+          "Bucket": "sourcebucket",
+          "BucketLoggingStatus": {
+            "LoggingEnabled": {
+              "TargetBucket": "targetbucket",
+              "TargetGrants": [
+                {
+                  "Grantee": {
+                    "Type": "Group",
+                    "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
+                  },
+                  "Permission": "READ"
+                }
+              ],
+              "TargetPrefix": "MyBucketLogs/"
+            }
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example sets logging policy on a bucket. For the Log Delivery group to deliver logs to the destination bucket, it needs permission for the READ_ACP action which the policy grants.",
+        "id": "set-logging-configuration-for-a-bucket-1482269119909",
+        "title": "Set logging configuration for a bucket"
+      }
+    ],
+    "PutBucketNotificationConfiguration": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "NotificationConfiguration": {
+            "TopicConfigurations": [
+              {
+                "Events": [
+                  "s3:ObjectCreated:*"
+                ],
+                "TopicArn": "arn:aws:sns:us-west-2:123456789012:s3-notification-topic"
+              }
+            ]
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example sets notification configuration on a bucket to publish the object created events to an SNS topic.",
+        "id": "set-notification-configuration-for-a-bucket-1482270296426",
+        "title": "Set notification configuration for a bucket"
+      }
+    ],
+    "PutBucketPolicy": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Policy": "{\"Version\": \"2012-10-17\", \"Statement\": [{ \"Sid\": \"id-1\",\"Effect\": \"Allow\",\"Principal\": {\"AWS\": \"arn:aws:iam::123456789012:root\"}, \"Action\": [ \"s3:PutObject\",\"s3:PutObjectAcl\"], \"Resource\": [\"arn:aws:s3:::acl3/*\" ] } ]}"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example sets a permission policy on a bucket.",
+        "id": "set-bucket-policy-1482448903302",
+        "title": "Set bucket policy"
+      }
+    ],
+    "PutBucketReplication": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "ReplicationConfiguration": {
+            "Role": "arn:aws:iam::123456789012:role/examplerole",
+            "Rules": [
+              {
+                "Destination": {
+                  "Bucket": "arn:aws:s3:::destinationbucket",
+                  "StorageClass": "STANDARD"
+                },
+                "Prefix": "",
+                "Status": "Enabled"
+              }
+            ]
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example sets replication configuration on a bucket.",
+        "id": "id-1",
+        "title": "Set replication configuration on a bucket"
+      }
+    ],
+    "PutBucketRequestPayment": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "RequestPaymentConfiguration": {
+            "Payer": "Requester"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example sets request payment configuration on a bucket so that person requesting the download is charged.",
+        "id": "set-request-payment-configuration-on-a-bucket-1482343596680",
+        "title": "Set request payment configuration on a bucket."
+      }
+    ],
+    "PutBucketTagging": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Tagging": {
+            "TagSet": [
+              {
+                "Key": "Key1",
+                "Value": "Value1"
+              },
+              {
+                "Key": "Key2",
+                "Value": "Value2"
+              }
+            ]
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example sets tags on a bucket. Any existing tags are replaced.",
+        "id": "set-tags-on-a-bucket-1482346269066",
+        "title": "Set tags on a bucket"
+      }
+    ],
+    "PutBucketVersioning": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "VersioningConfiguration": {
+            "MFADelete": "Disabled",
+            "Status": "Enabled"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example sets versioning configuration on bucket. The configuration enables versioning on the bucket.",
+        "id": "set-versioning-configuration-on-a-bucket-1482344186279",
+        "title": "Set versioning configuration on a bucket"
+      }
+    ],
+    "PutBucketWebsite": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "ContentMD5": "",
+          "WebsiteConfiguration": {
+            "ErrorDocument": {
+              "Key": "error.html"
+            },
+            "IndexDocument": {
+              "Suffix": "index.html"
+            }
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example adds website configuration to a bucket.",
+        "id": "set-website-configuration-on-a-bucket-1482346836261",
+        "title": "Set website configuration on a bucket"
+      }
+    ],
+    "PutObject": [
+      {
+        "input": {
+          "Body": "filetoupload",
+          "Bucket": "examplebucket",
+          "Key": "exampleobject",
+          "ServerSideEncryption": "AES256",
+          "Tagging": "key1=value1&key2=value2"
+        },
+        "output": {
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "ServerSideEncryption": "AES256",
+          "VersionId": "Ri.vC6qVlA4dEnjgRV4ZHsHoFIjqEMNt"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example uploads and object. The request specifies the optional server-side encryption option. The request also specifies optional object tags. If the bucket is versioning enabled, S3 returns version ID in response.",
+        "id": "to-upload-an-object-and-specify-server-side-encryption-and-object-tags-1483398331831",
+        "title": "To upload an object and specify server-side encryption and object tags"
+      },
+      {
+        "input": {
+          "ACL": "authenticated-read",
+          "Body": "filetoupload",
+          "Bucket": "examplebucket",
+          "Key": "exampleobject"
+        },
+        "output": {
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "VersionId": "Kirh.unyZwjQ69YxcQLA8z4F5j3kJJKr"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example uploads and object. The request specifies optional canned ACL (access control list) to all READ access to authenticated users. If the bucket is versioning enabled, S3 returns version ID in response.",
+        "id": "to-upload-an-object-and-specify-canned-acl-1483397779571",
+        "title": "To upload an object and specify canned ACL."
+      },
+      {
+        "input": {
+          "Body": "HappyFace.jpg",
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg"
+        },
+        "output": {
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "VersionId": "tpf3zF08nBplQK1XLOefGskR7mGDwcDk"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example uploads an object to a versioning-enabled bucket. The source file is specified using Windows file syntax. S3 returns VersionId of the newly created object.",
+        "id": "to-upload-an-object-1481760101010",
+        "title": "To upload an object"
+      },
+      {
+        "input": {
+          "Body": "filetoupload",
+          "Bucket": "examplebucket",
+          "Key": "objectkey"
+        },
+        "output": {
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "VersionId": "Bvq0EDKxOcXLJXNo_Lkz37eM3R4pfzyQ"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example creates an object. If the bucket is versioning enabled, S3 returns version ID in response.",
+        "id": "to-create-an-object-1483147613675",
+        "title": "To create an object."
+      },
+      {
+        "input": {
+          "Body": "c:\\HappyFace.jpg",
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg",
+          "Tagging": "key1=value1&key2=value2"
+        },
+        "output": {
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "VersionId": "psM2sYY4.o1501dSx8wMvnkOzSBB.V4a"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example uploads an object. The request specifies optional object tags. The bucket is versioned, therefore S3 returns version ID of the newly created object.",
+        "id": "to-upload-an-object-and-specify-optional-tags-1481762310955",
+        "title": "To upload an object and specify optional tags"
+      },
+      {
+        "input": {
+          "Body": "filetoupload",
+          "Bucket": "examplebucket",
+          "Key": "exampleobject",
+          "Metadata": {
+            "metadata1": "value1",
+            "metadata2": "value2"
+          }
+        },
+        "output": {
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "VersionId": "pSKidl4pHBiNwukdbcPXAIs.sshFFOc0"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example creates an object. The request also specifies optional metadata. If the bucket is versioning enabled, S3 returns version ID in response.",
+        "id": "to-upload-object-and-specify-user-defined-metadata-1483396974757",
+        "title": "To upload object and specify user-defined metadata"
+      },
+      {
+        "input": {
+          "Body": "HappyFace.jpg",
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg",
+          "ServerSideEncryption": "AES256",
+          "StorageClass": "STANDARD_IA"
+        },
+        "output": {
+          "ETag": "\"6805f2cfc46c0f04559748bb039d69ae\"",
+          "ServerSideEncryption": "AES256",
+          "VersionId": "CG612hodqujkf8FaaNfp8U..FIhLROcp"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example uploads an object. The request specifies optional request headers to directs S3 to use specific storage class and use server-side encryption.",
+        "id": "to-upload-an-object-(specify-optional-headers)",
+        "title": "To upload an object (specify optional headers)"
+      }
+    ],
+    "PutObjectAcl": [
+      {
+        "input": {
+          "AccessControlPolicy": {
+          },
+          "Bucket": "examplebucket",
+          "GrantFullControl": "emailaddress=user1@example.com,emailaddress=user2@example.com",
+          "GrantRead": "uri=http://acs.amazonaws.com/groups/global/AllUsers",
+          "Key": "HappyFace.jpg"
+        },
+        "output": {
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example adds grants to an object ACL. The first permission grants user1 and user2 FULL_CONTROL and the AllUsers group READ permission.",
+        "id": "to-grant-permissions-using-object-acl-1481835549285",
+        "title": "To grant permissions using object ACL"
+      }
+    ],
+    "PutObjectTagging": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "HappyFace.jpg",
+          "Tagging": {
+            "TagSet": [
+              {
+                "Key": "Key3",
+                "Value": "Value3"
+              },
+              {
+                "Key": "Key4",
+                "Value": "Value4"
+              }
+            ]
+          }
+        },
+        "output": {
+          "VersionId": "null"
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example adds tags to an existing object.",
+        "id": "to-add-tags-to-an-existing-object-1481764668793",
+        "title": "To add tags to an existing object"
+      }
+    ],
+    "RestoreObject": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "Key": "archivedobjectkey",
+          "RestoreRequest": {
+            "Days": 1,
+            "GlacierJobParameters": {
+              "Tier": "Expedited"
+            }
+          }
+        },
+        "output": {
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example restores for one day an archived copy of an object back into Amazon S3 bucket.",
+        "id": "to-restore-an-archived-object-1483049329953",
+        "title": "To restore an archived object"
+      }
+    ],
+    "UploadPart": [
+      {
+        "input": {
+          "Body": "fileToUpload",
+          "Bucket": "examplebucket",
+          "Key": "examplelargeobject",
+          "PartNumber": "1",
+          "UploadId": "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP3WA60CEg--"
+        },
+        "output": {
+          "ETag": "\"d8c2eafd90c266e19ab9dcacc479f8af\""
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example uploads part 1 of a multipart upload. The example specifies a file name for the part data. The Upload ID is same that is returned by the initiate multipart upload.",
+        "id": "to-upload-a-part-1481847914943",
+        "title": "To upload a part"
+      }
+    ],
+    "UploadPartCopy": [
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "CopySource": "/bucketname/sourceobjectkey",
+          "CopySourceRange": "bytes=1-100000",
+          "Key": "examplelargeobject",
+          "PartNumber": "2",
+          "UploadId": "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI4FI7PkP91We7Nrw--"
+        },
+        "output": {
+          "CopyPartResult": {
+            "ETag": "\"65d16d19e65a7508a51f043180edcc36\"",
+            "LastModified": "2016-12-29T21:44:28.000Z"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example uploads a part of a multipart upload by copying a specified byte range from an existing object as data source.",
+        "id": "to-upload-a-part-by-copying-byte-range-from-an-existing-object-as-data-source-1483048068594",
+        "title": "To upload a part by copying byte range from an existing object as data source"
+      },
+      {
+        "input": {
+          "Bucket": "examplebucket",
+          "CopySource": "bucketname/sourceobjectkey",
+          "Key": "examplelargeobject",
+          "PartNumber": "1",
+          "UploadId": "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI4FI7PkP91We7Nrw--"
+        },
+        "output": {
+          "CopyPartResult": {
+            "ETag": "\"b0c6f0e7e054ab8fa2536a2677f8734d\"",
+            "LastModified": "2016-12-29T21:24:43.000Z"
+          }
+        },
+        "comments": {
+          "input": {
+          },
+          "output": {
+          }
+        },
+        "description": "The following example uploads a part of a multipart upload by copying data from an existing object as data source.",
+        "id": "to-upload-a-part-by-copying-data-from-an-existing-object-as-data-source-1483046746348",
+        "title": "To upload a part by copying data from an existing object as data source"
+      }
+    ]
   }
 }

--- a/models/apis/s3/2006-03-01/paginators-1.json
+++ b/models/apis/s3/2006-03-01/paginators-1.json
@@ -4,15 +4,15 @@
       "result_key": "Buckets"
     },
     "ListMultipartUploads": {
+      "input_token": [
+        "KeyMarker",
+        "UploadIdMarker"
+      ],
       "limit_key": "MaxUploads",
       "more_results": "IsTruncated",
       "output_token": [
         "NextKeyMarker",
         "NextUploadIdMarker"
-      ],
-      "input_token": [
-        "KeyMarker",
-        "UploadIdMarker"
       ],
       "result_key": [
         "Uploads",
@@ -20,15 +20,15 @@
       ]
     },
     "ListObjectVersions": {
-      "more_results": "IsTruncated",
-      "limit_key": "MaxKeys",
-      "output_token": [
-        "NextKeyMarker",
-        "NextVersionIdMarker"
-      ],
       "input_token": [
         "KeyMarker",
         "VersionIdMarker"
+      ],
+      "limit_key": "MaxKeys",
+      "more_results": "IsTruncated",
+      "output_token": [
+        "NextKeyMarker",
+        "NextVersionIdMarker"
       ],
       "result_key": [
         "Versions",
@@ -37,29 +37,29 @@
       ]
     },
     "ListObjects": {
-      "more_results": "IsTruncated",
-      "limit_key": "MaxKeys",
-      "output_token": "NextMarker || Contents[-1].Key",
       "input_token": "Marker",
+      "limit_key": "MaxKeys",
+      "more_results": "IsTruncated",
+      "output_token": "NextMarker || Contents[-1].Key",
       "result_key": [
         "Contents",
         "CommonPrefixes"
       ]
     },
     "ListObjectsV2": {
+      "input_token": "ContinuationToken",
       "limit_key": "MaxKeys",
       "output_token": "NextContinuationToken",
-      "input_token": "ContinuationToken",
       "result_key": [
         "Contents",
         "CommonPrefixes"
       ]
     },
     "ListParts": {
-      "more_results": "IsTruncated",
-      "limit_key": "MaxParts",
-      "output_token": "NextPartNumberMarker",
       "input_token": "PartNumberMarker",
+      "limit_key": "MaxParts",
+      "more_results": "IsTruncated",
+      "output_token": "NextPartNumberMarker",
       "result_key": "Parts"
     }
   }

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/restjson"
 )
 
 const opAddFacetToObject = "AddFacetToObject"
@@ -84,10 +86,11 @@ func (c *CloudDirectory) AddFacetToObjectRequest(input *AddFacetToObjectInput) (
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -100,8 +103,8 @@ func (c *CloudDirectory) AddFacetToObjectRequest(input *AddFacetToObjectInput) (
 //   The specified resource could not be found.
 //
 //   * ErrCodeFacetValidationException "FacetValidationException"
-//   The Facet you provided was not well formed or could not be validated with
-//   the schema.
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AddFacetToObject
 func (c *CloudDirectory) AddFacetToObject(input *AddFacetToObjectInput) (*AddFacetToObjectOutput, error) {
@@ -170,8 +173,8 @@ func (c *CloudDirectory) ApplySchemaRequest(input *ApplySchemaInput) (req *reque
 
 // ApplySchema API operation for Amazon CloudDirectory.
 //
-// Copies input published schema into Directory with same name and version as
-// that of published schema .
+// Copies the input published schema into the Directory with the same name and
+// version as that of the published schema .
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -199,10 +202,11 @@ func (c *CloudDirectory) ApplySchemaRequest(input *ApplySchemaInput) (req *reque
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -213,8 +217,8 @@ func (c *CloudDirectory) ApplySchemaRequest(input *ApplySchemaInput) (req *reque
 //
 //   * ErrCodeInvalidAttachmentException "InvalidAttachmentException"
 //   Indicates that an attempt to attach an object with the same link name or
-//   to apply a schema with same name has occurred. Rename the link or the schema
-//   and then try again.
+//   to apply a schema with the same name has occurred. Rename the link or the
+//   schema and then try again.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ApplySchema
 func (c *CloudDirectory) ApplySchema(input *ApplySchemaInput) (*ApplySchemaOutput, error) {
@@ -316,10 +320,11 @@ func (c *CloudDirectory) AttachObjectRequest(input *AttachObjectInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -337,15 +342,16 @@ func (c *CloudDirectory) AttachObjectRequest(input *AttachObjectInput) (req *req
 //
 //   * ErrCodeInvalidAttachmentException "InvalidAttachmentException"
 //   Indicates that an attempt to attach an object with the same link name or
-//   to apply a schema with same name has occurred. Rename the link or the schema
-//   and then try again.
+//   to apply a schema with the same name has occurred. Rename the link or the
+//   schema and then try again.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeFacetValidationException "FacetValidationException"
-//   The Facet you provided was not well formed or could not be validated with
-//   the schema.
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachObject
 func (c *CloudDirectory) AttachObject(input *AttachObjectInput) (*AttachObjectOutput, error) {
@@ -443,10 +449,11 @@ func (c *CloudDirectory) AttachPolicyRequest(input *AttachPolicyInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -462,7 +469,7 @@ func (c *CloudDirectory) AttachPolicyRequest(input *AttachPolicyInput) (req *req
 //   The specified resource could not be found.
 //
 //   * ErrCodeNotPolicyException "NotPolicyException"
-//   Indicates the requested operation can only operate on policy objects.
+//   Indicates that the requested operation can only operate on policy objects.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachPolicy
 func (c *CloudDirectory) AttachPolicy(input *AttachPolicyInput) (*AttachPolicyOutput, error) {
@@ -559,10 +566,11 @@ func (c *CloudDirectory) AttachToIndexRequest(input *AttachToIndexInput) (req *r
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -583,7 +591,7 @@ func (c *CloudDirectory) AttachToIndexRequest(input *AttachToIndexInput) (req *r
 //   the appropriate attribute value.
 //
 //   * ErrCodeNotIndexException "NotIndexException"
-//   Indicates the requested operation can only operate on index objects.
+//   Indicates that the requested operation can only operate on index objects.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachToIndex
 func (c *CloudDirectory) AttachToIndex(input *AttachToIndexInput) (*AttachToIndexOutput, error) {
@@ -602,6 +610,128 @@ func (c *CloudDirectory) AttachToIndex(input *AttachToIndexInput) (*AttachToInde
 // for more information on using Contexts.
 func (c *CloudDirectory) AttachToIndexWithContext(ctx aws.Context, input *AttachToIndexInput, opts ...request.Option) (*AttachToIndexOutput, error) {
 	req, out := c.AttachToIndexRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opAttachTypedLink = "AttachTypedLink"
+
+// AttachTypedLinkRequest generates a "aws/request.Request" representing the
+// client's request for the AttachTypedLink operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See AttachTypedLink for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the AttachTypedLink method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the AttachTypedLinkRequest method.
+//    req, resp := client.AttachTypedLinkRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachTypedLink
+func (c *CloudDirectory) AttachTypedLinkRequest(input *AttachTypedLinkInput) (req *request.Request, output *AttachTypedLinkOutput) {
+	op := &request.Operation{
+		Name:       opAttachTypedLink,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/attach",
+	}
+
+	if input == nil {
+		input = &AttachTypedLinkInput{}
+	}
+
+	output = &AttachTypedLinkOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AttachTypedLink API operation for Amazon CloudDirectory.
+//
+// Attaches a typed link to a specified source and target object. For more information,
+// see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation AttachTypedLink for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeInvalidAttachmentException "InvalidAttachmentException"
+//   Indicates that an attempt to attach an object with the same link name or
+//   to apply a schema with the same name has occurred. Rename the link or the
+//   schema and then try again.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeFacetValidationException "FacetValidationException"
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachTypedLink
+func (c *CloudDirectory) AttachTypedLink(input *AttachTypedLinkInput) (*AttachTypedLinkOutput, error) {
+	req, out := c.AttachTypedLinkRequest(input)
+	return out, req.Send()
+}
+
+// AttachTypedLinkWithContext is the same as AttachTypedLink with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AttachTypedLink for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) AttachTypedLinkWithContext(ctx aws.Context, input *AttachTypedLinkInput, opts ...request.Option) (*AttachTypedLinkOutput, error) {
+	req, out := c.AttachTypedLinkRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -680,10 +810,11 @@ func (c *CloudDirectory) BatchReadRequest(input *BatchReadInput) (req *request.R
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -788,10 +919,11 @@ func (c *CloudDirectory) BatchWriteRequest(input *BatchWriteInput) (req *request
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -899,10 +1031,11 @@ func (c *CloudDirectory) CreateDirectoryRequest(input *CreateDirectoryInput) (re
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1014,10 +1147,11 @@ func (c *CloudDirectory) CreateFacetRequest(input *CreateFacetInput) (req *reque
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1031,6 +1165,10 @@ func (c *CloudDirectory) CreateFacetRequest(input *CreateFacetInput) (req *reque
 //
 //   * ErrCodeInvalidRuleException "InvalidRuleException"
 //   Occurs when any of the rule parameter keys or values are invalid.
+//
+//   * ErrCodeFacetValidationException "FacetValidationException"
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateFacet
 func (c *CloudDirectory) CreateFacet(input *CreateFacetInput) (*CreateFacetOutput, error) {
@@ -1128,10 +1266,11 @@ func (c *CloudDirectory) CreateIndexRequest(input *CreateIndexInput) (req *reque
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1144,15 +1283,15 @@ func (c *CloudDirectory) CreateIndexRequest(input *CreateIndexInput) (req *reque
 //   The specified resource could not be found.
 //
 //   * ErrCodeFacetValidationException "FacetValidationException"
-//   The Facet you provided was not well formed or could not be validated with
-//   the schema.
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
 //
 //   * ErrCodeLinkNameAlreadyInUseException "LinkNameAlreadyInUseException"
 //   Indicates that a link could not be created due to a naming conflict. Choose
 //   a different name and then try again.
 //
 //   * ErrCodeUnsupportedIndexTypeException "UnsupportedIndexTypeException"
-//   Indicates the requested index type is not supported.
+//   Indicates that the requested index type is not supported.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateIndex
 func (c *CloudDirectory) CreateIndex(input *CreateIndexInput) (*CreateIndexOutput, error) {
@@ -1252,10 +1391,11 @@ func (c *CloudDirectory) CreateObjectRequest(input *CreateObjectInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1271,15 +1411,15 @@ func (c *CloudDirectory) CreateObjectRequest(input *CreateObjectInput) (req *req
 //   The specified resource could not be found.
 //
 //   * ErrCodeFacetValidationException "FacetValidationException"
-//   The Facet you provided was not well formed or could not be validated with
-//   the schema.
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
 //
 //   * ErrCodeLinkNameAlreadyInUseException "LinkNameAlreadyInUseException"
 //   Indicates that a link could not be created due to a naming conflict. Choose
 //   a different name and then try again.
 //
 //   * ErrCodeUnsupportedIndexTypeException "UnsupportedIndexTypeException"
-//   Indicates the requested index type is not supported.
+//   Indicates that the requested index type is not supported.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateObject
 func (c *CloudDirectory) CreateObject(input *CreateObjectInput) (*CreateObjectOutput, error) {
@@ -1388,10 +1528,11 @@ func (c *CloudDirectory) CreateSchemaRequest(input *CreateSchemaInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1421,6 +1562,124 @@ func (c *CloudDirectory) CreateSchema(input *CreateSchemaInput) (*CreateSchemaOu
 // for more information on using Contexts.
 func (c *CloudDirectory) CreateSchemaWithContext(ctx aws.Context, input *CreateSchemaInput, opts ...request.Option) (*CreateSchemaOutput, error) {
 	req, out := c.CreateSchemaRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateTypedLinkFacet = "CreateTypedLinkFacet"
+
+// CreateTypedLinkFacetRequest generates a "aws/request.Request" representing the
+// client's request for the CreateTypedLinkFacet operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See CreateTypedLinkFacet for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the CreateTypedLinkFacet method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the CreateTypedLinkFacetRequest method.
+//    req, resp := client.CreateTypedLinkFacetRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateTypedLinkFacet
+func (c *CloudDirectory) CreateTypedLinkFacetRequest(input *CreateTypedLinkFacetInput) (req *request.Request, output *CreateTypedLinkFacetOutput) {
+	op := &request.Operation{
+		Name:       opCreateTypedLinkFacet,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/facet/create",
+	}
+
+	if input == nil {
+		input = &CreateTypedLinkFacetInput{}
+	}
+
+	output = &CreateTypedLinkFacetOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateTypedLinkFacet API operation for Amazon CloudDirectory.
+//
+// Creates a TypedLinkFacet. For more information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation CreateTypedLinkFacet for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeFacetAlreadyExistsException "FacetAlreadyExistsException"
+//   A facet with the same name already exists.
+//
+//   * ErrCodeInvalidRuleException "InvalidRuleException"
+//   Occurs when any of the rule parameter keys or values are invalid.
+//
+//   * ErrCodeFacetValidationException "FacetValidationException"
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateTypedLinkFacet
+func (c *CloudDirectory) CreateTypedLinkFacet(input *CreateTypedLinkFacetInput) (*CreateTypedLinkFacetOutput, error) {
+	req, out := c.CreateTypedLinkFacetRequest(input)
+	return out, req.Send()
+}
+
+// CreateTypedLinkFacetWithContext is the same as CreateTypedLinkFacet with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateTypedLinkFacet for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) CreateTypedLinkFacetWithContext(ctx aws.Context, input *CreateTypedLinkFacetInput, opts ...request.Option) (*CreateTypedLinkFacetOutput, error) {
+	req, out := c.CreateTypedLinkFacetRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1495,18 +1754,19 @@ func (c *CloudDirectory) DeleteDirectoryRequest(input *DeleteDirectoryInput) (re
 //   site to see if there are any operational issues with the service.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
 //   Access denied. Check your permissions.
 //
 //   * ErrCodeDirectoryDeletedException "DirectoryDeletedException"
-//   A directory that has been deleted has been attempted to be accessed. Note:
-//   The requested resource will eventually cease to exist.
+//   A directory that has been deleted and to which access has been attempted.
+//   Note: The requested resource will eventually cease to exist.
 //
 //   * ErrCodeRetryableConflictException "RetryableConflictException"
 //   Occurs when a conflict with a previous successful write is detected. For
@@ -1515,6 +1775,9 @@ func (c *CloudDirectory) DeleteDirectoryRequest(input *DeleteDirectoryInput) (re
 //   may result. This generally occurs when the previous write did not have time
 //   to propagate to the host serving the current request. A retry (with appropriate
 //   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteDirectory
 func (c *CloudDirectory) DeleteDirectory(input *DeleteDirectoryInput) (*DeleteDirectoryOutput, error) {
@@ -1583,8 +1846,8 @@ func (c *CloudDirectory) DeleteFacetRequest(input *DeleteFacetInput) (req *reque
 
 // DeleteFacet API operation for Amazon CloudDirectory.
 //
-// Deletes a given Facet. All attributes and Rules associated with the facet
-// will be deleted. Only development schema facets are allowed deletion.
+// Deletes a given Facet. All attributes and Rules that are associated with
+// the facet will be deleted. Only development schema facets are allowed deletion.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1612,10 +1875,11 @@ func (c *CloudDirectory) DeleteFacetRequest(input *DeleteFacetInput) (req *reque
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1628,7 +1892,7 @@ func (c *CloudDirectory) DeleteFacetRequest(input *DeleteFacetInput) (req *reque
 //   The specified Facet could not be found.
 //
 //   * ErrCodeFacetInUseException "FacetInUseException"
-//   Occurs when deleting a facet that contains an attribute which is a target
+//   Occurs when deleting a facet that contains an attribute that is a target
 //   to an attribute reference in a different facet.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteFacet
@@ -1727,10 +1991,11 @@ func (c *CloudDirectory) DeleteObjectRequest(input *DeleteObjectInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1743,7 +2008,7 @@ func (c *CloudDirectory) DeleteObjectRequest(input *DeleteObjectInput) (req *req
 //   The specified resource could not be found.
 //
 //   * ErrCodeObjectNotDetachedException "ObjectNotDetachedException"
-//   Indicates the requested operation cannot be completed because the object
+//   Indicates that the requested operation cannot be completed because the object
 //   has not been detached from the tree.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteObject
@@ -1842,10 +2107,11 @@ func (c *CloudDirectory) DeleteSchemaRequest(input *DeleteSchemaInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1875,6 +2141,117 @@ func (c *CloudDirectory) DeleteSchema(input *DeleteSchemaInput) (*DeleteSchemaOu
 // for more information on using Contexts.
 func (c *CloudDirectory) DeleteSchemaWithContext(ctx aws.Context, input *DeleteSchemaInput, opts ...request.Option) (*DeleteSchemaOutput, error) {
 	req, out := c.DeleteSchemaRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteTypedLinkFacet = "DeleteTypedLinkFacet"
+
+// DeleteTypedLinkFacetRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteTypedLinkFacet operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DeleteTypedLinkFacet for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DeleteTypedLinkFacet method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DeleteTypedLinkFacetRequest method.
+//    req, resp := client.DeleteTypedLinkFacetRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteTypedLinkFacet
+func (c *CloudDirectory) DeleteTypedLinkFacetRequest(input *DeleteTypedLinkFacetInput) (req *request.Request, output *DeleteTypedLinkFacetOutput) {
+	op := &request.Operation{
+		Name:       opDeleteTypedLinkFacet,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/facet/delete",
+	}
+
+	if input == nil {
+		input = &DeleteTypedLinkFacetInput{}
+	}
+
+	output = &DeleteTypedLinkFacetOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteTypedLinkFacet API operation for Amazon CloudDirectory.
+//
+// Deletes a TypedLinkFacet. For more information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation DeleteTypedLinkFacet for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeFacetNotFoundException "FacetNotFoundException"
+//   The specified Facet could not be found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteTypedLinkFacet
+func (c *CloudDirectory) DeleteTypedLinkFacet(input *DeleteTypedLinkFacetInput) (*DeleteTypedLinkFacetOutput, error) {
+	req, out := c.DeleteTypedLinkFacetRequest(input)
+	return out, req.Send()
+}
+
+// DeleteTypedLinkFacetWithContext is the same as DeleteTypedLinkFacet with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteTypedLinkFacet for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) DeleteTypedLinkFacetWithContext(ctx aws.Context, input *DeleteTypedLinkFacetInput, opts ...request.Option) (*DeleteTypedLinkFacetOutput, error) {
+	req, out := c.DeleteTypedLinkFacetRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1953,10 +2330,11 @@ func (c *CloudDirectory) DetachFromIndexRequest(input *DetachFromIndexInput) (re
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -1969,10 +2347,10 @@ func (c *CloudDirectory) DetachFromIndexRequest(input *DetachFromIndexInput) (re
 //   The specified resource could not be found.
 //
 //   * ErrCodeObjectAlreadyDetachedException "ObjectAlreadyDetachedException"
-//   Indicates the object is not attached to the index.
+//   Indicates that the object is not attached to the index.
 //
 //   * ErrCodeNotIndexException "NotIndexException"
-//   Indicates the requested operation can only operate on index objects.
+//   Indicates that the requested operation can only operate on index objects.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachFromIndex
 func (c *CloudDirectory) DetachFromIndex(input *DetachFromIndexInput) (*DetachFromIndexOutput, error) {
@@ -2070,10 +2448,11 @@ func (c *CloudDirectory) DetachObjectRequest(input *DetachObjectInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2180,10 +2559,11 @@ func (c *CloudDirectory) DetachPolicyRequest(input *DetachPolicyInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2199,7 +2579,7 @@ func (c *CloudDirectory) DetachPolicyRequest(input *DetachPolicyInput) (req *req
 //   The specified resource could not be found.
 //
 //   * ErrCodeNotPolicyException "NotPolicyException"
-//   Indicates the requested operation can only operate on policy objects.
+//   Indicates that the requested operation can only operate on policy objects.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachPolicy
 func (c *CloudDirectory) DetachPolicy(input *DetachPolicyInput) (*DetachPolicyOutput, error) {
@@ -2218,6 +2598,121 @@ func (c *CloudDirectory) DetachPolicy(input *DetachPolicyInput) (*DetachPolicyOu
 // for more information on using Contexts.
 func (c *CloudDirectory) DetachPolicyWithContext(ctx aws.Context, input *DetachPolicyInput, opts ...request.Option) (*DetachPolicyOutput, error) {
 	req, out := c.DetachPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDetachTypedLink = "DetachTypedLink"
+
+// DetachTypedLinkRequest generates a "aws/request.Request" representing the
+// client's request for the DetachTypedLink operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DetachTypedLink for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DetachTypedLink method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DetachTypedLinkRequest method.
+//    req, resp := client.DetachTypedLinkRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachTypedLink
+func (c *CloudDirectory) DetachTypedLinkRequest(input *DetachTypedLinkInput) (req *request.Request, output *DetachTypedLinkOutput) {
+	op := &request.Operation{
+		Name:       opDetachTypedLink,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/detach",
+	}
+
+	if input == nil {
+		input = &DetachTypedLinkInput{}
+	}
+
+	output = &DetachTypedLinkOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DetachTypedLink API operation for Amazon CloudDirectory.
+//
+// Detaches a typed link from a specified source and target object. For more
+// information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation DetachTypedLink for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeFacetValidationException "FacetValidationException"
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachTypedLink
+func (c *CloudDirectory) DetachTypedLink(input *DetachTypedLinkInput) (*DetachTypedLinkOutput, error) {
+	req, out := c.DetachTypedLinkRequest(input)
+	return out, req.Send()
+}
+
+// DetachTypedLinkWithContext is the same as DetachTypedLink with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DetachTypedLink for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) DetachTypedLinkWithContext(ctx aws.Context, input *DetachTypedLinkInput, opts ...request.Option) (*DetachTypedLinkOutput, error) {
+	req, out := c.DetachTypedLinkRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2284,8 +2779,8 @@ func (c *CloudDirectory) DisableDirectoryRequest(input *DisableDirectoryInput) (
 //   The specified resource could not be found.
 //
 //   * ErrCodeDirectoryDeletedException "DirectoryDeletedException"
-//   A directory that has been deleted has been attempted to be accessed. Note:
-//   The requested resource will eventually cease to exist.
+//   A directory that has been deleted and to which access has been attempted.
+//   Note: The requested resource will eventually cease to exist.
 //
 //   * ErrCodeInternalServiceException "InternalServiceException"
 //   Indicates a problem that must be resolved by Amazon Web Services. This might
@@ -2294,10 +2789,11 @@ func (c *CloudDirectory) DisableDirectoryRequest(input *DisableDirectoryInput) (
 //   site to see if there are any operational issues with the service.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2310,6 +2806,9 @@ func (c *CloudDirectory) DisableDirectoryRequest(input *DisableDirectoryInput) (
 //   may result. This generally occurs when the previous write did not have time
 //   to propagate to the host serving the current request. A retry (with appropriate
 //   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DisableDirectory
 func (c *CloudDirectory) DisableDirectory(input *DisableDirectoryInput) (*DisableDirectoryOutput, error) {
@@ -2393,8 +2892,8 @@ func (c *CloudDirectory) EnableDirectoryRequest(input *EnableDirectoryInput) (re
 //   The specified resource could not be found.
 //
 //   * ErrCodeDirectoryDeletedException "DirectoryDeletedException"
-//   A directory that has been deleted has been attempted to be accessed. Note:
-//   The requested resource will eventually cease to exist.
+//   A directory that has been deleted and to which access has been attempted.
+//   Note: The requested resource will eventually cease to exist.
 //
 //   * ErrCodeInternalServiceException "InternalServiceException"
 //   Indicates a problem that must be resolved by Amazon Web Services. This might
@@ -2403,10 +2902,11 @@ func (c *CloudDirectory) EnableDirectoryRequest(input *EnableDirectoryInput) (re
 //   site to see if there are any operational issues with the service.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2419,6 +2919,9 @@ func (c *CloudDirectory) EnableDirectoryRequest(input *EnableDirectoryInput) (re
 //   may result. This generally occurs when the previous write did not have time
 //   to propagate to the host serving the current request. A retry (with appropriate
 //   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/EnableDirectory
 func (c *CloudDirectory) EnableDirectory(input *EnableDirectoryInput) (*EnableDirectoryOutput, error) {
@@ -2515,10 +3018,11 @@ func (c *CloudDirectory) GetDirectoryRequest(input *GetDirectoryInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2591,7 +3095,7 @@ func (c *CloudDirectory) GetFacetRequest(input *GetFacetInput) (req *request.Req
 
 // GetFacet API operation for Amazon CloudDirectory.
 //
-// Gets details of the Facet, such as Facet Name, Attributes, Rules, or ObjectType.
+// Gets details of the Facet, such as facet name, attributes, Rules, or ObjectType.
 // You can call this on all kinds of schema facets -- published, development,
 // or applied.
 //
@@ -2621,10 +3125,11 @@ func (c *CloudDirectory) GetFacetRequest(input *GetFacetInput) (req *request.Req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2731,10 +3236,11 @@ func (c *CloudDirectory) GetObjectInformationRequest(input *GetObjectInformation
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2842,10 +3348,11 @@ func (c *CloudDirectory) GetSchemaAsJsonRequest(input *GetSchemaAsJsonInput) (re
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2855,7 +3362,8 @@ func (c *CloudDirectory) GetSchemaAsJsonRequest(input *GetSchemaAsJsonInput) (re
 //   The specified resource could not be found.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetSchemaAsJson
 func (c *CloudDirectory) GetSchemaAsJson(input *GetSchemaAsJsonInput) (*GetSchemaAsJsonOutput, error) {
@@ -2874,6 +3382,121 @@ func (c *CloudDirectory) GetSchemaAsJson(input *GetSchemaAsJsonInput) (*GetSchem
 // for more information on using Contexts.
 func (c *CloudDirectory) GetSchemaAsJsonWithContext(ctx aws.Context, input *GetSchemaAsJsonInput, opts ...request.Option) (*GetSchemaAsJsonOutput, error) {
 	req, out := c.GetSchemaAsJsonRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetTypedLinkFacetInformation = "GetTypedLinkFacetInformation"
+
+// GetTypedLinkFacetInformationRequest generates a "aws/request.Request" representing the
+// client's request for the GetTypedLinkFacetInformation operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetTypedLinkFacetInformation for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetTypedLinkFacetInformation method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetTypedLinkFacetInformationRequest method.
+//    req, resp := client.GetTypedLinkFacetInformationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetTypedLinkFacetInformation
+func (c *CloudDirectory) GetTypedLinkFacetInformationRequest(input *GetTypedLinkFacetInformationInput) (req *request.Request, output *GetTypedLinkFacetInformationOutput) {
+	op := &request.Operation{
+		Name:       opGetTypedLinkFacetInformation,
+		HTTPMethod: "POST",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/facet/get",
+	}
+
+	if input == nil {
+		input = &GetTypedLinkFacetInformationInput{}
+	}
+
+	output = &GetTypedLinkFacetInformationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetTypedLinkFacetInformation API operation for Amazon CloudDirectory.
+//
+// Returns the identity attribute order for a specific TypedLinkFacet. For more
+// information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation GetTypedLinkFacetInformation for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
+//   Indicates that the NextToken value is not valid.
+//
+//   * ErrCodeFacetNotFoundException "FacetNotFoundException"
+//   The specified Facet could not be found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetTypedLinkFacetInformation
+func (c *CloudDirectory) GetTypedLinkFacetInformation(input *GetTypedLinkFacetInformationInput) (*GetTypedLinkFacetInformationOutput, error) {
+	req, out := c.GetTypedLinkFacetInformationRequest(input)
+	return out, req.Send()
+}
+
+// GetTypedLinkFacetInformationWithContext is the same as GetTypedLinkFacetInformation with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetTypedLinkFacetInformation for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) GetTypedLinkFacetInformationWithContext(ctx aws.Context, input *GetTypedLinkFacetInformationInput, opts ...request.Option) (*GetTypedLinkFacetInformationOutput, error) {
+	req, out := c.GetTypedLinkFacetInformationRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2958,10 +3581,11 @@ func (c *CloudDirectory) ListAppliedSchemaArnsRequest(input *ListAppliedSchemaAr
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3124,10 +3748,11 @@ func (c *CloudDirectory) ListAttachedIndicesRequest(input *ListAttachedIndicesIn
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3262,7 +3887,7 @@ func (c *CloudDirectory) ListDevelopmentSchemaArnsRequest(input *ListDevelopment
 
 // ListDevelopmentSchemaArns API operation for Amazon CloudDirectory.
 //
-// Retrieves the ARNs of schemas in the development state.
+// Retrieves each Amazon Resource Name (ARN) of schemas in the development state.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3290,10 +3915,11 @@ func (c *CloudDirectory) ListDevelopmentSchemaArnsRequest(input *ListDevelopment
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3456,10 +4082,11 @@ func (c *CloudDirectory) ListDirectoriesRequest(input *ListDirectoriesInput) (re
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3619,10 +4246,11 @@ func (c *CloudDirectory) ListFacetAttributesRequest(input *ListFacetAttributesIn
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3788,10 +4416,11 @@ func (c *CloudDirectory) ListFacetNamesRequest(input *ListFacetNamesInput) (req 
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3875,6 +4504,123 @@ func (c *CloudDirectory) ListFacetNamesPagesWithContext(ctx aws.Context, input *
 	return p.Err()
 }
 
+const opListIncomingTypedLinks = "ListIncomingTypedLinks"
+
+// ListIncomingTypedLinksRequest generates a "aws/request.Request" representing the
+// client's request for the ListIncomingTypedLinks operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListIncomingTypedLinks for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListIncomingTypedLinks method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListIncomingTypedLinksRequest method.
+//    req, resp := client.ListIncomingTypedLinksRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIncomingTypedLinks
+func (c *CloudDirectory) ListIncomingTypedLinksRequest(input *ListIncomingTypedLinksInput) (req *request.Request, output *ListIncomingTypedLinksOutput) {
+	op := &request.Operation{
+		Name:       opListIncomingTypedLinks,
+		HTTPMethod: "POST",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/incoming",
+	}
+
+	if input == nil {
+		input = &ListIncomingTypedLinksInput{}
+	}
+
+	output = &ListIncomingTypedLinksOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListIncomingTypedLinks API operation for Amazon CloudDirectory.
+//
+// Returns a paginated list of all the incoming TypedLinkSpecifier information
+// for an object. It also supports filtering by typed link facet and identity
+// attributes. For more information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation ListIncomingTypedLinks for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
+//   Indicates that the NextToken value is not valid.
+//
+//   * ErrCodeFacetValidationException "FacetValidationException"
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIncomingTypedLinks
+func (c *CloudDirectory) ListIncomingTypedLinks(input *ListIncomingTypedLinksInput) (*ListIncomingTypedLinksOutput, error) {
+	req, out := c.ListIncomingTypedLinksRequest(input)
+	return out, req.Send()
+}
+
+// ListIncomingTypedLinksWithContext is the same as ListIncomingTypedLinks with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListIncomingTypedLinks for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) ListIncomingTypedLinksWithContext(ctx aws.Context, input *ListIncomingTypedLinksInput, opts ...request.Option) (*ListIncomingTypedLinksOutput, error) {
+	req, out := c.ListIncomingTypedLinksRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListIndex = "ListIndex"
 
 // ListIndexRequest generates a "aws/request.Request" representing the
@@ -3954,10 +4700,11 @@ func (c *CloudDirectory) ListIndexRequest(input *ListIndexInput) (req *request.R
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3970,7 +4717,7 @@ func (c *CloudDirectory) ListIndexRequest(input *ListIndexInput) (req *request.R
 //   The specified resource could not be found.
 //
 //   * ErrCodeNotIndexException "NotIndexException"
-//   Indicates the requested operation can only operate on index objects.
+//   Indicates that the requested operation can only operate on index objects.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIndex
 func (c *CloudDirectory) ListIndex(input *ListIndexInput) (*ListIndexOutput, error) {
@@ -4095,7 +4842,7 @@ func (c *CloudDirectory) ListObjectAttributesRequest(input *ListObjectAttributes
 
 // ListObjectAttributes API operation for Amazon CloudDirectory.
 //
-// Lists all attributes associated with an object.
+// Lists all attributes that are associated with an object.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4123,10 +4870,11 @@ func (c *CloudDirectory) ListObjectAttributesRequest(input *ListObjectAttributes
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -4145,8 +4893,8 @@ func (c *CloudDirectory) ListObjectAttributesRequest(input *ListObjectAttributes
 //   Indicates that the NextToken value is not valid.
 //
 //   * ErrCodeFacetValidationException "FacetValidationException"
-//   The Facet you provided was not well formed or could not be validated with
-//   the schema.
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectAttributes
 func (c *CloudDirectory) ListObjectAttributes(input *ListObjectAttributesInput) (*ListObjectAttributesOutput, error) {
@@ -4271,7 +5019,8 @@ func (c *CloudDirectory) ListObjectChildrenRequest(input *ListObjectChildrenInpu
 
 // ListObjectChildren API operation for Amazon CloudDirectory.
 //
-// Returns a paginated list of child objects associated with a given object.
+// Returns a paginated list of child objects that are associated with a given
+// object.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4299,10 +5048,11 @@ func (c *CloudDirectory) ListObjectChildrenRequest(input *ListObjectChildrenInpu
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -4321,7 +5071,7 @@ func (c *CloudDirectory) ListObjectChildrenRequest(input *ListObjectChildrenInpu
 //   Indicates that the NextToken value is not valid.
 //
 //   * ErrCodeNotNodeException "NotNodeException"
-//   Occurs when any invalid operations are performed on an object which is not
+//   Occurs when any invalid operations are performed on an object that is not
 //   a node, such as calling ListObjectChildren for a leaf node object.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectChildren
@@ -4456,7 +5206,8 @@ func (c *CloudDirectory) ListObjectParentPathsRequest(input *ListObjectParentPat
 // returns the number of paths based on user-defined MaxResults, in case there
 // are multiple paths to the parent. The order of the paths and nodes returned
 // is consistent among multiple API calls unless the objects are deleted or
-// moved. Paths not leading to directory root are ignored from the target object.
+// moved. Paths not leading to the directory root are ignored from the target
+// object.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4484,10 +5235,11 @@ func (c *CloudDirectory) ListObjectParentPathsRequest(input *ListObjectParentPat
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -4625,7 +5377,8 @@ func (c *CloudDirectory) ListObjectParentsRequest(input *ListObjectParentsInput)
 
 // ListObjectParents API operation for Amazon CloudDirectory.
 //
-// Lists parent objects associated with a given object in pagination fashion.
+// Lists parent objects that are associated with a given object in pagination
+// fashion.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4653,10 +5406,11 @@ func (c *CloudDirectory) ListObjectParentsRequest(input *ListObjectParentsInput)
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -4828,10 +5582,11 @@ func (c *CloudDirectory) ListObjectPoliciesRequest(input *ListObjectPoliciesInpu
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -4918,6 +5673,123 @@ func (c *CloudDirectory) ListObjectPoliciesPagesWithContext(ctx aws.Context, inp
 	return p.Err()
 }
 
+const opListOutgoingTypedLinks = "ListOutgoingTypedLinks"
+
+// ListOutgoingTypedLinksRequest generates a "aws/request.Request" representing the
+// client's request for the ListOutgoingTypedLinks operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListOutgoingTypedLinks for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListOutgoingTypedLinks method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListOutgoingTypedLinksRequest method.
+//    req, resp := client.ListOutgoingTypedLinksRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListOutgoingTypedLinks
+func (c *CloudDirectory) ListOutgoingTypedLinksRequest(input *ListOutgoingTypedLinksInput) (req *request.Request, output *ListOutgoingTypedLinksOutput) {
+	op := &request.Operation{
+		Name:       opListOutgoingTypedLinks,
+		HTTPMethod: "POST",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/outgoing",
+	}
+
+	if input == nil {
+		input = &ListOutgoingTypedLinksInput{}
+	}
+
+	output = &ListOutgoingTypedLinksOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListOutgoingTypedLinks API operation for Amazon CloudDirectory.
+//
+// Returns a paginated list of all the outgoing TypedLinkSpecifier information
+// for an object. It also supports filtering by typed link facet and identity
+// attributes. For more information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation ListOutgoingTypedLinks for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
+//   Indicates that the NextToken value is not valid.
+//
+//   * ErrCodeFacetValidationException "FacetValidationException"
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListOutgoingTypedLinks
+func (c *CloudDirectory) ListOutgoingTypedLinks(input *ListOutgoingTypedLinksInput) (*ListOutgoingTypedLinksOutput, error) {
+	req, out := c.ListOutgoingTypedLinksRequest(input)
+	return out, req.Send()
+}
+
+// ListOutgoingTypedLinksWithContext is the same as ListOutgoingTypedLinks with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListOutgoingTypedLinks for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) ListOutgoingTypedLinksWithContext(ctx aws.Context, input *ListOutgoingTypedLinksInput, opts ...request.Option) (*ListOutgoingTypedLinksOutput, error) {
+	req, out := c.ListOutgoingTypedLinksRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListPolicyAttachments = "ListPolicyAttachments"
 
 // ListPolicyAttachmentsRequest generates a "aws/request.Request" representing the
@@ -4997,10 +5869,11 @@ func (c *CloudDirectory) ListPolicyAttachmentsRequest(input *ListPolicyAttachmen
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -5019,7 +5892,7 @@ func (c *CloudDirectory) ListPolicyAttachmentsRequest(input *ListPolicyAttachmen
 //   The specified resource could not be found.
 //
 //   * ErrCodeNotPolicyException "NotPolicyException"
-//   Indicates the requested operation can only operate on policy objects.
+//   Indicates that the requested operation can only operate on policy objects.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPolicyAttachments
 func (c *CloudDirectory) ListPolicyAttachments(input *ListPolicyAttachmentsInput) (*ListPolicyAttachmentsOutput, error) {
@@ -5144,7 +6017,7 @@ func (c *CloudDirectory) ListPublishedSchemaArnsRequest(input *ListPublishedSche
 
 // ListPublishedSchemaArns API operation for Amazon CloudDirectory.
 //
-// Retrieves published schema ARNs.
+// Retrieves each published schema Amazon Resource Name (ARN).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5172,10 +6045,11 @@ func (c *CloudDirectory) ListPublishedSchemaArnsRequest(input *ListPublishedSche
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -5340,10 +6214,11 @@ func (c *CloudDirectory) ListTagsForResourceRequest(input *ListTagsForResourceIn
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -5429,6 +6304,345 @@ func (c *CloudDirectory) ListTagsForResourcePagesWithContext(ctx aws.Context, in
 	return p.Err()
 }
 
+const opListTypedLinkFacetAttributes = "ListTypedLinkFacetAttributes"
+
+// ListTypedLinkFacetAttributesRequest generates a "aws/request.Request" representing the
+// client's request for the ListTypedLinkFacetAttributes operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListTypedLinkFacetAttributes for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListTypedLinkFacetAttributes method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListTypedLinkFacetAttributesRequest method.
+//    req, resp := client.ListTypedLinkFacetAttributesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetAttributes
+func (c *CloudDirectory) ListTypedLinkFacetAttributesRequest(input *ListTypedLinkFacetAttributesInput) (req *request.Request, output *ListTypedLinkFacetAttributesOutput) {
+	op := &request.Operation{
+		Name:       opListTypedLinkFacetAttributes,
+		HTTPMethod: "POST",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/facet/attributes",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListTypedLinkFacetAttributesInput{}
+	}
+
+	output = &ListTypedLinkFacetAttributesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTypedLinkFacetAttributes API operation for Amazon CloudDirectory.
+//
+// Returns a paginated list of all attribute definitions for a particular TypedLinkFacet.
+// For more information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation ListTypedLinkFacetAttributes for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeFacetNotFoundException "FacetNotFoundException"
+//   The specified Facet could not be found.
+//
+//   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
+//   Indicates that the NextToken value is not valid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetAttributes
+func (c *CloudDirectory) ListTypedLinkFacetAttributes(input *ListTypedLinkFacetAttributesInput) (*ListTypedLinkFacetAttributesOutput, error) {
+	req, out := c.ListTypedLinkFacetAttributesRequest(input)
+	return out, req.Send()
+}
+
+// ListTypedLinkFacetAttributesWithContext is the same as ListTypedLinkFacetAttributes with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTypedLinkFacetAttributes for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) ListTypedLinkFacetAttributesWithContext(ctx aws.Context, input *ListTypedLinkFacetAttributesInput, opts ...request.Option) (*ListTypedLinkFacetAttributesOutput, error) {
+	req, out := c.ListTypedLinkFacetAttributesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListTypedLinkFacetAttributesPages iterates over the pages of a ListTypedLinkFacetAttributes operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListTypedLinkFacetAttributes method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListTypedLinkFacetAttributes operation.
+//    pageNum := 0
+//    err := client.ListTypedLinkFacetAttributesPages(params,
+//        func(page *ListTypedLinkFacetAttributesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *CloudDirectory) ListTypedLinkFacetAttributesPages(input *ListTypedLinkFacetAttributesInput, fn func(*ListTypedLinkFacetAttributesOutput, bool) bool) error {
+	return c.ListTypedLinkFacetAttributesPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListTypedLinkFacetAttributesPagesWithContext same as ListTypedLinkFacetAttributesPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) ListTypedLinkFacetAttributesPagesWithContext(ctx aws.Context, input *ListTypedLinkFacetAttributesInput, fn func(*ListTypedLinkFacetAttributesOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListTypedLinkFacetAttributesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListTypedLinkFacetAttributesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListTypedLinkFacetAttributesOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opListTypedLinkFacetNames = "ListTypedLinkFacetNames"
+
+// ListTypedLinkFacetNamesRequest generates a "aws/request.Request" representing the
+// client's request for the ListTypedLinkFacetNames operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListTypedLinkFacetNames for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListTypedLinkFacetNames method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListTypedLinkFacetNamesRequest method.
+//    req, resp := client.ListTypedLinkFacetNamesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetNames
+func (c *CloudDirectory) ListTypedLinkFacetNamesRequest(input *ListTypedLinkFacetNamesInput) (req *request.Request, output *ListTypedLinkFacetNamesOutput) {
+	op := &request.Operation{
+		Name:       opListTypedLinkFacetNames,
+		HTTPMethod: "POST",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/facet/list",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListTypedLinkFacetNamesInput{}
+	}
+
+	output = &ListTypedLinkFacetNamesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTypedLinkFacetNames API operation for Amazon CloudDirectory.
+//
+// Returns a paginated list of TypedLink facet names for a particular schema.
+// For more information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation ListTypedLinkFacetNames for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
+//   Indicates that the NextToken value is not valid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetNames
+func (c *CloudDirectory) ListTypedLinkFacetNames(input *ListTypedLinkFacetNamesInput) (*ListTypedLinkFacetNamesOutput, error) {
+	req, out := c.ListTypedLinkFacetNamesRequest(input)
+	return out, req.Send()
+}
+
+// ListTypedLinkFacetNamesWithContext is the same as ListTypedLinkFacetNames with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTypedLinkFacetNames for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) ListTypedLinkFacetNamesWithContext(ctx aws.Context, input *ListTypedLinkFacetNamesInput, opts ...request.Option) (*ListTypedLinkFacetNamesOutput, error) {
+	req, out := c.ListTypedLinkFacetNamesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListTypedLinkFacetNamesPages iterates over the pages of a ListTypedLinkFacetNames operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListTypedLinkFacetNames method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListTypedLinkFacetNames operation.
+//    pageNum := 0
+//    err := client.ListTypedLinkFacetNamesPages(params,
+//        func(page *ListTypedLinkFacetNamesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *CloudDirectory) ListTypedLinkFacetNamesPages(input *ListTypedLinkFacetNamesInput, fn func(*ListTypedLinkFacetNamesOutput, bool) bool) error {
+	return c.ListTypedLinkFacetNamesPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListTypedLinkFacetNamesPagesWithContext same as ListTypedLinkFacetNamesPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) ListTypedLinkFacetNamesPagesWithContext(ctx aws.Context, input *ListTypedLinkFacetNamesInput, fn func(*ListTypedLinkFacetNamesOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListTypedLinkFacetNamesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListTypedLinkFacetNamesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListTypedLinkFacetNamesOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opLookupPolicy = "LookupPolicy"
 
 // LookupPolicyRequest generates a "aws/request.Request" representing the
@@ -5485,7 +6699,8 @@ func (c *CloudDirectory) LookupPolicyRequest(input *LookupPolicyInput) (req *req
 // are present, and if some objects don't have the policies attached, it returns
 // the ObjectIdentifier for such objects. If policies are present, it returns
 // ObjectIdentifier, policyId, and policyType. Paths that don't lead to the
-// root from the target object are ignored.
+// root from the target object are ignored. For more information, see Policies
+// (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5513,10 +6728,11 @@ func (c *CloudDirectory) LookupPolicyRequest(input *LookupPolicyInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -5682,10 +6898,11 @@ func (c *CloudDirectory) PublishSchemaRequest(input *PublishSchemaInput) (req *r
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -5695,7 +6912,7 @@ func (c *CloudDirectory) PublishSchemaRequest(input *PublishSchemaInput) (req *r
 //   The specified resource could not be found.
 //
 //   * ErrCodeSchemaAlreadyPublishedException "SchemaAlreadyPublishedException"
-//   Indicates a schema is already published.
+//   Indicates that a schema is already published.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PublishSchema
 func (c *CloudDirectory) PublishSchema(input *PublishSchemaInput) (*PublishSchemaOutput, error) {
@@ -5794,10 +7011,11 @@ func (c *CloudDirectory) PutSchemaFromJsonRequest(input *PutSchemaFromJsonInput)
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -5904,10 +7122,11 @@ func (c *CloudDirectory) RemoveFacetFromObjectRequest(input *RemoveFacetFromObje
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -5920,8 +7139,8 @@ func (c *CloudDirectory) RemoveFacetFromObjectRequest(input *RemoveFacetFromObje
 //   The specified resource could not be found.
 //
 //   * ErrCodeFacetValidationException "FacetValidationException"
-//   The Facet you provided was not well formed or could not be validated with
-//   the schema.
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/RemoveFacetFromObject
 func (c *CloudDirectory) RemoveFacetFromObject(input *RemoveFacetFromObjectInput) (*RemoveFacetFromObjectOutput, error) {
@@ -5990,7 +7209,7 @@ func (c *CloudDirectory) TagResourceRequest(input *TagResourceInput) (req *reque
 
 // TagResource API operation for Amazon CloudDirectory.
 //
-// API for adding tags to a resource.
+// An API operation for adding tags to a resource.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6018,10 +7237,11 @@ func (c *CloudDirectory) TagResourceRequest(input *TagResourceInput) (req *reque
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -6102,7 +7322,7 @@ func (c *CloudDirectory) UntagResourceRequest(input *UntagResourceInput) (req *r
 
 // UntagResource API operation for Amazon CloudDirectory.
 //
-// API for removing tags from a resource.
+// An API operation for removing tags from a resource.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6130,10 +7350,11 @@ func (c *CloudDirectory) UntagResourceRequest(input *UntagResourceInput) (req *r
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -6248,10 +7469,11 @@ func (c *CloudDirectory) UpdateFacetRequest(input *UpdateFacetInput) (req *reque
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -6364,10 +7586,11 @@ func (c *CloudDirectory) UpdateObjectAttributesRequest(input *UpdateObjectAttrib
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -6380,8 +7603,8 @@ func (c *CloudDirectory) UpdateObjectAttributesRequest(input *UpdateObjectAttrib
 //   The specified resource could not be found.
 //
 //   * ErrCodeFacetValidationException "FacetValidationException"
-//   The Facet you provided was not well formed or could not be validated with
-//   the schema.
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateObjectAttributes
 func (c *CloudDirectory) UpdateObjectAttributes(input *UpdateObjectAttributesInput) (*UpdateObjectAttributesOutput, error) {
@@ -6479,10 +7702,11 @@ func (c *CloudDirectory) UpdateSchemaRequest(input *UpdateSchemaInput) (req *req
 //   backoff logic) is the recommended response to this exception.
 //
 //   * ErrCodeValidationException "ValidationException"
-//   Indicates your request is malformed in some manner. See the exception message.
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 //   for more information.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -6513,17 +7737,138 @@ func (c *CloudDirectory) UpdateSchemaWithContext(ctx aws.Context, input *UpdateS
 	return out, req.Send()
 }
 
+const opUpdateTypedLinkFacet = "UpdateTypedLinkFacet"
+
+// UpdateTypedLinkFacetRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateTypedLinkFacet operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See UpdateTypedLinkFacet for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the UpdateTypedLinkFacet method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the UpdateTypedLinkFacetRequest method.
+//    req, resp := client.UpdateTypedLinkFacetRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateTypedLinkFacet
+func (c *CloudDirectory) UpdateTypedLinkFacetRequest(input *UpdateTypedLinkFacetInput) (req *request.Request, output *UpdateTypedLinkFacetOutput) {
+	op := &request.Operation{
+		Name:       opUpdateTypedLinkFacet,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/amazonclouddirectory/2017-01-11/typedlink/facet",
+	}
+
+	if input == nil {
+		input = &UpdateTypedLinkFacetInput{}
+	}
+
+	output = &UpdateTypedLinkFacetOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateTypedLinkFacet API operation for Amazon CloudDirectory.
+//
+// Updates a TypedLinkFacet. For more information, see Typed link (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudDirectory's
+// API operation UpdateTypedLinkFacet for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   Indicates a problem that must be resolved by Amazon Web Services. This might
+//   be a transient error in which case you can retry your request until it succeeds.
+//   Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
+//   site to see if there are any operational issues with the service.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   Indicates that the provided ARN value is not valid.
+//
+//   * ErrCodeRetryableConflictException "RetryableConflictException"
+//   Occurs when a conflict with a previous successful write is detected. For
+//   example, if a write operation occurs on an object and then an attempt is
+//   made to read the object using “SERIALIZABLE” consistency, this exception
+//   may result. This generally occurs when the previous write did not have time
+//   to propagate to the host serving the current request. A retry (with appropriate
+//   backoff logic) is the recommended response to this exception.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that your request is malformed in some manner. See the exception
+//   message.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+//   for more information.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Access denied. Check your permissions.
+//
+//   * ErrCodeFacetValidationException "FacetValidationException"
+//   The Facet that you provided was not well formed or could not be validated
+//   with the schema.
+//
+//   * ErrCodeInvalidFacetUpdateException "InvalidFacetUpdateException"
+//   An attempt to modify a Facet resulted in an invalid schema exception.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeFacetNotFoundException "FacetNotFoundException"
+//   The specified Facet could not be found.
+//
+//   * ErrCodeInvalidRuleException "InvalidRuleException"
+//   Occurs when any of the rule parameter keys or values are invalid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateTypedLinkFacet
+func (c *CloudDirectory) UpdateTypedLinkFacet(input *UpdateTypedLinkFacetInput) (*UpdateTypedLinkFacetOutput, error) {
+	req, out := c.UpdateTypedLinkFacetRequest(input)
+	return out, req.Send()
+}
+
+// UpdateTypedLinkFacetWithContext is the same as UpdateTypedLinkFacet with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateTypedLinkFacet for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudDirectory) UpdateTypedLinkFacetWithContext(ctx aws.Context, input *UpdateTypedLinkFacetInput, opts ...request.Option) (*UpdateTypedLinkFacetOutput, error) {
+	req, out := c.UpdateTypedLinkFacetRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AddFacetToObjectRequest
 type AddFacetToObjectInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory where the object resides. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// the object resides. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Attributes on the facet you are adding to the object.
+	// Attributes on the facet that you are adding to the object.
 	ObjectAttributeList []*AttributeKeyAndValue `type:"list"`
 
 	// A reference to the object you are adding the specified facet to.
@@ -6624,13 +7969,14 @@ func (s AddFacetToObjectOutput) GoString() string {
 type ApplySchemaInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory into which the schema is copied. For more
-	// information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory into
+	// which the schema is copied. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Published schema ARN that needs to be copied. For more information, see arns.
+	// Published schema Amazon Resource Name (ARN) that needs to be copied. For
+	// more information, see arns.
 	//
 	// PublishedSchemaArn is a required field
 	PublishedSchemaArn *string `type:"string" required:"true"`
@@ -6678,12 +8024,13 @@ func (s *ApplySchemaInput) SetPublishedSchemaArn(v string) *ApplySchemaInput {
 type ApplySchemaOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Applied schema ARN associated with the copied schema in the Directory. You
-	// can use this ARN to describe the schema information applied on this directory.
+	// The applied schema ARN that is associated with the copied schema in the Directory.
+	// You can use this ARN to describe the schema information applied on this directory.
 	// For more information, see arns.
 	AppliedSchemaArn *string `type:"string"`
 
-	// ARN associated with the Directory. For more information, see arns.
+	// The ARN that is associated with the Directory. For more information, see
+	// arns.
 	DirectoryArn *string `type:"string"`
 }
 
@@ -6713,23 +8060,23 @@ func (s *ApplySchemaOutput) SetDirectoryArn(v string) *ApplySchemaOutput {
 type AttachObjectInput struct {
 	_ struct{} `type:"structure"`
 
-	// Child object reference to be attached to the object.
+	// The child object reference to be attached to the object.
 	//
 	// ChildReference is a required field
 	ChildReference *ObjectReference `type:"structure" required:"true"`
 
-	// ARN associated with the Directory where both objects reside. For more information,
-	// see arns.
+	// Amazon Resource Name (ARN) that is associated with the Directory where both
+	// objects reside. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Link name with which the child object is attached to the parent.
+	// The link name with which the child object is attached to the parent.
 	//
 	// LinkName is a required field
-	LinkName *string `type:"string" required:"true"`
+	LinkName *string `min:"1" type:"string" required:"true"`
 
-	// Parent object reference.
+	// The parent object reference.
 	//
 	// ParentReference is a required field
 	ParentReference *ObjectReference `type:"structure" required:"true"`
@@ -6756,6 +8103,9 @@ func (s *AttachObjectInput) Validate() error {
 	}
 	if s.LinkName == nil {
 		invalidParams.Add(request.NewErrParamRequired("LinkName"))
+	}
+	if s.LinkName != nil && len(*s.LinkName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LinkName", 1))
 	}
 	if s.ParentReference == nil {
 		invalidParams.Add(request.NewErrParamRequired("ParentReference"))
@@ -6795,7 +8145,7 @@ func (s *AttachObjectInput) SetParentReference(v *ObjectReference) *AttachObject
 type AttachObjectOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Attached ObjectIdentifier, which is the child ObjectIdentifier.
+	// The attached ObjectIdentifier, which is the child ObjectIdentifier.
 	AttachedObjectIdentifier *string `type:"string"`
 }
 
@@ -6819,16 +8169,16 @@ func (s *AttachObjectOutput) SetAttachedObjectIdentifier(v string) *AttachObject
 type AttachPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory where both objects reside. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// both objects reside. For more information, see arns.
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string"`
 
-	// Reference that identifies the object to which the policy will be attached.
+	// The reference that identifies the object to which the policy will be attached.
 	//
 	// ObjectReference is a required field
 	ObjectReference *ObjectReference `type:"structure" required:"true"`
 
-	// Reference associated with the policy object.
+	// The reference that is associated with the policy object.
 	//
 	// PolicyReference is a required field
 	PolicyReference *ObjectReference `type:"structure" required:"true"`
@@ -6897,7 +8247,8 @@ func (s AttachPolicyOutput) GoString() string {
 type AttachToIndexInput struct {
 	_ struct{} `type:"structure"`
 
-	// The ARN of the directory where the object and index exist.
+	// The Amazon Resource Name (ARN) of the directory where the object and index
+	// exist.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -6984,12 +8335,147 @@ func (s *AttachToIndexOutput) SetAttachedObjectIdentifier(v string) *AttachToInd
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachTypedLinkRequest
+type AttachTypedLinkInput struct {
+	_ struct{} `type:"structure"`
+
+	// An ordered set of attributes that are associated with the typed link.
+	//
+	// Attributes is a required field
+	Attributes []*AttributeNameAndValue `type:"list" required:"true"`
+
+	// The Amazon Resource Name (ARN) of the directory where you want to attach
+	// the typed link.
+	//
+	// DirectoryArn is a required field
+	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+
+	// Identifies the source object that the typed link will attach to.
+	//
+	// SourceObjectReference is a required field
+	SourceObjectReference *ObjectReference `type:"structure" required:"true"`
+
+	// Identifies the target object that the typed link will attach to.
+	//
+	// TargetObjectReference is a required field
+	TargetObjectReference *ObjectReference `type:"structure" required:"true"`
+
+	// Identifies the typed link facet that is associated with the typed link.
+	//
+	// TypedLinkFacet is a required field
+	TypedLinkFacet *TypedLinkSchemaAndFacetName `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s AttachTypedLinkInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttachTypedLinkInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachTypedLinkInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachTypedLinkInput"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.DirectoryArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryArn"))
+	}
+	if s.SourceObjectReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceObjectReference"))
+	}
+	if s.TargetObjectReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetObjectReference"))
+	}
+	if s.TypedLinkFacet == nil {
+		invalidParams.Add(request.NewErrParamRequired("TypedLinkFacet"))
+	}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.TypedLinkFacet != nil {
+		if err := s.TypedLinkFacet.Validate(); err != nil {
+			invalidParams.AddNested("TypedLinkFacet", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *AttachTypedLinkInput) SetAttributes(v []*AttributeNameAndValue) *AttachTypedLinkInput {
+	s.Attributes = v
+	return s
+}
+
+// SetDirectoryArn sets the DirectoryArn field's value.
+func (s *AttachTypedLinkInput) SetDirectoryArn(v string) *AttachTypedLinkInput {
+	s.DirectoryArn = &v
+	return s
+}
+
+// SetSourceObjectReference sets the SourceObjectReference field's value.
+func (s *AttachTypedLinkInput) SetSourceObjectReference(v *ObjectReference) *AttachTypedLinkInput {
+	s.SourceObjectReference = v
+	return s
+}
+
+// SetTargetObjectReference sets the TargetObjectReference field's value.
+func (s *AttachTypedLinkInput) SetTargetObjectReference(v *ObjectReference) *AttachTypedLinkInput {
+	s.TargetObjectReference = v
+	return s
+}
+
+// SetTypedLinkFacet sets the TypedLinkFacet field's value.
+func (s *AttachTypedLinkInput) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName) *AttachTypedLinkInput {
+	s.TypedLinkFacet = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachTypedLinkResponse
+type AttachTypedLinkOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Returns a typed link specifier as output.
+	TypedLinkSpecifier *TypedLinkSpecifier `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachTypedLinkOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttachTypedLinkOutput) GoString() string {
+	return s.String()
+}
+
+// SetTypedLinkSpecifier sets the TypedLinkSpecifier field's value.
+func (s *AttachTypedLinkOutput) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *AttachTypedLinkOutput {
+	s.TypedLinkSpecifier = v
+	return s
+}
+
 // A unique identifier for an attribute.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttributeKey
 type AttributeKey struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the facet the attribute exists within.
+	// The name of the facet that the attribute exists within.
 	//
 	// FacetName is a required field
 	FacetName *string `min:"1" type:"string" required:"true"`
@@ -6999,7 +8485,8 @@ type AttributeKey struct {
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// The ARN of the schema that contains the facet and attribute.
+	// The Amazon Resource Name (ARN) of the schema that contains the facet and
+	// attribute.
 	//
 	// SchemaArn is a required field
 	SchemaArn *string `type:"string" required:"true"`
@@ -7117,6 +8604,63 @@ func (s *AttributeKeyAndValue) SetValue(v *TypedAttributeValue) *AttributeKeyAnd
 	return s
 }
 
+// Identifies the attribute name and value for a typed link.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttributeNameAndValue
+type AttributeNameAndValue struct {
+	_ struct{} `type:"structure"`
+
+	// The attribute name of the typed link.
+	//
+	// AttributeName is a required field
+	AttributeName *string `min:"1" type:"string" required:"true"`
+
+	// The value for the typed link.
+	//
+	// Value is a required field
+	Value *TypedAttributeValue `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s AttributeNameAndValue) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttributeNameAndValue) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttributeNameAndValue) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttributeNameAndValue"}
+	if s.AttributeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeName"))
+	}
+	if s.AttributeName != nil && len(*s.AttributeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeName", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *AttributeNameAndValue) SetAttributeName(v string) *AttributeNameAndValue {
+	s.AttributeName = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *AttributeNameAndValue) SetValue(v *TypedAttributeValue) *AttributeNameAndValue {
+	s.Value = v
+	return s
+}
+
 // Represents the output of a batch add facet to object operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAddFacetToObject
 type BatchAddFacetToObject struct {
@@ -7221,7 +8765,7 @@ func (s BatchAddFacetToObjectResponse) GoString() string {
 type BatchAttachObject struct {
 	_ struct{} `type:"structure"`
 
-	// Child object reference to be attached to the object.
+	// The child object reference that is to be attached to the object.
 	//
 	// ChildReference is a required field
 	ChildReference *ObjectReference `type:"structure" required:"true"`
@@ -7229,9 +8773,9 @@ type BatchAttachObject struct {
 	// The name of the link.
 	//
 	// LinkName is a required field
-	LinkName *string `type:"string" required:"true"`
+	LinkName *string `min:"1" type:"string" required:"true"`
 
-	// Parent object reference.
+	// The parent object reference.
 	//
 	// ParentReference is a required field
 	ParentReference *ObjectReference `type:"structure" required:"true"`
@@ -7255,6 +8799,9 @@ func (s *BatchAttachObject) Validate() error {
 	}
 	if s.LinkName == nil {
 		invalidParams.Add(request.NewErrParamRequired("LinkName"))
+	}
+	if s.LinkName != nil && len(*s.LinkName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LinkName", 1))
 	}
 	if s.ParentReference == nil {
 		invalidParams.Add(request.NewErrParamRequired("ParentReference"))
@@ -7323,10 +8870,10 @@ type BatchCreateObject struct {
 	// The name of the link.
 	//
 	// LinkName is a required field
-	LinkName *string `type:"string" required:"true"`
+	LinkName *string `min:"1" type:"string" required:"true"`
 
-	// Attribute map, which contains an attribute ARN as the key and attribute value
-	// as the map value.
+	// An attribute map, which contains an attribute ARN as the key and attribute
+	// value as the map value.
 	//
 	// ObjectAttributeList is a required field
 	ObjectAttributeList []*AttributeKeyAndValue `type:"list" required:"true"`
@@ -7336,7 +8883,7 @@ type BatchCreateObject struct {
 	// ParentReference is a required field
 	ParentReference *ObjectReference `type:"structure" required:"true"`
 
-	// List of FacetArns that will be associated with the object. For more information,
+	// A list of FacetArns that will be associated with the object. For more information,
 	// see arns.
 	//
 	// SchemaFacet is a required field
@@ -7361,6 +8908,9 @@ func (s *BatchCreateObject) Validate() error {
 	}
 	if s.LinkName == nil {
 		invalidParams.Add(request.NewErrParamRequired("LinkName"))
+	}
+	if s.LinkName != nil && len(*s.LinkName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LinkName", 1))
 	}
 	if s.ObjectAttributeList == nil {
 		invalidParams.Add(request.NewErrParamRequired("ObjectAttributeList"))
@@ -7433,7 +8983,7 @@ func (s *BatchCreateObject) SetSchemaFacet(v []*SchemaFacet) *BatchCreateObject 
 type BatchCreateObjectResponse struct {
 	_ struct{} `type:"structure"`
 
-	// ID associated with the object.
+	// The ID that is associated with the object.
 	ObjectIdentifier *string `type:"string"`
 }
 
@@ -7458,7 +9008,7 @@ func (s *BatchCreateObjectResponse) SetObjectIdentifier(v string) *BatchCreateOb
 type BatchDeleteObject struct {
 	_ struct{} `type:"structure"`
 
-	// Reference that identifies the object.
+	// The reference that identifies the object.
 	//
 	// ObjectReference is a required field
 	ObjectReference *ObjectReference `type:"structure" required:"true"`
@@ -7523,7 +9073,7 @@ type BatchDetachObject struct {
 	// The name of the link.
 	//
 	// LinkName is a required field
-	LinkName *string `type:"string" required:"true"`
+	LinkName *string `min:"1" type:"string" required:"true"`
 
 	// Parent reference from which the object with the specified link name is detached.
 	//
@@ -7549,6 +9099,9 @@ func (s *BatchDetachObject) Validate() error {
 	}
 	if s.LinkName == nil {
 		invalidParams.Add(request.NewErrParamRequired("LinkName"))
+	}
+	if s.LinkName != nil && len(*s.LinkName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LinkName", 1))
 	}
 	if s.ParentReference == nil {
 		invalidParams.Add(request.NewErrParamRequired("ParentReference"))
@@ -7608,11 +9161,12 @@ func (s *BatchDetachObjectResponse) SetDetachedObjectIdentifier(v string) *Batch
 type BatchListObjectAttributes struct {
 	_ struct{} `type:"structure"`
 
-	// Used to filter the list of object attributes associated with a certain facet.
+	// Used to filter the list of object attributes that are associated with a certain
+	// facet.
 	FacetFilter *SchemaFacet `type:"structure"`
 
-	// Maximum number of items to be retrieved in a single call. This is an approximate
-	// number.
+	// The maximum number of items to be retrieved in a single call. This is an
+	// approximate number.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The pagination token.
@@ -7684,8 +9238,8 @@ func (s *BatchListObjectAttributes) SetObjectReference(v *ObjectReference) *Batc
 type BatchListObjectAttributesResponse struct {
 	_ struct{} `type:"structure"`
 
-	// Attributes map associated with the object. AttributeArn is the key; attribute
-	// value is the value.
+	// The attributes map that is associated with the object. AttributeArn is the
+	// key; attribute value is the value.
 	Attributes []*AttributeKeyAndValue `type:"list"`
 
 	// The pagination token.
@@ -7781,7 +9335,7 @@ func (s *BatchListObjectChildren) SetObjectReference(v *ObjectReference) *BatchL
 type BatchListObjectChildrenResponse struct {
 	_ struct{} `type:"structure"`
 
-	// Children structure, which is a map with key as the LinkName and ObjectIdentifier
+	// The children structure, which is a map with the key as the LinkName and ObjectIdentifier
 	// as the value.
 	Children map[string]*string `type:"map"`
 
@@ -7811,15 +9365,16 @@ func (s *BatchListObjectChildrenResponse) SetNextToken(v string) *BatchListObjec
 	return s
 }
 
-// Batch Read Exception structure, which contains exception type and message.
+// The batch read exception structure, which contains the exception type and
+// message.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadException
 type BatchReadException struct {
 	_ struct{} `type:"structure"`
 
-	// Exception message associated with the failure.
+	// An exception message that is associated with the failure.
 	Message *string `type:"string"`
 
-	// Type of exception, such as InvalidArnException.
+	// A type of exception, such as InvalidArnException.
 	Type *string `type:"string" enum:"BatchReadExceptionType"`
 }
 
@@ -7853,12 +9408,13 @@ type BatchReadInput struct {
 	// of an object is reflected in a subsequent read operation of that same object.
 	ConsistencyLevel *string `location:"header" locationName:"x-amz-consistency-level" type:"string" enum:"ConsistencyLevel"`
 
-	// ARN associated with the Directory. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory. For
+	// more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// List of operations that are part of the batch.
+	// A list of operations that are part of the batch.
 	//
 	// Operations is a required field
 	Operations []*BatchReadOperation `type:"list" required:"true"`
@@ -7923,7 +9479,7 @@ func (s *BatchReadInput) SetOperations(v []*BatchReadOperation) *BatchReadInput 
 type BatchReadOperation struct {
 	_ struct{} `type:"structure"`
 
-	// Lists all attributes associated with an object.
+	// Lists all attributes that are associated with an object.
 	ListObjectAttributes *BatchListObjectAttributes `type:"structure"`
 
 	// Returns a paginated list of child objects that are associated with a given
@@ -8011,7 +9567,7 @@ func (s *BatchReadOperationResponse) SetSuccessfulResponse(v *BatchReadSuccessfu
 type BatchReadOutput struct {
 	_ struct{} `type:"structure"`
 
-	// List of all the responses for each batch read.
+	// A list of all the responses for each batch read.
 	Responses []*BatchReadOperationResponse `type:"list"`
 }
 
@@ -8036,10 +9592,11 @@ func (s *BatchReadOutput) SetResponses(v []*BatchReadOperationResponse) *BatchRe
 type BatchReadSuccessfulResponse struct {
 	_ struct{} `type:"structure"`
 
-	// Lists all attributes associated with an object.
+	// Lists all attributes that are associated with an object.
 	ListObjectAttributes *BatchListObjectAttributesResponse `type:"structure"`
 
-	// Returns a paginated list of child objects associated with a given object.
+	// Returns a paginated list of child objects that are associated with a given
+	// object.
 	ListObjectChildren *BatchListObjectChildrenResponse `type:"structure"`
 }
 
@@ -8065,7 +9622,7 @@ func (s *BatchReadSuccessfulResponse) SetListObjectChildren(v *BatchListObjectCh
 	return s
 }
 
-// Batch operation to remove a facet from an object.
+// A batch operation to remove a facet from an object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchRemoveFacetFromObject
 type BatchRemoveFacetFromObject struct {
 	_ struct{} `type:"structure"`
@@ -8124,7 +9681,7 @@ func (s *BatchRemoveFacetFromObject) SetSchemaFacet(v *SchemaFacet) *BatchRemove
 	return s
 }
 
-// Empty result representing success.
+// An empty result that represents success.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchRemoveFacetFromObjectResponse
 type BatchRemoveFacetFromObjectResponse struct {
 	_ struct{} `type:"structure"`
@@ -8209,7 +9766,7 @@ func (s *BatchUpdateObjectAttributes) SetObjectReference(v *ObjectReference) *Ba
 type BatchUpdateObjectAttributesResponse struct {
 	_ struct{} `type:"structure"`
 
-	// ID associated with the object.
+	// ID that is associated with the object.
 	ObjectIdentifier *string `type:"string"`
 }
 
@@ -8233,12 +9790,13 @@ func (s *BatchUpdateObjectAttributesResponse) SetObjectIdentifier(v string) *Bat
 type BatchWriteInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory. For
+	// more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// List of operations that are part of the batch.
+	// A list of operations that are part of the batch.
 	//
 	// Operations is a required field
 	Operations []*BatchWriteOperation `type:"list" required:"true"`
@@ -8297,7 +9855,7 @@ func (s *BatchWriteInput) SetOperations(v []*BatchWriteOperation) *BatchWriteInp
 type BatchWriteOperation struct {
 	_ struct{} `type:"structure"`
 
-	// Batch operation adding a facet to an object.
+	// A batch operation that adds a facet to an object.
 	AddFacetToObject *BatchAddFacetToObject `type:"structure"`
 
 	// Attaches an object to a Directory.
@@ -8312,10 +9870,10 @@ type BatchWriteOperation struct {
 	// Detaches an object from a Directory.
 	DetachObject *BatchDetachObject `type:"structure"`
 
-	// Batch operation removing a facet from an object.
+	// A batch operation that removes a facet from an object.
 	RemoveFacetFromObject *BatchRemoveFacetFromObject `type:"structure"`
 
-	// Update a given object's attributes.
+	// Updates a given object's attributes.
 	UpdateObjectAttributes *BatchUpdateObjectAttributes `type:"structure"`
 }
 
@@ -8421,7 +9979,7 @@ func (s *BatchWriteOperation) SetUpdateObjectAttributes(v *BatchUpdateObjectAttr
 type BatchWriteOperationResponse struct {
 	_ struct{} `type:"structure"`
 
-	// Result of an add facet to object batch operation.
+	// The result of an add facet to object batch operation.
 	AddFacetToObject *BatchAddFacetToObjectResponse `type:"structure"`
 
 	// Attaches an object to a Directory.
@@ -8436,7 +9994,7 @@ type BatchWriteOperationResponse struct {
 	// Detaches an object from a Directory.
 	DetachObject *BatchDetachObjectResponse `type:"structure"`
 
-	// Result of a batch remove facet from object operation.
+	// The result of a batch remove facet from object operation.
 	RemoveFacetFromObject *BatchRemoveFacetFromObjectResponse `type:"structure"`
 
 	// Updates a given object’s attributes.
@@ -8499,7 +10057,7 @@ func (s *BatchWriteOperationResponse) SetUpdateObjectAttributes(v *BatchUpdateOb
 type BatchWriteOutput struct {
 	_ struct{} `type:"structure"`
 
-	// List of all the responses for each batch write.
+	// A list of all the responses for each batch write.
 	Responses []*BatchWriteOperationResponse `type:"list"`
 }
 
@@ -8523,13 +10081,13 @@ func (s *BatchWriteOutput) SetResponses(v []*BatchWriteOperationResponse) *Batch
 type CreateDirectoryInput struct {
 	_ struct{} `type:"structure"`
 
-	// Name of the Directory. Should be unique per account, per region.
+	// The name of the Directory. Should be unique per account, per region.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// ARN of the published schema that will be copied into the data Directory.
-	// For more information, see arns.
+	// The Amazon Resource Name (ARN) of the published schema that will be copied
+	// into the data Directory. For more information, see arns.
 	//
 	// SchemaArn is a required field
 	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -8580,19 +10138,20 @@ func (s *CreateDirectoryInput) SetSchemaArn(v string) *CreateDirectoryInput {
 type CreateDirectoryOutput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN of the published schema in the Directory. Once a published schema is
-	// copied into the directory, it has its own ARN which is referred to applied
+	// The ARN of the published schema in the Directory. Once a published schema
+	// is copied into the directory, it has its own ARN, which is referred to applied
 	// schema ARN. For more information, see arns.
 	//
 	// AppliedSchemaArn is a required field
 	AppliedSchemaArn *string `type:"string" required:"true"`
 
-	// ARN associated with the Directory. For more information, see arns.
+	// The ARN that is associated with the Directory. For more information, see
+	// arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `type:"string" required:"true"`
 
-	// Name of the Directory.
+	// The name of the Directory.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
@@ -8641,20 +10200,20 @@ func (s *CreateDirectoryOutput) SetObjectIdentifier(v string) *CreateDirectoryOu
 type CreateFacetInput struct {
 	_ struct{} `type:"structure"`
 
-	// Attributes associated with the Facet.e
+	// The attributes that are associated with the Facet.
 	Attributes []*FacetAttribute `type:"list"`
 
-	// Name of the Facet, which is unique for a given schema.
+	// The name of the Facet, which is unique for a given schema.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// Specifies whether a given object created from this facet is of type Node,
-	// Leaf Node, Policy or Index.
+	// Specifies whether a given object created from this facet is of type node,
+	// leaf node, policy or index.
 	//
 	//    * Node: Can have multiple children but one parent.
 	//
-	//    * Leaf Node: Cannot have children but can have multiple parents.
+	//    * Leaf node: Cannot have children but can have multiple parents.
 	//
 	//    * Policy: Allows you to store a policy document and policy type. For more
 	//    information, see Policies (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies).
@@ -8664,7 +10223,7 @@ type CreateFacetInput struct {
 	// ObjectType is a required field
 	ObjectType *string `type:"string" required:"true" enum:"ObjectType"`
 
-	// Schema ARN in which the new Facet will be created. For more information,
+	// The schema ARN in which the new Facet will be created. For more information,
 	// see arns.
 	//
 	// SchemaArn is a required field
@@ -8761,16 +10320,16 @@ type CreateIndexInput struct {
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Indicates whether objects with the same indexed attribute value can be added
-	// to the index.
+	// Indicates whether the attribute that is being indexed has unique values or
+	// not.
 	//
 	// IsUnique is a required field
 	IsUnique *bool `type:"boolean" required:"true"`
 
 	// The name of the link between the parent object and the index object.
-	LinkName *string `type:"string"`
+	LinkName *string `min:"1" type:"string"`
 
-	// Specifies the Attributes that should be indexed on. Currently only a single
+	// Specifies the attributes that should be indexed on. Currently only a single
 	// attribute is supported.
 	//
 	// OrderedIndexedAttributeList is a required field
@@ -8798,6 +10357,9 @@ func (s *CreateIndexInput) Validate() error {
 	}
 	if s.IsUnique == nil {
 		invalidParams.Add(request.NewErrParamRequired("IsUnique"))
+	}
+	if s.LinkName != nil && len(*s.LinkName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LinkName", 1))
 	}
 	if s.OrderedIndexedAttributeList == nil {
 		invalidParams.Add(request.NewErrParamRequired("OrderedIndexedAttributeList"))
@@ -8877,24 +10439,24 @@ func (s *CreateIndexOutput) SetObjectIdentifier(v string) *CreateIndexOutput {
 type CreateObjectInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory in which the object will be created. For
-	// more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory in which
+	// the object will be created. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
 	// The name of link that is used to attach this object to a parent.
-	LinkName *string `type:"string"`
+	LinkName *string `min:"1" type:"string"`
 
-	// Attribute map whose attribute ARN contains the key and attribute value as
-	// the map value.
+	// The attribute map whose attribute ARN contains the key and attribute value
+	// as the map value.
 	ObjectAttributeList []*AttributeKeyAndValue `type:"list"`
 
 	// If specified, the parent reference to which this object will be attached.
 	ParentReference *ObjectReference `type:"structure"`
 
-	// List of facet ARNs to be associated with the object. For more information,
-	// see arns.
+	// A list of schema facets to be associated with the object that contains SchemaArn
+	// and facet name. For more information, see arns.
 	//
 	// SchemaFacets is a required field
 	SchemaFacets []*SchemaFacet `type:"list" required:"true"`
@@ -8915,6 +10477,9 @@ func (s *CreateObjectInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateObjectInput"}
 	if s.DirectoryArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("DirectoryArn"))
+	}
+	if s.LinkName != nil && len(*s.LinkName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LinkName", 1))
 	}
 	if s.SchemaFacets == nil {
 		invalidParams.Add(request.NewErrParamRequired("SchemaFacets"))
@@ -8980,7 +10545,7 @@ func (s *CreateObjectInput) SetSchemaFacets(v []*SchemaFacet) *CreateObjectInput
 type CreateObjectOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifier associated with the object.
+	// The identifier that is associated with the object.
 	ObjectIdentifier *string `type:"string"`
 }
 
@@ -9004,8 +10569,8 @@ func (s *CreateObjectOutput) SetObjectIdentifier(v string) *CreateObjectOutput {
 type CreateSchemaInput struct {
 	_ struct{} `type:"structure"`
 
-	// Name associated with the schema. This is unique to each account and in each
-	// region.
+	// The name that is associated with the schema. This is unique to each account
+	// and in each region.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
@@ -9047,7 +10612,8 @@ func (s *CreateSchemaInput) SetName(v string) *CreateSchemaInput {
 type CreateSchemaOutput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the schema. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the schema. For more
+	// information, see arns.
 	SchemaArn *string `type:"string"`
 }
 
@@ -9065,6 +10631,80 @@ func (s CreateSchemaOutput) GoString() string {
 func (s *CreateSchemaOutput) SetSchemaArn(v string) *CreateSchemaOutput {
 	s.SchemaArn = &v
 	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateTypedLinkFacetRequest
+type CreateTypedLinkFacetInput struct {
+	_ struct{} `type:"structure"`
+
+	// Facet structure that is associated with the typed link facet.
+	//
+	// Facet is a required field
+	Facet *TypedLinkFacet `type:"structure" required:"true"`
+
+	// The Amazon Resource Name (ARN) that is associated with the schema. For more
+	// information, see arns.
+	//
+	// SchemaArn is a required field
+	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateTypedLinkFacetInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTypedLinkFacetInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTypedLinkFacetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTypedLinkFacetInput"}
+	if s.Facet == nil {
+		invalidParams.Add(request.NewErrParamRequired("Facet"))
+	}
+	if s.SchemaArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SchemaArn"))
+	}
+	if s.Facet != nil {
+		if err := s.Facet.Validate(); err != nil {
+			invalidParams.AddNested("Facet", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFacet sets the Facet field's value.
+func (s *CreateTypedLinkFacetInput) SetFacet(v *TypedLinkFacet) *CreateTypedLinkFacetInput {
+	s.Facet = v
+	return s
+}
+
+// SetSchemaArn sets the SchemaArn field's value.
+func (s *CreateTypedLinkFacetInput) SetSchemaArn(v string) *CreateTypedLinkFacetInput {
+	s.SchemaArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateTypedLinkFacetResponse
+type CreateTypedLinkFacetOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTypedLinkFacetOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTypedLinkFacetOutput) GoString() string {
+	return s.String()
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteDirectoryRequest
@@ -9141,7 +10781,8 @@ type DeleteFacetInput struct {
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// ARN associated with the Facet. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Facet. For more
+	// information, see arns.
 	//
 	// SchemaArn is a required field
 	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -9207,13 +10848,13 @@ func (s DeleteFacetOutput) GoString() string {
 type DeleteObjectInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory where the object resides. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// the object resides. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Reference that identifies the object.
+	// A reference that identifies the object.
 	//
 	// ObjectReference is a required field
 	ObjectReference *ObjectReference `type:"structure" required:"true"`
@@ -9276,7 +10917,8 @@ func (s DeleteObjectOutput) GoString() string {
 type DeleteSchemaInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN of the development schema. For more information, see arns.
+	// The Amazon Resource Name (ARN) of the development schema. For more information,
+	// see arns.
 	//
 	// SchemaArn is a required field
 	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -9315,7 +10957,7 @@ func (s *DeleteSchemaInput) SetSchemaArn(v string) *DeleteSchemaInput {
 type DeleteSchemaOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Input ARN that is returned as part of the response. For more information,
+	// The input ARN that is returned as part of the response. For more information,
 	// see arns.
 	SchemaArn *string `type:"string"`
 }
@@ -9336,11 +10978,81 @@ func (s *DeleteSchemaOutput) SetSchemaArn(v string) *DeleteSchemaOutput {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteTypedLinkFacetRequest
+type DeleteTypedLinkFacetInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique name of the typed link facet.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+
+	// The Amazon Resource Name (ARN) that is associated with the schema. For more
+	// information, see arns.
+	//
+	// SchemaArn is a required field
+	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteTypedLinkFacetInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTypedLinkFacetInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteTypedLinkFacetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteTypedLinkFacetInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SchemaArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SchemaArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteTypedLinkFacetInput) SetName(v string) *DeleteTypedLinkFacetInput {
+	s.Name = &v
+	return s
+}
+
+// SetSchemaArn sets the SchemaArn field's value.
+func (s *DeleteTypedLinkFacetInput) SetSchemaArn(v string) *DeleteTypedLinkFacetInput {
+	s.SchemaArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteTypedLinkFacetResponse
+type DeleteTypedLinkFacetOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTypedLinkFacetOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTypedLinkFacetOutput) GoString() string {
+	return s.String()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachFromIndexRequest
 type DetachFromIndexInput struct {
 	_ struct{} `type:"structure"`
 
-	// The ARN of the directory the index and object exist in.
+	// The Amazon Resource Name (ARN) of the directory the index and object exist
+	// in.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -9431,18 +11143,19 @@ func (s *DetachFromIndexOutput) SetDetachedObjectIdentifier(v string) *DetachFro
 type DetachObjectInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory where objects reside. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// objects reside. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Link name associated with the object that needs to be detached.
+	// The link name associated with the object that needs to be detached.
 	//
 	// LinkName is a required field
-	LinkName *string `type:"string" required:"true"`
+	LinkName *string `min:"1" type:"string" required:"true"`
 
-	// Parent reference from which the object with the specified link name is detached.
+	// The parent reference from which the object with the specified link name is
+	// detached.
 	//
 	// ParentReference is a required field
 	ParentReference *ObjectReference `type:"structure" required:"true"`
@@ -9466,6 +11179,9 @@ func (s *DetachObjectInput) Validate() error {
 	}
 	if s.LinkName == nil {
 		invalidParams.Add(request.NewErrParamRequired("LinkName"))
+	}
+	if s.LinkName != nil && len(*s.LinkName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LinkName", 1))
 	}
 	if s.ParentReference == nil {
 		invalidParams.Add(request.NewErrParamRequired("ParentReference"))
@@ -9523,8 +11239,8 @@ func (s *DetachObjectOutput) SetDetachedObjectIdentifier(v string) *DetachObject
 type DetachPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory where both objects reside. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// both objects reside. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -9602,6 +11318,80 @@ func (s DetachPolicyOutput) GoString() string {
 	return s.String()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachTypedLinkRequest
+type DetachTypedLinkInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the directory where you want to detach
+	// the typed link.
+	//
+	// DirectoryArn is a required field
+	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+
+	// Used to accept a typed link specifier as input.
+	//
+	// TypedLinkSpecifier is a required field
+	TypedLinkSpecifier *TypedLinkSpecifier `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s DetachTypedLinkInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DetachTypedLinkInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachTypedLinkInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachTypedLinkInput"}
+	if s.DirectoryArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryArn"))
+	}
+	if s.TypedLinkSpecifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("TypedLinkSpecifier"))
+	}
+	if s.TypedLinkSpecifier != nil {
+		if err := s.TypedLinkSpecifier.Validate(); err != nil {
+			invalidParams.AddNested("TypedLinkSpecifier", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDirectoryArn sets the DirectoryArn field's value.
+func (s *DetachTypedLinkInput) SetDirectoryArn(v string) *DetachTypedLinkInput {
+	s.DirectoryArn = &v
+	return s
+}
+
+// SetTypedLinkSpecifier sets the TypedLinkSpecifier field's value.
+func (s *DetachTypedLinkInput) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *DetachTypedLinkInput {
+	s.TypedLinkSpecifier = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachTypedLinkOutput
+type DetachTypedLinkOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachTypedLinkOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DetachTypedLinkOutput) GoString() string {
+	return s.String()
+}
+
 // Directory structure that includes the directory name and directory ARN.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/Directory
 type Directory struct {
@@ -9610,7 +11400,8 @@ type Directory struct {
 	// The date and time when the directory was created.
 	CreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// ARN associated with the directory. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the directory. For
+	// more information, see arns.
 	DirectoryArn *string `type:"string"`
 
 	// The name of the directory.
@@ -9792,7 +11583,7 @@ type Facet struct {
 	// The name of the Facet.
 	Name *string `min:"1" type:"string"`
 
-	// Object type associated with the facet. See CreateFacetRequest$ObjectType
+	// The object type that is associated with the facet. See CreateFacetRequest$ObjectType
 	// for more details.
 	ObjectType *string `type:"string" enum:"ObjectType"`
 }
@@ -9819,7 +11610,7 @@ func (s *Facet) SetObjectType(v string) *Facet {
 	return s
 }
 
-// Attribute associated with the Facet.
+// An attribute that is associated with the Facet.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/FacetAttribute
 type FacetAttribute struct {
 	_ struct{} `type:"structure"`
@@ -9829,8 +11620,8 @@ type FacetAttribute struct {
 	// for more information.
 	AttributeDefinition *FacetAttributeDefinition `type:"structure"`
 
-	// Attribute reference associated with the attribute. See Attribute References
-	// (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences)
+	// An attribute reference that is associated with the attribute. See Attribute
+	// References (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences)
 	// for more information.
 	AttributeReference *FacetAttributeReference `type:"structure"`
 
@@ -9971,21 +11762,21 @@ func (s *FacetAttributeDefinition) SetType(v string) *FacetAttributeDefinition {
 	return s
 }
 
-// Facet attribute reference that specifies the attribute definition which contains
-// attribute facet name and attribute name.
+// The facet attribute reference that specifies the attribute definition that
+// contains the attribute facet name and attribute name.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/FacetAttributeReference
 type FacetAttributeReference struct {
 	_ struct{} `type:"structure"`
 
-	// Target attribute name associated with the facet reference. See Attribute
-	// References (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences)
+	// The target attribute name that is associated with the facet reference. See
+	// Attribute References (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences)
 	// for more information.
 	//
 	// TargetAttributeName is a required field
 	TargetAttributeName *string `min:"1" type:"string" required:"true"`
 
-	// Target facet name associated with the facet reference. See Attribute References
-	// (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences)
+	// The target facet name that is associated with the facet reference. See Attribute
+	// References (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences)
 	// for more information.
 	//
 	// TargetFacetName is a required field
@@ -10159,7 +11950,8 @@ type GetFacetInput struct {
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// ARN associated with the Facet. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Facet. For more
+	// information, see arns.
 	//
 	// SchemaArn is a required field
 	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -10210,7 +12002,7 @@ func (s *GetFacetInput) SetSchemaArn(v string) *GetFacetInput {
 type GetFacetOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Facet structure associated with the facet.
+	// The Facet structure that is associated with the facet.
 	Facet *Facet `type:"structure"`
 }
 
@@ -10394,6 +12186,90 @@ func (s *GetSchemaAsJsonOutput) SetDocument(v string) *GetSchemaAsJsonOutput {
 // SetName sets the Name field's value.
 func (s *GetSchemaAsJsonOutput) SetName(v string) *GetSchemaAsJsonOutput {
 	s.Name = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetTypedLinkFacetInformationRequest
+type GetTypedLinkFacetInformationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique name of the typed link facet.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+
+	// The Amazon Resource Name (ARN) that is associated with the schema. For more
+	// information, see arns.
+	//
+	// SchemaArn is a required field
+	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetTypedLinkFacetInformationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetTypedLinkFacetInformationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetTypedLinkFacetInformationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetTypedLinkFacetInformationInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SchemaArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SchemaArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *GetTypedLinkFacetInformationInput) SetName(v string) *GetTypedLinkFacetInformationInput {
+	s.Name = &v
+	return s
+}
+
+// SetSchemaArn sets the SchemaArn field's value.
+func (s *GetTypedLinkFacetInformationInput) SetSchemaArn(v string) *GetTypedLinkFacetInformationInput {
+	s.SchemaArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetTypedLinkFacetInformationResponse
+type GetTypedLinkFacetInformationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A range filter that you provide for multiple attributes. The ability to filter
+	// typed links considers the order that the attributes are defined on the typed
+	// link facet. When providing ranges to typed link selection, any inexact ranges
+	// must be specified at the end. Any attributes that do not have a range specified
+	// are presumed to match the entire range. Filters are interpreted in the order
+	// of the attributes on the typed link facet, not the order in which they are
+	// supplied to any API calls.
+	IdentityAttributeOrder []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s GetTypedLinkFacetInformationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetTypedLinkFacetInformationOutput) GoString() string {
+	return s.String()
+}
+
+// SetIdentityAttributeOrder sets the IdentityAttributeOrder field's value.
+func (s *GetTypedLinkFacetInformationOutput) SetIdentityAttributeOrder(v []*string) *GetTypedLinkFacetInformationOutput {
+	s.IdentityAttributeOrder = v
 	return s
 }
 
@@ -10779,7 +12655,8 @@ func (s *ListDirectoriesInput) SetState(v string) *ListDirectoriesInput {
 type ListDirectoriesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Lists all directories associated with your account in pagination fashion.
+	// Lists all directories that are associated with your account in pagination
+	// fashion.
 	//
 	// Directories is a required field
 	Directories []*Directory `type:"list" required:"true"`
@@ -10924,13 +12801,13 @@ func (s *ListFacetAttributesOutput) SetNextToken(v string) *ListFacetAttributesO
 type ListFacetNamesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The maximum number of results to retrieve
+	// The maximum number of results to retrieve.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// The ARN to retrieve facet names from.
+	// The Amazon Resource Name (ARN) to retrieve facet names from.
 	//
 	// SchemaArn is a required field
 	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -11009,6 +12886,160 @@ func (s *ListFacetNamesOutput) SetFacetNames(v []*string) *ListFacetNamesOutput 
 
 // SetNextToken sets the NextToken field's value.
 func (s *ListFacetNamesOutput) SetNextToken(v string) *ListFacetNamesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIncomingTypedLinksRequest
+type ListIncomingTypedLinksInput struct {
+	_ struct{} `type:"structure"`
+
+	// The consistency level to execute the request at.
+	ConsistencyLevel *string `type:"string" enum:"ConsistencyLevel"`
+
+	// The Amazon Resource Name (ARN) of the directory where you want to list the
+	// typed links.
+	//
+	// DirectoryArn is a required field
+	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+
+	// Provides range filters for multiple attributes. When providing ranges to
+	// typed link selection, any inexact ranges must be specified at the end. Any
+	// attributes that do not have a range specified are presumed to match the entire
+	// range.
+	FilterAttributeRanges []*TypedLinkAttributeRange `type:"list"`
+
+	// Filters are interpreted in the order of the attributes on the typed link
+	// facet, not the order in which they are supplied to any API calls.
+	FilterTypedLink *TypedLinkSchemaAndFacetName `type:"structure"`
+
+	// The maximum number of results to retrieve.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// The pagination token.
+	NextToken *string `type:"string"`
+
+	// Reference that identifies the object whose attributes will be listed.
+	//
+	// ObjectReference is a required field
+	ObjectReference *ObjectReference `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s ListIncomingTypedLinksInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListIncomingTypedLinksInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListIncomingTypedLinksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListIncomingTypedLinksInput"}
+	if s.DirectoryArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryArn"))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.ObjectReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("ObjectReference"))
+	}
+	if s.FilterAttributeRanges != nil {
+		for i, v := range s.FilterAttributeRanges {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "FilterAttributeRanges", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.FilterTypedLink != nil {
+		if err := s.FilterTypedLink.Validate(); err != nil {
+			invalidParams.AddNested("FilterTypedLink", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetConsistencyLevel sets the ConsistencyLevel field's value.
+func (s *ListIncomingTypedLinksInput) SetConsistencyLevel(v string) *ListIncomingTypedLinksInput {
+	s.ConsistencyLevel = &v
+	return s
+}
+
+// SetDirectoryArn sets the DirectoryArn field's value.
+func (s *ListIncomingTypedLinksInput) SetDirectoryArn(v string) *ListIncomingTypedLinksInput {
+	s.DirectoryArn = &v
+	return s
+}
+
+// SetFilterAttributeRanges sets the FilterAttributeRanges field's value.
+func (s *ListIncomingTypedLinksInput) SetFilterAttributeRanges(v []*TypedLinkAttributeRange) *ListIncomingTypedLinksInput {
+	s.FilterAttributeRanges = v
+	return s
+}
+
+// SetFilterTypedLink sets the FilterTypedLink field's value.
+func (s *ListIncomingTypedLinksInput) SetFilterTypedLink(v *TypedLinkSchemaAndFacetName) *ListIncomingTypedLinksInput {
+	s.FilterTypedLink = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListIncomingTypedLinksInput) SetMaxResults(v int64) *ListIncomingTypedLinksInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIncomingTypedLinksInput) SetNextToken(v string) *ListIncomingTypedLinksInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetObjectReference sets the ObjectReference field's value.
+func (s *ListIncomingTypedLinksInput) SetObjectReference(v *ObjectReference) *ListIncomingTypedLinksInput {
+	s.ObjectReference = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIncomingTypedLinksResponse
+type ListIncomingTypedLinksOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Returns a typed link specifier as output.
+	LinkSpecifiers []*TypedLinkSpecifier `type:"list"`
+
+	// The pagination token.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListIncomingTypedLinksOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListIncomingTypedLinksOutput) GoString() string {
+	return s.String()
+}
+
+// SetLinkSpecifiers sets the LinkSpecifiers field's value.
+func (s *ListIncomingTypedLinksOutput) SetLinkSpecifiers(v []*TypedLinkSpecifier) *ListIncomingTypedLinksOutput {
+	s.LinkSpecifiers = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIncomingTypedLinksOutput) SetNextToken(v string) *ListIncomingTypedLinksOutput {
 	s.NextToken = &v
 	return s
 }
@@ -11156,23 +13187,24 @@ type ListObjectAttributesInput struct {
 	// of an object is reflected in a subsequent read operation of that same object.
 	ConsistencyLevel *string `location:"header" locationName:"x-amz-consistency-level" type:"string" enum:"ConsistencyLevel"`
 
-	// ARN associated with the Directory where the object resides. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// the object resides. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Used to filter the list of object attributes associated with a certain facet.
+	// Used to filter the list of object attributes that are associated with a certain
+	// facet.
 	FacetFilter *SchemaFacet `type:"structure"`
 
-	// Maximum number of items to be retrieved in a single call. This is an approximate
-	// number.
+	// The maximum number of items to be retrieved in a single call. This is an
+	// approximate number.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// Reference that identifies the object whose attributes will be listed.
+	// The reference that identifies the object whose attributes will be listed.
 	//
 	// ObjectReference is a required field
 	ObjectReference *ObjectReference `type:"structure" required:"true"`
@@ -11252,8 +13284,8 @@ func (s *ListObjectAttributesInput) SetObjectReference(v *ObjectReference) *List
 type ListObjectAttributesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Attributes map associated with the object. AttributeArn is the key, and attribute
-	// value is the value.
+	// Attributes map that is associated with the object. AttributeArn is the key,
+	// and attribute value is the value.
 	Attributes []*AttributeKeyAndValue `type:"list"`
 
 	// The pagination token.
@@ -11290,20 +13322,21 @@ type ListObjectChildrenInput struct {
 	// of an object is reflected in a subsequent read operation of that same object.
 	ConsistencyLevel *string `location:"header" locationName:"x-amz-consistency-level" type:"string" enum:"ConsistencyLevel"`
 
-	// ARN associated with the Directory where the object resides. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// the object resides. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Maximum number of items to be retrieved in a single call. This is an approximate
-	// number.
+	// The maximum number of items to be retrieved in a single call. This is an
+	// approximate number.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// Reference that identifies the object for which child objects are being listed.
+	// The reference that identifies the object for which child objects are being
+	// listed.
 	//
 	// ObjectReference is a required field
 	ObjectReference *ObjectReference `type:"structure" required:"true"`
@@ -11411,14 +13444,14 @@ type ListObjectParentPathsInput struct {
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Maximum number of items to be retrieved in a single call. This is an approximate
-	// number.
+	// The maximum number of items to be retrieved in a single call. This is an
+	// approximate number.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// Reference that identifies the object whose parent paths are listed.
+	// The reference that identifies the object whose parent paths are listed.
 	//
 	// ObjectReference is a required field
 	ObjectReference *ObjectReference `type:"structure" required:"true"`
@@ -11484,7 +13517,7 @@ type ListObjectParentPathsOutput struct {
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// Returns the path to the ObjectIdentifiers associated with the directory.
+	// Returns the path to the ObjectIdentifiers that are associated with the directory.
 	PathToObjectIdentifiersList []*PathToObjectIdentifiers `type:"list"`
 }
 
@@ -11518,20 +13551,21 @@ type ListObjectParentsInput struct {
 	// of an object is reflected in a subsequent read operation of that same object.
 	ConsistencyLevel *string `location:"header" locationName:"x-amz-consistency-level" type:"string" enum:"ConsistencyLevel"`
 
-	// ARN associated with the Directory where the object resides. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// the object resides. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Maximum number of items to be retrieved in a single call. This is an approximate
-	// number.
+	// The maximum number of items to be retrieved in a single call. This is an
+	// approximate number.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// Reference that identifies the object for which parent objects are being listed.
+	// The reference that identifies the object for which parent objects are being
+	// listed.
 	//
 	// ObjectReference is a required field
 	ObjectReference *ObjectReference `type:"structure" required:"true"`
@@ -11603,8 +13637,8 @@ type ListObjectParentsOutput struct {
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// Parent structure, which is a map with key as the ObjectIdentifier and LinkName
-	// as the value.
+	// The parent structure, which is a map with key as the ObjectIdentifier and
+	// LinkName as the value.
 	Parents map[string]*string `type:"map"`
 }
 
@@ -11638,14 +13672,14 @@ type ListObjectPoliciesInput struct {
 	// of an object is reflected in a subsequent read operation of that same object.
 	ConsistencyLevel *string `location:"header" locationName:"x-amz-consistency-level" type:"string" enum:"ConsistencyLevel"`
 
-	// ARN associated with the Directory where objects reside. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// objects reside. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Maximum number of items to be retrieved in a single call. This is an approximate
-	// number.
+	// The maximum number of items to be retrieved in a single call. This is an
+	// approximate number.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The pagination token.
@@ -11720,7 +13754,7 @@ func (s *ListObjectPoliciesInput) SetObjectReference(v *ObjectReference) *ListOb
 type ListObjectPoliciesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// List of policy ObjectIdentifiers, that are attached to the object.
+	// A list of policy ObjectIdentifiers, that are attached to the object.
 	AttachedPolicyIds []*string `type:"list"`
 
 	// The pagination token.
@@ -11749,6 +13783,160 @@ func (s *ListObjectPoliciesOutput) SetNextToken(v string) *ListObjectPoliciesOut
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListOutgoingTypedLinksRequest
+type ListOutgoingTypedLinksInput struct {
+	_ struct{} `type:"structure"`
+
+	// The consistency level to execute the request at.
+	ConsistencyLevel *string `type:"string" enum:"ConsistencyLevel"`
+
+	// The Amazon Resource Name (ARN) of the directory where you want to list the
+	// typed links.
+	//
+	// DirectoryArn is a required field
+	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+
+	// Provides range filters for multiple attributes. When providing ranges to
+	// typed link selection, any inexact ranges must be specified at the end. Any
+	// attributes that do not have a range specified are presumed to match the entire
+	// range.
+	FilterAttributeRanges []*TypedLinkAttributeRange `type:"list"`
+
+	// Filters are interpreted in the order of the attributes defined on the typed
+	// link facet, not the order they are supplied to any API calls.
+	FilterTypedLink *TypedLinkSchemaAndFacetName `type:"structure"`
+
+	// The maximum number of results to retrieve.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// The pagination token.
+	NextToken *string `type:"string"`
+
+	// A reference that identifies the object whose attributes will be listed.
+	//
+	// ObjectReference is a required field
+	ObjectReference *ObjectReference `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s ListOutgoingTypedLinksInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListOutgoingTypedLinksInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListOutgoingTypedLinksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListOutgoingTypedLinksInput"}
+	if s.DirectoryArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryArn"))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.ObjectReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("ObjectReference"))
+	}
+	if s.FilterAttributeRanges != nil {
+		for i, v := range s.FilterAttributeRanges {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "FilterAttributeRanges", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.FilterTypedLink != nil {
+		if err := s.FilterTypedLink.Validate(); err != nil {
+			invalidParams.AddNested("FilterTypedLink", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetConsistencyLevel sets the ConsistencyLevel field's value.
+func (s *ListOutgoingTypedLinksInput) SetConsistencyLevel(v string) *ListOutgoingTypedLinksInput {
+	s.ConsistencyLevel = &v
+	return s
+}
+
+// SetDirectoryArn sets the DirectoryArn field's value.
+func (s *ListOutgoingTypedLinksInput) SetDirectoryArn(v string) *ListOutgoingTypedLinksInput {
+	s.DirectoryArn = &v
+	return s
+}
+
+// SetFilterAttributeRanges sets the FilterAttributeRanges field's value.
+func (s *ListOutgoingTypedLinksInput) SetFilterAttributeRanges(v []*TypedLinkAttributeRange) *ListOutgoingTypedLinksInput {
+	s.FilterAttributeRanges = v
+	return s
+}
+
+// SetFilterTypedLink sets the FilterTypedLink field's value.
+func (s *ListOutgoingTypedLinksInput) SetFilterTypedLink(v *TypedLinkSchemaAndFacetName) *ListOutgoingTypedLinksInput {
+	s.FilterTypedLink = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListOutgoingTypedLinksInput) SetMaxResults(v int64) *ListOutgoingTypedLinksInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListOutgoingTypedLinksInput) SetNextToken(v string) *ListOutgoingTypedLinksInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetObjectReference sets the ObjectReference field's value.
+func (s *ListOutgoingTypedLinksInput) SetObjectReference(v *ObjectReference) *ListOutgoingTypedLinksInput {
+	s.ObjectReference = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListOutgoingTypedLinksResponse
+type ListOutgoingTypedLinksOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The pagination token.
+	NextToken *string `type:"string"`
+
+	// Returns a typed link specifier as output.
+	TypedLinkSpecifiers []*TypedLinkSpecifier `type:"list"`
+}
+
+// String returns the string representation
+func (s ListOutgoingTypedLinksOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListOutgoingTypedLinksOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListOutgoingTypedLinksOutput) SetNextToken(v string) *ListOutgoingTypedLinksOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTypedLinkSpecifiers sets the TypedLinkSpecifiers field's value.
+func (s *ListOutgoingTypedLinksOutput) SetTypedLinkSpecifiers(v []*TypedLinkSpecifier) *ListOutgoingTypedLinksOutput {
+	s.TypedLinkSpecifiers = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPolicyAttachmentsRequest
 type ListPolicyAttachmentsInput struct {
 	_ struct{} `type:"structure"`
@@ -11757,20 +13945,20 @@ type ListPolicyAttachmentsInput struct {
 	// of an object is reflected in a subsequent read operation of that same object.
 	ConsistencyLevel *string `location:"header" locationName:"x-amz-consistency-level" type:"string" enum:"ConsistencyLevel"`
 
-	// ARN associated with the Directory where objects reside. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// objects reside. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Maximum number of items to be retrieved in a single call. This is an approximate
-	// number.
+	// The maximum number of items to be retrieved in a single call. This is an
+	// approximate number.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// Reference that identifies the policy object.
+	// The reference that identifies the policy object.
 	//
 	// PolicyReference is a required field
 	PolicyReference *ObjectReference `type:"structure" required:"true"`
@@ -11842,7 +14030,7 @@ type ListPolicyAttachmentsOutput struct {
 	// The pagination token.
 	NextToken *string `type:"string"`
 
-	// List of ObjectIdentifiers to which the policy is attached.
+	// A list of ObjectIdentifiers to which the policy is attached.
 	ObjectIdentifiers []*string `type:"list"`
 }
 
@@ -11959,7 +14147,8 @@ type ListTagsForResourceInput struct {
 	// supported for tagging.
 	NextToken *string `type:"string"`
 
-	// ARN of the resource. Tagging is only supported for directories.
+	// The Amazon Resource Name (ARN) of the resource. Tagging is only supported
+	// for directories.
 	//
 	// ResourceArn is a required field
 	ResourceArn *string `type:"string" required:"true"`
@@ -12017,7 +14206,7 @@ type ListTagsForResourceOutput struct {
 	// when there are no more results to return.
 	NextToken *string `type:"string"`
 
-	// List of tag key value pairs associated with the response.
+	// A list of tag key value pairs that are associated with the response.
 	Tags []*Tag `type:"list"`
 }
 
@@ -12043,17 +14232,220 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetAttributesRequest
+type ListTypedLinkFacetAttributesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to retrieve.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// The unique name of the typed link facet.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+
+	// The pagination token.
+	NextToken *string `type:"string"`
+
+	// The Amazon Resource Name (ARN) that is associated with the schema. For more
+	// information, see arns.
+	//
+	// SchemaArn is a required field
+	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListTypedLinkFacetAttributesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTypedLinkFacetAttributesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTypedLinkFacetAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTypedLinkFacetAttributesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SchemaArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SchemaArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListTypedLinkFacetAttributesInput) SetMaxResults(v int64) *ListTypedLinkFacetAttributesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ListTypedLinkFacetAttributesInput) SetName(v string) *ListTypedLinkFacetAttributesInput {
+	s.Name = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTypedLinkFacetAttributesInput) SetNextToken(v string) *ListTypedLinkFacetAttributesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSchemaArn sets the SchemaArn field's value.
+func (s *ListTypedLinkFacetAttributesInput) SetSchemaArn(v string) *ListTypedLinkFacetAttributesInput {
+	s.SchemaArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetAttributesResponse
+type ListTypedLinkFacetAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An ordered set of attributes associate with the typed link.
+	Attributes []*TypedLinkAttributeDefinition `type:"list"`
+
+	// The pagination token.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListTypedLinkFacetAttributesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTypedLinkFacetAttributesOutput) GoString() string {
+	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *ListTypedLinkFacetAttributesOutput) SetAttributes(v []*TypedLinkAttributeDefinition) *ListTypedLinkFacetAttributesOutput {
+	s.Attributes = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTypedLinkFacetAttributesOutput) SetNextToken(v string) *ListTypedLinkFacetAttributesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetNamesRequest
+type ListTypedLinkFacetNamesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to retrieve.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// The pagination token.
+	NextToken *string `type:"string"`
+
+	// The Amazon Resource Name (ARN) that is associated with the schema. For more
+	// information, see arns.
+	//
+	// SchemaArn is a required field
+	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListTypedLinkFacetNamesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTypedLinkFacetNamesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTypedLinkFacetNamesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTypedLinkFacetNamesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.SchemaArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SchemaArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListTypedLinkFacetNamesInput) SetMaxResults(v int64) *ListTypedLinkFacetNamesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTypedLinkFacetNamesInput) SetNextToken(v string) *ListTypedLinkFacetNamesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSchemaArn sets the SchemaArn field's value.
+func (s *ListTypedLinkFacetNamesInput) SetSchemaArn(v string) *ListTypedLinkFacetNamesInput {
+	s.SchemaArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetNamesResponse
+type ListTypedLinkFacetNamesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The names of typed link facets that exist within the schema.
+	FacetNames []*string `type:"list"`
+
+	// The pagination token.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListTypedLinkFacetNamesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTypedLinkFacetNamesOutput) GoString() string {
+	return s.String()
+}
+
+// SetFacetNames sets the FacetNames field's value.
+func (s *ListTypedLinkFacetNamesOutput) SetFacetNames(v []*string) *ListTypedLinkFacetNamesOutput {
+	s.FacetNames = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTypedLinkFacetNamesOutput) SetNextToken(v string) *ListTypedLinkFacetNamesOutput {
+	s.NextToken = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/LookupPolicyRequest
 type LookupPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the Directory. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory. For
+	// more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Maximum number of items to be retrieved in a single call. This is an approximate
-	// number.
+	// The maximum number of items to be retrieved in a single call. This is an
+	// approximate number.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// The token to request the next page of results.
@@ -12126,7 +14518,7 @@ type LookupPolicyOutput struct {
 	NextToken *string `type:"string"`
 
 	// Provides list of path to policies. Policies contain PolicyId, ObjectIdentifier,
-	// and PolicyType.
+	// and PolicyType. For more information, see Policies (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies).
 	PolicyToPathList []*PolicyToPath `type:"list"`
 }
 
@@ -12157,7 +14549,7 @@ func (s *LookupPolicyOutput) SetPolicyToPathList(v []*PolicyToPath) *LookupPolic
 type ObjectAttributeAction struct {
 	_ struct{} `type:"structure"`
 
-	// Type can be either Update or Delete.
+	// A type that can be either Update or Delete.
 	ObjectAttributeActionType *string `type:"string" enum:"UpdateActionType"`
 
 	// The value that you want to update to.
@@ -12191,7 +14583,7 @@ func (s *ObjectAttributeAction) SetObjectAttributeUpdateValue(v *TypedAttributeV
 type ObjectAttributeRange struct {
 	_ struct{} `type:"structure"`
 
-	// The key of the attribute the attribute range covers.
+	// The key of the attribute that the attribute range covers.
 	AttributeKey *AttributeKey `type:"structure"`
 
 	// The range of attribute values being selected.
@@ -12289,15 +14681,22 @@ func (s *ObjectAttributeUpdate) SetObjectAttributeKey(v *AttributeKey) *ObjectAt
 	return s
 }
 
-// Reference that identifies an object.
+// The reference that identifies an object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ObjectReference
 type ObjectReference struct {
 	_ struct{} `type:"structure"`
 
-	// Allows you to specify an object. You can identify an object in one of the
-	// following ways:
+	// A path selector supports easy selection of an object by the parent/child
+	// links leading to it from the directory root. Use the link names from each
+	// parent/child link to construct the path. Path selectors start with a slash
+	// (/) and link names are separated by slashes. For more information about paths,
+	// see Accessing Objects (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#accessingobjects).
+	// You can identify an object in one of the following ways:
 	//
-	//    * $ObjectIdentifier - Identifies the object by ObjectIdentifier
+	//    * $ObjectIdentifier - An object identifier is an opaque string provided
+	//    by Amazon Cloud Directory. When creating objects, the system will provide
+	//    you with the identifier of the created object. An object’s identifier
+	//    is immutable and no two objects will ever share the same object identifier
 	//
 	//    * /some/path - Identifies the object based on path
 	//
@@ -12321,7 +14720,7 @@ func (s *ObjectReference) SetSelector(v string) *ObjectReference {
 	return s
 }
 
-// Returns the path to the ObjectIdentifiers associated with the directory.
+// Returns the path to the ObjectIdentifiers that is associated with the directory.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PathToObjectIdentifiers
 type PathToObjectIdentifiers struct {
 	_ struct{} `type:"structure"`
@@ -12330,7 +14729,7 @@ type PathToObjectIdentifiers struct {
 	// request.
 	ObjectIdentifiers []*string `type:"list"`
 
-	// The path used to identify the object starting from directory root.
+	// The path that is used to identify the object starting from directory root.
 	Path *string `type:"string"`
 }
 
@@ -12357,12 +14756,12 @@ func (s *PathToObjectIdentifiers) SetPath(v string) *PathToObjectIdentifiers {
 }
 
 // Contains the PolicyType, PolicyId, and the ObjectIdentifier to which it is
-// attached.
+// attached. For more information, see Policies (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies).
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PolicyAttachment
 type PolicyAttachment struct {
 	_ struct{} `type:"structure"`
 
-	// The ObjectIdentifier associated with PolicyAttachment.
+	// The ObjectIdentifier that is associated with PolicyAttachment.
 	ObjectIdentifier *string `type:"string"`
 
 	// The ID of PolicyAttachment.
@@ -12401,7 +14800,8 @@ func (s *PolicyAttachment) SetPolicyType(v string) *PolicyAttachment {
 }
 
 // Used when a regular object exists in a Directory and you want to find all
-// of the policies associated with that object and the parent to that object.
+// of the policies that are associated with that object and the parent to that
+// object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PolicyToPath
 type PolicyToPath struct {
 	_ struct{} `type:"structure"`
@@ -12439,16 +14839,17 @@ func (s *PolicyToPath) SetPolicies(v []*PolicyAttachment) *PolicyToPath {
 type PublishSchemaInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the development schema. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the development schema.
+	// For more information, see arns.
 	//
 	// DevelopmentSchemaArn is a required field
 	DevelopmentSchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// New name under which the schema will be published. If this is not provided,
+	// The new name under which the schema will be published. If this is not provided,
 	// the development schema is considered.
 	Name *string `min:"1" type:"string"`
 
-	// Version under which the schema will be published.
+	// The version under which the schema will be published.
 	//
 	// Version is a required field
 	Version *string `min:"1" type:"string" required:"true"`
@@ -12508,7 +14909,8 @@ func (s *PublishSchemaInput) SetVersion(v string) *PublishSchemaInput {
 type PublishSchemaOutput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the published schema. For more information, see arns.
+	// The ARN that is associated with the published schema. For more information,
+	// see arns.
 	PublishedSchemaArn *string `type:"string"`
 }
 
@@ -12692,12 +15094,13 @@ func (s RemoveFacetFromObjectOutput) GoString() string {
 	return s.String()
 }
 
-// Contains an ARN and parameters associated with the rule.
+// Contains an Amazon Resource Name (ARN) and parameters that are associated
+// with the rule.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/Rule
 type Rule struct {
 	_ struct{} `type:"structure"`
 
-	// Min and max parameters associated with the rule.
+	// The minimum and maximum parameters that are associated with the rule.
 	Parameters map[string]*string `type:"map"`
 
 	// The type of attribute validation rule.
@@ -12773,15 +15176,15 @@ func (s *SchemaFacet) SetSchemaArn(v string) *SchemaFacet {
 	return s
 }
 
-// Tag structure which contains tag key and value.
+// The tag structure that contains a tag key and value.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/Tag
 type Tag struct {
 	_ struct{} `type:"structure"`
 
-	// Key associated with the tag.
+	// The key that is associated with the tag.
 	Key *string `type:"string"`
 
-	// Value associated with the tag.
+	// The value that is associated with the tag.
 	Value *string `type:"string"`
 }
 
@@ -12811,12 +15214,13 @@ func (s *Tag) SetValue(v string) *Tag {
 type TagResourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN of the resource. Tagging is only supported for directories.
+	// The Amazon Resource Name (ARN) of the resource. Tagging is only supported
+	// for directories.
 	//
 	// ResourceArn is a required field
 	ResourceArn *string `type:"string" required:"true"`
 
-	// List of tag key value pairs.
+	// A list of tag key-value pairs.
 	//
 	// Tags is a required field
 	Tags []*Tag `type:"list" required:"true"`
@@ -12945,7 +15349,7 @@ func (s *TypedAttributeValue) SetStringValue(v string) *TypedAttributeValue {
 type TypedAttributeValueRange struct {
 	_ struct{} `type:"structure"`
 
-	// Inclusive or exclusive range end.
+	// The inclusive or exclusive range end.
 	//
 	// EndMode is a required field
 	EndMode *string `type:"string" required:"true" enum:"RangeMode"`
@@ -12953,7 +15357,7 @@ type TypedAttributeValueRange struct {
 	// The attribute value to terminate the range at.
 	EndValue *TypedAttributeValue `type:"structure"`
 
-	// Inclusive or exclusive range start.
+	// The inclusive or exclusive range start.
 	//
 	// StartMode is a required field
 	StartMode *string `type:"string" required:"true" enum:"RangeMode"`
@@ -13012,16 +15416,477 @@ func (s *TypedAttributeValueRange) SetStartValue(v *TypedAttributeValue) *TypedA
 	return s
 }
 
+// A typed link attribute definition.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkAttributeDefinition
+type TypedLinkAttributeDefinition struct {
+	_ struct{} `type:"structure"`
+
+	// The default value of the attribute (if configured).
+	DefaultValue *TypedAttributeValue `type:"structure"`
+
+	// Whether the attribute is mutable or not.
+	IsImmutable *bool `type:"boolean"`
+
+	// The unique name of the typed link attribute.
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+
+	// The required behavior of the TypedLinkAttributeDefinition.
+	//
+	// RequiredBehavior is a required field
+	RequiredBehavior *string `type:"string" required:"true" enum:"RequiredAttributeBehavior"`
+
+	// Validation rules that are attached to the attribute definition.
+	Rules map[string]*Rule `type:"map"`
+
+	// The type of the attribute.
+	//
+	// Type is a required field
+	Type *string `type:"string" required:"true" enum:"FacetAttributeType"`
+}
+
+// String returns the string representation
+func (s TypedLinkAttributeDefinition) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TypedLinkAttributeDefinition) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TypedLinkAttributeDefinition) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TypedLinkAttributeDefinition"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RequiredBehavior == nil {
+		invalidParams.Add(request.NewErrParamRequired("RequiredBehavior"))
+	}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDefaultValue sets the DefaultValue field's value.
+func (s *TypedLinkAttributeDefinition) SetDefaultValue(v *TypedAttributeValue) *TypedLinkAttributeDefinition {
+	s.DefaultValue = v
+	return s
+}
+
+// SetIsImmutable sets the IsImmutable field's value.
+func (s *TypedLinkAttributeDefinition) SetIsImmutable(v bool) *TypedLinkAttributeDefinition {
+	s.IsImmutable = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *TypedLinkAttributeDefinition) SetName(v string) *TypedLinkAttributeDefinition {
+	s.Name = &v
+	return s
+}
+
+// SetRequiredBehavior sets the RequiredBehavior field's value.
+func (s *TypedLinkAttributeDefinition) SetRequiredBehavior(v string) *TypedLinkAttributeDefinition {
+	s.RequiredBehavior = &v
+	return s
+}
+
+// SetRules sets the Rules field's value.
+func (s *TypedLinkAttributeDefinition) SetRules(v map[string]*Rule) *TypedLinkAttributeDefinition {
+	s.Rules = v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *TypedLinkAttributeDefinition) SetType(v string) *TypedLinkAttributeDefinition {
+	s.Type = &v
+	return s
+}
+
+// Identifies the range of attributes that are used by a specified filter.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkAttributeRange
+type TypedLinkAttributeRange struct {
+	_ struct{} `type:"structure"`
+
+	// The unique name of the typed link attribute.
+	AttributeName *string `min:"1" type:"string"`
+
+	// The range of attribute values that are being selected.
+	//
+	// Range is a required field
+	Range *TypedAttributeValueRange `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s TypedLinkAttributeRange) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TypedLinkAttributeRange) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TypedLinkAttributeRange) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TypedLinkAttributeRange"}
+	if s.AttributeName != nil && len(*s.AttributeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeName", 1))
+	}
+	if s.Range == nil {
+		invalidParams.Add(request.NewErrParamRequired("Range"))
+	}
+	if s.Range != nil {
+		if err := s.Range.Validate(); err != nil {
+			invalidParams.AddNested("Range", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *TypedLinkAttributeRange) SetAttributeName(v string) *TypedLinkAttributeRange {
+	s.AttributeName = &v
+	return s
+}
+
+// SetRange sets the Range field's value.
+func (s *TypedLinkAttributeRange) SetRange(v *TypedAttributeValueRange) *TypedLinkAttributeRange {
+	s.Range = v
+	return s
+}
+
+// Defines the typed links structure and its attributes. To create a typed link
+// facet, use the CreateTypedLinkFacet API.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkFacet
+type TypedLinkFacet struct {
+	_ struct{} `type:"structure"`
+
+	// An ordered set of attributes that are associate with the typed link. You
+	// can use typed link attributes when you need to represent the relationship
+	// between two objects or allow for quick filtering of incoming or outgoing
+	// typed links.
+	//
+	// Attributes is a required field
+	Attributes []*TypedLinkAttributeDefinition `type:"list" required:"true"`
+
+	// A range filter that you provide for multiple attributes. The ability to filter
+	// typed links considers the order that the attributes are defined on the typed
+	// link facet. When providing ranges to typed link selection, any inexact ranges
+	// must be specified at the end. Any attributes that do not have a range specified
+	// are presumed to match the entire range. Filters are interpreted in the order
+	// of the attributes on the typed link facet, not the order in which they are
+	// supplied to any API calls.
+	//
+	// IdentityAttributeOrder is a required field
+	IdentityAttributeOrder []*string `type:"list" required:"true"`
+
+	// The unique name of the typed link facet.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s TypedLinkFacet) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TypedLinkFacet) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TypedLinkFacet) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TypedLinkFacet"}
+	if s.Attributes == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attributes"))
+	}
+	if s.IdentityAttributeOrder == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityAttributeOrder"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Attributes != nil {
+		for i, v := range s.Attributes {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Attributes", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *TypedLinkFacet) SetAttributes(v []*TypedLinkAttributeDefinition) *TypedLinkFacet {
+	s.Attributes = v
+	return s
+}
+
+// SetIdentityAttributeOrder sets the IdentityAttributeOrder field's value.
+func (s *TypedLinkFacet) SetIdentityAttributeOrder(v []*string) *TypedLinkFacet {
+	s.IdentityAttributeOrder = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *TypedLinkFacet) SetName(v string) *TypedLinkFacet {
+	s.Name = &v
+	return s
+}
+
+// A typed link facet attribute update.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkFacetAttributeUpdate
+type TypedLinkFacetAttributeUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// The action to perform when updating the attribute.
+	//
+	// Action is a required field
+	Action *string `type:"string" required:"true" enum:"UpdateActionType"`
+
+	// The attribute to update.
+	//
+	// Attribute is a required field
+	Attribute *TypedLinkAttributeDefinition `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s TypedLinkFacetAttributeUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TypedLinkFacetAttributeUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TypedLinkFacetAttributeUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TypedLinkFacetAttributeUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.Attribute != nil {
+		if err := s.Attribute.Validate(); err != nil {
+			invalidParams.AddNested("Attribute", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAction sets the Action field's value.
+func (s *TypedLinkFacetAttributeUpdate) SetAction(v string) *TypedLinkFacetAttributeUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *TypedLinkFacetAttributeUpdate) SetAttribute(v *TypedLinkAttributeDefinition) *TypedLinkFacetAttributeUpdate {
+	s.Attribute = v
+	return s
+}
+
+// Identifies the schema Amazon Resource Name (ARN) and facet name for the typed
+// link.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkSchemaAndFacetName
+type TypedLinkSchemaAndFacetName struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) that is associated with the schema. For more
+	// information, see arns.
+	//
+	// SchemaArn is a required field
+	SchemaArn *string `type:"string" required:"true"`
+
+	// The unique name of the typed link facet.
+	//
+	// TypedLinkName is a required field
+	TypedLinkName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s TypedLinkSchemaAndFacetName) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TypedLinkSchemaAndFacetName) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TypedLinkSchemaAndFacetName) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TypedLinkSchemaAndFacetName"}
+	if s.SchemaArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SchemaArn"))
+	}
+	if s.TypedLinkName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TypedLinkName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetSchemaArn sets the SchemaArn field's value.
+func (s *TypedLinkSchemaAndFacetName) SetSchemaArn(v string) *TypedLinkSchemaAndFacetName {
+	s.SchemaArn = &v
+	return s
+}
+
+// SetTypedLinkName sets the TypedLinkName field's value.
+func (s *TypedLinkSchemaAndFacetName) SetTypedLinkName(v string) *TypedLinkSchemaAndFacetName {
+	s.TypedLinkName = &v
+	return s
+}
+
+// Contains all the information that is used to uniquely identify a typed link.
+// The parameters discussed in this topic are used to uniquely specify the typed
+// link being operated on. The AttachTypedLink API returns a typed link specifier
+// while the DetachTypedLink API accepts one as input. Similarly, the ListIncomingTypedLinks
+// and ListOutgoingTypedLinks API operations provide typed link specifiers as
+// output. You can also construct a typed link specifier from scratch.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkSpecifier
+type TypedLinkSpecifier struct {
+	_ struct{} `type:"structure"`
+
+	// Identifies the attribute value to update.
+	//
+	// IdentityAttributeValues is a required field
+	IdentityAttributeValues []*AttributeNameAndValue `type:"list" required:"true"`
+
+	// Identifies the source object that the typed link will attach to.
+	//
+	// SourceObjectReference is a required field
+	SourceObjectReference *ObjectReference `type:"structure" required:"true"`
+
+	// Identifies the target object that the typed link will attach to.
+	//
+	// TargetObjectReference is a required field
+	TargetObjectReference *ObjectReference `type:"structure" required:"true"`
+
+	// Identifies the typed link facet that is associated with the typed link.
+	//
+	// TypedLinkFacet is a required field
+	TypedLinkFacet *TypedLinkSchemaAndFacetName `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s TypedLinkSpecifier) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TypedLinkSpecifier) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TypedLinkSpecifier) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TypedLinkSpecifier"}
+	if s.IdentityAttributeValues == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityAttributeValues"))
+	}
+	if s.SourceObjectReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceObjectReference"))
+	}
+	if s.TargetObjectReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetObjectReference"))
+	}
+	if s.TypedLinkFacet == nil {
+		invalidParams.Add(request.NewErrParamRequired("TypedLinkFacet"))
+	}
+	if s.IdentityAttributeValues != nil {
+		for i, v := range s.IdentityAttributeValues {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "IdentityAttributeValues", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.TypedLinkFacet != nil {
+		if err := s.TypedLinkFacet.Validate(); err != nil {
+			invalidParams.AddNested("TypedLinkFacet", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetIdentityAttributeValues sets the IdentityAttributeValues field's value.
+func (s *TypedLinkSpecifier) SetIdentityAttributeValues(v []*AttributeNameAndValue) *TypedLinkSpecifier {
+	s.IdentityAttributeValues = v
+	return s
+}
+
+// SetSourceObjectReference sets the SourceObjectReference field's value.
+func (s *TypedLinkSpecifier) SetSourceObjectReference(v *ObjectReference) *TypedLinkSpecifier {
+	s.SourceObjectReference = v
+	return s
+}
+
+// SetTargetObjectReference sets the TargetObjectReference field's value.
+func (s *TypedLinkSpecifier) SetTargetObjectReference(v *ObjectReference) *TypedLinkSpecifier {
+	s.TargetObjectReference = v
+	return s
+}
+
+// SetTypedLinkFacet sets the TypedLinkFacet field's value.
+func (s *TypedLinkSpecifier) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName) *TypedLinkSpecifier {
+	s.TypedLinkFacet = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UntagResourceRequest
 type UntagResourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN of the resource. Tagging is only supported for directories.
+	// The Amazon Resource Name (ARN) of the resource. Tagging is only supported
+	// for directories.
 	//
 	// ResourceArn is a required field
 	ResourceArn *string `type:"string" required:"true"`
 
-	// Keys of the tag that needs to be removed from the resource.
+	// Keys of the tag that need to be removed from the resource.
 	//
 	// TagKeys is a required field
 	TagKeys []*string `type:"list" required:"true"`
@@ -13089,14 +15954,17 @@ type UpdateFacetInput struct {
 	// operation to perform.
 	AttributeUpdates []*FacetAttributeUpdate `type:"list"`
 
+	// The name of the facet.
+	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// Object type associated with the facet. See CreateFacetRequest$ObjectType
+	// The object type that is associated with the facet. See CreateFacetRequest$ObjectType
 	// for more details.
 	ObjectType *string `type:"string" enum:"ObjectType"`
 
-	// ARN associated with the Facet. For more information, see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Facet. For more
+	// information, see arns.
 	//
 	// SchemaArn is a required field
 	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -13184,18 +16052,18 @@ func (s UpdateFacetOutput) GoString() string {
 type UpdateObjectAttributesInput struct {
 	_ struct{} `type:"structure"`
 
-	// Attributes update structure.
+	// The attributes update structure.
 	//
 	// AttributeUpdates is a required field
 	AttributeUpdates []*ObjectAttributeUpdate `type:"list" required:"true"`
 
-	// ARN associated with the Directory where the object resides. For more information,
-	// see arns.
+	// The Amazon Resource Name (ARN) that is associated with the Directory where
+	// the object resides. For more information, see arns.
 	//
 	// DirectoryArn is a required field
 	DirectoryArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
 
-	// Reference that identifies the object.
+	// The reference that identifies the object.
 	//
 	// ObjectReference is a required field
 	ObjectReference *ObjectReference `type:"structure" required:"true"`
@@ -13262,7 +16130,7 @@ func (s *UpdateObjectAttributesInput) SetObjectReference(v *ObjectReference) *Up
 type UpdateObjectAttributesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// ObjectIdentifier of the updated object.
+	// The ObjectIdentifier of the updated object.
 	ObjectIdentifier *string `type:"string"`
 }
 
@@ -13286,12 +16154,13 @@ func (s *UpdateObjectAttributesOutput) SetObjectIdentifier(v string) *UpdateObje
 type UpdateSchemaInput struct {
 	_ struct{} `type:"structure"`
 
-	// Name of the schema.
+	// The name of the schema.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// ARN of the development schema. For more information, see arns.
+	// The Amazon Resource Name (ARN) of the development schema. For more information,
+	// see arns.
 	//
 	// SchemaArn is a required field
 	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
@@ -13342,7 +16211,8 @@ func (s *UpdateSchemaInput) SetSchemaArn(v string) *UpdateSchemaInput {
 type UpdateSchemaOutput struct {
 	_ struct{} `type:"structure"`
 
-	// ARN associated with the updated schema. For more information, see arns.
+	// The ARN that is associated with the updated schema. For more information,
+	// see arns.
 	SchemaArn *string `type:"string"`
 }
 
@@ -13360,6 +16230,119 @@ func (s UpdateSchemaOutput) GoString() string {
 func (s *UpdateSchemaOutput) SetSchemaArn(v string) *UpdateSchemaOutput {
 	s.SchemaArn = &v
 	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateTypedLinkFacetRequest
+type UpdateTypedLinkFacetInput struct {
+	_ struct{} `type:"structure"`
+
+	// Attributes update structure.
+	//
+	// AttributeUpdates is a required field
+	AttributeUpdates []*TypedLinkFacetAttributeUpdate `type:"list" required:"true"`
+
+	// A range filter that you provide for multiple attributes. The ability to filter
+	// typed links considers the order that the attributes are defined on the typed
+	// link facet. When providing ranges to a typed link selection, any inexact
+	// ranges must be specified at the end. Any attributes that do not have a range
+	// specified are presumed to match the entire range. Filters are interpreted
+	// in the order of the attributes on the typed link facet, not the order in
+	// which they are supplied to any API calls.
+	//
+	// IdentityAttributeOrder is a required field
+	IdentityAttributeOrder []*string `type:"list" required:"true"`
+
+	// The unique name of the typed link facet.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+
+	// The Amazon Resource Name (ARN) that is associated with the schema. For more
+	// information, see arns.
+	//
+	// SchemaArn is a required field
+	SchemaArn *string `location:"header" locationName:"x-amz-data-partition" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateTypedLinkFacetInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTypedLinkFacetInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateTypedLinkFacetInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateTypedLinkFacetInput"}
+	if s.AttributeUpdates == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeUpdates"))
+	}
+	if s.IdentityAttributeOrder == nil {
+		invalidParams.Add(request.NewErrParamRequired("IdentityAttributeOrder"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SchemaArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("SchemaArn"))
+	}
+	if s.AttributeUpdates != nil {
+		for i, v := range s.AttributeUpdates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "AttributeUpdates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttributeUpdates sets the AttributeUpdates field's value.
+func (s *UpdateTypedLinkFacetInput) SetAttributeUpdates(v []*TypedLinkFacetAttributeUpdate) *UpdateTypedLinkFacetInput {
+	s.AttributeUpdates = v
+	return s
+}
+
+// SetIdentityAttributeOrder sets the IdentityAttributeOrder field's value.
+func (s *UpdateTypedLinkFacetInput) SetIdentityAttributeOrder(v []*string) *UpdateTypedLinkFacetInput {
+	s.IdentityAttributeOrder = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateTypedLinkFacetInput) SetName(v string) *UpdateTypedLinkFacetInput {
+	s.Name = &v
+	return s
+}
+
+// SetSchemaArn sets the SchemaArn field's value.
+func (s *UpdateTypedLinkFacetInput) SetSchemaArn(v string) *UpdateTypedLinkFacetInput {
+	s.SchemaArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateTypedLinkFacetResponse
+type UpdateTypedLinkFacetOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateTypedLinkFacetOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTypedLinkFacetOutput) GoString() string {
+	return s.String()
 }
 
 const (

--- a/service/clouddirectory/clouddirectoryiface/interface.go
+++ b/service/clouddirectory/clouddirectoryiface/interface.go
@@ -80,6 +80,10 @@ type CloudDirectoryAPI interface {
 	AttachToIndexWithContext(aws.Context, *clouddirectory.AttachToIndexInput, ...request.Option) (*clouddirectory.AttachToIndexOutput, error)
 	AttachToIndexRequest(*clouddirectory.AttachToIndexInput) (*request.Request, *clouddirectory.AttachToIndexOutput)
 
+	AttachTypedLink(*clouddirectory.AttachTypedLinkInput) (*clouddirectory.AttachTypedLinkOutput, error)
+	AttachTypedLinkWithContext(aws.Context, *clouddirectory.AttachTypedLinkInput, ...request.Option) (*clouddirectory.AttachTypedLinkOutput, error)
+	AttachTypedLinkRequest(*clouddirectory.AttachTypedLinkInput) (*request.Request, *clouddirectory.AttachTypedLinkOutput)
+
 	BatchRead(*clouddirectory.BatchReadInput) (*clouddirectory.BatchReadOutput, error)
 	BatchReadWithContext(aws.Context, *clouddirectory.BatchReadInput, ...request.Option) (*clouddirectory.BatchReadOutput, error)
 	BatchReadRequest(*clouddirectory.BatchReadInput) (*request.Request, *clouddirectory.BatchReadOutput)
@@ -108,6 +112,10 @@ type CloudDirectoryAPI interface {
 	CreateSchemaWithContext(aws.Context, *clouddirectory.CreateSchemaInput, ...request.Option) (*clouddirectory.CreateSchemaOutput, error)
 	CreateSchemaRequest(*clouddirectory.CreateSchemaInput) (*request.Request, *clouddirectory.CreateSchemaOutput)
 
+	CreateTypedLinkFacet(*clouddirectory.CreateTypedLinkFacetInput) (*clouddirectory.CreateTypedLinkFacetOutput, error)
+	CreateTypedLinkFacetWithContext(aws.Context, *clouddirectory.CreateTypedLinkFacetInput, ...request.Option) (*clouddirectory.CreateTypedLinkFacetOutput, error)
+	CreateTypedLinkFacetRequest(*clouddirectory.CreateTypedLinkFacetInput) (*request.Request, *clouddirectory.CreateTypedLinkFacetOutput)
+
 	DeleteDirectory(*clouddirectory.DeleteDirectoryInput) (*clouddirectory.DeleteDirectoryOutput, error)
 	DeleteDirectoryWithContext(aws.Context, *clouddirectory.DeleteDirectoryInput, ...request.Option) (*clouddirectory.DeleteDirectoryOutput, error)
 	DeleteDirectoryRequest(*clouddirectory.DeleteDirectoryInput) (*request.Request, *clouddirectory.DeleteDirectoryOutput)
@@ -124,6 +132,10 @@ type CloudDirectoryAPI interface {
 	DeleteSchemaWithContext(aws.Context, *clouddirectory.DeleteSchemaInput, ...request.Option) (*clouddirectory.DeleteSchemaOutput, error)
 	DeleteSchemaRequest(*clouddirectory.DeleteSchemaInput) (*request.Request, *clouddirectory.DeleteSchemaOutput)
 
+	DeleteTypedLinkFacet(*clouddirectory.DeleteTypedLinkFacetInput) (*clouddirectory.DeleteTypedLinkFacetOutput, error)
+	DeleteTypedLinkFacetWithContext(aws.Context, *clouddirectory.DeleteTypedLinkFacetInput, ...request.Option) (*clouddirectory.DeleteTypedLinkFacetOutput, error)
+	DeleteTypedLinkFacetRequest(*clouddirectory.DeleteTypedLinkFacetInput) (*request.Request, *clouddirectory.DeleteTypedLinkFacetOutput)
+
 	DetachFromIndex(*clouddirectory.DetachFromIndexInput) (*clouddirectory.DetachFromIndexOutput, error)
 	DetachFromIndexWithContext(aws.Context, *clouddirectory.DetachFromIndexInput, ...request.Option) (*clouddirectory.DetachFromIndexOutput, error)
 	DetachFromIndexRequest(*clouddirectory.DetachFromIndexInput) (*request.Request, *clouddirectory.DetachFromIndexOutput)
@@ -135,6 +147,10 @@ type CloudDirectoryAPI interface {
 	DetachPolicy(*clouddirectory.DetachPolicyInput) (*clouddirectory.DetachPolicyOutput, error)
 	DetachPolicyWithContext(aws.Context, *clouddirectory.DetachPolicyInput, ...request.Option) (*clouddirectory.DetachPolicyOutput, error)
 	DetachPolicyRequest(*clouddirectory.DetachPolicyInput) (*request.Request, *clouddirectory.DetachPolicyOutput)
+
+	DetachTypedLink(*clouddirectory.DetachTypedLinkInput) (*clouddirectory.DetachTypedLinkOutput, error)
+	DetachTypedLinkWithContext(aws.Context, *clouddirectory.DetachTypedLinkInput, ...request.Option) (*clouddirectory.DetachTypedLinkOutput, error)
+	DetachTypedLinkRequest(*clouddirectory.DetachTypedLinkInput) (*request.Request, *clouddirectory.DetachTypedLinkOutput)
 
 	DisableDirectory(*clouddirectory.DisableDirectoryInput) (*clouddirectory.DisableDirectoryOutput, error)
 	DisableDirectoryWithContext(aws.Context, *clouddirectory.DisableDirectoryInput, ...request.Option) (*clouddirectory.DisableDirectoryOutput, error)
@@ -159,6 +175,10 @@ type CloudDirectoryAPI interface {
 	GetSchemaAsJson(*clouddirectory.GetSchemaAsJsonInput) (*clouddirectory.GetSchemaAsJsonOutput, error)
 	GetSchemaAsJsonWithContext(aws.Context, *clouddirectory.GetSchemaAsJsonInput, ...request.Option) (*clouddirectory.GetSchemaAsJsonOutput, error)
 	GetSchemaAsJsonRequest(*clouddirectory.GetSchemaAsJsonInput) (*request.Request, *clouddirectory.GetSchemaAsJsonOutput)
+
+	GetTypedLinkFacetInformation(*clouddirectory.GetTypedLinkFacetInformationInput) (*clouddirectory.GetTypedLinkFacetInformationOutput, error)
+	GetTypedLinkFacetInformationWithContext(aws.Context, *clouddirectory.GetTypedLinkFacetInformationInput, ...request.Option) (*clouddirectory.GetTypedLinkFacetInformationOutput, error)
+	GetTypedLinkFacetInformationRequest(*clouddirectory.GetTypedLinkFacetInformationInput) (*request.Request, *clouddirectory.GetTypedLinkFacetInformationOutput)
 
 	ListAppliedSchemaArns(*clouddirectory.ListAppliedSchemaArnsInput) (*clouddirectory.ListAppliedSchemaArnsOutput, error)
 	ListAppliedSchemaArnsWithContext(aws.Context, *clouddirectory.ListAppliedSchemaArnsInput, ...request.Option) (*clouddirectory.ListAppliedSchemaArnsOutput, error)
@@ -202,6 +222,10 @@ type CloudDirectoryAPI interface {
 	ListFacetNamesPages(*clouddirectory.ListFacetNamesInput, func(*clouddirectory.ListFacetNamesOutput, bool) bool) error
 	ListFacetNamesPagesWithContext(aws.Context, *clouddirectory.ListFacetNamesInput, func(*clouddirectory.ListFacetNamesOutput, bool) bool, ...request.Option) error
 
+	ListIncomingTypedLinks(*clouddirectory.ListIncomingTypedLinksInput) (*clouddirectory.ListIncomingTypedLinksOutput, error)
+	ListIncomingTypedLinksWithContext(aws.Context, *clouddirectory.ListIncomingTypedLinksInput, ...request.Option) (*clouddirectory.ListIncomingTypedLinksOutput, error)
+	ListIncomingTypedLinksRequest(*clouddirectory.ListIncomingTypedLinksInput) (*request.Request, *clouddirectory.ListIncomingTypedLinksOutput)
+
 	ListIndex(*clouddirectory.ListIndexInput) (*clouddirectory.ListIndexOutput, error)
 	ListIndexWithContext(aws.Context, *clouddirectory.ListIndexInput, ...request.Option) (*clouddirectory.ListIndexOutput, error)
 	ListIndexRequest(*clouddirectory.ListIndexInput) (*request.Request, *clouddirectory.ListIndexOutput)
@@ -244,6 +268,10 @@ type CloudDirectoryAPI interface {
 	ListObjectPoliciesPages(*clouddirectory.ListObjectPoliciesInput, func(*clouddirectory.ListObjectPoliciesOutput, bool) bool) error
 	ListObjectPoliciesPagesWithContext(aws.Context, *clouddirectory.ListObjectPoliciesInput, func(*clouddirectory.ListObjectPoliciesOutput, bool) bool, ...request.Option) error
 
+	ListOutgoingTypedLinks(*clouddirectory.ListOutgoingTypedLinksInput) (*clouddirectory.ListOutgoingTypedLinksOutput, error)
+	ListOutgoingTypedLinksWithContext(aws.Context, *clouddirectory.ListOutgoingTypedLinksInput, ...request.Option) (*clouddirectory.ListOutgoingTypedLinksOutput, error)
+	ListOutgoingTypedLinksRequest(*clouddirectory.ListOutgoingTypedLinksInput) (*request.Request, *clouddirectory.ListOutgoingTypedLinksOutput)
+
 	ListPolicyAttachments(*clouddirectory.ListPolicyAttachmentsInput) (*clouddirectory.ListPolicyAttachmentsOutput, error)
 	ListPolicyAttachmentsWithContext(aws.Context, *clouddirectory.ListPolicyAttachmentsInput, ...request.Option) (*clouddirectory.ListPolicyAttachmentsOutput, error)
 	ListPolicyAttachmentsRequest(*clouddirectory.ListPolicyAttachmentsInput) (*request.Request, *clouddirectory.ListPolicyAttachmentsOutput)
@@ -264,6 +292,20 @@ type CloudDirectoryAPI interface {
 
 	ListTagsForResourcePages(*clouddirectory.ListTagsForResourceInput, func(*clouddirectory.ListTagsForResourceOutput, bool) bool) error
 	ListTagsForResourcePagesWithContext(aws.Context, *clouddirectory.ListTagsForResourceInput, func(*clouddirectory.ListTagsForResourceOutput, bool) bool, ...request.Option) error
+
+	ListTypedLinkFacetAttributes(*clouddirectory.ListTypedLinkFacetAttributesInput) (*clouddirectory.ListTypedLinkFacetAttributesOutput, error)
+	ListTypedLinkFacetAttributesWithContext(aws.Context, *clouddirectory.ListTypedLinkFacetAttributesInput, ...request.Option) (*clouddirectory.ListTypedLinkFacetAttributesOutput, error)
+	ListTypedLinkFacetAttributesRequest(*clouddirectory.ListTypedLinkFacetAttributesInput) (*request.Request, *clouddirectory.ListTypedLinkFacetAttributesOutput)
+
+	ListTypedLinkFacetAttributesPages(*clouddirectory.ListTypedLinkFacetAttributesInput, func(*clouddirectory.ListTypedLinkFacetAttributesOutput, bool) bool) error
+	ListTypedLinkFacetAttributesPagesWithContext(aws.Context, *clouddirectory.ListTypedLinkFacetAttributesInput, func(*clouddirectory.ListTypedLinkFacetAttributesOutput, bool) bool, ...request.Option) error
+
+	ListTypedLinkFacetNames(*clouddirectory.ListTypedLinkFacetNamesInput) (*clouddirectory.ListTypedLinkFacetNamesOutput, error)
+	ListTypedLinkFacetNamesWithContext(aws.Context, *clouddirectory.ListTypedLinkFacetNamesInput, ...request.Option) (*clouddirectory.ListTypedLinkFacetNamesOutput, error)
+	ListTypedLinkFacetNamesRequest(*clouddirectory.ListTypedLinkFacetNamesInput) (*request.Request, *clouddirectory.ListTypedLinkFacetNamesOutput)
+
+	ListTypedLinkFacetNamesPages(*clouddirectory.ListTypedLinkFacetNamesInput, func(*clouddirectory.ListTypedLinkFacetNamesOutput, bool) bool) error
+	ListTypedLinkFacetNamesPagesWithContext(aws.Context, *clouddirectory.ListTypedLinkFacetNamesInput, func(*clouddirectory.ListTypedLinkFacetNamesOutput, bool) bool, ...request.Option) error
 
 	LookupPolicy(*clouddirectory.LookupPolicyInput) (*clouddirectory.LookupPolicyOutput, error)
 	LookupPolicyWithContext(aws.Context, *clouddirectory.LookupPolicyInput, ...request.Option) (*clouddirectory.LookupPolicyOutput, error)
@@ -303,6 +345,10 @@ type CloudDirectoryAPI interface {
 	UpdateSchema(*clouddirectory.UpdateSchemaInput) (*clouddirectory.UpdateSchemaOutput, error)
 	UpdateSchemaWithContext(aws.Context, *clouddirectory.UpdateSchemaInput, ...request.Option) (*clouddirectory.UpdateSchemaOutput, error)
 	UpdateSchemaRequest(*clouddirectory.UpdateSchemaInput) (*request.Request, *clouddirectory.UpdateSchemaOutput)
+
+	UpdateTypedLinkFacet(*clouddirectory.UpdateTypedLinkFacetInput) (*clouddirectory.UpdateTypedLinkFacetOutput, error)
+	UpdateTypedLinkFacetWithContext(aws.Context, *clouddirectory.UpdateTypedLinkFacetInput, ...request.Option) (*clouddirectory.UpdateTypedLinkFacetOutput, error)
+	UpdateTypedLinkFacetRequest(*clouddirectory.UpdateTypedLinkFacetInput) (*request.Request, *clouddirectory.UpdateTypedLinkFacetOutput)
 }
 
 var _ CloudDirectoryAPI = (*clouddirectory.CloudDirectory)(nil)

--- a/service/clouddirectory/doc.go
+++ b/service/clouddirectory/doc.go
@@ -4,8 +4,8 @@
 // requests to Amazon CloudDirectory.
 //
 // Amazon Cloud Directory is a component of the AWS Directory Service that simplifies
-// the development and management of cloud-scale web, mobile and IoT applications.
-// This guide describes the Cloud Directory operations that you can call programatically
+// the development and management of cloud-scale web, mobile, and IoT applications.
+// This guide describes the Cloud Directory operations that you can call programmatically
 // and includes detailed information on data types and errors. For information
 // about AWS Directory Services features, see AWS Directory Service (https://aws.amazon.com/directoryservice/)
 // and the AWS Directory Service Administration Guide (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/what_is.html).

--- a/service/clouddirectory/errors.go
+++ b/service/clouddirectory/errors.go
@@ -32,8 +32,8 @@ const (
 	// ErrCodeDirectoryDeletedException for service response error code
 	// "DirectoryDeletedException".
 	//
-	// A directory that has been deleted has been attempted to be accessed. Note:
-	// The requested resource will eventually cease to exist.
+	// A directory that has been deleted and to which access has been attempted.
+	// Note: The requested resource will eventually cease to exist.
 	ErrCodeDirectoryDeletedException = "DirectoryDeletedException"
 
 	// ErrCodeDirectoryNotDisabledException for service response error code
@@ -57,7 +57,7 @@ const (
 	// ErrCodeFacetInUseException for service response error code
 	// "FacetInUseException".
 	//
-	// Occurs when deleting a facet that contains an attribute which is a target
+	// Occurs when deleting a facet that contains an attribute that is a target
 	// to an attribute reference in a different facet.
 	ErrCodeFacetInUseException = "FacetInUseException"
 
@@ -70,8 +70,8 @@ const (
 	// ErrCodeFacetValidationException for service response error code
 	// "FacetValidationException".
 	//
-	// The Facet you provided was not well formed or could not be validated with
-	// the schema.
+	// The Facet that you provided was not well formed or could not be validated
+	// with the schema.
 	ErrCodeFacetValidationException = "FacetValidationException"
 
 	// ErrCodeIndexedAttributeMissingException for service response error code
@@ -100,8 +100,8 @@ const (
 	// "InvalidAttachmentException".
 	//
 	// Indicates that an attempt to attach an object with the same link name or
-	// to apply a schema with same name has occurred. Rename the link or the schema
-	// and then try again.
+	// to apply a schema with the same name has occurred. Rename the link or the
+	// schema and then try again.
 	ErrCodeInvalidAttachmentException = "InvalidAttachmentException"
 
 	// ErrCodeInvalidFacetUpdateException for service response error code
@@ -139,7 +139,7 @@ const (
 	// ErrCodeLimitExceededException for service response error code
 	// "LimitExceededException".
 	//
-	// Indicates limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
+	// Indicates that limits are exceeded. See Limits (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/limits.html)
 	// for more information.
 	ErrCodeLimitExceededException = "LimitExceededException"
 
@@ -153,32 +153,32 @@ const (
 	// ErrCodeNotIndexException for service response error code
 	// "NotIndexException".
 	//
-	// Indicates the requested operation can only operate on index objects.
+	// Indicates that the requested operation can only operate on index objects.
 	ErrCodeNotIndexException = "NotIndexException"
 
 	// ErrCodeNotNodeException for service response error code
 	// "NotNodeException".
 	//
-	// Occurs when any invalid operations are performed on an object which is not
+	// Occurs when any invalid operations are performed on an object that is not
 	// a node, such as calling ListObjectChildren for a leaf node object.
 	ErrCodeNotNodeException = "NotNodeException"
 
 	// ErrCodeNotPolicyException for service response error code
 	// "NotPolicyException".
 	//
-	// Indicates the requested operation can only operate on policy objects.
+	// Indicates that the requested operation can only operate on policy objects.
 	ErrCodeNotPolicyException = "NotPolicyException"
 
 	// ErrCodeObjectAlreadyDetachedException for service response error code
 	// "ObjectAlreadyDetachedException".
 	//
-	// Indicates the object is not attached to the index.
+	// Indicates that the object is not attached to the index.
 	ErrCodeObjectAlreadyDetachedException = "ObjectAlreadyDetachedException"
 
 	// ErrCodeObjectNotDetachedException for service response error code
 	// "ObjectNotDetachedException".
 	//
-	// Indicates the requested operation cannot be completed because the object
+	// Indicates that the requested operation cannot be completed because the object
 	// has not been detached from the tree.
 	ErrCodeObjectNotDetachedException = "ObjectNotDetachedException"
 
@@ -209,7 +209,7 @@ const (
 	// ErrCodeSchemaAlreadyPublishedException for service response error code
 	// "SchemaAlreadyPublishedException".
 	//
-	// Indicates a schema is already published.
+	// Indicates that a schema is already published.
 	ErrCodeSchemaAlreadyPublishedException = "SchemaAlreadyPublishedException"
 
 	// ErrCodeStillContainsLinksException for service response error code
@@ -222,12 +222,13 @@ const (
 	// ErrCodeUnsupportedIndexTypeException for service response error code
 	// "UnsupportedIndexTypeException".
 	//
-	// Indicates the requested index type is not supported.
+	// Indicates that the requested index type is not supported.
 	ErrCodeUnsupportedIndexTypeException = "UnsupportedIndexTypeException"
 
 	// ErrCodeValidationException for service response error code
 	// "ValidationException".
 	//
-	// Indicates your request is malformed in some manner. See the exception message.
+	// Indicates that your request is malformed in some manner. See the exception
+	// message.
 	ErrCodeValidationException = "ValidationException"
 )

--- a/service/clouddirectory/examples_test.go
+++ b/service/clouddirectory/examples_test.go
@@ -164,6 +164,50 @@ func ExampleCloudDirectory_AttachToIndex() {
 	fmt.Println(resp)
 }
 
+func ExampleCloudDirectory_AttachTypedLink() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.AttachTypedLinkInput{
+		Attributes: []*clouddirectory.AttributeNameAndValue{ // Required
+			{ // Required
+				AttributeName: aws.String("AttributeName"), // Required
+				Value: &clouddirectory.TypedAttributeValue{ // Required
+					BinaryValue:   []byte("PAYLOAD"),
+					BooleanValue:  aws.Bool(true),
+					DatetimeValue: aws.Time(time.Now()),
+					NumberValue:   aws.String("NumberAttributeValue"),
+					StringValue:   aws.String("StringAttributeValue"),
+				},
+			},
+			// More values...
+		},
+		DirectoryArn: aws.String("Arn"), // Required
+		SourceObjectReference: &clouddirectory.ObjectReference{ // Required
+			Selector: aws.String("SelectorObjectReference"),
+		},
+		TargetObjectReference: &clouddirectory.ObjectReference{ // Required
+			Selector: aws.String("SelectorObjectReference"),
+		},
+		TypedLinkFacet: &clouddirectory.TypedLinkSchemaAndFacetName{ // Required
+			SchemaArn:     aws.String("Arn"),           // Required
+			TypedLinkName: aws.String("TypedLinkName"), // Required
+		},
+	}
+	resp, err := svc.AttachTypedLink(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleCloudDirectory_BatchRead() {
 	sess := session.Must(session.NewSession())
 
@@ -528,6 +572,60 @@ func ExampleCloudDirectory_CreateSchema() {
 	fmt.Println(resp)
 }
 
+func ExampleCloudDirectory_CreateTypedLinkFacet() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.CreateTypedLinkFacetInput{
+		Facet: &clouddirectory.TypedLinkFacet{ // Required
+			Attributes: []*clouddirectory.TypedLinkAttributeDefinition{ // Required
+				{ // Required
+					Name:             aws.String("AttributeName"),             // Required
+					RequiredBehavior: aws.String("RequiredAttributeBehavior"), // Required
+					Type:             aws.String("FacetAttributeType"),        // Required
+					DefaultValue: &clouddirectory.TypedAttributeValue{
+						BinaryValue:   []byte("PAYLOAD"),
+						BooleanValue:  aws.Bool(true),
+						DatetimeValue: aws.Time(time.Now()),
+						NumberValue:   aws.String("NumberAttributeValue"),
+						StringValue:   aws.String("StringAttributeValue"),
+					},
+					IsImmutable: aws.Bool(true),
+					Rules: map[string]*clouddirectory.Rule{
+						"Key": { // Required
+							Parameters: map[string]*string{
+								"Key": aws.String("RuleParameterValue"), // Required
+								// More values...
+							},
+							Type: aws.String("RuleType"),
+						},
+						// More values...
+					},
+				},
+				// More values...
+			},
+			IdentityAttributeOrder: []*string{ // Required
+				aws.String("AttributeName"), // Required
+				// More values...
+			},
+			Name: aws.String("TypedLinkName"), // Required
+		},
+		SchemaArn: aws.String("Arn"), // Required
+	}
+	resp, err := svc.CreateTypedLinkFacet(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleCloudDirectory_DeleteDirectory() {
 	sess := session.Must(session.NewSession())
 
@@ -616,6 +714,28 @@ func ExampleCloudDirectory_DeleteSchema() {
 	fmt.Println(resp)
 }
 
+func ExampleCloudDirectory_DeleteTypedLinkFacet() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.DeleteTypedLinkFacetInput{
+		Name:      aws.String("TypedLinkName"), // Required
+		SchemaArn: aws.String("Arn"),           // Required
+	}
+	resp, err := svc.DeleteTypedLinkFacet(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleCloudDirectory_DetachFromIndex() {
 	sess := session.Must(session.NewSession())
 
@@ -683,6 +803,52 @@ func ExampleCloudDirectory_DetachPolicy() {
 		},
 	}
 	resp, err := svc.DetachPolicy(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleCloudDirectory_DetachTypedLink() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.DetachTypedLinkInput{
+		DirectoryArn: aws.String("Arn"), // Required
+		TypedLinkSpecifier: &clouddirectory.TypedLinkSpecifier{ // Required
+			IdentityAttributeValues: []*clouddirectory.AttributeNameAndValue{ // Required
+				{ // Required
+					AttributeName: aws.String("AttributeName"), // Required
+					Value: &clouddirectory.TypedAttributeValue{ // Required
+						BinaryValue:   []byte("PAYLOAD"),
+						BooleanValue:  aws.Bool(true),
+						DatetimeValue: aws.Time(time.Now()),
+						NumberValue:   aws.String("NumberAttributeValue"),
+						StringValue:   aws.String("StringAttributeValue"),
+					},
+				},
+				// More values...
+			},
+			SourceObjectReference: &clouddirectory.ObjectReference{ // Required
+				Selector: aws.String("SelectorObjectReference"),
+			},
+			TargetObjectReference: &clouddirectory.ObjectReference{ // Required
+				Selector: aws.String("SelectorObjectReference"),
+			},
+			TypedLinkFacet: &clouddirectory.TypedLinkSchemaAndFacetName{ // Required
+				SchemaArn:     aws.String("Arn"),           // Required
+				TypedLinkName: aws.String("TypedLinkName"), // Required
+			},
+		},
+	}
+	resp, err := svc.DetachTypedLink(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and
@@ -826,6 +992,28 @@ func ExampleCloudDirectory_GetSchemaAsJson() {
 	fmt.Println(resp)
 }
 
+func ExampleCloudDirectory_GetTypedLinkFacetInformation() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.GetTypedLinkFacetInformationInput{
+		Name:      aws.String("TypedLinkName"), // Required
+		SchemaArn: aws.String("Arn"),           // Required
+	}
+	resp, err := svc.GetTypedLinkFacetInformation(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleCloudDirectory_ListAppliedSchemaArns() {
 	sess := session.Must(session.NewSession())
 
@@ -956,6 +1144,61 @@ func ExampleCloudDirectory_ListFacetNames() {
 		NextToken:  aws.String("NextToken"),
 	}
 	resp, err := svc.ListFacetNames(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleCloudDirectory_ListIncomingTypedLinks() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.ListIncomingTypedLinksInput{
+		DirectoryArn: aws.String("Arn"), // Required
+		ObjectReference: &clouddirectory.ObjectReference{ // Required
+			Selector: aws.String("SelectorObjectReference"),
+		},
+		ConsistencyLevel: aws.String("ConsistencyLevel"),
+		FilterAttributeRanges: []*clouddirectory.TypedLinkAttributeRange{
+			{ // Required
+				Range: &clouddirectory.TypedAttributeValueRange{ // Required
+					EndMode:   aws.String("RangeMode"), // Required
+					StartMode: aws.String("RangeMode"), // Required
+					EndValue: &clouddirectory.TypedAttributeValue{
+						BinaryValue:   []byte("PAYLOAD"),
+						BooleanValue:  aws.Bool(true),
+						DatetimeValue: aws.Time(time.Now()),
+						NumberValue:   aws.String("NumberAttributeValue"),
+						StringValue:   aws.String("StringAttributeValue"),
+					},
+					StartValue: &clouddirectory.TypedAttributeValue{
+						BinaryValue:   []byte("PAYLOAD"),
+						BooleanValue:  aws.Bool(true),
+						DatetimeValue: aws.Time(time.Now()),
+						NumberValue:   aws.String("NumberAttributeValue"),
+						StringValue:   aws.String("StringAttributeValue"),
+					},
+				},
+				AttributeName: aws.String("AttributeName"),
+			},
+			// More values...
+		},
+		FilterTypedLink: &clouddirectory.TypedLinkSchemaAndFacetName{
+			SchemaArn:     aws.String("Arn"),           // Required
+			TypedLinkName: aws.String("TypedLinkName"), // Required
+		},
+		MaxResults: aws.Int64(1),
+		NextToken:  aws.String("NextToken"),
+	}
+	resp, err := svc.ListIncomingTypedLinks(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and
@@ -1161,6 +1404,61 @@ func ExampleCloudDirectory_ListObjectPolicies() {
 	fmt.Println(resp)
 }
 
+func ExampleCloudDirectory_ListOutgoingTypedLinks() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.ListOutgoingTypedLinksInput{
+		DirectoryArn: aws.String("Arn"), // Required
+		ObjectReference: &clouddirectory.ObjectReference{ // Required
+			Selector: aws.String("SelectorObjectReference"),
+		},
+		ConsistencyLevel: aws.String("ConsistencyLevel"),
+		FilterAttributeRanges: []*clouddirectory.TypedLinkAttributeRange{
+			{ // Required
+				Range: &clouddirectory.TypedAttributeValueRange{ // Required
+					EndMode:   aws.String("RangeMode"), // Required
+					StartMode: aws.String("RangeMode"), // Required
+					EndValue: &clouddirectory.TypedAttributeValue{
+						BinaryValue:   []byte("PAYLOAD"),
+						BooleanValue:  aws.Bool(true),
+						DatetimeValue: aws.Time(time.Now()),
+						NumberValue:   aws.String("NumberAttributeValue"),
+						StringValue:   aws.String("StringAttributeValue"),
+					},
+					StartValue: &clouddirectory.TypedAttributeValue{
+						BinaryValue:   []byte("PAYLOAD"),
+						BooleanValue:  aws.Bool(true),
+						DatetimeValue: aws.Time(time.Now()),
+						NumberValue:   aws.String("NumberAttributeValue"),
+						StringValue:   aws.String("StringAttributeValue"),
+					},
+				},
+				AttributeName: aws.String("AttributeName"),
+			},
+			// More values...
+		},
+		FilterTypedLink: &clouddirectory.TypedLinkSchemaAndFacetName{
+			SchemaArn:     aws.String("Arn"),           // Required
+			TypedLinkName: aws.String("TypedLinkName"), // Required
+		},
+		MaxResults: aws.Int64(1),
+		NextToken:  aws.String("NextToken"),
+	}
+	resp, err := svc.ListOutgoingTypedLinks(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
 func ExampleCloudDirectory_ListPolicyAttachments() {
 	sess := session.Must(session.NewSession())
 
@@ -1221,6 +1519,53 @@ func ExampleCloudDirectory_ListTagsForResource() {
 		NextToken:   aws.String("NextToken"),
 	}
 	resp, err := svc.ListTagsForResource(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleCloudDirectory_ListTypedLinkFacetAttributes() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.ListTypedLinkFacetAttributesInput{
+		Name:       aws.String("TypedLinkName"), // Required
+		SchemaArn:  aws.String("Arn"),           // Required
+		MaxResults: aws.Int64(1),
+		NextToken:  aws.String("NextToken"),
+	}
+	resp, err := svc.ListTypedLinkFacetAttributes(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleCloudDirectory_ListTypedLinkFacetNames() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.ListTypedLinkFacetNamesInput{
+		SchemaArn:  aws.String("Arn"), // Required
+		MaxResults: aws.Int64(1),
+		NextToken:  aws.String("NextToken"),
+	}
+	resp, err := svc.ListTypedLinkFacetNames(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and
@@ -1497,6 +1842,61 @@ func ExampleCloudDirectory_UpdateSchema() {
 		SchemaArn: aws.String("Arn"),        // Required
 	}
 	resp, err := svc.UpdateSchema(params)
+
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Pretty-print the response data.
+	fmt.Println(resp)
+}
+
+func ExampleCloudDirectory_UpdateTypedLinkFacet() {
+	sess := session.Must(session.NewSession())
+
+	svc := clouddirectory.New(sess)
+
+	params := &clouddirectory.UpdateTypedLinkFacetInput{
+		AttributeUpdates: []*clouddirectory.TypedLinkFacetAttributeUpdate{ // Required
+			{ // Required
+				Action: aws.String("UpdateActionType"), // Required
+				Attribute: &clouddirectory.TypedLinkAttributeDefinition{ // Required
+					Name:             aws.String("AttributeName"),             // Required
+					RequiredBehavior: aws.String("RequiredAttributeBehavior"), // Required
+					Type:             aws.String("FacetAttributeType"),        // Required
+					DefaultValue: &clouddirectory.TypedAttributeValue{
+						BinaryValue:   []byte("PAYLOAD"),
+						BooleanValue:  aws.Bool(true),
+						DatetimeValue: aws.Time(time.Now()),
+						NumberValue:   aws.String("NumberAttributeValue"),
+						StringValue:   aws.String("StringAttributeValue"),
+					},
+					IsImmutable: aws.Bool(true),
+					Rules: map[string]*clouddirectory.Rule{
+						"Key": { // Required
+							Parameters: map[string]*string{
+								"Key": aws.String("RuleParameterValue"), // Required
+								// More values...
+							},
+							Type: aws.String("RuleType"),
+						},
+						// More values...
+					},
+				},
+			},
+			// More values...
+		},
+		IdentityAttributeOrder: []*string{ // Required
+			aws.String("AttributeName"), // Required
+			// More values...
+		},
+		Name:      aws.String("TypedLinkName"), // Required
+		SchemaArn: aws.String("Arn"),           // Required
+	}
+	resp, err := svc.UpdateTypedLinkFacet(params)
 
 	if err != nil {
 		// Print the error, cast err to awserr.Error to get the Code and


### PR DESCRIPTION
Release v1.8.31 (2017-05-30)
===

### Service Client Updates
* `service/clouddirectory`: Updates service API, documentation, and paginators
  * Cloud Directory has launched support for Typed Links, enabling customers to create object-to-object relationships that are not hierarchical in nature. Typed Links enable customers to quickly query for data along these relationships. Customers can also enforce referential integrity using Typed Links, ensuring data in use is not inadvertently deleted.
* `service/s3`: Updates service paginators and examples
  * New example snippets for Amazon S3.

