### PR TITLE
v1.10.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+Release v1.10.15 (2017-07-24)
+===
+
+### Service Client Updates
+* `service/appstream`: Updates service API, documentation, and waiters
+  * Amazon AppStream 2.0 image builders and fleets can now access applications and network resources that rely on Microsoft Active Directory (AD) for authentication and permissions. This new feature allows you to join your streaming instances to your AD, so you can use your existing AD user management tools.
+* `service/ec2`: Updates service API and documentation
+  * Spot Fleet tagging capability allows customers to automatically tag instances launched by Spot Fleet. You can use this feature to label or distinguish instances created by distinct Spot Fleets. Tagging your EC2 instances also enables you to see instance cost allocation by tag in your AWS bill.
+
+### SDK Bugs
+* `aws/signer/v4`: Fix out of bounds panic in stripExcessSpaces [#1412](https://github.com/aws/aws-sdk-go/pull/1412)
+  * Fixes the out of bands panic in stripExcessSpaces caused by an incorrect calculation of the stripToIdx value. Simplified to code also.
+  * Fixes [#1411](https://github.com/aws/aws-sdk-go/issues/1411)
 Release v1.10.14 (2017-07-20)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,3 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* `aws/signer/v4`: Fix out of bounds panic in stripExcessSpaces [#1412](https://github.com/aws/aws-sdk-go/pull/1412)
-  * Fixes the out of bands panic in stripExcessSpaces caused by an incorrect calculation of the stripToIdx value. Simplified to code also.
-  * Fixes [#1411](https://github.com/aws/aws-sdk-go/issues/1411)

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.10.14"
+const SDKVersion = "1.10.15"

--- a/models/apis/appstream/2016-12-01/api-2.json
+++ b/models/apis/appstream/2016-12-01/api-2.json
@@ -24,7 +24,21 @@
         {"shape":"LimitExceededException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"ConcurrentModificationException"},
-        {"shape":"IncompatibleImageException"}
+        {"shape":"IncompatibleImageException"},
+        {"shape":"OperationNotPermittedException"}
+      ]
+    },
+    "CreateDirectoryConfig":{
+      "name":"CreateDirectoryConfig",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CreateDirectoryConfigRequest"},
+      "output":{"shape":"CreateDirectoryConfigResult"},
+      "errors":[
+        {"shape":"ResourceAlreadyExistsException"},
+        {"shape":"LimitExceededException"}
       ]
     },
     "CreateFleet":{
@@ -41,7 +55,9 @@
         {"shape":"ResourceNotFoundException"},
         {"shape":"LimitExceededException"},
         {"shape":"InvalidRoleException"},
-        {"shape":"ConcurrentModificationException"}
+        {"shape":"ConcurrentModificationException"},
+        {"shape":"InvalidParameterCombinationException"},
+        {"shape":"IncompatibleImageException"}
       ]
     },
     "CreateStack":{
@@ -76,6 +92,19 @@
         {"shape":"InvalidParameterCombinationException"}
       ]
     },
+    "DeleteDirectoryConfig":{
+      "name":"DeleteDirectoryConfig",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteDirectoryConfigRequest"},
+      "output":{"shape":"DeleteDirectoryConfigResult"},
+      "errors":[
+        {"shape":"ResourceInUseException"},
+        {"shape":"ResourceNotFoundException"}
+      ]
+    },
     "DeleteFleet":{
       "name":"DeleteFleet",
       "http":{
@@ -102,6 +131,18 @@
         {"shape":"ResourceInUseException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"ConcurrentModificationException"}
+      ]
+    },
+    "DescribeDirectoryConfigs":{
+      "name":"DescribeDirectoryConfigs",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeDirectoryConfigsRequest"},
+      "output":{"shape":"DescribeDirectoryConfigsResult"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"}
       ]
     },
     "DescribeFleets":{
@@ -221,6 +262,20 @@
         {"shape":"ConcurrentModificationException"}
       ]
     },
+    "UpdateDirectoryConfig":{
+      "name":"UpdateDirectoryConfig",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"UpdateDirectoryConfigRequest"},
+      "output":{"shape":"UpdateDirectoryConfigResult"},
+      "errors":[
+        {"shape":"ResourceInUseException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ConcurrentModificationException"}
+      ]
+    },
     "UpdateFleet":{
       "name":"UpdateFleet",
       "http":{
@@ -237,7 +292,8 @@
         {"shape":"ResourceNotAvailableException"},
         {"shape":"InvalidParameterCombinationException"},
         {"shape":"ConcurrentModificationException"},
-        {"shape":"IncompatibleImageException"}
+        {"shape":"IncompatibleImageException"},
+        {"shape":"OperationNotPermittedException"}
       ]
     },
     "UpdateStack":{
@@ -259,6 +315,17 @@
     }
   },
   "shapes":{
+    "AccountName":{
+      "type":"string",
+      "min":1,
+      "sensitive":true
+    },
+    "AccountPassword":{
+      "type":"string",
+      "max":127,
+      "min":1,
+      "sensitive":true
+    },
     "Application":{
       "type":"structure",
       "members":{
@@ -329,6 +396,25 @@
       },
       "exception":true
     },
+    "CreateDirectoryConfigRequest":{
+      "type":"structure",
+      "required":[
+        "DirectoryName",
+        "OrganizationalUnitDistinguishedNames",
+        "ServiceAccountCredentials"
+      ],
+      "members":{
+        "DirectoryName":{"shape":"DirectoryName"},
+        "OrganizationalUnitDistinguishedNames":{"shape":"OrganizationalUnitDistinguishedNamesList"},
+        "ServiceAccountCredentials":{"shape":"ServiceAccountCredentials"}
+      }
+    },
+    "CreateDirectoryConfigResult":{
+      "type":"structure",
+      "members":{
+        "DirectoryConfig":{"shape":"DirectoryConfig"}
+      }
+    },
     "CreateFleetRequest":{
       "type":"structure",
       "required":[
@@ -347,7 +433,8 @@
         "DisconnectTimeoutInSeconds":{"shape":"Integer"},
         "Description":{"shape":"Description"},
         "DisplayName":{"shape":"DisplayName"},
-        "EnableDefaultInternetAccess":{"shape":"BooleanObject"}
+        "EnableDefaultInternetAccess":{"shape":"BooleanObject"},
+        "DomainJoinInfo":{"shape":"DomainJoinInfo"}
       }
     },
     "CreateFleetResult":{
@@ -382,7 +469,7 @@
       "members":{
         "StackName":{"shape":"String"},
         "FleetName":{"shape":"String"},
-        "UserId":{"shape":"UserId"},
+        "UserId":{"shape":"StreamingUrlUserId"},
         "ApplicationId":{"shape":"String"},
         "Validity":{"shape":"Long"},
         "SessionContext":{"shape":"String"}
@@ -393,6 +480,18 @@
       "members":{
         "StreamingURL":{"shape":"String"},
         "Expires":{"shape":"Timestamp"}
+      }
+    },
+    "DeleteDirectoryConfigRequest":{
+      "type":"structure",
+      "required":["DirectoryName"],
+      "members":{
+        "DirectoryName":{"shape":"DirectoryName"}
+      }
+    },
+    "DeleteDirectoryConfigResult":{
+      "type":"structure",
+      "members":{
       }
     },
     "DeleteFleetRequest":{
@@ -417,6 +516,21 @@
     "DeleteStackResult":{
       "type":"structure",
       "members":{
+      }
+    },
+    "DescribeDirectoryConfigsRequest":{
+      "type":"structure",
+      "members":{
+        "DirectoryNames":{"shape":"DirectoryNameList"},
+        "MaxResults":{"shape":"Integer"},
+        "NextToken":{"shape":"String"}
+      }
+    },
+    "DescribeDirectoryConfigsResult":{
+      "type":"structure",
+      "members":{
+        "DirectoryConfigs":{"shape":"DirectoryConfigList"},
+        "NextToken":{"shape":"String"}
       }
     },
     "DescribeFleetsRequest":{
@@ -485,6 +599,25 @@
       "type":"string",
       "max":256
     },
+    "DirectoryConfig":{
+      "type":"structure",
+      "required":["DirectoryName"],
+      "members":{
+        "DirectoryName":{"shape":"DirectoryName"},
+        "OrganizationalUnitDistinguishedNames":{"shape":"OrganizationalUnitDistinguishedNamesList"},
+        "ServiceAccountCredentials":{"shape":"ServiceAccountCredentials"},
+        "CreatedTime":{"shape":"Timestamp"}
+      }
+    },
+    "DirectoryConfigList":{
+      "type":"list",
+      "member":{"shape":"DirectoryConfig"}
+    },
+    "DirectoryName":{"type":"string"},
+    "DirectoryNameList":{
+      "type":"list",
+      "member":{"shape":"DirectoryName"}
+    },
     "DisassociateFleetRequest":{
       "type":"structure",
       "required":[
@@ -504,6 +637,13 @@
     "DisplayName":{
       "type":"string",
       "max":100
+    },
+    "DomainJoinInfo":{
+      "type":"structure",
+      "members":{
+        "DirectoryName":{"shape":"DirectoryName"},
+        "OrganizationalUnitDistinguishedName":{"shape":"OrganizationalUnitDistinguishedName"}
+      }
     },
     "ErrorMessage":{"type":"string"},
     "ExpireSessionRequest":{
@@ -542,14 +682,16 @@
         "VpcConfig":{"shape":"VpcConfig"},
         "CreatedTime":{"shape":"Timestamp"},
         "FleetErrors":{"shape":"FleetErrors"},
-        "EnableDefaultInternetAccess":{"shape":"BooleanObject"}
+        "EnableDefaultInternetAccess":{"shape":"BooleanObject"},
+        "DomainJoinInfo":{"shape":"DomainJoinInfo"}
       }
     },
     "FleetAttribute":{
       "type":"string",
       "enum":[
         "VPC_CONFIGURATION",
-        "VPC_CONFIGURATION_SECURITY_GROUP_IDS"
+        "VPC_CONFIGURATION_SECURITY_GROUP_IDS",
+        "DOMAIN_JOIN_INFO"
       ]
     },
     "FleetAttributes":{
@@ -576,7 +718,21 @@
         "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION",
         "SUBNET_NOT_FOUND",
         "IMAGE_NOT_FOUND",
-        "INVALID_SUBNET_CONFIGURATION"
+        "INVALID_SUBNET_CONFIGURATION",
+        "SECURITY_GROUPS_NOT_FOUND",
+        "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION",
+        "DOMAIN_JOIN_ERROR_FILE_NOT_FOUND",
+        "DOMAIN_JOIN_ERROR_ACCESS_DENIED",
+        "DOMAIN_JOIN_ERROR_LOGON_FAILURE",
+        "DOMAIN_JOIN_ERROR_INVALID_PARAMETER",
+        "DOMAIN_JOIN_ERROR_MORE_DATA",
+        "DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN",
+        "DOMAIN_JOIN_ERROR_NOT_SUPPORTED",
+        "DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME",
+        "DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED",
+        "DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED",
+        "DOMAIN_JOIN_NERR_PASSWORD_EXPIRED",
+        "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR"
       ]
     },
     "FleetErrors":{
@@ -718,6 +874,14 @@
       },
       "exception":true
     },
+    "OrganizationalUnitDistinguishedName":{
+      "type":"string",
+      "max":2000
+    },
+    "OrganizationalUnitDistinguishedNamesList":{
+      "type":"list",
+      "member":{"shape":"OrganizationalUnitDistinguishedName"}
+    },
     "PlatformType":{
       "type":"string",
       "enum":["WINDOWS"]
@@ -758,6 +922,17 @@
       "type":"list",
       "member":{"shape":"String"},
       "max":5
+    },
+    "ServiceAccountCredentials":{
+      "type":"structure",
+      "required":[
+        "AccountName",
+        "AccountPassword"
+      ],
+      "members":{
+        "AccountName":{"shape":"AccountName"},
+        "AccountPassword":{"shape":"AccountPassword"}
+      }
     },
     "Session":{
       "type":"structure",
@@ -864,6 +1039,12 @@
       "type":"string",
       "enum":["HOMEFOLDERS"]
     },
+    "StreamingUrlUserId":{
+      "type":"string",
+      "max":32,
+      "min":2,
+      "pattern":"[\\w+=,.@-]*"
+    },
     "String":{
       "type":"string",
       "min":1
@@ -877,6 +1058,21 @@
       "member":{"shape":"String"}
     },
     "Timestamp":{"type":"timestamp"},
+    "UpdateDirectoryConfigRequest":{
+      "type":"structure",
+      "required":["DirectoryName"],
+      "members":{
+        "DirectoryName":{"shape":"DirectoryName"},
+        "OrganizationalUnitDistinguishedNames":{"shape":"OrganizationalUnitDistinguishedNamesList"},
+        "ServiceAccountCredentials":{"shape":"ServiceAccountCredentials"}
+      }
+    },
+    "UpdateDirectoryConfigResult":{
+      "type":"structure",
+      "members":{
+        "DirectoryConfig":{"shape":"DirectoryConfig"}
+      }
+    },
     "UpdateFleetRequest":{
       "type":"structure",
       "required":["Name"],
@@ -895,6 +1091,7 @@
         "Description":{"shape":"Description"},
         "DisplayName":{"shape":"DisplayName"},
         "EnableDefaultInternetAccess":{"shape":"BooleanObject"},
+        "DomainJoinInfo":{"shape":"DomainJoinInfo"},
         "AttributesToDelete":{"shape":"FleetAttributes"}
       }
     },

--- a/models/apis/appstream/2016-12-01/docs-2.json
+++ b/models/apis/appstream/2016-12-01/docs-2.json
@@ -3,25 +3,41 @@
   "service": "<fullname>Amazon AppStream 2.0</fullname> <p>API documentation for Amazon AppStream 2.0.</p>",
   "operations": {
     "AssociateFleet": "<p>Associate a fleet to a stack.</p>",
+    "CreateDirectoryConfig": "<p>Creates a directory configuration with the given parameters.</p>",
     "CreateFleet": "<p>Creates a new fleet.</p>",
     "CreateStack": "<p>Create a new stack.</p>",
     "CreateStreamingURL": "<p>Creates a URL to start an AppStream 2.0 streaming session for a user. By default, the URL is valid only for 1 minute from the time that it is generated.</p>",
+    "DeleteDirectoryConfig": "<p>Deletes the directory configuration with the given parameters.</p>",
     "DeleteFleet": "<p>Deletes a fleet.</p>",
     "DeleteStack": "<p>Deletes the stack. After this operation completes, the environment can no longer be activated, and any reservations made for the stack are released.</p>",
+    "DescribeDirectoryConfigs": "<p>Returns a list describing the specified directory configurations.</p>",
     "DescribeFleets": "<p>If fleet names are provided, this operation describes the specified fleets; otherwise, all the fleets in the account are described.</p>",
     "DescribeImages": "<p>Describes the images. If a list of names is not provided, all images in your account are returned. This operation does not return a paginated result.</p>",
-    "DescribeSessions": "<p>Describes the streaming sessions for a stack and a fleet. If a user ID is provided, this operation returns streaming sessions for only that user. Pass this value for the <code>nextToken</code> parameter in a subsequent call to this operation to retrieve the next set of items. If an authentication type is not provided, the operation defaults to users authenticated using a streaming URL.</p>",
-    "DescribeStacks": "<p>If stack names are not provided, this operation describes the specified stacks; otherwise, all stacks in the account are described. Pass the <code>nextToken</code> value in a subsequent call to this operation to retrieve the next set of items.</p>",
+    "DescribeSessions": "<p>Describes the streaming sessions for a stack and a fleet. If a user ID is provided, this operation returns streaming sessions for only that user. To retrieve the next set of items, pass this value for the <code>nextToken</code> parameter in a subsequent call to this operation. If an authentication type is not provided, the operation defaults to users authenticated using a streaming URL.</p>",
+    "DescribeStacks": "<p>If stack names are not provided, this operation describes the specified stacks; otherwise, all stacks in the account are described. To retrieve the next set of items, pass the <code>nextToken</code> value in a subsequent call to this operation.</p>",
     "DisassociateFleet": "<p>Disassociates a fleet from a stack.</p>",
     "ExpireSession": "<p>This operation immediately stops a streaming session.</p>",
     "ListAssociatedFleets": "<p>Lists all fleets associated with the stack.</p>",
     "ListAssociatedStacks": "<p>Lists all stacks to which the specified fleet is associated.</p>",
     "StartFleet": "<p>Starts a fleet.</p>",
     "StopFleet": "<p>Stops a fleet.</p>",
+    "UpdateDirectoryConfig": "<p>Updates the directory configuration with the given parameters.</p>",
     "UpdateFleet": "<p>Updates an existing fleet. All the attributes except the fleet name can be updated in the <b>STOPPED</b> state. When a fleet is in the <b>RUNNING</b> state, only <code>DisplayName</code> and <code>ComputeCapacity</code> can be updated. A fleet cannot be updated in a status of <b>STARTING</b> or <b>STOPPING</b>.</p>",
     "UpdateStack": "<p>Updates the specified fields in the stack with the specified name.</p>"
   },
   "shapes": {
+    "AccountName": {
+      "base": null,
+      "refs": {
+        "ServiceAccountCredentials$AccountName": "<p>The user name of an account in the directory that is used by AppStream 2.0 streaming instances to connect to the directory. This account must have the following privileges: create computer objects, join computers to the domain, change/reset the password on descendant computer objects for the organizational units specified.</p>"
+      }
+    },
+    "AccountPassword": {
+      "base": null,
+      "refs": {
+        "ServiceAccountCredentials$AccountPassword": "<p>The password for the user account for directory actions.</p>"
+      }
+    },
     "Application": {
       "base": "<p>An entry for a single application in the application catalog.</p>",
       "refs": {
@@ -63,7 +79,7 @@
     "Boolean": {
       "base": null,
       "refs": {
-        "Application$Enabled": "<p>An application can be disabled after image creation if there is a problem.</p>",
+        "Application$Enabled": "<p>If there is a problem, an application can be disabled after image creation.</p>",
         "Image$ImageBuilderSupported": "<p>Whether an image builder can be launched from this image.</p>",
         "UpdateFleetRequest$DeleteVpcConfig": "<p>Delete the VPC association for the specified fleet.</p>",
         "UpdateStackRequest$DeleteStorageConnectors": "<p>Remove all the storage connectors currently enabled for the stack.</p>"
@@ -72,9 +88,9 @@
     "BooleanObject": {
       "base": null,
       "refs": {
-        "CreateFleetRequest$EnableDefaultInternetAccess": "<p>Enables or disables default Internet access for the fleet.</p>",
-        "Fleet$EnableDefaultInternetAccess": "<p>Whether default Internet access is enabled for the fleet. </p>",
-        "UpdateFleetRequest$EnableDefaultInternetAccess": "<p>Enables or disables default Internet access for the fleet.</p>"
+        "CreateFleetRequest$EnableDefaultInternetAccess": "<p>Enables or disables default internet access for the fleet.</p>",
+        "Fleet$EnableDefaultInternetAccess": "<p>Whether default internet access is enabled for the fleet. </p>",
+        "UpdateFleetRequest$EnableDefaultInternetAccess": "<p>Enables or disables default internet access for the fleet.</p>"
       }
     },
     "ComputeCapacity": {
@@ -92,6 +108,16 @@
     },
     "ConcurrentModificationException": {
       "base": "<p>An API error occurred. Wait a few minutes and try again.</p>",
+      "refs": {
+      }
+    },
+    "CreateDirectoryConfigRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "CreateDirectoryConfigResult": {
+      "base": null,
       "refs": {
       }
     },
@@ -125,6 +151,16 @@
       "refs": {
       }
     },
+    "DeleteDirectoryConfigRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DeleteDirectoryConfigResult": {
+      "base": null,
+      "refs": {
+      }
+    },
     "DeleteFleetRequest": {
       "base": null,
       "refs": {
@@ -141,6 +177,16 @@
       }
     },
     "DeleteStackResult": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeDirectoryConfigsRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeDirectoryConfigsResult": {
       "base": null,
       "refs": {
       }
@@ -194,6 +240,37 @@
         "UpdateStackRequest$Description": "<p>The description displayed to end users on the AppStream 2.0 portal.</p>"
       }
     },
+    "DirectoryConfig": {
+      "base": "<p>Full directory configuration details, which are used to join domains for the AppStream 2.0 streaming instances.</p>",
+      "refs": {
+        "CreateDirectoryConfigResult$DirectoryConfig": "<p>Directory configuration details.</p>",
+        "DirectoryConfigList$member": null,
+        "UpdateDirectoryConfigResult$DirectoryConfig": "<p>The updated directory configuration details.</p>"
+      }
+    },
+    "DirectoryConfigList": {
+      "base": null,
+      "refs": {
+        "DescribeDirectoryConfigsResult$DirectoryConfigs": "<p>The list of directory configurations.</p>"
+      }
+    },
+    "DirectoryName": {
+      "base": null,
+      "refs": {
+        "CreateDirectoryConfigRequest$DirectoryName": "<p>The fully qualified name of the directory, such as corp.example.com</p>",
+        "DeleteDirectoryConfigRequest$DirectoryName": "<p>The name of the directory configuration to be deleted.</p>",
+        "DirectoryConfig$DirectoryName": "<p>The fully qualified name of the directory, such as corp.example.com</p>",
+        "DirectoryNameList$member": null,
+        "DomainJoinInfo$DirectoryName": "<p>The fully qualified name of the directory, such as corp.example.com</p>",
+        "UpdateDirectoryConfigRequest$DirectoryName": "<p>The name of the existing directory configuration to be updated.</p>"
+      }
+    },
+    "DirectoryNameList": {
+      "base": null,
+      "refs": {
+        "DescribeDirectoryConfigsRequest$DirectoryNames": "<p>A specific list of directory names.</p>"
+      }
+    },
     "DisassociateFleetRequest": {
       "base": null,
       "refs": {
@@ -211,6 +288,14 @@
         "CreateStackRequest$DisplayName": "<p>The name displayed to end users on the AppStream 2.0 portal.</p>",
         "UpdateFleetRequest$DisplayName": "<p>The name displayed to end users on the AppStream 2.0 portal.</p>",
         "UpdateStackRequest$DisplayName": "<p>The name displayed to end users on the AppStream 2.0 portal.</p>"
+      }
+    },
+    "DomainJoinInfo": {
+      "base": "<p>The <i>DirectoryName</i> and <i>OrganizationalUnitDistinguishedName</i> values, which are used to join domains for the AppStream 2.0 streaming instances.</p>",
+      "refs": {
+        "CreateFleetRequest$DomainJoinInfo": "<p>The <i>DirectoryName</i> and <i>OrganizationalUnitDistinguishedName</i> values, which are used to join domains for the AppStream 2.0 streaming instances.</p>",
+        "Fleet$DomainJoinInfo": "<p>The <i>DirectoryName</i> and <i>OrganizationalUnitDistinguishedName</i> values, which are used to join domains for the AppStream 2.0 streaming instances.</p>",
+        "UpdateFleetRequest$DomainJoinInfo": "<p>The <i>DirectoryName</i> and <i>OrganizationalUnitDistinguishedName</i> values, which are used to join domains for the AppStream 2.0 streaming instances.</p>"
       }
     },
     "ErrorMessage": {
@@ -303,7 +388,7 @@
     "ImageState": {
       "base": null,
       "refs": {
-        "Image$State": "<p>The image starts in the <b>PENDING</b> state, and then moves to <b>AVAILABLE</b> if image creation succeeds and <b>FAILED</b> if image creation has failed.</p>"
+        "Image$State": "<p>The image starts in the <b>PENDING</b> state. If image creation succeeds, it moves to <b>AVAILABLE</b>. If image creation fails, it moves to <b>FAILED</b>.</p>"
       }
     },
     "ImageStateChangeReason": {
@@ -333,6 +418,7 @@
         "ComputeCapacityStatus$Available": "<p>The number of currently available instances that can be used to stream sessions.</p>",
         "CreateFleetRequest$MaxUserDurationInSeconds": "<p>The maximum time for which a streaming session can run. The input can be any numeric value in seconds between 600 and 57600.</p>",
         "CreateFleetRequest$DisconnectTimeoutInSeconds": "<p>The time after disconnection when a session is considered to have ended. If a user who got disconnected reconnects within this timeout interval, the user is connected back to their previous session. The input can be any numeric value in seconds between 60 and 57600. </p>",
+        "DescribeDirectoryConfigsRequest$MaxResults": "<p>The size of each page of results.</p>",
         "DescribeSessionsRequest$Limit": "<p>The size of each page of results. The default value is 20 and the maximum supported value is 50.</p>",
         "Fleet$MaxUserDurationInSeconds": "<p>The maximum time for which a streaming session can run. The value can be any numeric value in seconds between 600 and 57600.</p>",
         "Fleet$DisconnectTimeoutInSeconds": "<p>The time after disconnection when a session is considered to have ended. If a user who got disconnected reconnects within this timeout interval, the user is connected back to their previous session. The input can be any numeric value in seconds between 60 and 57600.</p>",
@@ -398,6 +484,21 @@
       "refs": {
       }
     },
+    "OrganizationalUnitDistinguishedName": {
+      "base": null,
+      "refs": {
+        "DomainJoinInfo$OrganizationalUnitDistinguishedName": "<p>The distinguished name of the organizational unit to place the computer account in.</p>",
+        "OrganizationalUnitDistinguishedNamesList$member": null
+      }
+    },
+    "OrganizationalUnitDistinguishedNamesList": {
+      "base": null,
+      "refs": {
+        "CreateDirectoryConfigRequest$OrganizationalUnitDistinguishedNames": "<p>The list of the distinguished names of organizational units to place computer accounts in.</p>",
+        "DirectoryConfig$OrganizationalUnitDistinguishedNames": "<p>The list of the distinguished names of organizational units in which to place computer accounts.</p>",
+        "UpdateDirectoryConfigRequest$OrganizationalUnitDistinguishedNames": "<p>The list of the distinguished names of organizational units to place computer accounts in.</p>"
+      }
+    },
     "PlatformType": {
       "base": null,
       "refs": {
@@ -434,6 +535,14 @@
       "base": "<p>A list of security groups.</p>",
       "refs": {
         "VpcConfig$SecurityGroupIds": "<p>Security groups associated with the fleet.</p>"
+      }
+    },
+    "ServiceAccountCredentials": {
+      "base": "<p>The <i>AccountName</i> and <i>AccountPassword</i> of the service account, to be used by the streaming instance to connect to the directory.</p>",
+      "refs": {
+        "CreateDirectoryConfigRequest$ServiceAccountCredentials": "<p>The <i>AccountName</i> and <i>AccountPassword</i> values for the service account, which are used by the streaming instance to connect to the directory.</p>",
+        "DirectoryConfig$ServiceAccountCredentials": "<p>The <i>AccountName</i> and <i>AccountPassword</i> of the service account, to be used by the streaming instance to connect to the directory.</p>",
+        "UpdateDirectoryConfigRequest$ServiceAccountCredentials": "<p>The <i>AccountName</i> and <i>AccountPassword</i> values for the service account, which are used by the streaming instance to connect to the directory</p>"
       }
     },
     "Session": {
@@ -526,6 +635,12 @@
         "StorageConnector$ConnectorType": "<p>The type of storage connector. The possible values include: HOMEFOLDERS.</p>"
       }
     },
+    "StreamingUrlUserId": {
+      "base": null,
+      "refs": {
+        "CreateStreamingURLRequest$UserId": "<p>A unique user ID for whom the URL is generated.</p>"
+      }
+    },
     "String": {
       "base": null,
       "refs": {
@@ -537,7 +652,7 @@
         "AssociateFleetRequest$FleetName": "<p>The name of the fleet to associate.</p>",
         "AssociateFleetRequest$StackName": "<p>The name of the stack to which the fleet is associated.</p>",
         "CreateFleetRequest$ImageName": "<p>Unique name of the image used by the fleet.</p>",
-        "CreateFleetRequest$InstanceType": "<p>The instance type of compute resources for the fleet. Fleet instances are launched from this instance type.</p>",
+        "CreateFleetRequest$InstanceType": "<p>The instance type of compute resources for the fleet. Fleet instances are launched from this instance type. Available instance types are:</p> <ul> <li> <p>stream.standard.medium</p> </li> <li> <p>stream.standard.large</p> </li> <li> <p>stream.compute.large</p> </li> <li> <p>stream.compute.xlarge</p> </li> <li> <p>stream.compute.2xlarge</p> </li> <li> <p>stream.compute.4xlarge</p> </li> <li> <p>stream.compute.8xlarge</p> </li> <li> <p>stream.memory.large</p> </li> <li> <p>stream.memory.xlarge</p> </li> <li> <p>stream.memory.2xlarge</p> </li> <li> <p>stream.memory.4xlarge</p> </li> <li> <p>stream.memory.8xlarge</p> </li> </ul>",
         "CreateStackRequest$Name": "<p>The unique identifier for this stack.</p>",
         "CreateStreamingURLRequest$StackName": "<p>The stack for which the URL is generated.</p>",
         "CreateStreamingURLRequest$FleetName": "<p>The fleet for which the URL is generated.</p>",
@@ -546,6 +661,8 @@
         "CreateStreamingURLResult$StreamingURL": "<p>The URL to start the AppStream 2.0 streaming session.</p>",
         "DeleteFleetRequest$Name": "<p>The name of the fleet to be deleted.</p>",
         "DeleteStackRequest$Name": "<p>The name of the stack to delete.</p>",
+        "DescribeDirectoryConfigsRequest$NextToken": "<p>The DescribeDirectoryConfigsResult.NextToken from a previous call to DescribeDirectoryConfigs. If this is the first call, pass null.</p>",
+        "DescribeDirectoryConfigsResult$NextToken": "<p>If not null, more results are available. To retrieve the next set of items, pass this value for the NextToken parameter in a subsequent call to DescribeDirectoryConfigs.</p>",
         "DescribeFleetsRequest$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If this value is null, it retrieves the first page.</p>",
         "DescribeFleetsResult$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
         "DescribeSessionsRequest$StackName": "<p>The name of the stack for which to list sessions.</p>",
@@ -589,7 +706,7 @@
         "SubnetIdList$member": null,
         "UpdateFleetRequest$ImageName": "<p>The image name from which a fleet is created.</p>",
         "UpdateFleetRequest$Name": "<p>The name of the fleet.</p>",
-        "UpdateFleetRequest$InstanceType": "<p>The instance type of compute resources for the fleet. Fleet instances are launched from this instance type.</p>",
+        "UpdateFleetRequest$InstanceType": "<p>The instance type of compute resources for the fleet. Fleet instances are launched from this instance type. Available instance types are:</p> <ul> <li> <p>stream.standard.medium</p> </li> <li> <p>stream.standard.large</p> </li> <li> <p>stream.compute.large</p> </li> <li> <p>stream.compute.xlarge</p> </li> <li> <p>stream.compute.2xlarge</p> </li> <li> <p>stream.compute.4xlarge</p> </li> <li> <p>stream.compute.8xlarge</p> </li> <li> <p>stream.memory.large</p> </li> <li> <p>stream.memory.xlarge</p> </li> <li> <p>stream.memory.2xlarge</p> </li> <li> <p>stream.memory.4xlarge</p> </li> <li> <p>stream.memory.8xlarge</p> </li> </ul>",
         "UpdateStackRequest$Name": "<p>The name of the stack to update.</p>"
       }
     },
@@ -612,11 +729,22 @@
     "Timestamp": {
       "base": null,
       "refs": {
-        "CreateStreamingURLResult$Expires": "<p>Elapsed seconds after the Unix epoch, at which time this URL expires.</p>",
+        "CreateStreamingURLResult$Expires": "<p>Elapsed seconds after the Unix epoch, when this URL expires.</p>",
+        "DirectoryConfig$CreatedTime": "<p>The time stamp when the directory configuration was created within AppStream 2.0.</p>",
         "Fleet$CreatedTime": "<p>The time at which the fleet was created.</p>",
-        "Image$CreatedTime": "<p>The timestamp when the image was created.</p>",
+        "Image$CreatedTime": "<p>The time stamp when the image was created.</p>",
         "Image$PublicBaseImageReleasedDate": "<p>The AWS release date of the public base image. For private images, this date is the release date of the base image from which the image was created.</p>",
-        "Stack$CreatedTime": "<p>The timestamp when the stack was created.</p>"
+        "Stack$CreatedTime": "<p>The time stamp when the stack was created.</p>"
+      }
+    },
+    "UpdateDirectoryConfigRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "UpdateDirectoryConfigResult": {
+      "base": null,
+      "refs": {
       }
     },
     "UpdateFleetRequest": {
@@ -642,7 +770,6 @@
     "UserId": {
       "base": null,
       "refs": {
-        "CreateStreamingURLRequest$UserId": "<p>A unique user ID for whom the URL is generated.</p>",
         "DescribeSessionsRequest$UserId": "<p>The user for whom to list sessions. Use null to describe all the sessions for the stack and fleet.</p>",
         "Session$UserId": "<p>The identifier of the user for whom the session was created.</p>"
       }

--- a/models/apis/appstream/2016-12-01/waiters-2.json
+++ b/models/apis/appstream/2016-12-01/waiters-2.json
@@ -9,19 +9,19 @@
         {
           "state": "success",
           "matcher": "pathAll",
-          "argument": "fleets[].state",
+          "argument": "Fleets[].State",
           "expected": "ACTIVE"
         },
         {
           "state": "failure",
           "matcher": "pathAny",
-          "argument": "fleets[].state",
+          "argument": "Fleets[].State",
           "expected": "PENDING_DEACTIVATE"
         },
         {
           "state": "failure",
           "matcher": "pathAny",
-          "argument": "fleets[].state",
+          "argument": "Fleets[].State",
           "expected": "INACTIVE"
         }
       ]
@@ -34,19 +34,19 @@
         {
           "state": "success",
           "matcher": "pathAll",
-          "argument": "fleets[].state",
+          "argument": "Fleets[].State",
           "expected": "INACTIVE"
         },
         {
           "state": "failure",
           "matcher": "pathAny",
-          "argument": "fleets[].state",
+          "argument": "Fleets[].State",
           "expected": "PENDING_ACTIVATE"
         },
         {
           "state": "failure",
           "matcher": "pathAny",
-          "argument": "fleets[].state",
+          "argument": "Fleets[].State",
           "expected": "ACTIVE"
         }
       ]

--- a/models/apis/ec2/2016-11-15/api-2.json
+++ b/models/apis/ec2/2016-11-15/api-2.json
@@ -13894,6 +13894,10 @@
         "WeightedCapacity":{
           "shape":"Double",
           "locationName":"weightedCapacity"
+        },
+        "TagSpecifications":{
+          "shape":"SpotFleetTagSpecificationList",
+          "locationName":"tagSpecificationSet"
         }
       }
     },
@@ -14004,6 +14008,26 @@
       "type":"list",
       "member":{
         "shape":"SpotFleetRequestConfig",
+        "locationName":"item"
+      }
+    },
+    "SpotFleetTagSpecification":{
+      "type":"structure",
+      "members":{
+        "ResourceType":{
+          "shape":"ResourceType",
+          "locationName":"resourceType"
+        },
+        "Tags":{
+          "shape":"TagList",
+          "locationName":"tag"
+        }
+      }
+    },
+    "SpotFleetTagSpecificationList":{
+      "type":"list",
+      "member":{
+        "shape":"SpotFleetTagSpecification",
         "locationName":"item"
       }
     },

--- a/models/apis/ec2/2016-11-15/docs-2.json
+++ b/models/apis/ec2/2016-11-15/docs-2.json
@@ -1309,12 +1309,12 @@
       }
     },
     "CreateNetworkInterfacePermissionRequest": {
-      "base": null,
+      "base": "<p>Contains the parameters for CreateNetworkInterfacePermission.</p>",
       "refs": {
       }
     },
     "CreateNetworkInterfacePermissionResult": {
-      "base": null,
+      "base": "<p>Contains the output of CreateNetworkInterfacePermission.</p>",
       "refs": {
       }
     },
@@ -1660,12 +1660,12 @@
       }
     },
     "DeleteNetworkInterfacePermissionRequest": {
-      "base": null,
+      "base": "<p>Contains the parameters for DeleteNetworkInterfacePermission.</p>",
       "refs": {
       }
     },
     "DeleteNetworkInterfacePermissionResult": {
-      "base": null,
+      "base": "<p>Contains the output for DeleteNetworkInterfacePermission.</p>",
       "refs": {
       }
     },
@@ -2071,12 +2071,12 @@
       }
     },
     "DescribeNetworkInterfacePermissionsRequest": {
-      "base": null,
+      "base": "<p>Contains the parameters for DescribeNetworkInterfacePermissions.</p>",
       "refs": {
       }
     },
     "DescribeNetworkInterfacePermissionsResult": {
-      "base": null,
+      "base": "<p>Contains the output for DescribeNetworkInterfacePermissions.</p>",
       "refs": {
       }
     },
@@ -5063,6 +5063,7 @@
     "ResourceType": {
       "base": null,
       "refs": {
+        "SpotFleetTagSpecification$ResourceType": "<p>The type of resource. Currently, the only resource type that is supported is <code>instance</code>.</p>",
         "TagDescription$ResourceType": "<p>The resource type.</p>",
         "TagSpecification$ResourceType": "<p>The type of resource to tag. Currently, the resource types that support tagging on creation are <code>instance</code> and <code>volume</code>. </p>"
       }
@@ -5471,6 +5472,18 @@
       "base": null,
       "refs": {
         "DescribeSpotFleetRequestsResponse$SpotFleetRequestConfigs": "<p>Information about the configuration of your Spot fleet.</p>"
+      }
+    },
+    "SpotFleetTagSpecification": {
+      "base": "<p>The tags for a Spot fleet resource.</p>",
+      "refs": {
+        "SpotFleetTagSpecificationList$member": null
+      }
+    },
+    "SpotFleetTagSpecificationList": {
+      "base": null,
+      "refs": {
+        "SpotFleetLaunchSpecification$TagSpecifications": "<p>The tags to apply during creation.</p>"
       }
     },
     "SpotInstanceRequest": {
@@ -6739,6 +6752,7 @@
         "RouteTable$Tags": "<p>Any tags assigned to the route table.</p>",
         "SecurityGroup$Tags": "<p>Any tags assigned to the security group.</p>",
         "Snapshot$Tags": "<p>Any tags assigned to the snapshot.</p>",
+        "SpotFleetTagSpecification$Tags": "<p>The tags.</p>",
         "SpotInstanceRequest$Tags": "<p>Any tags assigned to the resource.</p>",
         "Subnet$Tags": "<p>Any tags assigned to the subnet.</p>",
         "TagSpecification$Tags": "<p>The tags to apply to the resource.</p>",

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -78,6 +78,9 @@ func (c *AppStream) AssociateFleetRequest(input *AssociateFleetInput) (req *requ
 //   * ErrCodeIncompatibleImageException "IncompatibleImageException"
 //   The image does not support storage connectors.
 //
+//   * ErrCodeOperationNotPermittedException "OperationNotPermittedException"
+//   The attempted operation is not permitted.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/AssociateFleet
 func (c *AppStream) AssociateFleet(input *AssociateFleetInput) (*AssociateFleetOutput, error) {
 	req, out := c.AssociateFleetRequest(input)
@@ -95,6 +98,89 @@ func (c *AppStream) AssociateFleet(input *AssociateFleetInput) (*AssociateFleetO
 // for more information on using Contexts.
 func (c *AppStream) AssociateFleetWithContext(ctx aws.Context, input *AssociateFleetInput, opts ...request.Option) (*AssociateFleetOutput, error) {
 	req, out := c.AssociateFleetRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateDirectoryConfig = "CreateDirectoryConfig"
+
+// CreateDirectoryConfigRequest generates a "aws/request.Request" representing the
+// client's request for the CreateDirectoryConfig operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See CreateDirectoryConfig for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the CreateDirectoryConfig method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the CreateDirectoryConfigRequest method.
+//    req, resp := client.CreateDirectoryConfigRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateDirectoryConfig
+func (c *AppStream) CreateDirectoryConfigRequest(input *CreateDirectoryConfigInput) (req *request.Request, output *CreateDirectoryConfigOutput) {
+	op := &request.Operation{
+		Name:       opCreateDirectoryConfig,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateDirectoryConfigInput{}
+	}
+
+	output = &CreateDirectoryConfigOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateDirectoryConfig API operation for Amazon AppStream.
+//
+// Creates a directory configuration with the given parameters.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon AppStream's
+// API operation CreateDirectoryConfig for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
+//   The specified resource already exists.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The requested limit exceeds the permitted limit for an account.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateDirectoryConfig
+func (c *AppStream) CreateDirectoryConfig(input *CreateDirectoryConfigInput) (*CreateDirectoryConfigOutput, error) {
+	req, out := c.CreateDirectoryConfigRequest(input)
+	return out, req.Send()
+}
+
+// CreateDirectoryConfigWithContext is the same as CreateDirectoryConfig with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateDirectoryConfig for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) CreateDirectoryConfigWithContext(ctx aws.Context, input *CreateDirectoryConfigInput, opts ...request.Option) (*CreateDirectoryConfigOutput, error) {
+	req, out := c.CreateDirectoryConfigRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -172,6 +258,12 @@ func (c *AppStream) CreateFleetRequest(input *CreateFleetInput) (req *request.Re
 //
 //   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
 //   An API error occurred. Wait a few minutes and try again.
+//
+//   * ErrCodeInvalidParameterCombinationException "InvalidParameterCombinationException"
+//   Indicates an incorrect combination of parameters, or a missing parameter.
+//
+//   * ErrCodeIncompatibleImageException "IncompatibleImageException"
+//   The image does not support storage connectors.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateFleet
 func (c *AppStream) CreateFleet(input *CreateFleetInput) (*CreateFleetOutput, error) {
@@ -380,6 +472,89 @@ func (c *AppStream) CreateStreamingURLWithContext(ctx aws.Context, input *Create
 	return out, req.Send()
 }
 
+const opDeleteDirectoryConfig = "DeleteDirectoryConfig"
+
+// DeleteDirectoryConfigRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteDirectoryConfig operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DeleteDirectoryConfig for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DeleteDirectoryConfig method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DeleteDirectoryConfigRequest method.
+//    req, resp := client.DeleteDirectoryConfigRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DeleteDirectoryConfig
+func (c *AppStream) DeleteDirectoryConfigRequest(input *DeleteDirectoryConfigInput) (req *request.Request, output *DeleteDirectoryConfigOutput) {
+	op := &request.Operation{
+		Name:       opDeleteDirectoryConfig,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteDirectoryConfigInput{}
+	}
+
+	output = &DeleteDirectoryConfigOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteDirectoryConfig API operation for Amazon AppStream.
+//
+// Deletes the directory configuration with the given parameters.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon AppStream's
+// API operation DeleteDirectoryConfig for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//   The specified resource is in use.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DeleteDirectoryConfig
+func (c *AppStream) DeleteDirectoryConfig(input *DeleteDirectoryConfigInput) (*DeleteDirectoryConfigOutput, error) {
+	req, out := c.DeleteDirectoryConfigRequest(input)
+	return out, req.Send()
+}
+
+// DeleteDirectoryConfigWithContext is the same as DeleteDirectoryConfig with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteDirectoryConfig for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) DeleteDirectoryConfigWithContext(ctx aws.Context, input *DeleteDirectoryConfigInput, opts ...request.Option) (*DeleteDirectoryConfigOutput, error) {
+	req, out := c.DeleteDirectoryConfigRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteFleet = "DeleteFleet"
 
 // DeleteFleetRequest generates a "aws/request.Request" representing the
@@ -548,6 +723,86 @@ func (c *AppStream) DeleteStack(input *DeleteStackInput) (*DeleteStackOutput, er
 // for more information on using Contexts.
 func (c *AppStream) DeleteStackWithContext(ctx aws.Context, input *DeleteStackInput, opts ...request.Option) (*DeleteStackOutput, error) {
 	req, out := c.DeleteStackRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeDirectoryConfigs = "DescribeDirectoryConfigs"
+
+// DescribeDirectoryConfigsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeDirectoryConfigs operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeDirectoryConfigs for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeDirectoryConfigs method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeDirectoryConfigsRequest method.
+//    req, resp := client.DescribeDirectoryConfigsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DescribeDirectoryConfigs
+func (c *AppStream) DescribeDirectoryConfigsRequest(input *DescribeDirectoryConfigsInput) (req *request.Request, output *DescribeDirectoryConfigsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeDirectoryConfigs,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeDirectoryConfigsInput{}
+	}
+
+	output = &DescribeDirectoryConfigsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeDirectoryConfigs API operation for Amazon AppStream.
+//
+// Returns a list describing the specified directory configurations.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon AppStream's
+// API operation DescribeDirectoryConfigs for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DescribeDirectoryConfigs
+func (c *AppStream) DescribeDirectoryConfigs(input *DescribeDirectoryConfigsInput) (*DescribeDirectoryConfigsOutput, error) {
+	req, out := c.DescribeDirectoryConfigsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeDirectoryConfigsWithContext is the same as DescribeDirectoryConfigs with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeDirectoryConfigs for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) DescribeDirectoryConfigsWithContext(ctx aws.Context, input *DescribeDirectoryConfigsInput, opts ...request.Option) (*DescribeDirectoryConfigsOutput, error) {
+	req, out := c.DescribeDirectoryConfigsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -761,10 +1016,11 @@ func (c *AppStream) DescribeSessionsRequest(input *DescribeSessionsInput) (req *
 // DescribeSessions API operation for Amazon AppStream.
 //
 // Describes the streaming sessions for a stack and a fleet. If a user ID is
-// provided, this operation returns streaming sessions for only that user. Pass
-// this value for the nextToken parameter in a subsequent call to this operation
-// to retrieve the next set of items. If an authentication type is not provided,
-// the operation defaults to users authenticated using a streaming URL.
+// provided, this operation returns streaming sessions for only that user. To
+// retrieve the next set of items, pass this value for the nextToken parameter
+// in a subsequent call to this operation. If an authentication type is not
+// provided, the operation defaults to users authenticated using a streaming
+// URL.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -845,8 +1101,8 @@ func (c *AppStream) DescribeStacksRequest(input *DescribeStacksInput) (req *requ
 // DescribeStacks API operation for Amazon AppStream.
 //
 // If stack names are not provided, this operation describes the specified stacks;
-// otherwise, all stacks in the account are described. Pass the nextToken value
-// in a subsequent call to this operation to retrieve the next set of items.
+// otherwise, all stacks in the account are described. To retrieve the next
+// set of items, pass the nextToken value in a subsequent call to this operation.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1364,6 +1620,92 @@ func (c *AppStream) StopFleetWithContext(ctx aws.Context, input *StopFleetInput,
 	return out, req.Send()
 }
 
+const opUpdateDirectoryConfig = "UpdateDirectoryConfig"
+
+// UpdateDirectoryConfigRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateDirectoryConfig operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See UpdateDirectoryConfig for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the UpdateDirectoryConfig method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the UpdateDirectoryConfigRequest method.
+//    req, resp := client.UpdateDirectoryConfigRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/UpdateDirectoryConfig
+func (c *AppStream) UpdateDirectoryConfigRequest(input *UpdateDirectoryConfigInput) (req *request.Request, output *UpdateDirectoryConfigOutput) {
+	op := &request.Operation{
+		Name:       opUpdateDirectoryConfig,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateDirectoryConfigInput{}
+	}
+
+	output = &UpdateDirectoryConfigOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateDirectoryConfig API operation for Amazon AppStream.
+//
+// Updates the directory configuration with the given parameters.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon AppStream's
+// API operation UpdateDirectoryConfig for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//   The specified resource is in use.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   An API error occurred. Wait a few minutes and try again.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/UpdateDirectoryConfig
+func (c *AppStream) UpdateDirectoryConfig(input *UpdateDirectoryConfigInput) (*UpdateDirectoryConfigOutput, error) {
+	req, out := c.UpdateDirectoryConfigRequest(input)
+	return out, req.Send()
+}
+
+// UpdateDirectoryConfigWithContext is the same as UpdateDirectoryConfig with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateDirectoryConfig for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) UpdateDirectoryConfigWithContext(ctx aws.Context, input *UpdateDirectoryConfigInput, opts ...request.Option) (*UpdateDirectoryConfigOutput, error) {
+	req, out := c.UpdateDirectoryConfigRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opUpdateFleet = "UpdateFleet"
 
 // UpdateFleetRequest generates a "aws/request.Request" representing the
@@ -1445,6 +1787,9 @@ func (c *AppStream) UpdateFleetRequest(input *UpdateFleetInput) (req *request.Re
 //
 //   * ErrCodeIncompatibleImageException "IncompatibleImageException"
 //   The image does not support storage connectors.
+//
+//   * ErrCodeOperationNotPermittedException "OperationNotPermittedException"
+//   The attempted operation is not permitted.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/UpdateFleet
 func (c *AppStream) UpdateFleet(input *UpdateFleetInput) (*UpdateFleetOutput, error) {
@@ -1571,7 +1916,7 @@ type Application struct {
 	// The name of the application shown to the end users.
 	DisplayName *string `min:"1" type:"string"`
 
-	// An application can be disabled after image creation if there is a problem.
+	// If there is a problem, an application can be disabled after image creation.
 	Enabled *bool `type:"boolean"`
 
 	// The URL for the application icon. This URL may be time-limited.
@@ -1810,6 +2155,104 @@ func (s *ComputeCapacityStatus) SetRunning(v int64) *ComputeCapacityStatus {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateDirectoryConfigRequest
+type CreateDirectoryConfigInput struct {
+	_ struct{} `type:"structure"`
+
+	// The fully qualified name of the directory, such as corp.example.com
+	//
+	// DirectoryName is a required field
+	DirectoryName *string `type:"string" required:"true"`
+
+	// The list of the distinguished names of organizational units to place computer
+	// accounts in.
+	//
+	// OrganizationalUnitDistinguishedNames is a required field
+	OrganizationalUnitDistinguishedNames []*string `type:"list" required:"true"`
+
+	// The AccountName and AccountPassword values for the service account, which
+	// are used by the streaming instance to connect to the directory.
+	//
+	// ServiceAccountCredentials is a required field
+	ServiceAccountCredentials *ServiceAccountCredentials `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateDirectoryConfigInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateDirectoryConfigInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateDirectoryConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateDirectoryConfigInput"}
+	if s.DirectoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryName"))
+	}
+	if s.OrganizationalUnitDistinguishedNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("OrganizationalUnitDistinguishedNames"))
+	}
+	if s.ServiceAccountCredentials == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServiceAccountCredentials"))
+	}
+	if s.ServiceAccountCredentials != nil {
+		if err := s.ServiceAccountCredentials.Validate(); err != nil {
+			invalidParams.AddNested("ServiceAccountCredentials", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDirectoryName sets the DirectoryName field's value.
+func (s *CreateDirectoryConfigInput) SetDirectoryName(v string) *CreateDirectoryConfigInput {
+	s.DirectoryName = &v
+	return s
+}
+
+// SetOrganizationalUnitDistinguishedNames sets the OrganizationalUnitDistinguishedNames field's value.
+func (s *CreateDirectoryConfigInput) SetOrganizationalUnitDistinguishedNames(v []*string) *CreateDirectoryConfigInput {
+	s.OrganizationalUnitDistinguishedNames = v
+	return s
+}
+
+// SetServiceAccountCredentials sets the ServiceAccountCredentials field's value.
+func (s *CreateDirectoryConfigInput) SetServiceAccountCredentials(v *ServiceAccountCredentials) *CreateDirectoryConfigInput {
+	s.ServiceAccountCredentials = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateDirectoryConfigResult
+type CreateDirectoryConfigOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Directory configuration details.
+	DirectoryConfig *DirectoryConfig `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDirectoryConfigOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateDirectoryConfigOutput) GoString() string {
+	return s.String()
+}
+
+// SetDirectoryConfig sets the DirectoryConfig field's value.
+func (s *CreateDirectoryConfigOutput) SetDirectoryConfig(v *DirectoryConfig) *CreateDirectoryConfigOutput {
+	s.DirectoryConfig = v
+	return s
+}
+
 // Contains the parameters for the new fleet to create.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateFleetRequest
 type CreateFleetInput struct {
@@ -1832,7 +2275,11 @@ type CreateFleetInput struct {
 	// The display name of the fleet.
 	DisplayName *string `type:"string"`
 
-	// Enables or disables default Internet access for the fleet.
+	// The DirectoryName and OrganizationalUnitDistinguishedName values, which are
+	// used to join domains for the AppStream 2.0 streaming instances.
+	DomainJoinInfo *DomainJoinInfo `type:"structure"`
+
+	// Enables or disables default internet access for the fleet.
 	EnableDefaultInternetAccess *bool `type:"boolean"`
 
 	// Unique name of the image used by the fleet.
@@ -1841,7 +2288,31 @@ type CreateFleetInput struct {
 	ImageName *string `min:"1" type:"string" required:"true"`
 
 	// The instance type of compute resources for the fleet. Fleet instances are
-	// launched from this instance type.
+	// launched from this instance type. Available instance types are:
+	//
+	//    * stream.standard.medium
+	//
+	//    * stream.standard.large
+	//
+	//    * stream.compute.large
+	//
+	//    * stream.compute.xlarge
+	//
+	//    * stream.compute.2xlarge
+	//
+	//    * stream.compute.4xlarge
+	//
+	//    * stream.compute.8xlarge
+	//
+	//    * stream.memory.large
+	//
+	//    * stream.memory.xlarge
+	//
+	//    * stream.memory.2xlarge
+	//
+	//    * stream.memory.4xlarge
+	//
+	//    * stream.memory.8xlarge
 	//
 	// InstanceType is a required field
 	InstanceType *string `min:"1" type:"string" required:"true"`
@@ -1923,6 +2394,12 @@ func (s *CreateFleetInput) SetDisconnectTimeoutInSeconds(v int64) *CreateFleetIn
 // SetDisplayName sets the DisplayName field's value.
 func (s *CreateFleetInput) SetDisplayName(v string) *CreateFleetInput {
 	s.DisplayName = &v
+	return s
+}
+
+// SetDomainJoinInfo sets the DomainJoinInfo field's value.
+func (s *CreateFleetInput) SetDomainJoinInfo(v *DomainJoinInfo) *CreateFleetInput {
+	s.DomainJoinInfo = v
 	return s
 }
 
@@ -2203,7 +2680,7 @@ func (s *CreateStreamingURLInput) SetValidity(v int64) *CreateStreamingURLInput 
 type CreateStreamingURLOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Elapsed seconds after the Unix epoch, at which time this URL expires.
+	// Elapsed seconds after the Unix epoch, when this URL expires.
 	Expires *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// The URL to start the AppStream 2.0 streaming session.
@@ -2230,6 +2707,60 @@ func (s *CreateStreamingURLOutput) SetExpires(v time.Time) *CreateStreamingURLOu
 func (s *CreateStreamingURLOutput) SetStreamingURL(v string) *CreateStreamingURLOutput {
 	s.StreamingURL = &v
 	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DeleteDirectoryConfigRequest
+type DeleteDirectoryConfigInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the directory configuration to be deleted.
+	//
+	// DirectoryName is a required field
+	DirectoryName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteDirectoryConfigInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDirectoryConfigInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteDirectoryConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteDirectoryConfigInput"}
+	if s.DirectoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDirectoryName sets the DirectoryName field's value.
+func (s *DeleteDirectoryConfigInput) SetDirectoryName(v string) *DeleteDirectoryConfigInput {
+	s.DirectoryName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DeleteDirectoryConfigResult
+type DeleteDirectoryConfigOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDirectoryConfigOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDirectoryConfigOutput) GoString() string {
+	return s.String()
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DeleteFleetRequest
@@ -2344,6 +2875,96 @@ func (s DeleteStackOutput) String() string {
 // GoString returns the string representation
 func (s DeleteStackOutput) GoString() string {
 	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DescribeDirectoryConfigsRequest
+type DescribeDirectoryConfigsInput struct {
+	_ struct{} `type:"structure"`
+
+	// A specific list of directory names.
+	DirectoryNames []*string `type:"list"`
+
+	// The size of each page of results.
+	MaxResults *int64 `type:"integer"`
+
+	// The DescribeDirectoryConfigsResult.NextToken from a previous call to DescribeDirectoryConfigs.
+	// If this is the first call, pass null.
+	NextToken *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeDirectoryConfigsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDirectoryConfigsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeDirectoryConfigsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeDirectoryConfigsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDirectoryNames sets the DirectoryNames field's value.
+func (s *DescribeDirectoryConfigsInput) SetDirectoryNames(v []*string) *DescribeDirectoryConfigsInput {
+	s.DirectoryNames = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeDirectoryConfigsInput) SetMaxResults(v int64) *DescribeDirectoryConfigsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeDirectoryConfigsInput) SetNextToken(v string) *DescribeDirectoryConfigsInput {
+	s.NextToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DescribeDirectoryConfigsResult
+type DescribeDirectoryConfigsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The list of directory configurations.
+	DirectoryConfigs []*DirectoryConfig `type:"list"`
+
+	// If not null, more results are available. To retrieve the next set of items,
+	// pass this value for the NextToken parameter in a subsequent call to DescribeDirectoryConfigs.
+	NextToken *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeDirectoryConfigsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDirectoryConfigsOutput) GoString() string {
+	return s.String()
+}
+
+// SetDirectoryConfigs sets the DirectoryConfigs field's value.
+func (s *DescribeDirectoryConfigsOutput) SetDirectoryConfigs(v []*DirectoryConfig) *DescribeDirectoryConfigsOutput {
+	s.DirectoryConfigs = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeDirectoryConfigsOutput) SetNextToken(v string) *DescribeDirectoryConfigsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DescribeFleetsRequest
@@ -2699,6 +3320,64 @@ func (s *DescribeStacksOutput) SetStacks(v []*Stack) *DescribeStacksOutput {
 	return s
 }
 
+// Full directory configuration details, which are used to join domains for
+// the AppStream 2.0 streaming instances.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DirectoryConfig
+type DirectoryConfig struct {
+	_ struct{} `type:"structure"`
+
+	// The time stamp when the directory configuration was created within AppStream
+	// 2.0.
+	CreatedTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The fully qualified name of the directory, such as corp.example.com
+	//
+	// DirectoryName is a required field
+	DirectoryName *string `type:"string" required:"true"`
+
+	// The list of the distinguished names of organizational units in which to place
+	// computer accounts.
+	OrganizationalUnitDistinguishedNames []*string `type:"list"`
+
+	// The AccountName and AccountPassword of the service account, to be used by
+	// the streaming instance to connect to the directory.
+	ServiceAccountCredentials *ServiceAccountCredentials `type:"structure"`
+}
+
+// String returns the string representation
+func (s DirectoryConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DirectoryConfig) GoString() string {
+	return s.String()
+}
+
+// SetCreatedTime sets the CreatedTime field's value.
+func (s *DirectoryConfig) SetCreatedTime(v time.Time) *DirectoryConfig {
+	s.CreatedTime = &v
+	return s
+}
+
+// SetDirectoryName sets the DirectoryName field's value.
+func (s *DirectoryConfig) SetDirectoryName(v string) *DirectoryConfig {
+	s.DirectoryName = &v
+	return s
+}
+
+// SetOrganizationalUnitDistinguishedNames sets the OrganizationalUnitDistinguishedNames field's value.
+func (s *DirectoryConfig) SetOrganizationalUnitDistinguishedNames(v []*string) *DirectoryConfig {
+	s.OrganizationalUnitDistinguishedNames = v
+	return s
+}
+
+// SetServiceAccountCredentials sets the ServiceAccountCredentials field's value.
+func (s *DirectoryConfig) SetServiceAccountCredentials(v *ServiceAccountCredentials) *DirectoryConfig {
+	s.ServiceAccountCredentials = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DisassociateFleetRequest
 type DisassociateFleetInput struct {
 	_ struct{} `type:"structure"`
@@ -2771,6 +3450,42 @@ func (s DisassociateFleetOutput) String() string {
 // GoString returns the string representation
 func (s DisassociateFleetOutput) GoString() string {
 	return s.String()
+}
+
+// The DirectoryName and OrganizationalUnitDistinguishedName values, which are
+// used to join domains for the AppStream 2.0 streaming instances.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DomainJoinInfo
+type DomainJoinInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The fully qualified name of the directory, such as corp.example.com
+	DirectoryName *string `type:"string"`
+
+	// The distinguished name of the organizational unit to place the computer account
+	// in.
+	OrganizationalUnitDistinguishedName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DomainJoinInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DomainJoinInfo) GoString() string {
+	return s.String()
+}
+
+// SetDirectoryName sets the DirectoryName field's value.
+func (s *DomainJoinInfo) SetDirectoryName(v string) *DomainJoinInfo {
+	s.DirectoryName = &v
+	return s
+}
+
+// SetOrganizationalUnitDistinguishedName sets the OrganizationalUnitDistinguishedName field's value.
+func (s *DomainJoinInfo) SetOrganizationalUnitDistinguishedName(v string) *DomainJoinInfo {
+	s.OrganizationalUnitDistinguishedName = &v
+	return s
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/ExpireSessionRequest
@@ -2860,7 +3575,11 @@ type Fleet struct {
 	// The name displayed to end users on the AppStream 2.0 portal.
 	DisplayName *string `min:"1" type:"string"`
 
-	// Whether default Internet access is enabled for the fleet.
+	// The DirectoryName and OrganizationalUnitDistinguishedName values, which are
+	// used to join domains for the AppStream 2.0 streaming instances.
+	DomainJoinInfo *DomainJoinInfo `type:"structure"`
+
+	// Whether default internet access is enabled for the fleet.
 	EnableDefaultInternetAccess *bool `type:"boolean"`
 
 	// The list of fleet errors is appended to this list.
@@ -2938,6 +3657,12 @@ func (s *Fleet) SetDisconnectTimeoutInSeconds(v int64) *Fleet {
 // SetDisplayName sets the DisplayName field's value.
 func (s *Fleet) SetDisplayName(v string) *Fleet {
 	s.DisplayName = &v
+	return s
+}
+
+// SetDomainJoinInfo sets the DomainJoinInfo field's value.
+func (s *Fleet) SetDomainJoinInfo(v *DomainJoinInfo) *Fleet {
+	s.DomainJoinInfo = v
 	return s
 }
 
@@ -3038,7 +3763,7 @@ type Image struct {
 	// The source image ARN from which this image was created.
 	BaseImageArn *string `type:"string"`
 
-	// The timestamp when the image was created.
+	// The time stamp when the image was created.
 	CreatedTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// A meaningful description for the image.
@@ -3062,8 +3787,8 @@ type Image struct {
 	// is the release date of the base image from which the image was created.
 	PublicBaseImageReleasedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The image starts in the PENDING state, and then moves to AVAILABLE if image
-	// creation succeeds and FAILED if image creation has failed.
+	// The image starts in the PENDING state. If image creation succeeds, it moves
+	// to AVAILABLE. If image creation fails, it moves to FAILED.
 	State *string `type:"string" enum:"ImageState"`
 
 	// The reason why the last state change occurred.
@@ -3375,6 +4100,71 @@ func (s *ListAssociatedStacksOutput) SetNextToken(v string) *ListAssociatedStack
 	return s
 }
 
+// The AccountName and AccountPassword of the service account, to be used by
+// the streaming instance to connect to the directory.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/ServiceAccountCredentials
+type ServiceAccountCredentials struct {
+	_ struct{} `type:"structure"`
+
+	// The user name of an account in the directory that is used by AppStream 2.0
+	// streaming instances to connect to the directory. This account must have the
+	// following privileges: create computer objects, join computers to the domain,
+	// change/reset the password on descendant computer objects for the organizational
+	// units specified.
+	//
+	// AccountName is a required field
+	AccountName *string `min:"1" type:"string" required:"true"`
+
+	// The password for the user account for directory actions.
+	//
+	// AccountPassword is a required field
+	AccountPassword *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ServiceAccountCredentials) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ServiceAccountCredentials) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ServiceAccountCredentials) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ServiceAccountCredentials"}
+	if s.AccountName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountName"))
+	}
+	if s.AccountName != nil && len(*s.AccountName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountName", 1))
+	}
+	if s.AccountPassword == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountPassword"))
+	}
+	if s.AccountPassword != nil && len(*s.AccountPassword) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountPassword", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountName sets the AccountName field's value.
+func (s *ServiceAccountCredentials) SetAccountName(v string) *ServiceAccountCredentials {
+	s.AccountName = &v
+	return s
+}
+
+// SetAccountPassword sets the AccountPassword field's value.
+func (s *ServiceAccountCredentials) SetAccountPassword(v string) *ServiceAccountCredentials {
+	s.AccountPassword = &v
+	return s
+}
+
 // Contains the parameters for a streaming session.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/Session
 type Session struct {
@@ -3465,7 +4255,7 @@ type Stack struct {
 	// The ARN of the stack.
 	Arn *string `type:"string"`
 
-	// The timestamp when the stack was created.
+	// The time stamp when the stack was created.
 	CreatedTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// A meaningful description for the stack.
@@ -3738,6 +4528,94 @@ func (s *StorageConnector) SetResourceIdentifier(v string) *StorageConnector {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/UpdateDirectoryConfigRequest
+type UpdateDirectoryConfigInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the existing directory configuration to be updated.
+	//
+	// DirectoryName is a required field
+	DirectoryName *string `type:"string" required:"true"`
+
+	// The list of the distinguished names of organizational units to place computer
+	// accounts in.
+	OrganizationalUnitDistinguishedNames []*string `type:"list"`
+
+	// The AccountName and AccountPassword values for the service account, which
+	// are used by the streaming instance to connect to the directory
+	ServiceAccountCredentials *ServiceAccountCredentials `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateDirectoryConfigInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDirectoryConfigInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateDirectoryConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateDirectoryConfigInput"}
+	if s.DirectoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DirectoryName"))
+	}
+	if s.ServiceAccountCredentials != nil {
+		if err := s.ServiceAccountCredentials.Validate(); err != nil {
+			invalidParams.AddNested("ServiceAccountCredentials", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDirectoryName sets the DirectoryName field's value.
+func (s *UpdateDirectoryConfigInput) SetDirectoryName(v string) *UpdateDirectoryConfigInput {
+	s.DirectoryName = &v
+	return s
+}
+
+// SetOrganizationalUnitDistinguishedNames sets the OrganizationalUnitDistinguishedNames field's value.
+func (s *UpdateDirectoryConfigInput) SetOrganizationalUnitDistinguishedNames(v []*string) *UpdateDirectoryConfigInput {
+	s.OrganizationalUnitDistinguishedNames = v
+	return s
+}
+
+// SetServiceAccountCredentials sets the ServiceAccountCredentials field's value.
+func (s *UpdateDirectoryConfigInput) SetServiceAccountCredentials(v *ServiceAccountCredentials) *UpdateDirectoryConfigInput {
+	s.ServiceAccountCredentials = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/UpdateDirectoryConfigResult
+type UpdateDirectoryConfigOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The updated directory configuration details.
+	DirectoryConfig *DirectoryConfig `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateDirectoryConfigOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDirectoryConfigOutput) GoString() string {
+	return s.String()
+}
+
+// SetDirectoryConfig sets the DirectoryConfig field's value.
+func (s *UpdateDirectoryConfigOutput) SetDirectoryConfig(v *DirectoryConfig) *UpdateDirectoryConfigOutput {
+	s.DirectoryConfig = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/UpdateFleetRequest
 type UpdateFleetInput struct {
 	_ struct{} `type:"structure"`
@@ -3763,14 +4641,42 @@ type UpdateFleetInput struct {
 	// The name displayed to end users on the AppStream 2.0 portal.
 	DisplayName *string `type:"string"`
 
-	// Enables or disables default Internet access for the fleet.
+	// The DirectoryName and OrganizationalUnitDistinguishedName values, which are
+	// used to join domains for the AppStream 2.0 streaming instances.
+	DomainJoinInfo *DomainJoinInfo `type:"structure"`
+
+	// Enables or disables default internet access for the fleet.
 	EnableDefaultInternetAccess *bool `type:"boolean"`
 
 	// The image name from which a fleet is created.
 	ImageName *string `min:"1" type:"string"`
 
 	// The instance type of compute resources for the fleet. Fleet instances are
-	// launched from this instance type.
+	// launched from this instance type. Available instance types are:
+	//
+	//    * stream.standard.medium
+	//
+	//    * stream.standard.large
+	//
+	//    * stream.compute.large
+	//
+	//    * stream.compute.xlarge
+	//
+	//    * stream.compute.2xlarge
+	//
+	//    * stream.compute.4xlarge
+	//
+	//    * stream.compute.8xlarge
+	//
+	//    * stream.memory.large
+	//
+	//    * stream.memory.xlarge
+	//
+	//    * stream.memory.2xlarge
+	//
+	//    * stream.memory.4xlarge
+	//
+	//    * stream.memory.8xlarge
 	InstanceType *string `min:"1" type:"string"`
 
 	// The maximum time for which a streaming session can run. The input can be
@@ -3856,6 +4762,12 @@ func (s *UpdateFleetInput) SetDisconnectTimeoutInSeconds(v int64) *UpdateFleetIn
 // SetDisplayName sets the DisplayName field's value.
 func (s *UpdateFleetInput) SetDisplayName(v string) *UpdateFleetInput {
 	s.DisplayName = &v
+	return s
+}
+
+// SetDomainJoinInfo sets the DomainJoinInfo field's value.
+func (s *UpdateFleetInput) SetDomainJoinInfo(v *DomainJoinInfo) *UpdateFleetInput {
+	s.DomainJoinInfo = v
 	return s
 }
 
@@ -4084,6 +4996,9 @@ const (
 
 	// FleetAttributeVpcConfigurationSecurityGroupIds is a FleetAttribute enum value
 	FleetAttributeVpcConfigurationSecurityGroupIds = "VPC_CONFIGURATION_SECURITY_GROUP_IDS"
+
+	// FleetAttributeDomainJoinInfo is a FleetAttribute enum value
+	FleetAttributeDomainJoinInfo = "DOMAIN_JOIN_INFO"
 )
 
 const (
@@ -4119,6 +5034,48 @@ const (
 
 	// FleetErrorCodeInvalidSubnetConfiguration is a FleetErrorCode enum value
 	FleetErrorCodeInvalidSubnetConfiguration = "INVALID_SUBNET_CONFIGURATION"
+
+	// FleetErrorCodeSecurityGroupsNotFound is a FleetErrorCode enum value
+	FleetErrorCodeSecurityGroupsNotFound = "SECURITY_GROUPS_NOT_FOUND"
+
+	// FleetErrorCodeIamServiceRoleMissingDescribeSecurityGroupsAction is a FleetErrorCode enum value
+	FleetErrorCodeIamServiceRoleMissingDescribeSecurityGroupsAction = "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION"
+
+	// FleetErrorCodeDomainJoinErrorFileNotFound is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinErrorFileNotFound = "DOMAIN_JOIN_ERROR_FILE_NOT_FOUND"
+
+	// FleetErrorCodeDomainJoinErrorAccessDenied is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinErrorAccessDenied = "DOMAIN_JOIN_ERROR_ACCESS_DENIED"
+
+	// FleetErrorCodeDomainJoinErrorLogonFailure is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinErrorLogonFailure = "DOMAIN_JOIN_ERROR_LOGON_FAILURE"
+
+	// FleetErrorCodeDomainJoinErrorInvalidParameter is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinErrorInvalidParameter = "DOMAIN_JOIN_ERROR_INVALID_PARAMETER"
+
+	// FleetErrorCodeDomainJoinErrorMoreData is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinErrorMoreData = "DOMAIN_JOIN_ERROR_MORE_DATA"
+
+	// FleetErrorCodeDomainJoinErrorNoSuchDomain is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinErrorNoSuchDomain = "DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN"
+
+	// FleetErrorCodeDomainJoinErrorNotSupported is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinErrorNotSupported = "DOMAIN_JOIN_ERROR_NOT_SUPPORTED"
+
+	// FleetErrorCodeDomainJoinNerrInvalidWorkgroupName is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinNerrInvalidWorkgroupName = "DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME"
+
+	// FleetErrorCodeDomainJoinNerrWorkstationNotStarted is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinNerrWorkstationNotStarted = "DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED"
+
+	// FleetErrorCodeDomainJoinErrorDsMachineAccountQuotaExceeded is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinErrorDsMachineAccountQuotaExceeded = "DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED"
+
+	// FleetErrorCodeDomainJoinNerrPasswordExpired is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinNerrPasswordExpired = "DOMAIN_JOIN_NERR_PASSWORD_EXPIRED"
+
+	// FleetErrorCodeDomainJoinInternalServiceError is a FleetErrorCode enum value
+	FleetErrorCodeDomainJoinInternalServiceError = "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR"
 )
 
 const (

--- a/service/appstream/appstreamiface/interface.go
+++ b/service/appstream/appstreamiface/interface.go
@@ -64,6 +64,10 @@ type AppStreamAPI interface {
 	AssociateFleetWithContext(aws.Context, *appstream.AssociateFleetInput, ...request.Option) (*appstream.AssociateFleetOutput, error)
 	AssociateFleetRequest(*appstream.AssociateFleetInput) (*request.Request, *appstream.AssociateFleetOutput)
 
+	CreateDirectoryConfig(*appstream.CreateDirectoryConfigInput) (*appstream.CreateDirectoryConfigOutput, error)
+	CreateDirectoryConfigWithContext(aws.Context, *appstream.CreateDirectoryConfigInput, ...request.Option) (*appstream.CreateDirectoryConfigOutput, error)
+	CreateDirectoryConfigRequest(*appstream.CreateDirectoryConfigInput) (*request.Request, *appstream.CreateDirectoryConfigOutput)
+
 	CreateFleet(*appstream.CreateFleetInput) (*appstream.CreateFleetOutput, error)
 	CreateFleetWithContext(aws.Context, *appstream.CreateFleetInput, ...request.Option) (*appstream.CreateFleetOutput, error)
 	CreateFleetRequest(*appstream.CreateFleetInput) (*request.Request, *appstream.CreateFleetOutput)
@@ -76,6 +80,10 @@ type AppStreamAPI interface {
 	CreateStreamingURLWithContext(aws.Context, *appstream.CreateStreamingURLInput, ...request.Option) (*appstream.CreateStreamingURLOutput, error)
 	CreateStreamingURLRequest(*appstream.CreateStreamingURLInput) (*request.Request, *appstream.CreateStreamingURLOutput)
 
+	DeleteDirectoryConfig(*appstream.DeleteDirectoryConfigInput) (*appstream.DeleteDirectoryConfigOutput, error)
+	DeleteDirectoryConfigWithContext(aws.Context, *appstream.DeleteDirectoryConfigInput, ...request.Option) (*appstream.DeleteDirectoryConfigOutput, error)
+	DeleteDirectoryConfigRequest(*appstream.DeleteDirectoryConfigInput) (*request.Request, *appstream.DeleteDirectoryConfigOutput)
+
 	DeleteFleet(*appstream.DeleteFleetInput) (*appstream.DeleteFleetOutput, error)
 	DeleteFleetWithContext(aws.Context, *appstream.DeleteFleetInput, ...request.Option) (*appstream.DeleteFleetOutput, error)
 	DeleteFleetRequest(*appstream.DeleteFleetInput) (*request.Request, *appstream.DeleteFleetOutput)
@@ -83,6 +91,10 @@ type AppStreamAPI interface {
 	DeleteStack(*appstream.DeleteStackInput) (*appstream.DeleteStackOutput, error)
 	DeleteStackWithContext(aws.Context, *appstream.DeleteStackInput, ...request.Option) (*appstream.DeleteStackOutput, error)
 	DeleteStackRequest(*appstream.DeleteStackInput) (*request.Request, *appstream.DeleteStackOutput)
+
+	DescribeDirectoryConfigs(*appstream.DescribeDirectoryConfigsInput) (*appstream.DescribeDirectoryConfigsOutput, error)
+	DescribeDirectoryConfigsWithContext(aws.Context, *appstream.DescribeDirectoryConfigsInput, ...request.Option) (*appstream.DescribeDirectoryConfigsOutput, error)
+	DescribeDirectoryConfigsRequest(*appstream.DescribeDirectoryConfigsInput) (*request.Request, *appstream.DescribeDirectoryConfigsOutput)
 
 	DescribeFleets(*appstream.DescribeFleetsInput) (*appstream.DescribeFleetsOutput, error)
 	DescribeFleetsWithContext(aws.Context, *appstream.DescribeFleetsInput, ...request.Option) (*appstream.DescribeFleetsOutput, error)
@@ -123,6 +135,10 @@ type AppStreamAPI interface {
 	StopFleet(*appstream.StopFleetInput) (*appstream.StopFleetOutput, error)
 	StopFleetWithContext(aws.Context, *appstream.StopFleetInput, ...request.Option) (*appstream.StopFleetOutput, error)
 	StopFleetRequest(*appstream.StopFleetInput) (*request.Request, *appstream.StopFleetOutput)
+
+	UpdateDirectoryConfig(*appstream.UpdateDirectoryConfigInput) (*appstream.UpdateDirectoryConfigOutput, error)
+	UpdateDirectoryConfigWithContext(aws.Context, *appstream.UpdateDirectoryConfigInput, ...request.Option) (*appstream.UpdateDirectoryConfigOutput, error)
+	UpdateDirectoryConfigRequest(*appstream.UpdateDirectoryConfigInput) (*request.Request, *appstream.UpdateDirectoryConfigOutput)
 
 	UpdateFleet(*appstream.UpdateFleetInput) (*appstream.UpdateFleetOutput, error)
 	UpdateFleetWithContext(aws.Context, *appstream.UpdateFleetInput, ...request.Option) (*appstream.UpdateFleetOutput, error)

--- a/service/appstream/waiters.go
+++ b/service/appstream/waiters.go
@@ -33,17 +33,17 @@ func (c *AppStream) WaitUntilFleetStartedWithContext(ctx aws.Context, input *Des
 		Acceptors: []request.WaiterAcceptor{
 			{
 				State:   request.SuccessWaiterState,
-				Matcher: request.PathAllWaiterMatch, Argument: "fleets[].state",
+				Matcher: request.PathAllWaiterMatch, Argument: "Fleets[].State",
 				Expected: "ACTIVE",
 			},
 			{
 				State:   request.FailureWaiterState,
-				Matcher: request.PathAnyWaiterMatch, Argument: "fleets[].state",
+				Matcher: request.PathAnyWaiterMatch, Argument: "Fleets[].State",
 				Expected: "PENDING_DEACTIVATE",
 			},
 			{
 				State:   request.FailureWaiterState,
-				Matcher: request.PathAnyWaiterMatch, Argument: "fleets[].state",
+				Matcher: request.PathAnyWaiterMatch, Argument: "Fleets[].State",
 				Expected: "INACTIVE",
 			},
 		},
@@ -89,17 +89,17 @@ func (c *AppStream) WaitUntilFleetStoppedWithContext(ctx aws.Context, input *Des
 		Acceptors: []request.WaiterAcceptor{
 			{
 				State:   request.SuccessWaiterState,
-				Matcher: request.PathAllWaiterMatch, Argument: "fleets[].state",
+				Matcher: request.PathAllWaiterMatch, Argument: "Fleets[].State",
 				Expected: "INACTIVE",
 			},
 			{
 				State:   request.FailureWaiterState,
-				Matcher: request.PathAnyWaiterMatch, Argument: "fleets[].state",
+				Matcher: request.PathAnyWaiterMatch, Argument: "Fleets[].State",
 				Expected: "PENDING_ACTIVATE",
 			},
 			{
 				State:   request.FailureWaiterState,
-				Matcher: request.PathAnyWaiterMatch, Argument: "fleets[].state",
+				Matcher: request.PathAnyWaiterMatch, Argument: "Fleets[].State",
 				Expected: "ACTIVE",
 			},
 		},

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -25094,6 +25094,7 @@ func (s *CreateNetworkInterfaceOutput) SetNetworkInterface(v *NetworkInterface) 
 	return s
 }
 
+// Contains the parameters for CreateNetworkInterfacePermission.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateNetworkInterfacePermissionRequest
 type CreateNetworkInterfacePermissionInput struct {
 	_ struct{} `type:"structure"`
@@ -25177,6 +25178,7 @@ func (s *CreateNetworkInterfacePermissionInput) SetPermission(v string) *CreateN
 	return s
 }
 
+// Contains the output of CreateNetworkInterfacePermission.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CreateNetworkInterfacePermissionResult
 type CreateNetworkInterfacePermissionOutput struct {
 	_ struct{} `type:"structure"`
@@ -27665,6 +27667,7 @@ func (s DeleteNetworkInterfaceOutput) GoString() string {
 	return s.String()
 }
 
+// Contains the parameters for DeleteNetworkInterfacePermission.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteNetworkInterfacePermissionRequest
 type DeleteNetworkInterfacePermissionInput struct {
 	_ struct{} `type:"structure"`
@@ -27726,6 +27729,7 @@ func (s *DeleteNetworkInterfacePermissionInput) SetNetworkInterfacePermissionId(
 	return s
 }
 
+// Contains the output for DeleteNetworkInterfacePermission.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteNetworkInterfacePermissionResult
 type DeleteNetworkInterfacePermissionOutput struct {
 	_ struct{} `type:"structure"`
@@ -32411,6 +32415,7 @@ func (s *DescribeNetworkInterfaceAttributeOutput) SetSourceDestCheck(v *Attribut
 	return s
 }
 
+// Contains the parameters for DescribeNetworkInterfacePermissions.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeNetworkInterfacePermissionsRequest
 type DescribeNetworkInterfacePermissionsInput struct {
 	_ struct{} `type:"structure"`
@@ -32477,6 +32482,7 @@ func (s *DescribeNetworkInterfacePermissionsInput) SetNextToken(v string) *Descr
 	return s
 }
 
+// Contains the output for DescribeNetworkInterfacePermissions.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeNetworkInterfacePermissionsResult
 type DescribeNetworkInterfacePermissionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -54039,6 +54045,9 @@ type SpotFleetLaunchSpecification struct {
 	// subnets, separate them using commas; for example, "subnet-a61dafcf, subnet-65ea5f08".
 	SubnetId *string `locationName:"subnetId" type:"string"`
 
+	// The tags to apply during creation.
+	TagSpecifications []*SpotFleetTagSpecification `locationName:"tagSpecificationSet" locationNameList:"item" type:"list"`
+
 	// The user data to make available to the instances. If you are using an AWS
 	// SDK or command line tool, Base64-encoding is performed for you, and you can
 	// load the text from a file. Otherwise, you must provide Base64-encoded text.
@@ -54171,6 +54180,12 @@ func (s *SpotFleetLaunchSpecification) SetSpotPrice(v string) *SpotFleetLaunchSp
 // SetSubnetId sets the SubnetId field's value.
 func (s *SpotFleetLaunchSpecification) SetSubnetId(v string) *SpotFleetLaunchSpecification {
 	s.SubnetId = &v
+	return s
+}
+
+// SetTagSpecifications sets the TagSpecifications field's value.
+func (s *SpotFleetLaunchSpecification) SetTagSpecifications(v []*SpotFleetTagSpecification) *SpotFleetLaunchSpecification {
+	s.TagSpecifications = v
 	return s
 }
 
@@ -54480,6 +54495,41 @@ func (s *SpotFleetRequestConfigData) SetValidFrom(v time.Time) *SpotFleetRequest
 // SetValidUntil sets the ValidUntil field's value.
 func (s *SpotFleetRequestConfigData) SetValidUntil(v time.Time) *SpotFleetRequestConfigData {
 	s.ValidUntil = &v
+	return s
+}
+
+// The tags for a Spot fleet resource.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/SpotFleetTagSpecification
+type SpotFleetTagSpecification struct {
+	_ struct{} `type:"structure"`
+
+	// The type of resource. Currently, the only resource type that is supported
+	// is instance.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
+
+	// The tags.
+	Tags []*Tag `locationName:"tag" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s SpotFleetTagSpecification) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SpotFleetTagSpecification) GoString() string {
+	return s.String()
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *SpotFleetTagSpecification) SetResourceType(v string) *SpotFleetTagSpecification {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *SpotFleetTagSpecification) SetTags(v []*Tag) *SpotFleetTagSpecification {
+	s.Tags = v
 	return s
 }
 


### PR DESCRIPTION
Release v1.10.15 (2017-07-24)
===

### Service Client Updates
* `service/appstream`: Updates service API, documentation, and waiters
  * Amazon AppStream 2.0 image builders and fleets can now access applications and network resources that rely on Microsoft Active Directory (AD) for authentication and permissions. This new feature allows you to join your streaming instances to your AD, so you can use your existing AD user management tools.
* `service/ec2`: Updates service API and documentation
  * Spot Fleet tagging capability allows customers to automatically tag instances launched by Spot Fleet. You can use this feature to label or distinguish instances created by distinct Spot Fleets. Tagging your EC2 instances also enables you to see instance cost allocation by tag in your AWS bill.

### SDK Bugs
* `aws/signer/v4`: Fix out of bounds panic in stripExcessSpaces [#1412](https://github.com/aws/aws-sdk-go/pull/1412)
  * Fixes the out of bands panic in stripExcessSpaces caused by an incorrect calculation of the stripToIdx value. Simplified to code also.
  * Fixes [#1411](https://github.com/aws/aws-sdk-go/issues/1411)
