### PR TITLE
make UploadPartWithContext retry 10 times before returning err

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -1,3 +1,4 @@
+// TODO make each little part of a multi part upload, retry a few times vs. just 1 shot == failure
 package s3manager
 
 import (


### PR DESCRIPTION
if you have 100 parts, each 50 MB, if 99 work but 1 fail, it's nice to just try that 1 failure a few times so user doesn't have to re-upload all 100 parts again.