### PR TITLE
Update doc generation templates

### DIFF
--- a/doc-src/aws-godoc/templates/package_default.html
+++ b/doc-src/aws-godoc/templates/package_default.html
@@ -146,14 +146,14 @@
 		</div> <!-- #pkg-callgraph -->
 
 		{{with .Consts}}
-			<h2 id="pkg-constants">Constants <a class="permalink" href="pkg-constants">¶</a></h2>
+			<h2 id="pkg-constants">Constants <a class="permalink" href="#pkg-constants">¶</a></h2>
 			{{range .}}
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}
 			{{end}}
 		{{end}}
 		{{with .Vars}}
-			<h2 id="pkg-variables">Variables <a class="permalink" href="pkg-variables">¶</a></h2>
+			<h2 id="pkg-variables">Variables <a class="permalink" href="#pkg-variables">¶</a></h2>
 			{{range .}}
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}
@@ -201,7 +201,7 @@
 
 			{{range .Methods}}
 				{{$name_html := html .Name}}
-				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$tname_html}}">¶</a></h3>
+				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$tname_html}}.{{$name_html}}">¶</a></h3>
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}
 				{{$name := printf "%s_%s" $tname .Name}}

--- a/doc-src/aws-godoc/templates/package_service.html
+++ b/doc-src/aws-godoc/templates/package_service.html
@@ -96,7 +96,7 @@
 		</div><!-- .expanded -->
 		</div><!-- #pkg-index -->
 		{{ if $.HasPaginators -}}
-		<div id="pkg-pagination " class="toggle">
+		<div id="pkg-pagination " class="toggleVisible">
 			<div class="collapsed">
 				<h2 class="toggleButton" title="Click to show Index section">Paginators ▹</h2>
 			</div>
@@ -114,7 +114,7 @@
 			</div>
 		</div>
 		{{ end -}}
-		<div id="pkg-types" class="toggle">
+		<div id="pkg-types" class="toggleVisible">
 			<div class="collapsed">
 				<h2 class="toggleButton" title="Click to show Index section">Types ▹</h2>
 			</div>
@@ -130,7 +130,7 @@
 					{{ range .Methods -}}
 					{{ if is_setter $.PDoc.Name . -}}
 					{{ $name_html := html .Name -}}
-					<dd><a href="#{{$tname_html}}.{{$name_html}}">{{name_only_html $ . | sanitize}}</a></dd>
+					<dd><a href="#{{$tname_html}}.{{$name_html}}">{{node_html $ .Decl false | sanitize}}</a></dd>
 					{{ end -}}
 					{{ end -}}
 				{{ end -}}
@@ -250,9 +250,9 @@
 			{{ range .Methods -}}
 				{{ $name_html := html .Name -}}
 				{{ if is_op_deprecated $.PDoc.Name .Name -}}
-				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a><div class="deprecated">Deprecated</div> <a class="permalink" href="#{{$name_html}}">¶</a></h3>
+				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a><div class="deprecated">Deprecated</div> <a class="permalink" href="#{{$tname_html}}.{{$name_html}}">¶</a></h3>
 				{{ else }}
-				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$name_html}}">¶</a></h3>
+				<h3 id="{{$tname_html}}.{{$name_html}}">func ({{html .Recv}}) <a href="{{posLink_url $ .Decl}}">{{$name_html}}</a> <a class="permalink" href="#{{$tname_html}}.{{$name_html}}">¶</a></h3>
 				{{ end -}}
 				<pre>{{node_html $ .Decl true}}</pre>
 				{{comment_html .Doc}}


### PR DESCRIPTION
Fixes the SDK's API Reference doc service client pages to generate the
fragment links correctly.
