### PR TITLE
v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Release v1.10.0 (2017-06-20)
+===
+
+### Service Client Updates
+* `service/workdocs`: Updates service API and documentation
+  * This release provides a new API to retrieve the activities performed by WorkDocs users.
+
+### SDK Features
+* `aws/credentials/plugincreds`: Add support for Go plugin for credentials [#1320](https://github.com/aws/aws-sdk-go/pull/1320)
+  * Adds support for using plugins to retrieve credentials for API requests. This change adds a new package plugincreds under aws/credentials. See the `example/aws/credentials/plugincreds` folder in the SDK for example usage.
+
 Release v1.9.00 (2017-06-19)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,4 @@
 ### SDK Features
-* `aws/credentials/plugincreds`: Add support for Go plugin for credentials [#1320](https://github.com/aws/aws-sdk-go/pull/1320)
-  * Adds support for using plugins to retrieve credentials for API requests. This change adds a new package plugincreds under aws/credentials. See the `example/aws/credentials/plugincreds` folder in the SDK for example usage.
 
 ### SDK Enhancements
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.9.44"
+const SDKVersion = "1.10.0"

--- a/models/apis/workdocs/2016-05-01/api-2.json
+++ b/models/apis/workdocs/2016-05-01/api-2.json
@@ -320,6 +320,23 @@
         {"shape":"ServiceUnavailableException"}
       ]
     },
+    "DescribeActivities":{
+      "name":"DescribeActivities",
+      "http":{
+        "method":"GET",
+        "requestUri":"/api/v1/activities",
+        "responseCode":200
+      },
+      "input":{"shape":"DescribeActivitiesRequest"},
+      "output":{"shape":"DescribeActivitiesResponse"},
+      "errors":[
+        {"shape":"UnauthorizedOperationException"},
+        {"shape":"UnauthorizedResourceAccessException"},
+        {"shape":"InvalidArgumentException"},
+        {"shape":"FailedDependencyException"},
+        {"shape":"ServiceUnavailableException"}
+      ]
+    },
     "DescribeComments":{
       "name":"DescribeComments",
       "http":{
@@ -406,6 +423,23 @@
         {"shape":"ServiceUnavailableException"}
       ]
     },
+    "DescribeRootFolders":{
+      "name":"DescribeRootFolders",
+      "http":{
+        "method":"GET",
+        "requestUri":"/api/v1/me/root",
+        "responseCode":200
+      },
+      "input":{"shape":"DescribeRootFoldersRequest"},
+      "output":{"shape":"DescribeRootFoldersResponse"},
+      "errors":[
+        {"shape":"UnauthorizedOperationException"},
+        {"shape":"UnauthorizedResourceAccessException"},
+        {"shape":"InvalidArgumentException"},
+        {"shape":"FailedDependencyException"},
+        {"shape":"ServiceUnavailableException"}
+      ]
+    },
     "DescribeUsers":{
       "name":"DescribeUsers",
       "http":{
@@ -421,6 +455,23 @@
         {"shape":"FailedDependencyException"},
         {"shape":"ServiceUnavailableException"},
         {"shape":"InvalidArgumentException"}
+      ]
+    },
+    "GetCurrentUser":{
+      "name":"GetCurrentUser",
+      "http":{
+        "method":"GET",
+        "requestUri":"/api/v1/me",
+        "responseCode":200
+      },
+      "input":{"shape":"GetCurrentUserRequest"},
+      "output":{"shape":"GetCurrentUserResponse"},
+      "errors":[
+        {"shape":"EntityNotExistsException"},
+        {"shape":"UnauthorizedOperationException"},
+        {"shape":"UnauthorizedResourceAccessException"},
+        {"shape":"FailedDependencyException"},
+        {"shape":"ServiceUnavailableException"}
       ]
     },
     "GetDocument":{
@@ -691,6 +742,55 @@
         "User":{"shape":"User"}
       }
     },
+    "Activity":{
+      "type":"structure",
+      "members":{
+        "Type":{"shape":"ActivityType"},
+        "TimeStamp":{"shape":"TimestampType"},
+        "OrganizationId":{"shape":"IdType"},
+        "Initiator":{"shape":"UserMetadata"},
+        "Participants":{"shape":"Participants"},
+        "ResourceMetadata":{"shape":"ResourceMetadata"},
+        "OriginalParent":{"shape":"ResourceMetadata"},
+        "CommentMetadata":{"shape":"CommentMetadata"}
+      }
+    },
+    "ActivityType":{
+      "type":"string",
+      "enum":[
+        "DOCUMENT_CHECKED_IN",
+        "DOCUMENT_CHECKED_OUT",
+        "DOCUMENT_RENAMED",
+        "DOCUMENT_VERSION_UPLOADED",
+        "DOCUMENT_VERSION_DELETED",
+        "DOCUMENT_RECYCLED",
+        "DOCUMENT_RESTORED",
+        "DOCUMENT_REVERTED",
+        "DOCUMENT_SHARED",
+        "DOCUMENT_UNSHARED",
+        "DOCUMENT_SHARE_PERMISSION_CHANGED",
+        "DOCUMENT_SHAREABLE_LINK_CREATED",
+        "DOCUMENT_SHAREABLE_LINK_REMOVED",
+        "DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED",
+        "DOCUMENT_MOVED",
+        "DOCUMENT_COMMENT_ADDED",
+        "DOCUMENT_COMMENT_DELETED",
+        "DOCUMENT_ANNOTATION_ADDED",
+        "DOCUMENT_ANNOTATION_DELETED",
+        "FOLDER_CREATED",
+        "FOLDER_DELETED",
+        "FOLDER_RENAMED",
+        "FOLDER_RECYCLED",
+        "FOLDER_RESTORED",
+        "FOLDER_SHARED",
+        "FOLDER_UNSHARED",
+        "FOLDER_SHARE_PERMISSION_CHANGED",
+        "FOLDER_SHAREABLE_LINK_CREATED",
+        "FOLDER_SHAREABLE_LINK_REMOVED",
+        "FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED",
+        "FOLDER_MOVED"
+      ]
+    },
     "AddResourcePermissionsRequest":{
       "type":"structure",
       "required":[
@@ -748,6 +848,16 @@
     "CommentList":{
       "type":"list",
       "member":{"shape":"Comment"}
+    },
+    "CommentMetadata":{
+      "type":"structure",
+      "members":{
+        "CommentId":{"shape":"CommentIdType"},
+        "Contributor":{"shape":"User"},
+        "CreatedTimestamp":{"shape":"TimestampType"},
+        "CommentStatus":{"shape":"CommentStatusType"},
+        "RecipientId":{"shape":"IdType"}
+      }
     },
     "CommentStatusType":{
       "type":"string",
@@ -952,7 +1062,7 @@
       "type":"string",
       "max":56,
       "min":1,
-      "pattern":"[a-zA-Z0-9_-][a-zA-Z0-9 _-]*"
+      "pattern":"[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
     },
     "CustomMetadataLimitExceededException":{
       "type":"structure",
@@ -971,9 +1081,9 @@
     },
     "CustomMetadataValueType":{
       "type":"string",
-      "max":56,
+      "max":256,
       "min":1,
-      "pattern":"[a-zA-Z0-9_-][a-zA-Z0-9 _-]*"
+      "pattern":"[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
     },
     "DeactivateUserRequest":{
       "type":"structure",
@@ -1178,6 +1288,53 @@
         }
       }
     },
+    "DescribeActivitiesRequest":{
+      "type":"structure",
+      "members":{
+        "AuthenticationToken":{
+          "shape":"AuthenticationHeaderType",
+          "location":"header",
+          "locationName":"Authentication"
+        },
+        "StartTime":{
+          "shape":"TimestampType",
+          "location":"querystring",
+          "locationName":"startTime"
+        },
+        "EndTime":{
+          "shape":"TimestampType",
+          "location":"querystring",
+          "locationName":"endTime"
+        },
+        "OrganizationId":{
+          "shape":"IdType",
+          "location":"querystring",
+          "locationName":"organizationId"
+        },
+        "UserId":{
+          "shape":"IdType",
+          "location":"querystring",
+          "locationName":"userId"
+        },
+        "Limit":{
+          "shape":"LimitType",
+          "location":"querystring",
+          "locationName":"limit"
+        },
+        "Marker":{
+          "shape":"MarkerType",
+          "location":"querystring",
+          "locationName":"marker"
+        }
+      }
+    },
+    "DescribeActivitiesResponse":{
+      "type":"structure",
+      "members":{
+        "UserActivities":{"shape":"UserActivities"},
+        "Marker":{"shape":"MarkerType"}
+      }
+    },
     "DescribeCommentsRequest":{
       "type":"structure",
       "required":[
@@ -1374,6 +1531,34 @@
       "type":"structure",
       "members":{
         "Principals":{"shape":"PrincipalList"},
+        "Marker":{"shape":"PageMarkerType"}
+      }
+    },
+    "DescribeRootFoldersRequest":{
+      "type":"structure",
+      "required":["AuthenticationToken"],
+      "members":{
+        "AuthenticationToken":{
+          "shape":"AuthenticationHeaderType",
+          "location":"header",
+          "locationName":"Authentication"
+        },
+        "Limit":{
+          "shape":"LimitType",
+          "location":"querystring",
+          "locationName":"limit"
+        },
+        "Marker":{
+          "shape":"PageMarkerType",
+          "location":"querystring",
+          "locationName":"marker"
+        }
+      }
+    },
+    "DescribeRootFoldersResponse":{
+      "type":"structure",
+      "members":{
+        "Folders":{"shape":"FolderMetadataList"},
         "Marker":{"shape":"PageMarkerType"}
       }
     },
@@ -1612,6 +1797,23 @@
       "type":"list",
       "member":{"shape":"FolderMetadata"}
     },
+    "GetCurrentUserRequest":{
+      "type":"structure",
+      "required":["AuthenticationToken"],
+      "members":{
+        "AuthenticationToken":{
+          "shape":"AuthenticationHeaderType",
+          "location":"header",
+          "locationName":"Authentication"
+        }
+      }
+    },
+    "GetCurrentUserResponse":{
+      "type":"structure",
+      "members":{
+        "User":{"shape":"User"}
+      }
+    },
     "GetDocumentPathRequest":{
       "type":"structure",
       "required":["DocumentId"],
@@ -1783,6 +1985,18 @@
         "CustomMetadata":{"shape":"CustomMetadataMap"}
       }
     },
+    "GroupMetadata":{
+      "type":"structure",
+      "members":{
+        "Id":{"shape":"IdType"},
+        "Name":{"shape":"GroupNameType"}
+      }
+    },
+    "GroupMetadataList":{
+      "type":"list",
+      "member":{"shape":"GroupMetadata"}
+    },
+    "GroupNameType":{"type":"string"},
     "HashType":{
       "type":"string",
       "max":128,
@@ -1857,9 +2071,9 @@
     },
     "Label":{
       "type":"string",
-      "max":20,
+      "max":32,
       "min":1,
-      "pattern":"[a-zA-Z0-9_-][a-zA-Z0-9 _-]*"
+      "pattern":"[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
     },
     "Labels":{
       "type":"list",
@@ -1922,6 +2136,13 @@
       "type":"string",
       "max":2048,
       "min":1
+    },
+    "Participants":{
+      "type":"structure",
+      "members":{
+        "Users":{"shape":"UserMetadataList"},
+        "Groups":{"shape":"GroupMetadataList"}
+      }
     },
     "PasswordType":{
       "type":"string",
@@ -2034,6 +2255,18 @@
       "min":1,
       "pattern":"[\\w+-.@]+"
     },
+    "ResourceMetadata":{
+      "type":"structure",
+      "members":{
+        "Type":{"shape":"ResourceType"},
+        "Name":{"shape":"ResourceNameType"},
+        "OriginalName":{"shape":"ResourceNameType"},
+        "Id":{"shape":"ResourceIdType"},
+        "VersionId":{"shape":"DocumentVersionIdType"},
+        "Owner":{"shape":"UserMetadata"},
+        "ParentId":{"shape":"ResourceIdType"}
+      }
+    },
     "ResourceNameType":{
       "type":"string",
       "max":255,
@@ -2071,6 +2304,13 @@
         "RESTORING",
         "RECYCLING",
         "RECYCLED"
+      ]
+    },
+    "ResourceType":{
+      "type":"string",
+      "enum":[
+        "FOLDER",
+        "DOCUMENT"
       ]
     },
     "RolePermissionType":{
@@ -2366,6 +2606,10 @@
         "Storage":{"shape":"UserStorageMetadata"}
       }
     },
+    "UserActivities":{
+      "type":"list",
+      "member":{"shape":"Activity"}
+    },
     "UserAttributeValueType":{
       "type":"string",
       "max":64,
@@ -2383,6 +2627,20 @@
       "max":2000,
       "min":1,
       "pattern":"[&\\w+-.@, ]+"
+    },
+    "UserMetadata":{
+      "type":"structure",
+      "members":{
+        "Id":{"shape":"IdType"},
+        "Username":{"shape":"UsernameType"},
+        "GivenName":{"shape":"UserAttributeValueType"},
+        "Surname":{"shape":"UserAttributeValueType"},
+        "EmailAddress":{"shape":"EmailAddressType"}
+      }
+    },
+    "UserMetadataList":{
+      "type":"list",
+      "member":{"shape":"UserMetadata"}
     },
     "UserSortType":{
       "type":"string",

--- a/models/apis/workdocs/2016-05-01/docs-2.json
+++ b/models/apis/workdocs/2016-05-01/docs-2.json
@@ -20,12 +20,15 @@
     "DeleteLabels": "<p>Deletes the specified list of labels from a resource.</p>",
     "DeleteNotificationSubscription": "<p>Deletes the specified subscription from the specified organization.</p>",
     "DeleteUser": "<p>Deletes the specified user from a Simple AD or Microsoft AD directory.</p>",
+    "DescribeActivities": "<p>Describes the user activities in a specified time period.</p>",
     "DescribeComments": "<p>List all the comments for the specified document version.</p>",
     "DescribeDocumentVersions": "<p>Retrieves the document versions for the specified document.</p> <p>By default, only active versions are returned.</p>",
     "DescribeFolderContents": "<p>Describes the contents of the specified folder, including its documents and subfolders.</p> <p>By default, Amazon WorkDocs returns the first 100 active document and folder metadata items. If there are more results, the response includes a marker that you can use to request the next set of results. You can also request initialized documents.</p>",
     "DescribeNotificationSubscriptions": "<p>Lists the specified notification subscriptions.</p>",
     "DescribeResourcePermissions": "<p>Describes the permissions of a specified resource.</p>",
+    "DescribeRootFolders": "<p>Describes the current user's special folders; the <code>RootFolder</code> and the <code>RecyleBin</code>. <code>RootFolder</code> is the root of user's files and folders and <code>RecyleBin</code> is the root of recycled items. This is not a valid action for SigV4 (administrative API) clients.</p>",
     "DescribeUsers": "<p>Describes the specified users. You can describe all users or filter the results (for example, by status or organization).</p> <p>By default, Amazon WorkDocs returns the first 24 active or pending users. If there are more results, the response includes a marker that you can use to request the next set of results.</p>",
+    "GetCurrentUser": "<p>Retrieves details of the current user for whom the authentication token was generated. This is not a valid action for SigV4 (administrative API) clients.</p>",
     "GetDocument": "<p>Retrieves details of a document.</p>",
     "GetDocumentPath": "<p>Retrieves the path information (the hierarchy from the root folder) for the requested document.</p> <p>By default, Amazon WorkDocs returns a maximum of 100 levels upwards from the requested document and only includes the IDs of the parent folders in the path. You can limit the maximum number of levels. You can also request the names of the parent folders.</p>",
     "GetDocumentVersion": "<p>Retrieves version metadata for the specified document.</p>",
@@ -53,6 +56,18 @@
     "ActivateUserResponse": {
       "base": null,
       "refs": {
+      }
+    },
+    "Activity": {
+      "base": "<p>Describes the activity information.</p>",
+      "refs": {
+        "UserActivities$member": null
+      }
+    },
+    "ActivityType": {
+      "base": null,
+      "refs": {
+        "Activity$Type": "<p>The activity type.</p>"
       }
     },
     "AddResourcePermissionsRequest": {
@@ -84,11 +99,14 @@
         "DeleteFolderRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "DeleteLabelsRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "DeleteUserRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
+        "DescribeActivitiesRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "DescribeCommentsRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "DescribeDocumentVersionsRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "DescribeFolderContentsRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "DescribeResourcePermissionsRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
+        "DescribeRootFoldersRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "DescribeUsersRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
+        "GetCurrentUserRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token.</p>",
         "GetDocumentPathRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "GetDocumentRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
         "GetDocumentVersionRequest$AuthenticationToken": "<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>",
@@ -127,6 +145,7 @@
         "Comment$CommentId": "<p>The ID of the comment.</p>",
         "Comment$ParentId": "<p>The ID of the parent comment.</p>",
         "Comment$ThreadId": "<p>The ID of the root comment in the thread.</p>",
+        "CommentMetadata$CommentId": "<p>The ID of the comment.</p>",
         "CreateCommentRequest$ParentId": "<p>The ID of the parent comment.</p>",
         "CreateCommentRequest$ThreadId": "<p>The ID of the root comment in the thread.</p>",
         "DeleteCommentRequest$CommentId": "<p>The ID of the comment.</p>"
@@ -138,10 +157,17 @@
         "DescribeCommentsResponse$Comments": "<p>The list of comments for the specified document version.</p>"
       }
     },
+    "CommentMetadata": {
+      "base": "<p>Describes the metadata of a comment.</p>",
+      "refs": {
+        "Activity$CommentMetadata": "<p>Metadata of the commenting activity. This is an optional field and is filled for commenting activities.</p>"
+      }
+    },
     "CommentStatusType": {
       "base": null,
       "refs": {
-        "Comment$Status": "<p>The status of the comment.</p>"
+        "Comment$Status": "<p>The status of the comment.</p>",
+        "CommentMetadata$CommentStatus": null
       }
     },
     "CommentTextType": {
@@ -316,6 +342,16 @@
       "refs": {
       }
     },
+    "DescribeActivitiesRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeActivitiesResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "DescribeCommentsRequest": {
       "base": null,
       "refs": {
@@ -362,6 +398,16 @@
       }
     },
     "DescribeResourcePermissionsResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeRootFoldersRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeRootFoldersResponse": {
       "base": null,
       "refs": {
       }
@@ -443,6 +489,7 @@
         "DescribeCommentsRequest$VersionId": "<p>The ID of the document version.</p>",
         "DocumentVersionMetadata$Id": "<p>The ID of the version.</p>",
         "GetDocumentVersionRequest$VersionId": "<p>The version ID of the document.</p>",
+        "ResourceMetadata$VersionId": "<p>The version ID of the resource. This is an optional field and is filled for action on document version.</p>",
         "UpdateDocumentVersionRequest$VersionId": "<p>The version ID of the document.</p>"
       }
     },
@@ -475,7 +522,8 @@
       "base": null,
       "refs": {
         "CreateUserRequest$EmailAddress": "<p>The email address of the user.</p>",
-        "User$EmailAddress": "<p>The email address of the user.</p>"
+        "User$EmailAddress": "<p>The email address of the user.</p>",
+        "UserMetadata$EmailAddress": "<p>The email address of the user.</p>"
       }
     },
     "EntityAlreadyExistsException": {
@@ -552,7 +600,18 @@
     "FolderMetadataList": {
       "base": null,
       "refs": {
-        "DescribeFolderContentsResponse$Folders": "<p>The subfolders in the specified folder.</p>"
+        "DescribeFolderContentsResponse$Folders": "<p>The subfolders in the specified folder.</p>",
+        "DescribeRootFoldersResponse$Folders": "<p>The user's special folders.</p>"
+      }
+    },
+    "GetCurrentUserRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "GetCurrentUserResponse": {
+      "base": null,
+      "refs": {
       }
     },
     "GetDocumentPathRequest": {
@@ -605,6 +664,24 @@
       "refs": {
       }
     },
+    "GroupMetadata": {
+      "base": "<p>Describes the metadata of a user group.</p>",
+      "refs": {
+        "GroupMetadataList$member": null
+      }
+    },
+    "GroupMetadataList": {
+      "base": null,
+      "refs": {
+        "Participants$Groups": "<p>The list of user groups.</p>"
+      }
+    },
+    "GroupNameType": {
+      "base": null,
+      "refs": {
+        "GroupMetadata$Name": "<p>The name of the group.</p>"
+      }
+    },
     "HashType": {
       "base": null,
       "refs": {
@@ -628,13 +705,17 @@
       "base": null,
       "refs": {
         "ActivateUserRequest$UserId": "<p>The ID of the user.</p>",
+        "Activity$OrganizationId": "<p>The ID of the organization.</p>",
         "Comment$RecipientId": "<p>If the comment is a reply to another user's comment, this field contains the user ID of the user being replied to.</p>",
+        "CommentMetadata$RecipientId": "<p>The ID of the user being replied to.</p>",
         "CreateNotificationSubscriptionRequest$OrganizationId": "<p>The ID of the organization.</p>",
         "CreateUserRequest$OrganizationId": "<p>The ID of the organization.</p>",
         "DeactivateUserRequest$UserId": "<p>The ID of the user.</p>",
         "DeleteNotificationSubscriptionRequest$SubscriptionId": "<p>The ID of the subscription.</p>",
         "DeleteNotificationSubscriptionRequest$OrganizationId": "<p>The ID of the organization.</p>",
         "DeleteUserRequest$UserId": "<p>The ID of the user.</p>",
+        "DescribeActivitiesRequest$OrganizationId": "<p>The ID of the organization. This is a mandatory parameter when using administrative API (SigV4) requests.</p>",
+        "DescribeActivitiesRequest$UserId": "<p>The ID of the user who performed the action. The response includes activities pertaining to this user. This is an optional parameter and is only applicable for administrative API (SigV4) requests.</p>",
         "DescribeNotificationSubscriptionsRequest$OrganizationId": "<p>The ID of the organization.</p>",
         "DescribeUsersRequest$OrganizationId": "<p>The ID of the organization.</p>",
         "DocumentMetadata$CreatorId": "<p>The ID of the creator.</p>",
@@ -643,6 +724,7 @@
         "FolderMetadata$CreatorId": "<p>The ID of the creator.</p>",
         "GetDocumentPathRequest$DocumentId": "<p>The ID of the document.</p>",
         "GetFolderPathRequest$FolderId": "<p>The ID of the folder.</p>",
+        "GroupMetadata$Id": "<p>The ID of the user group.</p>",
         "Principal$Id": "<p>The ID of the resource.</p>",
         "RemoveResourcePermissionRequest$PrincipalId": "<p>The principal ID of the resource.</p>",
         "ResourcePathComponent$Id": "<p>The ID of the resource path.</p>",
@@ -651,7 +733,8 @@
         "Subscription$SubscriptionId": "<p>The ID of the subscription.</p>",
         "UpdateUserRequest$UserId": "<p>The ID of the user.</p>",
         "User$Id": "<p>The ID of the user.</p>",
-        "User$OrganizationId": "<p>The ID of the organization.</p>"
+        "User$OrganizationId": "<p>The ID of the organization.</p>",
+        "UserMetadata$Id": "<p>The ID of the user.</p>"
       }
     },
     "IllegalUserStateException": {
@@ -702,11 +785,13 @@
     "LimitType": {
       "base": null,
       "refs": {
+        "DescribeActivitiesRequest$Limit": "<p>The maximum number of items to return.</p>",
         "DescribeCommentsRequest$Limit": "<p>The maximum number of items to return.</p>",
         "DescribeDocumentVersionsRequest$Limit": "<p>The maximum number of versions to return with this call.</p>",
         "DescribeFolderContentsRequest$Limit": "<p>The maximum number of items to return with this call.</p>",
         "DescribeNotificationSubscriptionsRequest$Limit": "<p>The maximum number of items to return with this call.</p>",
         "DescribeResourcePermissionsRequest$Limit": "<p>The maximum number of items to return with this call.</p>",
+        "DescribeRootFoldersRequest$Limit": "<p>The maximum number of items to return.</p>",
         "DescribeUsersRequest$Limit": "<p>The maximum number of items to return.</p>",
         "GetDocumentPathRequest$Limit": "<p>The maximum number of levels in the hierarchy to return.</p>",
         "GetFolderPathRequest$Limit": "<p>The maximum number of levels in the hierarchy to return.</p>"
@@ -722,6 +807,8 @@
     "MarkerType": {
       "base": null,
       "refs": {
+        "DescribeActivitiesRequest$Marker": "<p>The marker for the next set of results. (You received this marker from a previous call.)</p>",
+        "DescribeActivitiesResponse$Marker": "<p>The marker for the next set of results.</p>",
         "DescribeCommentsRequest$Marker": "<p>The marker for the next set of results. This marker was received from a previous call.</p>",
         "DescribeCommentsResponse$Marker": "<p>The marker for the next set of results. This marker was received from a previous call.</p>"
       }
@@ -756,10 +843,18 @@
         "DescribeNotificationSubscriptionsResponse$Marker": "<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>",
         "DescribeResourcePermissionsRequest$Marker": "<p>The marker for the next set of results. (You received this marker from a previous call)</p>",
         "DescribeResourcePermissionsResponse$Marker": "<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>",
+        "DescribeRootFoldersRequest$Marker": "<p>The marker for the next set of results. (You received this marker from a previous call.)</p>",
+        "DescribeRootFoldersResponse$Marker": "<p>The marker for the next set of results.</p>",
         "DescribeUsersRequest$Marker": "<p>The marker for the next set of results. (You received this marker from a previous call.)</p>",
         "DescribeUsersResponse$Marker": "<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>",
         "GetDocumentPathRequest$Marker": "<p>This value is not supported.</p>",
         "GetFolderPathRequest$Marker": "<p>This value is not supported.</p>"
+      }
+    },
+    "Participants": {
+      "base": "<p>Describes the users and/or user groups.</p>",
+      "refs": {
+        "Activity$Participants": "<p>The list of users or groups impacted by this action. This is an optional field and is filled for the following sharing activities: DOCUMENT_SHARED, DOCUMENT_SHARED, DOCUMENT_UNSHARED, FOLDER_SHARED, FOLDER_UNSHARED.</p>"
       }
     },
     "PasswordType": {
@@ -822,7 +917,7 @@
       }
     },
     "ResourceAlreadyCheckedOutException": {
-      "base": null,
+      "base": "<p>The resource is already checked out.</p>",
       "refs": {
       }
     },
@@ -856,6 +951,8 @@
         "InitiateDocumentVersionUploadRequest$ParentFolderId": "<p>The ID of the parent folder.</p>",
         "RemoveAllResourcePermissionsRequest$ResourceId": "<p>The ID of the resource.</p>",
         "RemoveResourcePermissionRequest$ResourceId": "<p>The ID of the resource.</p>",
+        "ResourceMetadata$Id": "<p>The ID of the resource.</p>",
+        "ResourceMetadata$ParentId": "<p>The parent ID of the resource before a rename operation.</p>",
         "ShareResult$ShareId": "<p>The ID of the resource that was shared.</p>",
         "UpdateDocumentRequest$DocumentId": "<p>The ID of the document.</p>",
         "UpdateDocumentRequest$ParentFolderId": "<p>The ID of the parent folder.</p>",
@@ -866,6 +963,13 @@
         "User$RecycleBinFolderId": "<p>The ID of the recycle bin folder.</p>"
       }
     },
+    "ResourceMetadata": {
+      "base": "<p>Describes the metadata of a resource.</p>",
+      "refs": {
+        "Activity$ResourceMetadata": "<p>The metadata of the resource involved in the user action.</p>",
+        "Activity$OriginalParent": "<p>The original parent of the resource. This is an optional field and is filled for move activities.</p>"
+      }
+    },
     "ResourceNameType": {
       "base": null,
       "refs": {
@@ -873,6 +977,8 @@
         "DocumentVersionMetadata$Name": "<p>The name of the version.</p>",
         "FolderMetadata$Name": "<p>The name of the folder.</p>",
         "InitiateDocumentVersionUploadRequest$Name": "<p>The name of the document.</p>",
+        "ResourceMetadata$Name": "<p>The name of the resource.</p>",
+        "ResourceMetadata$OriginalName": "<p>The original name of the resource prior to a rename operation.</p>",
         "ResourcePathComponent$Name": "<p>The name of the resource path.</p>",
         "UpdateDocumentRequest$Name": "<p>The name of the document.</p>",
         "UpdateFolderRequest$Name": "<p>The name of the folder.</p>"
@@ -910,6 +1016,12 @@
         "FolderMetadata$ResourceState": "<p>The resource state of the folder.</p>",
         "UpdateDocumentRequest$ResourceState": "<p>The resource state of the document. Note that only ACTIVE and RECYCLED are supported.</p>",
         "UpdateFolderRequest$ResourceState": "<p>The resource state of the folder. Note that only ACTIVE and RECYCLED are accepted values from the API.</p>"
+      }
+    },
+    "ResourceType": {
+      "base": null,
+      "refs": {
+        "ResourceMetadata$Type": "<p>The type of resource.</p>"
       }
     },
     "RolePermissionType": {
@@ -978,8 +1090,8 @@
       "refs": {
         "DescribeUsersResponse$TotalNumberOfUsers": "<p>The total number of users included in the results.</p>",
         "DocumentVersionMetadata$Size": "<p>The size of the document, in bytes.</p>",
-        "FolderMetadata$Size": null,
-        "FolderMetadata$LatestVersionSize": null,
+        "FolderMetadata$Size": "<p>The size of the folder metadata.</p>",
+        "FolderMetadata$LatestVersionSize": "<p>The size of the latest version of the folder metadata.</p>",
         "InitiateDocumentVersionUploadRequest$DocumentSizeInBytes": "<p>The size of the document, in bytes.</p>",
         "UserStorageMetadata$StorageUtilizedInBytes": "<p>The amount of storage utilized, in bytes.</p>"
       }
@@ -1052,7 +1164,11 @@
     "TimestampType": {
       "base": null,
       "refs": {
+        "Activity$TimeStamp": "<p>The timestamp when the action was performed.</p>",
         "Comment$CreatedTimestamp": "<p>The time that the comment was created.</p>",
+        "CommentMetadata$CreatedTimestamp": null,
+        "DescribeActivitiesRequest$StartTime": "<p>The timestamp that determines the starting time of the activities; the response includes the activities performed after the specified timestamp.</p>",
+        "DescribeActivitiesRequest$EndTime": "<p>The timestamp that determines the end time of the activities; the response includes the activities performed before the specified timestamp.</p>",
         "DocumentMetadata$CreatedTimestamp": "<p>The time when the document was created.</p>",
         "DocumentMetadata$ModifiedTimestamp": "<p>The time when the document was updated.</p>",
         "DocumentVersionMetadata$CreatedTimestamp": "<p>The time stamp when the document was first uploaded.</p>",
@@ -1131,9 +1247,17 @@
       "refs": {
         "ActivateUserResponse$User": "<p>The user information.</p>",
         "Comment$Contributor": "<p>The details of the user who made the comment.</p>",
+        "CommentMetadata$Contributor": "<p>The user who made the comment.</p>",
         "CreateUserResponse$User": "<p>The user information.</p>",
+        "GetCurrentUserResponse$User": "<p>Metadata of the user.</p>",
         "OrganizationUserList$member": null,
         "UpdateUserResponse$User": "<p>The user information.</p>"
+      }
+    },
+    "UserActivities": {
+      "base": null,
+      "refs": {
+        "DescribeActivitiesResponse$UserActivities": "<p>The list of activities for the specified user and time period.</p>"
       }
     },
     "UserAttributeValueType": {
@@ -1144,7 +1268,9 @@
         "UpdateUserRequest$GivenName": "<p>The given name of the user.</p>",
         "UpdateUserRequest$Surname": "<p>The surname of the user.</p>",
         "User$GivenName": "<p>The given name of the user.</p>",
-        "User$Surname": "<p>The surname of the user.</p>"
+        "User$Surname": "<p>The surname of the user.</p>",
+        "UserMetadata$GivenName": "<p>The given name of the user before a rename operation.</p>",
+        "UserMetadata$Surname": "<p>The surname of the user.</p>"
       }
     },
     "UserFilterType": {
@@ -1157,6 +1283,20 @@
       "base": null,
       "refs": {
         "DescribeUsersRequest$UserIds": "<p>The IDs of the users.</p>"
+      }
+    },
+    "UserMetadata": {
+      "base": "<p>Describes the metadata of the user.</p>",
+      "refs": {
+        "Activity$Initiator": "<p>The user who performed the action.</p>",
+        "ResourceMetadata$Owner": "<p>The owner of the resource.</p>",
+        "UserMetadataList$member": null
+      }
+    },
+    "UserMetadataList": {
+      "base": null,
+      "refs": {
+        "Participants$Users": "<p>The list of users.</p>"
       }
     },
     "UserSortType": {
@@ -1188,7 +1328,8 @@
       "base": null,
       "refs": {
         "CreateUserRequest$Username": "<p>The login name of the user.</p>",
-        "User$Username": "<p>The login name of the user.</p>"
+        "User$Username": "<p>The login name of the user.</p>",
+        "UserMetadata$Username": "<p>The username of the user.</p>"
       }
     }
   }

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -1767,6 +1767,100 @@ func (c *WorkDocs) DeleteUserWithContext(ctx aws.Context, input *DeleteUserInput
 	return out, req.Send()
 }
 
+const opDescribeActivities = "DescribeActivities"
+
+// DescribeActivitiesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeActivities operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeActivities for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeActivities method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeActivitiesRequest method.
+//    req, resp := client.DescribeActivitiesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeActivities
+func (c *WorkDocs) DescribeActivitiesRequest(input *DescribeActivitiesInput) (req *request.Request, output *DescribeActivitiesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeActivities,
+		HTTPMethod: "GET",
+		HTTPPath:   "/api/v1/activities",
+	}
+
+	if input == nil {
+		input = &DescribeActivitiesInput{}
+	}
+
+	output = &DescribeActivitiesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeActivities API operation for Amazon WorkDocs.
+//
+// Describes the user activities in a specified time period.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon WorkDocs's
+// API operation DescribeActivities for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeUnauthorizedOperationException "UnauthorizedOperationException"
+//   The operation is not permitted.
+//
+//   * ErrCodeUnauthorizedResourceAccessException "UnauthorizedResourceAccessException"
+//   The caller does not have access to perform the action on the resource.
+//
+//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
+//   The pagination marker and/or limit fields are not valid.
+//
+//   * ErrCodeFailedDependencyException "FailedDependencyException"
+//   The AWS Directory Service cannot reach an on-premises instance. Or a dependency
+//   under the control of the organization is failing, such as a connected active
+//   directory.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   One or more of the dependencies is unavailable.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeActivities
+func (c *WorkDocs) DescribeActivities(input *DescribeActivitiesInput) (*DescribeActivitiesOutput, error) {
+	req, out := c.DescribeActivitiesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeActivitiesWithContext is the same as DescribeActivities with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeActivities for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WorkDocs) DescribeActivitiesWithContext(ctx aws.Context, input *DescribeActivitiesInput, opts ...request.Option) (*DescribeActivitiesOutput, error) {
+	req, out := c.DescribeActivitiesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeComments = "DescribeComments"
 
 // DescribeCommentsRequest generates a "aws/request.Request" representing the
@@ -2358,6 +2452,103 @@ func (c *WorkDocs) DescribeResourcePermissionsWithContext(ctx aws.Context, input
 	return out, req.Send()
 }
 
+const opDescribeRootFolders = "DescribeRootFolders"
+
+// DescribeRootFoldersRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeRootFolders operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeRootFolders for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeRootFolders method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeRootFoldersRequest method.
+//    req, resp := client.DescribeRootFoldersRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeRootFolders
+func (c *WorkDocs) DescribeRootFoldersRequest(input *DescribeRootFoldersInput) (req *request.Request, output *DescribeRootFoldersOutput) {
+	op := &request.Operation{
+		Name:       opDescribeRootFolders,
+		HTTPMethod: "GET",
+		HTTPPath:   "/api/v1/me/root",
+	}
+
+	if input == nil {
+		input = &DescribeRootFoldersInput{}
+	}
+
+	output = &DescribeRootFoldersOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeRootFolders API operation for Amazon WorkDocs.
+//
+// Describes the current user's special folders; the RootFolder and the RecyleBin.
+// RootFolder is the root of user's files and folders and RecyleBin is the root
+// of recycled items. This is not a valid action for SigV4 (administrative API)
+// clients.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon WorkDocs's
+// API operation DescribeRootFolders for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeUnauthorizedOperationException "UnauthorizedOperationException"
+//   The operation is not permitted.
+//
+//   * ErrCodeUnauthorizedResourceAccessException "UnauthorizedResourceAccessException"
+//   The caller does not have access to perform the action on the resource.
+//
+//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
+//   The pagination marker and/or limit fields are not valid.
+//
+//   * ErrCodeFailedDependencyException "FailedDependencyException"
+//   The AWS Directory Service cannot reach an on-premises instance. Or a dependency
+//   under the control of the organization is failing, such as a connected active
+//   directory.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   One or more of the dependencies is unavailable.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeRootFolders
+func (c *WorkDocs) DescribeRootFolders(input *DescribeRootFoldersInput) (*DescribeRootFoldersOutput, error) {
+	req, out := c.DescribeRootFoldersRequest(input)
+	return out, req.Send()
+}
+
+// DescribeRootFoldersWithContext is the same as DescribeRootFolders with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeRootFolders for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WorkDocs) DescribeRootFoldersWithContext(ctx aws.Context, input *DescribeRootFoldersInput, opts ...request.Option) (*DescribeRootFoldersOutput, error) {
+	req, out := c.DescribeRootFoldersRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeUsers = "DescribeUsers"
 
 // DescribeUsersRequest generates a "aws/request.Request" representing the
@@ -2511,6 +2702,101 @@ func (c *WorkDocs) DescribeUsersPagesWithContext(ctx aws.Context, input *Describ
 		cont = fn(p.Page().(*DescribeUsersOutput), !p.HasNextPage())
 	}
 	return p.Err()
+}
+
+const opGetCurrentUser = "GetCurrentUser"
+
+// GetCurrentUserRequest generates a "aws/request.Request" representing the
+// client's request for the GetCurrentUser operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetCurrentUser for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetCurrentUser method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetCurrentUserRequest method.
+//    req, resp := client.GetCurrentUserRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetCurrentUser
+func (c *WorkDocs) GetCurrentUserRequest(input *GetCurrentUserInput) (req *request.Request, output *GetCurrentUserOutput) {
+	op := &request.Operation{
+		Name:       opGetCurrentUser,
+		HTTPMethod: "GET",
+		HTTPPath:   "/api/v1/me",
+	}
+
+	if input == nil {
+		input = &GetCurrentUserInput{}
+	}
+
+	output = &GetCurrentUserOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetCurrentUser API operation for Amazon WorkDocs.
+//
+// Retrieves details of the current user for whom the authentication token was
+// generated. This is not a valid action for SigV4 (administrative API) clients.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon WorkDocs's
+// API operation GetCurrentUser for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeEntityNotExistsException "EntityNotExistsException"
+//   The resource does not exist.
+//
+//   * ErrCodeUnauthorizedOperationException "UnauthorizedOperationException"
+//   The operation is not permitted.
+//
+//   * ErrCodeUnauthorizedResourceAccessException "UnauthorizedResourceAccessException"
+//   The caller does not have access to perform the action on the resource.
+//
+//   * ErrCodeFailedDependencyException "FailedDependencyException"
+//   The AWS Directory Service cannot reach an on-premises instance. Or a dependency
+//   under the control of the organization is failing, such as a connected active
+//   directory.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   One or more of the dependencies is unavailable.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetCurrentUser
+func (c *WorkDocs) GetCurrentUser(input *GetCurrentUserInput) (*GetCurrentUserOutput, error) {
+	req, out := c.GetCurrentUserRequest(input)
+	return out, req.Send()
+}
+
+// GetCurrentUserWithContext is the same as GetCurrentUser with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetCurrentUser for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WorkDocs) GetCurrentUserWithContext(ctx aws.Context, input *GetCurrentUserInput, opts ...request.Option) (*GetCurrentUserOutput, error) {
+	req, out := c.GetCurrentUserRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opGetDocument = "GetDocument"
@@ -3103,6 +3389,7 @@ func (c *WorkDocs) InitiateDocumentVersionUploadRequest(input *InitiateDocumentV
 //   version upload calls for a document that has been checked out from Web client.
 //
 //   * ErrCodeResourceAlreadyCheckedOutException "ResourceAlreadyCheckedOutException"
+//   The resource is already checked out.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/InitiateDocumentVersionUpload
 func (c *WorkDocs) InitiateDocumentVersionUpload(input *InitiateDocumentVersionUploadInput) (*InitiateDocumentVersionUploadOutput, error) {
@@ -3906,6 +4193,98 @@ func (s *ActivateUserOutput) SetUser(v *User) *ActivateUserOutput {
 	return s
 }
 
+// Describes the activity information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/Activity
+type Activity struct {
+	_ struct{} `type:"structure"`
+
+	// Metadata of the commenting activity. This is an optional field and is filled
+	// for commenting activities.
+	CommentMetadata *CommentMetadata `type:"structure"`
+
+	// The user who performed the action.
+	Initiator *UserMetadata `type:"structure"`
+
+	// The ID of the organization.
+	OrganizationId *string `min:"1" type:"string"`
+
+	// The original parent of the resource. This is an optional field and is filled
+	// for move activities.
+	OriginalParent *ResourceMetadata `type:"structure"`
+
+	// The list of users or groups impacted by this action. This is an optional
+	// field and is filled for the following sharing activities: DOCUMENT_SHARED,
+	// DOCUMENT_SHARED, DOCUMENT_UNSHARED, FOLDER_SHARED, FOLDER_UNSHARED.
+	Participants *Participants `type:"structure"`
+
+	// The metadata of the resource involved in the user action.
+	ResourceMetadata *ResourceMetadata `type:"structure"`
+
+	// The timestamp when the action was performed.
+	TimeStamp *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The activity type.
+	Type *string `type:"string" enum:"ActivityType"`
+}
+
+// String returns the string representation
+func (s Activity) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Activity) GoString() string {
+	return s.String()
+}
+
+// SetCommentMetadata sets the CommentMetadata field's value.
+func (s *Activity) SetCommentMetadata(v *CommentMetadata) *Activity {
+	s.CommentMetadata = v
+	return s
+}
+
+// SetInitiator sets the Initiator field's value.
+func (s *Activity) SetInitiator(v *UserMetadata) *Activity {
+	s.Initiator = v
+	return s
+}
+
+// SetOrganizationId sets the OrganizationId field's value.
+func (s *Activity) SetOrganizationId(v string) *Activity {
+	s.OrganizationId = &v
+	return s
+}
+
+// SetOriginalParent sets the OriginalParent field's value.
+func (s *Activity) SetOriginalParent(v *ResourceMetadata) *Activity {
+	s.OriginalParent = v
+	return s
+}
+
+// SetParticipants sets the Participants field's value.
+func (s *Activity) SetParticipants(v *Participants) *Activity {
+	s.Participants = v
+	return s
+}
+
+// SetResourceMetadata sets the ResourceMetadata field's value.
+func (s *Activity) SetResourceMetadata(v *ResourceMetadata) *Activity {
+	s.ResourceMetadata = v
+	return s
+}
+
+// SetTimeStamp sets the TimeStamp field's value.
+func (s *Activity) SetTimeStamp(v time.Time) *Activity {
+	s.TimeStamp = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Activity) SetType(v string) *Activity {
+	s.Type = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/AddResourcePermissionsRequest
 type AddResourcePermissionsInput struct {
 	_ struct{} `type:"structure"`
@@ -4108,6 +4487,65 @@ func (s *Comment) SetThreadId(v string) *Comment {
 // SetVisibility sets the Visibility field's value.
 func (s *Comment) SetVisibility(v string) *Comment {
 	s.Visibility = &v
+	return s
+}
+
+// Describes the metadata of a comment.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CommentMetadata
+type CommentMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the comment.
+	CommentId *string `min:"1" type:"string"`
+
+	CommentStatus *string `type:"string" enum:"CommentStatusType"`
+
+	// The user who made the comment.
+	Contributor *User `type:"structure"`
+
+	CreatedTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The ID of the user being replied to.
+	RecipientId *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s CommentMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CommentMetadata) GoString() string {
+	return s.String()
+}
+
+// SetCommentId sets the CommentId field's value.
+func (s *CommentMetadata) SetCommentId(v string) *CommentMetadata {
+	s.CommentId = &v
+	return s
+}
+
+// SetCommentStatus sets the CommentStatus field's value.
+func (s *CommentMetadata) SetCommentStatus(v string) *CommentMetadata {
+	s.CommentStatus = &v
+	return s
+}
+
+// SetContributor sets the Contributor field's value.
+func (s *CommentMetadata) SetContributor(v *User) *CommentMetadata {
+	s.Contributor = v
+	return s
+}
+
+// SetCreatedTimestamp sets the CreatedTimestamp field's value.
+func (s *CommentMetadata) SetCreatedTimestamp(v time.Time) *CommentMetadata {
+	s.CreatedTimestamp = &v
+	return s
+}
+
+// SetRecipientId sets the RecipientId field's value.
+func (s *CommentMetadata) SetRecipientId(v string) *CommentMetadata {
+	s.RecipientId = &v
 	return s
 }
 
@@ -5550,6 +5988,149 @@ func (s DeleteUserOutput) GoString() string {
 	return s.String()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeActivitiesRequest
+type DescribeActivitiesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Amazon WorkDocs authentication token. This field should not be set when using
+	// administrative API actions, as in accessing the API using AWS credentials.
+	AuthenticationToken *string `location:"header" locationName:"Authentication" min:"1" type:"string"`
+
+	// The timestamp that determines the end time of the activities; the response
+	// includes the activities performed before the specified timestamp.
+	EndTime *time.Time `location:"querystring" locationName:"endTime" type:"timestamp" timestampFormat:"unix"`
+
+	// The maximum number of items to return.
+	Limit *int64 `location:"querystring" locationName:"limit" min:"1" type:"integer"`
+
+	// The marker for the next set of results. (You received this marker from a
+	// previous call.)
+	Marker *string `location:"querystring" locationName:"marker" min:"1" type:"string"`
+
+	// The ID of the organization. This is a mandatory parameter when using administrative
+	// API (SigV4) requests.
+	OrganizationId *string `location:"querystring" locationName:"organizationId" min:"1" type:"string"`
+
+	// The timestamp that determines the starting time of the activities; the response
+	// includes the activities performed after the specified timestamp.
+	StartTime *time.Time `location:"querystring" locationName:"startTime" type:"timestamp" timestampFormat:"unix"`
+
+	// The ID of the user who performed the action. The response includes activities
+	// pertaining to this user. This is an optional parameter and is only applicable
+	// for administrative API (SigV4) requests.
+	UserId *string `location:"querystring" locationName:"userId" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeActivitiesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeActivitiesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeActivitiesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeActivitiesInput"}
+	if s.AuthenticationToken != nil && len(*s.AuthenticationToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthenticationToken", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+	if s.OrganizationId != nil && len(*s.OrganizationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OrganizationId", 1))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthenticationToken sets the AuthenticationToken field's value.
+func (s *DescribeActivitiesInput) SetAuthenticationToken(v string) *DescribeActivitiesInput {
+	s.AuthenticationToken = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *DescribeActivitiesInput) SetEndTime(v time.Time) *DescribeActivitiesInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeActivitiesInput) SetLimit(v int64) *DescribeActivitiesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeActivitiesInput) SetMarker(v string) *DescribeActivitiesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetOrganizationId sets the OrganizationId field's value.
+func (s *DescribeActivitiesInput) SetOrganizationId(v string) *DescribeActivitiesInput {
+	s.OrganizationId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *DescribeActivitiesInput) SetStartTime(v time.Time) *DescribeActivitiesInput {
+	s.StartTime = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *DescribeActivitiesInput) SetUserId(v string) *DescribeActivitiesInput {
+	s.UserId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeActivitiesResponse
+type DescribeActivitiesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The marker for the next set of results.
+	Marker *string `min:"1" type:"string"`
+
+	// The list of activities for the specified user and time period.
+	UserActivities []*Activity `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeActivitiesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeActivitiesOutput) GoString() string {
+	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeActivitiesOutput) SetMarker(v string) *DescribeActivitiesOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetUserActivities sets the UserActivities field's value.
+func (s *DescribeActivitiesOutput) SetUserActivities(v []*Activity) *DescribeActivitiesOutput {
+	s.UserActivities = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeCommentsRequest
 type DescribeCommentsInput struct {
 	_ struct{} `type:"structure"`
@@ -6198,6 +6779,107 @@ func (s *DescribeResourcePermissionsOutput) SetPrincipals(v []*Principal) *Descr
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeRootFoldersRequest
+type DescribeRootFoldersInput struct {
+	_ struct{} `type:"structure"`
+
+	// Amazon WorkDocs authentication token. This field should not be set when using
+	// administrative API actions, as in accessing the API using AWS credentials.
+	//
+	// AuthenticationToken is a required field
+	AuthenticationToken *string `location:"header" locationName:"Authentication" min:"1" type:"string" required:"true"`
+
+	// The maximum number of items to return.
+	Limit *int64 `location:"querystring" locationName:"limit" min:"1" type:"integer"`
+
+	// The marker for the next set of results. (You received this marker from a
+	// previous call.)
+	Marker *string `location:"querystring" locationName:"marker" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeRootFoldersInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRootFoldersInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeRootFoldersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeRootFoldersInput"}
+	if s.AuthenticationToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthenticationToken"))
+	}
+	if s.AuthenticationToken != nil && len(*s.AuthenticationToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthenticationToken", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.Marker != nil && len(*s.Marker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Marker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthenticationToken sets the AuthenticationToken field's value.
+func (s *DescribeRootFoldersInput) SetAuthenticationToken(v string) *DescribeRootFoldersInput {
+	s.AuthenticationToken = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *DescribeRootFoldersInput) SetLimit(v int64) *DescribeRootFoldersInput {
+	s.Limit = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeRootFoldersInput) SetMarker(v string) *DescribeRootFoldersInput {
+	s.Marker = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeRootFoldersResponse
+type DescribeRootFoldersOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The user's special folders.
+	Folders []*FolderMetadata `type:"list"`
+
+	// The marker for the next set of results.
+	Marker *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeRootFoldersOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRootFoldersOutput) GoString() string {
+	return s.String()
+}
+
+// SetFolders sets the Folders field's value.
+func (s *DescribeRootFoldersOutput) SetFolders(v []*FolderMetadata) *DescribeRootFoldersOutput {
+	s.Folders = v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeRootFoldersOutput) SetMarker(v string) *DescribeRootFoldersOutput {
+	s.Marker = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeUsersRequest
 type DescribeUsersInput struct {
 	_ struct{} `type:"structure"`
@@ -6618,6 +7300,7 @@ type FolderMetadata struct {
 	// List of labels on the folder.
 	Labels []*string `type:"list"`
 
+	// The size of the latest version of the folder metadata.
 	LatestVersionSize *int64 `type:"long"`
 
 	// The time when the folder was updated.
@@ -6635,6 +7318,7 @@ type FolderMetadata struct {
 	// The unique identifier created from the subfolders and documents of the folder.
 	Signature *string `type:"string"`
 
+	// The size of the folder metadata.
 	Size *int64 `type:"long"`
 }
 
@@ -6711,6 +7395,72 @@ func (s *FolderMetadata) SetSignature(v string) *FolderMetadata {
 // SetSize sets the Size field's value.
 func (s *FolderMetadata) SetSize(v int64) *FolderMetadata {
 	s.Size = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetCurrentUserRequest
+type GetCurrentUserInput struct {
+	_ struct{} `type:"structure"`
+
+	// Amazon WorkDocs authentication token.
+	//
+	// AuthenticationToken is a required field
+	AuthenticationToken *string `location:"header" locationName:"Authentication" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetCurrentUserInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCurrentUserInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCurrentUserInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCurrentUserInput"}
+	if s.AuthenticationToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthenticationToken"))
+	}
+	if s.AuthenticationToken != nil && len(*s.AuthenticationToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthenticationToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthenticationToken sets the AuthenticationToken field's value.
+func (s *GetCurrentUserInput) SetAuthenticationToken(v string) *GetCurrentUserInput {
+	s.AuthenticationToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetCurrentUserResponse
+type GetCurrentUserOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Metadata of the user.
+	User *User `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCurrentUserOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCurrentUserOutput) GoString() string {
+	return s.String()
+}
+
+// SetUser sets the User field's value.
+func (s *GetCurrentUserOutput) SetUser(v *User) *GetCurrentUserOutput {
+	s.User = v
 	return s
 }
 
@@ -7267,6 +8017,40 @@ func (s *GetFolderPathOutput) SetPath(v *ResourcePath) *GetFolderPathOutput {
 	return s
 }
 
+// Describes the metadata of a user group.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GroupMetadata
+type GroupMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the user group.
+	Id *string `min:"1" type:"string"`
+
+	// The name of the group.
+	Name *string `type:"string"`
+}
+
+// String returns the string representation
+func (s GroupMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GroupMetadata) GoString() string {
+	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *GroupMetadata) SetId(v string) *GroupMetadata {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GroupMetadata) SetName(v string) *GroupMetadata {
+	s.Name = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/InitiateDocumentVersionUploadRequest
 type InitiateDocumentVersionUploadInput struct {
 	_ struct{} `type:"structure"`
@@ -7415,6 +8199,40 @@ func (s *InitiateDocumentVersionUploadOutput) SetMetadata(v *DocumentMetadata) *
 // SetUploadMetadata sets the UploadMetadata field's value.
 func (s *InitiateDocumentVersionUploadOutput) SetUploadMetadata(v *UploadMetadata) *InitiateDocumentVersionUploadOutput {
 	s.UploadMetadata = v
+	return s
+}
+
+// Describes the users and/or user groups.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/Participants
+type Participants struct {
+	_ struct{} `type:"structure"`
+
+	// The list of user groups.
+	Groups []*GroupMetadata `type:"list"`
+
+	// The list of users.
+	Users []*UserMetadata `type:"list"`
+}
+
+// String returns the string representation
+func (s Participants) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Participants) GoString() string {
+	return s.String()
+}
+
+// SetGroups sets the Groups field's value.
+func (s *Participants) SetGroups(v []*GroupMetadata) *Participants {
+	s.Groups = v
+	return s
+}
+
+// SetUsers sets the Users field's value.
+func (s *Participants) SetUsers(v []*UserMetadata) *Participants {
+	s.Users = v
 	return s
 }
 
@@ -7659,6 +8477,86 @@ func (s RemoveResourcePermissionOutput) String() string {
 // GoString returns the string representation
 func (s RemoveResourcePermissionOutput) GoString() string {
 	return s.String()
+}
+
+// Describes the metadata of a resource.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ResourceMetadata
+type ResourceMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the resource.
+	Id *string `min:"1" type:"string"`
+
+	// The name of the resource.
+	Name *string `min:"1" type:"string"`
+
+	// The original name of the resource prior to a rename operation.
+	OriginalName *string `min:"1" type:"string"`
+
+	// The owner of the resource.
+	Owner *UserMetadata `type:"structure"`
+
+	// The parent ID of the resource before a rename operation.
+	ParentId *string `min:"1" type:"string"`
+
+	// The type of resource.
+	Type *string `type:"string" enum:"ResourceType"`
+
+	// The version ID of the resource. This is an optional field and is filled for
+	// action on document version.
+	VersionId *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ResourceMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResourceMetadata) GoString() string {
+	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *ResourceMetadata) SetId(v string) *ResourceMetadata {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ResourceMetadata) SetName(v string) *ResourceMetadata {
+	s.Name = &v
+	return s
+}
+
+// SetOriginalName sets the OriginalName field's value.
+func (s *ResourceMetadata) SetOriginalName(v string) *ResourceMetadata {
+	s.OriginalName = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *ResourceMetadata) SetOwner(v *UserMetadata) *ResourceMetadata {
+	s.Owner = v
+	return s
+}
+
+// SetParentId sets the ParentId field's value.
+func (s *ResourceMetadata) SetParentId(v string) *ResourceMetadata {
+	s.ParentId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ResourceMetadata) SetType(v string) *ResourceMetadata {
+	s.Type = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *ResourceMetadata) SetVersionId(v string) *ResourceMetadata {
+	s.VersionId = &v
+	return s
 }
 
 // Describes the path information of a resource.
@@ -8560,6 +9458,67 @@ func (s *User) SetUsername(v string) *User {
 	return s
 }
 
+// Describes the metadata of the user.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UserMetadata
+type UserMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// The email address of the user.
+	EmailAddress *string `min:"1" type:"string"`
+
+	// The given name of the user before a rename operation.
+	GivenName *string `min:"1" type:"string"`
+
+	// The ID of the user.
+	Id *string `min:"1" type:"string"`
+
+	// The surname of the user.
+	Surname *string `min:"1" type:"string"`
+
+	// The username of the user.
+	Username *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s UserMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UserMetadata) GoString() string {
+	return s.String()
+}
+
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *UserMetadata) SetEmailAddress(v string) *UserMetadata {
+	s.EmailAddress = &v
+	return s
+}
+
+// SetGivenName sets the GivenName field's value.
+func (s *UserMetadata) SetGivenName(v string) *UserMetadata {
+	s.GivenName = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UserMetadata) SetId(v string) *UserMetadata {
+	s.Id = &v
+	return s
+}
+
+// SetSurname sets the Surname field's value.
+func (s *UserMetadata) SetSurname(v string) *UserMetadata {
+	s.Surname = &v
+	return s
+}
+
+// SetUsername sets the Username field's value.
+func (s *UserMetadata) SetUsername(v string) *UserMetadata {
+	s.Username = &v
+	return s
+}
+
 // Describes the storage for a user.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UserStorageMetadata
 type UserStorageMetadata struct {
@@ -8593,6 +9552,101 @@ func (s *UserStorageMetadata) SetStorageUtilizedInBytes(v int64) *UserStorageMet
 	s.StorageUtilizedInBytes = &v
 	return s
 }
+
+const (
+	// ActivityTypeDocumentCheckedIn is a ActivityType enum value
+	ActivityTypeDocumentCheckedIn = "DOCUMENT_CHECKED_IN"
+
+	// ActivityTypeDocumentCheckedOut is a ActivityType enum value
+	ActivityTypeDocumentCheckedOut = "DOCUMENT_CHECKED_OUT"
+
+	// ActivityTypeDocumentRenamed is a ActivityType enum value
+	ActivityTypeDocumentRenamed = "DOCUMENT_RENAMED"
+
+	// ActivityTypeDocumentVersionUploaded is a ActivityType enum value
+	ActivityTypeDocumentVersionUploaded = "DOCUMENT_VERSION_UPLOADED"
+
+	// ActivityTypeDocumentVersionDeleted is a ActivityType enum value
+	ActivityTypeDocumentVersionDeleted = "DOCUMENT_VERSION_DELETED"
+
+	// ActivityTypeDocumentRecycled is a ActivityType enum value
+	ActivityTypeDocumentRecycled = "DOCUMENT_RECYCLED"
+
+	// ActivityTypeDocumentRestored is a ActivityType enum value
+	ActivityTypeDocumentRestored = "DOCUMENT_RESTORED"
+
+	// ActivityTypeDocumentReverted is a ActivityType enum value
+	ActivityTypeDocumentReverted = "DOCUMENT_REVERTED"
+
+	// ActivityTypeDocumentShared is a ActivityType enum value
+	ActivityTypeDocumentShared = "DOCUMENT_SHARED"
+
+	// ActivityTypeDocumentUnshared is a ActivityType enum value
+	ActivityTypeDocumentUnshared = "DOCUMENT_UNSHARED"
+
+	// ActivityTypeDocumentSharePermissionChanged is a ActivityType enum value
+	ActivityTypeDocumentSharePermissionChanged = "DOCUMENT_SHARE_PERMISSION_CHANGED"
+
+	// ActivityTypeDocumentShareableLinkCreated is a ActivityType enum value
+	ActivityTypeDocumentShareableLinkCreated = "DOCUMENT_SHAREABLE_LINK_CREATED"
+
+	// ActivityTypeDocumentShareableLinkRemoved is a ActivityType enum value
+	ActivityTypeDocumentShareableLinkRemoved = "DOCUMENT_SHAREABLE_LINK_REMOVED"
+
+	// ActivityTypeDocumentShareableLinkPermissionChanged is a ActivityType enum value
+	ActivityTypeDocumentShareableLinkPermissionChanged = "DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED"
+
+	// ActivityTypeDocumentMoved is a ActivityType enum value
+	ActivityTypeDocumentMoved = "DOCUMENT_MOVED"
+
+	// ActivityTypeDocumentCommentAdded is a ActivityType enum value
+	ActivityTypeDocumentCommentAdded = "DOCUMENT_COMMENT_ADDED"
+
+	// ActivityTypeDocumentCommentDeleted is a ActivityType enum value
+	ActivityTypeDocumentCommentDeleted = "DOCUMENT_COMMENT_DELETED"
+
+	// ActivityTypeDocumentAnnotationAdded is a ActivityType enum value
+	ActivityTypeDocumentAnnotationAdded = "DOCUMENT_ANNOTATION_ADDED"
+
+	// ActivityTypeDocumentAnnotationDeleted is a ActivityType enum value
+	ActivityTypeDocumentAnnotationDeleted = "DOCUMENT_ANNOTATION_DELETED"
+
+	// ActivityTypeFolderCreated is a ActivityType enum value
+	ActivityTypeFolderCreated = "FOLDER_CREATED"
+
+	// ActivityTypeFolderDeleted is a ActivityType enum value
+	ActivityTypeFolderDeleted = "FOLDER_DELETED"
+
+	// ActivityTypeFolderRenamed is a ActivityType enum value
+	ActivityTypeFolderRenamed = "FOLDER_RENAMED"
+
+	// ActivityTypeFolderRecycled is a ActivityType enum value
+	ActivityTypeFolderRecycled = "FOLDER_RECYCLED"
+
+	// ActivityTypeFolderRestored is a ActivityType enum value
+	ActivityTypeFolderRestored = "FOLDER_RESTORED"
+
+	// ActivityTypeFolderShared is a ActivityType enum value
+	ActivityTypeFolderShared = "FOLDER_SHARED"
+
+	// ActivityTypeFolderUnshared is a ActivityType enum value
+	ActivityTypeFolderUnshared = "FOLDER_UNSHARED"
+
+	// ActivityTypeFolderSharePermissionChanged is a ActivityType enum value
+	ActivityTypeFolderSharePermissionChanged = "FOLDER_SHARE_PERMISSION_CHANGED"
+
+	// ActivityTypeFolderShareableLinkCreated is a ActivityType enum value
+	ActivityTypeFolderShareableLinkCreated = "FOLDER_SHAREABLE_LINK_CREATED"
+
+	// ActivityTypeFolderShareableLinkRemoved is a ActivityType enum value
+	ActivityTypeFolderShareableLinkRemoved = "FOLDER_SHAREABLE_LINK_REMOVED"
+
+	// ActivityTypeFolderShareableLinkPermissionChanged is a ActivityType enum value
+	ActivityTypeFolderShareableLinkPermissionChanged = "FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED"
+
+	// ActivityTypeFolderMoved is a ActivityType enum value
+	ActivityTypeFolderMoved = "FOLDER_MOVED"
+)
 
 const (
 	// CommentStatusTypeDraft is a CommentStatusType enum value
@@ -8736,6 +9790,14 @@ const (
 
 	// ResourceStateTypeRecycled is a ResourceStateType enum value
 	ResourceStateTypeRecycled = "RECYCLED"
+)
+
+const (
+	// ResourceTypeFolder is a ResourceType enum value
+	ResourceTypeFolder = "FOLDER"
+
+	// ResourceTypeDocument is a ResourceType enum value
+	ResourceTypeDocument = "DOCUMENT"
 )
 
 const (

--- a/service/workdocs/errors.go
+++ b/service/workdocs/errors.go
@@ -89,6 +89,8 @@ const (
 
 	// ErrCodeResourceAlreadyCheckedOutException for service response error code
 	// "ResourceAlreadyCheckedOutException".
+	//
+	// The resource is already checked out.
 	ErrCodeResourceAlreadyCheckedOutException = "ResourceAlreadyCheckedOutException"
 
 	// ErrCodeServiceUnavailableException for service response error code

--- a/service/workdocs/workdocsiface/interface.go
+++ b/service/workdocs/workdocsiface/interface.go
@@ -132,6 +132,10 @@ type WorkDocsAPI interface {
 	DeleteUserWithContext(aws.Context, *workdocs.DeleteUserInput, ...request.Option) (*workdocs.DeleteUserOutput, error)
 	DeleteUserRequest(*workdocs.DeleteUserInput) (*request.Request, *workdocs.DeleteUserOutput)
 
+	DescribeActivities(*workdocs.DescribeActivitiesInput) (*workdocs.DescribeActivitiesOutput, error)
+	DescribeActivitiesWithContext(aws.Context, *workdocs.DescribeActivitiesInput, ...request.Option) (*workdocs.DescribeActivitiesOutput, error)
+	DescribeActivitiesRequest(*workdocs.DescribeActivitiesInput) (*request.Request, *workdocs.DescribeActivitiesOutput)
+
 	DescribeComments(*workdocs.DescribeCommentsInput) (*workdocs.DescribeCommentsOutput, error)
 	DescribeCommentsWithContext(aws.Context, *workdocs.DescribeCommentsInput, ...request.Option) (*workdocs.DescribeCommentsOutput, error)
 	DescribeCommentsRequest(*workdocs.DescribeCommentsInput) (*request.Request, *workdocs.DescribeCommentsOutput)
@@ -158,12 +162,20 @@ type WorkDocsAPI interface {
 	DescribeResourcePermissionsWithContext(aws.Context, *workdocs.DescribeResourcePermissionsInput, ...request.Option) (*workdocs.DescribeResourcePermissionsOutput, error)
 	DescribeResourcePermissionsRequest(*workdocs.DescribeResourcePermissionsInput) (*request.Request, *workdocs.DescribeResourcePermissionsOutput)
 
+	DescribeRootFolders(*workdocs.DescribeRootFoldersInput) (*workdocs.DescribeRootFoldersOutput, error)
+	DescribeRootFoldersWithContext(aws.Context, *workdocs.DescribeRootFoldersInput, ...request.Option) (*workdocs.DescribeRootFoldersOutput, error)
+	DescribeRootFoldersRequest(*workdocs.DescribeRootFoldersInput) (*request.Request, *workdocs.DescribeRootFoldersOutput)
+
 	DescribeUsers(*workdocs.DescribeUsersInput) (*workdocs.DescribeUsersOutput, error)
 	DescribeUsersWithContext(aws.Context, *workdocs.DescribeUsersInput, ...request.Option) (*workdocs.DescribeUsersOutput, error)
 	DescribeUsersRequest(*workdocs.DescribeUsersInput) (*request.Request, *workdocs.DescribeUsersOutput)
 
 	DescribeUsersPages(*workdocs.DescribeUsersInput, func(*workdocs.DescribeUsersOutput, bool) bool) error
 	DescribeUsersPagesWithContext(aws.Context, *workdocs.DescribeUsersInput, func(*workdocs.DescribeUsersOutput, bool) bool, ...request.Option) error
+
+	GetCurrentUser(*workdocs.GetCurrentUserInput) (*workdocs.GetCurrentUserOutput, error)
+	GetCurrentUserWithContext(aws.Context, *workdocs.GetCurrentUserInput, ...request.Option) (*workdocs.GetCurrentUserOutput, error)
+	GetCurrentUserRequest(*workdocs.GetCurrentUserInput) (*request.Request, *workdocs.GetCurrentUserOutput)
 
 	GetDocument(*workdocs.GetDocumentInput) (*workdocs.GetDocumentOutput, error)
 	GetDocumentWithContext(aws.Context, *workdocs.GetDocumentInput, ...request.Option) (*workdocs.GetDocumentOutput, error)


### PR DESCRIPTION
Release v1.10.0 (2017-06-20)
===

### Service Client Updates
* `service/workdocs`: Updates service API and documentation
  * This release provides a new API to retrieve the activities performed by WorkDocs users.

### SDK Features
* `aws/credentials/plugincreds`: Add support for Go plugin for credentials [#1320](https://github.com/aws/aws-sdk-go/pull/1320)
  * Adds support for using plugins to retrieve credentials for API requests. This change adds a new package plugincreds under aws/credentials. See the `example/aws/credentials/plugincreds` folder in the SDK for example usage.

