### PR TITLE
service/s3/s3manager: Fix panic from DeleteListIterator when listing is empty

### DIFF
--- a/service/s3/s3manager/batch.go
+++ b/service/s3/s3manager/batch.go
@@ -155,11 +155,11 @@ func (iter *DeleteListIterator) Next() bool {
 		iter.objects = iter.objects[1:]
 	}
 
-	if len(iter.objects) == 0 {
-		return iter.Paginator.Next()
+	if len(iter.objects) == 0 && iter.Paginator.Next() {
+		iter.objects = iter.Paginator.Page().(*s3.ListObjectsOutput).Contents
 	}
 
-	return true
+	return len(iter.objects) > 0
 }
 
 // Err will return the last known error from Next.
@@ -169,11 +169,6 @@ func (iter *DeleteListIterator) Err() error {
 
 // DeleteObject will return the current object to be deleted.
 func (iter *DeleteListIterator) DeleteObject() BatchDeleteObject {
-	if len(iter.objects) == 0 {
-		p := iter.Paginator.Page().(*s3.ListObjectsOutput)
-		iter.objects = p.Contents
-	}
-
 	return BatchDeleteObject{
 		Object: &s3.DeleteObjectInput{
 			Bucket: iter.Bucket,


### PR DESCRIPTION
I wanted to use DeleteListIterator to delete an S3 prefix before running an integration test. I noticed that if there were no keys with the prefix I was deleting the AWS SDK would panic. This is down to a faulty assumption about `Pagination.Next()`, specifically `DeleteListIterator` assumes that if `Pagination.Next()` is true there will be more elements. However `Pagination.Next()` is _always_ true the first time it is called (save for an request error), so if the listing is empty the iterator indicates it has a next element which leads to the panic.

The first commit extends the test to demonstrate the bug, and the second commit fixes it. If you would like me to squash these I will.