### PR TITLE
Improve AWS generated godocs for API generation list, and type linking

### DIFF
--- a/doc-src/aws-godoc/templates/package_default.html
+++ b/doc-src/aws-godoc/templates/package_default.html
@@ -146,14 +146,14 @@
 		</div> <!-- #pkg-callgraph -->
 
 		{{with .Consts}}
-			<h2 id="pkg-constants">Constants</h2>
+			<h2 id="pkg-constants">Constants <a class="permalink" href="pkg-constants">¶</a></h2>
 			{{range .}}
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}
 			{{end}}
 		{{end}}
 		{{with .Vars}}
-			<h2 id="pkg-variables">Variables</h2>
+			<h2 id="pkg-variables">Variables <a class="permalink" href="pkg-variables">¶</a></h2>
 			{{range .}}
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}
@@ -162,7 +162,7 @@
 		{{range .Funcs}}
 			{{/* Name is a string - no need for FSet */}}
 			{{$name_html := html .Name}}
-			<h2 id="{{$name_html}}">func <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a></h2>
+			<h2 id="{{$name_html}}">func <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$name_html}}">¶</a></h2>
 			<pre>{{node_html $ .Decl true}}</pre>
 			{{comment_html .Doc}}
 			{{example_html $ .Name}}
@@ -172,7 +172,7 @@
 		{{range .Types}}
 			{{$tname := .Name}}
 			{{$tname_html := html .Name}}
-			<h2 id="{{$tname_html}}">type <a href="{{posLink_url $ .Decl}}">{{$tname_html}}</a></h2>
+			<h2 id="{{$tname_html}}">type <a href="{{posLink_url $ .Decl}}">{{$tname_html}}</a> <a class="permalink" href="#{{$tname_html}}">¶</a></h2>
 			<pre>{{node_html $ .Decl true}}</pre>
 			{{comment_html .Doc}}
 
@@ -192,7 +192,7 @@
 
 			{{range .Funcs}}
 				{{$name_html := html .Name}}
-				<h3 id="{{$name_html}}">func <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a></h3>
+				<h3 id="{{$name_html}}">func <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$name_html}}">¶</a></h3>
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}
 				{{example_html $ .Name}}
@@ -201,7 +201,7 @@
 
 			{{range .Methods}}
 				{{$name_html := html .Name}}
-				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a></h3>
+				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$tname_html}}">¶</a></h3>
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}
 				{{$name := printf "%s_%s" $tname .Name}}

--- a/doc-src/aws-godoc/templates/package_service.html
+++ b/doc-src/aws-godoc/templates/package_service.html
@@ -51,7 +51,7 @@
 		</div>
 		{{example_html $ ""}}
 
-		<div id="pkg-operations" class="toggle">
+		<div id="pkg-operations" class="toggleVisible">
 		<div class="collapsed">
 			<h2 class="toggleButton" title="Click to show Index section">Operations ▹</h2>
 		</div>
@@ -78,7 +78,7 @@
 				{{ if (ne .Name "Validate") -}}
 					{{ $name_html := html .Name -}}
 					{{ if not (is_op_deprecated $.PDoc.Name .Name) -}}
-					<dd><a href="#{{$tname_html}}.{{$name_html}}">{{client_html $ .Decl false | sanitize}}</a></dd>
+					<dd>&nbsp; &nbsp; <a href="#{{$tname_html}}.{{$name_html}}">{{.Name}}</a></dd>
 					{{ end -}}
 				{{ end -}}
 				{{ end -}}
@@ -207,7 +207,7 @@
 			</div>
 		{{ end -}}
 		{{ with .Vars -}}
-			<h2 id="pkg-variables">Variables</h2>
+			<h2 id="pkg-variables">Variables <a class="permalink" href="#pkg-variables">¶</a></h2>
 			{{ range . -}}
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{ comment_html .Doc -}}
@@ -216,7 +216,7 @@
 		{{ range .Funcs -}}
 			{{/*  Name is a string - no need for FSet */ -}}
 			{{ $name_html := html .Name -}}
-			<h2 id="{{$name_html}}">func <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a></h2>
+			<h2 id="{{$name_html}}">func <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$name_html}}">¶</a></h2>
 			<pre>{{node_html $ .Decl true}}</pre>
 			{{comment_html .Doc}}
 			{{example_html $ .Name}}
@@ -225,7 +225,7 @@
 		{{ range .Types -}}
 			{{$tname := .Name -}}
 			{{$tname_html := html .Name -}}
-			<h2 id="{{$tname_html}}">type <a href="{{posLink_url $ .Decl}}">{{$tname_html}}</a></h2>
+			<h2 id="{{$tname_html}}">type <a href="{{posLink_url $ .Decl}}">{{$tname_html}}</a> <a class="permalink" href="#{{$tname_html}}">¶</a></h2>
 			<pre>{{node_html $ .Decl true}}</pre>
 			{{comment_html .Doc}}
 			{{ range .Consts -}}
@@ -241,7 +241,7 @@
 			{{ methodset_html $ $tname -}}
 			{{ range .Funcs -}}
 				{{ $name_html := html .Name -}}
-				<h3 id="{{$name_html}}">func <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a></h3>
+				<h3 id="{{$name_html}}">func <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$name_html}}">¶</a></h3>
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}
 				{{example_html $ .Name}}
@@ -250,9 +250,9 @@
 			{{ range .Methods -}}
 				{{ $name_html := html .Name -}}
 				{{ if is_op_deprecated $.PDoc.Name .Name -}}
-				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a><div class="deprecated">Deprecated</div></h3>
+				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a><div class="deprecated">Deprecated</div> <a class="permalink" href="#{{$name_html}}">¶</a></h3>
 				{{ else }}
-				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a></h3>
+				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$name_html}}">¶</a></h3>
 				{{ end -}}
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}

--- a/doc-src/aws-godoc/templates/style.css
+++ b/doc-src/aws-godoc/templates/style.css
@@ -1041,3 +1041,10 @@ a.error {
 		white-space: pre-wrap;
 	}
 }
+
+.permalink {
+	display: none;
+}
+:hover > .permalink {
+	display: inline;
+}


### PR DESCRIPTION
Improves the SDK's API reference guide generation of API operation list by removing the function signature from the operation method in the link. This reduces noise and makes it easier to navigate through the list of API operations per service. The operation method detail doc generation is unchanged.

Also updates the doc generation to include header permalinks to types and methods making sharing links easier.