### PR TITLE
v1.10.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+Release v1.10.13 (2017-07-19)
+===
+
+### Service Client Updates
+* `service/budgets`: Updates service API and documentation
+  * Update budget Management API's to list/create/update RI_UTILIZATION type budget. Update budget Management API's to support DAILY timeUnit for RI_UTILIZATION type budget.
+
+### SDK Enhancements
+* `service/s3`:  Use interfaces assertions instead of ValuesAtPath for S3 field lookups. [#1401](https://github.com/aws/aws-sdk-go/pull/1401)
+  * Improves the performance across the board for all S3 API calls by removing the usage of `ValuesAtPath` being used for every S3 API call.
+
+### SDK Bugs
+* `aws/request`: waiter test bug
+  * waiters_test.go file would sometimes fail due to travis hiccups. This occurs because a test would sometimes fail the cancel check and succeed the timeout. However, the timeout check should never occur in that test. This fix introduces a new field that dictates how waiters will sleep.
 Release v1.10.12 (2017-07-17)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,9 +1,5 @@
 ### SDK Features
 
 ### SDK Enhancements
-* `service/s3`:  Use interfaces assertions instead of ValuesAtPath for S3 field lookups. [#1401](https://github.com/aws/aws-sdk-go/pull/1401)
-  * Improves the performance across the board for all S3 API calls by removing the usage of `ValuesAtPath` being used for every S3 API call.
 
 ### SDK Bugs
-* `aws/request`: waiter test bug
-  * waiters_test.go file would sometimes fail due to travis hiccups. This occurs because a test would sometimes fail the cancel check and succeed the timeout. However, the timeout check should never occur in that test. This fix introduces a new field that dictates how waiters will sleep.

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.10.12"
+const SDKVersion = "1.10.13"

--- a/models/apis/budgets/2016-10-20/api-2.json
+++ b/models/apis/budgets/2016-10-20/api-2.json
@@ -236,13 +236,14 @@
     "BudgetName":{
       "type":"string",
       "max":100,
-      "pattern":"[^:]+"
+      "pattern":"[^:\\\\]+"
     },
     "BudgetType":{
       "type":"string",
       "enum":[
         "USAGE",
-        "COST"
+        "COST",
+        "RI_UTILIZATION"
       ]
     },
     "Budgets":{
@@ -588,7 +589,7 @@
       ],
       "members":{
         "Amount":{"shape":"NumericValue"},
-        "Unit":{"shape":"GenericString"}
+        "Unit":{"shape":"UnitValue"}
       }
     },
     "Subscriber":{
@@ -629,10 +630,15 @@
     "TimeUnit":{
       "type":"string",
       "enum":[
+        "DAILY",
         "MONTHLY",
         "QUARTERLY",
         "ANNUALLY"
       ]
+    },
+    "UnitValue":{
+      "type":"string",
+      "min":1
     },
     "UpdateBudgetRequest":{
       "type":"structure",

--- a/models/apis/budgets/2016-10-20/docs-2.json
+++ b/models/apis/budgets/2016-10-20/docs-2.json
@@ -45,7 +45,7 @@
       }
     },
     "BudgetName": {
-      "base": "A string represents the budget name. No \":\" character is allowed.",
+      "base": "A string represents the budget name. No \":\" and \"\\\" character is allowed.",
       "refs": {
         "Budget$BudgetName": null,
         "CreateNotificationRequest$BudgetName": null,
@@ -61,7 +61,7 @@
       }
     },
     "BudgetType": {
-      "base": "The type of a budget. Can be COST or USAGE.",
+      "base": "The type of a budget. It should be COST, USAGE, or RI_UTILIZATION.",
       "refs": {
         "Budget$BudgetType": null
       }
@@ -236,7 +236,6 @@
         "DescribeSubscribersForNotificationRequest$NextToken": null,
         "DescribeSubscribersForNotificationResponse$NextToken": null,
         "DimensionValues$member": null,
-        "Spend$Unit": null,
         "Subscriber$Address": null
       }
     },
@@ -365,9 +364,15 @@
       }
     },
     "TimeUnit": {
-      "base": "The time unit of the budget. e.g. weekly, monthly, etc.",
+      "base": "The time unit of the budget. e.g. MONTHLY, QUARTERLY, etc.",
       "refs": {
         "Budget$TimeUnit": null
+      }
+    },
+    "UnitValue": {
+      "base": "A string to represent budget spend unit. It should be not null and not empty.",
+      "refs": {
+        "Spend$Unit": null
       }
     },
     "UpdateBudgetRequest": {

--- a/service/budgets/api.go
+++ b/service/budgets/api.go
@@ -1167,12 +1167,12 @@ type Budget struct {
 	// BudgetLimit is a required field
 	BudgetLimit *Spend `type:"structure" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// The type of a budget. Can be COST or USAGE.
+	// The type of a budget. It should be COST, USAGE, or RI_UTILIZATION.
 	//
 	// BudgetType is a required field
 	BudgetType *string `type:"string" required:"true" enum:"BudgetType"`
@@ -1193,7 +1193,7 @@ type Budget struct {
 	// TimePeriod is a required field
 	TimePeriod *TimePeriod `type:"structure" required:"true"`
 
-	// The time unit of the budget. e.g. weekly, monthly, etc.
+	// The time unit of the budget. e.g. MONTHLY, QUARTERLY, etc.
 	//
 	// TimeUnit is a required field
 	TimeUnit *string `type:"string" required:"true" enum:"TimeUnit"`
@@ -1536,7 +1536,7 @@ type CreateNotificationInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -1654,7 +1654,7 @@ type CreateSubscriberInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -1765,7 +1765,7 @@ type DeleteBudgetInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -1836,7 +1836,7 @@ type DeleteNotificationInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -1927,7 +1927,7 @@ type DeleteSubscriberInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -2038,7 +2038,7 @@ type DescribeBudgetInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -2215,7 +2215,7 @@ type DescribeNotificationsForBudgetInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -2326,7 +2326,7 @@ type DescribeSubscribersForNotificationInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -2604,10 +2604,10 @@ type Spend struct {
 	// Amount is a required field
 	Amount *string `type:"string" required:"true"`
 
-	// A generic String.
+	// A string to represent budget spend unit. It should be not null and not empty.
 	//
 	// Unit is a required field
-	Unit *string `type:"string" required:"true"`
+	Unit *string `min:"1" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -2628,6 +2628,9 @@ func (s *Spend) Validate() error {
 	}
 	if s.Unit == nil {
 		invalidParams.Add(request.NewErrParamRequired("Unit"))
+	}
+	if s.Unit != nil && len(*s.Unit) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Unit", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2840,7 +2843,7 @@ type UpdateNotificationInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -2951,7 +2954,7 @@ type UpdateSubscriberInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" character is allowed.
+	// A string represents the budget name. No ":" and "\" character is allowed.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -3073,13 +3076,16 @@ func (s UpdateSubscriberOutput) GoString() string {
 	return s.String()
 }
 
-// The type of a budget. Can be COST or USAGE.
+// The type of a budget. It should be COST, USAGE, or RI_UTILIZATION.
 const (
 	// BudgetTypeUsage is a BudgetType enum value
 	BudgetTypeUsage = "USAGE"
 
 	// BudgetTypeCost is a BudgetType enum value
 	BudgetTypeCost = "COST"
+
+	// BudgetTypeRiUtilization is a BudgetType enum value
+	BudgetTypeRiUtilization = "RI_UTILIZATION"
 )
 
 // The comparison operator of a notification. Currently we support less than,
@@ -3113,8 +3119,11 @@ const (
 	SubscriptionTypeEmail = "EMAIL"
 )
 
-// The time unit of the budget. e.g. weekly, monthly, etc.
+// The time unit of the budget. e.g. MONTHLY, QUARTERLY, etc.
 const (
+	// TimeUnitDaily is a TimeUnit enum value
+	TimeUnitDaily = "DAILY"
+
 	// TimeUnitMonthly is a TimeUnit enum value
 	TimeUnitMonthly = "MONTHLY"
 


### PR DESCRIPTION
Release v1.10.13 (2017-07-19)
===

### Service Client Updates
* `service/budgets`: Updates service API and documentation
  * Update budget Management API's to list/create/update RI_UTILIZATION type budget. Update budget Management API's to support DAILY timeUnit for RI_UTILIZATION type budget.

### SDK Enhancements
* `service/s3`:  Use interfaces assertions instead of ValuesAtPath for S3 field lookups. [#1401](https://github.com/aws/aws-sdk-go/pull/1401)
  * Improves the performance across the board for all S3 API calls by removing the usage of `ValuesAtPath` being used for every S3 API call.

### SDK Bugs
* `aws/request`: waiter test bug
  * waiters_test.go file would sometimes fail due to travis hiccups. This occurs because a test would sometimes fail the cancel check and succeed the timeout. However, the timeout check should never occur in that test. This fix introduces a new field that dictates how waiters will sleep.
