### PR TITLE
API Marshaling: Add generated marshalers for RESTXML protocol

### DIFF
--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -358,6 +358,7 @@ func generateTestSuite(filename string) string {
 		svcPrefix := inout + "Service" + strconv.Itoa(i+1)
 		suite.API.Metadata.ServiceAbbreviation = svcPrefix + "ProtocolTest"
 		suite.API.Operations = map[string]*api.Operation{}
+
 		for idx, c := range suite.Cases {
 			c.Given.ExportedName = svcPrefix + "TestCaseOperation" + strconv.Itoa(idx+1)
 			suite.API.Operations[c.Given.ExportedName] = c.Given
@@ -369,6 +370,9 @@ func generateTestSuite(filename string) string {
 		suite.API.NoConstServiceNames = true // don't generate service names
 		suite.API.Setup()
 		suite.API.Metadata.EndpointPrefix = suite.API.PackageName()
+
+		// TODO until generated marshalers are all supported
+		suite.API.EnableSelectGeneratedMarshalers()
 
 		// Sort in order for deterministic test generation
 		names := make([]string, 0, len(suite.API.Shapes))

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -46,6 +46,10 @@ type API struct {
 	// Set to true to not generate struct field accessors
 	NoGenStructFieldAccessors bool
 
+	// Set to true to not generate (un)marshalers
+	NoGenMarshalers   bool
+	NoGenUnmarshalers bool
+
 	SvcClientImportPath string
 
 	initialized bool
@@ -270,6 +274,9 @@ func (a *API) APIGoCode() string {
 	a.imports["github.com/aws/aws-sdk-go/aws/request"] = true
 	if a.OperationHasOutputPlaceholder() {
 		a.imports["github.com/aws/aws-sdk-go/private/protocol/"+a.ProtocolPackage()] = true
+		a.imports["github.com/aws/aws-sdk-go/private/protocol"] = true
+	}
+	if !a.NoGenMarshalers || !a.NoGenUnmarshalers {
 		a.imports["github.com/aws/aws-sdk-go/private/protocol"] = true
 	}
 

--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -47,6 +47,21 @@ func (a *API) customizationPasses() {
 	if fn := svcCustomizations[a.PackageName()]; fn != nil {
 		fn(a)
 	}
+
+	// TODO until generated marshalers are all supported
+	a.EnableSelectGeneratedMarshalers()
+}
+
+func (a *API) EnableSelectGeneratedMarshalers() {
+	// Selectivily enable generated marshalers as available
+	a.NoGenMarshalers = true
+	a.NoGenUnmarshalers = true
+
+	// Enable generated marshalers
+	switch a.Metadata.Protocol {
+	case "rest-xml":
+		a.NoGenMarshalers = false
+	}
 }
 
 // s3Customizations customizes the API generation to replace values specific to S3.

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -62,7 +62,6 @@ func (a *API) resolveReferences() {
 		}
 	}
 
-	// TODO put this somewhere better
 	for _, s := range a.Shapes {
 		switch s.Type {
 		case "list":

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -61,6 +61,16 @@ func (a *API) resolveReferences() {
 			o.ErrorRefs[i].Shape.IsError = true
 		}
 	}
+
+	// TODO put this somewhere better
+	for _, s := range a.Shapes {
+		switch s.Type {
+		case "list":
+			s.MemberRef.Shape.UsedInList = true
+		case "map":
+			s.ValueRef.Shape.UsedInMap = true
+		}
+	}
 }
 
 // A referenceResolver provides a way to resolve shape references to

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -78,6 +78,9 @@ type Shape struct {
 
 	OrigShapeName string `json:"-"`
 
+	UsedInMap  bool
+	UsedInList bool
+
 	// Defines if the shape is a placeholder and should not be used directly
 	Placeholder bool
 
@@ -185,10 +188,18 @@ func (s *Shape) GoStructValueType(name string, ref *ShapeRef) string {
 	return v
 }
 
+func (s *Shape) IsRefPayload(name string) bool {
+	return s.Payload == name
+}
+
+func (s *Shape) IsRefPayloadReader(name string, ref *ShapeRef) bool {
+	return (ref.Streaming || ref.Shape.Streaming) && s.IsRefPayload(name)
+}
+
 // GoStructType returns the type of a struct field based on the API
 // model definition.
 func (s *Shape) GoStructType(name string, ref *ShapeRef) string {
-	if (ref.Streaming || ref.Shape.Streaming) && s.Payload == name {
+	if s.IsRefPayloadReader(name, ref) {
 		rtype := "io.ReadSeeker"
 		if strings.HasSuffix(s.ShapeName, "Output") {
 			rtype = "io.ReadCloser"
@@ -513,7 +524,9 @@ func (s *Shape) NestedShape() *Shape {
 }
 
 var structShapeTmpl = template.Must(template.New("StructShape").Funcs(template.FuncMap{
-	"GetCrosslinkURL": GetCrosslinkURL,
+	"GetCrosslinkURL":      GetCrosslinkURL,
+	"MarshalShapeGoCode":   MarshalShapeGoCode,
+	"UnmarshalShapeGoCode": UnmarshalShapeGoCode,
 }).Parse(`
 {{ .Docstring }}
 {{ if ne $.OrigShapeName "" -}}
@@ -597,6 +610,13 @@ func (s *{{ $builderShapeName }}) get{{ $name }}() (v {{ $context.GoStructValueT
 
 {{ end }}
 {{ end }}
+
+{{ if not $.API.NoGenMarshalers -}}
+{{ MarshalShapeGoCode $ }}
+{{- end }}
+{{ if not $.API.NoGenUnmarshalers -}}
+{{ UnmarshalShapeGoCode $ }}
+{{- end }}
 `))
 
 var enumShapeTmpl = template.Must(template.New("EnumShape").Parse(`

--- a/private/model/api/shape_marshal.go
+++ b/private/model/api/shape_marshal.go
@@ -1,0 +1,519 @@
+// +build codegen
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// MarshalShapeGoCode renders the shape's MarshalFields method with marshalers
+// for each field within the shape. A string is returned of the rendered Go code.
+//
+// Will panic if error.
+func MarshalShapeGoCode(s *Shape) string {
+	w := &bytes.Buffer{}
+	if err := marshalShapeTmpl.Execute(w, s); err != nil {
+		panic(fmt.Sprintf("failed to render shape's fields marshaler, %v", err))
+	}
+
+	return w.String()
+}
+
+// MarshalShapeRefGoCode renders protocol encode for the shape ref's type.
+//
+// Will panic if error.
+func MarshalShapeRefGoCode(refName string, ref *ShapeRef, context *Shape) string {
+	if ref.XMLAttribute {
+		return "// Skipping " + refName + " XML Attribute."
+	}
+	if context.IsRefPayloadReader(refName, ref) {
+		if strings.HasSuffix(context.ShapeName, "Output") {
+			return "// Skipping " + refName + " Output type's body not valid."
+		}
+	}
+
+	mRef := marshalShapeRef{
+		Name:    refName,
+		Ref:     ref,
+		Context: context,
+	}
+
+	switch mRef.Location() {
+	case "StatusCode":
+		return "// ignoring invalid encode state, StatusCode. " + refName
+	}
+
+	w := &bytes.Buffer{}
+	if err := marshalShapeRefTmpl.ExecuteTemplate(w, "encode field", mRef); err != nil {
+		panic(fmt.Sprintf("failed to marshal shape ref, %s, %v", ref.Shape.Type, err))
+	}
+
+	return w.String()
+}
+
+var marshalShapeTmpl = template.Must(template.New("marshalShapeTmpl").Funcs(
+	map[string]interface{}{
+		"MarshalShapeRefGoCode": MarshalShapeRefGoCode,
+	},
+).Parse(`
+{{ $shapeName := $.ShapeName -}}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *{{ $shapeName }}) MarshalFields(e protocol.FieldEncoder) error {
+	{{ range $name, $ref := $.MemberRefs -}}
+		{{ MarshalShapeRefGoCode $name $ref $ }}
+	{{ end }}
+	return nil
+}
+
+{{ if $.UsedInList -}}
+func encode{{ $shapeName }}List(vs []*{{ $shapeName }}) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+{{- end }}
+
+{{ if $.UsedInMap -}}
+func encode{{ $shapeName }}Map(vs map[string]*{{ $shapeName }}) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+{{- end }}
+`))
+
+var marshalShapeRefTmpl = template.Must(template.New("marshalShapeRefTmpl").Parse(`
+{{ define "encode field" -}}
+	{{ if $.IsIdempotencyToken -}}
+		{{ template "idempotency token" $ }}
+	{
+		v := {{ $.Name }}
+	{{ else -}}
+	if {{ template "is ref set" $ }} {
+		v := {{ template "ref value" $ }}
+	{{- end }}
+		{{ if $.HasAttributes -}}
+			{{ template "attributes" $ }}
+		{{- end }}
+		e.Set{{ $.MarshalerType }}(protocol.{{ $.Location }}Target, "{{ $.LocationName }}", {{ template "marshaler" $ }}, {{ template "metadata" $ }})
+	}
+{{- end }}
+
+{{ define "marshaler" -}}
+	{{- if $.IsShapeType "list" -}}
+		{{- $helperName := $.EncodeHelperName "list" -}}
+		{{- if $helperName -}}
+			{{ $helperName }}
+		{{- else -}}
+			func(le protocol.ListEncoder) {
+				{{ $memberRef := $.ListMemberRef -}}
+				for _, item := range v {
+					v := {{ if $memberRef.Ref.UseIndirection }}*{{ end }}item
+					le.ListAdd{{ $memberRef.MarshalerType }}({{ template "marshaler" $memberRef }})
+				}
+			}
+		{{- end -}}
+	{{- else if $.IsShapeType "map" -}}
+		{{- $helperName := $.EncodeHelperName "map" -}}
+		{{- if $helperName -}}
+			{{ $helperName }}
+		{{- else -}}
+			func(me protocol.MapEncoder) {
+				{{ $valueRef := $.MapValueRef -}}
+				for k, item := range v {
+					v := {{ if $valueRef.Ref.UseIndirection }}*{{ end }}item
+					me.MapSet{{ $valueRef.MarshalerType }}(k, {{ template "marshaler" $valueRef }})
+				}
+			}
+		{{- end -}}
+	{{- else if $.IsShapeType "structure" -}}
+		v
+	{{- else if $.IsShapeType "timestamp" -}}
+		protocol.TimeValue{V: v, Format: {{ $.TimeFormat }} }
+	{{- else if $.IsShapeType "jsonvalue" -}}
+		protocol.JSONValue{V: v {{ if eq $.Location "Header" }}, Base64: true{{ end }} }
+	{{- else if $.IsPayloadStream -}}
+		protocol.{{ $.GoType }}{{ $.MarshalerType }}{V:v}
+	{{- else -}}
+		protocol.{{ $.GoType }}{{ $.MarshalerType }}(v)
+	{{- end -}}
+{{- end }}
+
+{{ define "metadata" -}}
+	protocol.Metadata{
+		{{- if $.IsFlattened -}}
+			Flatten: true,
+		{{- end -}}
+
+		{{- if $.HasAttributes -}}
+			Attributes: attrs,
+		{{- end -}}
+
+		{{- if $.XMLNamespacePrefix -}}
+			XMLNamespacePrefix: "{{ $.XMLNamespacePrefix }}",
+		{{- end -}}
+
+		{{- if $.XMLNamespaceURI -}}
+			XMLNamespaceURI: "{{ $.XMLNamespaceURI }}",
+		{{- end -}}
+
+		{{- if $.ListLocationName -}}
+			ListLocationName: "{{ $.ListLocationName }}",
+		{{- end -}}
+
+		{{- if $.MapLocationNameKey -}}
+			MapLocationNameKey: "{{ $.MapLocationNameKey }}",
+		{{- end -}}
+
+		{{- if $.MapLocationNameValue -}}
+			MapLocationNameValue: "{{ $.MapLocationNameValue }}",
+		{{- end -}}
+	}
+{{- end }}
+
+{{ define "ref value" -}}
+	{{ if $.Ref.UseIndirection }}*{{ end }}s.{{ $.Name }}
+{{- end}}
+
+{{ define "is ref set" -}}
+	{{ $isList := $.IsShapeType "list" -}}
+	{{ $isMap := $.IsShapeType "map" -}}
+	{{- if or $isList $isMap -}}
+		len(s.{{ $.Name }}) > 0
+	{{- else -}}
+		s.{{ $.Name }} != nil
+	{{- end -}}
+{{- end }}
+
+{{ define "attributes" -}}
+	attrs := make([]protocol.Attribute, 0, {{ $.NumAttributes }})
+	// TODO only create array if an attribute value is set
+
+	{{ range $name, $child := $.ChildrenRefs -}}
+		{{ if $child.Ref.XMLAttribute -}}
+			if s.{{ $.Name }}.{{ $name }} != nil {
+				v := {{ if $child.Ref.UseIndirection }}*{{ end }}s.{{ $.Name }}.{{ $name }}
+				attrs = append(attrs, protocol.Attribute{Name: "{{ $child.LocationName }}", Value: {{ template "marshaler" $child }}, Meta: {{ template "metadata" $child }}})
+			}
+		{{- end }}
+	{{- end }}
+{{- end }}
+
+{{ define "idempotency token" -}}
+    var {{ $.Name }} string
+	if {{ template "is ref set" $ }} {
+		{{ $.Name }} = {{ template "ref value" $ }}
+	} else {
+		{{ $.Name }} = protocol.GetIdempotencyToken()
+	}
+{{- end }}
+`))
+
+type marshalShapeRef struct {
+	Name    string
+	Ref     *ShapeRef
+	Context *Shape
+}
+
+func (r marshalShapeRef) ListMemberRef() marshalShapeRef {
+	return marshalShapeRef{
+		Name:    r.Name + "ListMember",
+		Ref:     &r.Ref.Shape.MemberRef,
+		Context: r.Ref.Shape,
+	}
+}
+func (r marshalShapeRef) MapValueRef() marshalShapeRef {
+	return marshalShapeRef{
+		Name:    r.Name + "MapValue",
+		Ref:     &r.Ref.Shape.ValueRef,
+		Context: r.Ref.Shape,
+	}
+}
+func (r marshalShapeRef) ChildrenRefs() map[string]marshalShapeRef {
+	children := map[string]marshalShapeRef{}
+
+	for name, ref := range r.Ref.Shape.MemberRefs {
+		children[name] = marshalShapeRef{
+			Name:    name,
+			Ref:     ref,
+			Context: r.Ref.Shape,
+		}
+	}
+
+	return children
+}
+func (r marshalShapeRef) IsShapeType(typ string) bool {
+	return r.Ref.Shape.Type == typ
+}
+func (r marshalShapeRef) IsPayloadStream() bool {
+	return r.Context.IsRefPayloadReader(r.Name, r.Ref)
+}
+func (r marshalShapeRef) MarshalerType() string {
+	switch r.Ref.Shape.Type {
+	case "list":
+		return "List"
+	case "map":
+		return "Map"
+	case "structure":
+		return "Fields"
+	default:
+		// Streams have a special case
+		if r.Context.IsRefPayload(r.Name) {
+			return "Stream"
+		}
+		return "Value"
+	}
+}
+func (r marshalShapeRef) EncodeHelperName(typ string) string {
+	if r.Ref.Shape.Type != typ {
+		return ""
+	}
+
+	var memberRef marshalShapeRef
+	switch r.Ref.Shape.Type {
+	case "map":
+		memberRef = r.MapValueRef()
+	case "list":
+		memberRef = r.ListMemberRef()
+	default:
+		return ""
+	}
+
+	switch memberRef.Ref.Shape.Type {
+	case "list", "map":
+		return ""
+	case "structure":
+		shapeName := memberRef.Ref.Shape.ShapeName
+		return "encode" + shapeName + strings.Title(typ) + "(v)"
+	default:
+		return "protocol.Encode" + memberRef.GoType() + strings.Title(typ) + "(v)"
+	}
+}
+func (r marshalShapeRef) GoType() string {
+	switch r.Ref.Shape.Type {
+	case "boolean":
+		return "Bool"
+	case "string", "character":
+		return "String"
+	case "integer", "long":
+		return "Int64"
+	case "float", "double":
+		return "Float64"
+	case "timestamp":
+		return "Time"
+	case "jsonvalue":
+		return "JSONValue"
+	case "blob":
+		if r.Context.IsRefPayloadReader(r.Name, r.Ref) {
+			if strings.HasSuffix(r.Context.ShapeName, "Output") {
+				return "ReadCloser"
+			}
+			return "ReadSeeker"
+		}
+		return "Bytes"
+	default:
+		panic(fmt.Sprintf("unknown marshal shape ref type, %s", r.Ref.Shape.Type))
+	}
+}
+func (r marshalShapeRef) Location() string {
+	var loc string
+	if l := r.Ref.Location; len(l) > 0 {
+		loc = l
+	} else if l := r.Ref.Shape.Location; len(l) > 0 {
+		loc = l
+	}
+
+	switch loc {
+	case "querystring":
+		return "Query"
+	case "header":
+		return "Header"
+	case "headers": // headers means key is header prefix
+		return "Headers"
+	case "uri":
+		return "Path"
+	case "StatusCode":
+		return "StatusCode"
+	default:
+		if len(loc) != 0 {
+			panic(fmt.Sprintf("unknown marshal shape ref location, %s", loc))
+		}
+
+		if r.Context.IsRefPayload(r.Name) {
+			return "Payload"
+		}
+
+		return "Body"
+	}
+}
+func (r marshalShapeRef) LocationName() string {
+	if l := r.Ref.QueryName; len(l) > 0 {
+		// Special case for EC2 query
+		return l
+	}
+
+	locName := r.Name
+	if l := r.Ref.LocationName; len(l) > 0 {
+		locName = l
+	} else if l := r.Ref.Shape.LocationName; len(l) > 0 {
+		locName = l
+	}
+
+	return locName
+}
+func (r marshalShapeRef) IsFlattened() bool {
+	return r.Ref.Flattened || r.Ref.Shape.Flattened
+}
+func (r marshalShapeRef) XMLNamespacePrefix() string {
+	if v := r.Ref.XMLNamespace.Prefix; len(v) != 0 {
+		return v
+	}
+	return r.Ref.Shape.XMLNamespace.Prefix
+}
+func (r marshalShapeRef) XMLNamespaceURI() string {
+	if v := r.Ref.XMLNamespace.URI; len(v) != 0 {
+		return v
+	}
+	return r.Ref.Shape.XMLNamespace.URI
+}
+func (r marshalShapeRef) ListLocationName() string {
+	if v := r.Ref.Shape.MemberRef.LocationName; len(v) > 0 {
+		if !(r.Ref.Shape.Flattened || r.Ref.Flattened) {
+			return v
+		}
+	}
+	return ""
+}
+func (r marshalShapeRef) MapLocationNameKey() string {
+	return r.Ref.Shape.KeyRef.LocationName
+}
+func (r marshalShapeRef) MapLocationNameValue() string {
+	return r.Ref.Shape.ValueRef.LocationName
+}
+func (r marshalShapeRef) HasAttributes() bool {
+	for _, ref := range r.Ref.Shape.MemberRefs {
+		if ref.XMLAttribute {
+			return true
+		}
+	}
+	return false
+}
+func (r marshalShapeRef) NumAttributes() (n int) {
+	for _, ref := range r.Ref.Shape.MemberRefs {
+		if ref.XMLAttribute {
+			n++
+		}
+	}
+	return n
+}
+func (r marshalShapeRef) IsIdempotencyToken() bool {
+	return r.Ref.IdempotencyToken || r.Ref.Shape.IdempotencyToken
+}
+func (r marshalShapeRef) TimeFormat() string {
+	switch r.Location() {
+	case "Header", "Headers":
+		return "protocol.RFC822TimeFromat"
+	default:
+		switch r.Context.API.Metadata.Protocol {
+		case "json", "rest-json":
+			return "protocol.FormatUnixTime"
+		case "rest-xml", "ec2", "query":
+			return "protocol.ISO8601TimeFormat"
+		default:
+			panic(fmt.Sprintf("unable to determine time format for %s ref", r.Name))
+		}
+	}
+}
+
+// UnmarshalShapeGoCode renders the shape's UnmarshalAWS method with unmarshalers
+// for each field within the shape. A string is returned of the rendered Go code.
+//
+// Will panic if error.
+func UnmarshalShapeGoCode(s *Shape) string {
+	w := &bytes.Buffer{}
+	if err := unmarshalShapeTmpl.Execute(w, s); err != nil {
+		panic(fmt.Sprintf("failed to render shape's fields unmarshaler, %v", err))
+	}
+
+	return w.String()
+}
+
+var unmarshalShapeTmpl = template.Must(template.New("unmarshalShapeTmpl").Funcs(
+	template.FuncMap{
+		"UnmarshalShapeRefGoCode": UnmarshalShapeRefGoCode,
+	},
+).Parse(`
+{{ $shapeName := $.ShapeName -}}
+
+// UnmarshalAWS decodes the AWS API shape using the passed in protocol decoder.
+func (s *{{ $shapeName }}) UnmarshalAWS(d protocol.FieldDecoder) {
+	{{ range $name, $ref := $.MemberRefs -}}
+		{{ UnmarshalShapeRefGoCode $name $ref $ }}
+	{{ end }}
+}
+
+{{ if $.UsedInList -}}
+func decode{{ $shapeName }}List(vsp *[]*{{ $shapeName }}) func(int, protocol.ListDecoder) {
+	return func(n int, ld protocol.ListDecoder) {
+		vs := make([]{{ $shapeName }}, n)
+		*vsp = make([]*{{ $shapeName }}, n)
+		for i := 0; i < n; i++ {
+			ld.ListGetUnmarshaler(&vs[i])
+			(*vsp)[i] = &vs[i]
+		}
+	}
+}
+{{- end }}
+
+{{ if $.UsedInMap -}}
+func decode{{ $shapeName }}Map(vsp *map[string]*{{ $shapeName }}) func([]string, protocol.MapDecoder) {
+	return func(ks []string, md protocol.MapDecoder) {
+		vs := make(map[string]*{{ $shapeName }}, n)
+		for _, k range ks {
+			v := &{{ $shapeName }}{}
+			md.MapGetUnmarshaler(k, v)
+			vs[k] = v
+		}
+	}
+}
+{{- end }}
+`))
+
+// UnmarshalShapeRefGoCode generates the Go code to unmarshal an API shape.
+func UnmarshalShapeRefGoCode(refName string, ref *ShapeRef, context *Shape) string {
+	if ref.XMLAttribute {
+		return "// Skipping " + refName + " XML Attribute."
+	}
+
+	mRef := marshalShapeRef{
+		Name:    refName,
+		Ref:     ref,
+		Context: context,
+	}
+
+	switch mRef.Location() {
+	case "Path":
+		return "// ignoring invalid decode state, Path. " + refName
+	case "Query":
+		return "// ignoring invalid decode state, Query. " + refName
+	}
+
+	w := &bytes.Buffer{}
+	if err := unmarshalShapeRefTmpl.ExecuteTemplate(w, "decode", mRef); err != nil {
+		panic(fmt.Sprintf("failed to decode shape ref, %s, %v", ref.Shape.Type, err))
+	}
+
+	return w.String()
+}
+
+var unmarshalShapeRefTmpl = template.Must(template.New("unmarshalShapeRefTmpl").Parse(`
+//  Decode {{ $.Name }} {{ $.GoType }} {{ $.MarshalerType }} to {{ $.Location }} at {{ $.LocationName }}
+`))

--- a/private/model/api/shape_marshal.go
+++ b/private/model/api/shape_marshal.go
@@ -195,7 +195,6 @@ var marshalShapeRefTmpl = template.Must(template.New("marshalShapeRefTmpl").Pars
 
 {{ define "attributes" -}}
 	attrs := make([]protocol.Attribute, 0, {{ $.NumAttributes }})
-	// TODO only create array if an attribute value is set
 
 	{{ range $name, $child := $.ChildrenRefs -}}
 		{{ if $child.Ref.XMLAttribute -}}

--- a/private/protocol/decode.go
+++ b/private/protocol/decode.go
@@ -1,0 +1,112 @@
+package protocol
+
+import (
+	"io"
+	"time"
+)
+
+// FieldUnmarshaler used by protocol unmarshaling to unmarshal a type's nested fields.
+type FieldUnmarshaler interface {
+	UnmarshalFields(FieldDecoder) error
+}
+
+// A FieldValue is a value that will be unmarshalered from the decoder to
+// a concrete value.
+type FieldValue interface{}
+
+// ListDecoder provides the interface for unmarshaling list elements from the
+// underlying decoder.
+type ListDecoder interface {
+	ListGet(fn func(v FieldValue))
+	ListGetList(fn func(n int, ld ListDecoder))
+	ListGetMap(fn func(ks []string, md MapDecoder))
+	ListGetFields(m FieldUnmarshaler)
+}
+
+// MapDecoder provides the interface for unmarshaling map elements from the
+// underlying decoder. The map key the value is retrieved from is k.
+type MapDecoder interface {
+	MapGet(k string, fn func(v FieldValue))
+	MapGetList(k string, fn func(n int, ld ListDecoder))
+	MapGetMap(k string, fn func(ks []string, fd FieldDecoder))
+	MapGetFields(k string, fn func() FieldUnmarshaler)
+}
+
+// FieldDecoder provides the interface for unmarshaling values from a type. The
+// value is retrieved from the location referenced to by the Target. The field
+// name that the value is retrieved from is k.
+type FieldDecoder interface {
+	Get(t Target, k string, fn func(v FieldValue), meta Metadata)
+	GetList(t Target, k string, fn func(n int, ld ListDecoder), meta Metadata)
+	GetMap(t Target, k string, fn func(ks []string, md MapDecoder), meta Metadata)
+	GetFields(t Target, k string, fn func() FieldUnmarshaler, meta Metadata)
+}
+
+// DecodeBool converts a FieldValue into a bool pointer, updating the value
+// pointed to by the input.
+func DecodeBool(vp **bool) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(bool)
+		**vp = v.(bool)
+	}
+}
+
+// DecodeString converts a FieldValue into a string pointer, updating the value
+// pointed to by the input.
+func DecodeString(vp **string) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(string)
+		**vp = v.(string)
+	}
+}
+
+// DecodeInt64 converts a FieldValue into an int64 pointer, updating the value
+// pointed to by the input.
+func DecodeInt64(vp **int64) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(int64)
+		**vp = v.(int64)
+	}
+}
+
+// DecodeFloat64 converts a FieldValue into a float64 pointer, updating the value
+// pointed to by the input.
+func DecodeFloat64(vp **float64) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(float64)
+		**vp = v.(float64)
+	}
+}
+
+// DecodeTime converts a FieldValue into a time pointer, updating the value
+// pointed to by the input.
+func DecodeTime(vp **time.Time) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(time.Time)
+		**vp = v.(time.Time)
+	}
+}
+
+// DecodeBytes converts a FieldValue into a bytes slice, updating the value
+// pointed to by the input.
+func DecodeBytes(vp *[]byte) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = v.([]byte)
+	}
+}
+
+// DecodeReadCloser converts a FieldValue into an io.ReadCloser, updating the value
+// pointed to by the input.
+func DecodeReadCloser(vp *io.ReadCloser) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = v.(io.ReadCloser)
+	}
+}
+
+// DecodeReadSeeker converts a FieldValue into an io.ReadCloser, updating the value
+// pointed to by the input.
+func DecodeReadSeeker(vp *io.ReadSeeker) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = v.(io.ReadSeeker)
+	}
+}

--- a/private/protocol/encode.go
+++ b/private/protocol/encode.go
@@ -1,0 +1,148 @@
+package protocol
+
+import (
+	"io"
+	"time"
+)
+
+// A FieldMarshaler interface is used to marshal struct fields when encoding.
+type FieldMarshaler interface {
+	MarshalFields(FieldEncoder) error
+}
+
+// ValueMarshaler provides a generic type for all encoding field values to be
+// passed into a encoder's methods with.
+type ValueMarshaler interface {
+	MarshalValue() (string, error)
+	//	MarshalValueBuf([]byte) ([]byte, error)
+}
+
+// A StreamMarshaler interface is used to marshal a stream when encoding.
+type StreamMarshaler interface {
+	MarshalStream() (io.ReadSeeker, error)
+}
+
+// A ListEncoder provides the interface for encoders that will encode List elements.
+type ListEncoder interface {
+	ListAddValue(v ValueMarshaler)
+	ListAddList(fn func(ListEncoder))
+	ListAddMap(fn func(MapEncoder))
+	ListAddFields(m FieldMarshaler)
+}
+
+// A MapEncoder provides the interface for encoders that will encode map elements.
+type MapEncoder interface {
+	MapSetValue(k string, v ValueMarshaler)
+	MapSetList(k string, fn func(ListEncoder))
+	MapSetMap(k string, fn func(MapEncoder))
+	MapSetFields(k string, m FieldMarshaler)
+}
+
+// A FieldEncoder provides the interface for encoding struct field members.
+type FieldEncoder interface {
+	SetValue(t Target, k string, v ValueMarshaler, meta Metadata)
+	SetStream(t Target, k string, v StreamMarshaler, meta Metadata)
+	SetList(t Target, k string, fn func(ListEncoder), meta Metadata)
+	SetMap(t Target, k string, fn func(MapEncoder), meta Metadata)
+	SetFields(t Target, k string, m FieldMarshaler, meta Metadata)
+}
+
+// EncodeStringList returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeStringList(vs []*string) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(StringValue(*v))
+		}
+	}
+}
+
+// EncodeStringMap returns a function that will add the map's values to
+// a map Encoder.
+func EncodeStringMap(vs map[string]*string) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, StringValue(*v))
+		}
+	}
+}
+
+// EncodeInt64List returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeInt64List(vs []*int64) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(Int64Value(*v))
+		}
+	}
+}
+
+// EncodeInt64Map returns a function that will add the map's values to
+// a map Encoder.
+func EncodeInt64Map(vs map[string]*int64) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, Int64Value(*v))
+		}
+	}
+}
+
+// EncodeFloat64List returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeFloat64List(vs []*float64) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(Float64Value(*v))
+		}
+	}
+}
+
+// EncodeFloat64Map returns a function that will add the map's values to
+// a map Encoder.
+func EncodeFloat64Map(vs map[string]*float64) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, Float64Value(*v))
+		}
+	}
+}
+
+// EncodeBoolList returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeBoolList(vs []*bool) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(BoolValue(*v))
+		}
+	}
+}
+
+// EncodeBoolMap returns a function that will add the map's values to
+// a map Encoder.
+func EncodeBoolMap(vs map[string]*bool) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, BoolValue(*v))
+		}
+	}
+}
+
+// EncodeTimeList returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeTimeList(vs []*time.Time) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(TimeValue{V: *v})
+		}
+	}
+}
+
+// EncodeTimeMap returns a function that will add the map's values to
+// a map Encoder.
+func EncodeTimeMap(vs map[string]*time.Time) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, TimeValue{V: *v})
+		}
+	}
+}

--- a/private/protocol/encode.go
+++ b/private/protocol/encode.go
@@ -14,7 +14,7 @@ type FieldMarshaler interface {
 // passed into a encoder's methods with.
 type ValueMarshaler interface {
 	MarshalValue() (string, error)
-	//	MarshalValueBuf([]byte) ([]byte, error)
+	MarshalValueBuf([]byte) ([]byte, error)
 }
 
 // A StreamMarshaler interface is used to marshal a stream when encoding.

--- a/private/protocol/fields.go
+++ b/private/protocol/fields.go
@@ -1,0 +1,122 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+// BoolValue provies encoding of bool for AWS protocols.
+type BoolValue bool
+
+// MarshalValue formats the value into a string for encoding.
+func (v BoolValue) MarshalValue() (string, error) {
+	return strconv.FormatBool(bool(v)), nil
+}
+
+// BytesValue provies encoding of string for AWS protocols.
+type BytesValue string
+
+// MarshalValue formats the value into a string for encoding.
+func (v BytesValue) MarshalValue() (string, error) {
+	return base64.StdEncoding.EncodeToString([]byte(v)), nil
+}
+
+// StringValue provies encoding of string for AWS protocols.
+type StringValue string
+
+// MarshalValue formats the value into a string for encoding.
+func (v StringValue) MarshalValue() (string, error) {
+	return string(v), nil
+}
+
+// Int64Value provies encoding of int64 for AWS protocols.
+type Int64Value int64
+
+// MarshalValue formats the value into a string for encoding.
+func (v Int64Value) MarshalValue() (string, error) {
+	return strconv.FormatInt(int64(v), 10), nil
+}
+
+// Float64Value provies encoding of float64 for AWS protocols.
+type Float64Value float64
+
+// MarshalValue formats the value into a string for encoding.
+func (v Float64Value) MarshalValue() (string, error) {
+	return strconv.FormatFloat(float64(v), 'f', -1, 64), nil
+}
+
+// JSONValue provies encoding of aws.JSONValues for AWS protocols.
+type JSONValue struct {
+	V      aws.JSONValue
+	Base64 bool
+}
+
+// MarshalValue formats the value into a string for encoding.
+func (v JSONValue) MarshalValue() (string, error) {
+	b, err := json.Marshal(v.V)
+	if err != nil {
+		return "", err
+	}
+
+	if v.Base64 {
+		return base64.StdEncoding.EncodeToString(b), nil
+	}
+
+	return string(b), nil
+}
+
+// Time formats for protocol time fields.
+const (
+	ISO8601TimeFormat = "2006-01-02T15:04:05Z"         // ISO 8601 formated time.
+	RFC822TimeFromat  = "Mon, 2 Jan 2006 15:04:05 GMT" // RFC822 formatted time.
+	UnixTimeFormat    = "unix time format"             // Special case for Unix time
+)
+
+// TimeValue provies encoding of time.Time for AWS protocols.
+type TimeValue struct {
+	V      time.Time
+	Format string
+}
+
+// MarshalValue formats the value into a string givin a format for encoding.
+func (v TimeValue) MarshalValue() (string, error) {
+	t := time.Time(v.V)
+
+	if v.Format == UnixTimeFormat {
+		return strconv.FormatInt(t.UTC().Unix(), 10), nil
+	}
+	return t.UTC().Format(v.Format), nil
+}
+
+// A ReadSeekerStream wrapps an io.ReadSeeker to be used as a StreamMarshaler.
+type ReadSeekerStream struct {
+	V io.ReadSeeker
+}
+
+// MarshalStream returns the wrapped io.ReadSeeker for encoding.
+func (v ReadSeekerStream) MarshalStream() (io.ReadSeeker, error) {
+	return v.V, nil
+}
+
+// A BytesStream aliases a byte slice to be used as a StreamMarshaler.
+type BytesStream []byte
+
+// MarshalStream marshals a byte slice into an io.ReadSeeker for encoding.
+func (v BytesStream) MarshalStream() (io.ReadSeeker, error) {
+	return bytes.NewReader([]byte(v)), nil
+}
+
+// A StringStream aliases a string to be used as a StreamMarshaler.
+type StringStream string
+
+// MarshalStream marshals a string into an io.ReadSeeker for encoding.
+func (v StringStream) MarshalStream() (io.ReadSeeker, error) {
+	return strings.NewReader(string(v)), nil
+}

--- a/private/protocol/header_encoder.go
+++ b/private/protocol/header_encoder.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"fmt"
 	"net/http"
 )
 
@@ -63,7 +64,9 @@ func (e *HeaderMapEncoder) MapSetMap(k string, fn func(me MapEncoder)) {
 }
 
 // MapSetFields Is not implemented, query map of FieldMarshaler is undefined.
-func (e *HeaderMapEncoder) MapSetFields(k string, m FieldMarshaler) {}
+func (e *HeaderMapEncoder) MapSetFields(k string, m FieldMarshaler) {
+	e.Err = fmt.Errorf("header map encoder MapSetFields not supported, %s", k)
+}
 
 // HeaderListEncoder will encode list values nested into a header key.
 type HeaderListEncoder struct {
@@ -88,10 +91,16 @@ func (e *HeaderListEncoder) ListAddValue(v ValueMarshaler) {
 }
 
 // ListAddList Is not implemented, header list of list is undefined.
-func (e *HeaderListEncoder) ListAddList(fn func(ListEncoder)) {}
+func (e *HeaderListEncoder) ListAddList(fn func(ListEncoder)) {
+	e.Err = fmt.Errorf("header list encoder ListAddList not supported, %s", e.Key)
+}
 
 // ListAddMap Is not implemented, header list of map is undefined.
-func (e *HeaderListEncoder) ListAddMap(fn func(MapEncoder)) {}
+func (e *HeaderListEncoder) ListAddMap(fn func(MapEncoder)) {
+	e.Err = fmt.Errorf("header list encoder ListAddMap not supported, %s", e.Key)
+}
 
 // ListAddFields Is not implemented, query list of FieldMarshaler is undefined.
-func (e *HeaderListEncoder) ListAddFields(m FieldMarshaler) {}
+func (e *HeaderListEncoder) ListAddFields(m FieldMarshaler) {
+	e.Err = fmt.Errorf("header list encoder ListAddFields not supported, %s", e.Key)
+}

--- a/private/protocol/header_encoder.go
+++ b/private/protocol/header_encoder.go
@@ -1,0 +1,97 @@
+package protocol
+
+import (
+	"net/http"
+)
+
+// HeaderMapEncoder builds a map valu
+type HeaderMapEncoder struct {
+	Prefix string
+	Header http.Header
+	Err    error
+}
+
+// MapSetValue adds a single value to the header.
+func (e *HeaderMapEncoder) MapSetValue(k string, v ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	str, err := v.MarshalValue()
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	e.Header.Set(k, str)
+}
+
+// MapSetList executes the passed in callback with a list encoder based on
+// the context of this HeaderMapEncoder.
+func (e *HeaderMapEncoder) MapSetList(k string, fn func(le ListEncoder)) {
+	if e.Err != nil {
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	nested := HeaderListEncoder{Key: k, Header: e.Header}
+	fn(&nested)
+	e.Err = nested.Err
+}
+
+// MapSetMap sets the header element with nested maps appending the
+// passed in k to the prefix if one was set.
+func (e *HeaderMapEncoder) MapSetMap(k string, fn func(me MapEncoder)) {
+	if e.Err != nil {
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	nested := HeaderMapEncoder{Prefix: k, Header: e.Header}
+	fn(&nested)
+	e.Err = nested.Err
+}
+
+// MapSetFields Is not implemented, query map of FieldMarshaler is undefined.
+func (e *HeaderMapEncoder) MapSetFields(k string, m FieldMarshaler) {}
+
+// HeaderListEncoder will encode list values nested into a header key.
+type HeaderListEncoder struct {
+	Key    string
+	Header http.Header
+	Err    error
+}
+
+// ListAddValue encodes an individual list value into the header.
+func (e *HeaderListEncoder) ListAddValue(v ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	str, err := v.MarshalValue()
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	e.Header.Add(e.Key, str)
+}
+
+// ListAddList Is not implemented, header list of list is undefined.
+func (e *HeaderListEncoder) ListAddList(fn func(ListEncoder)) {}
+
+// ListAddMap Is not implemented, header list of map is undefined.
+func (e *HeaderListEncoder) ListAddMap(fn func(MapEncoder)) {}
+
+// ListAddFields Is not implemented, query list of FieldMarshaler is undefined.
+func (e *HeaderListEncoder) ListAddFields(m FieldMarshaler) {}

--- a/private/protocol/metadata.go
+++ b/private/protocol/metadata.go
@@ -1,0 +1,24 @@
+package protocol
+
+// An Attribute is a FieldValue that resides within the imediant context of
+// another field. Such as XML attribute for tags.
+type Attribute struct {
+	Name  string
+	Value ValueMarshaler
+	Meta  Metadata
+}
+
+// Metadata is a collection of configuration flags for encoders to render the
+// output.
+type Metadata struct {
+	Attributes []Attribute
+
+	Flatten bool
+
+	ListLocationName     string
+	MapLocationNameKey   string
+	MapLocationNameValue string
+
+	XMLNamespacePrefix string
+	XMLNamespaceURI    string
+}

--- a/private/protocol/path_replace.go
+++ b/private/protocol/path_replace.go
@@ -1,0 +1,136 @@
+package protocol
+
+import (
+	"bytes"
+	"fmt"
+)
+
+const (
+	uriTokenStart = '{'
+	uriTokenStop  = '}'
+	uriTokenSkip  = '+'
+)
+
+func bufCap(b []byte, n int) []byte {
+	if cap(b) < n {
+		return make([]byte, 0, n)
+	}
+
+	return b[0:0]
+}
+
+// PathReplace replaces path elements using field buffers
+type PathReplace struct {
+	// May mutate path slice
+	path     []byte
+	rawPath  []byte
+	fieldBuf []byte
+}
+
+// NewPathReplace creats a built PathReplace value that can be used to replace
+// path elements.
+func NewPathReplace(path string) PathReplace {
+	return PathReplace{
+		path:    []byte(path),
+		rawPath: []byte(path),
+	}
+}
+
+// Encode returns an unescaped path, and escaped path.
+func (r *PathReplace) Encode() (path string, rawPath string) {
+	return string(r.path), string(r.rawPath)
+}
+
+// ReplaceElement replaces a single element in the path string.
+func (r *PathReplace) ReplaceElement(key, val string) (err error) {
+	r.path, r.fieldBuf, err = replacePathElement(r.path, r.fieldBuf, key, val, false)
+	r.rawPath, r.fieldBuf, err = replacePathElement(r.rawPath, r.fieldBuf, key, val, true)
+	return err
+}
+
+func replacePathElement(path, fieldBuf []byte, key, val string, escape bool) ([]byte, []byte, error) {
+	fieldBuf = bufCap(fieldBuf, len(key)+3) // { <key> [+] }
+	fieldBuf = append(fieldBuf, uriTokenStart)
+	fieldBuf = append(fieldBuf, key...)
+
+	start := bytes.Index(path, fieldBuf)
+	end := start + len(fieldBuf)
+	if start < 0 || len(path[end:]) == 0 {
+		// TODO what to do about error?
+		return path, fieldBuf, fmt.Errorf("invalid path index, start=%d,end=%d. %s", start, end, path)
+	}
+
+	encodeSep := true
+	if path[end] == uriTokenSkip {
+		// '+' token means do not escape slashes
+		encodeSep = false
+		end++
+	}
+
+	if escape {
+		val = escapePath(val, encodeSep)
+	}
+
+	if path[end] != uriTokenStop {
+		return path, fieldBuf, fmt.Errorf("invalid path element, does not contain token stop, %s", path)
+	}
+	end++
+
+	fieldBuf = bufCap(fieldBuf, len(val))
+	fieldBuf = append(fieldBuf, val...)
+
+	keyLen := end - start
+	valLen := len(fieldBuf)
+
+	if keyLen == valLen {
+		copy(path[start:], fieldBuf)
+		return path, fieldBuf, nil
+	}
+
+	newLen := len(path) + (valLen - keyLen)
+	if len(path) < newLen {
+		path = path[:cap(path)]
+	}
+	if cap(path) < newLen {
+		newURI := make([]byte, newLen)
+		copy(newURI, path)
+		path = newURI
+	}
+
+	// shift
+	copy(path[start+valLen:], path[end:])
+	path = path[:newLen]
+	copy(path[start:], fieldBuf)
+
+	return path, fieldBuf, nil
+}
+
+// copied from rest.EscapePath
+// escapes part of a URL path in Amazon style
+func escapePath(path string, encodeSep bool) string {
+	var buf bytes.Buffer
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if noEscape[c] || (c == '/' && !encodeSep) {
+			buf.WriteByte(c)
+		} else {
+			fmt.Fprintf(&buf, "%%%02X", c)
+		}
+	}
+	return buf.String()
+}
+
+var noEscape [256]bool
+
+func init() {
+	for i := 0; i < len(noEscape); i++ {
+		// AWS expects every character except these to be escaped
+		noEscape[i] = (i >= 'A' && i <= 'Z') ||
+			(i >= 'a' && i <= 'z') ||
+			(i >= '0' && i <= '9') ||
+			i == '-' ||
+			i == '.' ||
+			i == '_' ||
+			i == '~'
+	}
+}

--- a/private/protocol/path_replace_test.go
+++ b/private/protocol/path_replace_test.go
@@ -1,0 +1,74 @@
+package protocol
+
+import "testing"
+
+func TestPathReplace(t *testing.T) {
+	cases := []struct {
+		Orig, ExpPath, ExpRawPath, Key, Val string
+	}{
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/123/{key+}",
+			ExpRawPath: "/123/{key+}",
+			Key:        "bucket", Val: "123",
+		},
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/{bucket}/abc",
+			ExpRawPath: "/{bucket}/abc",
+			Key:        "key", Val: "abc",
+		},
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/{bucket}/a/b/c",
+			ExpRawPath: "/{bucket}/a/b/c",
+			Key:        "key", Val: "a/b/c",
+		},
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/1/2/3/{key+}",
+			ExpRawPath: "/1%2F2%2F3/{key+}",
+			Key:        "bucket", Val: "1/2/3",
+		},
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/reallylongvaluegoesheregrowingarray/{key+}",
+			ExpRawPath: "/reallylongvaluegoesheregrowingarray/{key+}",
+			Key:        "bucket", Val: "reallylongvaluegoesheregrowingarray",
+		},
+	}
+
+	for i, c := range cases {
+		r := NewPathReplace(c.Orig)
+
+		r.ReplaceElement(c.Key, c.Val)
+		path, rawPath := r.Encode()
+		if e, a := c.ExpPath, path; a != e {
+			t.Errorf("%d, expect uri path to be %q got %q", i, e, a)
+		}
+		if e, a := c.ExpRawPath, rawPath; a != e {
+			t.Errorf("%d, expect uri raw path to be %q got %q", i, e, a)
+		}
+	}
+}
+
+func TestPathReplace_Multiple(t *testing.T) {
+	const (
+		origURI    = "/{bucket}/{key+}"
+		expPath    = "/something/123/other/thing"
+		expRawPath = "/something%2F123/other/thing"
+	)
+
+	r := NewPathReplace(origURI)
+
+	r.ReplaceElement("bucket", "something/123")
+	r.ReplaceElement("key", "other/thing")
+
+	path, rawPath := r.Encode()
+	if e, a := expPath, path; a != e {
+		t.Errorf("expect uri path to be %q got %q", e, a)
+	}
+	if e, a := expRawPath, rawPath; a != e {
+		t.Errorf("expect uri path to be %q got %q", e, a)
+	}
+}

--- a/private/protocol/query_encoder.go
+++ b/private/protocol/query_encoder.go
@@ -1,0 +1,94 @@
+package protocol
+
+import "net/url"
+
+// QueryMapEncoder builds a query string.
+type QueryMapEncoder struct {
+	Prefix string
+	Query  url.Values
+	Err    error
+}
+
+// MapSetValue adds a single value to the query.
+func (e *QueryMapEncoder) MapSetValue(k string, v ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	str, err := v.MarshalValue()
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	e.Query.Add(k, str)
+}
+
+// MapSetList executes the passed in callback with a list encoder based on
+// the context of this QueryMapEncoder.
+func (e *QueryMapEncoder) MapSetList(k string, fn func(le ListEncoder)) {
+	if e.Err != nil {
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	nested := QueryListEncoder{Key: k, Query: e.Query}
+	fn(&nested)
+	e.Err = nested.Err
+}
+
+// MapSetMap sets the query string element with nested maps appending the
+// passed in k to the prefix if one was set.
+func (e *QueryMapEncoder) MapSetMap(k string, fn func(me MapEncoder)) {
+	if e.Err != nil {
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	nested := QueryMapEncoder{Prefix: k, Query: e.Query}
+	e.Err = nested.Err
+}
+
+// MapSetFields Is not implemented, query map of map is undefined.
+func (e *QueryMapEncoder) MapSetFields(k string, m FieldMarshaler) {}
+
+// QueryListEncoder will encode list values nested into a query key.
+type QueryListEncoder struct {
+	Key   string
+	Query url.Values
+	Err   error
+}
+
+// ListAddValue encodes an individual list value into the querystring.
+func (e *QueryListEncoder) ListAddValue(v ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	str, err := v.MarshalValue()
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	e.Query.Add(e.Key, str)
+}
+
+// ListAddList Is not implemented, query list of list is undefined.
+func (e *QueryListEncoder) ListAddList(fn func(le ListEncoder)) {}
+
+// ListAddMap Is not implemented, query list of map is undefined.
+func (e *QueryListEncoder) ListAddMap(fn func(fe MapEncoder)) {}
+
+// ListAddFields Is not implemented, query list of FieldMarshaler is undefined.
+func (e *QueryListEncoder) ListAddFields(m FieldMarshaler) {}

--- a/private/protocol/query_encoder.go
+++ b/private/protocol/query_encoder.go
@@ -1,6 +1,9 @@
 package protocol
 
-import "net/url"
+import (
+	"fmt"
+	"net/url"
+)
 
 // QueryMapEncoder builds a query string.
 type QueryMapEncoder struct {
@@ -60,7 +63,9 @@ func (e *QueryMapEncoder) MapSetMap(k string, fn func(me MapEncoder)) {
 }
 
 // MapSetFields Is not implemented, query map of map is undefined.
-func (e *QueryMapEncoder) MapSetFields(k string, m FieldMarshaler) {}
+func (e *QueryMapEncoder) MapSetFields(k string, m FieldMarshaler) {
+	e.Err = fmt.Errorf("query map encoder MapSetFields not supported, %s", e.Prefix)
+}
 
 // QueryListEncoder will encode list values nested into a query key.
 type QueryListEncoder struct {
@@ -85,10 +90,16 @@ func (e *QueryListEncoder) ListAddValue(v ValueMarshaler) {
 }
 
 // ListAddList Is not implemented, query list of list is undefined.
-func (e *QueryListEncoder) ListAddList(fn func(le ListEncoder)) {}
+func (e *QueryListEncoder) ListAddList(fn func(le ListEncoder)) {
+	e.Err = fmt.Errorf("query list encoder ListAddList not supported, %s", e.Key)
+}
 
 // ListAddMap Is not implemented, query list of map is undefined.
-func (e *QueryListEncoder) ListAddMap(fn func(fe MapEncoder)) {}
+func (e *QueryListEncoder) ListAddMap(fn func(fe MapEncoder)) {
+	e.Err = fmt.Errorf("query list encoder ListAddMap not supported, %s", e.Key)
+}
 
 // ListAddFields Is not implemented, query list of FieldMarshaler is undefined.
-func (e *QueryListEncoder) ListAddFields(m FieldMarshaler) {}
+func (e *QueryListEncoder) ListAddFields(m FieldMarshaler) {
+	e.Err = fmt.Errorf("query list encoder ListAddFields not supported, %s", e.Key)
+}

--- a/private/protocol/rest/encode.go
+++ b/private/protocol/rest/encode.go
@@ -1,0 +1,150 @@
+package rest
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+// An Encoder provides encoding of REST URI path, query, and header components
+// of an HTTP request. Can also encode a stream as the payload.
+//
+// Does not support SetFields.
+type Encoder struct {
+	req *http.Request
+
+	path protocol.PathReplace
+
+	query  url.Values
+	header http.Header
+
+	payload io.ReadSeeker
+
+	err error
+}
+
+// NewEncoder creates a new encoder from the passed in request. All query and
+// header values will be added on top of the request's existing values. Overwriting
+// duplicate values.
+func NewEncoder(req *http.Request) *Encoder {
+	e := &Encoder{
+		req: req,
+
+		path:   protocol.NewPathReplace(req.URL.Path),
+		query:  req.URL.Query(),
+		header: req.Header,
+	}
+
+	return e
+}
+
+// Encode will return the request and body if one was set. If the body
+// payload was not set the io.ReadSeeker will be nil.
+//
+// returns any error if one occured while encoding the API's parameters.
+func (e *Encoder) Encode() (*http.Request, io.ReadSeeker, error) {
+	if e.err != nil {
+		return nil, nil, e.err
+	}
+
+	e.req.URL.Path, e.req.URL.RawPath = e.path.Encode()
+	e.req.URL.RawQuery = e.query.Encode()
+	e.req.Header = e.header
+
+	return e.req, e.payload, nil
+}
+
+// SetValue will set a value to the header, path, query.
+//
+// If the request's method is GET all BodyTarget values will be written to
+// the query string.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	var str string
+	str, e.err = v.MarshalValue()
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.HeaderTarget:
+		e.header.Set(k, str)
+	case protocol.PathTarget:
+		e.path.ReplaceElement(k, str)
+	case protocol.QueryTarget:
+		e.query.Set(k, str)
+	case protocol.BodyTarget:
+		if e.req.Method != "GET" {
+			e.err = fmt.Errorf("body target not supported for rest non-GET methods %s, %s", t, k)
+			return
+		}
+		e.query.Set(k, str)
+	default:
+		e.err = fmt.Errorf("unknown SetValue rest encode target, %s, %s", t, k)
+	}
+}
+
+// SetStream will set the stream to the payload of the request.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		e.payload, e.err = v.MarshalStream()
+	default:
+		e.err = fmt.Errorf("unknown SetStream rest encode target, %s, %s", t, k)
+	}
+}
+
+// SetList will set the nested list values to the header or query.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.QueryTarget:
+		nested := protocol.QueryListEncoder{Key: k, Query: e.query}
+		fn(&nested)
+		e.err = nested.Err
+	case protocol.HeaderTarget:
+		nested := protocol.HeaderListEncoder{Key: k, Header: e.header}
+		fn(&nested)
+		e.err = nested.Err
+	default:
+		e.err = fmt.Errorf("unknown SetList rest encode target, %s, %s", t, k)
+	}
+}
+
+// SetMap will set the nested map values to the header or query.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(fe protocol.MapEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.QueryTarget:
+		nested := protocol.QueryMapEncoder{Query: e.query}
+		fn(&nested)
+		e.err = nested.Err
+	case protocol.HeadersTarget:
+		nested := protocol.HeaderMapEncoder{Prefix: k, Header: e.header}
+		fn(&nested)
+		e.err = nested.Err
+	default:
+		e.err = fmt.Errorf("unknown SetMap rest encode target, %s, %s", t, k)
+	}
+}
+
+// SetFields is not supported for REST encoder.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	e.err = fmt.Errorf("rest encoder SetFields not supported, %s, %s", t, k)
+}

--- a/private/protocol/rest/encode_test.go
+++ b/private/protocol/rest/encode_test.go
@@ -1,0 +1,357 @@
+package rest
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+type shape struct {
+	HeaderValue   *string
+	PathValue     *string
+	QueryValue    *string
+	QueryList     []*string
+	HeadersMap    map[string]*string
+	QueryMap      map[string]*string
+	QueryMapList  map[string][]*string
+	BodyValue     *string
+	PayloadString *string
+	PayloadBytes  []byte
+	PayloadReader io.ReadSeeker
+}
+
+func (s *shape) MarshalAWS(e protocol.FieldEncoder) {
+	if s.HeaderValue != nil {
+		e.SetValue(protocol.HeaderTarget, "header-value", protocol.StringValue(*s.HeaderValue), protocol.Metadata{})
+	}
+	if s.PathValue != nil {
+		e.SetValue(protocol.PathTarget, "key", protocol.StringValue(*s.PathValue), protocol.Metadata{})
+	}
+	if s.QueryValue != nil {
+		e.SetValue(protocol.QueryTarget, "queryKey", protocol.StringValue(*s.QueryValue), protocol.Metadata{})
+	}
+	if len(s.QueryList) > 0 {
+		e.SetList(protocol.QueryTarget, "queryKey", func(le protocol.ListEncoder) {
+			for _, v := range s.QueryList {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.HeadersMap) > 0 {
+		e.SetMap(protocol.HeadersTarget, "prefix-", func(me protocol.MapEncoder) {
+			for k, v := range s.HeadersMap {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.QueryMap) > 0 {
+		e.SetMap(protocol.QueryTarget, "unused", func(me protocol.MapEncoder) {
+			for k, v := range s.QueryMap {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.QueryMapList) > 0 {
+		e.SetMap(protocol.QueryTarget, "unused", func(me protocol.MapEncoder) {
+			for k, v := range s.QueryMapList {
+				me.MapSetList(k, func(le protocol.ListEncoder) {
+					for _, v := range v {
+						le.ListAddValue(protocol.StringValue(*v))
+					}
+				})
+			}
+		}, protocol.Metadata{})
+	}
+	if s.BodyValue != nil {
+		e.SetValue(protocol.BodyTarget, "bodyValue", protocol.StringValue(*s.BodyValue), protocol.Metadata{})
+	}
+	if s.PayloadString != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadString", protocol.StringStream(*s.PayloadString), protocol.Metadata{})
+	}
+	if s.PayloadBytes != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadBytes", protocol.BytesStream(s.PayloadBytes), protocol.Metadata{})
+	}
+	if s.PayloadReader != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadReader", protocol.ReadSeekerStream{V: s.PayloadReader}, protocol.Metadata{})
+	}
+}
+
+func TestSetHeaderValue(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		HeaderValue: aws.String("thevalue"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	if e, a := "thevalue", req.Header.Get("header-value"); e != a {
+		t.Errorf("expect %s header value, got %s", e, a)
+	}
+}
+
+func TestSetPathValue(t *testing.T) {
+	req, body, err := encode("GET", "/{key}", shape{
+		PathValue: aws.String("value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	if e, a := "/value", req.URL.Path; e != a {
+		t.Errorf("expect %s path, got %s", e, a)
+	}
+}
+
+func TestSetQueryValue(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		QueryValue: aws.String("queryValue"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 1, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	if e, a := "queryValue", query.Get("queryKey"); e != a {
+		t.Errorf("expect %s for 'queryKey' querystring, got %s", e, a)
+	}
+}
+
+func TestSetBody(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		BodyValue: aws.String("a value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 1, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	if e, a := "a value", query.Get("bodyValue"); e != a {
+		t.Errorf("expect %s for 'bodyValue' querystring, got %s", e, a)
+	}
+}
+
+func TestSetBody_Error(t *testing.T) {
+	req, body, err := encode("POST", "/path", shape{
+		BodyValue: aws.String("a value"),
+	})
+
+	if err == nil {
+		t.Fatalf("expect error, got none")
+	}
+	if e, a := "body target not supported", err.Error(); !strings.Contains(a, e) {
+		t.Errorf("expect %q to be in error %q, was not", e, a)
+	}
+
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+	if req != nil {
+		t.Errorf("expect no req, got %v", req)
+	}
+}
+
+func TestSetQueryList(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		QueryList: []*string{aws.String("a"), aws.String("b")},
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 1, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	vs, ok := query["queryKey"]
+	if !ok {
+		t.Fatalf("expect queryKey to exist, was not found")
+	}
+	for i, v := range []string{"a", "b"} {
+		if e, a := v, vs[i]; e != a {
+			t.Errorf("expect %s for 'queryKey[%d]' querystring, got %s", e, i, a)
+		}
+	}
+}
+
+func TestSetHeadersMap(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		HeadersMap: map[string]*string{
+			"abc":  aws.String("123"),
+			"else": aws.String("other"),
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	if e, a := 2, len(req.Header); e != a {
+		t.Errorf("expect %d header values, got %d", e, a)
+	}
+	for k, v := range map[string]string{"abc": "123", "else": "other"} {
+		if e, a := v, req.Header.Get("prefix-"+k); e != a {
+			t.Errorf("expect %s for 'prefix-%s' header, got %s", e, k, a)
+		}
+	}
+}
+
+func TestSetQueryMap(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		QueryMap: map[string]*string{
+			"a": aws.String("abc"),
+			"b": aws.String("123"),
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 2, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	for k, v := range map[string]string{"a": "abc", "b": "123"} {
+		if e, a := v, query.Get(k); e != a {
+			t.Errorf("expect %s for '%s' querystring, got %s", e, k, a)
+		}
+	}
+}
+
+func TestSetQueryMapList(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		QueryMapList: map[string][]*string{
+			"a": {aws.String("a1"), aws.String("a2")},
+			"b": {aws.String("b1"), aws.String("b2")},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 2, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	for k, vs := range map[string][]string{"a": []string{"a1", "a2"}, "b": []string{"b1", "b2"}} {
+		as, ok := query[k]
+		if !ok {
+			t.Fatalf("expect %s to exist, was not", k)
+		}
+		for i, v := range vs {
+			if e, a := v, as[i]; e != a {
+				t.Errorf("expect %s for '%s' querystring, got %s", e, k, a)
+			}
+		}
+	}
+}
+
+func TestSetPayloadString(t *testing.T) {
+	_, body, err := encode("POST", "/path", shape{
+		PayloadString: aws.String("a value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no encode error, got %v", err)
+	}
+	if body == nil {
+		t.Fatalf("expect body, got none")
+	}
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatalf("expect no body read error, got %v", err)
+	}
+	if e, a := "a value", string(b); e != a {
+		t.Errorf("expect %s body, got %s", e, a)
+	}
+}
+func TestSetPayloadBytes(t *testing.T) {
+	_, body, err := encode("POST", "/path", shape{
+		PayloadBytes: []byte("a value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no encode error, got %v", err)
+	}
+	if body == nil {
+		t.Fatalf("expect body, got none")
+	}
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatalf("expect no body read error, got %v", err)
+	}
+	if e, a := "a value", string(b); e != a {
+		t.Errorf("expect %s body, got %s", e, a)
+	}
+}
+func TestSetPayloadReader(t *testing.T) {
+	_, body, err := encode("POST", "/path", shape{
+		PayloadReader: strings.NewReader("a value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no encode error, got %v", err)
+	}
+	if body == nil {
+		t.Fatalf("expect body, got none")
+	}
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatalf("expect no body read error, got %v", err)
+	}
+	if e, a := "a value", string(b); e != a {
+		t.Errorf("expect %s body, got %s", e, a)
+	}
+}
+
+func encode(method, path string, s shape) (*http.Request, io.ReadSeeker, error) {
+	origReq, _ := http.NewRequest(method, "https://service.amazonaws.com"+path, nil)
+
+	e := NewEncoder(origReq)
+	s.MarshalAWS(e)
+	return e.Encode()
+}

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -321,6 +321,12 @@ type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService1TestShapeInputService1TestCaseOperation2Input struct {
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 
@@ -341,16 +347,50 @@ func (s *InputService1TestShapeInputService1TestCaseOperation2Input) SetName(v s
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService1TestShapeInputService1TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService1TestShapeInputService1TestCaseOperation3Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation3Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService1TestShapeInputService1TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService2ProtocolTest provides the API operation methods for making requests to
@@ -519,8 +559,40 @@ func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetThird(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.First != nil {
+		v := *s.First
+
+		e.SetValue(protocol.BodyTarget, "First", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Fourth != nil {
+		v := *s.Fourth
+
+		e.SetValue(protocol.BodyTarget, "Fourth", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Second != nil {
+		v := *s.Second
+
+		e.SetValue(protocol.BodyTarget, "Second", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Third != nil {
+		v := *s.Third
+
+		e.SetValue(protocol.BodyTarget, "Third", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService3ProtocolTest provides the API operation methods for making requests to
@@ -728,6 +800,12 @@ type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService3TestShapeInputService3TestCaseOperation2Input struct {
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 
@@ -748,8 +826,30 @@ func (s *InputService3TestShapeInputService3TestCaseOperation2Input) SetSubStruc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubStructure != nil {
+		v := s.SubStructure
+
+		e.SetFields(protocol.BodyTarget, "SubStructure", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService3TestShapeInputService3TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService3TestShapeSubStructure struct {
@@ -770,6 +870,22 @@ func (s *InputService3TestShapeSubStructure) SetBar(v string) *InputService3Test
 func (s *InputService3TestShapeSubStructure) SetFoo(v string) *InputService3TestShapeSubStructure {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeSubStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bar != nil {
+		v := *s.Bar
+
+		e.SetValue(protocol.BodyTarget, "Bar", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService4ProtocolTest provides the API operation methods for making requests to
@@ -922,8 +1038,30 @@ func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetSubStruc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubStructure != nil {
+		v := s.SubStructure
+
+		e.SetFields(protocol.BodyTarget, "SubStructure", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService4TestShapeSubStructure struct {
@@ -944,6 +1082,22 @@ func (s *InputService4TestShapeSubStructure) SetBar(v string) *InputService4Test
 func (s *InputService4TestShapeSubStructure) SetFoo(v string) *InputService4TestShapeSubStructure {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeSubStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bar != nil {
+		v := *s.Bar
+
+		e.SetValue(protocol.BodyTarget, "Bar", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService5ProtocolTest provides the API operation methods for making requests to
@@ -1088,8 +1242,25 @@ func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "ListParam", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService6ProtocolTest provides the API operation methods for making requests to
@@ -1234,8 +1405,25 @@ func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "AlternateName", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "NotMember"})
+	}
+
+	return nil
+}
+
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService7ProtocolTest provides the API operation methods for making requests to
@@ -1380,8 +1568,25 @@ func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "ListParam", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService8ProtocolTest provides the API operation methods for making requests to
@@ -1526,8 +1731,25 @@ func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService9ProtocolTest provides the API operation methods for making requests to
@@ -1672,8 +1894,25 @@ func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "item", encodeInputService9TestShapeSingleFieldStructList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService9TestShapeSingleFieldStruct struct {
@@ -1686,6 +1925,25 @@ type InputService9TestShapeSingleFieldStruct struct {
 func (s *InputService9TestShapeSingleFieldStruct) SetElement(v string) *InputService9TestShapeSingleFieldStruct {
 	s.Element = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeSingleFieldStruct) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Element != nil {
+		v := *s.Element
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputService9TestShapeSingleFieldStructList(vs []*InputService9TestShapeSingleFieldStruct) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // InputService10ProtocolTest provides the API operation methods for making requests to
@@ -1830,8 +2088,25 @@ func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetStruct
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StructureParam != nil {
+		v := s.StructureParam
+
+		e.SetFields(protocol.BodyTarget, "StructureParam", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService10TestShapeStructureShape struct {
@@ -1853,6 +2128,22 @@ func (s *InputService10TestShapeStructureShape) SetB(v []byte) *InputService10Te
 func (s *InputService10TestShapeStructureShape) SetT(v time.Time) *InputService10TestShapeStructureShape {
 	s.T = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeStructureShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.B != nil {
+		v := s.B
+
+		e.SetValue(protocol.BodyTarget, "b", protocol.BytesValue(v), protocol.Metadata{})
+	}
+	if s.T != nil {
+		v := *s.T
+
+		e.SetValue(protocol.BodyTarget, "t", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService11ProtocolTest provides the API operation methods for making requests to
@@ -1997,8 +2288,25 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Foo) > 0 {
+		v := s.Foo
+
+		e.SetMap(protocol.HeadersTarget, "x-foo-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService12ProtocolTest provides the API operation methods for making requests to
@@ -2143,8 +2451,25 @@ func (s *InputService12TestShapeInputService12TestCaseOperation1Input) SetItems(
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.QueryTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService13ProtocolTest provides the API operation methods for making requests to
@@ -2297,8 +2622,30 @@ func (s *InputService13TestShapeInputService13TestCaseOperation1Input) SetQueryD
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryDoc) > 0 {
+		v := s.QueryDoc
+
+		e.SetMap(protocol.QueryTarget, "QueryDoc", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService14ProtocolTest provides the API operation methods for making requests to
@@ -2451,8 +2798,35 @@ func (s *InputService14TestShapeInputService14TestCaseOperation1Input) SetQueryD
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryDoc) > 0 {
+		v := s.QueryDoc
+
+		e.SetMap(protocol.QueryTarget, "QueryDoc", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService15ProtocolTest provides the API operation methods for making requests to
@@ -2660,6 +3034,12 @@ type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService15TestShapeInputService15TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -2672,8 +3052,25 @@ func (s *InputService15TestShapeInputService15TestCaseOperation2Input) SetBoolQu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BoolQuery != nil {
+		v := *s.BoolQuery
+
+		e.SetValue(protocol.QueryTarget, "bool-query", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService15TestShapeInputService15TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService16ProtocolTest provides the API operation methods for making requests to
@@ -2818,8 +3215,25 @@ func (s *InputService16TestShapeInputService16TestCaseOperation1Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetStream(protocol.PayloadTarget, "foo", protocol.StringStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService17ProtocolTest provides the API operation methods for making requests to
@@ -3027,6 +3441,12 @@ type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService17TestShapeInputService17TestCaseOperation2Input struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
@@ -3039,8 +3459,25 @@ func (s *InputService17TestShapeInputService17TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetStream(protocol.PayloadTarget, "foo", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService17TestShapeInputService17TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService18ProtocolTest provides the API operation methods for making requests to
@@ -3398,16 +3835,45 @@ func (s *InputService18TestShapeFooShape) SetBaz(v string) *InputService18TestSh
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeFooShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Baz != nil {
+		v := *s.Baz
+
+		e.SetValue(protocol.BodyTarget, "baz", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService18TestShapeInputService18TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService18TestShapeInputService18TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService18TestShapeInputService18TestCaseOperation4Input struct {
@@ -3422,8 +3888,25 @@ func (s *InputService18TestShapeInputService18TestCaseOperation4Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation4Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetFields(protocol.PayloadTarget, "foo", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService18TestShapeInputService18TestCaseOperation4Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService19ProtocolTest provides the API operation methods for making requests to
@@ -3568,6 +4051,23 @@ func (s *InputService19TestShapeGrant) SetGrantee(v *InputService19TestShapeGran
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeGrant) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Grantee != nil {
+		v := s.Grantee
+		attrs := make([]protocol.Attribute, 0, 1)
+		// TODO only create array if an attribute value is set
+
+		if s.Grantee.Type != nil {
+			v := *s.Grantee.Type
+			attrs = append(attrs, protocol.Attribute{Name: "xsi:type", Value: protocol.StringValue(v), Meta: protocol.Metadata{}})
+		}
+		e.SetFields(protocol.BodyTarget, "Grantee", v, protocol.Metadata{Attributes: attrs, XMLNamespacePrefix: "xsi", XMLNamespaceURI: "http://www.w3.org/2001/XMLSchema-instance"})
+	}
+
+	return nil
+}
+
 type InputService19TestShapeGrantee struct {
 	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 
@@ -3588,6 +4088,18 @@ func (s *InputService19TestShapeGrantee) SetType(v string) *InputService19TestSh
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeGrantee) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// Skipping Type XML Attribute.
+
+	return nil
+}
+
 type InputService19TestShapeInputService19TestCaseOperation1Input struct {
 	_ struct{} `type:"structure" payload:"Grant"`
 
@@ -3600,8 +4112,25 @@ func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetGrant(
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Grant != nil {
+		v := s.Grant
+
+		e.SetFields(protocol.PayloadTarget, "Grant", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService19TestShapeInputService19TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService20ProtocolTest provides the API operation methods for making requests to
@@ -3754,8 +4283,30 @@ func (s *InputService20TestShapeInputService20TestCaseOperation1Input) SetKey(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService20TestShapeInputService20TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService21ProtocolTest provides the API operation methods for making requests to
@@ -3963,6 +4514,12 @@ type InputService21TestShapeInputService21TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -3975,8 +4532,25 @@ func (s *InputService21TestShapeInputService21TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.QueryTarget, "param-name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService22ProtocolTest provides the API operation methods for making requests to
@@ -4468,20 +5042,50 @@ type InputService22TestShapeInputService22TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService22TestShapeInputService22TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService22TestShapeInputService22TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService22TestShapeInputService22TestCaseOperation4Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService22TestShapeInputService22TestCaseOperation5Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation5Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService22TestShapeInputService22TestCaseOperation6Input struct {
@@ -4496,8 +5100,25 @@ func (s *InputService22TestShapeInputService22TestCaseOperation6Input) SetRecurs
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation6Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RecursiveStruct != nil {
+		v := s.RecursiveStruct
+
+		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService22TestShapeInputService22TestCaseOperation6Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation6Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService22TestShapeRecursiveStructType struct {
@@ -4534,6 +5155,48 @@ func (s *InputService22TestShapeRecursiveStructType) SetRecursiveMap(v map[strin
 func (s *InputService22TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService22TestShapeRecursiveStructType) *InputService22TestShapeRecursiveStructType {
 	s.RecursiveStruct = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeRecursiveStructType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NoRecurse != nil {
+		v := *s.NoRecurse
+
+		e.SetValue(protocol.BodyTarget, "NoRecurse", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RecursiveList) > 0 {
+		v := s.RecursiveList
+
+		e.SetList(protocol.BodyTarget, "RecursiveList", encodeInputService22TestShapeRecursiveStructTypeList(v), protocol.Metadata{})
+	}
+	if len(s.RecursiveMap) > 0 {
+		v := s.RecursiveMap
+
+		e.SetMap(protocol.BodyTarget, "RecursiveMap", encodeInputService22TestShapeRecursiveStructTypeMap(v), protocol.Metadata{})
+	}
+	if s.RecursiveStruct != nil {
+		v := s.RecursiveStruct
+
+		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputService22TestShapeRecursiveStructTypeList(vs []*InputService22TestShapeRecursiveStructType) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
+func encodeInputService22TestShapeRecursiveStructTypeMap(vs map[string]*InputService22TestShapeRecursiveStructType) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // InputService23ProtocolTest provides the API operation methods for making requests to
@@ -4678,8 +5341,25 @@ func (s *InputService23TestShapeInputService23TestCaseOperation1Input) SetTimeAr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService23TestShapeInputService23TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TimeArgInHeader != nil {
+		v := *s.TimeArgInHeader
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-timearg", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService23TestShapeInputService23TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService23TestShapeInputService23TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService24ProtocolTest provides the API operation methods for making requests to
@@ -4887,6 +5567,12 @@ type InputService24TestShapeInputService24TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService24TestShapeInputService24TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService24TestShapeInputService24TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -4899,8 +5585,31 @@ func (s *InputService24TestShapeInputService24TestCaseOperation2Input) SetToken(
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService24TestShapeInputService24TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	var Token string
+	if s.Token != nil {
+		Token = *s.Token
+	} else {
+		Token = protocol.GetIdempotencyToken()
+	}
+	{
+		v := Token
+
+		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService24TestShapeInputService24TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService24TestShapeInputService24TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 //

--- a/private/protocol/restxml/encode.go
+++ b/private/protocol/restxml/encode.go
@@ -1,0 +1,160 @@
+package restxml
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/rest"
+	"github.com/aws/aws-sdk-go/private/protocol/xml"
+)
+
+// An Encoder provides encoding of the AWS RESTXML protocol. This encoder combindes
+// the XML and REST encoders deligating to them for their associated targets.
+//
+// It is invalid to set a XML and stream payload on the same encoder.
+type Encoder struct {
+	method      string
+	reqEncoder  *rest.Encoder
+	bodyEncoder *xml.Encoder
+
+	buf *bytes.Buffer
+	err error
+}
+
+// NewEncoder creates a new encoder for encoding the AWS RESTXML protocol.
+// The request passed in will be the base the path, query, and headers encoded
+// will be set on top of.
+func NewEncoder(req *http.Request) *Encoder {
+	e := &Encoder{
+		method:      req.Method,
+		reqEncoder:  rest.NewEncoder(req),
+		bodyEncoder: xml.NewEncoder(),
+	}
+
+	return e
+}
+
+// Encode returns the encoded request, and body payload. If no payload body was
+// set nil will be returned.  If an error occurred while encoding the API an
+// error will be returned.
+func (e *Encoder) Encode() (*http.Request, io.ReadSeeker, error) {
+	req, payloadBody, err := e.reqEncoder.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	xmlBody, err := e.bodyEncoder.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	havePayload := payloadBody != nil
+	haveXML := xmlBody != nil
+
+	if havePayload == haveXML && haveXML {
+		return nil, nil, fmt.Errorf("unexpected XML body and request payload for AWSMarshaler")
+	}
+
+	body := payloadBody
+	if body == nil {
+		body = xmlBody
+	}
+
+	return req, body, err
+}
+
+// SetValue will set a value to the header, path, query, or body.
+//
+// If the request's method is GET all BodyTarget values will be written to
+// the query string.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PathTarget:
+		fallthrough
+	case protocol.QueryTarget:
+		fallthrough
+	case protocol.HeaderTarget:
+		e.reqEncoder.SetValue(t, k, v, meta)
+	case protocol.BodyTarget:
+		if e.method == "GET" {
+			e.reqEncoder.SetValue(t, k, v, meta)
+		} else {
+			e.bodyEncoder.SetValue(t, k, v, meta)
+		}
+	default:
+		e.err = fmt.Errorf("unknown SetValue restxml encode target, %s, %s", t, k)
+	}
+}
+
+// SetStream will set the stream to the payload of the request.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		e.reqEncoder.SetStream(t, k, v, meta)
+	default:
+		e.err = fmt.Errorf("invalid target %s, for SetStream, must be PayloadTarget", t)
+	}
+}
+
+// SetList will set the nested list values to the header, query, or body.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.HeaderTarget:
+		fallthrough
+	case protocol.QueryTarget:
+		e.reqEncoder.SetList(t, k, fn, meta)
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetList(t, k, fn, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetList restxml encode target, %s, %s", t, k)
+	}
+}
+
+// SetMap will set the nested map values to the header, query, or body.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(me protocol.MapEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.QueryTarget:
+		fallthrough
+	case protocol.HeadersTarget:
+		e.reqEncoder.SetMap(t, k, fn, meta)
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetMap(t, k, fn, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetMap restxml encode target, %s, %s", t, k)
+	}
+}
+
+// SetFields will set the nested type's fields to the body.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		fallthrough
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetFields(t, k, m, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetMarshaler restxml encode target, %s, %s", t, k)
+	}
+}

--- a/private/protocol/restxml/encode_test.go
+++ b/private/protocol/restxml/encode_test.go
@@ -1,0 +1,86 @@
+package restxml
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+func TestEncodeNestedShape(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		PayloadShape: &nestedShape{
+			Value: aws.String("some value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payloadShape><value>some value</value></payloadShape>`
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodeNestedStream(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		PayloadStream: strings.NewReader("some value"),
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := "some value"
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+type shape struct {
+	PayloadShape  *nestedShape
+	PayloadStream io.ReadSeeker
+}
+
+func (s *shape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PayloadShape != nil {
+		e.SetFields(protocol.PayloadTarget, "payloadShape", s.PayloadShape, protocol.Metadata{})
+	}
+	if s.PayloadStream != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadReader", protocol.ReadSeekerStream{V: s.PayloadStream}, protocol.Metadata{})
+	}
+	return nil
+}
+
+type nestedShape struct {
+	Value *string
+}
+
+func (s *nestedShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	return nil
+}
+
+func encode(method, path string, s shape) (*http.Request, io.ReadSeeker, error) {
+	origReq, _ := http.NewRequest(method, "https://service.amazonaws.com"+path, nil)
+
+	e := NewEncoder(origReq)
+	s.MarshalFields(e)
+	return e.Encode()
+}

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -244,8 +244,20 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation2Output struct {
@@ -338,6 +350,67 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetTimes
 func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.TrueBool = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Char != nil {
+		v := *s.Char
+
+		e.SetValue(protocol.BodyTarget, "Char", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Double != nil {
+		v := *s.Double
+
+		e.SetValue(protocol.BodyTarget, "Double", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.FalseBool != nil {
+		v := *s.FalseBool
+
+		e.SetValue(protocol.BodyTarget, "FalseBool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Float != nil {
+		v := *s.Float
+
+		e.SetValue(protocol.BodyTarget, "Float", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.ImaHeader != nil {
+		v := *s.ImaHeader
+
+		e.SetValue(protocol.HeaderTarget, "ImaHeader", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImaHeaderLocation != nil {
+		v := *s.ImaHeaderLocation
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Long != nil {
+		v := *s.Long
+
+		e.SetValue(protocol.BodyTarget, "Long", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Num != nil {
+		v := *s.Num
+
+		e.SetValue(protocol.BodyTarget, "FooNum", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Str != nil {
+		v := *s.Str
+
+		e.SetValue(protocol.BodyTarget, "Str", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.BodyTarget, "Timestamp", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.TrueBool != nil {
+		v := *s.TrueBool
+
+		e.SetValue(protocol.BodyTarget, "TrueBool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService2ProtocolTest provides the API operation methods for making requests to
@@ -471,6 +544,12 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -482,6 +561,17 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetBlob(v []byte) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
 	s.Blob = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Blob != nil {
+		v := s.Blob
+
+		e.SetValue(protocol.BodyTarget, "Blob", protocol.BytesValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService3ProtocolTest provides the API operation methods for making requests to
@@ -615,6 +705,12 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -625,6 +721,17 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetListMember(v []*string) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
 	s.ListMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService4ProtocolTest provides the API operation methods for making requests to
@@ -758,6 +865,12 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -768,6 +881,17 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
 	s.ListMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "item"})
+	}
+
+	return nil
 }
 
 // OutputService5ProtocolTest provides the API operation methods for making requests to
@@ -901,6 +1025,12 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -911,6 +1041,17 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetListMember(v []*string) *OutputService5TestShapeOutputService5TestCaseOperation1Output {
 	s.ListMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // OutputService6ProtocolTest provides the API operation methods for making requests to
@@ -1044,6 +1185,12 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1056,6 +1203,17 @@ func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetMap(v
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Map) > 0 {
+		v := s.Map
+
+		e.SetMap(protocol.BodyTarget, "Map", encodeOutputService6TestShapeSingleStructureMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService6TestShapeSingleStructure struct {
 	_ struct{} `type:"structure"`
 
@@ -1066,6 +1224,25 @@ type OutputService6TestShapeSingleStructure struct {
 func (s *OutputService6TestShapeSingleStructure) SetFoo(v string) *OutputService6TestShapeSingleStructure {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeSingleStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputService6TestShapeSingleStructureMap(vs map[string]*OutputService6TestShapeSingleStructure) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // OutputService7ProtocolTest provides the API operation methods for making requests to
@@ -1199,6 +1376,12 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1209,6 +1392,17 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService7TestShapeOutputService7TestCaseOperation1Output {
 	s.Map = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Map) > 0 {
+		v := s.Map
+
+		e.SetMap(protocol.BodyTarget, "Map", protocol.EncodeStringMap(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // OutputService8ProtocolTest provides the API operation methods for making requests to
@@ -1342,6 +1536,12 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1352,6 +1552,17 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService8TestShapeOutputService8TestCaseOperation1Output {
 	s.Map = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Map) > 0 {
+		v := s.Map
+
+		e.SetMap(protocol.BodyTarget, "Map", protocol.EncodeStringMap(v), protocol.Metadata{MapLocationNameKey: "foo", MapLocationNameValue: "bar"})
+	}
+
+	return nil
 }
 
 // OutputService9ProtocolTest provides the API operation methods for making requests to
@@ -1485,6 +1696,12 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure" payload:"Data"`
 
@@ -1505,6 +1722,22 @@ func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetHeade
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Data != nil {
+		v := s.Data
+
+		e.SetFields(protocol.PayloadTarget, "Data", v, protocol.Metadata{})
+	}
+	if s.Header != nil {
+		v := *s.Header
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService9TestShapeSingleStructure struct {
 	_ struct{} `type:"structure"`
 
@@ -1515,6 +1748,17 @@ type OutputService9TestShapeSingleStructure struct {
 func (s *OutputService9TestShapeSingleStructure) SetFoo(v string) *OutputService9TestShapeSingleStructure {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeSingleStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService10ProtocolTest provides the API operation methods for making requests to
@@ -1648,6 +1892,12 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure" payload:"Stream"`
 
@@ -1658,6 +1908,17 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetStream(v []byte) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
 	s.Stream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Stream != nil {
+		v := s.Stream
+
+		e.SetStream(protocol.PayloadTarget, "Stream", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService11ProtocolTest provides the API operation methods for making requests to
@@ -1791,6 +2052,12 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1865,6 +2132,57 @@ func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetTim
 func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetTrueBool(v bool) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
 	s.TrueBool = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Char != nil {
+		v := *s.Char
+
+		e.SetValue(protocol.HeaderTarget, "x-char", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Double != nil {
+		v := *s.Double
+
+		e.SetValue(protocol.HeaderTarget, "x-double", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.FalseBool != nil {
+		v := *s.FalseBool
+
+		e.SetValue(protocol.HeaderTarget, "x-false-bool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Float != nil {
+		v := *s.Float
+
+		e.SetValue(protocol.HeaderTarget, "x-float", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Integer != nil {
+		v := *s.Integer
+
+		e.SetValue(protocol.HeaderTarget, "x-int", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Long != nil {
+		v := *s.Long
+
+		e.SetValue(protocol.HeaderTarget, "x-long", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Str != nil {
+		v := *s.Str
+
+		e.SetValue(protocol.HeaderTarget, "x-str", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.HeaderTarget, "x-timestamp", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.TrueBool != nil {
+		v := *s.TrueBool
+
+		e.SetValue(protocol.HeaderTarget, "x-true-bool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService12ProtocolTest provides the API operation methods for making requests to
@@ -1998,6 +2316,12 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -2008,6 +2332,17 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetFoo(v string) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 //

--- a/private/protocol/target.go
+++ b/private/protocol/target.go
@@ -1,0 +1,38 @@
+package protocol
+
+import "fmt"
+
+// Target is the encode and decode targets of protocol marshaling.
+type Target int
+
+// The protocol marshaling targets.
+const (
+	PathTarget Target = iota
+	QueryTarget
+	HeaderTarget
+	HeadersTarget
+	StatusCodeTarget
+	BodyTarget
+	PayloadTarget
+)
+
+func (e Target) String() string {
+	switch e {
+	case PathTarget:
+		return "Path"
+	case QueryTarget:
+		return "Query"
+	case HeaderTarget:
+		return "Header"
+	case HeadersTarget:
+		return "Headers"
+	case StatusCodeTarget:
+		return "StatusCode"
+	case BodyTarget:
+		return "Body"
+	case PayloadTarget:
+		return "Payload"
+	default:
+		panic(fmt.Sprintf("// unknown encoding target, %d", e))
+	}
+}

--- a/private/protocol/xml/encode.go
+++ b/private/protocol/xml/encode.go
@@ -1,0 +1,381 @@
+package xml
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+// An Encoder provides encoding of the AWS XML protocol. This encoder will will
+// write all content to XML. Only supports body and payload targets.
+type Encoder struct {
+	encoder    *xml.Encoder
+	encodedBuf *bytes.Buffer
+	fieldBuf   *bytes.Buffer
+	err        error
+}
+
+// NewEncoder creates a new encoder for encoding AWS XML protocol. Only encodes
+// fields into the XML body, and error is returned if target is anything other
+// than Body or Payload.
+func NewEncoder() *Encoder {
+	encodedBuf := &bytes.Buffer{}
+	return &Encoder{
+		encodedBuf: encodedBuf,
+		encoder:    xml.NewEncoder(encodedBuf),
+		fieldBuf:   bytes.NewBuffer(nil),
+	}
+}
+
+// Encode returns the encoded XMl reader. An error will be returned if one was
+// encountered while building the XML body.
+func (e *Encoder) Encode() (io.ReadSeeker, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+
+	if err := e.encoder.Flush(); err != nil {
+		return nil, fmt.Errorf("unable to marshal XML, %v", err)
+	}
+
+	if e.encodedBuf.Len() == 0 {
+		return nil, nil
+	}
+
+	return bytes.NewReader(e.encodedBuf.Bytes()), e.err
+}
+
+// SetValue sets an individual value to the XML body.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	if t != protocol.BodyTarget && t != protocol.PayloadTarget {
+		e.err = fmt.Errorf(" invalid target %s for xml encoder SetValue, %s", t, k)
+		return
+	}
+
+	e.err = addValueToken(e.encoder, e.fieldBuf, k, v, meta)
+}
+
+// SetStream is not supported for XML protocol marshaling.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	e.err = fmt.Errorf("xml encoder SetStream not supported, %s, %s", t, k)
+}
+
+// SetList creates an XML list and calls the passed in fn callback with a list encoder.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	if t != protocol.BodyTarget && t != protocol.PayloadTarget {
+		e.err = fmt.Errorf(" invalid target %s for xml encoder SetValue, %s", t, k)
+		return
+	}
+
+	le := ListEncoder{Base: e,
+		Flatten:  meta.Flatten,
+		ListName: meta.ListLocationName,
+	}
+	if v := meta.ListLocationName; len(v) == 0 {
+		if le.Flatten {
+			le.ListName = k
+		} else {
+			le.ListName = "member"
+		}
+	}
+
+	var tok xml.StartElement
+	if !le.Flatten {
+		tok, e.err = xmlStartElem(k, meta)
+		if e.err != nil {
+			return
+		}
+		e.encoder.EncodeToken(tok)
+	}
+
+	fn(&le)
+
+	if !le.Flatten {
+		e.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+	}
+}
+
+// SetMap creates an XML map and calls the passed in fn callback with a map encoder.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(me protocol.MapEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	if t != protocol.BodyTarget && t != protocol.PayloadTarget {
+		e.err = fmt.Errorf(" invalid target %s for xml encoder SetValue, %s", t, k)
+		return
+	}
+
+	me := MapEncoder{Base: e,
+		Flatten:   meta.Flatten,
+		KeyName:   meta.MapLocationNameKey,
+		ValueName: meta.MapLocationNameValue,
+	}
+
+	tok, err := xmlStartElem(k, meta)
+	if err != nil {
+		e.err = err
+		return
+	}
+
+	e.encoder.EncodeToken(tok)
+
+	fn(&me)
+
+	e.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+}
+
+// SetFields sets the nested fields to the XML body.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	if t != protocol.BodyTarget && t != protocol.PayloadTarget {
+		e.err = fmt.Errorf(" invalid target %s for xml encoder SetFields, %s", t, k)
+		return
+	}
+
+	tok, err := xmlStartElem(k, meta)
+	if err != nil {
+		e.err = err
+		return
+	}
+
+	e.encoder.EncodeToken(tok)
+	m.MarshalFields(e)
+	e.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+}
+
+// A ListEncoder encodes elements within a list for the XML encoder.
+type ListEncoder struct {
+	Base     *Encoder
+	Flatten  bool
+	ListName string
+	Err      error
+}
+
+// ListAddValue will add the value to the list.
+func (e *ListEncoder) ListAddValue(v protocol.ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	e.Err = addValueToken(e.Base.encoder, e.Base.fieldBuf, e.ListName, v, protocol.Metadata{})
+}
+
+// ListAddList is not supported for XML encoder.
+func (e *ListEncoder) ListAddList(fn func(le protocol.ListEncoder)) {
+	e.Err = fmt.Errorf("xml encoder ListAddList not supported, %s", e.ListName)
+}
+
+// ListAddMap is not supported for XML encoder.
+func (e *ListEncoder) ListAddMap(fn func(me protocol.MapEncoder)) {
+	e.Err = fmt.Errorf("xml encoder ListAddMap not supported, %s", e.ListName)
+}
+
+// ListAddFields will set the nested type's fields to the list.
+func (e *ListEncoder) ListAddFields(m protocol.FieldMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	var tok xml.StartElement
+	tok, e.Err = xmlStartElem(e.ListName, protocol.Metadata{})
+	if e.Err != nil {
+		return
+	}
+
+	e.Base.encoder.EncodeToken(tok)
+	m.MarshalFields(e.Base)
+	e.Base.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+}
+
+// A MapEncoder encodes key values pair map values for the XML encoder.
+type MapEncoder struct {
+	Base      *Encoder
+	Flatten   bool
+	KeyName   string
+	ValueName string
+	Err       error
+}
+
+// MapSetValue sets a map value.
+func (e *MapEncoder) MapSetValue(k string, v protocol.ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	var tok xml.StartElement
+	if !e.Flatten {
+		tok, e.Err = xmlStartElem("entry", protocol.Metadata{})
+		if e.Err != nil {
+			return
+		}
+		e.Base.encoder.EncodeToken(tok)
+	}
+
+	keyName, valueName := e.KeyName, e.ValueName
+	if len(keyName) == 0 {
+		keyName = "key"
+	}
+	if len(valueName) == 0 {
+		valueName = "value"
+	}
+
+	e.Err = addValueToken(e.Base.encoder, e.Base.fieldBuf, keyName, protocol.StringValue(k), protocol.Metadata{})
+	if e.Err != nil {
+		return
+	}
+
+	e.Err = addValueToken(e.Base.encoder, e.Base.fieldBuf, valueName, v, protocol.Metadata{})
+	if e.Err != nil {
+		return
+	}
+
+	if !e.Flatten {
+		e.Base.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+	}
+}
+
+// MapSetList is not supported.
+func (e *MapEncoder) MapSetList(k string, fn func(le protocol.ListEncoder)) {
+	e.Err = fmt.Errorf("xml map encoder MapSetList not supported, %s", k)
+}
+
+// MapSetMap is not supported.
+func (e *MapEncoder) MapSetMap(k string, fn func(me protocol.MapEncoder)) {
+	e.Err = fmt.Errorf("xml map encoder MapSetMap not supported, %s", k)
+}
+
+// MapSetFields will set the nested type's fields under the map.
+func (e *MapEncoder) MapSetFields(k string, m protocol.FieldMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	var tok xml.StartElement
+	if !e.Flatten {
+		tok, e.Err = xmlStartElem("entry", protocol.Metadata{})
+		if e.Err != nil {
+			return
+		}
+		e.Base.encoder.EncodeToken(tok)
+	}
+
+	keyName, valueName := e.KeyName, e.ValueName
+	if len(keyName) == 0 {
+		keyName = "key"
+	}
+	if len(valueName) == 0 {
+		valueName = "value"
+	}
+
+	e.Err = addValueToken(e.Base.encoder, e.Base.fieldBuf, keyName, protocol.StringValue(k), protocol.Metadata{})
+	if e.Err != nil {
+		return
+	}
+
+	valTok, err := xmlStartElem(valueName, protocol.Metadata{})
+	if err != nil {
+		e.Err = err
+		return
+	}
+	e.Base.encoder.EncodeToken(valTok)
+
+	m.MarshalFields(e.Base)
+
+	e.Base.encoder.EncodeToken(xml.EndElement{Name: valTok.Name})
+
+	if !e.Flatten {
+		e.Base.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+	}
+}
+
+func addValueToken(e *xml.Encoder, fieldBuf *bytes.Buffer, k string, v protocol.ValueMarshaler, meta protocol.Metadata) error {
+	str, err := v.MarshalValue()
+	if err != nil {
+		return err
+	}
+
+	fieldBuf.Reset()
+	_, err = fieldBuf.WriteString(str)
+	if err != nil {
+		return err
+	}
+
+	tok, err := xmlStartElem(k, meta)
+	if err != nil {
+		return err
+	}
+
+	e.EncodeToken(tok)
+	e.EncodeToken(xml.CharData(fieldBuf.Bytes()))
+	e.EncodeToken(xml.EndElement{Name: tok.Name})
+
+	return nil
+}
+
+func xmlStartElem(k string, meta protocol.Metadata) (xml.StartElement, error) {
+	tok := xml.StartElement{Name: xmlName(k, meta)}
+	attrs, err := buildAttributes(meta)
+	if err != nil {
+		return xml.StartElement{}, err
+	}
+	tok.Attr = attrs
+
+	return tok, nil
+}
+
+func xmlName(k string, meta protocol.Metadata) xml.Name {
+	name := xml.Name{Local: k}
+
+	// TODO need to do something with namespace?
+	//	if len(meta.XMLNamespacePrefix) > 0  && len(meta.XMLNamespaceURI) {
+	//		name.Space = prefix
+	//	}
+
+	return name
+}
+
+func buildAttributes(meta protocol.Metadata) ([]xml.Attr, error) {
+	n := len(meta.Attributes)
+	if len(meta.XMLNamespaceURI) > 0 {
+		n++
+	}
+
+	if n == 0 {
+		return nil, nil
+	}
+
+	attrs := make([]xml.Attr, n)
+
+	for _, a := range meta.Attributes {
+		str, err := a.Value.MarshalValue()
+		if err != nil {
+			return nil, err
+		}
+
+		attrs = append(attrs, xml.Attr{Name: xmlName(a.Name, a.Meta), Value: str})
+	}
+
+	if uri := meta.XMLNamespaceURI; len(uri) > 0 {
+		attr := xml.Attr{
+			Name:  xml.Name{Local: "xmlns"},
+			Value: uri,
+		}
+		if p := meta.XMLNamespacePrefix; len(p) > 0 {
+			attr.Name.Local += ":" + p
+		}
+		attrs = append(attrs, attr)
+	}
+
+	return attrs, nil
+}

--- a/private/protocol/xml/encode_test.go
+++ b/private/protocol/xml/encode_test.go
@@ -1,0 +1,549 @@
+package xml
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+func TestEncodeAttribute(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			AttrValue: aws.String("value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload attrkey="value"></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodeNamespace(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			Namespace: &nestedShape{
+				Prefixed: aws.String("abc"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><namespace xmlns:prefix="https://example.com"><prefixed>abc</prefixed></namespace></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodeNestedShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			Nested: &nestedShape{
+				Value: aws.String("expected value"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><nested><value>expected value</value></nested></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapString(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapStr: map[string]*string{
+				"abc": aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapstr><entry><key>abc</key><value>123</value></entry></mapstr></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapFlatten(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapFlatten: map[string]*string{
+				"abc": aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapFlatten><key>abc</key><value>123</value></mapFlatten></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapNamed(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapNamed: map[string]*string{
+				"abc": aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapNamed><entry><namedKey>abc</namedKey><namedValue>123</namedValue></entry></mapNamed></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapShape: map[string]*nestedShape{
+				"abc": {Value: aws.String("1")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapShape><entry><key>abc</key><value><value>1</value></value></entry></mapShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapFlattenShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapFlattenShape: map[string]*nestedShape{
+				"abc": {Value: aws.String("1")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapFlattenShape><key>abc</key><value><value>1</value></value></mapFlattenShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapNamedShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapNamedShape: map[string]*nestedShape{
+				"abc": {Value: aws.String("1")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapNamedShape><entry><namedKey>abc</namedKey><namedValue><value>1</value></namedValue></entry></mapNamedShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListString(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListStr: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><liststr><member>abc</member><member>123</member></liststr></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListFlatten(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListFlatten: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listFlatten>abc</listFlatten><listFlatten>123</listFlatten></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListFlattened(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListFlatten: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listFlatten>abc</listFlatten><listFlatten>123</listFlatten></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListNamed(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListNamed: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listNamed><namedMember>abc</namedMember><namedMember>123</namedMember></listNamed></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListShape: []*nestedShape{
+				{Value: aws.String("abc")},
+				{Value: aws.String("123")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listShape><member><value>abc</value></member><member><value>123</value></member></listShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListFlattenShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListFlattenShape: []*nestedShape{
+				{Value: aws.String("abc")},
+				{Value: aws.String("123")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listFlattenShape><value>abc</value></listFlattenShape><listFlattenShape><value>123</value></listFlattenShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListNamedShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListNamedShape: []*nestedShape{
+				{Value: aws.String("abc")},
+				{Value: aws.String("123")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listNamedShape><namedMember><value>abc</value></namedMember><namedMember><value>123</value></namedMember></listNamedShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+type baseShape struct {
+	Payload *payloadShape
+}
+
+func (s *baseShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		attrs := make([]protocol.Attribute, 0, 1)
+		if s.Payload.AttrValue != nil {
+			attrs = append(attrs, protocol.Attribute{
+				Name:  "attrkey",
+				Value: protocol.StringValue(*s.Payload.AttrValue),
+				Meta:  protocol.Metadata{},
+			})
+		}
+		e.SetFields(protocol.PayloadTarget, "payload", s.Payload, protocol.Metadata{Attributes: attrs})
+	}
+	return nil
+}
+
+type payloadShape struct {
+	AttrValue        *string
+	Namespace        *nestedShape
+	Nested           *nestedShape
+	MapStr           map[string]*string
+	MapFlatten       map[string]*string
+	MapNamed         map[string]*string
+	MapShape         map[string]*nestedShape
+	MapFlattenShape  map[string]*nestedShape
+	MapNamedShape    map[string]*nestedShape
+	ListStr          []*string
+	ListFlatten      []*string
+	ListNamed        []*string
+	ListShape        []*nestedShape
+	ListFlattenShape []*nestedShape
+	ListNamedShape   []*nestedShape
+}
+
+func (s *payloadShape) MarshalFields(e protocol.FieldEncoder) error {
+	// Attribute values are skipped
+	if s.Namespace != nil {
+		e.SetFields(protocol.BodyTarget, "namespace", s.Namespace, protocol.Metadata{
+			XMLNamespaceURI: "https://example.com", XMLNamespacePrefix: "prefix",
+		})
+	}
+	if s.Nested != nil {
+		e.SetFields(protocol.BodyTarget, "nested", s.Nested, protocol.Metadata{})
+	}
+	if len(s.MapStr) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapstr", func(me protocol.MapEncoder) {
+			for k, v := range s.MapStr {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.MapFlatten) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapFlatten", func(me protocol.MapEncoder) {
+			for k, v := range s.MapFlatten {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.MapNamed) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapNamed", func(me protocol.MapEncoder) {
+			for k, v := range s.MapNamed {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			MapLocationNameKey: "namedKey", MapLocationNameValue: "namedValue",
+		})
+	}
+	if len(s.MapShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapShape", encodeNestedShapeMap(s.MapShape), protocol.Metadata{})
+	}
+	if len(s.MapFlattenShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapFlattenShape", encodeNestedShapeMap(s.MapFlattenShape), protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.MapNamedShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapNamedShape", encodeNestedShapeMap(s.MapNamedShape), protocol.Metadata{
+			MapLocationNameKey: "namedKey", MapLocationNameValue: "namedValue",
+		})
+	}
+	if len(s.ListStr) > 0 {
+		e.SetList(protocol.BodyTarget, "liststr", func(le protocol.ListEncoder) {
+			for _, v := range s.ListStr {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.ListFlatten) > 0 {
+		e.SetList(protocol.BodyTarget, "listFlatten", func(le protocol.ListEncoder) {
+			for _, v := range s.ListFlatten {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.ListNamed) > 0 {
+		e.SetList(protocol.BodyTarget, "listNamed", func(le protocol.ListEncoder) {
+			for _, v := range s.ListNamed {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			ListLocationName: "namedMember",
+		})
+	}
+	if len(s.ListShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listShape", encodeNestedShapeList(s.ListShape), protocol.Metadata{})
+	}
+	if len(s.ListFlattenShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listFlattenShape", encodeNestedShapeList(s.ListFlattenShape), protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.ListNamedShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listNamedShape", encodeNestedShapeList(s.ListNamedShape), protocol.Metadata{
+			ListLocationName: "namedMember",
+		})
+	}
+	return nil
+}
+
+type nestedShape struct {
+	Value    *string
+	Prefixed *string
+}
+
+func (s *nestedShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	if s.Prefixed != nil {
+		e.SetValue(protocol.BodyTarget, "prefixed", protocol.StringValue(*s.Prefixed), protocol.Metadata{
+			XMLNamespacePrefix: "prefix",
+		})
+	}
+	return nil
+}
+func encodeNestedShapeMap(vs map[string]*nestedShape) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+func encodeNestedShapeList(vs []*nestedShape) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
+func encode(s baseShape) (io.ReadSeeker, error) {
+	e := NewEncoder()
+	s.MarshalFields(e)
+	return e.Encode()
+}

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -3162,6 +3162,27 @@ func (s *ActiveTrustedSigners) SetQuantity(v int64) *ActiveTrustedSigners {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActiveTrustedSigners) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeSignerList(v), protocol.Metadata{ListLocationName: "Signer"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about CNAMEs (alternate domain names),
 // if any, for this distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Aliases
@@ -3212,6 +3233,22 @@ func (s *Aliases) SetItems(v []*string) *Aliases {
 func (s *Aliases) SetQuantity(v int64) *Aliases {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Aliases) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "CNAME"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that controls which HTTP methods CloudFront processes and
@@ -3306,6 +3343,27 @@ func (s *AllowedMethods) SetItems(v []*string) *AllowedMethods {
 func (s *AllowedMethods) SetQuantity(v int64) *AllowedMethods {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AllowedMethods) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CachedMethods != nil {
+		v := s.CachedMethods
+
+		e.SetFields(protocol.BodyTarget, "CachedMethods", v, protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Method"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes how CloudFront processes requests.
@@ -3615,6 +3673,80 @@ func (s *CacheBehavior) SetViewerProtocolPolicy(v string) *CacheBehavior {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CacheBehavior) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AllowedMethods != nil {
+		v := s.AllowedMethods
+
+		e.SetFields(protocol.BodyTarget, "AllowedMethods", v, protocol.Metadata{})
+	}
+	if s.Compress != nil {
+		v := *s.Compress
+
+		e.SetValue(protocol.BodyTarget, "Compress", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DefaultTTL != nil {
+		v := *s.DefaultTTL
+
+		e.SetValue(protocol.BodyTarget, "DefaultTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ForwardedValues != nil {
+		v := s.ForwardedValues
+
+		e.SetFields(protocol.BodyTarget, "ForwardedValues", v, protocol.Metadata{})
+	}
+	if s.LambdaFunctionAssociations != nil {
+		v := s.LambdaFunctionAssociations
+
+		e.SetFields(protocol.BodyTarget, "LambdaFunctionAssociations", v, protocol.Metadata{})
+	}
+	if s.MaxTTL != nil {
+		v := *s.MaxTTL
+
+		e.SetValue(protocol.BodyTarget, "MaxTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinTTL != nil {
+		v := *s.MinTTL
+
+		e.SetValue(protocol.BodyTarget, "MinTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PathPattern != nil {
+		v := *s.PathPattern
+
+		e.SetValue(protocol.BodyTarget, "PathPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SmoothStreaming != nil {
+		v := *s.SmoothStreaming
+
+		e.SetValue(protocol.BodyTarget, "SmoothStreaming", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.TargetOriginId != nil {
+		v := *s.TargetOriginId
+
+		e.SetValue(protocol.BodyTarget, "TargetOriginId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrustedSigners != nil {
+		v := s.TrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
+	}
+	if s.ViewerProtocolPolicy != nil {
+		v := *s.ViewerProtocolPolicy
+
+		e.SetValue(protocol.BodyTarget, "ViewerProtocolPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCacheBehaviorList(vs []*CacheBehavior) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains zero or more CacheBehavior elements.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CacheBehaviors
 type CacheBehaviors struct {
@@ -3673,6 +3805,22 @@ func (s *CacheBehaviors) SetItems(v []*CacheBehavior) *CacheBehaviors {
 func (s *CacheBehaviors) SetQuantity(v int64) *CacheBehaviors {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CacheBehaviors) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeCacheBehaviorList(v), protocol.Metadata{ListLocationName: "CacheBehavior"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that controls whether CloudFront caches the response to requests
@@ -3741,6 +3889,22 @@ func (s *CachedMethods) SetQuantity(v int64) *CachedMethods {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CachedMethods) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Method"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that specifies whether you want CloudFront to forward cookies
 // to the origin and, if so, which ones. For more information about forwarding
 // cookies to the origin, see How CloudFront Forwards, Caches, and Logs Cookies
@@ -3794,6 +3958,22 @@ func (s *CookieNames) SetItems(v []*string) *CookieNames {
 func (s *CookieNames) SetQuantity(v int64) *CookieNames {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CookieNames) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Name"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that specifies whether you want CloudFront to forward cookies
@@ -3871,6 +4051,22 @@ func (s *CookiePreference) SetWhitelistedNames(v *CookieNames) *CookiePreference
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CookiePreference) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Forward != nil {
+		v := *s.Forward
+
+		e.SetValue(protocol.BodyTarget, "Forward", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WhitelistedNames != nil {
+		v := s.WhitelistedNames
+
+		e.SetFields(protocol.BodyTarget, "WhitelistedNames", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The request to create a new origin access identity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateCloudFrontOriginAccessIdentityRequest
 type CreateCloudFrontOriginAccessIdentityInput struct {
@@ -3916,6 +4112,17 @@ func (s *CreateCloudFrontOriginAccessIdentityInput) SetCloudFrontOriginAccessIde
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateCloudFrontOriginAccessIdentityResult
 type CreateCloudFrontOriginAccessIdentityOutput struct {
@@ -3958,6 +4165,27 @@ func (s *CreateCloudFrontOriginAccessIdentityOutput) SetETag(v string) *CreateCl
 func (s *CreateCloudFrontOriginAccessIdentityOutput) SetLocation(v string) *CreateCloudFrontOriginAccessIdentityOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create a new distribution.
@@ -4005,6 +4233,17 @@ func (s *CreateDistributionInput) SetDistributionConfig(v *DistributionConfig) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateDistributionResult
 type CreateDistributionOutput struct {
@@ -4047,6 +4286,27 @@ func (s *CreateDistributionOutput) SetETag(v string) *CreateDistributionOutput {
 func (s *CreateDistributionOutput) SetLocation(v string) *CreateDistributionOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Distribution != nil {
+		v := s.Distribution
+
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create a new distribution with tags.
@@ -4094,6 +4354,17 @@ func (s *CreateDistributionWithTagsInput) SetDistributionConfigWithTags(v *Distr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDistributionWithTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfigWithTags != nil {
+		v := s.DistributionConfigWithTags
+
+		e.SetFields(protocol.PayloadTarget, "DistributionConfigWithTags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateDistributionWithTagsResult
 type CreateDistributionWithTagsOutput struct {
@@ -4136,6 +4407,27 @@ func (s *CreateDistributionWithTagsOutput) SetETag(v string) *CreateDistribution
 func (s *CreateDistributionWithTagsOutput) SetLocation(v string) *CreateDistributionWithTagsOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDistributionWithTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Distribution != nil {
+		v := s.Distribution
+
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create an invalidation.
@@ -4197,6 +4489,22 @@ func (s *CreateInvalidationInput) SetInvalidationBatch(v *InvalidationBatch) *Cr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateInvalidationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionId != nil {
+		v := *s.DistributionId
+
+		e.SetValue(protocol.PathTarget, "DistributionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvalidationBatch != nil {
+		v := s.InvalidationBatch
+
+		e.SetFields(protocol.PayloadTarget, "InvalidationBatch", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateInvalidationResult
 type CreateInvalidationOutput struct {
@@ -4230,6 +4538,22 @@ func (s *CreateInvalidationOutput) SetInvalidation(v *Invalidation) *CreateInval
 func (s *CreateInvalidationOutput) SetLocation(v string) *CreateInvalidationOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateInvalidationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Invalidation != nil {
+		v := s.Invalidation
+
+		e.SetFields(protocol.PayloadTarget, "Invalidation", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create a new streaming distribution.
@@ -4277,6 +4601,17 @@ func (s *CreateStreamingDistributionInput) SetStreamingDistributionConfig(v *Str
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateStreamingDistributionResult
 type CreateStreamingDistributionOutput struct {
@@ -4319,6 +4654,27 @@ func (s *CreateStreamingDistributionOutput) SetLocation(v string) *CreateStreami
 func (s *CreateStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *CreateStreamingDistributionOutput {
 	s.StreamingDistribution = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistribution != nil {
+		v := s.StreamingDistribution
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create a new streaming distribution with tags.
@@ -4366,6 +4722,17 @@ func (s *CreateStreamingDistributionWithTagsInput) SetStreamingDistributionConfi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStreamingDistributionWithTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamingDistributionConfigWithTags != nil {
+		v := s.StreamingDistributionConfigWithTags
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfigWithTags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateStreamingDistributionWithTagsResult
 type CreateStreamingDistributionWithTagsOutput struct {
@@ -4407,6 +4774,27 @@ func (s *CreateStreamingDistributionWithTagsOutput) SetLocation(v string) *Creat
 func (s *CreateStreamingDistributionWithTagsOutput) SetStreamingDistribution(v *StreamingDistribution) *CreateStreamingDistributionWithTagsOutput {
 	s.StreamingDistribution = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStreamingDistributionWithTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistribution != nil {
+		v := s.StreamingDistribution
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that controls:
@@ -4538,6 +4926,40 @@ func (s *CustomErrorResponse) SetResponsePagePath(v string) *CustomErrorResponse
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CustomErrorResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorCachingMinTTL != nil {
+		v := *s.ErrorCachingMinTTL
+
+		e.SetValue(protocol.BodyTarget, "ErrorCachingMinTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ErrorCode != nil {
+		v := *s.ErrorCode
+
+		e.SetValue(protocol.BodyTarget, "ErrorCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ResponseCode != nil {
+		v := *s.ResponseCode
+
+		e.SetValue(protocol.BodyTarget, "ResponseCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponsePagePath != nil {
+		v := *s.ResponsePagePath
+
+		e.SetValue(protocol.BodyTarget, "ResponsePagePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCustomErrorResponseList(vs []*CustomErrorResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that controls:
 //
 //    * Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range
@@ -4609,6 +5031,22 @@ func (s *CustomErrorResponses) SetQuantity(v int64) *CustomErrorResponses {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CustomErrorResponses) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeCustomErrorResponseList(v), protocol.Metadata{ListLocationName: "CustomErrorResponse"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the list of Custom Headers for each origin.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CustomHeaders
 type CustomHeaders struct {
@@ -4668,6 +5106,22 @@ func (s *CustomHeaders) SetItems(v []*OriginCustomHeader) *CustomHeaders {
 func (s *CustomHeaders) SetQuantity(v int64) *CustomHeaders {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CustomHeaders) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeOriginCustomHeaderList(v), protocol.Metadata{ListLocationName: "OriginCustomHeader"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A customer origin.
@@ -4781,6 +5235,42 @@ func (s *CustomOriginConfig) SetOriginReadTimeout(v int64) *CustomOriginConfig {
 func (s *CustomOriginConfig) SetOriginSslProtocols(v *OriginSslProtocols) *CustomOriginConfig {
 	s.OriginSslProtocols = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CustomOriginConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HTTPPort != nil {
+		v := *s.HTTPPort
+
+		e.SetValue(protocol.BodyTarget, "HTTPPort", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HTTPSPort != nil {
+		v := *s.HTTPSPort
+
+		e.SetValue(protocol.BodyTarget, "HTTPSPort", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OriginKeepaliveTimeout != nil {
+		v := *s.OriginKeepaliveTimeout
+
+		e.SetValue(protocol.BodyTarget, "OriginKeepaliveTimeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OriginProtocolPolicy != nil {
+		v := *s.OriginProtocolPolicy
+
+		e.SetValue(protocol.BodyTarget, "OriginProtocolPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginReadTimeout != nil {
+		v := *s.OriginReadTimeout
+
+		e.SetValue(protocol.BodyTarget, "OriginReadTimeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OriginSslProtocols != nil {
+		v := s.OriginSslProtocols
+
+		e.SetFields(protocol.BodyTarget, "OriginSslProtocols", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes the default cache behavior if you do not specify
@@ -5031,6 +5521,67 @@ func (s *DefaultCacheBehavior) SetViewerProtocolPolicy(v string) *DefaultCacheBe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DefaultCacheBehavior) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AllowedMethods != nil {
+		v := s.AllowedMethods
+
+		e.SetFields(protocol.BodyTarget, "AllowedMethods", v, protocol.Metadata{})
+	}
+	if s.Compress != nil {
+		v := *s.Compress
+
+		e.SetValue(protocol.BodyTarget, "Compress", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DefaultTTL != nil {
+		v := *s.DefaultTTL
+
+		e.SetValue(protocol.BodyTarget, "DefaultTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ForwardedValues != nil {
+		v := s.ForwardedValues
+
+		e.SetFields(protocol.BodyTarget, "ForwardedValues", v, protocol.Metadata{})
+	}
+	if s.LambdaFunctionAssociations != nil {
+		v := s.LambdaFunctionAssociations
+
+		e.SetFields(protocol.BodyTarget, "LambdaFunctionAssociations", v, protocol.Metadata{})
+	}
+	if s.MaxTTL != nil {
+		v := *s.MaxTTL
+
+		e.SetValue(protocol.BodyTarget, "MaxTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinTTL != nil {
+		v := *s.MinTTL
+
+		e.SetValue(protocol.BodyTarget, "MinTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SmoothStreaming != nil {
+		v := *s.SmoothStreaming
+
+		e.SetValue(protocol.BodyTarget, "SmoothStreaming", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.TargetOriginId != nil {
+		v := *s.TargetOriginId
+
+		e.SetValue(protocol.BodyTarget, "TargetOriginId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrustedSigners != nil {
+		v := s.TrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
+	}
+	if s.ViewerProtocolPolicy != nil {
+		v := *s.ViewerProtocolPolicy
+
+		e.SetValue(protocol.BodyTarget, "ViewerProtocolPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Deletes a origin access identity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteCloudFrontOriginAccessIdentityRequest
 type DeleteCloudFrontOriginAccessIdentityInput struct {
@@ -5081,6 +5632,22 @@ func (s *DeleteCloudFrontOriginAccessIdentityInput) SetIfMatch(v string) *Delete
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteCloudFrontOriginAccessIdentityOutput
 type DeleteCloudFrontOriginAccessIdentityOutput struct {
 	_ struct{} `type:"structure"`
@@ -5094,6 +5661,12 @@ func (s DeleteCloudFrontOriginAccessIdentityOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCloudFrontOriginAccessIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // This action deletes a web distribution. To delete a web distribution using
@@ -5180,6 +5753,22 @@ func (s *DeleteDistributionInput) SetIfMatch(v string) *DeleteDistributionInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteDistributionOutput
 type DeleteDistributionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5193,6 +5782,12 @@ func (s DeleteDistributionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The request to delete a streaming distribution.
@@ -5245,6 +5840,22 @@ func (s *DeleteStreamingDistributionInput) SetIfMatch(v string) *DeleteStreaming
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteStreamingDistributionOutput
 type DeleteStreamingDistributionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5258,6 +5869,12 @@ func (s DeleteStreamingDistributionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteStreamingDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The distribution's information.
@@ -5373,6 +5990,52 @@ func (s *Distribution) SetLastModifiedTime(v time.Time) *Distribution {
 func (s *Distribution) SetStatus(v string) *Distribution {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Distribution) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ActiveTrustedSigners != nil {
+		v := s.ActiveTrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "ActiveTrustedSigners", v, protocol.Metadata{})
+	}
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.BodyTarget, "DistributionConfig", v, protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InProgressInvalidationBatches != nil {
+		v := *s.InProgressInvalidationBatches
+
+		e.SetValue(protocol.BodyTarget, "InProgressInvalidationBatches", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LastModifiedTime != nil {
+		v := *s.LastModifiedTime
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A distribution configuration.
@@ -5742,6 +6405,92 @@ func (s *DistributionConfig) SetWebACLId(v string) *DistributionConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DistributionConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Aliases != nil {
+		v := s.Aliases
+
+		e.SetFields(protocol.BodyTarget, "Aliases", v, protocol.Metadata{})
+	}
+	if s.CacheBehaviors != nil {
+		v := s.CacheBehaviors
+
+		e.SetFields(protocol.BodyTarget, "CacheBehaviors", v, protocol.Metadata{})
+	}
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CustomErrorResponses != nil {
+		v := s.CustomErrorResponses
+
+		e.SetFields(protocol.BodyTarget, "CustomErrorResponses", v, protocol.Metadata{})
+	}
+	if s.DefaultCacheBehavior != nil {
+		v := s.DefaultCacheBehavior
+
+		e.SetFields(protocol.BodyTarget, "DefaultCacheBehavior", v, protocol.Metadata{})
+	}
+	if s.DefaultRootObject != nil {
+		v := *s.DefaultRootObject
+
+		e.SetValue(protocol.BodyTarget, "DefaultRootObject", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HttpVersion != nil {
+		v := *s.HttpVersion
+
+		e.SetValue(protocol.BodyTarget, "HttpVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsIPV6Enabled != nil {
+		v := *s.IsIPV6Enabled
+
+		e.SetValue(protocol.BodyTarget, "IsIPV6Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Logging != nil {
+		v := s.Logging
+
+		e.SetFields(protocol.BodyTarget, "Logging", v, protocol.Metadata{})
+	}
+	if s.Origins != nil {
+		v := s.Origins
+
+		e.SetFields(protocol.BodyTarget, "Origins", v, protocol.Metadata{})
+	}
+	if s.PriceClass != nil {
+		v := *s.PriceClass
+
+		e.SetValue(protocol.BodyTarget, "PriceClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Restrictions != nil {
+		v := s.Restrictions
+
+		e.SetFields(protocol.BodyTarget, "Restrictions", v, protocol.Metadata{})
+	}
+	if s.ViewerCertificate != nil {
+		v := s.ViewerCertificate
+
+		e.SetFields(protocol.BodyTarget, "ViewerCertificate", v, protocol.Metadata{})
+	}
+	if s.WebACLId != nil {
+		v := *s.WebACLId
+
+		e.SetValue(protocol.BodyTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A distribution Configuration and a list of tags to be associated with the
 // distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DistributionConfigWithTags
@@ -5805,6 +6554,22 @@ func (s *DistributionConfigWithTags) SetDistributionConfig(v *DistributionConfig
 func (s *DistributionConfigWithTags) SetTags(v *Tags) *DistributionConfigWithTags {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DistributionConfigWithTags) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.BodyTarget, "DistributionConfig", v, protocol.Metadata{})
+	}
+	if s.Tags != nil {
+		v := s.Tags
+
+		e.SetFields(protocol.BodyTarget, "Tags", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A distribution list.
@@ -5889,6 +6654,42 @@ func (s *DistributionList) SetNextMarker(v string) *DistributionList {
 func (s *DistributionList) SetQuantity(v int64) *DistributionList {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DistributionList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeDistributionSummaryList(v), protocol.Metadata{ListLocationName: "DistributionSummary"})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A summary of the information about a CloudFront distribution.
@@ -6125,6 +6926,110 @@ func (s *DistributionSummary) SetWebACLId(v string) *DistributionSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DistributionSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Aliases != nil {
+		v := s.Aliases
+
+		e.SetFields(protocol.BodyTarget, "Aliases", v, protocol.Metadata{})
+	}
+	if s.CacheBehaviors != nil {
+		v := s.CacheBehaviors
+
+		e.SetFields(protocol.BodyTarget, "CacheBehaviors", v, protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CustomErrorResponses != nil {
+		v := s.CustomErrorResponses
+
+		e.SetFields(protocol.BodyTarget, "CustomErrorResponses", v, protocol.Metadata{})
+	}
+	if s.DefaultCacheBehavior != nil {
+		v := s.DefaultCacheBehavior
+
+		e.SetFields(protocol.BodyTarget, "DefaultCacheBehavior", v, protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HttpVersion != nil {
+		v := *s.HttpVersion
+
+		e.SetValue(protocol.BodyTarget, "HttpVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsIPV6Enabled != nil {
+		v := *s.IsIPV6Enabled
+
+		e.SetValue(protocol.BodyTarget, "IsIPV6Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedTime != nil {
+		v := *s.LastModifiedTime
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Origins != nil {
+		v := s.Origins
+
+		e.SetFields(protocol.BodyTarget, "Origins", v, protocol.Metadata{})
+	}
+	if s.PriceClass != nil {
+		v := *s.PriceClass
+
+		e.SetValue(protocol.BodyTarget, "PriceClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Restrictions != nil {
+		v := s.Restrictions
+
+		e.SetFields(protocol.BodyTarget, "Restrictions", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ViewerCertificate != nil {
+		v := s.ViewerCertificate
+
+		e.SetFields(protocol.BodyTarget, "ViewerCertificate", v, protocol.Metadata{})
+	}
+	if s.WebACLId != nil {
+		v := *s.WebACLId
+
+		e.SetValue(protocol.BodyTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDistributionSummaryList(vs []*DistributionSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that specifies how CloudFront handles query strings and cookies.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ForwardedValues
 type ForwardedValues struct {
@@ -6240,6 +7145,32 @@ func (s *ForwardedValues) SetQueryStringCacheKeys(v *QueryStringCacheKeys) *Forw
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ForwardedValues) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Cookies != nil {
+		v := s.Cookies
+
+		e.SetFields(protocol.BodyTarget, "Cookies", v, protocol.Metadata{})
+	}
+	if s.Headers != nil {
+		v := s.Headers
+
+		e.SetFields(protocol.BodyTarget, "Headers", v, protocol.Metadata{})
+	}
+	if s.QueryString != nil {
+		v := *s.QueryString
+
+		e.SetValue(protocol.BodyTarget, "QueryString", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.QueryStringCacheKeys != nil {
+		v := s.QueryStringCacheKeys
+
+		e.SetFields(protocol.BodyTarget, "QueryStringCacheKeys", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that controls the countries in which your content is distributed.
 // CloudFront determines the location of your users using MaxMind GeoIP databases.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GeoRestriction
@@ -6328,6 +7259,27 @@ func (s *GeoRestriction) SetRestrictionType(v string) *GeoRestriction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GeoRestriction) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Location"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RestrictionType != nil {
+		v := *s.RestrictionType
+
+		e.SetValue(protocol.BodyTarget, "RestrictionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The origin access identity's configuration information. For more information,
 // see CloudFrontOriginAccessIdentityConfigComplexType.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetCloudFrontOriginAccessIdentityConfigRequest
@@ -6369,6 +7321,17 @@ func (s *GetCloudFrontOriginAccessIdentityConfigInput) SetId(v string) *GetCloud
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCloudFrontOriginAccessIdentityConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetCloudFrontOriginAccessIdentityConfigResult
 type GetCloudFrontOriginAccessIdentityConfigOutput struct {
@@ -6401,6 +7364,22 @@ func (s *GetCloudFrontOriginAccessIdentityConfigOutput) SetCloudFrontOriginAcces
 func (s *GetCloudFrontOriginAccessIdentityConfigOutput) SetETag(v string) *GetCloudFrontOriginAccessIdentityConfigOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCloudFrontOriginAccessIdentityConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get an origin access identity's information.
@@ -6443,6 +7422,17 @@ func (s *GetCloudFrontOriginAccessIdentityInput) SetId(v string) *GetCloudFrontO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetCloudFrontOriginAccessIdentityResult
 type GetCloudFrontOriginAccessIdentityOutput struct {
@@ -6476,6 +7466,22 @@ func (s *GetCloudFrontOriginAccessIdentityOutput) SetCloudFrontOriginAccessIdent
 func (s *GetCloudFrontOriginAccessIdentityOutput) SetETag(v string) *GetCloudFrontOriginAccessIdentityOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get a distribution configuration.
@@ -6518,6 +7524,17 @@ func (s *GetDistributionConfigInput) SetId(v string) *GetDistributionConfigInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDistributionConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetDistributionConfigResult
 type GetDistributionConfigOutput struct {
@@ -6550,6 +7567,22 @@ func (s *GetDistributionConfigOutput) SetDistributionConfig(v *DistributionConfi
 func (s *GetDistributionConfigOutput) SetETag(v string) *GetDistributionConfigOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDistributionConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get a distribution's information.
@@ -6592,6 +7625,17 @@ func (s *GetDistributionInput) SetId(v string) *GetDistributionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetDistributionResult
 type GetDistributionOutput struct {
@@ -6624,6 +7668,22 @@ func (s *GetDistributionOutput) SetDistribution(v *Distribution) *GetDistributio
 func (s *GetDistributionOutput) SetETag(v string) *GetDistributionOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Distribution != nil {
+		v := s.Distribution
+
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get an invalidation's information.
@@ -6680,6 +7740,22 @@ func (s *GetInvalidationInput) SetId(v string) *GetInvalidationInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetInvalidationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionId != nil {
+		v := *s.DistributionId
+
+		e.SetValue(protocol.PathTarget, "DistributionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetInvalidationResult
 type GetInvalidationOutput struct {
@@ -6704,6 +7780,17 @@ func (s GetInvalidationOutput) GoString() string {
 func (s *GetInvalidationOutput) SetInvalidation(v *Invalidation) *GetInvalidationOutput {
 	s.Invalidation = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetInvalidationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Invalidation != nil {
+		v := s.Invalidation
+
+		e.SetFields(protocol.PayloadTarget, "Invalidation", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // To request to get a streaming distribution configuration.
@@ -6746,6 +7833,17 @@ func (s *GetStreamingDistributionConfigInput) SetId(v string) *GetStreamingDistr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStreamingDistributionConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetStreamingDistributionConfigResult
 type GetStreamingDistributionConfigOutput struct {
@@ -6778,6 +7876,22 @@ func (s *GetStreamingDistributionConfigOutput) SetETag(v string) *GetStreamingDi
 func (s *GetStreamingDistributionConfigOutput) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *GetStreamingDistributionConfigOutput {
 	s.StreamingDistributionConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStreamingDistributionConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get a streaming distribution's information.
@@ -6820,6 +7934,17 @@ func (s *GetStreamingDistributionInput) SetId(v string) *GetStreamingDistributio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetStreamingDistributionResult
 type GetStreamingDistributionOutput struct {
@@ -6853,6 +7978,22 @@ func (s *GetStreamingDistributionOutput) SetETag(v string) *GetStreamingDistribu
 func (s *GetStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *GetStreamingDistributionOutput {
 	s.StreamingDistribution = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistribution != nil {
+		v := s.StreamingDistribution
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that specifies the headers that you want CloudFront to forward
@@ -6937,6 +8078,22 @@ func (s *Headers) SetQuantity(v int64) *Headers {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Headers) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Name"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An invalidation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Invalidation
 type Invalidation struct {
@@ -6996,6 +8153,32 @@ func (s *Invalidation) SetInvalidationBatch(v *InvalidationBatch) *Invalidation 
 func (s *Invalidation) SetStatus(v string) *Invalidation {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Invalidation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreateTime != nil {
+		v := *s.CreateTime
+
+		e.SetValue(protocol.BodyTarget, "CreateTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvalidationBatch != nil {
+		v := s.InvalidationBatch
+
+		e.SetFields(protocol.BodyTarget, "InvalidationBatch", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An invalidation batch.
@@ -7072,6 +8255,22 @@ func (s *InvalidationBatch) SetCallerReference(v string) *InvalidationBatch {
 func (s *InvalidationBatch) SetPaths(v *Paths) *InvalidationBatch {
 	s.Paths = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvalidationBatch) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Paths != nil {
+		v := s.Paths
+
+		e.SetFields(protocol.BodyTarget, "Paths", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The InvalidationList complex type describes the list of invalidation objects.
@@ -7161,6 +8360,42 @@ func (s *InvalidationList) SetQuantity(v int64) *InvalidationList {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvalidationList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeInvalidationSummaryList(v), protocol.Metadata{ListLocationName: "InvalidationSummary"})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A summary of an invalidation request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/InvalidationSummary
 type InvalidationSummary struct {
@@ -7208,6 +8443,35 @@ func (s *InvalidationSummary) SetStatus(v string) *InvalidationSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvalidationSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreateTime != nil {
+		v := *s.CreateTime
+
+		e.SetValue(protocol.BodyTarget, "CreateTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInvalidationSummaryList(vs []*InvalidationSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that lists the active CloudFront key pairs, if any, that are
 // associated with AwsAccountNumber.
 //
@@ -7252,6 +8516,22 @@ func (s *KeyPairIds) SetQuantity(v int64) *KeyPairIds {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyPairIds) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "KeyPairId"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains a Lambda function association.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/LambdaFunctionAssociation
 type LambdaFunctionAssociation struct {
@@ -7293,6 +8573,30 @@ func (s *LambdaFunctionAssociation) SetEventType(v string) *LambdaFunctionAssoci
 func (s *LambdaFunctionAssociation) SetLambdaFunctionARN(v string) *LambdaFunctionAssociation {
 	s.LambdaFunctionARN = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LambdaFunctionAssociation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventType != nil {
+		v := *s.EventType
+
+		e.SetValue(protocol.BodyTarget, "EventType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LambdaFunctionARN != nil {
+		v := *s.LambdaFunctionARN
+
+		e.SetValue(protocol.BodyTarget, "LambdaFunctionARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLambdaFunctionAssociationList(vs []*LambdaFunctionAssociation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that specifies a list of Lambda functions associations for
@@ -7355,6 +8659,22 @@ func (s *LambdaFunctionAssociations) SetQuantity(v int64) *LambdaFunctionAssocia
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LambdaFunctionAssociations) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeLambdaFunctionAssociationList(v), protocol.Metadata{ListLocationName: "LambdaFunctionAssociation"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The request to list origin access identities.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListCloudFrontOriginAccessIdentitiesRequest
 type ListCloudFrontOriginAccessIdentitiesInput struct {
@@ -7393,6 +8713,22 @@ func (s *ListCloudFrontOriginAccessIdentitiesInput) SetMaxItems(v int64) *ListCl
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCloudFrontOriginAccessIdentitiesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListCloudFrontOriginAccessIdentitiesResult
 type ListCloudFrontOriginAccessIdentitiesOutput struct {
@@ -7416,6 +8752,17 @@ func (s ListCloudFrontOriginAccessIdentitiesOutput) GoString() string {
 func (s *ListCloudFrontOriginAccessIdentitiesOutput) SetCloudFrontOriginAccessIdentityList(v *OriginAccessIdentityList) *ListCloudFrontOriginAccessIdentitiesOutput {
 	s.CloudFrontOriginAccessIdentityList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCloudFrontOriginAccessIdentitiesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityList != nil {
+		v := s.CloudFrontOriginAccessIdentityList
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list distributions that are associated with a specified AWS
@@ -7484,6 +8831,27 @@ func (s *ListDistributionsByWebACLIdInput) SetWebACLId(v string) *ListDistributi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDistributionsByWebACLIdInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.WebACLId != nil {
+		v := *s.WebACLId
+
+		e.SetValue(protocol.PathTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The response to a request to list the distributions that are associated with
 // a specified AWS WAF web ACL.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListDistributionsByWebACLIdResult
@@ -7508,6 +8876,17 @@ func (s ListDistributionsByWebACLIdOutput) GoString() string {
 func (s *ListDistributionsByWebACLIdOutput) SetDistributionList(v *DistributionList) *ListDistributionsByWebACLIdOutput {
 	s.DistributionList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDistributionsByWebACLIdOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionList != nil {
+		v := s.DistributionList
+
+		e.SetFields(protocol.PayloadTarget, "DistributionList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list your distributions.
@@ -7548,6 +8927,22 @@ func (s *ListDistributionsInput) SetMaxItems(v int64) *ListDistributionsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDistributionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListDistributionsResult
 type ListDistributionsOutput struct {
@@ -7571,6 +8966,17 @@ func (s ListDistributionsOutput) GoString() string {
 func (s *ListDistributionsOutput) SetDistributionList(v *DistributionList) *ListDistributionsOutput {
 	s.DistributionList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDistributionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionList != nil {
+		v := s.DistributionList
+
+		e.SetFields(protocol.PayloadTarget, "DistributionList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list invalidations.
@@ -7638,6 +9044,27 @@ func (s *ListInvalidationsInput) SetMaxItems(v int64) *ListInvalidationsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListInvalidationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionId != nil {
+		v := *s.DistributionId
+
+		e.SetValue(protocol.PathTarget, "DistributionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListInvalidationsResult
 type ListInvalidationsOutput struct {
@@ -7661,6 +9088,17 @@ func (s ListInvalidationsOutput) GoString() string {
 func (s *ListInvalidationsOutput) SetInvalidationList(v *InvalidationList) *ListInvalidationsOutput {
 	s.InvalidationList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListInvalidationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InvalidationList != nil {
+		v := s.InvalidationList
+
+		e.SetFields(protocol.PayloadTarget, "InvalidationList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list your streaming distributions.
@@ -7697,6 +9135,22 @@ func (s *ListStreamingDistributionsInput) SetMaxItems(v int64) *ListStreamingDis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListStreamingDistributionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListStreamingDistributionsResult
 type ListStreamingDistributionsOutput struct {
@@ -7720,6 +9174,17 @@ func (s ListStreamingDistributionsOutput) GoString() string {
 func (s *ListStreamingDistributionsOutput) SetStreamingDistributionList(v *StreamingDistributionList) *ListStreamingDistributionsOutput {
 	s.StreamingDistributionList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListStreamingDistributionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamingDistributionList != nil {
+		v := s.StreamingDistributionList
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list tags for a CloudFront resource.
@@ -7762,6 +9227,17 @@ func (s *ListTagsForResourceInput) SetResource(v string) *ListTagsForResourceInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListTagsForResourceResult
 type ListTagsForResourceOutput struct {
@@ -7787,6 +9263,17 @@ func (s ListTagsForResourceOutput) GoString() string {
 func (s *ListTagsForResourceOutput) SetTags(v *Tags) *ListTagsForResourceOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Tags != nil {
+		v := s.Tags
+
+		e.SetFields(protocol.PayloadTarget, "Tags", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that controls whether access logs are written for the distribution.
@@ -7882,6 +9369,32 @@ func (s *LoggingConfig) SetIncludeCookies(v bool) *LoggingConfig {
 func (s *LoggingConfig) SetPrefix(v string) *LoggingConfig {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.IncludeCookies != nil {
+		v := *s.IncludeCookies
+
+		e.SetValue(protocol.BodyTarget, "IncludeCookies", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes the Amazon S3 bucket or the HTTP server (for
@@ -8048,6 +9561,50 @@ func (s *Origin) SetS3OriginConfig(v *S3OriginConfig) *Origin {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Origin) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CustomHeaders != nil {
+		v := s.CustomHeaders
+
+		e.SetFields(protocol.BodyTarget, "CustomHeaders", v, protocol.Metadata{})
+	}
+	if s.CustomOriginConfig != nil {
+		v := s.CustomOriginConfig
+
+		e.SetFields(protocol.BodyTarget, "CustomOriginConfig", v, protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginPath != nil {
+		v := *s.OriginPath
+
+		e.SetValue(protocol.BodyTarget, "OriginPath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3OriginConfig != nil {
+		v := s.S3OriginConfig
+
+		e.SetFields(protocol.BodyTarget, "S3OriginConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOriginList(vs []*Origin) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // CloudFront origin access identity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CloudFrontOriginAccessIdentity
 type OriginAccessIdentity struct {
@@ -8095,6 +9652,27 @@ func (s *OriginAccessIdentity) SetId(v string) *OriginAccessIdentity {
 func (s *OriginAccessIdentity) SetS3CanonicalUserId(v string) *OriginAccessIdentity {
 	s.S3CanonicalUserId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginAccessIdentity) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
+
+		e.SetFields(protocol.BodyTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3CanonicalUserId != nil {
+		v := *s.S3CanonicalUserId
+
+		e.SetValue(protocol.BodyTarget, "S3CanonicalUserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Origin access identity configuration. Send a GET request to the /CloudFront
@@ -8163,6 +9741,22 @@ func (s *OriginAccessIdentityConfig) SetCallerReference(v string) *OriginAccessI
 func (s *OriginAccessIdentityConfig) SetComment(v string) *OriginAccessIdentityConfig {
 	s.Comment = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginAccessIdentityConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Lists the origin access identities for CloudFront.Send a GET request to the
@@ -8259,6 +9853,42 @@ func (s *OriginAccessIdentityList) SetQuantity(v int64) *OriginAccessIdentityLis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginAccessIdentityList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeOriginAccessIdentitySummaryList(v), protocol.Metadata{ListLocationName: "CloudFrontOriginAccessIdentitySummary"})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Summary of the information about a CloudFront origin access identity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CloudFrontOriginAccessIdentitySummary
 type OriginAccessIdentitySummary struct {
@@ -8309,6 +9939,35 @@ func (s *OriginAccessIdentitySummary) SetId(v string) *OriginAccessIdentitySumma
 func (s *OriginAccessIdentitySummary) SetS3CanonicalUserId(v string) *OriginAccessIdentitySummary {
 	s.S3CanonicalUserId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginAccessIdentitySummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3CanonicalUserId != nil {
+		v := *s.S3CanonicalUserId
+
+		e.SetValue(protocol.BodyTarget, "S3CanonicalUserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOriginAccessIdentitySummaryList(vs []*OriginAccessIdentitySummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains HeaderName and HeaderValue elements, if any,
@@ -8369,6 +10028,30 @@ func (s *OriginCustomHeader) SetHeaderValue(v string) *OriginCustomHeader {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginCustomHeader) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HeaderName != nil {
+		v := *s.HeaderName
+
+		e.SetValue(protocol.BodyTarget, "HeaderName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HeaderValue != nil {
+		v := *s.HeaderValue
+
+		e.SetValue(protocol.BodyTarget, "HeaderValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOriginCustomHeaderList(vs []*OriginCustomHeader) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains information about the SSL/TLS protocols that
 // CloudFront can use when establishing an HTTPS connection with your origin.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/OriginSslProtocols
@@ -8423,6 +10106,22 @@ func (s *OriginSslProtocols) SetItems(v []*string) *OriginSslProtocols {
 func (s *OriginSslProtocols) SetQuantity(v int64) *OriginSslProtocols {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginSslProtocols) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "SslProtocol"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about origins for this distribution.
@@ -8487,6 +10186,22 @@ func (s *Origins) SetQuantity(v int64) *Origins {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Origins) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeOriginList(v), protocol.Metadata{ListLocationName: "Origin"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the objects that you want
 // to invalidate. For more information, see Specifying the Objects to Invalidate
 // (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects)
@@ -8539,6 +10254,22 @@ func (s *Paths) SetQuantity(v int64) *Paths {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Paths) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Path"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/QueryStringCacheKeys
 type QueryStringCacheKeys struct {
 	_ struct{} `type:"structure"`
@@ -8589,6 +10320,22 @@ func (s *QueryStringCacheKeys) SetQuantity(v int64) *QueryStringCacheKeys {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QueryStringCacheKeys) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Name"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that identifies ways in which you want to restrict distribution
 // of your content.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Restrictions
@@ -8634,6 +10381,17 @@ func (s *Restrictions) Validate() error {
 func (s *Restrictions) SetGeoRestriction(v *GeoRestriction) *Restrictions {
 	s.GeoRestriction = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Restrictions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GeoRestriction != nil {
+		v := s.GeoRestriction
+
+		e.SetFields(protocol.BodyTarget, "GeoRestriction", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the Amazon S3 bucket from
@@ -8707,6 +10465,22 @@ func (s *S3Origin) SetOriginAccessIdentity(v string) *S3Origin {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *S3Origin) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginAccessIdentity != nil {
+		v := *s.OriginAccessIdentity
+
+		e.SetValue(protocol.BodyTarget, "OriginAccessIdentity", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the Amazon S3 origin. If the
 // origin is a custom origin, use the CustomOriginConfig element instead.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/S3OriginConfig
@@ -8770,6 +10544,17 @@ func (s *S3OriginConfig) SetOriginAccessIdentity(v string) *S3OriginConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *S3OriginConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OriginAccessIdentity != nil {
+		v := *s.OriginAccessIdentity
+
+		e.SetValue(protocol.BodyTarget, "OriginAccessIdentity", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that lists the AWS accounts that were included in the TrustedSigners
 // complex type, as well as their active CloudFront key pair IDs, if any.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Signer
@@ -8809,6 +10594,30 @@ func (s *Signer) SetAwsAccountNumber(v string) *Signer {
 func (s *Signer) SetKeyPairIds(v *KeyPairIds) *Signer {
 	s.KeyPairIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Signer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AwsAccountNumber != nil {
+		v := *s.AwsAccountNumber
+
+		e.SetValue(protocol.BodyTarget, "AwsAccountNumber", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyPairIds != nil {
+		v := s.KeyPairIds
+
+		e.SetFields(protocol.BodyTarget, "KeyPairIds", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSignerList(vs []*Signer) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A streaming distribution.
@@ -8911,6 +10720,47 @@ func (s *StreamingDistribution) SetStatus(v string) *StreamingDistribution {
 func (s *StreamingDistribution) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *StreamingDistribution {
 	s.StreamingDistributionConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistribution) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ActiveTrustedSigners != nil {
+		v := s.ActiveTrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "ActiveTrustedSigners", v, protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedTime != nil {
+		v := *s.LastModifiedTime
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.BodyTarget, "StreamingDistributionConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The RTMP distribution's configuration information.
@@ -9075,6 +10925,52 @@ func (s *StreamingDistributionConfig) SetTrustedSigners(v *TrustedSigners) *Stre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistributionConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Aliases != nil {
+		v := s.Aliases
+
+		e.SetFields(protocol.BodyTarget, "Aliases", v, protocol.Metadata{})
+	}
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Logging != nil {
+		v := s.Logging
+
+		e.SetFields(protocol.BodyTarget, "Logging", v, protocol.Metadata{})
+	}
+	if s.PriceClass != nil {
+		v := *s.PriceClass
+
+		e.SetValue(protocol.BodyTarget, "PriceClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Origin != nil {
+		v := s.S3Origin
+
+		e.SetFields(protocol.BodyTarget, "S3Origin", v, protocol.Metadata{})
+	}
+	if s.TrustedSigners != nil {
+		v := s.TrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A streaming distribution Configuration and a list of tags to be associated
 // with the streaming distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/StreamingDistributionConfigWithTags
@@ -9138,6 +11034,22 @@ func (s *StreamingDistributionConfigWithTags) SetStreamingDistributionConfig(v *
 func (s *StreamingDistributionConfigWithTags) SetTags(v *Tags) *StreamingDistributionConfigWithTags {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistributionConfigWithTags) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.BodyTarget, "StreamingDistributionConfig", v, protocol.Metadata{})
+	}
+	if s.Tags != nil {
+		v := s.Tags
+
+		e.SetFields(protocol.BodyTarget, "Tags", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A streaming distribution list.
@@ -9223,6 +11135,42 @@ func (s *StreamingDistributionList) SetNextMarker(v string) *StreamingDistributi
 func (s *StreamingDistributionList) SetQuantity(v int64) *StreamingDistributionList {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistributionList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeStreamingDistributionSummaryList(v), protocol.Metadata{ListLocationName: "StreamingDistributionSummary"})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A summary of the information for an Amazon CloudFront streaming distribution.
@@ -9375,6 +11323,75 @@ func (s *StreamingDistributionSummary) SetTrustedSigners(v *TrustedSigners) *Str
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistributionSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Aliases != nil {
+		v := s.Aliases
+
+		e.SetFields(protocol.BodyTarget, "Aliases", v, protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedTime != nil {
+		v := *s.LastModifiedTime
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.PriceClass != nil {
+		v := *s.PriceClass
+
+		e.SetValue(protocol.BodyTarget, "PriceClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Origin != nil {
+		v := s.S3Origin
+
+		e.SetFields(protocol.BodyTarget, "S3Origin", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrustedSigners != nil {
+		v := s.TrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStreamingDistributionSummaryList(vs []*StreamingDistributionSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that controls whether access logs are written for this streaming
 // distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/StreamingLoggingConfig
@@ -9452,6 +11469,27 @@ func (s *StreamingLoggingConfig) SetPrefix(v string) *StreamingLoggingConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingLoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains Tag key and Tag value.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Tag
 type Tag struct {
@@ -9510,6 +11548,30 @@ func (s *Tag) SetValue(v string) *Tag {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains zero or more Tag elements.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/TagKeys
 type TagKeys struct {
@@ -9533,6 +11595,17 @@ func (s TagKeys) GoString() string {
 func (s *TagKeys) SetItems(v []*string) *TagKeys {
 	s.Items = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagKeys) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Key"})
+	}
+
+	return nil
 }
 
 // The request to add tags to a CloudFront resource.
@@ -9594,6 +11667,22 @@ func (s *TagResourceInput) SetTags(v *Tags) *TagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tags != nil {
+		v := s.Tags
+
+		e.SetFields(protocol.PayloadTarget, "Tags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/TagResourceOutput
 type TagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -9607,6 +11696,12 @@ func (s TagResourceOutput) String() string {
 // GoString returns the string representation
 func (s TagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains zero or more Tag elements.
@@ -9652,6 +11747,17 @@ func (s *Tags) Validate() error {
 func (s *Tags) SetItems(v []*Tag) *Tags {
 	s.Items = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tags) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+
+	return nil
 }
 
 // A complex type that specifies the AWS accounts, if any, that you want to
@@ -9736,6 +11842,27 @@ func (s *TrustedSigners) SetQuantity(v int64) *TrustedSigners {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TrustedSigners) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "AwsAccountNumber"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The request to remove tags from a CloudFront resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UntagResourceRequest
 type UntagResourceInput struct {
@@ -9790,6 +11917,22 @@ func (s *UntagResourceInput) SetTagKeys(v *TagKeys) *UntagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TagKeys != nil {
+		v := s.TagKeys
+
+		e.SetFields(protocol.PayloadTarget, "TagKeys", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UntagResourceOutput
 type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -9803,6 +11946,12 @@ func (s UntagResourceOutput) String() string {
 // GoString returns the string representation
 func (s UntagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The request to update an origin access identity.
@@ -9874,6 +12023,27 @@ func (s *UpdateCloudFrontOriginAccessIdentityInput) SetIfMatch(v string) *Update
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UpdateCloudFrontOriginAccessIdentityResult
 type UpdateCloudFrontOriginAccessIdentityOutput struct {
@@ -9906,6 +12076,22 @@ func (s *UpdateCloudFrontOriginAccessIdentityOutput) SetCloudFrontOriginAccessId
 func (s *UpdateCloudFrontOriginAccessIdentityOutput) SetETag(v string) *UpdateCloudFrontOriginAccessIdentityOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to update a distribution.
@@ -9977,6 +12163,27 @@ func (s *UpdateDistributionInput) SetIfMatch(v string) *UpdateDistributionInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UpdateDistributionResult
 type UpdateDistributionOutput struct {
@@ -10009,6 +12216,22 @@ func (s *UpdateDistributionOutput) SetDistribution(v *Distribution) *UpdateDistr
 func (s *UpdateDistributionOutput) SetETag(v string) *UpdateDistributionOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Distribution != nil {
+		v := s.Distribution
+
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to update a streaming distribution.
@@ -10080,6 +12303,27 @@ func (s *UpdateStreamingDistributionInput) SetStreamingDistributionConfig(v *Str
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UpdateStreamingDistributionResult
 type UpdateStreamingDistributionOutput struct {
@@ -10112,6 +12356,22 @@ func (s *UpdateStreamingDistributionOutput) SetETag(v string) *UpdateStreamingDi
 func (s *UpdateStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *UpdateStreamingDistributionOutput {
 	s.StreamingDistribution = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistribution != nil {
+		v := s.StreamingDistribution
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that specifies the following:
@@ -10319,6 +12579,47 @@ func (s *ViewerCertificate) SetMinimumProtocolVersion(v string) *ViewerCertifica
 func (s *ViewerCertificate) SetSSLSupportMethod(v string) *ViewerCertificate {
 	s.SSLSupportMethod = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ViewerCertificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACMCertificateArn != nil {
+		v := *s.ACMCertificateArn
+
+		e.SetValue(protocol.BodyTarget, "ACMCertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Certificate != nil {
+		v := *s.Certificate
+
+		e.SetValue(protocol.BodyTarget, "Certificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateSource != nil {
+		v := *s.CertificateSource
+
+		e.SetValue(protocol.BodyTarget, "CertificateSource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CloudFrontDefaultCertificate != nil {
+		v := *s.CloudFrontDefaultCertificate
+
+		e.SetValue(protocol.BodyTarget, "CloudFrontDefaultCertificate", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.IAMCertificateId != nil {
+		v := *s.IAMCertificateId
+
+		e.SetValue(protocol.BodyTarget, "IAMCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MinimumProtocolVersion != nil {
+		v := *s.MinimumProtocolVersion
+
+		e.SetValue(protocol.BodyTarget, "MinimumProtocolVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSLSupportMethod != nil {
+		v := *s.SSLSupportMethod
+
+		e.SetValue(protocol.BodyTarget, "SSLSupportMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opAssociateVPCWithHostedZone = "AssociateVPCWithHostedZone"
@@ -5480,6 +5481,22 @@ func (s *AlarmIdentifier) SetRegion(v string) *AlarmIdentifier {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AlarmIdentifier) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Alias resource record sets only: Information about the CloudFront distribution,
 // Elastic Beanstalk environment, ELB load balancer, Amazon S3 bucket, or Amazon
 // Route 53 resource record set that you're redirecting queries to. An Elastic
@@ -5713,6 +5730,27 @@ func (s *AliasTarget) SetHostedZoneId(v string) *AliasTarget {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AliasTarget) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DNSName != nil {
+		v := *s.DNSName
+
+		e.SetValue(protocol.BodyTarget, "DNSName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EvaluateTargetHealth != nil {
+		v := *s.EvaluateTargetHealth
+
+		e.SetValue(protocol.BodyTarget, "EvaluateTargetHealth", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the request to associate a
 // VPC with a private hosted zone.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/AssociateVPCWithHostedZoneRequest
@@ -5787,6 +5825,27 @@ func (s *AssociateVPCWithHostedZoneInput) SetVPC(v *VPC) *AssociateVPCWithHosted
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateVPCWithHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the AssociateVPCWithHostedZone
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/AssociateVPCWithHostedZoneResponse
@@ -5813,6 +5872,17 @@ func (s AssociateVPCWithHostedZoneOutput) GoString() string {
 func (s *AssociateVPCWithHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *AssociateVPCWithHostedZoneOutput {
 	s.ChangeInfo = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateVPCWithHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The information for each resource record set that you want to change.
@@ -5924,6 +5994,30 @@ func (s *Change) SetResourceRecordSet(v *ResourceRecordSet) *Change {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Change) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceRecordSet != nil {
+		v := s.ResourceRecordSet
+
+		e.SetFields(protocol.BodyTarget, "ResourceRecordSet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeChangeList(vs []*Change) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The information for a change request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ChangeBatch
 type ChangeBatch struct {
@@ -5984,6 +6078,22 @@ func (s *ChangeBatch) SetChanges(v []*Change) *ChangeBatch {
 func (s *ChangeBatch) SetComment(v string) *ChangeBatch {
 	s.Comment = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeBatch) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Changes) > 0 {
+		v := s.Changes
+
+		e.SetList(protocol.BodyTarget, "Changes", encodeChangeList(v), protocol.Metadata{ListLocationName: "Change"})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes change information about changes made to your
@@ -6053,6 +6163,32 @@ func (s *ChangeInfo) SetSubmittedAt(v time.Time) *ChangeInfo {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubmittedAt != nil {
+		v := *s.SubmittedAt
+
+		e.SetValue(protocol.BodyTarget, "SubmittedAt", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains change information for the resource record set.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ChangeResourceRecordSetsRequest
 type ChangeResourceRecordSetsInput struct {
@@ -6113,6 +6249,22 @@ func (s *ChangeResourceRecordSetsInput) SetHostedZoneId(v string) *ChangeResourc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeResourceRecordSetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeBatch != nil {
+		v := s.ChangeBatch
+
+		e.SetFields(protocol.BodyTarget, "ChangeBatch", v, protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing the response for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ChangeResourceRecordSetsResponse
 type ChangeResourceRecordSetsOutput struct {
@@ -6142,6 +6294,17 @@ func (s ChangeResourceRecordSetsOutput) GoString() string {
 func (s *ChangeResourceRecordSetsOutput) SetChangeInfo(v *ChangeInfo) *ChangeResourceRecordSetsOutput {
 	s.ChangeInfo = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeResourceRecordSetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the tags that you want to
@@ -6232,6 +6395,32 @@ func (s *ChangeTagsForResourceInput) SetResourceType(v string) *ChangeTagsForRes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AddTags) > 0 {
+		v := s.AddTags
+
+		e.SetList(protocol.BodyTarget, "AddTags", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+	if len(s.RemoveTagKeys) > 0 {
+		v := s.RemoveTagKeys
+
+		e.SetList(protocol.BodyTarget, "RemoveTagKeys", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Key"})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Empty response for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ChangeTagsForResourceResponse
 type ChangeTagsForResourceOutput struct {
@@ -6246,6 +6435,12 @@ func (s ChangeTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ChangeTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains information about the CloudWatch alarm that
@@ -6361,6 +6556,52 @@ func (s *CloudWatchAlarmConfiguration) SetThreshold(v float64) *CloudWatchAlarmC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CloudWatchAlarmConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComparisonOperator != nil {
+		v := *s.ComparisonOperator
+
+		e.SetValue(protocol.BodyTarget, "ComparisonOperator", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Dimensions) > 0 {
+		v := s.Dimensions
+
+		e.SetList(protocol.BodyTarget, "Dimensions", encodeDimensionList(v), protocol.Metadata{ListLocationName: "Dimension"})
+	}
+	if s.EvaluationPeriods != nil {
+		v := *s.EvaluationPeriods
+
+		e.SetValue(protocol.BodyTarget, "EvaluationPeriods", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MetricName != nil {
+		v := *s.MetricName
+
+		e.SetValue(protocol.BodyTarget, "MetricName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Namespace != nil {
+		v := *s.Namespace
+
+		e.SetValue(protocol.BodyTarget, "Namespace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Period != nil {
+		v := *s.Period
+
+		e.SetValue(protocol.BodyTarget, "Period", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Statistic != nil {
+		v := *s.Statistic
+
+		e.SetValue(protocol.BodyTarget, "Statistic", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Threshold != nil {
+		v := *s.Threshold
+
+		e.SetValue(protocol.BodyTarget, "Threshold", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the health check request information.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateHealthCheckRequest
 type CreateHealthCheckInput struct {
@@ -6442,6 +6683,22 @@ func (s *CreateHealthCheckInput) SetHealthCheckConfig(v *HealthCheckConfig) *Cre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HealthCheckConfig != nil {
+		v := s.HealthCheckConfig
+
+		e.SetFields(protocol.BodyTarget, "HealthCheckConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing the response information for the new health check.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateHealthCheckResponse
 type CreateHealthCheckOutput struct {
@@ -6478,6 +6735,22 @@ func (s *CreateHealthCheckOutput) SetHealthCheck(v *HealthCheck) *CreateHealthCh
 func (s *CreateHealthCheckOutput) SetLocation(v string) *CreateHealthCheckOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheck != nil {
+		v := s.HealthCheck
+
+		e.SetFields(protocol.BodyTarget, "HealthCheck", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the request to create a hosted
@@ -6598,6 +6871,37 @@ func (s *CreateHostedZoneInput) SetVPC(v *VPC) *CreateHostedZoneInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DelegationSetId != nil {
+		v := *s.DelegationSetId
+
+		e.SetValue(protocol.BodyTarget, "DelegationSetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneConfig != nil {
+		v := s.HostedZoneConfig
+
+		e.SetFields(protocol.BodyTarget, "HostedZoneConfig", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing the response information for the hosted zone.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateHostedZoneResponse
 type CreateHostedZoneOutput struct {
@@ -6668,6 +6972,37 @@ func (s *CreateHostedZoneOutput) SetVPC(v *VPC) *CreateHostedZoneOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+	if s.DelegationSet != nil {
+		v := s.DelegationSet
+
+		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
+	}
+	if s.HostedZone != nil {
+		v := s.HostedZone
+
+		e.SetFields(protocol.BodyTarget, "HostedZone", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateQueryLoggingConfigRequest
 type CreateQueryLoggingConfigInput struct {
 	_ struct{} `locationName:"CreateQueryLoggingConfigRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
@@ -6730,6 +7065,22 @@ func (s *CreateQueryLoggingConfigInput) SetHostedZoneId(v string) *CreateQueryLo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudWatchLogsLogGroupArn != nil {
+		v := *s.CloudWatchLogsLogGroupArn
+
+		e.SetValue(protocol.BodyTarget, "CloudWatchLogsLogGroupArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateQueryLoggingConfigResponse
 type CreateQueryLoggingConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -6767,6 +7118,22 @@ func (s *CreateQueryLoggingConfigOutput) SetLocation(v string) *CreateQueryLoggi
 func (s *CreateQueryLoggingConfigOutput) SetQueryLoggingConfig(v *QueryLoggingConfig) *CreateQueryLoggingConfigOutput {
 	s.QueryLoggingConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.QueryLoggingConfig != nil {
+		v := s.QueryLoggingConfig
+
+		e.SetFields(protocol.BodyTarget, "QueryLoggingConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateReusableDelegationSetRequest
@@ -6825,6 +7192,22 @@ func (s *CreateReusableDelegationSetInput) SetHostedZoneId(v string) *CreateReus
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateReusableDelegationSetResponse
 type CreateReusableDelegationSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -6860,6 +7243,22 @@ func (s *CreateReusableDelegationSetOutput) SetDelegationSet(v *DelegationSet) *
 func (s *CreateReusableDelegationSetOutput) SetLocation(v string) *CreateReusableDelegationSetOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSet != nil {
+		v := s.DelegationSet
+
+		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the traffic policy that you
@@ -6925,6 +7324,27 @@ func (s *CreateTrafficPolicyInput) SetDocument(v string) *CreateTrafficPolicyInp
 func (s *CreateTrafficPolicyInput) SetName(v string) *CreateTrafficPolicyInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the resource record sets that
@@ -7036,6 +7456,37 @@ func (s *CreateTrafficPolicyInstanceInput) SetTrafficPolicyVersion(v int64) *Cre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TTL != nil {
+		v := *s.TTL
+
+		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyId != nil {
+		v := *s.TrafficPolicyId
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersion != nil {
+		v := *s.TrafficPolicyVersion
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicyInstance
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateTrafficPolicyInstanceResponse
@@ -7075,6 +7526,22 @@ func (s *CreateTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstance != nil {
+		v := s.TrafficPolicyInstance
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicy
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateTrafficPolicyResponse
@@ -7112,6 +7579,22 @@ func (s *CreateTrafficPolicyOutput) SetLocation(v string) *CreateTrafficPolicyOu
 func (s *CreateTrafficPolicyOutput) SetTrafficPolicy(v *TrafficPolicy) *CreateTrafficPolicyOutput {
 	s.TrafficPolicy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicy != nil {
+		v := s.TrafficPolicy
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the traffic policy that you
@@ -7184,6 +7667,27 @@ func (s *CreateTrafficPolicyVersionInput) SetId(v string) *CreateTrafficPolicyVe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicyVersion
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateTrafficPolicyVersionResponse
@@ -7222,6 +7726,22 @@ func (s *CreateTrafficPolicyVersionOutput) SetLocation(v string) *CreateTrafficP
 func (s *CreateTrafficPolicyVersionOutput) SetTrafficPolicy(v *TrafficPolicy) *CreateTrafficPolicyVersionOutput {
 	s.TrafficPolicy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicy != nil {
+		v := s.TrafficPolicy
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the request to authorize associating
@@ -7287,6 +7807,22 @@ func (s *CreateVPCAssociationAuthorizationInput) SetVPC(v *VPC) *CreateVPCAssoci
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateVPCAssociationAuthorizationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information from a CreateVPCAssociationAuthorization
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateVPCAssociationAuthorizationResponse
@@ -7324,6 +7860,22 @@ func (s *CreateVPCAssociationAuthorizationOutput) SetHostedZoneId(v string) *Cre
 func (s *CreateVPCAssociationAuthorizationOutput) SetVPC(v *VPC) *CreateVPCAssociationAuthorizationOutput {
 	s.VPC = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateVPCAssociationAuthorizationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that lists the name servers in a delegation set, as well as
@@ -7374,6 +7926,35 @@ func (s *DelegationSet) SetNameServers(v []*string) *DelegationSet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DelegationSet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.NameServers) > 0 {
+		v := s.NameServers
+
+		e.SetList(protocol.BodyTarget, "NameServers", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "NameServer"})
+	}
+
+	return nil
+}
+
+func encodeDelegationSetList(vs []*DelegationSet) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // This action deletes a health check.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteHealthCheckRequest
 type DeleteHealthCheckInput struct {
@@ -7414,6 +7995,17 @@ func (s *DeleteHealthCheckInput) SetHealthCheckId(v string) *DeleteHealthCheckIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An empty element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteHealthCheckResponse
 type DeleteHealthCheckOutput struct {
@@ -7428,6 +8020,12 @@ func (s DeleteHealthCheckOutput) String() string {
 // GoString returns the string representation
 func (s DeleteHealthCheckOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete a hosted zone.
@@ -7470,6 +8068,17 @@ func (s *DeleteHostedZoneInput) SetId(v string) *DeleteHostedZoneInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a DeleteHostedZone request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteHostedZoneResponse
 type DeleteHostedZoneOutput struct {
@@ -7496,6 +8105,17 @@ func (s DeleteHostedZoneOutput) GoString() string {
 func (s *DeleteHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *DeleteHostedZoneOutput {
 	s.ChangeInfo = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteQueryLoggingConfigRequest
@@ -7540,6 +8160,17 @@ func (s *DeleteQueryLoggingConfigInput) SetId(v string) *DeleteQueryLoggingConfi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteQueryLoggingConfigResponse
 type DeleteQueryLoggingConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -7553,6 +8184,12 @@ func (s DeleteQueryLoggingConfigOutput) String() string {
 // GoString returns the string representation
 func (s DeleteQueryLoggingConfigOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete a reusable delegation set.
@@ -7595,6 +8232,17 @@ func (s *DeleteReusableDelegationSetInput) SetId(v string) *DeleteReusableDelega
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An empty element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteReusableDelegationSetResponse
 type DeleteReusableDelegationSetOutput struct {
@@ -7609,6 +8257,12 @@ func (s DeleteReusableDelegationSetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteReusableDelegationSetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete a specified traffic policy version.
@@ -7671,6 +8325,22 @@ func (s *DeleteTrafficPolicyInput) SetVersion(v int64) *DeleteTrafficPolicyInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to delete a specified traffic policy instance.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteTrafficPolicyInstanceRequest
 type DeleteTrafficPolicyInstanceInput struct {
@@ -7718,6 +8388,17 @@ func (s *DeleteTrafficPolicyInstanceInput) SetId(v string) *DeleteTrafficPolicyI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An empty element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteTrafficPolicyInstanceResponse
 type DeleteTrafficPolicyInstanceOutput struct {
@@ -7734,6 +8415,12 @@ func (s DeleteTrafficPolicyInstanceOutput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 // An empty element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteTrafficPolicyResponse
 type DeleteTrafficPolicyOutput struct {
@@ -7748,6 +8435,12 @@ func (s DeleteTrafficPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTrafficPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains information about the request to remove authorization
@@ -7815,6 +8508,22 @@ func (s *DeleteVPCAssociationAuthorizationInput) SetVPC(v *VPC) *DeleteVPCAssoci
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVPCAssociationAuthorizationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Empty response for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteVPCAssociationAuthorizationResponse
 type DeleteVPCAssociationAuthorizationOutput struct {
@@ -7829,6 +8538,12 @@ func (s DeleteVPCAssociationAuthorizationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVPCAssociationAuthorizationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVPCAssociationAuthorizationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // For the metric that the CloudWatch alarm is associated with, a complex type
@@ -7870,6 +8585,30 @@ func (s *Dimension) SetName(v string) *Dimension {
 func (s *Dimension) SetValue(v string) *Dimension {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Dimension) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDimensionList(vs []*Dimension) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains information about the VPC that you want to disassociate
@@ -7942,6 +8681,27 @@ func (s *DisassociateVPCFromHostedZoneInput) SetVPC(v *VPC) *DisassociateVPCFrom
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateVPCFromHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the disassociate
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DisassociateVPCFromHostedZoneResponse
@@ -7969,6 +8729,17 @@ func (s DisassociateVPCFromHostedZoneOutput) GoString() string {
 func (s *DisassociateVPCFromHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *DisassociateVPCFromHostedZoneOutput {
 	s.ChangeInfo = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateVPCFromHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about a geo location.
@@ -8037,6 +8808,27 @@ func (s *GeoLocation) SetCountryCode(v string) *GeoLocation {
 func (s *GeoLocation) SetSubdivisionCode(v string) *GeoLocation {
 	s.SubdivisionCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GeoLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinentCode != nil {
+		v := *s.ContinentCode
+
+		e.SetValue(protocol.BodyTarget, "ContinentCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CountryCode != nil {
+		v := *s.CountryCode
+
+		e.SetValue(protocol.BodyTarget, "CountryCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubdivisionCode != nil {
+		v := *s.SubdivisionCode
+
+		e.SetValue(protocol.BodyTarget, "SubdivisionCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the codes and full continent, country, and subdivision
@@ -8112,6 +8904,50 @@ func (s *GeoLocationDetails) SetSubdivisionName(v string) *GeoLocationDetails {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GeoLocationDetails) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinentCode != nil {
+		v := *s.ContinentCode
+
+		e.SetValue(protocol.BodyTarget, "ContinentCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinentName != nil {
+		v := *s.ContinentName
+
+		e.SetValue(protocol.BodyTarget, "ContinentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CountryCode != nil {
+		v := *s.CountryCode
+
+		e.SetValue(protocol.BodyTarget, "CountryCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CountryName != nil {
+		v := *s.CountryName
+
+		e.SetValue(protocol.BodyTarget, "CountryName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubdivisionCode != nil {
+		v := *s.SubdivisionCode
+
+		e.SetValue(protocol.BodyTarget, "SubdivisionCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubdivisionName != nil {
+		v := *s.SubdivisionName
+
+		e.SetValue(protocol.BodyTarget, "SubdivisionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGeoLocationDetailsList(vs []*GeoLocationDetails) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The input for a GetChange request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetChangeRequest
 type GetChangeInput struct {
@@ -8154,6 +8990,17 @@ func (s *GetChangeInput) SetId(v string) *GetChangeInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetChangeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the ChangeInfo element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetChangeResponse
 type GetChangeOutput struct {
@@ -8181,6 +9028,17 @@ func (s *GetChangeOutput) SetChangeInfo(v *ChangeInfo) *GetChangeOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetChangeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetCheckerIpRangesRequest
 type GetCheckerIpRangesInput struct {
 	_ struct{} `type:"structure"`
@@ -8194,6 +9052,12 @@ func (s GetCheckerIpRangesInput) String() string {
 // GoString returns the string representation
 func (s GetCheckerIpRangesInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCheckerIpRangesInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetCheckerIpRangesResponse
@@ -8218,6 +9082,17 @@ func (s GetCheckerIpRangesOutput) GoString() string {
 func (s *GetCheckerIpRangesOutput) SetCheckerIpRanges(v []*string) *GetCheckerIpRangesOutput {
 	s.CheckerIpRanges = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCheckerIpRangesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CheckerIpRanges) > 0 {
+		v := s.CheckerIpRanges
+
+		e.SetList(protocol.BodyTarget, "CheckerIpRanges", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for information about whether a specified geographic location is
@@ -8301,6 +9176,27 @@ func (s *GetGeoLocationInput) SetSubdivisionCode(v string) *GetGeoLocationInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGeoLocationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinentCode != nil {
+		v := *s.ContinentCode
+
+		e.SetValue(protocol.QueryTarget, "continentcode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CountryCode != nil {
+		v := *s.CountryCode
+
+		e.SetValue(protocol.QueryTarget, "countrycode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubdivisionCode != nil {
+		v := *s.SubdivisionCode
+
+		e.SetValue(protocol.QueryTarget, "subdivisioncode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the specified geolocation
 // code.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetGeoLocationResponse
@@ -8330,6 +9226,17 @@ func (s *GetGeoLocationOutput) SetGeoLocationDetails(v *GeoLocationDetails) *Get
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGeoLocationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GeoLocationDetails != nil {
+		v := s.GeoLocationDetails
+
+		e.SetFields(protocol.BodyTarget, "GeoLocationDetails", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request for the number of health checks that are associated with the current
 // AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckCountRequest
@@ -8345,6 +9252,12 @@ func (s GetHealthCheckCountInput) String() string {
 // GoString returns the string representation
 func (s GetHealthCheckCountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckCountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains the response to a GetHealthCheckCount request.
@@ -8372,6 +9285,17 @@ func (s GetHealthCheckCountOutput) GoString() string {
 func (s *GetHealthCheckCountOutput) SetHealthCheckCount(v int64) *GetHealthCheckCountOutput {
 	s.HealthCheckCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckCountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckCount != nil {
+		v := *s.HealthCheckCount
+
+		e.SetValue(protocol.BodyTarget, "HealthCheckCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about a specified health check.
@@ -8417,6 +9341,17 @@ func (s *GetHealthCheckInput) SetHealthCheckId(v string) *GetHealthCheckInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request for the reason that a health check failed most recently.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckLastFailureReasonRequest
 type GetHealthCheckLastFailureReasonInput struct {
@@ -8459,6 +9394,17 @@ func (s *GetHealthCheckLastFailureReasonInput) SetHealthCheckId(v string) *GetHe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckLastFailureReasonInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a GetHealthCheckLastFailureReason
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckLastFailureReasonResponse
@@ -8488,6 +9434,17 @@ func (s *GetHealthCheckLastFailureReasonOutput) SetHealthCheckObservations(v []*
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckLastFailureReasonOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.HealthCheckObservations) > 0 {
+		v := s.HealthCheckObservations
+
+		e.SetList(protocol.BodyTarget, "HealthCheckObservations", encodeHealthCheckObservationList(v), protocol.Metadata{ListLocationName: "HealthCheckObservation"})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a GetHealthCheck request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckResponse
 type GetHealthCheckOutput struct {
@@ -8514,6 +9471,17 @@ func (s GetHealthCheckOutput) GoString() string {
 func (s *GetHealthCheckOutput) SetHealthCheck(v *HealthCheck) *GetHealthCheckOutput {
 	s.HealthCheck = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheck != nil {
+		v := s.HealthCheck
+
+		e.SetFields(protocol.BodyTarget, "HealthCheck", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get the status for a health check.
@@ -8562,6 +9530,17 @@ func (s *GetHealthCheckStatusInput) SetHealthCheckId(v string) *GetHealthCheckSt
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a GetHealthCheck request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckStatusResponse
 type GetHealthCheckStatusOutput struct {
@@ -8590,6 +9569,17 @@ func (s *GetHealthCheckStatusOutput) SetHealthCheckObservations(v []*HealthCheck
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.HealthCheckObservations) > 0 {
+		v := s.HealthCheckObservations
+
+		e.SetList(protocol.BodyTarget, "HealthCheckObservations", encodeHealthCheckObservationList(v), protocol.Metadata{ListLocationName: "HealthCheckObservation"})
+	}
+
+	return nil
+}
+
 // A request to retrieve a count of all the hosted zones that are associated
 // with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHostedZoneCountRequest
@@ -8605,6 +9595,12 @@ func (s GetHostedZoneCountInput) String() string {
 // GoString returns the string representation
 func (s GetHostedZoneCountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneCountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains the response to a GetHostedZoneCount request.
@@ -8633,6 +9629,17 @@ func (s GetHostedZoneCountOutput) GoString() string {
 func (s *GetHostedZoneCountOutput) SetHostedZoneCount(v int64) *GetHostedZoneCountOutput {
 	s.HostedZoneCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneCountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneCount != nil {
+		v := *s.HostedZoneCount
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about a specified hosted zone.
@@ -8673,6 +9680,17 @@ func (s *GetHostedZoneInput) Validate() error {
 func (s *GetHostedZoneInput) SetId(v string) *GetHostedZoneInput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contain the response to a GetHostedZone request.
@@ -8723,6 +9741,27 @@ func (s *GetHostedZoneOutput) SetVPCs(v []*VPC) *GetHostedZoneOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSet != nil {
+		v := s.DelegationSet
+
+		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
+	}
+	if s.HostedZone != nil {
+		v := s.HostedZone
+
+		e.SetFields(protocol.BodyTarget, "HostedZone", v, protocol.Metadata{})
+	}
+	if len(s.VPCs) > 0 {
+		v := s.VPCs
+
+		e.SetList(protocol.BodyTarget, "VPCs", encodeVPCList(v), protocol.Metadata{ListLocationName: "VPC"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetQueryLoggingConfigRequest
 type GetQueryLoggingConfigInput struct {
 	_ struct{} `type:"structure"`
@@ -8766,6 +9805,17 @@ func (s *GetQueryLoggingConfigInput) SetId(v string) *GetQueryLoggingConfigInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetQueryLoggingConfigResponse
 type GetQueryLoggingConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -8791,6 +9841,17 @@ func (s GetQueryLoggingConfigOutput) GoString() string {
 func (s *GetQueryLoggingConfigOutput) SetQueryLoggingConfig(v *QueryLoggingConfig) *GetQueryLoggingConfigOutput {
 	s.QueryLoggingConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.QueryLoggingConfig != nil {
+		v := s.QueryLoggingConfig
+
+		e.SetFields(protocol.BodyTarget, "QueryLoggingConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about a specified reusable delegation set.
@@ -8834,6 +9895,17 @@ func (s *GetReusableDelegationSetInput) SetId(v string) *GetReusableDelegationSe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to the GetReusableDelegationSet
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetReusableDelegationSetResponse
@@ -8860,6 +9932,17 @@ func (s GetReusableDelegationSetOutput) GoString() string {
 func (s *GetReusableDelegationSetOutput) SetDelegationSet(v *DelegationSet) *GetReusableDelegationSetOutput {
 	s.DelegationSet = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSet != nil {
+		v := s.DelegationSet
+
+		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets information about a specific traffic policy version.
@@ -8923,6 +10006,22 @@ func (s *GetTrafficPolicyInput) SetVersion(v int64) *GetTrafficPolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to get the number of traffic policy instances that are associated
 // with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetTrafficPolicyInstanceCountRequest
@@ -8938,6 +10037,12 @@ func (s GetTrafficPolicyInstanceCountInput) String() string {
 // GoString returns the string representation
 func (s GetTrafficPolicyInstanceCountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInstanceCountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains information about the resource record sets that
@@ -8967,6 +10072,17 @@ func (s GetTrafficPolicyInstanceCountOutput) GoString() string {
 func (s *GetTrafficPolicyInstanceCountOutput) SetTrafficPolicyInstanceCount(v int64) *GetTrafficPolicyInstanceCountOutput {
 	s.TrafficPolicyInstanceCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInstanceCountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicyInstanceCount != nil {
+		v := *s.TrafficPolicyInstanceCount
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets information about a specified traffic policy instance.
@@ -9012,6 +10128,17 @@ func (s *GetTrafficPolicyInstanceInput) SetId(v string) *GetTrafficPolicyInstanc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the resource record sets that
 // Amazon Route 53 created based on a specified traffic policy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetTrafficPolicyInstanceResponse
@@ -9040,6 +10167,17 @@ func (s *GetTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficPoli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicyInstance != nil {
+		v := s.TrafficPolicyInstance
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetTrafficPolicyResponse
 type GetTrafficPolicyOutput struct {
@@ -9065,6 +10203,17 @@ func (s GetTrafficPolicyOutput) GoString() string {
 func (s *GetTrafficPolicyOutput) SetTrafficPolicy(v *TrafficPolicy) *GetTrafficPolicyOutput {
 	s.TrafficPolicy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicy != nil {
+		v := s.TrafficPolicy
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about one health check that is associated
@@ -9141,6 +10290,45 @@ func (s *HealthCheck) SetHealthCheckVersion(v int64) *HealthCheck {
 func (s *HealthCheck) SetId(v string) *HealthCheck {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HealthCheck) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CloudWatchAlarmConfiguration != nil {
+		v := s.CloudWatchAlarmConfiguration
+
+		e.SetFields(protocol.BodyTarget, "CloudWatchAlarmConfiguration", v, protocol.Metadata{})
+	}
+	if s.HealthCheckConfig != nil {
+		v := s.HealthCheckConfig
+
+		e.SetFields(protocol.BodyTarget, "HealthCheckConfig", v, protocol.Metadata{})
+	}
+	if s.HealthCheckVersion != nil {
+		v := *s.HealthCheckVersion
+
+		e.SetValue(protocol.BodyTarget, "HealthCheckVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHealthCheckList(vs []*HealthCheck) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains information about the health check.
@@ -9554,6 +10742,92 @@ func (s *HealthCheckConfig) SetType(v string) *HealthCheckConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HealthCheckConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlarmIdentifier != nil {
+		v := s.AlarmIdentifier
+
+		e.SetFields(protocol.BodyTarget, "AlarmIdentifier", v, protocol.Metadata{})
+	}
+	if len(s.ChildHealthChecks) > 0 {
+		v := s.ChildHealthChecks
+
+		e.SetList(protocol.BodyTarget, "ChildHealthChecks", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ChildHealthCheck"})
+	}
+	if s.EnableSNI != nil {
+		v := *s.EnableSNI
+
+		e.SetValue(protocol.BodyTarget, "EnableSNI", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FailureThreshold != nil {
+		v := *s.FailureThreshold
+
+		e.SetValue(protocol.BodyTarget, "FailureThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FullyQualifiedDomainName != nil {
+		v := *s.FullyQualifiedDomainName
+
+		e.SetValue(protocol.BodyTarget, "FullyQualifiedDomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HealthThreshold != nil {
+		v := *s.HealthThreshold
+
+		e.SetValue(protocol.BodyTarget, "HealthThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IPAddress != nil {
+		v := *s.IPAddress
+
+		e.SetValue(protocol.BodyTarget, "IPAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InsufficientDataHealthStatus != nil {
+		v := *s.InsufficientDataHealthStatus
+
+		e.SetValue(protocol.BodyTarget, "InsufficientDataHealthStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Inverted != nil {
+		v := *s.Inverted
+
+		e.SetValue(protocol.BodyTarget, "Inverted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MeasureLatency != nil {
+		v := *s.MeasureLatency
+
+		e.SetValue(protocol.BodyTarget, "MeasureLatency", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Port != nil {
+		v := *s.Port
+
+		e.SetValue(protocol.BodyTarget, "Port", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Regions) > 0 {
+		v := s.Regions
+
+		e.SetList(protocol.BodyTarget, "Regions", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Region"})
+	}
+	if s.RequestInterval != nil {
+		v := *s.RequestInterval
+
+		e.SetValue(protocol.BodyTarget, "RequestInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ResourcePath != nil {
+		v := *s.ResourcePath
+
+		e.SetValue(protocol.BodyTarget, "ResourcePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SearchString != nil {
+		v := *s.SearchString
+
+		e.SetValue(protocol.BodyTarget, "SearchString", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the last failure reason as reported by one Amazon
 // Route 53 health checker.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/HealthCheckObservation
@@ -9599,6 +10873,35 @@ func (s *HealthCheckObservation) SetRegion(v string) *HealthCheckObservation {
 func (s *HealthCheckObservation) SetStatusReport(v *StatusReport) *HealthCheckObservation {
 	s.StatusReport = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HealthCheckObservation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IPAddress != nil {
+		v := *s.IPAddress
+
+		e.SetValue(protocol.BodyTarget, "IPAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusReport != nil {
+		v := s.StatusReport
+
+		e.SetFields(protocol.BodyTarget, "StatusReport", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHealthCheckObservationList(vs []*HealthCheckObservation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains general information about the hosted zone.
@@ -9676,6 +10979,45 @@ func (s *HostedZone) SetResourceRecordSetCount(v int64) *HostedZone {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HostedZone) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Config != nil {
+		v := s.Config
+
+		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceRecordSetCount != nil {
+		v := *s.ResourceRecordSetCount
+
+		e.SetValue(protocol.BodyTarget, "ResourceRecordSetCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHostedZoneList(vs []*HostedZone) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains an optional comment about your hosted zone.
 // If you don't want to specify a comment, omit both the HostedZoneConfig and
 // Comment elements.
@@ -9710,6 +11052,22 @@ func (s *HostedZoneConfig) SetComment(v string) *HostedZoneConfig {
 func (s *HostedZoneConfig) SetPrivateZone(v bool) *HostedZoneConfig {
 	s.PrivateZone = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HostedZoneConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrivateZone != nil {
+		v := *s.PrivateZone
+
+		e.SetValue(protocol.BodyTarget, "PrivateZone", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get a list of geographic locations that Amazon Route 53 supports
@@ -9808,6 +11166,32 @@ func (s *ListGeoLocationsInput) SetStartSubdivisionCode(v string) *ListGeoLocati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGeoLocationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartContinentCode != nil {
+		v := *s.StartContinentCode
+
+		e.SetValue(protocol.QueryTarget, "startcontinentcode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartCountryCode != nil {
+		v := *s.StartCountryCode
+
+		e.SetValue(protocol.QueryTarget, "startcountrycode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartSubdivisionCode != nil {
+		v := *s.StartSubdivisionCode
+
+		e.SetValue(protocol.QueryTarget, "startsubdivisioncode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListGeoLocationsResponse
 type ListGeoLocationsOutput struct {
@@ -9895,6 +11279,42 @@ func (s *ListGeoLocationsOutput) SetNextSubdivisionCode(v string) *ListGeoLocati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGeoLocationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.GeoLocationDetailsList) > 0 {
+		v := s.GeoLocationDetailsList
+
+		e.SetList(protocol.BodyTarget, "GeoLocationDetailsList", encodeGeoLocationDetailsList(v), protocol.Metadata{ListLocationName: "GeoLocationDetails"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextContinentCode != nil {
+		v := *s.NextContinentCode
+
+		e.SetValue(protocol.BodyTarget, "NextContinentCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextCountryCode != nil {
+		v := *s.NextCountryCode
+
+		e.SetValue(protocol.BodyTarget, "NextCountryCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextSubdivisionCode != nil {
+		v := *s.NextSubdivisionCode
+
+		e.SetValue(protocol.BodyTarget, "NextSubdivisionCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to retrieve a list of the health checks that are associated with
 // the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListHealthChecksRequest
@@ -9939,6 +11359,22 @@ func (s *ListHealthChecksInput) SetMarker(v string) *ListHealthChecksInput {
 func (s *ListHealthChecksInput) SetMaxItems(v string) *ListHealthChecksInput {
 	s.MaxItems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHealthChecksInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the response to a ListHealthChecks request.
@@ -10018,6 +11454,37 @@ func (s *ListHealthChecksOutput) SetNextMarker(v string) *ListHealthChecksOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHealthChecksOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.HealthChecks) > 0 {
+		v := s.HealthChecks
+
+		e.SetList(protocol.BodyTarget, "HealthChecks", encodeHealthCheckList(v), protocol.Metadata{ListLocationName: "HealthCheck"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Retrieves a list of the public and private hosted zones that are associated
 // with the current AWS account in ASCII order by domain name.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListHostedZonesByNameRequest
@@ -10077,6 +11544,27 @@ func (s *ListHostedZonesByNameInput) SetHostedZoneId(v string) *ListHostedZonesB
 func (s *ListHostedZonesByNameInput) SetMaxItems(v string) *ListHostedZonesByNameInput {
 	s.MaxItems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHostedZonesByNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DNSName != nil {
+		v := *s.DNSName
+
+		e.SetValue(protocol.QueryTarget, "dnsname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the response information for the request.
@@ -10182,6 +11670,47 @@ func (s *ListHostedZonesByNameOutput) SetNextHostedZoneId(v string) *ListHostedZ
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHostedZonesByNameOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DNSName != nil {
+		v := *s.DNSName
+
+		e.SetValue(protocol.BodyTarget, "DNSName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.HostedZones) > 0 {
+		v := s.HostedZones
+
+		e.SetList(protocol.BodyTarget, "HostedZones", encodeHostedZoneList(v), protocol.Metadata{ListLocationName: "HostedZone"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextDNSName != nil {
+		v := *s.NextDNSName
+
+		e.SetValue(protocol.BodyTarget, "NextDNSName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextHostedZoneId != nil {
+		v := *s.NextHostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "NextHostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to retrieve a list of the public and private hosted zones that
 // are associated with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListHostedZonesRequest
@@ -10238,6 +11767,27 @@ func (s *ListHostedZonesInput) SetMarker(v string) *ListHostedZonesInput {
 func (s *ListHostedZonesInput) SetMaxItems(v string) *ListHostedZonesInput {
 	s.MaxItems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHostedZonesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSetId != nil {
+		v := *s.DelegationSetId
+
+		e.SetValue(protocol.QueryTarget, "delegationsetid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListHostedZonesResponse
@@ -10318,6 +11868,37 @@ func (s *ListHostedZonesOutput) SetNextMarker(v string) *ListHostedZonesOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHostedZonesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.HostedZones) > 0 {
+		v := s.HostedZones
+
+		e.SetList(protocol.BodyTarget, "HostedZones", encodeHostedZoneList(v), protocol.Metadata{ListLocationName: "HostedZone"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListQueryLoggingConfigsRequest
 type ListQueryLoggingConfigsInput struct {
 	_ struct{} `type:"structure"`
@@ -10376,6 +11957,27 @@ func (s *ListQueryLoggingConfigsInput) SetNextToken(v string) *ListQueryLoggingC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListQueryLoggingConfigsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxresults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nexttoken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListQueryLoggingConfigsResponse
 type ListQueryLoggingConfigsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10417,6 +12019,22 @@ func (s *ListQueryLoggingConfigsOutput) SetNextToken(v string) *ListQueryLogging
 func (s *ListQueryLoggingConfigsOutput) SetQueryLoggingConfigs(v []*QueryLoggingConfig) *ListQueryLoggingConfigsOutput {
 	s.QueryLoggingConfigs = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListQueryLoggingConfigsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryLoggingConfigs) > 0 {
+		v := s.QueryLoggingConfigs
+
+		e.SetList(protocol.BodyTarget, "QueryLoggingConfigs", encodeQueryLoggingConfigList(v), protocol.Metadata{ListLocationName: "QueryLoggingConfig"})
+	}
+
+	return nil
 }
 
 // A request for the resource record sets that are associated with a specified
@@ -10531,6 +12149,37 @@ func (s *ListResourceRecordSetsInput) SetStartRecordType(v string) *ListResource
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListResourceRecordSetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartRecordIdentifier != nil {
+		v := *s.StartRecordIdentifier
+
+		e.SetValue(protocol.QueryTarget, "identifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartRecordName != nil {
+		v := *s.StartRecordName
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartRecordType != nil {
+		v := *s.StartRecordType
+
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains list information for the resource record set.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListResourceRecordSetsResponse
 type ListResourceRecordSetsOutput struct {
@@ -10615,6 +12264,42 @@ func (s *ListResourceRecordSetsOutput) SetResourceRecordSets(v []*ResourceRecord
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListResourceRecordSetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextRecordIdentifier != nil {
+		v := *s.NextRecordIdentifier
+
+		e.SetValue(protocol.BodyTarget, "NextRecordIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextRecordName != nil {
+		v := *s.NextRecordName
+
+		e.SetValue(protocol.BodyTarget, "NextRecordName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextRecordType != nil {
+		v := *s.NextRecordType
+
+		e.SetValue(protocol.BodyTarget, "NextRecordType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResourceRecordSets) > 0 {
+		v := s.ResourceRecordSets
+
+		e.SetList(protocol.BodyTarget, "ResourceRecordSets", encodeResourceRecordSetList(v), protocol.Metadata{ListLocationName: "ResourceRecordSet"})
+	}
+
+	return nil
+}
+
 // A request to get a list of the reusable delegation sets that are associated
 // with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListReusableDelegationSetsRequest
@@ -10659,6 +12344,22 @@ func (s *ListReusableDelegationSetsInput) SetMarker(v string) *ListReusableDeleg
 func (s *ListReusableDelegationSetsInput) SetMaxItems(v string) *ListReusableDelegationSetsInput {
 	s.MaxItems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListReusableDelegationSetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the reusable delegation sets
@@ -10738,6 +12439,37 @@ func (s *ListReusableDelegationSetsOutput) SetNextMarker(v string) *ListReusable
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListReusableDelegationSetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DelegationSets) > 0 {
+		v := s.DelegationSets
+
+		e.SetList(protocol.BodyTarget, "DelegationSets", encodeDelegationSetList(v), protocol.Metadata{ListLocationName: "DelegationSet"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing information about a request for a list of the tags
 // that are associated with an individual resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTagsForResourceRequest
@@ -10797,6 +12529,22 @@ func (s *ListTagsForResourceInput) SetResourceType(v string) *ListTagsForResourc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the health checks or hosted
 // zones for which you want to list tags.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTagsForResourceResponse
@@ -10823,6 +12571,17 @@ func (s ListTagsForResourceOutput) GoString() string {
 func (s *ListTagsForResourceOutput) SetResourceTagSet(v *ResourceTagSet) *ListTagsForResourceOutput {
 	s.ResourceTagSet = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceTagSet != nil {
+		v := s.ResourceTagSet
+
+		e.SetFields(protocol.BodyTarget, "ResourceTagSet", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the health checks or hosted
@@ -10888,6 +12647,22 @@ func (s *ListTagsForResourcesInput) SetResourceType(v string) *ListTagsForResour
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourcesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ResourceIds) > 0 {
+		v := s.ResourceIds
+
+		e.SetList(protocol.BodyTarget, "ResourceIds", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ResourceId"})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing tags for the specified resources.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTagsForResourcesResponse
 type ListTagsForResourcesOutput struct {
@@ -10913,6 +12688,17 @@ func (s ListTagsForResourcesOutput) GoString() string {
 func (s *ListTagsForResourcesOutput) SetResourceTagSets(v []*ResourceTagSet) *ListTagsForResourcesOutput {
 	s.ResourceTagSets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourcesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ResourceTagSets) > 0 {
+		v := s.ResourceTagSets
+
+		e.SetList(protocol.BodyTarget, "ResourceTagSets", encodeResourceTagSetList(v), protocol.Metadata{ListLocationName: "ResourceTagSet"})
+	}
+
+	return nil
 }
 
 // A complex type that contains the information about the request to list the
@@ -10972,6 +12758,22 @@ func (s *ListTrafficPoliciesInput) SetMaxItems(v string) *ListTrafficPoliciesInp
 func (s *ListTrafficPoliciesInput) SetTrafficPolicyIdMarker(v string) *ListTrafficPoliciesInput {
 	s.TrafficPolicyIdMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyIdMarker != nil {
+		v := *s.TrafficPolicyIdMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyid", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the response information for the request.
@@ -11038,6 +12840,32 @@ func (s *ListTrafficPoliciesOutput) SetTrafficPolicyIdMarker(v string) *ListTraf
 func (s *ListTrafficPoliciesOutput) SetTrafficPolicySummaries(v []*TrafficPolicySummary) *ListTrafficPoliciesOutput {
 	s.TrafficPolicySummaries = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyIdMarker != nil {
+		v := *s.TrafficPolicyIdMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicySummaries) > 0 {
+		v := s.TrafficPolicySummaries
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicySummaries", encodeTrafficPolicySummaryList(v), protocol.Metadata{ListLocationName: "TrafficPolicySummary"})
+	}
+
+	return nil
 }
 
 // A request for the traffic policy instances that you created in a specified
@@ -11130,6 +12958,32 @@ func (s *ListTrafficPolicyInstancesByHostedZoneInput) SetTrafficPolicyInstanceTy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesByHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancename", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancetype", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyInstancesByHostedZoneResponse
 type ListTrafficPolicyInstancesByHostedZoneOutput struct {
@@ -11204,6 +13058,37 @@ func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstanceT
 func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstances(v []*TrafficPolicyInstance) *ListTrafficPolicyInstancesByHostedZoneOutput {
 	s.TrafficPolicyInstances = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesByHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceNameMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceTypeMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicyInstances) > 0 {
+		v := s.TrafficPolicyInstances
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
+	}
+
+	return nil
 }
 
 // A complex type that contains the information about the request to list your
@@ -11337,6 +13222,42 @@ func (s *ListTrafficPolicyInstancesByPolicyInput) SetTrafficPolicyVersion(v int6
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesByPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneIdMarker != nil {
+		v := *s.HostedZoneIdMarker
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyId != nil {
+		v := *s.TrafficPolicyId
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancename", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancetype", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersion != nil {
+		v := *s.TrafficPolicyVersion
+
+		e.SetValue(protocol.QueryTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyInstancesByPolicyResponse
 type ListTrafficPolicyInstancesByPolicyOutput struct {
@@ -11425,6 +13346,42 @@ func (s *ListTrafficPolicyInstancesByPolicyOutput) SetTrafficPolicyInstances(v [
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesByPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneIdMarker != nil {
+		v := *s.HostedZoneIdMarker
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceNameMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceTypeMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicyInstances) > 0 {
+		v := s.TrafficPolicyInstances
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
+	}
+
+	return nil
+}
+
 // A request to get information about the traffic policy instances that you
 // created by using the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyInstancesRequest
@@ -11505,6 +13462,32 @@ func (s *ListTrafficPolicyInstancesInput) SetTrafficPolicyInstanceNameMarker(v s
 func (s *ListTrafficPolicyInstancesInput) SetTrafficPolicyInstanceTypeMarker(v string) *ListTrafficPolicyInstancesInput {
 	s.TrafficPolicyInstanceTypeMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneIdMarker != nil {
+		v := *s.HostedZoneIdMarker
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancename", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancetype", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the response information for the request.
@@ -11596,6 +13579,42 @@ func (s *ListTrafficPolicyInstancesOutput) SetTrafficPolicyInstances(v []*Traffi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneIdMarker != nil {
+		v := *s.HostedZoneIdMarker
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceNameMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceTypeMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicyInstances) > 0 {
+		v := s.TrafficPolicyInstances
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
+	}
+
+	return nil
+}
+
 // A complex type that contains the information about the request to list your
 // traffic policies.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyVersionsRequest
@@ -11671,6 +13690,27 @@ func (s *ListTrafficPolicyVersionsInput) SetTrafficPolicyVersionMarker(v string)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersionMarker != nil {
+		v := *s.TrafficPolicyVersionMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyversion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyVersionsResponse
 type ListTrafficPolicyVersionsOutput struct {
@@ -11741,6 +13781,32 @@ func (s *ListTrafficPolicyVersionsOutput) SetTrafficPolicyVersionMarker(v string
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicies) > 0 {
+		v := s.TrafficPolicies
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicies", encodeTrafficPolicyList(v), protocol.Metadata{ListLocationName: "TrafficPolicy"})
+	}
+	if s.TrafficPolicyVersionMarker != nil {
+		v := *s.TrafficPolicyVersionMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersionMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about that can be associated with
 // your hosted zone.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListVPCAssociationAuthorizationsRequest
@@ -11807,6 +13873,27 @@ func (s *ListVPCAssociationAuthorizationsInput) SetNextToken(v string) *ListVPCA
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVPCAssociationAuthorizationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxresults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nexttoken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListVPCAssociationAuthorizationsResponse
 type ListVPCAssociationAuthorizationsOutput struct {
@@ -11857,6 +13944,27 @@ func (s *ListVPCAssociationAuthorizationsOutput) SetNextToken(v string) *ListVPC
 func (s *ListVPCAssociationAuthorizationsOutput) SetVPCs(v []*VPC) *ListVPCAssociationAuthorizationsOutput {
 	s.VPCs = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVPCAssociationAuthorizationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.VPCs) > 0 {
+		v := s.VPCs
+
+		e.SetList(protocol.BodyTarget, "VPCs", encodeVPCList(v), protocol.Metadata{ListLocationName: "VPC"})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about a configuration for DNS query
@@ -11910,6 +14018,35 @@ func (s *QueryLoggingConfig) SetId(v string) *QueryLoggingConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QueryLoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudWatchLogsLogGroupArn != nil {
+		v := *s.CloudWatchLogsLogGroupArn
+
+		e.SetValue(protocol.BodyTarget, "CloudWatchLogsLogGroupArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeQueryLoggingConfigList(vs []*QueryLoggingConfig) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information specific to the resource record.
 //
 // If you're creating an alias resource record set, omit ResourceRecord.
@@ -11959,6 +14096,25 @@ func (s *ResourceRecord) Validate() error {
 func (s *ResourceRecord) SetValue(v string) *ResourceRecord {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceRecord) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourceRecordList(vs []*ResourceRecord) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about the resource record set to create or delete.
@@ -12493,6 +14649,85 @@ func (s *ResourceRecordSet) SetWeight(v int64) *ResourceRecordSet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceRecordSet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AliasTarget != nil {
+		v := s.AliasTarget
+
+		e.SetFields(protocol.BodyTarget, "AliasTarget", v, protocol.Metadata{})
+	}
+	if s.Failover != nil {
+		v := *s.Failover
+
+		e.SetValue(protocol.BodyTarget, "Failover", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GeoLocation != nil {
+		v := s.GeoLocation
+
+		e.SetFields(protocol.BodyTarget, "GeoLocation", v, protocol.Metadata{})
+	}
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.BodyTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MultiValueAnswer != nil {
+		v := *s.MultiValueAnswer
+
+		e.SetValue(protocol.BodyTarget, "MultiValueAnswer", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResourceRecords) > 0 {
+		v := s.ResourceRecords
+
+		e.SetList(protocol.BodyTarget, "ResourceRecords", encodeResourceRecordList(v), protocol.Metadata{ListLocationName: "ResourceRecord"})
+	}
+	if s.SetIdentifier != nil {
+		v := *s.SetIdentifier
+
+		e.SetValue(protocol.BodyTarget, "SetIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TTL != nil {
+		v := *s.TTL
+
+		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceId != nil {
+		v := *s.TrafficPolicyInstanceId
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Weight != nil {
+		v := *s.Weight
+
+		e.SetValue(protocol.BodyTarget, "Weight", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourceRecordSetList(vs []*ResourceRecordSet) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type containing a resource and its associated tags.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ResourceTagSet
 type ResourceTagSet struct {
@@ -12540,6 +14775,35 @@ func (s *ResourceTagSet) SetTags(v []*Tag) *ResourceTagSet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceTagSet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.BodyTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.BodyTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+
+	return nil
+}
+
+func encodeResourceTagSetList(vs []*ResourceTagSet) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains the status that one Amazon Route 53 health checker
 // reports and the time of the health check.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/StatusReport
@@ -12577,6 +14841,22 @@ func (s *StatusReport) SetCheckedTime(v time.Time) *StatusReport {
 func (s *StatusReport) SetStatus(v string) *StatusReport {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StatusReport) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CheckedTime != nil {
+		v := *s.CheckedTime
+
+		e.SetValue(protocol.BodyTarget, "CheckedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about a tag that you want to add
@@ -12629,6 +14909,30 @@ func (s *Tag) SetKey(v string) *Tag {
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Gets the value that Amazon Route 53 returns in response to a DNS request
@@ -12740,6 +15044,42 @@ func (s *TestDNSAnswerInput) SetResolverIP(v string) *TestDNSAnswerInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestDNSAnswerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EDNS0ClientSubnetIP != nil {
+		v := *s.EDNS0ClientSubnetIP
+
+		e.SetValue(protocol.QueryTarget, "edns0clientsubnetip", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EDNS0ClientSubnetMask != nil {
+		v := *s.EDNS0ClientSubnetMask
+
+		e.SetValue(protocol.QueryTarget, "edns0clientsubnetmask", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecordName != nil {
+		v := *s.RecordName
+
+		e.SetValue(protocol.QueryTarget, "recordname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecordType != nil {
+		v := *s.RecordType
+
+		e.SetValue(protocol.QueryTarget, "recordtype", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResolverIP != nil {
+		v := *s.ResolverIP
+
+		e.SetValue(protocol.QueryTarget, "resolverip", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a TestDNSAnswer request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/TestDNSAnswerResponse
 type TestDNSAnswerOutput struct {
@@ -12828,6 +15168,42 @@ func (s *TestDNSAnswerOutput) SetResponseCode(v string) *TestDNSAnswerOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestDNSAnswerOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Nameserver != nil {
+		v := *s.Nameserver
+
+		e.SetValue(protocol.BodyTarget, "Nameserver", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RecordData) > 0 {
+		v := s.RecordData
+
+		e.SetList(protocol.BodyTarget, "RecordData", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "RecordDataEntry"})
+	}
+	if s.RecordName != nil {
+		v := *s.RecordName
+
+		e.SetValue(protocol.BodyTarget, "RecordName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecordType != nil {
+		v := *s.RecordType
+
+		e.SetValue(protocol.BodyTarget, "RecordType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseCode != nil {
+		v := *s.ResponseCode
+
+		e.SetValue(protocol.BodyTarget, "ResponseCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains settings for a traffic policy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/TrafficPolicy
 type TrafficPolicy struct {
@@ -12911,6 +15287,50 @@ func (s *TrafficPolicy) SetType(v string) *TrafficPolicy {
 func (s *TrafficPolicy) SetVersion(v int64) *TrafficPolicy {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TrafficPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTrafficPolicyList(vs []*TrafficPolicy) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains settings for the new traffic policy instance.
@@ -13046,6 +15466,65 @@ func (s *TrafficPolicyInstance) SetTrafficPolicyVersion(v int64) *TrafficPolicyI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TrafficPolicyInstance) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TTL != nil {
+		v := *s.TTL
+
+		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyId != nil {
+		v := *s.TrafficPolicyId
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyType != nil {
+		v := *s.TrafficPolicyType
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersion != nil {
+		v := *s.TrafficPolicyVersion
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTrafficPolicyInstanceList(vs []*TrafficPolicyInstance) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains information about the latest version of one
 // traffic policy that is associated with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/TrafficPolicySummary
@@ -13118,6 +15597,45 @@ func (s *TrafficPolicySummary) SetTrafficPolicyCount(v int64) *TrafficPolicySumm
 func (s *TrafficPolicySummary) SetType(v string) *TrafficPolicySummary {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TrafficPolicySummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyCount != nil {
+		v := *s.TrafficPolicyCount
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTrafficPolicySummaryList(vs []*TrafficPolicySummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains information about a request to update a health
@@ -13488,6 +16006,87 @@ func (s *UpdateHealthCheckInput) SetSearchString(v string) *UpdateHealthCheckInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlarmIdentifier != nil {
+		v := s.AlarmIdentifier
+
+		e.SetFields(protocol.BodyTarget, "AlarmIdentifier", v, protocol.Metadata{})
+	}
+	if len(s.ChildHealthChecks) > 0 {
+		v := s.ChildHealthChecks
+
+		e.SetList(protocol.BodyTarget, "ChildHealthChecks", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ChildHealthCheck"})
+	}
+	if s.EnableSNI != nil {
+		v := *s.EnableSNI
+
+		e.SetValue(protocol.BodyTarget, "EnableSNI", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FailureThreshold != nil {
+		v := *s.FailureThreshold
+
+		e.SetValue(protocol.BodyTarget, "FailureThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FullyQualifiedDomainName != nil {
+		v := *s.FullyQualifiedDomainName
+
+		e.SetValue(protocol.BodyTarget, "FullyQualifiedDomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HealthCheckVersion != nil {
+		v := *s.HealthCheckVersion
+
+		e.SetValue(protocol.BodyTarget, "HealthCheckVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HealthThreshold != nil {
+		v := *s.HealthThreshold
+
+		e.SetValue(protocol.BodyTarget, "HealthThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IPAddress != nil {
+		v := *s.IPAddress
+
+		e.SetValue(protocol.BodyTarget, "IPAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InsufficientDataHealthStatus != nil {
+		v := *s.InsufficientDataHealthStatus
+
+		e.SetValue(protocol.BodyTarget, "InsufficientDataHealthStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Inverted != nil {
+		v := *s.Inverted
+
+		e.SetValue(protocol.BodyTarget, "Inverted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Port != nil {
+		v := *s.Port
+
+		e.SetValue(protocol.BodyTarget, "Port", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Regions) > 0 {
+		v := s.Regions
+
+		e.SetList(protocol.BodyTarget, "Regions", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Region"})
+	}
+	if s.ResourcePath != nil {
+		v := *s.ResourcePath
+
+		e.SetValue(protocol.BodyTarget, "ResourcePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SearchString != nil {
+		v := *s.SearchString
+
+		e.SetValue(protocol.BodyTarget, "SearchString", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/UpdateHealthCheckResponse
 type UpdateHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
@@ -13513,6 +16112,17 @@ func (s UpdateHealthCheckOutput) GoString() string {
 func (s *UpdateHealthCheckOutput) SetHealthCheck(v *HealthCheck) *UpdateHealthCheckOutput {
 	s.HealthCheck = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheck != nil {
+		v := s.HealthCheck
+
+		e.SetFields(protocol.BodyTarget, "HealthCheck", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to update the comment for a hosted zone.
@@ -13565,6 +16175,22 @@ func (s *UpdateHostedZoneCommentInput) SetId(v string) *UpdateHostedZoneCommentI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateHostedZoneCommentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to the UpdateHostedZoneComment
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/UpdateHostedZoneCommentResponse
@@ -13591,6 +16217,17 @@ func (s UpdateHostedZoneCommentOutput) GoString() string {
 func (s *UpdateHostedZoneCommentOutput) SetHostedZone(v *HostedZone) *UpdateHostedZoneCommentOutput {
 	s.HostedZone = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateHostedZoneCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZone != nil {
+		v := s.HostedZone
+
+		e.SetFields(protocol.BodyTarget, "HostedZone", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the traffic policy that you
@@ -13670,6 +16307,27 @@ func (s *UpdateTrafficPolicyCommentInput) SetVersion(v int64) *UpdateTrafficPoli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTrafficPolicyCommentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the traffic policy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/UpdateTrafficPolicyCommentResponse
 type UpdateTrafficPolicyCommentOutput struct {
@@ -13695,6 +16353,17 @@ func (s UpdateTrafficPolicyCommentOutput) GoString() string {
 func (s *UpdateTrafficPolicyCommentOutput) SetTrafficPolicy(v *TrafficPolicy) *UpdateTrafficPolicyCommentOutput {
 	s.TrafficPolicy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTrafficPolicyCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicy != nil {
+		v := s.TrafficPolicy
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the resource record sets that
@@ -13792,6 +16461,32 @@ func (s *UpdateTrafficPolicyInstanceInput) SetTrafficPolicyVersion(v int64) *Upd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TTL != nil {
+		v := *s.TTL
+
+		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyId != nil {
+		v := *s.TrafficPolicyId
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersion != nil {
+		v := *s.TrafficPolicyVersion
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the resource record sets that
 // Amazon Route 53 created based on a specified traffic policy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/UpdateTrafficPolicyInstanceResponse
@@ -13818,6 +16513,17 @@ func (s UpdateTrafficPolicyInstanceOutput) GoString() string {
 func (s *UpdateTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficPolicyInstance) *UpdateTrafficPolicyInstanceOutput {
 	s.TrafficPolicyInstance = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicyInstance != nil {
+		v := s.TrafficPolicyInstance
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // (Private hosted zones only) A complex type that contains information about
@@ -13866,6 +16572,30 @@ func (s *VPC) SetVPCId(v string) *VPC {
 func (s *VPC) SetVPCRegion(v string) *VPC {
 	s.VPCRegion = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VPC) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VPCId != nil {
+		v := *s.VPCId
+
+		e.SetValue(protocol.BodyTarget, "VPCId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPCRegion != nil {
+		v := *s.VPCRegion
+
+		e.SetValue(protocol.BodyTarget, "VPCRegion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVPCList(vs []*VPC) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -5971,6 +5971,17 @@ func (s *AbortIncompleteMultipartUpload) SetDaysAfterInitiation(v int64) *AbortI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortIncompleteMultipartUpload) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DaysAfterInitiation != nil {
+		v := *s.DaysAfterInitiation
+
+		e.SetValue(protocol.BodyTarget, "DaysAfterInitiation", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AbortMultipartUploadRequest
 type AbortMultipartUploadInput struct {
 	_ struct{} `type:"structure"`
@@ -6054,6 +6065,32 @@ func (s *AbortMultipartUploadInput) SetUploadId(v string) *AbortMultipartUploadI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AbortMultipartUploadOutput
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -6079,6 +6116,17 @@ func (s *AbortMultipartUploadOutput) SetRequestCharged(v string) *AbortMultipart
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AccelerateConfiguration
 type AccelerateConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -6101,6 +6149,17 @@ func (s AccelerateConfiguration) GoString() string {
 func (s *AccelerateConfiguration) SetStatus(v string) *AccelerateConfiguration {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccelerateConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AccessControlPolicy
@@ -6155,6 +6214,22 @@ func (s *AccessControlPolicy) SetOwner(v *Owner) *AccessControlPolicy {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccessControlPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Grants) > 0 {
+		v := s.Grants
+
+		e.SetList(protocol.BodyTarget, "AccessControlList", encodeGrantList(v), protocol.Metadata{ListLocationName: "Grant"})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsAndOperator
 type AnalyticsAndOperator struct {
 	_ struct{} `type:"structure"`
@@ -6206,6 +6281,22 @@ func (s *AnalyticsAndOperator) SetPrefix(v string) *AnalyticsAndOperator {
 func (s *AnalyticsAndOperator) SetTags(v []*Tag) *AnalyticsAndOperator {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsAndOperator) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsConfiguration
@@ -6283,6 +6374,35 @@ func (s *AnalyticsConfiguration) SetStorageClassAnalysis(v *StorageClassAnalysis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClassAnalysis != nil {
+		v := s.StorageClassAnalysis
+
+		e.SetFields(protocol.BodyTarget, "StorageClassAnalysis", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAnalyticsConfigurationList(vs []*AnalyticsConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsExportDestination
 type AnalyticsExportDestination struct {
 	_ struct{} `type:"structure"`
@@ -6325,6 +6445,17 @@ func (s *AnalyticsExportDestination) Validate() error {
 func (s *AnalyticsExportDestination) SetS3BucketDestination(v *AnalyticsS3BucketDestination) *AnalyticsExportDestination {
 	s.S3BucketDestination = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsExportDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.S3BucketDestination != nil {
+		v := s.S3BucketDestination
+
+		e.SetFields(protocol.BodyTarget, "S3BucketDestination", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsFilter
@@ -6388,6 +6519,27 @@ func (s *AnalyticsFilter) SetPrefix(v string) *AnalyticsFilter {
 func (s *AnalyticsFilter) SetTag(v *Tag) *AnalyticsFilter {
 	s.Tag = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.And != nil {
+		v := s.And
+
+		e.SetFields(protocol.BodyTarget, "And", v, protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tag != nil {
+		v := s.Tag
+
+		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsS3BucketDestination
@@ -6470,6 +6622,32 @@ func (s *AnalyticsS3BucketDestination) SetPrefix(v string) *AnalyticsS3BucketDes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsS3BucketDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BucketAccountId != nil {
+		v := *s.BucketAccountId
+
+		e.SetValue(protocol.BodyTarget, "BucketAccountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Bucket
 type Bucket struct {
 	_ struct{} `type:"structure"`
@@ -6501,6 +6679,30 @@ func (s *Bucket) SetCreationDate(v time.Time) *Bucket {
 func (s *Bucket) SetName(v string) *Bucket {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Bucket) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBucketList(vs []*Bucket) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/BucketLifecycleConfiguration
@@ -6550,6 +6752,17 @@ func (s *BucketLifecycleConfiguration) SetRules(v []*LifecycleRule) *BucketLifec
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BucketLifecycleConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeLifecycleRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/BucketLoggingStatus
 type BucketLoggingStatus struct {
 	_ struct{} `type:"structure"`
@@ -6586,6 +6799,17 @@ func (s *BucketLoggingStatus) Validate() error {
 func (s *BucketLoggingStatus) SetLoggingEnabled(v *LoggingEnabled) *BucketLoggingStatus {
 	s.LoggingEnabled = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BucketLoggingStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggingEnabled != nil {
+		v := s.LoggingEnabled
+
+		e.SetFields(protocol.BodyTarget, "LoggingEnabled", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CORSConfiguration
@@ -6633,6 +6857,17 @@ func (s *CORSConfiguration) Validate() error {
 func (s *CORSConfiguration) SetCORSRules(v []*CORSRule) *CORSConfiguration {
 	s.CORSRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CORSConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CORSRules) > 0 {
+		v := s.CORSRules
+
+		e.SetList(protocol.BodyTarget, "CORSRule", encodeCORSRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CORSRule
@@ -6719,6 +6954,45 @@ func (s *CORSRule) SetMaxAgeSeconds(v int64) *CORSRule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CORSRule) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AllowedHeaders) > 0 {
+		v := s.AllowedHeaders
+
+		e.SetList(protocol.BodyTarget, "AllowedHeader", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.AllowedMethods) > 0 {
+		v := s.AllowedMethods
+
+		e.SetList(protocol.BodyTarget, "AllowedMethod", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.AllowedOrigins) > 0 {
+		v := s.AllowedOrigins
+
+		e.SetList(protocol.BodyTarget, "AllowedOrigin", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.ExposeHeaders) > 0 {
+		v := s.ExposeHeaders
+
+		e.SetList(protocol.BodyTarget, "ExposeHeader", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.MaxAgeSeconds != nil {
+		v := *s.MaxAgeSeconds
+
+		e.SetValue(protocol.BodyTarget, "MaxAgeSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCORSRuleList(vs []*CORSRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CloudFunctionConfiguration
 type CloudFunctionConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -6777,6 +7051,37 @@ func (s *CloudFunctionConfiguration) SetInvocationRole(v string) *CloudFunctionC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CloudFunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFunction != nil {
+		v := *s.CloudFunction
+
+		e.SetValue(protocol.BodyTarget, "CloudFunction", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Event != nil {
+		v := *s.Event
+
+		e.SetValue(protocol.BodyTarget, "Event", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvocationRole != nil {
+		v := *s.InvocationRole
+
+		e.SetValue(protocol.BodyTarget, "InvocationRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CommonPrefix
 type CommonPrefix struct {
 	_ struct{} `type:"structure"`
@@ -6798,6 +7103,25 @@ func (s CommonPrefix) GoString() string {
 func (s *CommonPrefix) SetPrefix(v string) *CommonPrefix {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CommonPrefix) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCommonPrefixList(vs []*CommonPrefix) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CompleteMultipartUploadRequest
@@ -6889,6 +7213,37 @@ func (s *CompleteMultipartUploadInput) SetRequestPayer(v string) *CompleteMultip
 func (s *CompleteMultipartUploadInput) SetUploadId(v string) *CompleteMultipartUploadInput {
 	s.UploadId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MultipartUpload != nil {
+		v := s.MultipartUpload
+
+		e.SetFields(protocol.PayloadTarget, "CompleteMultipartUpload", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CompleteMultipartUploadOutput
@@ -6995,6 +7350,57 @@ func (s *CompleteMultipartUploadOutput) SetVersionId(v string) *CompleteMultipar
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.BodyTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CompletedMultipartUpload
 type CompletedMultipartUpload struct {
 	_ struct{} `type:"structure"`
@@ -7016,6 +7422,17 @@ func (s CompletedMultipartUpload) GoString() string {
 func (s *CompletedMultipartUpload) SetParts(v []*CompletedPart) *CompletedMultipartUpload {
 	s.Parts = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompletedMultipartUpload) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Parts) > 0 {
+		v := s.Parts
+
+		e.SetList(protocol.BodyTarget, "Part", encodeCompletedPartList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CompletedPart
@@ -7050,6 +7467,30 @@ func (s *CompletedPart) SetETag(v string) *CompletedPart {
 func (s *CompletedPart) SetPartNumber(v int64) *CompletedPart {
 	s.PartNumber = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompletedPart) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.BodyTarget, "PartNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCompletedPartList(vs []*CompletedPart) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Condition
@@ -7093,6 +7534,22 @@ func (s *Condition) SetHttpErrorCodeReturnedEquals(v string) *Condition {
 func (s *Condition) SetKeyPrefixEquals(v string) *Condition {
 	s.KeyPrefixEquals = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Condition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpErrorCodeReturnedEquals != nil {
+		v := *s.HttpErrorCodeReturnedEquals
+
+		e.SetValue(protocol.BodyTarget, "HttpErrorCodeReturnedEquals", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyPrefixEquals != nil {
+		v := *s.KeyPrefixEquals
+
+		e.SetValue(protocol.BodyTarget, "KeyPrefixEquals", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CopyObjectRequest
@@ -7479,6 +7936,177 @@ func (s *CopyObjectInput) SetWebsiteRedirectLocation(v string) *CopyObjectInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CopyObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySource != nil {
+		v := *s.CopySource
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfMatch != nil {
+		v := *s.CopySourceIfMatch
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfModifiedSince != nil {
+		v := *s.CopySourceIfModifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-modified-since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.CopySourceIfNoneMatch != nil {
+		v := *s.CopySourceIfNoneMatch
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-none-match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfUnmodifiedSince != nil {
+		v := *s.CopySourceIfUnmodifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-unmodified-since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerAlgorithm != nil {
+		v := *s.CopySourceSSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerKey != nil {
+		v := *s.CopySourceSSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerKeyMD5 != nil {
+		v := *s.CopySourceSSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MetadataDirective != nil {
+		v := *s.MetadataDirective
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-metadata-directive", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := *s.Tagging
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TaggingDirective != nil {
+		v := *s.TaggingDirective
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging-directive", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CopyObjectOutput
 type CopyObjectOutput struct {
 	_ struct{} `type:"structure" payload:"CopyObjectResult"`
@@ -7580,6 +8208,57 @@ func (s *CopyObjectOutput) SetVersionId(v string) *CopyObjectOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CopyObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CopyObjectResult != nil {
+		v := s.CopyObjectResult
+
+		e.SetFields(protocol.PayloadTarget, "CopyObjectResult", v, protocol.Metadata{})
+	}
+	if s.CopySourceVersionId != nil {
+		v := *s.CopySourceVersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CopyObjectResult
 type CopyObjectResult struct {
 	_ struct{} `type:"structure"`
@@ -7609,6 +8288,22 @@ func (s *CopyObjectResult) SetETag(v string) *CopyObjectResult {
 func (s *CopyObjectResult) SetLastModified(v time.Time) *CopyObjectResult {
 	s.LastModified = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CopyObjectResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CopyPartResult
@@ -7644,6 +8339,22 @@ func (s *CopyPartResult) SetLastModified(v time.Time) *CopyPartResult {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CopyPartResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateBucketConfiguration
 type CreateBucketConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -7667,6 +8378,17 @@ func (s CreateBucketConfiguration) GoString() string {
 func (s *CreateBucketConfiguration) SetLocationConstraint(v string) *CreateBucketConfiguration {
 	s.LocationConstraint = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBucketConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LocationConstraint != nil {
+		v := *s.LocationConstraint
+
+		e.SetValue(protocol.BodyTarget, "LocationConstraint", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateBucketRequest
@@ -7776,6 +8498,52 @@ func (s *CreateBucketInput) SetGrantWriteACP(v string) *CreateBucketInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBucketInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreateBucketConfiguration != nil {
+		v := s.CreateBucketConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "CreateBucketConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWrite != nil {
+		v := *s.GrantWrite
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateBucketOutput
 type CreateBucketOutput struct {
 	_ struct{} `type:"structure"`
@@ -7797,6 +8565,17 @@ func (s CreateBucketOutput) GoString() string {
 func (s *CreateBucketOutput) SetLocation(v string) *CreateBucketOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateMultipartUploadRequest
@@ -8071,6 +8850,127 @@ func (s *CreateMultipartUploadInput) SetWebsiteRedirectLocation(v string) *Creat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := *s.Tagging
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateMultipartUploadOutput
 type CreateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -8191,6 +9091,62 @@ func (s *CreateMultipartUploadOutput) SetUploadId(v string) *CreateMultipartUplo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortDate != nil {
+		v := *s.AbortDate
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-date", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.AbortRuleId != nil {
+		v := *s.AbortRuleId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-rule-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Delete
 type Delete struct {
 	_ struct{} `type:"structure"`
@@ -8246,6 +9202,22 @@ func (s *Delete) SetObjects(v []*ObjectIdentifier) *Delete {
 func (s *Delete) SetQuiet(v bool) *Delete {
 	s.Quiet = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Delete) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Objects) > 0 {
+		v := s.Objects
+
+		e.SetList(protocol.BodyTarget, "Object", encodeObjectIdentifierList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Quiet != nil {
+		v := *s.Quiet
+
+		e.SetValue(protocol.BodyTarget, "Quiet", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketAnalyticsConfigurationRequest
@@ -8308,6 +9280,22 @@ func (s *DeleteBucketAnalyticsConfigurationInput) SetId(v string) *DeleteBucketA
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketAnalyticsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketAnalyticsConfigurationOutput
 type DeleteBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -8321,6 +9309,12 @@ func (s DeleteBucketAnalyticsConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketAnalyticsConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketCorsRequest
@@ -8367,6 +9361,17 @@ func (s *DeleteBucketCorsInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketCorsOutput
 type DeleteBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8380,6 +9385,12 @@ func (s DeleteBucketCorsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketCorsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketRequest
@@ -8424,6 +9435,17 @@ func (s *DeleteBucketInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketInventoryConfigurationRequest
@@ -8486,6 +9508,22 @@ func (s *DeleteBucketInventoryConfigurationInput) SetId(v string) *DeleteBucketI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketInventoryConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketInventoryConfigurationOutput
 type DeleteBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -8499,6 +9537,12 @@ func (s DeleteBucketInventoryConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketInventoryConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketLifecycleRequest
@@ -8545,6 +9589,17 @@ func (s *DeleteBucketLifecycleInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketLifecycleOutput
 type DeleteBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
@@ -8558,6 +9613,12 @@ func (s DeleteBucketLifecycleOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketLifecycleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketMetricsConfigurationRequest
@@ -8620,6 +9681,22 @@ func (s *DeleteBucketMetricsConfigurationInput) SetId(v string) *DeleteBucketMet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketMetricsConfigurationOutput
 type DeleteBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -8635,6 +9712,12 @@ func (s DeleteBucketMetricsConfigurationOutput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketOutput
 type DeleteBucketOutput struct {
 	_ struct{} `type:"structure"`
@@ -8648,6 +9731,12 @@ func (s DeleteBucketOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketPolicyRequest
@@ -8694,6 +9783,17 @@ func (s *DeleteBucketPolicyInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketPolicyOutput
 type DeleteBucketPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -8707,6 +9807,12 @@ func (s DeleteBucketPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketReplicationRequest
@@ -8753,6 +9859,17 @@ func (s *DeleteBucketReplicationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketReplicationOutput
 type DeleteBucketReplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -8766,6 +9883,12 @@ func (s DeleteBucketReplicationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketReplicationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketTaggingRequest
@@ -8812,6 +9935,17 @@ func (s *DeleteBucketTaggingInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketTaggingOutput
 type DeleteBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -8825,6 +9959,12 @@ func (s DeleteBucketTaggingOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketTaggingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketWebsiteRequest
@@ -8871,6 +10011,17 @@ func (s *DeleteBucketWebsiteInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketWebsiteOutput
 type DeleteBucketWebsiteOutput struct {
 	_ struct{} `type:"structure"`
@@ -8884,6 +10035,12 @@ func (s DeleteBucketWebsiteOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketWebsiteOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteMarkerEntry
@@ -8944,6 +10101,45 @@ func (s *DeleteMarkerEntry) SetOwner(v *Owner) *DeleteMarkerEntry {
 func (s *DeleteMarkerEntry) SetVersionId(v string) *DeleteMarkerEntry {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMarkerEntry) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsLatest != nil {
+		v := *s.IsLatest
+
+		e.SetValue(protocol.BodyTarget, "IsLatest", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeleteMarkerEntryList(vs []*DeleteMarkerEntry) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectRequest
@@ -9036,6 +10232,37 @@ func (s *DeleteObjectInput) SetVersionId(v string) *DeleteObjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MFA != nil {
+		v := *s.MFA
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mfa", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectOutput
 type DeleteObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -9079,6 +10306,27 @@ func (s *DeleteObjectOutput) SetRequestCharged(v string) *DeleteObjectOutput {
 func (s *DeleteObjectOutput) SetVersionId(v string) *DeleteObjectOutput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeleteMarker != nil {
+		v := *s.DeleteMarker
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-delete-marker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectTaggingRequest
@@ -9149,6 +10397,27 @@ func (s *DeleteObjectTaggingInput) SetVersionId(v string) *DeleteObjectTaggingIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectTaggingOutput
 type DeleteObjectTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -9171,6 +10440,17 @@ func (s DeleteObjectTaggingOutput) GoString() string {
 func (s *DeleteObjectTaggingOutput) SetVersionId(v string) *DeleteObjectTaggingOutput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectsRequest
@@ -9256,6 +10536,32 @@ func (s *DeleteObjectsInput) SetRequestPayer(v string) *DeleteObjectsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delete != nil {
+		v := s.Delete
+
+		e.SetFields(protocol.PayloadTarget, "Delete", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.MFA != nil {
+		v := *s.MFA
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mfa", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectsOutput
 type DeleteObjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9295,6 +10601,27 @@ func (s *DeleteObjectsOutput) SetErrors(v []*Error) *DeleteObjectsOutput {
 func (s *DeleteObjectsOutput) SetRequestCharged(v string) *DeleteObjectsOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Deleted) > 0 {
+		v := s.Deleted
+
+		e.SetList(protocol.BodyTarget, "Deleted", encodeDeletedObjectList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.Errors) > 0 {
+		v := s.Errors
+
+		e.SetList(protocol.BodyTarget, "Error", encodeErrorList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeletedObject
@@ -9342,6 +10669,40 @@ func (s *DeletedObject) SetKey(v string) *DeletedObject {
 func (s *DeletedObject) SetVersionId(v string) *DeletedObject {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletedObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeleteMarker != nil {
+		v := *s.DeleteMarker
+
+		e.SetValue(protocol.BodyTarget, "DeleteMarker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DeleteMarkerVersionId != nil {
+		v := *s.DeleteMarkerVersionId
+
+		e.SetValue(protocol.BodyTarget, "DeleteMarkerVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeletedObjectList(vs []*DeletedObject) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Destination
@@ -9400,6 +10761,22 @@ func (s *Destination) SetStorageClass(v string) *Destination {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Destination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Error
 type Error struct {
 	_ struct{} `type:"structure"`
@@ -9447,6 +10824,40 @@ func (s *Error) SetVersionId(v string) *Error {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Error) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Code != nil {
+		v := *s.Code
+
+		e.SetValue(protocol.BodyTarget, "Code", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeErrorList(vs []*Error) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ErrorDocument
 type ErrorDocument struct {
 	_ struct{} `type:"structure"`
@@ -9489,6 +10900,17 @@ func (s *ErrorDocument) SetKey(v string) *ErrorDocument {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ErrorDocument) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for key value pair that defines the criteria for the filter rule.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/FilterRule
 type FilterRule struct {
@@ -9523,6 +10945,30 @@ func (s *FilterRule) SetName(v string) *FilterRule {
 func (s *FilterRule) SetValue(v string) *FilterRule {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FilterRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFilterRuleList(vs []*FilterRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAccelerateConfigurationRequest
@@ -9571,6 +11017,17 @@ func (s *GetBucketAccelerateConfigurationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAccelerateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAccelerateConfigurationOutput
 type GetBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -9593,6 +11050,17 @@ func (s GetBucketAccelerateConfigurationOutput) GoString() string {
 func (s *GetBucketAccelerateConfigurationOutput) SetStatus(v string) *GetBucketAccelerateConfigurationOutput {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAccelerateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAclRequest
@@ -9639,6 +11107,17 @@ func (s *GetBucketAclInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAclOutput
 type GetBucketAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -9669,6 +11148,22 @@ func (s *GetBucketAclOutput) SetGrants(v []*Grant) *GetBucketAclOutput {
 func (s *GetBucketAclOutput) SetOwner(v *Owner) *GetBucketAclOutput {
 	s.Owner = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAclOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Grants) > 0 {
+		v := s.Grants
+
+		e.SetList(protocol.BodyTarget, "AccessControlList", encodeGrantList(v), protocol.Metadata{ListLocationName: "Grant"})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAnalyticsConfigurationRequest
@@ -9731,6 +11226,22 @@ func (s *GetBucketAnalyticsConfigurationInput) SetId(v string) *GetBucketAnalyti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAnalyticsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAnalyticsConfigurationOutput
 type GetBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"AnalyticsConfiguration"`
@@ -9753,6 +11264,17 @@ func (s GetBucketAnalyticsConfigurationOutput) GoString() string {
 func (s *GetBucketAnalyticsConfigurationOutput) SetAnalyticsConfiguration(v *AnalyticsConfiguration) *GetBucketAnalyticsConfigurationOutput {
 	s.AnalyticsConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AnalyticsConfiguration != nil {
+		v := s.AnalyticsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "AnalyticsConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketCorsRequest
@@ -9799,6 +11321,17 @@ func (s *GetBucketCorsInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketCorsOutput
 type GetBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9820,6 +11353,17 @@ func (s GetBucketCorsOutput) GoString() string {
 func (s *GetBucketCorsOutput) SetCORSRules(v []*CORSRule) *GetBucketCorsOutput {
 	s.CORSRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CORSRules) > 0 {
+		v := s.CORSRules
+
+		e.SetList(protocol.BodyTarget, "CORSRule", encodeCORSRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketInventoryConfigurationRequest
@@ -9882,6 +11426,22 @@ func (s *GetBucketInventoryConfigurationInput) SetId(v string) *GetBucketInvento
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketInventoryConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketInventoryConfigurationOutput
 type GetBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"InventoryConfiguration"`
@@ -9904,6 +11464,17 @@ func (s GetBucketInventoryConfigurationOutput) GoString() string {
 func (s *GetBucketInventoryConfigurationOutput) SetInventoryConfiguration(v *InventoryConfiguration) *GetBucketInventoryConfigurationOutput {
 	s.InventoryConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InventoryConfiguration != nil {
+		v := s.InventoryConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "InventoryConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLifecycleConfigurationRequest
@@ -9950,6 +11521,17 @@ func (s *GetBucketLifecycleConfigurationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLifecycleConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLifecycleConfigurationOutput
 type GetBucketLifecycleConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -9971,6 +11553,17 @@ func (s GetBucketLifecycleConfigurationOutput) GoString() string {
 func (s *GetBucketLifecycleConfigurationOutput) SetRules(v []*LifecycleRule) *GetBucketLifecycleConfigurationOutput {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLifecycleConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeLifecycleRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLifecycleRequest
@@ -10017,6 +11610,17 @@ func (s *GetBucketLifecycleInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLifecycleOutput
 type GetBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
@@ -10038,6 +11642,17 @@ func (s GetBucketLifecycleOutput) GoString() string {
 func (s *GetBucketLifecycleOutput) SetRules(v []*Rule) *GetBucketLifecycleOutput {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLocationRequest
@@ -10084,6 +11699,17 @@ func (s *GetBucketLocationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLocationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLocationOutput
 type GetBucketLocationOutput struct {
 	_ struct{} `type:"structure"`
@@ -10105,6 +11731,17 @@ func (s GetBucketLocationOutput) GoString() string {
 func (s *GetBucketLocationOutput) SetLocationConstraint(v string) *GetBucketLocationOutput {
 	s.LocationConstraint = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLocationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LocationConstraint != nil {
+		v := *s.LocationConstraint
+
+		e.SetValue(protocol.BodyTarget, "LocationConstraint", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLoggingRequest
@@ -10151,6 +11788,17 @@ func (s *GetBucketLoggingInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLoggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLoggingOutput
 type GetBucketLoggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -10172,6 +11820,17 @@ func (s GetBucketLoggingOutput) GoString() string {
 func (s *GetBucketLoggingOutput) SetLoggingEnabled(v *LoggingEnabled) *GetBucketLoggingOutput {
 	s.LoggingEnabled = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLoggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggingEnabled != nil {
+		v := s.LoggingEnabled
+
+		e.SetFields(protocol.BodyTarget, "LoggingEnabled", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketMetricsConfigurationRequest
@@ -10234,6 +11893,22 @@ func (s *GetBucketMetricsConfigurationInput) SetId(v string) *GetBucketMetricsCo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketMetricsConfigurationOutput
 type GetBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"MetricsConfiguration"`
@@ -10256,6 +11931,17 @@ func (s GetBucketMetricsConfigurationOutput) GoString() string {
 func (s *GetBucketMetricsConfigurationOutput) SetMetricsConfiguration(v *MetricsConfiguration) *GetBucketMetricsConfigurationOutput {
 	s.MetricsConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MetricsConfiguration != nil {
+		v := s.MetricsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "MetricsConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketNotificationConfigurationRequest
@@ -10304,6 +11990,17 @@ func (s *GetBucketNotificationConfigurationRequest) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketNotificationConfigurationRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketPolicyRequest
 type GetBucketPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -10348,6 +12045,17 @@ func (s *GetBucketPolicyInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketPolicyOutput
 type GetBucketPolicyOutput struct {
 	_ struct{} `type:"structure" payload:"Policy"`
@@ -10370,6 +12078,17 @@ func (s GetBucketPolicyOutput) GoString() string {
 func (s *GetBucketPolicyOutput) SetPolicy(v string) *GetBucketPolicyOutput {
 	s.Policy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetStream(protocol.PayloadTarget, "Policy", protocol.StringStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketReplicationRequest
@@ -10416,6 +12135,17 @@ func (s *GetBucketReplicationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketReplicationOutput
 type GetBucketReplicationOutput struct {
 	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
@@ -10439,6 +12169,17 @@ func (s GetBucketReplicationOutput) GoString() string {
 func (s *GetBucketReplicationOutput) SetReplicationConfiguration(v *ReplicationConfiguration) *GetBucketReplicationOutput {
 	s.ReplicationConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ReplicationConfiguration != nil {
+		v := s.ReplicationConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "ReplicationConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketRequestPaymentRequest
@@ -10485,6 +12226,17 @@ func (s *GetBucketRequestPaymentInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketRequestPaymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketRequestPaymentOutput
 type GetBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -10507,6 +12259,17 @@ func (s GetBucketRequestPaymentOutput) GoString() string {
 func (s *GetBucketRequestPaymentOutput) SetPayer(v string) *GetBucketRequestPaymentOutput {
 	s.Payer = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketRequestPaymentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payer != nil {
+		v := *s.Payer
+
+		e.SetValue(protocol.BodyTarget, "Payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketTaggingRequest
@@ -10553,6 +12316,17 @@ func (s *GetBucketTaggingInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketTaggingOutput
 type GetBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -10575,6 +12349,17 @@ func (s GetBucketTaggingOutput) GoString() string {
 func (s *GetBucketTaggingOutput) SetTagSet(v []*Tag) *GetBucketTaggingOutput {
 	s.TagSet = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TagSet) > 0 {
+		v := s.TagSet
+
+		e.SetList(protocol.BodyTarget, "TagSet", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketVersioningRequest
@@ -10621,6 +12406,17 @@ func (s *GetBucketVersioningInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketVersioningInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketVersioningOutput
 type GetBucketVersioningOutput struct {
 	_ struct{} `type:"structure"`
@@ -10654,6 +12450,22 @@ func (s *GetBucketVersioningOutput) SetMFADelete(v string) *GetBucketVersioningO
 func (s *GetBucketVersioningOutput) SetStatus(v string) *GetBucketVersioningOutput {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketVersioningOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MFADelete != nil {
+		v := *s.MFADelete
+
+		e.SetValue(protocol.BodyTarget, "MfaDelete", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketWebsiteRequest
@@ -10698,6 +12510,17 @@ func (s *GetBucketWebsiteInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketWebsiteOutput
@@ -10745,6 +12568,32 @@ func (s *GetBucketWebsiteOutput) SetRedirectAllRequestsTo(v *RedirectAllRequests
 func (s *GetBucketWebsiteOutput) SetRoutingRules(v []*RoutingRule) *GetBucketWebsiteOutput {
 	s.RoutingRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorDocument != nil {
+		v := s.ErrorDocument
+
+		e.SetFields(protocol.BodyTarget, "ErrorDocument", v, protocol.Metadata{})
+	}
+	if s.IndexDocument != nil {
+		v := s.IndexDocument
+
+		e.SetFields(protocol.BodyTarget, "IndexDocument", v, protocol.Metadata{})
+	}
+	if s.RedirectAllRequestsTo != nil {
+		v := s.RedirectAllRequestsTo
+
+		e.SetFields(protocol.BodyTarget, "RedirectAllRequestsTo", v, protocol.Metadata{})
+	}
+	if len(s.RoutingRules) > 0 {
+		v := s.RoutingRules
+
+		e.SetList(protocol.BodyTarget, "RoutingRules", encodeRoutingRuleList(v), protocol.Metadata{ListLocationName: "RoutingRule"})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectAclRequest
@@ -10827,6 +12676,32 @@ func (s *GetObjectAclInput) SetVersionId(v string) *GetObjectAclInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectAclOutput
 type GetObjectAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -10867,6 +12742,27 @@ func (s *GetObjectAclOutput) SetOwner(v *Owner) *GetObjectAclOutput {
 func (s *GetObjectAclOutput) SetRequestCharged(v string) *GetObjectAclOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectAclOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Grants) > 0 {
+		v := s.Grants
+
+		e.SetList(protocol.BodyTarget, "AccessControlList", encodeGrantList(v), protocol.Metadata{ListLocationName: "Grant"})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectRequest
@@ -11102,6 +12998,107 @@ func (s *GetObjectInput) SetSSECustomerKeyMD5(v string) *GetObjectInput {
 func (s *GetObjectInput) SetVersionId(v string) *GetObjectInput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfModifiedSince != nil {
+		v := *s.IfModifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "If-Modified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.IfNoneMatch != nil {
+		v := *s.IfNoneMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-None-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfUnmodifiedSince != nil {
+		v := *s.IfUnmodifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "If-Unmodified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseCacheControl != nil {
+		v := *s.ResponseCacheControl
+
+		e.SetValue(protocol.QueryTarget, "response-cache-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseContentDisposition != nil {
+		v := *s.ResponseContentDisposition
+
+		e.SetValue(protocol.QueryTarget, "response-content-disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseContentEncoding != nil {
+		v := *s.ResponseContentEncoding
+
+		e.SetValue(protocol.QueryTarget, "response-content-encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseContentLanguage != nil {
+		v := *s.ResponseContentLanguage
+
+		e.SetValue(protocol.QueryTarget, "response-content-language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseContentType != nil {
+		v := *s.ResponseContentType
+
+		e.SetValue(protocol.QueryTarget, "response-content-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseExpires != nil {
+		v := *s.ResponseExpires
+
+		e.SetValue(protocol.QueryTarget, "response-expires", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectOutput
@@ -11388,6 +13385,148 @@ func (s *GetObjectOutput) SetWebsiteRedirectLocation(v string) *GetObjectOutput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcceptRanges != nil {
+		v := *s.AcceptRanges
+
+		e.SetValue(protocol.HeaderTarget, "accept-ranges", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// Skipping Body Output type's body not valid.
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentRange != nil {
+		v := *s.ContentRange
+
+		e.SetValue(protocol.HeaderTarget, "Content-Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeleteMarker != nil {
+		v := *s.DeleteMarker
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-delete-marker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MissingMeta != nil {
+		v := *s.MissingMeta
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-missing-meta", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PartsCount != nil {
+		v := *s.PartsCount
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mp-parts-count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ReplicationStatus != nil {
+		v := *s.ReplicationStatus
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-replication-status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Restore != nil {
+		v := *s.Restore
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-restore", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TagCount != nil {
+		v := *s.TagCount
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging-count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectTaggingRequest
 type GetObjectTaggingInput struct {
 	_ struct{} `type:"structure"`
@@ -11455,6 +13594,27 @@ func (s *GetObjectTaggingInput) SetVersionId(v string) *GetObjectTaggingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectTaggingOutput
 type GetObjectTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -11485,6 +13645,22 @@ func (s *GetObjectTaggingOutput) SetTagSet(v []*Tag) *GetObjectTaggingOutput {
 func (s *GetObjectTaggingOutput) SetVersionId(v string) *GetObjectTaggingOutput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TagSet) > 0 {
+		v := s.TagSet
+
+		e.SetList(protocol.BodyTarget, "TagSet", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectTorrentRequest
@@ -11558,6 +13734,27 @@ func (s *GetObjectTorrentInput) SetRequestPayer(v string) *GetObjectTorrentInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectTorrentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectTorrentOutput
 type GetObjectTorrentOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -11589,6 +13786,18 @@ func (s *GetObjectTorrentOutput) SetBody(v io.ReadCloser) *GetObjectTorrentOutpu
 func (s *GetObjectTorrentOutput) SetRequestCharged(v string) *GetObjectTorrentOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectTorrentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// Skipping Body Output type's body not valid.
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GlacierJobParameters
@@ -11628,6 +13837,17 @@ func (s *GlacierJobParameters) Validate() error {
 func (s *GlacierJobParameters) SetTier(v string) *GlacierJobParameters {
 	s.Tier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GlacierJobParameters) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Tier != nil {
+		v := *s.Tier
+
+		e.SetValue(protocol.BodyTarget, "Tier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Grant
@@ -11675,6 +13895,36 @@ func (s *Grant) SetGrantee(v *Grantee) *Grant {
 func (s *Grant) SetPermission(v string) *Grant {
 	s.Permission = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Grant) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Grantee != nil {
+		v := s.Grantee
+		attrs := make([]protocol.Attribute, 0, 1)
+		// TODO only create array if an attribute value is set
+
+		if s.Grantee.Type != nil {
+			v := *s.Grantee.Type
+			attrs = append(attrs, protocol.Attribute{Name: "xsi:type", Value: protocol.StringValue(v), Meta: protocol.Metadata{}})
+		}
+		e.SetFields(protocol.BodyTarget, "Grantee", v, protocol.Metadata{Attributes: attrs, XMLNamespacePrefix: "xsi", XMLNamespaceURI: "http://www.w3.org/2001/XMLSchema-instance"})
+	}
+	if s.Permission != nil {
+		v := *s.Permission
+
+		e.SetValue(protocol.BodyTarget, "Permission", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGrantList(vs []*Grant) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Grantee
@@ -11752,6 +14002,33 @@ func (s *Grantee) SetURI(v string) *Grantee {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Grantee) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisplayName != nil {
+		v := *s.DisplayName
+
+		e.SetValue(protocol.BodyTarget, "DisplayName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// Skipping Type XML Attribute.
+	if s.URI != nil {
+		v := *s.URI
+
+		e.SetValue(protocol.BodyTarget, "URI", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadBucketRequest
 type HeadBucketInput struct {
 	_ struct{} `type:"structure"`
@@ -11796,6 +14073,17 @@ func (s *HeadBucketInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HeadBucketInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadBucketOutput
 type HeadBucketOutput struct {
 	_ struct{} `type:"structure"`
@@ -11809,6 +14097,12 @@ func (s HeadBucketOutput) String() string {
 // GoString returns the string representation
 func (s HeadBucketOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HeadBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadObjectRequest
@@ -11991,6 +14285,77 @@ func (s *HeadObjectInput) SetSSECustomerKeyMD5(v string) *HeadObjectInput {
 func (s *HeadObjectInput) SetVersionId(v string) *HeadObjectInput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HeadObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfModifiedSince != nil {
+		v := *s.IfModifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "If-Modified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.IfNoneMatch != nil {
+		v := *s.IfNoneMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-None-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfUnmodifiedSince != nil {
+		v := *s.IfUnmodifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "If-Unmodified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadObjectOutput
@@ -12250,6 +14615,137 @@ func (s *HeadObjectOutput) SetWebsiteRedirectLocation(v string) *HeadObjectOutpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HeadObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcceptRanges != nil {
+		v := *s.AcceptRanges
+
+		e.SetValue(protocol.HeaderTarget, "accept-ranges", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeleteMarker != nil {
+		v := *s.DeleteMarker
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-delete-marker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MissingMeta != nil {
+		v := *s.MissingMeta
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-missing-meta", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PartsCount != nil {
+		v := *s.PartsCount
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mp-parts-count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ReplicationStatus != nil {
+		v := *s.ReplicationStatus
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-replication-status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Restore != nil {
+		v := *s.Restore
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-restore", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/IndexDocument
 type IndexDocument struct {
 	_ struct{} `type:"structure"`
@@ -12292,6 +14788,17 @@ func (s *IndexDocument) SetSuffix(v string) *IndexDocument {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IndexDocument) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Suffix != nil {
+		v := *s.Suffix
+
+		e.SetValue(protocol.BodyTarget, "Suffix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Initiator
 type Initiator struct {
 	_ struct{} `type:"structure"`
@@ -12324,6 +14831,22 @@ func (s *Initiator) SetDisplayName(v string) *Initiator {
 func (s *Initiator) SetID(v string) *Initiator {
 	s.ID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Initiator) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisplayName != nil {
+		v := *s.DisplayName
+
+		e.SetValue(protocol.BodyTarget, "DisplayName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryConfiguration
@@ -12455,6 +14978,55 @@ func (s *InventoryConfiguration) SetSchedule(v *InventorySchedule) *InventoryCon
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "Destination", v, protocol.Metadata{})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludedObjectVersions != nil {
+		v := *s.IncludedObjectVersions
+
+		e.SetValue(protocol.BodyTarget, "IncludedObjectVersions", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsEnabled != nil {
+		v := *s.IsEnabled
+
+		e.SetValue(protocol.BodyTarget, "IsEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.OptionalFields) > 0 {
+		v := s.OptionalFields
+
+		e.SetList(protocol.BodyTarget, "OptionalFields", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Field"})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInventoryConfigurationList(vs []*InventoryConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryDestination
 type InventoryDestination struct {
 	_ struct{} `type:"structure"`
@@ -12500,6 +15072,17 @@ func (s *InventoryDestination) SetS3BucketDestination(v *InventoryS3BucketDestin
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.S3BucketDestination != nil {
+		v := s.S3BucketDestination
+
+		e.SetFields(protocol.BodyTarget, "S3BucketDestination", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryFilter
 type InventoryFilter struct {
 	_ struct{} `type:"structure"`
@@ -12537,6 +15120,17 @@ func (s *InventoryFilter) Validate() error {
 func (s *InventoryFilter) SetPrefix(v string) *InventoryFilter {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryS3BucketDestination
@@ -12618,6 +15212,32 @@ func (s *InventoryS3BucketDestination) SetPrefix(v string) *InventoryS3BucketDes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryS3BucketDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.BodyTarget, "AccountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventorySchedule
 type InventorySchedule struct {
 	_ struct{} `type:"structure"`
@@ -12657,6 +15277,17 @@ func (s *InventorySchedule) SetFrequency(v string) *InventorySchedule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventorySchedule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Frequency != nil {
+		v := *s.Frequency
+
+		e.SetValue(protocol.BodyTarget, "Frequency", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for object key name prefix and suffix filtering rules.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/S3KeyFilter
 type KeyFilter struct {
@@ -12681,6 +15312,17 @@ func (s KeyFilter) GoString() string {
 func (s *KeyFilter) SetFilterRules(v []*FilterRule) *KeyFilter {
 	s.FilterRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FilterRules) > 0 {
+		v := s.FilterRules
+
+		e.SetList(protocol.BodyTarget, "FilterRule", encodeFilterRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Container for specifying the AWS Lambda notification configuration.
@@ -12756,6 +15398,40 @@ func (s *LambdaFunctionConfiguration) SetLambdaFunctionArn(v string) *LambdaFunc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LambdaFunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LambdaFunctionArn != nil {
+		v := *s.LambdaFunctionArn
+
+		e.SetValue(protocol.BodyTarget, "CloudFunction", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLambdaFunctionConfigurationList(vs []*LambdaFunctionConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LifecycleConfiguration
 type LifecycleConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -12803,6 +15479,17 @@ func (s *LifecycleConfiguration) SetRules(v []*Rule) *LifecycleConfiguration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LifecycleExpiration
 type LifecycleExpiration struct {
 	_ struct{} `type:"structure"`
@@ -12848,6 +15535,27 @@ func (s *LifecycleExpiration) SetDays(v int64) *LifecycleExpiration {
 func (s *LifecycleExpiration) SetExpiredObjectDeleteMarker(v bool) *LifecycleExpiration {
 	s.ExpiredObjectDeleteMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleExpiration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Date != nil {
+		v := *s.Date
+
+		e.SetValue(protocol.BodyTarget, "Date", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Days != nil {
+		v := *s.Days
+
+		e.SetValue(protocol.BodyTarget, "Days", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ExpiredObjectDeleteMarker != nil {
+		v := *s.ExpiredObjectDeleteMarker
+
+		e.SetValue(protocol.BodyTarget, "ExpiredObjectDeleteMarker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LifecycleRule
@@ -12971,6 +15679,65 @@ func (s *LifecycleRule) SetTransitions(v []*Transition) *LifecycleRule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortIncompleteMultipartUpload != nil {
+		v := s.AbortIncompleteMultipartUpload
+
+		e.SetFields(protocol.BodyTarget, "AbortIncompleteMultipartUpload", v, protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := s.Expiration
+
+		e.SetFields(protocol.BodyTarget, "Expiration", v, protocol.Metadata{})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NoncurrentVersionExpiration != nil {
+		v := s.NoncurrentVersionExpiration
+
+		e.SetFields(protocol.BodyTarget, "NoncurrentVersionExpiration", v, protocol.Metadata{})
+	}
+	if len(s.NoncurrentVersionTransitions) > 0 {
+		v := s.NoncurrentVersionTransitions
+
+		e.SetList(protocol.BodyTarget, "NoncurrentVersionTransition", encodeNoncurrentVersionTransitionList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Transitions) > 0 {
+		v := s.Transitions
+
+		e.SetList(protocol.BodyTarget, "Transition", encodeTransitionList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
+func encodeLifecycleRuleList(vs []*LifecycleRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // This is used in a Lifecycle Rule Filter to apply a logical AND to two or
 // more predicates. The Lifecycle Rule will apply to any object matching all
 // of the predicates configured inside the And operator.
@@ -13025,6 +15792,22 @@ func (s *LifecycleRuleAndOperator) SetPrefix(v string) *LifecycleRuleAndOperator
 func (s *LifecycleRuleAndOperator) SetTags(v []*Tag) *LifecycleRuleAndOperator {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleRuleAndOperator) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // The Filter is used to identify objects that a Lifecycle Rule applies to.
@@ -13093,6 +15876,27 @@ func (s *LifecycleRuleFilter) SetTag(v *Tag) *LifecycleRuleFilter {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleRuleFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.And != nil {
+		v := s.And
+
+		e.SetFields(protocol.BodyTarget, "And", v, protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tag != nil {
+		v := s.Tag
+
+		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketAnalyticsConfigurationsRequest
 type ListBucketAnalyticsConfigurationsInput struct {
 	_ struct{} `type:"structure"`
@@ -13149,6 +15953,22 @@ func (s *ListBucketAnalyticsConfigurationsInput) SetContinuationToken(v string) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketAnalyticsConfigurationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketAnalyticsConfigurationsOutput
 type ListBucketAnalyticsConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13202,6 +16022,32 @@ func (s *ListBucketAnalyticsConfigurationsOutput) SetIsTruncated(v bool) *ListBu
 func (s *ListBucketAnalyticsConfigurationsOutput) SetNextContinuationToken(v string) *ListBucketAnalyticsConfigurationsOutput {
 	s.NextContinuationToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketAnalyticsConfigurationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AnalyticsConfigurationList) > 0 {
+		v := s.AnalyticsConfigurationList
+
+		e.SetList(protocol.BodyTarget, "AnalyticsConfiguration", encodeAnalyticsConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "ContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.NextContinuationToken != nil {
+		v := *s.NextContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketInventoryConfigurationsRequest
@@ -13262,6 +16108,22 @@ func (s *ListBucketInventoryConfigurationsInput) SetContinuationToken(v string) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketInventoryConfigurationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketInventoryConfigurationsOutput
 type ListBucketInventoryConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13315,6 +16177,32 @@ func (s *ListBucketInventoryConfigurationsOutput) SetIsTruncated(v bool) *ListBu
 func (s *ListBucketInventoryConfigurationsOutput) SetNextContinuationToken(v string) *ListBucketInventoryConfigurationsOutput {
 	s.NextContinuationToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketInventoryConfigurationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "ContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InventoryConfigurationList) > 0 {
+		v := s.InventoryConfigurationList
+
+		e.SetList(protocol.BodyTarget, "InventoryConfiguration", encodeInventoryConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.NextContinuationToken != nil {
+		v := *s.NextContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketMetricsConfigurationsRequest
@@ -13375,6 +16263,22 @@ func (s *ListBucketMetricsConfigurationsInput) SetContinuationToken(v string) *L
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketMetricsConfigurationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketMetricsConfigurationsOutput
 type ListBucketMetricsConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13432,6 +16336,32 @@ func (s *ListBucketMetricsConfigurationsOutput) SetNextContinuationToken(v strin
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketMetricsConfigurationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "ContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.MetricsConfigurationList) > 0 {
+		v := s.MetricsConfigurationList
+
+		e.SetList(protocol.BodyTarget, "MetricsConfiguration", encodeMetricsConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.NextContinuationToken != nil {
+		v := *s.NextContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketsInput
 type ListBucketsInput struct {
 	_ struct{} `type:"structure"`
@@ -13445,6 +16375,12 @@ func (s ListBucketsInput) String() string {
 // GoString returns the string representation
 func (s ListBucketsInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketsInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketsOutput
@@ -13476,6 +16412,22 @@ func (s *ListBucketsOutput) SetBuckets(v []*Bucket) *ListBucketsOutput {
 func (s *ListBucketsOutput) SetOwner(v *Owner) *ListBucketsOutput {
 	s.Owner = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Buckets) > 0 {
+		v := s.Buckets
+
+		e.SetList(protocol.BodyTarget, "Buckets", encodeBucketList(v), protocol.Metadata{ListLocationName: "Bucket"})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListMultipartUploadsRequest
@@ -13585,6 +16537,47 @@ func (s *ListMultipartUploadsInput) SetPrefix(v string) *ListMultipartUploadsInp
 func (s *ListMultipartUploadsInput) SetUploadIdMarker(v string) *ListMultipartUploadsInput {
 	s.UploadIdMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListMultipartUploadsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.QueryTarget, "delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.QueryTarget, "encoding-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMarker != nil {
+		v := *s.KeyMarker
+
+		e.SetValue(protocol.QueryTarget, "key-marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxUploads != nil {
+		v := *s.MaxUploads
+
+		e.SetValue(protocol.QueryTarget, "max-uploads", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadIdMarker != nil {
+		v := *s.UploadIdMarker
+
+		e.SetValue(protocol.QueryTarget, "upload-id-marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListMultipartUploadsOutput
@@ -13721,6 +16714,72 @@ func (s *ListMultipartUploadsOutput) SetUploads(v []*MultipartUpload) *ListMulti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListMultipartUploadsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.CommonPrefixes) > 0 {
+		v := s.CommonPrefixes
+
+		e.SetList(protocol.BodyTarget, "CommonPrefixes", encodeCommonPrefixList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.BodyTarget, "Delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.BodyTarget, "EncodingType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.KeyMarker != nil {
+		v := *s.KeyMarker
+
+		e.SetValue(protocol.BodyTarget, "KeyMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxUploads != nil {
+		v := *s.MaxUploads
+
+		e.SetValue(protocol.BodyTarget, "MaxUploads", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextKeyMarker != nil {
+		v := *s.NextKeyMarker
+
+		e.SetValue(protocol.BodyTarget, "NextKeyMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextUploadIdMarker != nil {
+		v := *s.NextUploadIdMarker
+
+		e.SetValue(protocol.BodyTarget, "NextUploadIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadIdMarker != nil {
+		v := *s.UploadIdMarker
+
+		e.SetValue(protocol.BodyTarget, "UploadIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Uploads) > 0 {
+		v := s.Uploads
+
+		e.SetList(protocol.BodyTarget, "Upload", encodeMultipartUploadList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectVersionsRequest
 type ListObjectVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -13823,6 +16882,47 @@ func (s *ListObjectVersionsInput) SetPrefix(v string) *ListObjectVersionsInput {
 func (s *ListObjectVersionsInput) SetVersionIdMarker(v string) *ListObjectVersionsInput {
 	s.VersionIdMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.QueryTarget, "delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.QueryTarget, "encoding-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMarker != nil {
+		v := *s.KeyMarker
+
+		e.SetValue(protocol.QueryTarget, "key-marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.QueryTarget, "max-keys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionIdMarker != nil {
+		v := *s.VersionIdMarker
+
+		e.SetValue(protocol.QueryTarget, "version-id-marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectVersionsOutput
@@ -13953,6 +17053,77 @@ func (s *ListObjectVersionsOutput) SetVersions(v []*ObjectVersion) *ListObjectVe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CommonPrefixes) > 0 {
+		v := s.CommonPrefixes
+
+		e.SetList(protocol.BodyTarget, "CommonPrefixes", encodeCommonPrefixList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.DeleteMarkers) > 0 {
+		v := s.DeleteMarkers
+
+		e.SetList(protocol.BodyTarget, "DeleteMarker", encodeDeleteMarkerEntryList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.BodyTarget, "Delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.BodyTarget, "EncodingType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.KeyMarker != nil {
+		v := *s.KeyMarker
+
+		e.SetValue(protocol.BodyTarget, "KeyMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.BodyTarget, "MaxKeys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextKeyMarker != nil {
+		v := *s.NextKeyMarker
+
+		e.SetValue(protocol.BodyTarget, "NextKeyMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextVersionIdMarker != nil {
+		v := *s.NextVersionIdMarker
+
+		e.SetValue(protocol.BodyTarget, "NextVersionIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionIdMarker != nil {
+		v := *s.VersionIdMarker
+
+		e.SetValue(protocol.BodyTarget, "VersionIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Version", encodeObjectVersionList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectsRequest
 type ListObjectsInput struct {
 	_ struct{} `type:"structure"`
@@ -14059,6 +17230,47 @@ func (s *ListObjectsInput) SetRequestPayer(v string) *ListObjectsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.QueryTarget, "delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.QueryTarget, "encoding-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.QueryTarget, "max-keys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectsOutput
 type ListObjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -14162,6 +17374,62 @@ func (s *ListObjectsOutput) SetNextMarker(v string) *ListObjectsOutput {
 func (s *ListObjectsOutput) SetPrefix(v string) *ListObjectsOutput {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CommonPrefixes) > 0 {
+		v := s.CommonPrefixes
+
+		e.SetList(protocol.BodyTarget, "CommonPrefixes", encodeCommonPrefixList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.Contents) > 0 {
+		v := s.Contents
+
+		e.SetList(protocol.BodyTarget, "Contents", encodeObjectList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.BodyTarget, "Delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.BodyTarget, "EncodingType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.BodyTarget, "MaxKeys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectsV2Request
@@ -14288,6 +17556,57 @@ func (s *ListObjectsV2Input) SetRequestPayer(v string) *ListObjectsV2Input {
 func (s *ListObjectsV2Input) SetStartAfter(v string) *ListObjectsV2Input {
 	s.StartAfter = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectsV2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.QueryTarget, "delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.QueryTarget, "encoding-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FetchOwner != nil {
+		v := *s.FetchOwner
+
+		e.SetValue(protocol.QueryTarget, "fetch-owner", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.QueryTarget, "max-keys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartAfter != nil {
+		v := *s.StartAfter
+
+		e.SetValue(protocol.QueryTarget, "start-after", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectsV2Output
@@ -14424,6 +17743,72 @@ func (s *ListObjectsV2Output) SetStartAfter(v string) *ListObjectsV2Output {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectsV2Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CommonPrefixes) > 0 {
+		v := s.CommonPrefixes
+
+		e.SetList(protocol.BodyTarget, "CommonPrefixes", encodeCommonPrefixList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.Contents) > 0 {
+		v := s.Contents
+
+		e.SetList(protocol.BodyTarget, "Contents", encodeObjectList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "ContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.BodyTarget, "Delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.BodyTarget, "EncodingType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.KeyCount != nil {
+		v := *s.KeyCount
+
+		e.SetValue(protocol.BodyTarget, "KeyCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.BodyTarget, "MaxKeys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextContinuationToken != nil {
+		v := *s.NextContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartAfter != nil {
+		v := *s.StartAfter
+
+		e.SetValue(protocol.BodyTarget, "StartAfter", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListPartsRequest
 type ListPartsInput struct {
 	_ struct{} `type:"structure"`
@@ -14526,6 +17911,42 @@ func (s *ListPartsInput) SetRequestPayer(v string) *ListPartsInput {
 func (s *ListPartsInput) SetUploadId(v string) *ListPartsInput {
 	s.UploadId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxParts != nil {
+		v := *s.MaxParts
+
+		e.SetValue(protocol.QueryTarget, "max-parts", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PartNumberMarker != nil {
+		v := *s.PartNumberMarker
+
+		e.SetValue(protocol.QueryTarget, "part-number-marker", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListPartsOutput
@@ -14678,6 +18099,82 @@ func (s *ListPartsOutput) SetUploadId(v string) *ListPartsOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortDate != nil {
+		v := *s.AbortDate
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-date", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.AbortRuleId != nil {
+		v := *s.AbortRuleId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-rule-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Initiator != nil {
+		v := s.Initiator
+
+		e.SetFields(protocol.BodyTarget, "Initiator", v, protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxParts != nil {
+		v := *s.MaxParts
+
+		e.SetValue(protocol.BodyTarget, "MaxParts", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextPartNumberMarker != nil {
+		v := *s.NextPartNumberMarker
+
+		e.SetValue(protocol.BodyTarget, "NextPartNumberMarker", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.PartNumberMarker != nil {
+		v := *s.PartNumberMarker
+
+		e.SetValue(protocol.BodyTarget, "PartNumberMarker", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Parts) > 0 {
+		v := s.Parts
+
+		e.SetList(protocol.BodyTarget, "Part", encodePartList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LoggingEnabled
 type LoggingEnabled struct {
 	_ struct{} `type:"structure"`
@@ -14745,6 +18242,27 @@ func (s *LoggingEnabled) SetTargetPrefix(v string) *LoggingEnabled {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LoggingEnabled) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TargetBucket != nil {
+		v := *s.TargetBucket
+
+		e.SetValue(protocol.BodyTarget, "TargetBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TargetGrants) > 0 {
+		v := s.TargetGrants
+
+		e.SetList(protocol.BodyTarget, "TargetGrants", encodeTargetGrantList(v), protocol.Metadata{ListLocationName: "Grant"})
+	}
+	if s.TargetPrefix != nil {
+		v := *s.TargetPrefix
+
+		e.SetValue(protocol.BodyTarget, "TargetPrefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MetricsAndOperator
 type MetricsAndOperator struct {
 	_ struct{} `type:"structure"`
@@ -14796,6 +18314,22 @@ func (s *MetricsAndOperator) SetPrefix(v string) *MetricsAndOperator {
 func (s *MetricsAndOperator) SetTags(v []*Tag) *MetricsAndOperator {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MetricsAndOperator) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MetricsConfiguration
@@ -14851,6 +18385,30 @@ func (s *MetricsConfiguration) SetFilter(v *MetricsFilter) *MetricsConfiguration
 func (s *MetricsConfiguration) SetId(v string) *MetricsConfiguration {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MetricsConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMetricsConfigurationList(vs []*MetricsConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MetricsFilter
@@ -14915,6 +18473,27 @@ func (s *MetricsFilter) SetPrefix(v string) *MetricsFilter {
 func (s *MetricsFilter) SetTag(v *Tag) *MetricsFilter {
 	s.Tag = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MetricsFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.And != nil {
+		v := s.And
+
+		e.SetFields(protocol.BodyTarget, "And", v, protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tag != nil {
+		v := s.Tag
+
+		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MultipartUpload
@@ -14985,6 +18564,50 @@ func (s *MultipartUpload) SetUploadId(v string) *MultipartUpload {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MultipartUpload) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Initiated != nil {
+		v := *s.Initiated
+
+		e.SetValue(protocol.BodyTarget, "Initiated", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Initiator != nil {
+		v := s.Initiator
+
+		e.SetFields(protocol.BodyTarget, "Initiator", v, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMultipartUploadList(vs []*MultipartUpload) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Specifies when noncurrent object versions expire. Upon expiration, Amazon
 // S3 permanently deletes the noncurrent object versions. You set this lifecycle
 // configuration action on a bucket that has versioning enabled (or suspended)
@@ -15015,6 +18638,17 @@ func (s NoncurrentVersionExpiration) GoString() string {
 func (s *NoncurrentVersionExpiration) SetNoncurrentDays(v int64) *NoncurrentVersionExpiration {
 	s.NoncurrentDays = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NoncurrentVersionExpiration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NoncurrentDays != nil {
+		v := *s.NoncurrentDays
+
+		e.SetValue(protocol.BodyTarget, "NoncurrentDays", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the transition rule that describes when noncurrent objects
@@ -15056,6 +18690,30 @@ func (s *NoncurrentVersionTransition) SetNoncurrentDays(v int64) *NoncurrentVers
 func (s *NoncurrentVersionTransition) SetStorageClass(v string) *NoncurrentVersionTransition {
 	s.StorageClass = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NoncurrentVersionTransition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NoncurrentDays != nil {
+		v := *s.NoncurrentDays
+
+		e.SetValue(protocol.BodyTarget, "NoncurrentDays", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeNoncurrentVersionTransitionList(vs []*NoncurrentVersionTransition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for specifying the notification configuration of the bucket. If
@@ -15139,6 +18797,27 @@ func (s *NotificationConfiguration) SetTopicConfigurations(v []*TopicConfigurati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NotificationConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LambdaFunctionConfigurations) > 0 {
+		v := s.LambdaFunctionConfigurations
+
+		e.SetList(protocol.BodyTarget, "CloudFunctionConfiguration", encodeLambdaFunctionConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.QueueConfigurations) > 0 {
+		v := s.QueueConfigurations
+
+		e.SetList(protocol.BodyTarget, "QueueConfiguration", encodeQueueConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.TopicConfigurations) > 0 {
+		v := s.TopicConfigurations
+
+		e.SetList(protocol.BodyTarget, "TopicConfiguration", encodeTopicConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/NotificationConfigurationDeprecated
 type NotificationConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
@@ -15178,6 +18857,27 @@ func (s *NotificationConfigurationDeprecated) SetTopicConfiguration(v *TopicConf
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NotificationConfigurationDeprecated) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFunctionConfiguration != nil {
+		v := s.CloudFunctionConfiguration
+
+		e.SetFields(protocol.BodyTarget, "CloudFunctionConfiguration", v, protocol.Metadata{})
+	}
+	if s.QueueConfiguration != nil {
+		v := s.QueueConfiguration
+
+		e.SetFields(protocol.BodyTarget, "QueueConfiguration", v, protocol.Metadata{})
+	}
+	if s.TopicConfiguration != nil {
+		v := s.TopicConfiguration
+
+		e.SetFields(protocol.BodyTarget, "TopicConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for object key name filtering rules. For information about key
 // name filtering, go to Configuring Event Notifications (http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/NotificationConfigurationFilter
@@ -15202,6 +18902,17 @@ func (s NotificationConfigurationFilter) GoString() string {
 func (s *NotificationConfigurationFilter) SetKey(v *KeyFilter) *NotificationConfigurationFilter {
 	s.Key = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NotificationConfigurationFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := s.Key
+
+		e.SetFields(protocol.BodyTarget, "S3Key", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Object
@@ -15268,6 +18979,50 @@ func (s *Object) SetStorageClass(v string) *Object {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Object) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectList(vs []*Object) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ObjectIdentifier
 type ObjectIdentifier struct {
 	_ struct{} `type:"structure"`
@@ -15317,6 +19072,30 @@ func (s *ObjectIdentifier) SetKey(v string) *ObjectIdentifier {
 func (s *ObjectIdentifier) SetVersionId(v string) *ObjectIdentifier {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectIdentifier) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectIdentifierList(vs []*ObjectIdentifier) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ObjectVersion
@@ -15405,6 +19184,60 @@ func (s *ObjectVersion) SetVersionId(v string) *ObjectVersion {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsLatest != nil {
+		v := *s.IsLatest
+
+		e.SetValue(protocol.BodyTarget, "IsLatest", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectVersionList(vs []*ObjectVersion) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Owner
 type Owner struct {
 	_ struct{} `type:"structure"`
@@ -15434,6 +19267,22 @@ func (s *Owner) SetDisplayName(v string) *Owner {
 func (s *Owner) SetID(v string) *Owner {
 	s.ID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Owner) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisplayName != nil {
+		v := *s.DisplayName
+
+		e.SetValue(protocol.BodyTarget, "DisplayName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Part
@@ -15486,6 +19335,40 @@ func (s *Part) SetPartNumber(v int64) *Part {
 func (s *Part) SetSize(v int64) *Part {
 	s.Size = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Part) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.BodyTarget, "PartNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePartList(vs []*Part) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAccelerateConfigurationRequest
@@ -15548,6 +19431,22 @@ func (s *PutBucketAccelerateConfigurationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAccelerateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccelerateConfiguration != nil {
+		v := s.AccelerateConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "AccelerateConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAccelerateConfigurationOutput
 type PutBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -15561,6 +19460,12 @@ func (s PutBucketAccelerateConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketAccelerateConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAccelerateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAclRequest
@@ -15675,6 +19580,52 @@ func (s *PutBucketAclInput) SetGrantWriteACP(v string) *PutBucketAclInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccessControlPolicy != nil {
+		v := s.AccessControlPolicy
+
+		e.SetFields(protocol.PayloadTarget, "AccessControlPolicy", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWrite != nil {
+		v := *s.GrantWrite
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAclOutput
 type PutBucketAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -15688,6 +19639,12 @@ func (s PutBucketAclOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketAclOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAclOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAnalyticsConfigurationRequest
@@ -15769,6 +19726,27 @@ func (s *PutBucketAnalyticsConfigurationInput) SetId(v string) *PutBucketAnalyti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAnalyticsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AnalyticsConfiguration != nil {
+		v := s.AnalyticsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "AnalyticsConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAnalyticsConfigurationOutput
 type PutBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -15782,6 +19760,12 @@ func (s PutBucketAnalyticsConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketAnalyticsConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketCorsRequest
@@ -15845,6 +19829,22 @@ func (s *PutBucketCorsInput) SetCORSConfiguration(v *CORSConfiguration) *PutBuck
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CORSConfiguration != nil {
+		v := s.CORSConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "CORSConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketCorsOutput
 type PutBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -15858,6 +19858,12 @@ func (s PutBucketCorsOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketCorsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketInventoryConfigurationRequest
@@ -15939,6 +19945,27 @@ func (s *PutBucketInventoryConfigurationInput) SetInventoryConfiguration(v *Inve
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketInventoryConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InventoryConfiguration != nil {
+		v := s.InventoryConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "InventoryConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketInventoryConfigurationOutput
 type PutBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -15952,6 +19979,12 @@ func (s PutBucketInventoryConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketInventoryConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLifecycleConfigurationRequest
@@ -16011,6 +20044,22 @@ func (s *PutBucketLifecycleConfigurationInput) SetLifecycleConfiguration(v *Buck
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLifecycleConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LifecycleConfiguration != nil {
+		v := s.LifecycleConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "LifecycleConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLifecycleConfigurationOutput
 type PutBucketLifecycleConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16024,6 +20073,12 @@ func (s PutBucketLifecycleConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketLifecycleConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLifecycleConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLifecycleRequest
@@ -16083,6 +20138,22 @@ func (s *PutBucketLifecycleInput) SetLifecycleConfiguration(v *LifecycleConfigur
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LifecycleConfiguration != nil {
+		v := s.LifecycleConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "LifecycleConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLifecycleOutput
 type PutBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
@@ -16096,6 +20167,12 @@ func (s PutBucketLifecycleOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketLifecycleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLoggingRequest
@@ -16159,6 +20236,22 @@ func (s *PutBucketLoggingInput) SetBucketLoggingStatus(v *BucketLoggingStatus) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLoggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BucketLoggingStatus != nil {
+		v := s.BucketLoggingStatus
+
+		e.SetFields(protocol.PayloadTarget, "BucketLoggingStatus", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLoggingOutput
 type PutBucketLoggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -16172,6 +20265,12 @@ func (s PutBucketLoggingOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketLoggingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLoggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketMetricsConfigurationRequest
@@ -16253,6 +20352,27 @@ func (s *PutBucketMetricsConfigurationInput) SetMetricsConfiguration(v *MetricsC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricsConfiguration != nil {
+		v := s.MetricsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "MetricsConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketMetricsConfigurationOutput
 type PutBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16266,6 +20386,12 @@ func (s PutBucketMetricsConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketMetricsConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketNotificationConfigurationRequest
@@ -16332,6 +20458,22 @@ func (s *PutBucketNotificationConfigurationInput) SetNotificationConfiguration(v
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketNotificationConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NotificationConfiguration != nil {
+		v := s.NotificationConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "NotificationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketNotificationConfigurationOutput
 type PutBucketNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16345,6 +20487,12 @@ func (s PutBucketNotificationConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketNotificationConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketNotificationConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketNotificationRequest
@@ -16403,6 +20551,22 @@ func (s *PutBucketNotificationInput) SetNotificationConfiguration(v *Notificatio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketNotificationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NotificationConfiguration != nil {
+		v := s.NotificationConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "NotificationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketNotificationOutput
 type PutBucketNotificationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16416,6 +20580,12 @@ func (s PutBucketNotificationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketNotificationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketNotificationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketPolicyRequest
@@ -16476,6 +20646,22 @@ func (s *PutBucketPolicyInput) SetPolicy(v string) *PutBucketPolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetStream(protocol.PayloadTarget, "Policy", protocol.StringStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketPolicyOutput
 type PutBucketPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -16489,6 +20675,12 @@ func (s PutBucketPolicyOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketReplicationRequest
@@ -16555,6 +20747,22 @@ func (s *PutBucketReplicationInput) SetReplicationConfiguration(v *ReplicationCo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ReplicationConfiguration != nil {
+		v := s.ReplicationConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "ReplicationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketReplicationOutput
 type PutBucketReplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16568,6 +20776,12 @@ func (s PutBucketReplicationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketReplicationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketRequestPaymentRequest
@@ -16631,6 +20845,22 @@ func (s *PutBucketRequestPaymentInput) SetRequestPaymentConfiguration(v *Request
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketRequestPaymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPaymentConfiguration != nil {
+		v := s.RequestPaymentConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "RequestPaymentConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketRequestPaymentOutput
 type PutBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -16644,6 +20874,12 @@ func (s PutBucketRequestPaymentOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketRequestPaymentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketRequestPaymentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketTaggingRequest
@@ -16707,6 +20943,22 @@ func (s *PutBucketTaggingInput) SetTagging(v *Tagging) *PutBucketTaggingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := s.Tagging
+
+		e.SetFields(protocol.PayloadTarget, "Tagging", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketTaggingOutput
 type PutBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -16720,6 +20972,12 @@ func (s PutBucketTaggingOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketTaggingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketVersioningRequest
@@ -16788,6 +21046,27 @@ func (s *PutBucketVersioningInput) SetVersioningConfiguration(v *VersioningConfi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketVersioningInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MFA != nil {
+		v := *s.MFA
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mfa", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersioningConfiguration != nil {
+		v := s.VersioningConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "VersioningConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketVersioningOutput
 type PutBucketVersioningOutput struct {
 	_ struct{} `type:"structure"`
@@ -16801,6 +21080,12 @@ func (s PutBucketVersioningOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketVersioningOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketVersioningOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketWebsiteRequest
@@ -16864,6 +21149,22 @@ func (s *PutBucketWebsiteInput) SetWebsiteConfiguration(v *WebsiteConfiguration)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteConfiguration != nil {
+		v := s.WebsiteConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "WebsiteConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketWebsiteOutput
 type PutBucketWebsiteOutput struct {
 	_ struct{} `type:"structure"`
@@ -16877,6 +21178,12 @@ func (s PutBucketWebsiteOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketWebsiteOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectAclRequest
@@ -17027,6 +21334,67 @@ func (s *PutObjectAclInput) SetVersionId(v string) *PutObjectAclInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccessControlPolicy != nil {
+		v := s.AccessControlPolicy
+
+		e.SetFields(protocol.PayloadTarget, "AccessControlPolicy", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWrite != nil {
+		v := *s.GrantWrite
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectAclOutput
 type PutObjectAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -17050,6 +21418,17 @@ func (s PutObjectAclOutput) GoString() string {
 func (s *PutObjectAclOutput) SetRequestCharged(v string) *PutObjectAclOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectAclOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectRequest
@@ -17347,6 +21726,137 @@ func (s *PutObjectInput) SetWebsiteRedirectLocation(v string) *PutObjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := *s.Tagging
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectOutput
 type PutObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -17442,6 +21952,52 @@ func (s *PutObjectOutput) SetVersionId(v string) *PutObjectOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectTaggingRequest
 type PutObjectTaggingInput struct {
 	_ struct{} `type:"structure" payload:"Tagging"`
@@ -17526,6 +22082,32 @@ func (s *PutObjectTaggingInput) SetVersionId(v string) *PutObjectTaggingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := s.Tagging
+
+		e.SetFields(protocol.PayloadTarget, "Tagging", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectTaggingOutput
 type PutObjectTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -17547,6 +22129,17 @@ func (s PutObjectTaggingOutput) GoString() string {
 func (s *PutObjectTaggingOutput) SetVersionId(v string) *PutObjectTaggingOutput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for specifying an configuration when you want Amazon S3 to publish
@@ -17623,6 +22216,40 @@ func (s *QueueConfiguration) SetQueueArn(v string) *QueueConfiguration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QueueConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.QueueArn != nil {
+		v := *s.QueueArn
+
+		e.SetValue(protocol.BodyTarget, "Queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeQueueConfigurationList(vs []*QueueConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/QueueConfigurationDeprecated
 type QueueConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
@@ -17671,6 +22298,32 @@ func (s *QueueConfigurationDeprecated) SetId(v string) *QueueConfigurationDeprec
 func (s *QueueConfigurationDeprecated) SetQueue(v string) *QueueConfigurationDeprecated {
 	s.Queue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QueueConfigurationDeprecated) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Event != nil {
+		v := *s.Event
+
+		e.SetValue(protocol.BodyTarget, "Event", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Queue != nil {
+		v := *s.Queue
+
+		e.SetValue(protocol.BodyTarget, "Queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Redirect
@@ -17742,6 +22395,37 @@ func (s *Redirect) SetReplaceKeyWith(v string) *Redirect {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Redirect) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostName != nil {
+		v := *s.HostName
+
+		e.SetValue(protocol.BodyTarget, "HostName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpRedirectCode != nil {
+		v := *s.HttpRedirectCode
+
+		e.SetValue(protocol.BodyTarget, "HttpRedirectCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ReplaceKeyPrefixWith != nil {
+		v := *s.ReplaceKeyPrefixWith
+
+		e.SetValue(protocol.BodyTarget, "ReplaceKeyPrefixWith", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ReplaceKeyWith != nil {
+		v := *s.ReplaceKeyWith
+
+		e.SetValue(protocol.BodyTarget, "ReplaceKeyWith", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RedirectAllRequestsTo
 type RedirectAllRequestsTo struct {
 	_ struct{} `type:"structure"`
@@ -17789,6 +22473,22 @@ func (s *RedirectAllRequestsTo) SetHostName(v string) *RedirectAllRequestsTo {
 func (s *RedirectAllRequestsTo) SetProtocol(v string) *RedirectAllRequestsTo {
 	s.Protocol = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RedirectAllRequestsTo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostName != nil {
+		v := *s.HostName
+
+		e.SetValue(protocol.BodyTarget, "HostName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for replication rules. You can add as many as 1,000 rules. Total
@@ -17856,6 +22556,22 @@ func (s *ReplicationConfiguration) SetRole(v string) *ReplicationConfiguration {
 func (s *ReplicationConfiguration) SetRules(v []*ReplicationRule) *ReplicationConfiguration {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReplicationConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeReplicationRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ReplicationRule
@@ -17939,6 +22655,40 @@ func (s *ReplicationRule) SetStatus(v string) *ReplicationRule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReplicationRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "Destination", v, protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeReplicationRuleList(vs []*ReplicationRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RequestPaymentConfiguration
 type RequestPaymentConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -17976,6 +22726,17 @@ func (s *RequestPaymentConfiguration) Validate() error {
 func (s *RequestPaymentConfiguration) SetPayer(v string) *RequestPaymentConfiguration {
 	s.Payer = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RequestPaymentConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payer != nil {
+		v := *s.Payer
+
+		e.SetValue(protocol.BodyTarget, "Payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RestoreObjectRequest
@@ -18070,6 +22831,37 @@ func (s *RestoreObjectInput) SetVersionId(v string) *RestoreObjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RestoreObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestoreRequest != nil {
+		v := s.RestoreRequest
+
+		e.SetFields(protocol.PayloadTarget, "RestoreRequest", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RestoreObjectOutput
 type RestoreObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -18093,6 +22885,17 @@ func (s RestoreObjectOutput) GoString() string {
 func (s *RestoreObjectOutput) SetRequestCharged(v string) *RestoreObjectOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RestoreObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RestoreRequest
@@ -18148,6 +22951,22 @@ func (s *RestoreRequest) SetGlacierJobParameters(v *GlacierJobParameters) *Resto
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RestoreRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Days != nil {
+		v := *s.Days
+
+		e.SetValue(protocol.BodyTarget, "Days", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GlacierJobParameters != nil {
+		v := s.GlacierJobParameters
+
+		e.SetFields(protocol.BodyTarget, "GlacierJobParameters", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RoutingRule
 type RoutingRule struct {
 	_ struct{} `type:"structure"`
@@ -18199,6 +23018,30 @@ func (s *RoutingRule) SetCondition(v *Condition) *RoutingRule {
 func (s *RoutingRule) SetRedirect(v *Redirect) *RoutingRule {
 	s.Redirect = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RoutingRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Condition != nil {
+		v := s.Condition
+
+		e.SetFields(protocol.BodyTarget, "Condition", v, protocol.Metadata{})
+	}
+	if s.Redirect != nil {
+		v := s.Redirect
+
+		e.SetFields(protocol.BodyTarget, "Redirect", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRoutingRuleList(vs []*RoutingRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Rule
@@ -18316,6 +23159,60 @@ func (s *Rule) SetTransition(v *Transition) *Rule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Rule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortIncompleteMultipartUpload != nil {
+		v := s.AbortIncompleteMultipartUpload
+
+		e.SetFields(protocol.BodyTarget, "AbortIncompleteMultipartUpload", v, protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := s.Expiration
+
+		e.SetFields(protocol.BodyTarget, "Expiration", v, protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NoncurrentVersionExpiration != nil {
+		v := s.NoncurrentVersionExpiration
+
+		e.SetFields(protocol.BodyTarget, "NoncurrentVersionExpiration", v, protocol.Metadata{})
+	}
+	if s.NoncurrentVersionTransition != nil {
+		v := s.NoncurrentVersionTransition
+
+		e.SetFields(protocol.BodyTarget, "NoncurrentVersionTransition", v, protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Transition != nil {
+		v := s.Transition
+
+		e.SetFields(protocol.BodyTarget, "Transition", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRuleList(vs []*Rule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/StorageClassAnalysis
 type StorageClassAnalysis struct {
 	_ struct{} `type:"structure"`
@@ -18354,6 +23251,17 @@ func (s *StorageClassAnalysis) Validate() error {
 func (s *StorageClassAnalysis) SetDataExport(v *StorageClassAnalysisDataExport) *StorageClassAnalysis {
 	s.DataExport = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageClassAnalysis) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DataExport != nil {
+		v := s.DataExport
+
+		e.SetFields(protocol.BodyTarget, "DataExport", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/StorageClassAnalysisDataExport
@@ -18414,6 +23322,22 @@ func (s *StorageClassAnalysisDataExport) SetOutputSchemaVersion(v string) *Stora
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageClassAnalysisDataExport) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "Destination", v, protocol.Metadata{})
+	}
+	if s.OutputSchemaVersion != nil {
+		v := *s.OutputSchemaVersion
+
+		e.SetValue(protocol.BodyTarget, "OutputSchemaVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Tag
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -18470,6 +23394,30 @@ func (s *Tag) SetValue(v string) *Tag {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Tagging
 type Tagging struct {
 	_ struct{} `type:"structure"`
@@ -18517,6 +23465,17 @@ func (s *Tagging) SetTagSet(v []*Tag) *Tagging {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tagging) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TagSet) > 0 {
+		v := s.TagSet
+
+		e.SetList(protocol.BodyTarget, "TagSet", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/TargetGrant
 type TargetGrant struct {
 	_ struct{} `type:"structure"`
@@ -18562,6 +23521,36 @@ func (s *TargetGrant) SetGrantee(v *Grantee) *TargetGrant {
 func (s *TargetGrant) SetPermission(v string) *TargetGrant {
 	s.Permission = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TargetGrant) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Grantee != nil {
+		v := s.Grantee
+		attrs := make([]protocol.Attribute, 0, 1)
+		// TODO only create array if an attribute value is set
+
+		if s.Grantee.Type != nil {
+			v := *s.Grantee.Type
+			attrs = append(attrs, protocol.Attribute{Name: "xsi:type", Value: protocol.StringValue(v), Meta: protocol.Metadata{}})
+		}
+		e.SetFields(protocol.BodyTarget, "Grantee", v, protocol.Metadata{Attributes: attrs, XMLNamespacePrefix: "xsi", XMLNamespaceURI: "http://www.w3.org/2001/XMLSchema-instance"})
+	}
+	if s.Permission != nil {
+		v := *s.Permission
+
+		e.SetValue(protocol.BodyTarget, "Permission", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTargetGrantList(vs []*TargetGrant) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for specifying the configuration when you want Amazon S3 to publish
@@ -18638,6 +23627,40 @@ func (s *TopicConfiguration) SetTopicArn(v string) *TopicConfiguration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TopicArn != nil {
+		v := *s.TopicArn
+
+		e.SetValue(protocol.BodyTarget, "Topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTopicConfigurationList(vs []*TopicConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/TopicConfigurationDeprecated
 type TopicConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
@@ -18690,6 +23713,32 @@ func (s *TopicConfigurationDeprecated) SetTopic(v string) *TopicConfigurationDep
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicConfigurationDeprecated) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Event != nil {
+		v := *s.Event
+
+		e.SetValue(protocol.BodyTarget, "Event", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.BodyTarget, "Topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Transition
 type Transition struct {
 	_ struct{} `type:"structure"`
@@ -18732,6 +23781,35 @@ func (s *Transition) SetDays(v int64) *Transition {
 func (s *Transition) SetStorageClass(v string) *Transition {
 	s.StorageClass = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Transition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Date != nil {
+		v := *s.Date
+
+		e.SetValue(protocol.BodyTarget, "Date", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Days != nil {
+		v := *s.Days
+
+		e.SetValue(protocol.BodyTarget, "Days", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTransitionList(vs []*Transition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/UploadPartCopyRequest
@@ -18978,6 +24056,97 @@ func (s *UploadPartCopyInput) SetUploadId(v string) *UploadPartCopyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadPartCopyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySource != nil {
+		v := *s.CopySource
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfMatch != nil {
+		v := *s.CopySourceIfMatch
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfModifiedSince != nil {
+		v := *s.CopySourceIfModifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-modified-since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.CopySourceIfNoneMatch != nil {
+		v := *s.CopySourceIfNoneMatch
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-none-match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfUnmodifiedSince != nil {
+		v := *s.CopySourceIfUnmodifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-unmodified-since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.CopySourceRange != nil {
+		v := *s.CopySourceRange
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerAlgorithm != nil {
+		v := *s.CopySourceSSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerKey != nil {
+		v := *s.CopySourceSSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerKeyMD5 != nil {
+		v := *s.CopySourceSSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/UploadPartCopyOutput
 type UploadPartCopyOutput struct {
 	_ struct{} `type:"structure" payload:"CopyPartResult"`
@@ -19061,6 +24230,47 @@ func (s *UploadPartCopyOutput) SetSSEKMSKeyId(v string) *UploadPartCopyOutput {
 func (s *UploadPartCopyOutput) SetServerSideEncryption(v string) *UploadPartCopyOutput {
 	s.ServerSideEncryption = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadPartCopyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CopyPartResult != nil {
+		v := s.CopyPartResult
+
+		e.SetFields(protocol.PayloadTarget, "CopyPartResult", v, protocol.Metadata{})
+	}
+	if s.CopySourceVersionId != nil {
+		v := *s.CopySourceVersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/UploadPartRequest
@@ -19227,6 +24437,62 @@ func (s *UploadPartInput) SetUploadId(v string) *UploadPartInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/UploadPartOutput
 type UploadPartOutput struct {
 	_ struct{} `type:"structure"`
@@ -19303,6 +24569,42 @@ func (s *UploadPartOutput) SetServerSideEncryption(v string) *UploadPartOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadPartOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/VersioningConfiguration
 type VersioningConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -19336,6 +24638,22 @@ func (s *VersioningConfiguration) SetMFADelete(v string) *VersioningConfiguratio
 func (s *VersioningConfiguration) SetStatus(v string) *VersioningConfiguration {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VersioningConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MFADelete != nil {
+		v := *s.MFADelete
+
+		e.SetValue(protocol.BodyTarget, "MfaDelete", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/WebsiteConfiguration
@@ -19418,6 +24736,32 @@ func (s *WebsiteConfiguration) SetRedirectAllRequestsTo(v *RedirectAllRequestsTo
 func (s *WebsiteConfiguration) SetRoutingRules(v []*RoutingRule) *WebsiteConfiguration {
 	s.RoutingRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WebsiteConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorDocument != nil {
+		v := s.ErrorDocument
+
+		e.SetFields(protocol.BodyTarget, "ErrorDocument", v, protocol.Metadata{})
+	}
+	if s.IndexDocument != nil {
+		v := s.IndexDocument
+
+		e.SetFields(protocol.BodyTarget, "IndexDocument", v, protocol.Metadata{})
+	}
+	if s.RedirectAllRequestsTo != nil {
+		v := s.RedirectAllRequestsTo
+
+		e.SetFields(protocol.BodyTarget, "RedirectAllRequestsTo", v, protocol.Metadata{})
+	}
+	if len(s.RoutingRules) > 0 {
+		v := s.RoutingRules
+
+		e.SetList(protocol.BodyTarget, "RoutingRules", encodeRoutingRuleList(v), protocol.Metadata{ListLocationName: "RoutingRule"})
+	}
+
+	return nil
 }
 
 const (

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -13902,7 +13902,6 @@ func (s *Grant) MarshalFields(e protocol.FieldEncoder) error {
 	if s.Grantee != nil {
 		v := s.Grantee
 		attrs := make([]protocol.Attribute, 0, 1)
-		// TODO only create array if an attribute value is set
 
 		if s.Grantee.Type != nil {
 			v := *s.Grantee.Type
@@ -23528,7 +23527,6 @@ func (s *TargetGrant) MarshalFields(e protocol.FieldEncoder) error {
 	if s.Grantee != nil {
 		v := s.Grantee
 		attrs := make([]protocol.Attribute, 0, 1)
-		// TODO only create array if an attribute value is set
 
 		if s.Grantee.Type != nil {
 			v := *s.Grantee.Type


### PR DESCRIPTION
This change is the start of an iterative set of changes that will
replace the SDK's current reflection base protocol marshalers with
generated code for each API type.

This works starts with the RESTXML protocol's encoders. The following
benchmarks show a significant improvement of execution speed and reduced
memory usage.

Benchmarks of RESTXML build and full request lifecycle between master and this change. `Build` benchmarks focus on just the marshaling of the request's input parameters. `Request` benchmarks provide a view of the impact of the changes in context to a full request lifecycle. Does not include network latency, nor umarshaling of a response object.

```
go test -tags bench -run NONE -bench ".*" -benchmem ./private/protocol/restxml
```

```
benchmark                                            old ns/op     new ns/op     delta
BenchmarkRESTXMLBuild_Complex_CFCreateDistro-8       264834        59891         -77.39%
BenchmarkRESTXMLBuild_Simple_CFDeleteDistro-8        9666          5894          -39.02%
BenchmarkRESTXMLBuild_REST_S3HeadObject-8            19723         7340          -62.78%
BenchmarkRESTXMLBuild_XML_S3PutObjectAcl-8           44739         15656         -65.01%
BenchmarkRESTXMLRequest_Complex_CFCreateDistro-8     586238        292755        -50.06%
BenchmarkRESTXMLRequest_Simple_CFDeleteDistro-8      168954        158484        -6.20%
BenchmarkRESTXMLRequest_REST_S3HeadObject-8          228720        199964        -12.57%
BenchmarkRESTXMLRequest_XML_S3PutObjectAcl-8         253821        206911        -18.48%

benchmark                                            old allocs     new allocs     delta
BenchmarkRESTXMLBuild_Complex_CFCreateDistro-8       1332           478            -64.11%
BenchmarkRESTXMLBuild_Simple_CFDeleteDistro-8        63             44             -30.16%
BenchmarkRESTXMLBuild_REST_S3HeadObject-8            134            57             -57.46%
BenchmarkRESTXMLBuild_XML_S3PutObjectAcl-8           247            113            -54.25%
BenchmarkRESTXMLRequest_Complex_CFCreateDistro-8     1641           786            -52.10%
BenchmarkRESTXMLRequest_Simple_CFDeleteDistro-8      230            211            -8.26%
BenchmarkRESTXMLRequest_REST_S3HeadObject-8          443            366            -17.38%
BenchmarkRESTXMLRequest_XML_S3PutObjectAcl-8         466            331            -28.97%

benchmark                                            old bytes     new bytes     delta
BenchmarkRESTXMLBuild_Complex_CFCreateDistro-8       87893         27936         -68.22%
BenchmarkRESTXMLBuild_Simple_CFDeleteDistro-8        8104          7880          -2.76%
BenchmarkRESTXMLBuild_REST_S3HeadObject-8            9544          8800          -7.80%
BenchmarkRESTXMLBuild_XML_S3PutObjectAcl-8           17701         11704         -33.88%
BenchmarkRESTXMLRequest_Complex_CFCreateDistro-8     141892        80852         -43.02%
BenchmarkRESTXMLRequest_Simple_CFDeleteDistro-8      52773         52543         -0.44%
BenchmarkRESTXMLRequest_REST_S3HeadObject-8          61947         61193         -1.22%
BenchmarkRESTXMLRequest_XML_S3PutObjectAcl-8         70800         64671         -8.66%
```

Work in progress PR:
* [x] Fill out missing rest or XML encoder implementations
* [x] Code generation templates need to be cleaned up.
* [x] Refactor code generation to do inline nested complex type marshaling. e.g. map[string][]int64
* [x] Verify correctness of marshaling
* [x] Linting
* [x] Make sure all unsupported encoder modes set error.