### PR TITLE
Add pointer conversion utilities to transform int64 to time.Time

### DIFF
--- a/aws/convert_types.go
+++ b/aws/convert_types.go
@@ -311,6 +311,24 @@ func TimeValue(v *time.Time) time.Time {
 	return time.Time{}
 }
 
+// SecondsTimeValue converts an int64 pointer to a time.Time value with
+// a time resolution of seconds or time.Time{} if the pointer is nil.
+func SecondsTimeValue(v *int64) time.Time {
+	if v != nil {
+		return time.Unix((*v / 1000), 0)
+	}
+	return time.Time{}
+}
+
+// MillisecondsTimeValue converts an int64 pointer to a time.Time value with
+// a time resolution of milliseconds or time.Time{} if the pointer is nil.
+func MillisecondsTimeValue(v *int64) time.Time {
+	if v != nil {
+		return time.Unix(0, (*v * 1000000))
+	}
+	return time.Time{}
+}
+
 // TimeUnixMilli returns a Unix timestamp in milliseconds from "January 1, 1970 UTC".
 // The result is undefined if the Unix time cannot be represented by an int64.
 // Which includes calling TimeUnixMilli on a zero Time is undefined.

--- a/aws/convert_types.go
+++ b/aws/convert_types.go
@@ -311,8 +311,8 @@ func TimeValue(v *time.Time) time.Time {
 	return time.Time{}
 }
 
-// SecondsTimeValue converts an int64 pointer to a time.Time value with
-// a time resolution of seconds or time.Time{} if the pointer is nil.
+// SecondsTimeValue converts an int64 pointer to a time.Time value
+// representing seconds since Epoch or time.Time{} if the pointer is nil.
 func SecondsTimeValue(v *int64) time.Time {
 	if v != nil {
 		return time.Unix((*v / 1000), 0)
@@ -320,8 +320,8 @@ func SecondsTimeValue(v *int64) time.Time {
 	return time.Time{}
 }
 
-// MillisecondsTimeValue converts an int64 pointer to a time.Time value with
-// a time resolution of milliseconds or time.Time{} if the pointer is nil.
+// MillisecondsTimeValue converts an int64 pointer to a time.Time value
+// representing milliseconds sinch Epoch or time.Time{} if the pointer is nil.
 func MillisecondsTimeValue(v *int64) time.Time {
 	if v != nil {
 		return time.Unix(0, (*v * 1000000))

--- a/aws/convert_types_test.go
+++ b/aws/convert_types_test.go
@@ -435,3 +435,36 @@ func TestTimeMap(t *testing.T) {
 		assert.Equal(t, in, out2, "Unexpected value at idx %d", idx)
 	}
 }
+
+type TimeValueTestCase struct {
+	in        int64
+	outSecs   time.Time
+	outMillis time.Time
+}
+
+var testCasesTimeValue = []TimeValueTestCase{
+	{
+		in:        int64(1501558289000),
+		outSecs:   time.Unix(1501558289, 0),
+		outMillis: time.Unix(1501558289, 0),
+	},
+	{
+		in:        int64(1501558289001),
+		outSecs:   time.Unix(1501558289, 0),
+		outMillis: time.Unix(1501558289, 1*1000000),
+	},
+}
+
+func TestSecondsTimeValue(t *testing.T) {
+	for idx, testCase := range testCasesTimeValue {
+		out := SecondsTimeValue(&testCase.in)
+		assert.Equal(t, testCase.outSecs, out, "Unexpected value for time value at %d", idx)
+	}
+}
+
+func TestMillisecondsTimeValue(t *testing.T) {
+	for idx, testCase := range testCasesTimeValue {
+		out := MillisecondsTimeValue(&testCase.in)
+		assert.Equal(t, testCase.outMillis, out, "Unexpected value for time value at %d", idx)
+	}
+}


### PR DESCRIPTION
See: #1432 for discussion around adding this feature.