### PR TITLE
aws/credentials: Fix shared credential providers filename

### DIFF
--- a/aws/credentials/shared_credentials_provider.go
+++ b/aws/credentials/shared_credentials_provider.go
@@ -130,7 +130,7 @@ func (p *SharedCredentialsProvider) filename() (string, error) {
 		return "", ErrSharedCredentialsHomeNotFound
 	}
 
-	p.Filename = shareddefaults.SharedConfigFilename()
+	p.Filename = shareddefaults.SharedCredentialsFilename()
 
 	return p.Filename, nil
 }


### PR DESCRIPTION
In #1308 the filename was being retrieved with the SharedConfigFilename
utility function not SharedCredentialsFilename function.

This bug caused the `session.New` with the SharedCredentials file to break.

Fix #1313