### PR TITLE
service/s3/s3manager: Fix Downloader ignoring Range get parameter

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,6 @@
 ### SDK Bugs
 * `aws/credentials`: Fixes shared credential provider's default filename on Windows. [#1308](https://github.com/aws/aws-sdk-go/pull/1308)
   * The shared credentials provider would attempt to use the wrong filename on Windows if the `HOME` environment variable was defined.
+* `service/s3/s3manager`: service/s3/s3manager: Fix Downloader ignoring Range get parameter [#1311](https://github.com/aws/aws-sdk-go/pull/1311)
+  * Fixes the S3 Download Manager ignoring the GetObjectInput's Range parameter. If this parameter is provided it will force the downloader to fallback to a single GetObject request disabling concurrency and automatic part size gets.
+  * Fixes [#1296](https://github.com/aws/aws-sdk-go/issues/1296)

--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -464,7 +464,7 @@ type dlchunk struct {
 // position to its end (or EOF).
 //
 // If a range is specified on the dlchunk the size will be ignored when writing.
-// as the total size may not of bee known ahead of time.
+// as the total size may not of be known ahead of time.
 func (c *dlchunk) Write(p []byte) (n int, err error) {
 	if c.cur >= c.size && len(c.withRange) == 0 {
 		return 0, io.EOF

--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -32,10 +32,14 @@ type Downloader struct {
 	// The buffer size (in bytes) to use when buffering data into chunks and
 	// sending them as parts to S3. The minimum allowed part size is 5MB, and
 	// if this value is set to zero, the DefaultDownloadPartSize value will be used.
+	//
+	// PartSize is ignored if the Range input parameter is provided.
 	PartSize int64
 
 	// The number of goroutines to spin up in parallel when sending parts.
 	// If this is set to zero, the DefaultDownloadConcurrency value will be used.
+	//
+	// Concurrency is ignored if the Range input parameter is provided.
 	Concurrency int
 
 	// An S3 client to use when performing downloads.
@@ -130,6 +134,10 @@ type maxRetrier interface {
 //
 // The w io.WriterAt can be satisfied by an os.File to do multipart concurrent
 // downloads, or in memory []byte wrapper using aws.WriteAtBuffer.
+//
+// If the GetObjectInput's Range value is provided that will cause the downloader
+// to perform a single GetObjectInput request for that object's range. This will
+// caused the part size, and concurrency configurations to be ignored.
 func (d Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*Downloader)) (n int64, err error) {
 	return d.DownloadWithContext(aws.BackgroundContext(), w, input, options...)
 }
@@ -153,6 +161,10 @@ func (d Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, options ..
 // downloads, or in memory []byte wrapper using aws.WriteAtBuffer.
 //
 // It is safe to call this method concurrently across goroutines.
+//
+// If the GetObjectInput's Range value is provided that will cause the downloader
+// to perform a single GetObjectInput request for that object's range. This will
+// caused the part size, and concurrency configurations to be ignored.
 func (d Downloader) DownloadWithContext(ctx aws.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*Downloader)) (n int64, err error) {
 	impl := downloader{w: w, in: input, cfg: d, ctx: ctx}
 
@@ -199,6 +211,14 @@ type downloader struct {
 // download performs the implementation of the object download across ranged
 // GETs.
 func (d *downloader) download() (n int64, err error) {
+	// If range is specified fall back to single download of that range
+	// this enables the functionality of ranged gets with the downloader but
+	// at the cost of no multipart downloads.
+	if rng := aws.StringValue(d.in.Range); len(rng) > 0 {
+		d.downloadRange(rng)
+		return d.written, d.err
+	}
+
 	// Spin off first worker to check additional header information
 	d.getChunk()
 
@@ -285,14 +305,32 @@ func (d *downloader) getChunk() {
 	}
 }
 
-// downloadChunk downloads the chunk froom s3
+// downloadRange downloads an Object given the passed in Byte-Range value.
+// The chunk used down download the range will be configured for that range.
+func (d *downloader) downloadRange(rng string) {
+	if d.getErr() != nil {
+		return
+	}
+
+	chunk := dlchunk{w: d.w, start: d.pos}
+	// Ranges specified will short circuit the multipart download
+	chunk.withRange = rng
+
+	if err := d.downloadChunk(chunk); err != nil {
+		d.setErr(err)
+	}
+
+	// Update the position based on the amount of data received.
+	d.pos = d.written
+}
+
+// downloadChunk downloads the chunk from s3
 func (d *downloader) downloadChunk(chunk dlchunk) error {
 	in := &s3.GetObjectInput{}
 	awsutil.Copy(in, d.in)
 
 	// Get the next byte range of data
-	rng := fmt.Sprintf("bytes=%d-%d", chunk.start, chunk.start+chunk.size-1)
-	in.Range = &rng
+	in.Range = aws.String(chunk.ByteRange())
 
 	var n int64
 	var err error
@@ -417,12 +455,18 @@ type dlchunk struct {
 	start int64
 	size  int64
 	cur   int64
+
+	// specifies the byte range the chunk should be downloaded with.
+	withRange string
 }
 
 // Write wraps io.WriterAt for the dlchunk, writing from the dlchunk's start
 // position to its end (or EOF).
+//
+// If a range is specified on the dlchunk the size will be ignored when writing.
+// as the total size may not of bee known ahead of time.
 func (c *dlchunk) Write(p []byte) (n int, err error) {
-	if c.cur >= c.size {
+	if c.cur >= c.size && len(c.withRange) == 0 {
 		return 0, io.EOF
 	}
 
@@ -430,4 +474,14 @@ func (c *dlchunk) Write(p []byte) (n int, err error) {
 	c.cur += int64(n)
 
 	return
+}
+
+// ByteRange returns a HTTP Byte-Range header value that should be used by the
+// client to request the chunk's range.
+func (c *dlchunk) ByteRange() string {
+	if len(c.withRange) != 0 {
+		return c.withRange
+	}
+
+	return fmt.Sprintf("bytes=%d-%d", c.start, c.start+c.size-1)
 }

--- a/service/s3/s3manager/download_test.go
+++ b/service/s3/s3manager/download_test.go
@@ -268,7 +268,7 @@ func TestDownloadSetPartSize(t *testing.T) {
 		t.Fatalf("expect no error, got %v", err)
 	}
 	if e, a := int64(3), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject", "GetObject", "GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
@@ -314,7 +314,7 @@ func TestDownloadError(t *testing.T) {
 		t.Errorf("expect %s error code, got %s", e, a)
 	}
 	if e, a := int64(1), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject", "GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
@@ -342,7 +342,7 @@ func TestDownloadNonChunk(t *testing.T) {
 		t.Fatalf("expect no error, got %v", err)
 	}
 	if e, a := int64(len(buf2MB)), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
@@ -374,7 +374,7 @@ func TestDownloadNoContentRangeLength(t *testing.T) {
 		t.Fatalf("expect no error, got %v", err)
 	}
 	if e, a := int64(len(buf2MB)), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject", "GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
@@ -406,7 +406,7 @@ func TestDownloadContentRangeTotalAny(t *testing.T) {
 		t.Fatalf("expect no error, got %v", err)
 	}
 	if e, a := int64(len(buf2MB)), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject", "GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
@@ -442,7 +442,7 @@ func TestDownloadPartBodyRetry_SuccessRetry(t *testing.T) {
 		t.Fatalf("expect no error, got %v", err)
 	}
 	if e, a := int64(3), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject", "GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
@@ -472,7 +472,7 @@ func TestDownloadPartBodyRetry_SuccessNoRetry(t *testing.T) {
 		t.Fatalf("expect no error, got %v", err)
 	}
 	if e, a := int64(3), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
@@ -505,7 +505,7 @@ func TestDownloadPartBodyRetry_FailRetry(t *testing.T) {
 		t.Errorf("expect %q error message to be in %q", e, a)
 	}
 	if e, a := int64(2), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
@@ -562,7 +562,7 @@ func TestDownload_WithRange(t *testing.T) {
 		t.Fatalf("expect no error, got %v", err)
 	}
 	if e, a := int64(5), n; e != a {
-		t.Errorf("expect %d bytes read, got %d", n)
+		t.Errorf("expect %d bytes read, got %d", e, a)
 	}
 	expectCalls := []string{"GetObject"}
 	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {

--- a/service/s3/s3manager/download_test.go
+++ b/service/s3/s3manager/download_test.go
@@ -6,14 +6,13 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -199,16 +198,30 @@ func TestDownloadOrder(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(len(buf12MB)), n)
-	assert.Equal(t, []string{"GetObject", "GetObject", "GetObject"}, *names)
-	assert.Equal(t, []string{"bytes=0-5242879", "bytes=5242880-10485759", "bytes=10485760-15728639"}, *ranges)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := int64(len(buf12MB)), n; e != a {
+		t.Errorf("expect %d buffer length, got %d", e, a)
+	}
+
+	expectCalls := []string{"GetObject", "GetObject", "GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
+
+	expectRngs := []string{"bytes=0-5242879", "bytes=5242880-10485759", "bytes=10485760-15728639"}
+	if e, a := expectRngs, *ranges; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v ranges, got %v", e, a)
+	}
 
 	count := 0
 	for _, b := range w.Bytes() {
 		count += int(b)
 	}
-	assert.Equal(t, 0, count)
+	if count != 0 {
+		t.Errorf("expect 0 count, got %d", count)
+	}
 }
 
 func TestDownloadZero(t *testing.T) {
@@ -221,10 +234,21 @@ func TestDownloadZero(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(0), n)
-	assert.Equal(t, []string{"GetObject"}, *names)
-	assert.Equal(t, []string{"bytes=0-5242879"}, *ranges)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expect 0 bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
+
+	expectRngs := []string{"bytes=0-5242879"}
+	if e, a := expectRngs, *ranges; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v ranges, got %v", e, a)
+	}
 }
 
 func TestDownloadSetPartSize(t *testing.T) {
@@ -240,11 +264,24 @@ func TestDownloadSetPartSize(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(3), n)
-	assert.Equal(t, []string{"GetObject", "GetObject", "GetObject"}, *names)
-	assert.Equal(t, []string{"bytes=0-0", "bytes=1-1", "bytes=2-2"}, *ranges)
-	assert.Equal(t, []byte{1, 2, 3}, w.Bytes())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := int64(3), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject", "GetObject", "GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
+	expectRngs := []string{"bytes=0-0", "bytes=1-1", "bytes=2-2"}
+	if e, a := expectRngs, *ranges; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v ranges, got %v", e, a)
+	}
+	expectBytes := []byte{1, 2, 3}
+	if e, a := expectBytes, w.Bytes(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v bytes, got %v", e, a)
+	}
 }
 
 func TestDownloadError(t *testing.T) {
@@ -269,10 +306,24 @@ func TestDownloadError(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.NotNil(t, err)
-	assert.Equal(t, int64(1), n)
-	assert.Equal(t, []string{"GetObject", "GetObject"}, *names)
-	assert.Equal(t, []byte{1}, w.Bytes())
+	if err == nil {
+		t.Fatalf("expect error, got none")
+	}
+	aerr := err.(awserr.Error)
+	if e, a := "BadRequest", aerr.Code(); e != a {
+		t.Errorf("expect %s error code, got %s", e, a)
+	}
+	if e, a := int64(1), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject", "GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
+	expectBytes := []byte{1}
+	if e, a := expectBytes, w.Bytes(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v bytes, got %v", e, a)
+	}
 }
 
 func TestDownloadNonChunk(t *testing.T) {
@@ -287,15 +338,24 @@ func TestDownloadNonChunk(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(len(buf2MB)), n)
-	assert.Equal(t, []string{"GetObject"}, *names)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := int64(len(buf2MB)), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
 
 	count := 0
 	for _, b := range w.Bytes() {
 		count += int(b)
 	}
-	assert.Equal(t, 0, count)
+	if count != 0 {
+		t.Errorf("expect 0 count, got %d", count)
+	}
 }
 
 func TestDownloadNoContentRangeLength(t *testing.T) {
@@ -310,15 +370,24 @@ func TestDownloadNoContentRangeLength(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(len(buf2MB)), n)
-	assert.Equal(t, []string{"GetObject", "GetObject"}, *names)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := int64(len(buf2MB)), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject", "GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
 
 	count := 0
 	for _, b := range w.Bytes() {
 		count += int(b)
 	}
-	assert.Equal(t, 0, count)
+	if count != 0 {
+		t.Errorf("expect 0 count, got %d", count)
+	}
 }
 
 func TestDownloadContentRangeTotalAny(t *testing.T) {
@@ -333,15 +402,24 @@ func TestDownloadContentRangeTotalAny(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(len(buf2MB)), n)
-	assert.Equal(t, []string{"GetObject", "GetObject"}, *names)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := int64(len(buf2MB)), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject", "GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
 
 	count := 0
 	for _, b := range w.Bytes() {
 		count += int(b)
 	}
-	assert.Equal(t, 0, count)
+	if count != 0 {
+		t.Errorf("expect 0 count, got %d", count)
+	}
 }
 
 func TestDownloadPartBodyRetry_SuccessRetry(t *testing.T) {
@@ -360,10 +438,19 @@ func TestDownloadPartBodyRetry_SuccessRetry(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(3), n)
-	assert.Equal(t, []string{"GetObject", "GetObject"}, *names)
-	assert.Equal(t, []byte("123"), w.Bytes())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := int64(3), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject", "GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
+	if e, a := "123", string(w.Bytes()); e != a {
+		t.Errorf("expect %q response, got %q", e, a)
+	}
 }
 
 func TestDownloadPartBodyRetry_SuccessNoRetry(t *testing.T) {
@@ -381,10 +468,19 @@ func TestDownloadPartBodyRetry_SuccessNoRetry(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(3), n)
-	assert.Equal(t, []string{"GetObject"}, *names)
-	assert.Equal(t, []byte("abc"), w.Bytes())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := int64(3), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
+	if e, a := "abc", string(w.Bytes()); e != a {
+		t.Errorf("expect %q response, got %q", e, a)
+	}
 }
 
 func TestDownloadPartBodyRetry_FailRetry(t *testing.T) {
@@ -402,10 +498,22 @@ func TestDownloadPartBodyRetry_FailRetry(t *testing.T) {
 		Key:    aws.String("key"),
 	})
 
-	assert.Error(t, err)
-	assert.Equal(t, int64(2), n)
-	assert.Equal(t, []string{"GetObject"}, *names)
-	assert.Equal(t, []byte("ab"), w.Bytes())
+	if err == nil {
+		t.Fatalf("expect error, got none")
+	}
+	if e, a := "unexpected EOF", err.Error(); !strings.Contains(a, e) {
+		t.Errorf("expect %q error message to be in %q", e, a)
+	}
+	if e, a := int64(2), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
+	if e, a := "ab", string(w.Bytes()); e != a {
+		t.Errorf("expect %q response, got %q", e, a)
+	}
 }
 
 func TestDownloadWithContextCanceled(t *testing.T) {
@@ -450,11 +558,24 @@ func TestDownload_WithRange(t *testing.T) {
 		Range:  aws.String("bytes=2-6"),
 	})
 
-	assert.Nil(t, err)
-	assert.Equal(t, int64(5), n)
-	assert.Equal(t, []string{"GetObject"}, *names)
-	assert.Equal(t, []string{"bytes=2-6"}, *ranges)
-	assert.Equal(t, []byte{2, 3, 4, 5, 6}, w.Bytes())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := int64(5), n; e != a {
+		t.Errorf("expect %d bytes read, got %d", n)
+	}
+	expectCalls := []string{"GetObject"}
+	if e, a := expectCalls, *names; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v API calls, got %v", e, a)
+	}
+	expectRngs := []string{"bytes=2-6"}
+	if e, a := expectRngs, *ranges; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v ranges, got %v", e, a)
+	}
+	expectBytes := []byte{2, 3, 4, 5, 6}
+	if e, a := expectBytes, w.Bytes(); !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v bytes, got %v", e, a)
+	}
 }
 
 func TestDownload_WithFailure(t *testing.T) {


### PR DESCRIPTION
Fixes the S3 Download Manager ignoring the GetObjectInput's Range
parameter. If this parameter is provided it will force the downloader to
fallback to a single GetObject request disabling concurrency and
automatic part size gets.

Fix #1296