### PR TITLE
v1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Release v1.10.4 (2017-06-27)
+===
+
+### Service Client Updates
+* `service/servicecatalog`: Updates service API, documentation, and paginators
+  * Proper tagging of resources is critical to post-launch operations such as billing, cost allocation, and resource management. By using Service Catalog's TagOption Library, administrators can define a library of re-usable TagOptions that conform to company standards, and associate these with Service Catalog portfolios and products. Learn how to move your current tags to the new library, create new TagOptions, and view and associate your library items with portfolios and products. Understand how to ensure that the right tags are created on products launched through Service Catalog and how to provide users with defined selectable tags.
+
+### SDK Bugs
+* `aws/signer/v4`: checking length on `stripExcessSpaces` [#1372](https://github.com/aws/aws-sdk-go/issues/1372)
+  * Fixes a bug where `stripExcessSpaces` did not check length against the slice.
+  * Fixes: [#1371](https://github.com/aws/aws-sdk-go/issues/1371)
 Release v1.10.3 (2017-06-23)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,3 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* `aws/signer/v4`: checking length on `stripExcessSpaces` [#1372](https://github.com/aws/aws-sdk-go/issues/1372)
-  * Fixes a bug where `stripExcessSpaces` did not check length against the slice.
-  * Fixes: [#1371](https://github.com/aws/aws-sdk-go/issues/1371)

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.10.3"
+const SDKVersion = "1.10.4"

--- a/models/apis/servicecatalog/2015-12-10/api-2.json
+++ b/models/apis/servicecatalog/2015-12-10/api-2.json
@@ -53,6 +53,23 @@
         {"shape":"LimitExceededException"}
       ]
     },
+    "AssociateTagOptionWithResource":{
+      "name":"AssociateTagOptionWithResource",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"AssociateTagOptionWithResourceInput"},
+      "output":{"shape":"AssociateTagOptionWithResourceOutput"},
+      "errors":[
+        {"shape":"TagOptionNotMigratedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidParametersException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"DuplicateResourceException"},
+        {"shape":"InvalidStateException"}
+      ]
+    },
     "CreateConstraint":{
       "name":"CreateConstraint",
       "http":{
@@ -78,7 +95,8 @@
       "output":{"shape":"CreatePortfolioOutput"},
       "errors":[
         {"shape":"InvalidParametersException"},
-        {"shape":"LimitExceededException"}
+        {"shape":"LimitExceededException"},
+        {"shape":"TagOptionNotMigratedException"}
       ]
     },
     "CreatePortfolioShare":{
@@ -105,7 +123,8 @@
       "output":{"shape":"CreateProductOutput"},
       "errors":[
         {"shape":"InvalidParametersException"},
-        {"shape":"LimitExceededException"}
+        {"shape":"LimitExceededException"},
+        {"shape":"TagOptionNotMigratedException"}
       ]
     },
     "CreateProvisioningArtifact":{
@@ -119,6 +138,20 @@
       "errors":[
         {"shape":"ResourceNotFoundException"},
         {"shape":"InvalidParametersException"},
+        {"shape":"LimitExceededException"}
+      ]
+    },
+    "CreateTagOption":{
+      "name":"CreateTagOption",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CreateTagOptionInput"},
+      "output":{"shape":"CreateTagOptionOutput"},
+      "errors":[
+        {"shape":"TagOptionNotMigratedException"},
+        {"shape":"DuplicateResourceException"},
         {"shape":"LimitExceededException"}
       ]
     },
@@ -146,7 +179,8 @@
       "errors":[
         {"shape":"ResourceNotFoundException"},
         {"shape":"InvalidParametersException"},
-        {"shape":"ResourceInUseException"}
+        {"shape":"ResourceInUseException"},
+        {"shape":"TagOptionNotMigratedException"}
       ]
     },
     "DeletePortfolioShare":{
@@ -172,7 +206,8 @@
       "errors":[
         {"shape":"ResourceNotFoundException"},
         {"shape":"ResourceInUseException"},
-        {"shape":"InvalidParametersException"}
+        {"shape":"InvalidParametersException"},
+        {"shape":"TagOptionNotMigratedException"}
       ]
     },
     "DeleteProvisioningArtifact":{
@@ -300,6 +335,19 @@
         {"shape":"ResourceNotFoundException"}
       ]
     },
+    "DescribeTagOption":{
+      "name":"DescribeTagOption",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeTagOptionInput"},
+      "output":{"shape":"DescribeTagOptionOutput"},
+      "errors":[
+        {"shape":"TagOptionNotMigratedException"},
+        {"shape":"ResourceNotFoundException"}
+      ]
+    },
     "DisassociatePrincipalFromPortfolio":{
       "name":"DisassociatePrincipalFromPortfolio",
       "http":{
@@ -323,7 +371,21 @@
       "output":{"shape":"DisassociateProductFromPortfolioOutput"},
       "errors":[
         {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceInUseException"},
         {"shape":"InvalidParametersException"}
+      ]
+    },
+    "DisassociateTagOptionFromResource":{
+      "name":"DisassociateTagOptionFromResource",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DisassociateTagOptionFromResourceInput"},
+      "output":{"shape":"DisassociateTagOptionFromResourceOutput"},
+      "errors":[
+        {"shape":"TagOptionNotMigratedException"},
+        {"shape":"ResourceNotFoundException"}
       ]
     },
     "ListAcceptedPortfolioShares":{
@@ -439,6 +501,33 @@
         {"shape":"InvalidParametersException"}
       ]
     },
+    "ListResourcesForTagOption":{
+      "name":"ListResourcesForTagOption",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ListResourcesForTagOptionInput"},
+      "output":{"shape":"ListResourcesForTagOptionOutput"},
+      "errors":[
+        {"shape":"TagOptionNotMigratedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidParametersException"}
+      ]
+    },
+    "ListTagOptions":{
+      "name":"ListTagOptions",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ListTagOptionsInput"},
+      "output":{"shape":"ListTagOptionsOutput"},
+      "errors":[
+        {"shape":"TagOptionNotMigratedException"},
+        {"shape":"InvalidParametersException"}
+      ]
+    },
     "ProvisionProduct":{
       "name":"ProvisionProduct",
       "http":{
@@ -538,7 +627,8 @@
       "errors":[
         {"shape":"InvalidParametersException"},
         {"shape":"ResourceNotFoundException"},
-        {"shape":"LimitExceededException"}
+        {"shape":"LimitExceededException"},
+        {"shape":"TagOptionNotMigratedException"}
       ]
     },
     "UpdateProduct":{
@@ -551,7 +641,8 @@
       "output":{"shape":"UpdateProductOutput"},
       "errors":[
         {"shape":"ResourceNotFoundException"},
-        {"shape":"InvalidParametersException"}
+        {"shape":"InvalidParametersException"},
+        {"shape":"TagOptionNotMigratedException"}
       ]
     },
     "UpdateProvisionedProduct":{
@@ -577,6 +668,21 @@
       "output":{"shape":"UpdateProvisioningArtifactOutput"},
       "errors":[
         {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidParametersException"}
+      ]
+    },
+    "UpdateTagOption":{
+      "name":"UpdateTagOption",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"UpdateTagOptionInput"},
+      "output":{"shape":"UpdateTagOptionOutput"},
+      "errors":[
+        {"shape":"TagOptionNotMigratedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"DuplicateResourceException"},
         {"shape":"InvalidParametersException"}
       ]
     }
@@ -664,6 +770,22 @@
       }
     },
     "AssociateProductWithPortfolioOutput":{
+      "type":"structure",
+      "members":{
+      }
+    },
+    "AssociateTagOptionWithResourceInput":{
+      "type":"structure",
+      "required":[
+        "ResourceId",
+        "TagOptionId"
+      ],
+      "members":{
+        "ResourceId":{"shape":"ResourceId"},
+        "TagOptionId":{"shape":"TagOptionId"}
+      }
+    },
+    "AssociateTagOptionWithResourceOutput":{
       "type":"structure",
       "members":{
       }
@@ -836,6 +958,23 @@
         "Status":{"shape":"Status"}
       }
     },
+    "CreateTagOptionInput":{
+      "type":"structure",
+      "required":[
+        "Key",
+        "Value"
+      ],
+      "members":{
+        "Key":{"shape":"TagOptionKey"},
+        "Value":{"shape":"TagOptionValue"}
+      }
+    },
+    "CreateTagOptionOutput":{
+      "type":"structure",
+      "members":{
+        "TagOptionDetail":{"shape":"TagOptionDetail"}
+      }
+    },
     "CreatedTime":{"type":"timestamp"},
     "CreationTime":{"type":"timestamp"},
     "DefaultValue":{"type":"string"},
@@ -940,7 +1079,8 @@
       "type":"structure",
       "members":{
         "PortfolioDetail":{"shape":"PortfolioDetail"},
-        "Tags":{"shape":"Tags"}
+        "Tags":{"shape":"Tags"},
+        "TagOptions":{"shape":"TagOptionDetails"}
       }
     },
     "DescribeProductAsAdminInput":{
@@ -956,7 +1096,8 @@
       "members":{
         "ProductViewDetail":{"shape":"ProductViewDetail"},
         "ProvisioningArtifactSummaries":{"shape":"ProvisioningArtifactSummaries"},
-        "Tags":{"shape":"Tags"}
+        "Tags":{"shape":"Tags"},
+        "TagOptions":{"shape":"TagOptionDetails"}
       }
     },
     "DescribeProductInput":{
@@ -1042,7 +1183,8 @@
       "members":{
         "ProvisioningArtifactParameters":{"shape":"ProvisioningArtifactParameters"},
         "ConstraintSummaries":{"shape":"ConstraintSummaries"},
-        "UsageInstructions":{"shape":"UsageInstructions"}
+        "UsageInstructions":{"shape":"UsageInstructions"},
+        "TagOptions":{"shape":"TagOptionSummaries"}
       }
     },
     "DescribeRecordInput":{
@@ -1061,6 +1203,19 @@
         "RecordDetail":{"shape":"RecordDetail"},
         "RecordOutputs":{"shape":"RecordOutputs"},
         "NextPageToken":{"shape":"PageToken"}
+      }
+    },
+    "DescribeTagOptionInput":{
+      "type":"structure",
+      "required":["Id"],
+      "members":{
+        "Id":{"shape":"TagOptionId"}
+      }
+    },
+    "DescribeTagOptionOutput":{
+      "type":"structure",
+      "members":{
+        "TagOptionDetail":{"shape":"TagOptionDetail"}
       }
     },
     "Description":{"type":"string"},
@@ -1098,6 +1253,22 @@
       "members":{
       }
     },
+    "DisassociateTagOptionFromResourceInput":{
+      "type":"structure",
+      "required":[
+        "ResourceId",
+        "TagOptionId"
+      ],
+      "members":{
+        "ResourceId":{"shape":"ResourceId"},
+        "TagOptionId":{"shape":"TagOptionId"}
+      }
+    },
+    "DisassociateTagOptionFromResourceOutput":{
+      "type":"structure",
+      "members":{
+      }
+    },
     "DuplicateResourceException":{
       "type":"structure",
       "members":{
@@ -1122,6 +1293,12 @@
     "InstructionType":{"type":"string"},
     "InstructionValue":{"type":"string"},
     "InvalidParametersException":{
+      "type":"structure",
+      "members":{
+      },
+      "exception":true
+    },
+    "InvalidStateException":{
       "type":"structure",
       "members":{
       },
@@ -1298,6 +1475,46 @@
       "members":{
         "Key":{"shape":"SearchFilterKey"},
         "Value":{"shape":"SearchFilterValue"}
+      }
+    },
+    "ListResourcesForTagOptionInput":{
+      "type":"structure",
+      "required":["TagOptionId"],
+      "members":{
+        "TagOptionId":{"shape":"TagOptionId"},
+        "ResourceType":{"shape":"ResourceType"},
+        "PageSize":{"shape":"PageSize"},
+        "PageToken":{"shape":"PageToken"}
+      }
+    },
+    "ListResourcesForTagOptionOutput":{
+      "type":"structure",
+      "members":{
+        "ResourceDetails":{"shape":"ResourceDetails"},
+        "PageToken":{"shape":"PageToken"}
+      }
+    },
+    "ListTagOptionsFilters":{
+      "type":"structure",
+      "members":{
+        "Key":{"shape":"TagOptionKey"},
+        "Value":{"shape":"TagOptionValue"},
+        "Active":{"shape":"TagOptionActive"}
+      }
+    },
+    "ListTagOptionsInput":{
+      "type":"structure",
+      "members":{
+        "Filters":{"shape":"ListTagOptionsFilters"},
+        "PageSize":{"shape":"PageSize"},
+        "PageToken":{"shape":"PageToken"}
+      }
+    },
+    "ListTagOptionsOutput":{
+      "type":"structure",
+      "members":{
+        "TagOptionDetails":{"shape":"TagOptionDetails"},
+        "PageToken":{"shape":"PageToken"}
       }
     },
     "NoEcho":{"type":"boolean"},
@@ -1747,6 +1964,26 @@
       "max":150,
       "min":1
     },
+    "ResourceDetail":{
+      "type":"structure",
+      "members":{
+        "Id":{"shape":"ResourceDetailId"},
+        "ARN":{"shape":"ResourceDetailARN"},
+        "Name":{"shape":"ResourceDetailName"},
+        "Description":{"shape":"ResourceDetailDescription"},
+        "CreatedTime":{"shape":"ResourceDetailCreatedTime"}
+      }
+    },
+    "ResourceDetailARN":{"type":"string"},
+    "ResourceDetailCreatedTime":{"type":"timestamp"},
+    "ResourceDetailDescription":{"type":"string"},
+    "ResourceDetailId":{"type":"string"},
+    "ResourceDetailName":{"type":"string"},
+    "ResourceDetails":{
+      "type":"list",
+      "member":{"shape":"ResourceDetail"}
+    },
+    "ResourceId":{"type":"string"},
     "ResourceInUseException":{
       "type":"structure",
       "members":{
@@ -1759,6 +1996,7 @@
       },
       "exception":true
     },
+    "ResourceType":{"type":"string"},
     "ScanProvisionedProductsInput":{
       "type":"structure",
       "members":{
@@ -1854,6 +2092,58 @@
     "TagKeys":{
       "type":"list",
       "member":{"shape":"TagKey"}
+    },
+    "TagOptionActive":{"type":"boolean"},
+    "TagOptionDetail":{
+      "type":"structure",
+      "members":{
+        "Key":{"shape":"TagOptionKey"},
+        "Value":{"shape":"TagOptionValue"},
+        "Active":{"shape":"TagOptionActive"},
+        "Id":{"shape":"TagOptionId"}
+      }
+    },
+    "TagOptionDetails":{
+      "type":"list",
+      "member":{"shape":"TagOptionDetail"}
+    },
+    "TagOptionId":{
+      "type":"string",
+      "max":100,
+      "min":1
+    },
+    "TagOptionKey":{
+      "type":"string",
+      "max":128,
+      "min":1,
+      "pattern":"^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "TagOptionNotMigratedException":{
+      "type":"structure",
+      "members":{
+      },
+      "exception":true
+    },
+    "TagOptionSummaries":{
+      "type":"list",
+      "member":{"shape":"TagOptionSummary"}
+    },
+    "TagOptionSummary":{
+      "type":"structure",
+      "members":{
+        "Key":{"shape":"TagOptionKey"},
+        "Values":{"shape":"TagOptionValues"}
+      }
+    },
+    "TagOptionValue":{
+      "type":"string",
+      "max":256,
+      "min":1,
+      "pattern":"^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "TagOptionValues":{
+      "type":"list",
+      "member":{"shape":"TagOptionValue"}
     },
     "TagValue":{
       "type":"string",
@@ -2003,6 +2293,21 @@
     "UpdateProvisioningParameters":{
       "type":"list",
       "member":{"shape":"UpdateProvisioningParameter"}
+    },
+    "UpdateTagOptionInput":{
+      "type":"structure",
+      "required":["Id"],
+      "members":{
+        "Id":{"shape":"TagOptionId"},
+        "Value":{"shape":"TagOptionValue"},
+        "Active":{"shape":"TagOptionActive"}
+      }
+    },
+    "UpdateTagOptionOutput":{
+      "type":"structure",
+      "members":{
+        "TagOptionDetail":{"shape":"TagOptionDetail"}
+      }
     },
     "UpdatedTime":{"type":"timestamp"},
     "UsageInstruction":{

--- a/models/apis/servicecatalog/2015-12-10/docs-2.json
+++ b/models/apis/servicecatalog/2015-12-10/docs-2.json
@@ -5,11 +5,13 @@
     "AcceptPortfolioShare": "<p>Accepts an offer to share a portfolio.</p>",
     "AssociatePrincipalWithPortfolio": "<p>Associates the specified principal ARN with the specified portfolio.</p>",
     "AssociateProductWithPortfolio": "<p>Associates a product with a portfolio.</p>",
+    "AssociateTagOptionWithResource": "<p>Associate a TagOption identifier with a resource identifier.</p>",
     "CreateConstraint": "<p>Creates a new constraint. For more information, see <a href=\"http://docs.aws.amazon.com/servicecatalog/latest/adminguide/constraints.html\">Using Constraints</a>.</p>",
     "CreatePortfolio": "<p>Creates a new portfolio.</p>",
     "CreatePortfolioShare": "<p>Creates a new portfolio share.</p>",
     "CreateProduct": "<p>Creates a new product.</p>",
     "CreateProvisioningArtifact": "<p>Create a new provisioning artifact for the specified product. This operation does not work with a product that has been shared with you.</p> <p>See the bottom of this topic for an example JSON request.</p>",
+    "CreateTagOption": "<p>Create a new TagOption.</p>",
     "DeleteConstraint": "<p>Deletes the specified constraint.</p>",
     "DeletePortfolio": "<p>Deletes the specified portfolio. This operation does not work with a portfolio that has been shared with you or if it has products, users, constraints, or shared accounts associated with it.</p>",
     "DeletePortfolioShare": "<p>Deletes the specified portfolio share.</p>",
@@ -22,10 +24,12 @@
     "DescribeProductView": "<p>Retrieves information about a specified product.</p> <p>This operation is functionally identical to <a>DescribeProduct</a> except that it takes as input <code>ProductViewId</code> instead of <code>ProductId</code>.</p>",
     "DescribeProvisionedProduct": "<p>Retrieve detailed information about the provisioned product.</p>",
     "DescribeProvisioningArtifact": "<p>Retrieves detailed information about the specified provisioning artifact.</p>",
-    "DescribeProvisioningParameters": "<p>Provides information about parameters required to provision a specified product in a specified manner. Use this operation to obtain the list of <code>ProvisioningArtifactParameters</code> parameters available to call the <a>ProvisionProduct</a> operation for the specified product.</p>",
+    "DescribeProvisioningParameters": "<p>Provides information about parameters required to provision a specified product in a specified manner. Use this operation to obtain the list of <code>ProvisioningArtifactParameters</code> parameters available to call the <a>ProvisionProduct</a> operation for the specified product.</p> <p>If the output contains a TagOption key with an empty list of values, there is a TagOption conflict for that key. The end user cannot take action to fix the conflict, and launch is not blocked. In subsequent calls to the <code>ProvisionProduct</code> operation, do not include conflicted TagOption keys as tags. Calls to <code>ProvisionProduct</code> with empty TagOption values cause the error \"Parameter validation failed: Missing required parameter in Tags[<i>N</i>]:<i>Value</i> \". Calls to <code>ProvisionProduct</code> with conflicted TagOption keys automatically tag the provisioned product with the conflicted keys with the value \"<code>sc-tagoption-conflict-portfolioId-productId</code>\".</p>",
     "DescribeRecord": "<p>Retrieves a paginated list of the full details of a specific request. Use this operation after calling a request operation (<a>ProvisionProduct</a>, <a>TerminateProvisionedProduct</a>, or <a>UpdateProvisionedProduct</a>). </p>",
+    "DescribeTagOption": "<p>Describes a TagOption.</p>",
     "DisassociatePrincipalFromPortfolio": "<p>Disassociates a previously associated principal ARN from a specified portfolio.</p>",
     "DisassociateProductFromPortfolio": "<p>Disassociates the specified product from the specified portfolio. </p>",
+    "DisassociateTagOptionFromResource": "<p>Disassociates a TagOption from a resource.</p>",
     "ListAcceptedPortfolioShares": "<p>Lists details of all portfolios for which sharing was accepted by this account.</p>",
     "ListConstraintsForPortfolio": "<p>Retrieves detailed constraint information for the specified portfolio and product.</p>",
     "ListLaunchPaths": "<p>Returns a paginated list of all paths to a specified product. A path is how the user has access to a specified product, and is necessary when provisioning a product. A path also determines the constraints put on the product.</p>",
@@ -35,7 +39,9 @@
     "ListPrincipalsForPortfolio": "<p>Lists all principal ARNs associated with the specified portfolio.</p>",
     "ListProvisioningArtifacts": "<p>Lists all provisioning artifacts associated with the specified product.</p>",
     "ListRecordHistory": "<p>Returns a paginated list of all performed requests, in the form of RecordDetails objects that are filtered as specified.</p>",
-    "ProvisionProduct": "<p>Requests a <i>provision</i> of a specified product. A <i>provisioned product</i> is a resourced instance for a product. For example, provisioning a CloudFormation-template-backed product results in launching a CloudFormation stack and all the underlying resources that come with it. </p> <p>You can check the status of this request using the <a>DescribeRecord</a> operation.</p>",
+    "ListResourcesForTagOption": "<p>Lists resources associated with a TagOption.</p>",
+    "ListTagOptions": "<p>Lists detailed TagOptions information.</p>",
+    "ProvisionProduct": "<p>Requests a <i>provision</i> of a specified product. A <i>provisioned product</i> is a resourced instance for a product. For example, provisioning a CloudFormation-template-backed product results in launching a CloudFormation stack and all the underlying resources that come with it. </p> <p>You can check the status of this request using the <a>DescribeRecord</a> operation. The error \"Parameter validation failed: Missing required parameter in Tags[<i>N</i>]:<i>Value</i>\" indicates that your request contains a tag which has a tag key but no corresponding tag value (value is empty or null). Your call may have included values returned from a <code>DescribeProvisioningParameters</code> call that resulted in a TagOption key with an empty list. This happens when TagOption keys are in conflict. For more information, see <a>DescribeProvisioningParameters</a>.</p>",
     "RejectPortfolioShare": "<p>Rejects an offer to share a portfolio.</p>",
     "ScanProvisionedProducts": "<p>Returns a paginated list of all the ProvisionedProduct objects that are currently available (not terminated). </p>",
     "SearchProducts": "<p>Returns a paginated list all of the <code>Products</code> objects to which the caller has access. </p> <p>The output of this operation can be used as input for other operations, such as <a>DescribeProductView</a>.</p>",
@@ -45,7 +51,8 @@
     "UpdatePortfolio": "<p>Updates the specified portfolio's details. This operation does not work with a product that has been shared with you.</p>",
     "UpdateProduct": "<p>Updates an existing product.</p>",
     "UpdateProvisionedProduct": "<p>Requests updates to the configuration of an existing ProvisionedProduct object. If there are tags associated with the object, they cannot be updated or added with this operation. Depending on the specific updates requested, this operation may update with no interruption, with some interruption, or replace the ProvisionedProduct object entirely. </p> <p>You can check the status of this request using the <a>DescribeRecord</a> operation.</p>",
-    "UpdateProvisioningArtifact": "<p>Updates an existing provisioning artifact's information. This operation does not work on a provisioning artifact associated with a product that has been shared with you.</p>"
+    "UpdateProvisioningArtifact": "<p>Updates an existing provisioning artifact's information. This operation does not work on a provisioning artifact associated with a product that has been shared with you.</p>",
+    "UpdateTagOption": "<p>Updates an existing TagOption.</p>"
   },
   "shapes": {
     "AcceptLanguage": {
@@ -188,6 +195,16 @@
       "refs": {
       }
     },
+    "AssociateTagOptionWithResourceInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "AssociateTagOptionWithResourceOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
     "AttributeValue": {
       "base": null,
       "refs": {
@@ -294,6 +311,16 @@
       }
     },
     "CreateProvisioningArtifactOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "CreateTagOptionInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "CreateTagOptionOutput": {
       "base": null,
       "refs": {
       }
@@ -459,6 +486,16 @@
       "refs": {
       }
     },
+    "DescribeTagOptionInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeTagOptionOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
     "Description": {
       "base": null,
       "refs": {
@@ -482,6 +519,16 @@
       }
     },
     "DisassociateProductFromPortfolioOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DisassociateTagOptionFromResourceInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DisassociateTagOptionFromResourceOutput": {
       "base": null,
       "refs": {
       }
@@ -546,7 +593,7 @@
         "LaunchPathSummary$Id": "<p>The unique identifier of the product path.</p>",
         "ListConstraintsForPortfolioInput$PortfolioId": "<p>The portfolio identifier.</p>",
         "ListConstraintsForPortfolioInput$ProductId": "<p>The product identifier.</p>",
-        "ListLaunchPathsInput$ProductId": "<p>The product identifier.. Identifies the product for which to retrieve <code>LaunchPathSummaries</code> information.</p>",
+        "ListLaunchPathsInput$ProductId": "<p>The product identifier. Identifies the product for which to retrieve <code>LaunchPathSummaries</code> information.</p>",
         "ListPortfolioAccessInput$PortfolioId": "<p>The portfolio identifier.</p>",
         "ListPortfoliosForProductInput$ProductId": "<p>The product identifier.</p>",
         "ListPrincipalsForPortfolioInput$PortfolioId": "<p>The portfolio identifier.</p>",
@@ -559,7 +606,7 @@
         "ProvisionProductInput$PathId": "<p>The identifier of the path for this product's provisioning. This value is optional if the product has a default path, and is required if there is more than one path for the specified product.</p>",
         "ProvisioningArtifact$Id": "<p>The identifier for the artifact. This is sometimes referred to as the product version.</p>",
         "ProvisioningArtifactDetail$Id": "<p>The identifier of the provisioning artifact. This is sometimes referred to as the product version.</p>",
-        "ProvisioningArtifactSummary$Id": "<p>The provisioning artifact identifier.</p>",
+        "ProvisioningArtifactSummary$Id": "<p>The identifier of the provisioning artifact.</p>",
         "RecordDetail$RecordId": "<p>The identifier of the ProvisionedProduct object record.</p>",
         "RecordDetail$ProvisionedProductId": "<p>The identifier of the ProvisionedProduct object.</p>",
         "RecordDetail$ProductId": "<p>The product identifier.</p>",
@@ -612,6 +659,11 @@
     },
     "InvalidParametersException": {
       "base": "<p>One or more parameters provided to the operation are invalid.</p>",
+      "refs": {
+      }
+    },
+    "InvalidStateException": {
+      "base": "<p>An attempt was made to modify a resource that is in an invalid state. Inspect the resource you are using for this operation to ensure that all resource states are valid before retrying the operation.</p>",
       "refs": {
       }
     },
@@ -734,6 +786,32 @@
         "ListRecordHistoryInput$SearchFilter": "<p>The filter to limit search results. </p>"
       }
     },
+    "ListResourcesForTagOptionInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListResourcesForTagOptionOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTagOptionsFilters": {
+      "base": "<p>The ListTagOptions filters.</p>",
+      "refs": {
+        "ListTagOptionsInput$Filters": "<p>The list of filters with which to limit search results. If no search filters are specified, the output is all TagOptions. </p>"
+      }
+    },
+    "ListTagOptionsInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTagOptionsOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
     "NoEcho": {
       "base": null,
       "refs": {
@@ -775,6 +853,8 @@
         "ListPortfoliosInput$PageSize": "<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>",
         "ListPrincipalsForPortfolioInput$PageSize": "<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>",
         "ListRecordHistoryInput$PageSize": "<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>",
+        "ListResourcesForTagOptionInput$PageSize": "<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>",
+        "ListTagOptionsInput$PageSize": "<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>",
         "ScanProvisionedProductsInput$PageSize": "<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>",
         "SearchProductsAsAdminInput$PageSize": "<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>",
         "SearchProductsInput$PageSize": "<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>"
@@ -801,6 +881,10 @@
         "ListProvisioningArtifactsOutput$NextPageToken": "<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
         "ListRecordHistoryInput$PageToken": "<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>",
         "ListRecordHistoryOutput$NextPageToken": "<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
+        "ListResourcesForTagOptionInput$PageToken": "<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>",
+        "ListResourcesForTagOptionOutput$PageToken": "<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>",
+        "ListTagOptionsInput$PageToken": "<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>",
+        "ListTagOptionsOutput$PageToken": "<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>",
         "ScanProvisionedProductsInput$PageToken": "<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>",
         "ScanProvisionedProductsOutput$NextPageToken": "<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
         "SearchProductsAsAdminInput$PageToken": "<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>",
@@ -1123,7 +1207,7 @@
       "refs": {
         "ProvisioningArtifact$Description": "<p>The text description of the artifact.</p>",
         "ProvisioningArtifactProperties$Description": "<p>The text description of the provisioning artifact properties.</p>",
-        "ProvisioningArtifactSummary$Description": "<p>The provisioning artifact description.</p>",
+        "ProvisioningArtifactSummary$Description": "<p>The description of the provisioning artifact.</p>",
         "UpdateProvisioningArtifactInput$Description": "<p>The updated text description of the provisioning artifact.</p>"
       }
     },
@@ -1172,7 +1256,7 @@
         "ProvisioningArtifactDetail$Name": "<p>The name assigned to the provisioning artifact.</p>",
         "ProvisioningArtifactDetail$Description": "<p>The text description of the provisioning artifact.</p>",
         "ProvisioningArtifactProperties$Name": "<p>The name assigned to the provisioning artifact properties.</p>",
-        "ProvisioningArtifactSummary$Name": "<p>The provisioning artifact name.</p>",
+        "ProvisioningArtifactSummary$Name": "<p>The name of the provisioning artifact.</p>",
         "UpdateProvisioningArtifactInput$Name": "<p>The updated name of the provisioning artifact.</p>"
       }
     },
@@ -1202,7 +1286,7 @@
       }
     },
     "ProvisioningArtifactSummary": {
-      "base": "<p>Summary information about a provisioning artifact.</p>",
+      "base": "<p>Stores summary information about a provisioning artifact.</p>",
       "refs": {
         "ProvisioningArtifactSummaries$member": null
       }
@@ -1276,7 +1360,7 @@
     "RecordStatus": {
       "base": null,
       "refs": {
-        "RecordDetail$Status": "<p>The status of the ProvisionedProduct object.</p> <p> <code>CREATED</code> - Request created but the operation has not yet started.</p> <p> <code>IN_PROGRESS</code> - The requested operation is in-progress.</p> <p> <code>IN_PROGRESS_IN_ERROR</code> - The provisioned product is under change but the requested operation failed and some remediation is occurring. For example, a roll-back.</p> <p> <code>SUCCEEDED</code> - The requested operation has successfully completed.</p> <p> <code>FAILED</code> - The requested operation has completed but has failed. Investigate using the error messages returned.</p>"
+        "RecordDetail$Status": "<p>The status of the ProvisionedProduct object.</p> <p> <code>CREATED</code> - Request created but the operation has not yet started.</p> <p> <code>IN_PROGRESS</code> - The requested operation is in-progress.</p> <p> <code>IN_PROGRESS_IN_ERROR</code> - The provisioned product is under change but the requested operation failed and some remediation is occurring. For example, a rollback.</p> <p> <code>SUCCEEDED</code> - The requested operation has successfully completed.</p> <p> <code>FAILED</code> - The requested operation has completed but has failed. Investigate using the error messages returned.</p>"
       }
     },
     "RecordTag": {
@@ -1326,6 +1410,55 @@
         "ProductViewDetail$ProductARN": "<p>The ARN associated with the product.</p>"
       }
     },
+    "ResourceDetail": {
+      "base": "<p>Detailed resource information.</p>",
+      "refs": {
+        "ResourceDetails$member": null
+      }
+    },
+    "ResourceDetailARN": {
+      "base": null,
+      "refs": {
+        "ResourceDetail$ARN": "<p>ARN of the resource.</p>"
+      }
+    },
+    "ResourceDetailCreatedTime": {
+      "base": null,
+      "refs": {
+        "ResourceDetail$CreatedTime": "<p>Creation time of the resource.</p>"
+      }
+    },
+    "ResourceDetailDescription": {
+      "base": null,
+      "refs": {
+        "ResourceDetail$Description": "<p>Description of the resource.</p>"
+      }
+    },
+    "ResourceDetailId": {
+      "base": null,
+      "refs": {
+        "ResourceDetail$Id": "<p>Identifier of the resource.</p>"
+      }
+    },
+    "ResourceDetailName": {
+      "base": null,
+      "refs": {
+        "ResourceDetail$Name": "<p>Name of the resource.</p>"
+      }
+    },
+    "ResourceDetails": {
+      "base": null,
+      "refs": {
+        "ListResourcesForTagOptionOutput$ResourceDetails": "<p>The resulting detailed resource information.</p>"
+      }
+    },
+    "ResourceId": {
+      "base": null,
+      "refs": {
+        "AssociateTagOptionWithResourceInput$ResourceId": "<p>The resource identifier.</p>",
+        "DisassociateTagOptionFromResourceInput$ResourceId": "<p>Identifier of the resource from which to disassociate the TagOption.</p>"
+      }
+    },
     "ResourceInUseException": {
       "base": "<p>The operation was requested against a resource that is currently in use. Free the resource from use and retry the operation.</p>",
       "refs": {
@@ -1334,6 +1467,12 @@
     "ResourceNotFoundException": {
       "base": "<p>The specified resource was not found.</p>",
       "refs": {
+      }
+    },
+    "ResourceType": {
+      "base": null,
+      "refs": {
+        "ListResourcesForTagOptionInput$ResourceType": "<p>Resource type.</p>"
       }
     },
     "ScanProvisionedProductsInput": {
@@ -1422,7 +1561,7 @@
       }
     },
     "Tag": {
-      "base": "<p>Key/value pairs to associate with this provisioning. These tags are entirely discretionary and are propagated to the resources created in the provisioning.</p>",
+      "base": "<p>Key-value pairs to associate with this provisioning. These tags are entirely discretionary and are propagated to the resources created in the provisioning.</p>",
       "refs": {
         "AddTags$member": null,
         "Tags$member": null
@@ -1440,6 +1579,84 @@
       "refs": {
         "UpdatePortfolioInput$RemoveTags": "<p>Tags to remove from the existing list of tags associated with the portfolio.</p>",
         "UpdateProductInput$RemoveTags": "<p>Tags to remove from the existing list of tags associated with the product.</p>"
+      }
+    },
+    "TagOptionActive": {
+      "base": null,
+      "refs": {
+        "ListTagOptionsFilters$Active": "<p>The ListTagOptionsFilters active state.</p>",
+        "TagOptionDetail$Active": "<p>The TagOptionDetail active state.</p>",
+        "UpdateTagOptionInput$Active": "<p>The updated active state.</p>"
+      }
+    },
+    "TagOptionDetail": {
+      "base": "<p>The TagOption details.</p>",
+      "refs": {
+        "CreateTagOptionOutput$TagOptionDetail": "<p>The resulting detailed TagOption information.</p>",
+        "DescribeTagOptionOutput$TagOptionDetail": "<p>The resulting detailed TagOption information.</p>",
+        "TagOptionDetails$member": null,
+        "UpdateTagOptionOutput$TagOptionDetail": "<p>The resulting detailed TagOption information.</p>"
+      }
+    },
+    "TagOptionDetails": {
+      "base": null,
+      "refs": {
+        "DescribePortfolioOutput$TagOptions": "<p>TagOptions associated with the portfolio.</p>",
+        "DescribeProductAsAdminOutput$TagOptions": "<p>List of TagOptions associated with the product.</p>",
+        "ListTagOptionsOutput$TagOptionDetails": "<p>The resulting detailed TagOption information.</p>"
+      }
+    },
+    "TagOptionId": {
+      "base": null,
+      "refs": {
+        "AssociateTagOptionWithResourceInput$TagOptionId": "<p>The TagOption identifier.</p>",
+        "DescribeTagOptionInput$Id": "<p>The identifier of the TagOption.</p>",
+        "DisassociateTagOptionFromResourceInput$TagOptionId": "<p>Identifier of the TagOption to disassociate from the resource.</p>",
+        "ListResourcesForTagOptionInput$TagOptionId": "<p>Identifier of the TagOption.</p>",
+        "TagOptionDetail$Id": "<p>The TagOptionDetail identifier.</p>",
+        "UpdateTagOptionInput$Id": "<p>The identifier of the constraint to update.</p>"
+      }
+    },
+    "TagOptionKey": {
+      "base": null,
+      "refs": {
+        "CreateTagOptionInput$Key": "<p>The TagOption key.</p>",
+        "ListTagOptionsFilters$Key": "<p>The ListTagOptionsFilters key.</p>",
+        "TagOptionDetail$Key": "<p>The TagOptionDetail key.</p>",
+        "TagOptionSummary$Key": "<p>The TagOptionSummary key.</p>"
+      }
+    },
+    "TagOptionNotMigratedException": {
+      "base": "<p>An operation requiring TagOptions failed because the TagOptions migration process has not been performed for this account. Please use the AWS console to perform the migration process before retrying the operation.</p>",
+      "refs": {
+      }
+    },
+    "TagOptionSummaries": {
+      "base": null,
+      "refs": {
+        "DescribeProvisioningParametersOutput$TagOptions": "<p>List of TagOptions associated with the provisioned provisioning parameters.</p>"
+      }
+    },
+    "TagOptionSummary": {
+      "base": "<p>The TagOption summary key-value pair.</p>",
+      "refs": {
+        "TagOptionSummaries$member": null
+      }
+    },
+    "TagOptionValue": {
+      "base": null,
+      "refs": {
+        "CreateTagOptionInput$Value": "<p>The TagOption value.</p>",
+        "ListTagOptionsFilters$Value": "<p>The ListTagOptionsFilters value.</p>",
+        "TagOptionDetail$Value": "<p>The TagOptionDetail value.</p>",
+        "TagOptionValues$member": null,
+        "UpdateTagOptionInput$Value": "<p>The updated value.</p>"
+      }
+    },
+    "TagOptionValues": {
+      "base": null,
+      "refs": {
+        "TagOptionSummary$Values": "<p>The TagOptionSummary value.</p>"
       }
     },
     "TagValue": {
@@ -1533,6 +1750,16 @@
         "UpdateProvisionedProductInput$ProvisioningParameters": "<p>A list of <code>ProvisioningParameter</code> objects used to update the ProvisionedProduct object.</p>"
       }
     },
+    "UpdateTagOptionInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "UpdateTagOptionOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
     "UpdatedTime": {
       "base": null,
       "refs": {
@@ -1560,7 +1787,7 @@
     "Verbose": {
       "base": null,
       "refs": {
-        "DescribeProvisioningArtifactInput$Verbose": "<p>Selects verbose results. If set to true, the CloudFormation template is returned.</p>"
+        "DescribeProvisioningArtifactInput$Verbose": "<p>Enable a verbose level of details for the provisioning artifact.</p>"
       }
     }
   }

--- a/models/apis/servicecatalog/2015-12-10/paginators-1.json
+++ b/models/apis/servicecatalog/2015-12-10/paginators-1.json
@@ -1,4 +1,14 @@
 {
   "pagination": {
+    "ListResourcesForTagOption": {
+      "input_token": "PageToken",
+      "output_token": "PageToken",
+      "limit_key": "PageSize"
+    },
+    "ListTagOptions": {
+      "input_token": "PageToken",
+      "output_token": "PageToken",
+      "limit_key": "PageSize"
+    }
   }
 }

--- a/service/servicecatalog/api.go
+++ b/service/servicecatalog/api.go
@@ -272,6 +272,106 @@ func (c *ServiceCatalog) AssociateProductWithPortfolioWithContext(ctx aws.Contex
 	return out, req.Send()
 }
 
+const opAssociateTagOptionWithResource = "AssociateTagOptionWithResource"
+
+// AssociateTagOptionWithResourceRequest generates a "aws/request.Request" representing the
+// client's request for the AssociateTagOptionWithResource operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See AssociateTagOptionWithResource for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the AssociateTagOptionWithResource method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the AssociateTagOptionWithResourceRequest method.
+//    req, resp := client.AssociateTagOptionWithResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/AssociateTagOptionWithResource
+func (c *ServiceCatalog) AssociateTagOptionWithResourceRequest(input *AssociateTagOptionWithResourceInput) (req *request.Request, output *AssociateTagOptionWithResourceOutput) {
+	op := &request.Operation{
+		Name:       opAssociateTagOptionWithResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &AssociateTagOptionWithResourceInput{}
+	}
+
+	output = &AssociateTagOptionWithResourceOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AssociateTagOptionWithResource API operation for AWS Service Catalog.
+//
+// Associate a TagOption identifier with a resource identifier.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Service Catalog's
+// API operation AssociateTagOptionWithResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+//   * ErrCodeInvalidParametersException "InvalidParametersException"
+//   One or more parameters provided to the operation are invalid.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The current limits of the service would have been exceeded by this operation.
+//   Reduce the resource use or increase the service limits and retry the operation.
+//
+//   * ErrCodeDuplicateResourceException "DuplicateResourceException"
+//   The specified resource is a duplicate.
+//
+//   * ErrCodeInvalidStateException "InvalidStateException"
+//   An attempt was made to modify a resource that is in an invalid state. Inspect
+//   the resource you are using for this operation to ensure that all resource
+//   states are valid before retrying the operation.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/AssociateTagOptionWithResource
+func (c *ServiceCatalog) AssociateTagOptionWithResource(input *AssociateTagOptionWithResourceInput) (*AssociateTagOptionWithResourceOutput, error) {
+	req, out := c.AssociateTagOptionWithResourceRequest(input)
+	return out, req.Send()
+}
+
+// AssociateTagOptionWithResourceWithContext is the same as AssociateTagOptionWithResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AssociateTagOptionWithResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) AssociateTagOptionWithResourceWithContext(ctx aws.Context, input *AssociateTagOptionWithResourceInput, opts ...request.Option) (*AssociateTagOptionWithResourceOutput, error) {
+	req, out := c.AssociateTagOptionWithResourceRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateConstraint = "CreateConstraint"
 
 // CreateConstraintRequest generates a "aws/request.Request" representing the
@@ -423,6 +523,11 @@ func (c *ServiceCatalog) CreatePortfolioRequest(input *CreatePortfolioInput) (re
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The current limits of the service would have been exceeded by this operation.
 //   Reduce the resource use or increase the service limits and retry the operation.
+//
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/CreatePortfolio
 func (c *ServiceCatalog) CreatePortfolio(input *CreatePortfolioInput) (*CreatePortfolioOutput, error) {
@@ -595,6 +700,11 @@ func (c *ServiceCatalog) CreateProductRequest(input *CreateProductInput) (req *r
 //   The current limits of the service would have been exceeded by this operation.
 //   Reduce the resource use or increase the service limits and retry the operation.
 //
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/CreateProduct
 func (c *ServiceCatalog) CreateProduct(input *CreateProductInput) (*CreateProductOutput, error) {
 	req, out := c.CreateProductRequest(input)
@@ -702,6 +812,95 @@ func (c *ServiceCatalog) CreateProvisioningArtifact(input *CreateProvisioningArt
 // for more information on using Contexts.
 func (c *ServiceCatalog) CreateProvisioningArtifactWithContext(ctx aws.Context, input *CreateProvisioningArtifactInput, opts ...request.Option) (*CreateProvisioningArtifactOutput, error) {
 	req, out := c.CreateProvisioningArtifactRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateTagOption = "CreateTagOption"
+
+// CreateTagOptionRequest generates a "aws/request.Request" representing the
+// client's request for the CreateTagOption operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See CreateTagOption for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the CreateTagOption method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the CreateTagOptionRequest method.
+//    req, resp := client.CreateTagOptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/CreateTagOption
+func (c *ServiceCatalog) CreateTagOptionRequest(input *CreateTagOptionInput) (req *request.Request, output *CreateTagOptionOutput) {
+	op := &request.Operation{
+		Name:       opCreateTagOption,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateTagOptionInput{}
+	}
+
+	output = &CreateTagOptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateTagOption API operation for AWS Service Catalog.
+//
+// Create a new TagOption.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Service Catalog's
+// API operation CreateTagOption for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
+//   * ErrCodeDuplicateResourceException "DuplicateResourceException"
+//   The specified resource is a duplicate.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The current limits of the service would have been exceeded by this operation.
+//   Reduce the resource use or increase the service limits and retry the operation.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/CreateTagOption
+func (c *ServiceCatalog) CreateTagOption(input *CreateTagOptionInput) (*CreateTagOptionOutput, error) {
+	req, out := c.CreateTagOptionRequest(input)
+	return out, req.Send()
+}
+
+// CreateTagOptionWithContext is the same as CreateTagOption with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateTagOption for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) CreateTagOptionWithContext(ctx aws.Context, input *CreateTagOptionInput, opts ...request.Option) (*CreateTagOptionOutput, error) {
+	req, out := c.CreateTagOptionRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -856,6 +1055,11 @@ func (c *ServiceCatalog) DeletePortfolioRequest(input *DeletePortfolioInput) (re
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The operation was requested against a resource that is currently in use.
 //   Free the resource from use and retry the operation.
+//
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DeletePortfolio
 func (c *ServiceCatalog) DeletePortfolio(input *DeletePortfolioInput) (*DeletePortfolioOutput, error) {
@@ -1024,6 +1228,11 @@ func (c *ServiceCatalog) DeleteProductRequest(input *DeleteProductInput) (req *r
 //
 //   * ErrCodeInvalidParametersException "InvalidParametersException"
 //   One or more parameters provided to the operation are invalid.
+//
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DeleteProduct
 func (c *ServiceCatalog) DeleteProduct(input *DeleteProductInput) (*DeleteProductOutput, error) {
@@ -1760,6 +1969,15 @@ func (c *ServiceCatalog) DescribeProvisioningParametersRequest(input *DescribePr
 // parameters available to call the ProvisionProduct operation for the specified
 // product.
 //
+// If the output contains a TagOption key with an empty list of values, there
+// is a TagOption conflict for that key. The end user cannot take action to
+// fix the conflict, and launch is not blocked. In subsequent calls to the ProvisionProduct
+// operation, do not include conflicted TagOption keys as tags. Calls to ProvisionProduct
+// with empty TagOption values cause the error "Parameter validation failed:
+// Missing required parameter in Tags[N]:Value ". Calls to ProvisionProduct
+// with conflicted TagOption keys automatically tag the provisioned product
+// with the conflicted keys with the value "sc-tagoption-conflict-portfolioId-productId".
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -1873,6 +2091,91 @@ func (c *ServiceCatalog) DescribeRecord(input *DescribeRecordInput) (*DescribeRe
 // for more information on using Contexts.
 func (c *ServiceCatalog) DescribeRecordWithContext(ctx aws.Context, input *DescribeRecordInput, opts ...request.Option) (*DescribeRecordOutput, error) {
 	req, out := c.DescribeRecordRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeTagOption = "DescribeTagOption"
+
+// DescribeTagOptionRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeTagOption operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeTagOption for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeTagOption method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeTagOptionRequest method.
+//    req, resp := client.DescribeTagOptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DescribeTagOption
+func (c *ServiceCatalog) DescribeTagOptionRequest(input *DescribeTagOptionInput) (req *request.Request, output *DescribeTagOptionOutput) {
+	op := &request.Operation{
+		Name:       opDescribeTagOption,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeTagOptionInput{}
+	}
+
+	output = &DescribeTagOptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeTagOption API operation for AWS Service Catalog.
+//
+// Describes a TagOption.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Service Catalog's
+// API operation DescribeTagOption for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DescribeTagOption
+func (c *ServiceCatalog) DescribeTagOption(input *DescribeTagOptionInput) (*DescribeTagOptionOutput, error) {
+	req, out := c.DescribeTagOptionRequest(input)
+	return out, req.Send()
+}
+
+// DescribeTagOptionWithContext is the same as DescribeTagOption with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeTagOption for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) DescribeTagOptionWithContext(ctx aws.Context, input *DescribeTagOptionInput, opts ...request.Option) (*DescribeTagOptionOutput, error) {
+	req, out := c.DescribeTagOptionRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2019,6 +2322,10 @@ func (c *ServiceCatalog) DisassociateProductFromPortfolioRequest(input *Disassoc
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The specified resource was not found.
 //
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//   The operation was requested against a resource that is currently in use.
+//   Free the resource from use and retry the operation.
+//
 //   * ErrCodeInvalidParametersException "InvalidParametersException"
 //   One or more parameters provided to the operation are invalid.
 //
@@ -2039,6 +2346,91 @@ func (c *ServiceCatalog) DisassociateProductFromPortfolio(input *DisassociatePro
 // for more information on using Contexts.
 func (c *ServiceCatalog) DisassociateProductFromPortfolioWithContext(ctx aws.Context, input *DisassociateProductFromPortfolioInput, opts ...request.Option) (*DisassociateProductFromPortfolioOutput, error) {
 	req, out := c.DisassociateProductFromPortfolioRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDisassociateTagOptionFromResource = "DisassociateTagOptionFromResource"
+
+// DisassociateTagOptionFromResourceRequest generates a "aws/request.Request" representing the
+// client's request for the DisassociateTagOptionFromResource operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DisassociateTagOptionFromResource for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DisassociateTagOptionFromResource method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DisassociateTagOptionFromResourceRequest method.
+//    req, resp := client.DisassociateTagOptionFromResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DisassociateTagOptionFromResource
+func (c *ServiceCatalog) DisassociateTagOptionFromResourceRequest(input *DisassociateTagOptionFromResourceInput) (req *request.Request, output *DisassociateTagOptionFromResourceOutput) {
+	op := &request.Operation{
+		Name:       opDisassociateTagOptionFromResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DisassociateTagOptionFromResourceInput{}
+	}
+
+	output = &DisassociateTagOptionFromResourceOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DisassociateTagOptionFromResource API operation for AWS Service Catalog.
+//
+// Disassociates a TagOption from a resource.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Service Catalog's
+// API operation DisassociateTagOptionFromResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DisassociateTagOptionFromResource
+func (c *ServiceCatalog) DisassociateTagOptionFromResource(input *DisassociateTagOptionFromResourceInput) (*DisassociateTagOptionFromResourceOutput, error) {
+	req, out := c.DisassociateTagOptionFromResourceRequest(input)
+	return out, req.Send()
+}
+
+// DisassociateTagOptionFromResourceWithContext is the same as DisassociateTagOptionFromResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DisassociateTagOptionFromResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) DisassociateTagOptionFromResourceWithContext(ctx aws.Context, input *DisassociateTagOptionFromResourceInput, opts ...request.Option) (*DisassociateTagOptionFromResourceOutput, error) {
+	req, out := c.DisassociateTagOptionFromResourceRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2784,6 +3176,291 @@ func (c *ServiceCatalog) ListRecordHistoryWithContext(ctx aws.Context, input *Li
 	return out, req.Send()
 }
 
+const opListResourcesForTagOption = "ListResourcesForTagOption"
+
+// ListResourcesForTagOptionRequest generates a "aws/request.Request" representing the
+// client's request for the ListResourcesForTagOption operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListResourcesForTagOption for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListResourcesForTagOption method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListResourcesForTagOptionRequest method.
+//    req, resp := client.ListResourcesForTagOptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListResourcesForTagOption
+func (c *ServiceCatalog) ListResourcesForTagOptionRequest(input *ListResourcesForTagOptionInput) (req *request.Request, output *ListResourcesForTagOptionOutput) {
+	op := &request.Operation{
+		Name:       opListResourcesForTagOption,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"PageToken"},
+			OutputTokens:    []string{"PageToken"},
+			LimitToken:      "PageSize",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListResourcesForTagOptionInput{}
+	}
+
+	output = &ListResourcesForTagOptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListResourcesForTagOption API operation for AWS Service Catalog.
+//
+// Lists resources associated with a TagOption.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Service Catalog's
+// API operation ListResourcesForTagOption for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+//   * ErrCodeInvalidParametersException "InvalidParametersException"
+//   One or more parameters provided to the operation are invalid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListResourcesForTagOption
+func (c *ServiceCatalog) ListResourcesForTagOption(input *ListResourcesForTagOptionInput) (*ListResourcesForTagOptionOutput, error) {
+	req, out := c.ListResourcesForTagOptionRequest(input)
+	return out, req.Send()
+}
+
+// ListResourcesForTagOptionWithContext is the same as ListResourcesForTagOption with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListResourcesForTagOption for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) ListResourcesForTagOptionWithContext(ctx aws.Context, input *ListResourcesForTagOptionInput, opts ...request.Option) (*ListResourcesForTagOptionOutput, error) {
+	req, out := c.ListResourcesForTagOptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListResourcesForTagOptionPages iterates over the pages of a ListResourcesForTagOption operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListResourcesForTagOption method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListResourcesForTagOption operation.
+//    pageNum := 0
+//    err := client.ListResourcesForTagOptionPages(params,
+//        func(page *ListResourcesForTagOptionOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ServiceCatalog) ListResourcesForTagOptionPages(input *ListResourcesForTagOptionInput, fn func(*ListResourcesForTagOptionOutput, bool) bool) error {
+	return c.ListResourcesForTagOptionPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListResourcesForTagOptionPagesWithContext same as ListResourcesForTagOptionPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) ListResourcesForTagOptionPagesWithContext(ctx aws.Context, input *ListResourcesForTagOptionInput, fn func(*ListResourcesForTagOptionOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListResourcesForTagOptionInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListResourcesForTagOptionRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListResourcesForTagOptionOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opListTagOptions = "ListTagOptions"
+
+// ListTagOptionsRequest generates a "aws/request.Request" representing the
+// client's request for the ListTagOptions operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListTagOptions for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListTagOptions method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListTagOptionsRequest method.
+//    req, resp := client.ListTagOptionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListTagOptions
+func (c *ServiceCatalog) ListTagOptionsRequest(input *ListTagOptionsInput) (req *request.Request, output *ListTagOptionsOutput) {
+	op := &request.Operation{
+		Name:       opListTagOptions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"PageToken"},
+			OutputTokens:    []string{"PageToken"},
+			LimitToken:      "PageSize",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListTagOptionsInput{}
+	}
+
+	output = &ListTagOptionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTagOptions API operation for AWS Service Catalog.
+//
+// Lists detailed TagOptions information.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Service Catalog's
+// API operation ListTagOptions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
+//   * ErrCodeInvalidParametersException "InvalidParametersException"
+//   One or more parameters provided to the operation are invalid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListTagOptions
+func (c *ServiceCatalog) ListTagOptions(input *ListTagOptionsInput) (*ListTagOptionsOutput, error) {
+	req, out := c.ListTagOptionsRequest(input)
+	return out, req.Send()
+}
+
+// ListTagOptionsWithContext is the same as ListTagOptions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTagOptions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) ListTagOptionsWithContext(ctx aws.Context, input *ListTagOptionsInput, opts ...request.Option) (*ListTagOptionsOutput, error) {
+	req, out := c.ListTagOptionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListTagOptionsPages iterates over the pages of a ListTagOptions operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListTagOptions method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListTagOptions operation.
+//    pageNum := 0
+//    err := client.ListTagOptionsPages(params,
+//        func(page *ListTagOptionsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ServiceCatalog) ListTagOptionsPages(input *ListTagOptionsInput, fn func(*ListTagOptionsOutput, bool) bool) error {
+	return c.ListTagOptionsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListTagOptionsPagesWithContext same as ListTagOptionsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) ListTagOptionsPagesWithContext(ctx aws.Context, input *ListTagOptionsInput, fn func(*ListTagOptionsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListTagOptionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListTagOptionsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListTagOptionsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opProvisionProduct = "ProvisionProduct"
 
 // ProvisionProductRequest generates a "aws/request.Request" representing the
@@ -2835,6 +3512,12 @@ func (c *ServiceCatalog) ProvisionProductRequest(input *ProvisionProductInput) (
 // resources that come with it.
 //
 // You can check the status of this request using the DescribeRecord operation.
+// The error "Parameter validation failed: Missing required parameter in Tags[N]:Value"
+// indicates that your request contains a tag which has a tag key but no corresponding
+// tag value (value is empty or null). Your call may have included values returned
+// from a DescribeProvisioningParameters call that resulted in a TagOption key
+// with an empty list. This happens when TagOption keys are in conflict. For
+// more information, see DescribeProvisioningParameters.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3442,6 +4125,11 @@ func (c *ServiceCatalog) UpdatePortfolioRequest(input *UpdatePortfolioInput) (re
 //   The current limits of the service would have been exceeded by this operation.
 //   Reduce the resource use or increase the service limits and retry the operation.
 //
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/UpdatePortfolio
 func (c *ServiceCatalog) UpdatePortfolio(input *UpdatePortfolioInput) (*UpdatePortfolioOutput, error) {
 	req, out := c.UpdatePortfolioRequest(input)
@@ -3524,6 +4212,11 @@ func (c *ServiceCatalog) UpdateProductRequest(input *UpdateProductInput) (req *r
 //
 //   * ErrCodeInvalidParametersException "InvalidParametersException"
 //   One or more parameters provided to the operation are invalid.
+//
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/UpdateProduct
 func (c *ServiceCatalog) UpdateProduct(input *UpdateProductInput) (*UpdateProductOutput, error) {
@@ -3716,6 +4409,97 @@ func (c *ServiceCatalog) UpdateProvisioningArtifact(input *UpdateProvisioningArt
 // for more information on using Contexts.
 func (c *ServiceCatalog) UpdateProvisioningArtifactWithContext(ctx aws.Context, input *UpdateProvisioningArtifactInput, opts ...request.Option) (*UpdateProvisioningArtifactOutput, error) {
 	req, out := c.UpdateProvisioningArtifactRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateTagOption = "UpdateTagOption"
+
+// UpdateTagOptionRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateTagOption operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See UpdateTagOption for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the UpdateTagOption method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the UpdateTagOptionRequest method.
+//    req, resp := client.UpdateTagOptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/UpdateTagOption
+func (c *ServiceCatalog) UpdateTagOptionRequest(input *UpdateTagOptionInput) (req *request.Request, output *UpdateTagOptionOutput) {
+	op := &request.Operation{
+		Name:       opUpdateTagOption,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateTagOptionInput{}
+	}
+
+	output = &UpdateTagOptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateTagOption API operation for AWS Service Catalog.
+//
+// Updates an existing TagOption.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Service Catalog's
+// API operation UpdateTagOption for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTagOptionNotMigratedException "TagOptionNotMigratedException"
+//   An operation requiring TagOptions failed because the TagOptions migration
+//   process has not been performed for this account. Please use the AWS console
+//   to perform the migration process before retrying the operation.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+//   * ErrCodeDuplicateResourceException "DuplicateResourceException"
+//   The specified resource is a duplicate.
+//
+//   * ErrCodeInvalidParametersException "InvalidParametersException"
+//   One or more parameters provided to the operation are invalid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/UpdateTagOption
+func (c *ServiceCatalog) UpdateTagOption(input *UpdateTagOptionInput) (*UpdateTagOptionOutput, error) {
+	req, out := c.UpdateTagOptionRequest(input)
+	return out, req.Send()
+}
+
+// UpdateTagOptionWithContext is the same as UpdateTagOption with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateTagOption for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ServiceCatalog) UpdateTagOptionWithContext(ctx aws.Context, input *UpdateTagOptionInput, opts ...request.Option) (*UpdateTagOptionOutput, error) {
+	req, out := c.UpdateTagOptionRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4044,6 +4828,77 @@ func (s AssociateProductWithPortfolioOutput) String() string {
 
 // GoString returns the string representation
 func (s AssociateProductWithPortfolioOutput) GoString() string {
+	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/AssociateTagOptionWithResourceInput
+type AssociateTagOptionWithResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The resource identifier.
+	//
+	// ResourceId is a required field
+	ResourceId *string `type:"string" required:"true"`
+
+	// The TagOption identifier.
+	//
+	// TagOptionId is a required field
+	TagOptionId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s AssociateTagOptionWithResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociateTagOptionWithResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociateTagOptionWithResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociateTagOptionWithResourceInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.TagOptionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagOptionId"))
+	}
+	if s.TagOptionId != nil && len(*s.TagOptionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TagOptionId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *AssociateTagOptionWithResourceInput) SetResourceId(v string) *AssociateTagOptionWithResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTagOptionId sets the TagOptionId field's value.
+func (s *AssociateTagOptionWithResourceInput) SetTagOptionId(v string) *AssociateTagOptionWithResourceInput {
+	s.TagOptionId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/AssociateTagOptionWithResourceOutput
+type AssociateTagOptionWithResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociateTagOptionWithResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociateTagOptionWithResourceOutput) GoString() string {
 	return s.String()
 }
 
@@ -4934,6 +5789,89 @@ func (s *CreateProvisioningArtifactOutput) SetStatus(v string) *CreateProvisioni
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/CreateTagOptionInput
+type CreateTagOptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The TagOption key.
+	//
+	// Key is a required field
+	Key *string `min:"1" type:"string" required:"true"`
+
+	// The TagOption value.
+	//
+	// Value is a required field
+	Value *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateTagOptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTagOptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTagOptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTagOptionInput"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value == nil {
+		invalidParams.Add(request.NewErrParamRequired("Value"))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *CreateTagOptionInput) SetKey(v string) *CreateTagOptionInput {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *CreateTagOptionInput) SetValue(v string) *CreateTagOptionInput {
+	s.Value = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/CreateTagOptionOutput
+type CreateTagOptionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The resulting detailed TagOption information.
+	TagOptionDetail *TagOptionDetail `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTagOptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTagOptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetTagOptionDetail sets the TagOptionDetail field's value.
+func (s *CreateTagOptionOutput) SetTagOptionDetail(v *TagOptionDetail) *CreateTagOptionOutput {
+	s.TagOptionDetail = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DeleteConstraintInput
 type DeleteConstraintInput struct {
 	_ struct{} `type:"structure"`
@@ -5510,6 +6448,9 @@ type DescribePortfolioOutput struct {
 	// Detailed portfolio information.
 	PortfolioDetail *PortfolioDetail `type:"structure"`
 
+	// TagOptions associated with the portfolio.
+	TagOptions []*TagOptionDetail `type:"list"`
+
 	// Tags associated with the portfolio.
 	Tags []*Tag `type:"list"`
 }
@@ -5527,6 +6468,12 @@ func (s DescribePortfolioOutput) GoString() string {
 // SetPortfolioDetail sets the PortfolioDetail field's value.
 func (s *DescribePortfolioOutput) SetPortfolioDetail(v *PortfolioDetail) *DescribePortfolioOutput {
 	s.PortfolioDetail = v
+	return s
+}
+
+// SetTagOptions sets the TagOptions field's value.
+func (s *DescribePortfolioOutput) SetTagOptions(v []*TagOptionDetail) *DescribePortfolioOutput {
+	s.TagOptions = v
 	return s
 }
 
@@ -5606,6 +6553,9 @@ type DescribeProductAsAdminOutput struct {
 	// A list of provisioning artifact summaries for the product.
 	ProvisioningArtifactSummaries []*ProvisioningArtifactSummary `type:"list"`
 
+	// List of TagOptions associated with the product.
+	TagOptions []*TagOptionDetail `type:"list"`
+
 	// Tags associated with the product.
 	Tags []*Tag `type:"list"`
 }
@@ -5629,6 +6579,12 @@ func (s *DescribeProductAsAdminOutput) SetProductViewDetail(v *ProductViewDetail
 // SetProvisioningArtifactSummaries sets the ProvisioningArtifactSummaries field's value.
 func (s *DescribeProductAsAdminOutput) SetProvisioningArtifactSummaries(v []*ProvisioningArtifactSummary) *DescribeProductAsAdminOutput {
 	s.ProvisioningArtifactSummaries = v
+	return s
+}
+
+// SetTagOptions sets the TagOptions field's value.
+func (s *DescribeProductAsAdminOutput) SetTagOptions(v []*TagOptionDetail) *DescribeProductAsAdminOutput {
+	s.TagOptions = v
 	return s
 }
 
@@ -5937,7 +6893,7 @@ type DescribeProvisioningArtifactInput struct {
 	// ProvisioningArtifactId is a required field
 	ProvisioningArtifactId *string `min:"1" type:"string" required:"true"`
 
-	// Selects verbose results. If set to true, the CloudFormation template is returned.
+	// Enable a verbose level of details for the provisioning artifact.
 	Verbose *bool `type:"boolean"`
 }
 
@@ -6142,6 +7098,9 @@ type DescribeProvisioningParametersOutput struct {
 	// includes a list of allowable values and additional metadata about each parameter.
 	ProvisioningArtifactParameters []*ProvisioningArtifactParameter `type:"list"`
 
+	// List of TagOptions associated with the provisioned provisioning parameters.
+	TagOptions []*TagOptionSummary `type:"list"`
+
 	// Any additional metadata specifically related to the provisioning of the product.
 	// For example, see the Version field of the CloudFormation template.
 	UsageInstructions []*UsageInstruction `type:"list"`
@@ -6166,6 +7125,12 @@ func (s *DescribeProvisioningParametersOutput) SetConstraintSummaries(v []*Const
 // SetProvisioningArtifactParameters sets the ProvisioningArtifactParameters field's value.
 func (s *DescribeProvisioningParametersOutput) SetProvisioningArtifactParameters(v []*ProvisioningArtifactParameter) *DescribeProvisioningParametersOutput {
 	s.ProvisioningArtifactParameters = v
+	return s
+}
+
+// SetTagOptions sets the TagOptions field's value.
+func (s *DescribeProvisioningParametersOutput) SetTagOptions(v []*TagOptionSummary) *DescribeProvisioningParametersOutput {
+	s.TagOptions = v
 	return s
 }
 
@@ -6300,6 +7265,72 @@ func (s *DescribeRecordOutput) SetRecordDetail(v *RecordDetail) *DescribeRecordO
 // SetRecordOutputs sets the RecordOutputs field's value.
 func (s *DescribeRecordOutput) SetRecordOutputs(v []*RecordOutput) *DescribeRecordOutput {
 	s.RecordOutputs = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DescribeTagOptionInput
+type DescribeTagOptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The identifier of the TagOption.
+	//
+	// Id is a required field
+	Id *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeTagOptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagOptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTagOptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTagOptionInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetId sets the Id field's value.
+func (s *DescribeTagOptionInput) SetId(v string) *DescribeTagOptionInput {
+	s.Id = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DescribeTagOptionOutput
+type DescribeTagOptionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The resulting detailed TagOption information.
+	TagOptionDetail *TagOptionDetail `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTagOptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagOptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetTagOptionDetail sets the TagOptionDetail field's value.
+func (s *DescribeTagOptionOutput) SetTagOptionDetail(v *TagOptionDetail) *DescribeTagOptionOutput {
+	s.TagOptionDetail = v
 	return s
 }
 
@@ -6484,6 +7515,77 @@ func (s DisassociateProductFromPortfolioOutput) String() string {
 
 // GoString returns the string representation
 func (s DisassociateProductFromPortfolioOutput) GoString() string {
+	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DisassociateTagOptionFromResourceInput
+type DisassociateTagOptionFromResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// Identifier of the resource from which to disassociate the TagOption.
+	//
+	// ResourceId is a required field
+	ResourceId *string `type:"string" required:"true"`
+
+	// Identifier of the TagOption to disassociate from the resource.
+	//
+	// TagOptionId is a required field
+	TagOptionId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DisassociateTagOptionFromResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateTagOptionFromResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisassociateTagOptionFromResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisassociateTagOptionFromResourceInput"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.TagOptionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagOptionId"))
+	}
+	if s.TagOptionId != nil && len(*s.TagOptionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TagOptionId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *DisassociateTagOptionFromResourceInput) SetResourceId(v string) *DisassociateTagOptionFromResourceInput {
+	s.ResourceId = &v
+	return s
+}
+
+// SetTagOptionId sets the TagOptionId field's value.
+func (s *DisassociateTagOptionFromResourceInput) SetTagOptionId(v string) *DisassociateTagOptionFromResourceInput {
+	s.TagOptionId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/DisassociateTagOptionFromResourceOutput
+type DisassociateTagOptionFromResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisassociateTagOptionFromResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateTagOptionFromResourceOutput) GoString() string {
 	return s.String()
 }
 
@@ -6780,7 +7882,7 @@ type ListLaunchPathsInput struct {
 	// page of size PageSize.
 	PageToken *string `type:"string"`
 
-	// The product identifier.. Identifies the product for which to retrieve LaunchPathSummaries
+	// The product identifier. Identifies the product for which to retrieve LaunchPathSummaries
 	// information.
 	//
 	// ProductId is a required field
@@ -7515,6 +8617,266 @@ func (s *ListRecordHistorySearchFilter) SetKey(v string) *ListRecordHistorySearc
 // SetValue sets the Value field's value.
 func (s *ListRecordHistorySearchFilter) SetValue(v string) *ListRecordHistorySearchFilter {
 	s.Value = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListResourcesForTagOptionInput
+type ListResourcesForTagOptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of items to return in the results. If more results exist
+	// than fit in the specified PageSize, the value of NextPageToken in the response
+	// is non-null.
+	PageSize *int64 `type:"integer"`
+
+	// The page token of the first page retrieved. If null, this retrieves the first
+	// page of size PageSize.
+	PageToken *string `type:"string"`
+
+	// Resource type.
+	ResourceType *string `type:"string"`
+
+	// Identifier of the TagOption.
+	//
+	// TagOptionId is a required field
+	TagOptionId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListResourcesForTagOptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListResourcesForTagOptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListResourcesForTagOptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListResourcesForTagOptionInput"}
+	if s.TagOptionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagOptionId"))
+	}
+	if s.TagOptionId != nil && len(*s.TagOptionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TagOptionId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListResourcesForTagOptionInput) SetPageSize(v int64) *ListResourcesForTagOptionInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListResourcesForTagOptionInput) SetPageToken(v string) *ListResourcesForTagOptionInput {
+	s.PageToken = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ListResourcesForTagOptionInput) SetResourceType(v string) *ListResourcesForTagOptionInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTagOptionId sets the TagOptionId field's value.
+func (s *ListResourcesForTagOptionInput) SetTagOptionId(v string) *ListResourcesForTagOptionInput {
+	s.TagOptionId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListResourcesForTagOptionOutput
+type ListResourcesForTagOptionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The page token of the first page retrieved. If null, this retrieves the first
+	// page of size PageSize.
+	PageToken *string `type:"string"`
+
+	// The resulting detailed resource information.
+	ResourceDetails []*ResourceDetail `type:"list"`
+}
+
+// String returns the string representation
+func (s ListResourcesForTagOptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListResourcesForTagOptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListResourcesForTagOptionOutput) SetPageToken(v string) *ListResourcesForTagOptionOutput {
+	s.PageToken = &v
+	return s
+}
+
+// SetResourceDetails sets the ResourceDetails field's value.
+func (s *ListResourcesForTagOptionOutput) SetResourceDetails(v []*ResourceDetail) *ListResourcesForTagOptionOutput {
+	s.ResourceDetails = v
+	return s
+}
+
+// The ListTagOptions filters.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListTagOptionsFilters
+type ListTagOptionsFilters struct {
+	_ struct{} `type:"structure"`
+
+	// The ListTagOptionsFilters active state.
+	Active *bool `type:"boolean"`
+
+	// The ListTagOptionsFilters key.
+	Key *string `min:"1" type:"string"`
+
+	// The ListTagOptionsFilters value.
+	Value *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListTagOptionsFilters) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagOptionsFilters) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagOptionsFilters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagOptionsFilters"}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetActive sets the Active field's value.
+func (s *ListTagOptionsFilters) SetActive(v bool) *ListTagOptionsFilters {
+	s.Active = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *ListTagOptionsFilters) SetKey(v string) *ListTagOptionsFilters {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *ListTagOptionsFilters) SetValue(v string) *ListTagOptionsFilters {
+	s.Value = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListTagOptionsInput
+type ListTagOptionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The list of filters with which to limit search results. If no search filters
+	// are specified, the output is all TagOptions.
+	Filters *ListTagOptionsFilters `type:"structure"`
+
+	// The maximum number of items to return in the results. If more results exist
+	// than fit in the specified PageSize, the value of NextPageToken in the response
+	// is non-null.
+	PageSize *int64 `type:"integer"`
+
+	// The page token of the first page retrieved. If null, this retrieves the first
+	// page of size PageSize.
+	PageToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListTagOptionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagOptionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagOptionsInput"}
+	if s.Filters != nil {
+		if err := s.Filters.Validate(); err != nil {
+			invalidParams.AddNested("Filters", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFilters sets the Filters field's value.
+func (s *ListTagOptionsInput) SetFilters(v *ListTagOptionsFilters) *ListTagOptionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListTagOptionsInput) SetPageSize(v int64) *ListTagOptionsInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListTagOptionsInput) SetPageToken(v string) *ListTagOptionsInput {
+	s.PageToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ListTagOptionsOutput
+type ListTagOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The page token of the first page retrieved. If null, this retrieves the first
+	// page of size PageSize.
+	PageToken *string `type:"string"`
+
+	// The resulting detailed TagOption information.
+	TagOptionDetails []*TagOptionDetail `type:"list"`
+}
+
+// String returns the string representation
+func (s ListTagOptionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagOptionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *ListTagOptionsOutput) SetPageToken(v string) *ListTagOptionsOutput {
+	s.PageToken = &v
+	return s
+}
+
+// SetTagOptionDetails sets the TagOptionDetails field's value.
+func (s *ListTagOptionsOutput) SetTagOptionDetails(v []*TagOptionDetail) *ListTagOptionsOutput {
+	s.TagOptionDetails = v
 	return s
 }
 
@@ -8452,7 +9814,7 @@ func (s *ProvisioningArtifactProperties) SetType(v string) *ProvisioningArtifact
 	return s
 }
 
-// Summary information about a provisioning artifact.
+// Stores summary information about a provisioning artifact.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ProvisioningArtifactSummary
 type ProvisioningArtifactSummary struct {
 	_ struct{} `type:"structure"`
@@ -8460,13 +9822,13 @@ type ProvisioningArtifactSummary struct {
 	// The UTC timestamp of the creation time.
 	CreatedTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The provisioning artifact description.
+	// The description of the provisioning artifact.
 	Description *string `type:"string"`
 
-	// The provisioning artifact identifier.
+	// The identifier of the provisioning artifact.
 	Id *string `min:"1" type:"string"`
 
-	// The provisioning artifact name.
+	// The name of the provisioning artifact.
 	Name *string `type:"string"`
 
 	// The provisioning artifact metadata. This data is used with products created
@@ -8608,7 +9970,7 @@ type RecordDetail struct {
 	// IN_PROGRESS - The requested operation is in-progress.
 	//
 	// IN_PROGRESS_IN_ERROR - The provisioned product is under change but the requested
-	// operation failed and some remediation is occurring. For example, a roll-back.
+	// operation failed and some remediation is occurring. For example, a rollback.
 	//
 	// SUCCEEDED - The requested operation has successfully completed.
 	//
@@ -8894,6 +10256,67 @@ func (s RejectPortfolioShareOutput) String() string {
 // GoString returns the string representation
 func (s RejectPortfolioShareOutput) GoString() string {
 	return s.String()
+}
+
+// Detailed resource information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ResourceDetail
+type ResourceDetail struct {
+	_ struct{} `type:"structure"`
+
+	// ARN of the resource.
+	ARN *string `type:"string"`
+
+	// Creation time of the resource.
+	CreatedTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// Description of the resource.
+	Description *string `type:"string"`
+
+	// Identifier of the resource.
+	Id *string `type:"string"`
+
+	// Name of the resource.
+	Name *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ResourceDetail) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResourceDetail) GoString() string {
+	return s.String()
+}
+
+// SetARN sets the ARN field's value.
+func (s *ResourceDetail) SetARN(v string) *ResourceDetail {
+	s.ARN = &v
+	return s
+}
+
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *ResourceDetail) SetCreatedTime(v time.Time) *ResourceDetail {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ResourceDetail) SetDescription(v string) *ResourceDetail {
+	s.Description = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ResourceDetail) SetId(v string) *ResourceDetail {
+	s.Id = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ResourceDetail) SetName(v string) *ResourceDetail {
+	s.Name = &v
+	return s
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/ScanProvisionedProductsInput
@@ -9268,7 +10691,7 @@ func (s *SearchProductsOutput) SetProductViewSummaries(v []*ProductViewSummary) 
 	return s
 }
 
-// Key/value pairs to associate with this provisioning. These tags are entirely
+// Key-value pairs to associate with this provisioning. These tags are entirely
 // discretionary and are propagated to the resources created in the provisioning.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/Tag
 type Tag struct {
@@ -9326,6 +10749,92 @@ func (s *Tag) SetKey(v string) *Tag {
 // SetValue sets the Value field's value.
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
+	return s
+}
+
+// The TagOption details.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/TagOptionDetail
+type TagOptionDetail struct {
+	_ struct{} `type:"structure"`
+
+	// The TagOptionDetail active state.
+	Active *bool `type:"boolean"`
+
+	// The TagOptionDetail identifier.
+	Id *string `min:"1" type:"string"`
+
+	// The TagOptionDetail key.
+	Key *string `min:"1" type:"string"`
+
+	// The TagOptionDetail value.
+	Value *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s TagOptionDetail) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagOptionDetail) GoString() string {
+	return s.String()
+}
+
+// SetActive sets the Active field's value.
+func (s *TagOptionDetail) SetActive(v bool) *TagOptionDetail {
+	s.Active = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *TagOptionDetail) SetId(v string) *TagOptionDetail {
+	s.Id = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *TagOptionDetail) SetKey(v string) *TagOptionDetail {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *TagOptionDetail) SetValue(v string) *TagOptionDetail {
+	s.Value = &v
+	return s
+}
+
+// The TagOption summary key-value pair.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/TagOptionSummary
+type TagOptionSummary struct {
+	_ struct{} `type:"structure"`
+
+	// The TagOptionSummary key.
+	Key *string `min:"1" type:"string"`
+
+	// The TagOptionSummary value.
+	Values []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s TagOptionSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagOptionSummary) GoString() string {
+	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *TagOptionSummary) SetKey(v string) *TagOptionSummary {
+	s.Key = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *TagOptionSummary) SetValues(v []*string) *TagOptionSummary {
+	s.Values = v
 	return s
 }
 
@@ -10271,6 +11780,93 @@ func (s *UpdateProvisioningParameter) SetUsePreviousValue(v bool) *UpdateProvisi
 // SetValue sets the Value field's value.
 func (s *UpdateProvisioningParameter) SetValue(v string) *UpdateProvisioningParameter {
 	s.Value = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/UpdateTagOptionInput
+type UpdateTagOptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The updated active state.
+	Active *bool `type:"boolean"`
+
+	// The identifier of the constraint to update.
+	//
+	// Id is a required field
+	Id *string `min:"1" type:"string" required:"true"`
+
+	// The updated value.
+	Value *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s UpdateTagOptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTagOptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateTagOptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateTagOptionInput"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
+	if s.Value != nil && len(*s.Value) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Value", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetActive sets the Active field's value.
+func (s *UpdateTagOptionInput) SetActive(v bool) *UpdateTagOptionInput {
+	s.Active = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UpdateTagOptionInput) SetId(v string) *UpdateTagOptionInput {
+	s.Id = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *UpdateTagOptionInput) SetValue(v string) *UpdateTagOptionInput {
+	s.Value = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/servicecatalog-2015-12-10/UpdateTagOptionOutput
+type UpdateTagOptionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The resulting detailed TagOption information.
+	TagOptionDetail *TagOptionDetail `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateTagOptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTagOptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetTagOptionDetail sets the TagOptionDetail field's value.
+func (s *UpdateTagOptionOutput) SetTagOptionDetail(v *TagOptionDetail) *UpdateTagOptionOutput {
+	s.TagOptionDetail = v
 	return s
 }
 

--- a/service/servicecatalog/errors.go
+++ b/service/servicecatalog/errors.go
@@ -16,6 +16,14 @@ const (
 	// One or more parameters provided to the operation are invalid.
 	ErrCodeInvalidParametersException = "InvalidParametersException"
 
+	// ErrCodeInvalidStateException for service response error code
+	// "InvalidStateException".
+	//
+	// An attempt was made to modify a resource that is in an invalid state. Inspect
+	// the resource you are using for this operation to ensure that all resource
+	// states are valid before retrying the operation.
+	ErrCodeInvalidStateException = "InvalidStateException"
+
 	// ErrCodeLimitExceededException for service response error code
 	// "LimitExceededException".
 	//
@@ -35,4 +43,12 @@ const (
 	//
 	// The specified resource was not found.
 	ErrCodeResourceNotFoundException = "ResourceNotFoundException"
+
+	// ErrCodeTagOptionNotMigratedException for service response error code
+	// "TagOptionNotMigratedException".
+	//
+	// An operation requiring TagOptions failed because the TagOptions migration
+	// process has not been performed for this account. Please use the AWS console
+	// to perform the migration process before retrying the operation.
+	ErrCodeTagOptionNotMigratedException = "TagOptionNotMigratedException"
 )

--- a/service/servicecatalog/servicecatalogiface/interface.go
+++ b/service/servicecatalog/servicecatalogiface/interface.go
@@ -72,6 +72,10 @@ type ServiceCatalogAPI interface {
 	AssociateProductWithPortfolioWithContext(aws.Context, *servicecatalog.AssociateProductWithPortfolioInput, ...request.Option) (*servicecatalog.AssociateProductWithPortfolioOutput, error)
 	AssociateProductWithPortfolioRequest(*servicecatalog.AssociateProductWithPortfolioInput) (*request.Request, *servicecatalog.AssociateProductWithPortfolioOutput)
 
+	AssociateTagOptionWithResource(*servicecatalog.AssociateTagOptionWithResourceInput) (*servicecatalog.AssociateTagOptionWithResourceOutput, error)
+	AssociateTagOptionWithResourceWithContext(aws.Context, *servicecatalog.AssociateTagOptionWithResourceInput, ...request.Option) (*servicecatalog.AssociateTagOptionWithResourceOutput, error)
+	AssociateTagOptionWithResourceRequest(*servicecatalog.AssociateTagOptionWithResourceInput) (*request.Request, *servicecatalog.AssociateTagOptionWithResourceOutput)
+
 	CreateConstraint(*servicecatalog.CreateConstraintInput) (*servicecatalog.CreateConstraintOutput, error)
 	CreateConstraintWithContext(aws.Context, *servicecatalog.CreateConstraintInput, ...request.Option) (*servicecatalog.CreateConstraintOutput, error)
 	CreateConstraintRequest(*servicecatalog.CreateConstraintInput) (*request.Request, *servicecatalog.CreateConstraintOutput)
@@ -91,6 +95,10 @@ type ServiceCatalogAPI interface {
 	CreateProvisioningArtifact(*servicecatalog.CreateProvisioningArtifactInput) (*servicecatalog.CreateProvisioningArtifactOutput, error)
 	CreateProvisioningArtifactWithContext(aws.Context, *servicecatalog.CreateProvisioningArtifactInput, ...request.Option) (*servicecatalog.CreateProvisioningArtifactOutput, error)
 	CreateProvisioningArtifactRequest(*servicecatalog.CreateProvisioningArtifactInput) (*request.Request, *servicecatalog.CreateProvisioningArtifactOutput)
+
+	CreateTagOption(*servicecatalog.CreateTagOptionInput) (*servicecatalog.CreateTagOptionOutput, error)
+	CreateTagOptionWithContext(aws.Context, *servicecatalog.CreateTagOptionInput, ...request.Option) (*servicecatalog.CreateTagOptionOutput, error)
+	CreateTagOptionRequest(*servicecatalog.CreateTagOptionInput) (*request.Request, *servicecatalog.CreateTagOptionOutput)
 
 	DeleteConstraint(*servicecatalog.DeleteConstraintInput) (*servicecatalog.DeleteConstraintOutput, error)
 	DeleteConstraintWithContext(aws.Context, *servicecatalog.DeleteConstraintInput, ...request.Option) (*servicecatalog.DeleteConstraintOutput, error)
@@ -148,6 +156,10 @@ type ServiceCatalogAPI interface {
 	DescribeRecordWithContext(aws.Context, *servicecatalog.DescribeRecordInput, ...request.Option) (*servicecatalog.DescribeRecordOutput, error)
 	DescribeRecordRequest(*servicecatalog.DescribeRecordInput) (*request.Request, *servicecatalog.DescribeRecordOutput)
 
+	DescribeTagOption(*servicecatalog.DescribeTagOptionInput) (*servicecatalog.DescribeTagOptionOutput, error)
+	DescribeTagOptionWithContext(aws.Context, *servicecatalog.DescribeTagOptionInput, ...request.Option) (*servicecatalog.DescribeTagOptionOutput, error)
+	DescribeTagOptionRequest(*servicecatalog.DescribeTagOptionInput) (*request.Request, *servicecatalog.DescribeTagOptionOutput)
+
 	DisassociatePrincipalFromPortfolio(*servicecatalog.DisassociatePrincipalFromPortfolioInput) (*servicecatalog.DisassociatePrincipalFromPortfolioOutput, error)
 	DisassociatePrincipalFromPortfolioWithContext(aws.Context, *servicecatalog.DisassociatePrincipalFromPortfolioInput, ...request.Option) (*servicecatalog.DisassociatePrincipalFromPortfolioOutput, error)
 	DisassociatePrincipalFromPortfolioRequest(*servicecatalog.DisassociatePrincipalFromPortfolioInput) (*request.Request, *servicecatalog.DisassociatePrincipalFromPortfolioOutput)
@@ -155,6 +167,10 @@ type ServiceCatalogAPI interface {
 	DisassociateProductFromPortfolio(*servicecatalog.DisassociateProductFromPortfolioInput) (*servicecatalog.DisassociateProductFromPortfolioOutput, error)
 	DisassociateProductFromPortfolioWithContext(aws.Context, *servicecatalog.DisassociateProductFromPortfolioInput, ...request.Option) (*servicecatalog.DisassociateProductFromPortfolioOutput, error)
 	DisassociateProductFromPortfolioRequest(*servicecatalog.DisassociateProductFromPortfolioInput) (*request.Request, *servicecatalog.DisassociateProductFromPortfolioOutput)
+
+	DisassociateTagOptionFromResource(*servicecatalog.DisassociateTagOptionFromResourceInput) (*servicecatalog.DisassociateTagOptionFromResourceOutput, error)
+	DisassociateTagOptionFromResourceWithContext(aws.Context, *servicecatalog.DisassociateTagOptionFromResourceInput, ...request.Option) (*servicecatalog.DisassociateTagOptionFromResourceOutput, error)
+	DisassociateTagOptionFromResourceRequest(*servicecatalog.DisassociateTagOptionFromResourceInput) (*request.Request, *servicecatalog.DisassociateTagOptionFromResourceOutput)
 
 	ListAcceptedPortfolioShares(*servicecatalog.ListAcceptedPortfolioSharesInput) (*servicecatalog.ListAcceptedPortfolioSharesOutput, error)
 	ListAcceptedPortfolioSharesWithContext(aws.Context, *servicecatalog.ListAcceptedPortfolioSharesInput, ...request.Option) (*servicecatalog.ListAcceptedPortfolioSharesOutput, error)
@@ -191,6 +207,20 @@ type ServiceCatalogAPI interface {
 	ListRecordHistory(*servicecatalog.ListRecordHistoryInput) (*servicecatalog.ListRecordHistoryOutput, error)
 	ListRecordHistoryWithContext(aws.Context, *servicecatalog.ListRecordHistoryInput, ...request.Option) (*servicecatalog.ListRecordHistoryOutput, error)
 	ListRecordHistoryRequest(*servicecatalog.ListRecordHistoryInput) (*request.Request, *servicecatalog.ListRecordHistoryOutput)
+
+	ListResourcesForTagOption(*servicecatalog.ListResourcesForTagOptionInput) (*servicecatalog.ListResourcesForTagOptionOutput, error)
+	ListResourcesForTagOptionWithContext(aws.Context, *servicecatalog.ListResourcesForTagOptionInput, ...request.Option) (*servicecatalog.ListResourcesForTagOptionOutput, error)
+	ListResourcesForTagOptionRequest(*servicecatalog.ListResourcesForTagOptionInput) (*request.Request, *servicecatalog.ListResourcesForTagOptionOutput)
+
+	ListResourcesForTagOptionPages(*servicecatalog.ListResourcesForTagOptionInput, func(*servicecatalog.ListResourcesForTagOptionOutput, bool) bool) error
+	ListResourcesForTagOptionPagesWithContext(aws.Context, *servicecatalog.ListResourcesForTagOptionInput, func(*servicecatalog.ListResourcesForTagOptionOutput, bool) bool, ...request.Option) error
+
+	ListTagOptions(*servicecatalog.ListTagOptionsInput) (*servicecatalog.ListTagOptionsOutput, error)
+	ListTagOptionsWithContext(aws.Context, *servicecatalog.ListTagOptionsInput, ...request.Option) (*servicecatalog.ListTagOptionsOutput, error)
+	ListTagOptionsRequest(*servicecatalog.ListTagOptionsInput) (*request.Request, *servicecatalog.ListTagOptionsOutput)
+
+	ListTagOptionsPages(*servicecatalog.ListTagOptionsInput, func(*servicecatalog.ListTagOptionsOutput, bool) bool) error
+	ListTagOptionsPagesWithContext(aws.Context, *servicecatalog.ListTagOptionsInput, func(*servicecatalog.ListTagOptionsOutput, bool) bool, ...request.Option) error
 
 	ProvisionProduct(*servicecatalog.ProvisionProductInput) (*servicecatalog.ProvisionProductOutput, error)
 	ProvisionProductWithContext(aws.Context, *servicecatalog.ProvisionProductInput, ...request.Option) (*servicecatalog.ProvisionProductOutput, error)
@@ -235,6 +265,10 @@ type ServiceCatalogAPI interface {
 	UpdateProvisioningArtifact(*servicecatalog.UpdateProvisioningArtifactInput) (*servicecatalog.UpdateProvisioningArtifactOutput, error)
 	UpdateProvisioningArtifactWithContext(aws.Context, *servicecatalog.UpdateProvisioningArtifactInput, ...request.Option) (*servicecatalog.UpdateProvisioningArtifactOutput, error)
 	UpdateProvisioningArtifactRequest(*servicecatalog.UpdateProvisioningArtifactInput) (*request.Request, *servicecatalog.UpdateProvisioningArtifactOutput)
+
+	UpdateTagOption(*servicecatalog.UpdateTagOptionInput) (*servicecatalog.UpdateTagOptionOutput, error)
+	UpdateTagOptionWithContext(aws.Context, *servicecatalog.UpdateTagOptionInput, ...request.Option) (*servicecatalog.UpdateTagOptionOutput, error)
+	UpdateTagOptionRequest(*servicecatalog.UpdateTagOptionInput) (*request.Request, *servicecatalog.UpdateTagOptionOutput)
 }
 
 var _ ServiceCatalogAPI = (*servicecatalog.ServiceCatalog)(nil)


### PR DESCRIPTION
Release v1.10.4 (2017-06-27)
===

### Service Client Updates
* `service/servicecatalog`: Updates service API, documentation, and paginators
  * Proper tagging of resources is critical to post-launch operations such as billing, cost allocation, and resource management. By using Service Catalog's TagOption Library, administrators can define a library of re-usable TagOptions that conform to company standards, and associate these with Service Catalog portfolios and products. Learn how to move your current tags to the new library, create new TagOptions, and view and associate your library items with portfolios and products. Understand how to ensure that the right tags are created on products launched through Service Catalog and how to provide users with defined selectable tags.

### SDK Bugs
* `aws/signer/v4`: checking length on `stripExcessSpaces` [#1372](https://github.com/aws/aws-sdk-go/issues/1372)
  * Fixes a bug where `stripExcessSpaces` did not check length against the slice.
  * Fixes: [#1371](https://github.com/aws/aws-sdk-go/issues/1371)
