### PR TITLE
Fix wrong documentation for client.DefaultRetryer

### DIFF
--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -15,11 +15,11 @@ import (
 // the MaxRetries method:
 //
 //		type retryer struct {
-//      service.DefaultRetryer
+//      client.DefaultRetryer
 //    }
 //
 //    // This implementation always has 100 max retries
-//    func (d retryer) MaxRetries() uint { return 100 }
+//    func (d retryer) MaxRetries() int { return 100 }
 type DefaultRetryer struct {
 	NumMaxRetries int
 }

--- a/aws/config.go
+++ b/aws/config.go
@@ -95,7 +95,7 @@ type Config struct {
 	// recoverable failures.
 	//
 	// When nil or the value does not implement the request.Retryer interface,
-	// the request.DefaultRetryer will be used.
+	// the client.DefaultRetryer will be used.
 	//
 	// When both Retryer and MaxRetries are non-nil, the former is used and
 	// the latter ignored.

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Retryer is an interface to control retry logic for a given service.
-// The default implementation used by most services is the service.DefaultRetryer
+// The default implementation used by most services is the client.DefaultRetryer
 // structure, which contains basic retry logic using exponential backoff.
 type Retryer interface {
 	RetryRules(*Request) time.Duration


### PR DESCRIPTION
Minor fixes in godoc for `client.DefaultRetryer`.