### PR TITLE
v1.10.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.10.30 (2017-08-22)
+===
+
+### Service Client Updates
+* `service/ssm`: Updates service API and documentation
+  * Changes to associations in Systems Manager State Manager can now be recorded. Previously, when you edited associations, you could not go back and review older association settings. Now, associations are versioned, and can be named using human-readable strings, allowing you to see a trail of association changes. You can also perform rate-based scheduling, which allows you to schedule associations more granularly.
+
 Release v1.10.29 (2017-08-21)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.10.29"
+const SDKVersion = "1.10.30"

--- a/models/apis/ssm/2014-11-06/api-2.json
+++ b/models/apis/ssm/2014-11-06/api-2.json
@@ -343,6 +343,7 @@
       "output":{"shape":"DescribeAssociationResult"},
       "errors":[
         {"shape":"AssociationDoesNotExist"},
+        {"shape":"InvalidAssociationVersion"},
         {"shape":"InternalServerError"},
         {"shape":"InvalidDocument"},
         {"shape":"InvalidInstanceId"}
@@ -879,6 +880,20 @@
         {"shape":"InternalServerError"}
       ]
     },
+    "ListAssociationVersions":{
+      "name":"ListAssociationVersions",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ListAssociationVersionsRequest"},
+      "output":{"shape":"ListAssociationVersionsResult"},
+      "errors":[
+        {"shape":"InternalServerError"},
+        {"shape":"InvalidNextToken"},
+        {"shape":"AssociationDoesNotExist"}
+      ]
+    },
     "ListAssociations":{
       "name":"ListAssociations",
       "http":{
@@ -1274,7 +1289,9 @@
         {"shape":"InvalidUpdate"},
         {"shape":"TooManyUpdates"},
         {"shape":"InvalidDocument"},
-        {"shape":"InvalidTarget"}
+        {"shape":"InvalidTarget"},
+        {"shape":"InvalidAssociationVersion"},
+        {"shape":"AssociationVersionLimitExceeded"}
       ]
     },
     "UpdateAssociationStatus":{
@@ -1490,11 +1507,13 @@
         "Name":{"shape":"DocumentName"},
         "InstanceId":{"shape":"InstanceId"},
         "AssociationId":{"shape":"AssociationId"},
+        "AssociationVersion":{"shape":"AssociationVersion"},
         "DocumentVersion":{"shape":"DocumentVersion"},
         "Targets":{"shape":"Targets"},
         "LastExecutionDate":{"shape":"DateTime"},
         "Overview":{"shape":"AssociationOverview"},
-        "ScheduleExpression":{"shape":"ScheduleExpression"}
+        "ScheduleExpression":{"shape":"ScheduleExpression"},
+        "AssociationName":{"shape":"AssociationName"}
       }
     },
     "AssociationAlreadyExists":{
@@ -1508,6 +1527,7 @@
       "members":{
         "Name":{"shape":"DocumentName"},
         "InstanceId":{"shape":"InstanceId"},
+        "AssociationVersion":{"shape":"AssociationVersion"},
         "Date":{"shape":"DateTime"},
         "LastUpdateAssociationDate":{"shape":"DateTime"},
         "Status":{"shape":"AssociationStatus"},
@@ -1519,7 +1539,8 @@
         "ScheduleExpression":{"shape":"ScheduleExpression"},
         "OutputLocation":{"shape":"InstanceAssociationOutputLocation"},
         "LastExecutionDate":{"shape":"DateTime"},
-        "LastSuccessfulExecutionDate":{"shape":"DateTime"}
+        "LastSuccessfulExecutionDate":{"shape":"DateTime"},
+        "AssociationName":{"shape":"AssociationName"}
       }
     },
     "AssociationDescriptionList":{
@@ -1555,7 +1576,8 @@
         "AssociationId",
         "AssociationStatusName",
         "LastExecutedBefore",
-        "LastExecutedAfter"
+        "LastExecutedAfter",
+        "AssociationName"
       ]
     },
     "AssociationFilterList":{
@@ -1586,6 +1608,10 @@
         "shape":"Association",
         "locationName":"Association"
       }
+    },
+    "AssociationName":{
+      "type":"string",
+      "pattern":"^[a-zA-Z0-9_\\-.]{3,128}$"
     },
     "AssociationOverview":{
       "type":"structure",
@@ -1621,6 +1647,37 @@
         "Success",
         "Failed"
       ]
+    },
+    "AssociationVersion":{
+      "type":"string",
+      "pattern":"([$]LATEST)|([1-9][0-9]*)"
+    },
+    "AssociationVersionInfo":{
+      "type":"structure",
+      "members":{
+        "AssociationId":{"shape":"AssociationId"},
+        "AssociationVersion":{"shape":"AssociationVersion"},
+        "CreatedDate":{"shape":"DateTime"},
+        "Name":{"shape":"DocumentName"},
+        "DocumentVersion":{"shape":"DocumentVersion"},
+        "Parameters":{"shape":"Parameters"},
+        "Targets":{"shape":"Targets"},
+        "ScheduleExpression":{"shape":"ScheduleExpression"},
+        "OutputLocation":{"shape":"InstanceAssociationOutputLocation"},
+        "AssociationName":{"shape":"AssociationName"}
+      }
+    },
+    "AssociationVersionLimitExceeded":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"String"}
+      },
+      "exception":true
+    },
+    "AssociationVersionList":{
+      "type":"list",
+      "member":{"shape":"AssociationVersionInfo"},
+      "min":1
     },
     "AttributeName":{
       "type":"string",
@@ -2213,7 +2270,8 @@
         "DocumentVersion":{"shape":"DocumentVersion"},
         "Targets":{"shape":"Targets"},
         "ScheduleExpression":{"shape":"ScheduleExpression"},
-        "OutputLocation":{"shape":"InstanceAssociationOutputLocation"}
+        "OutputLocation":{"shape":"InstanceAssociationOutputLocation"},
+        "AssociationName":{"shape":"AssociationName"}
       }
     },
     "CreateAssociationBatchResult":{
@@ -2233,7 +2291,8 @@
         "Parameters":{"shape":"Parameters"},
         "Targets":{"shape":"Targets"},
         "ScheduleExpression":{"shape":"ScheduleExpression"},
-        "OutputLocation":{"shape":"InstanceAssociationOutputLocation"}
+        "OutputLocation":{"shape":"InstanceAssociationOutputLocation"},
+        "AssociationName":{"shape":"AssociationName"}
       }
     },
     "CreateAssociationResult":{
@@ -2557,7 +2616,8 @@
       "members":{
         "Name":{"shape":"DocumentName"},
         "InstanceId":{"shape":"InstanceId"},
-        "AssociationId":{"shape":"AssociationId"}
+        "AssociationId":{"shape":"AssociationId"},
+        "AssociationVersion":{"shape":"AssociationVersion"}
       }
     },
     "DescribeAssociationResult":{
@@ -3686,7 +3746,8 @@
       "members":{
         "AssociationId":{"shape":"AssociationId"},
         "InstanceId":{"shape":"InstanceId"},
-        "Content":{"shape":"DocumentContent"}
+        "Content":{"shape":"DocumentContent"},
+        "AssociationVersion":{"shape":"AssociationVersion"}
       }
     },
     "InstanceAssociationExecutionSummary":{
@@ -3721,13 +3782,15 @@
         "AssociationId":{"shape":"AssociationId"},
         "Name":{"shape":"DocumentName"},
         "DocumentVersion":{"shape":"DocumentVersion"},
+        "AssociationVersion":{"shape":"AssociationVersion"},
         "InstanceId":{"shape":"InstanceId"},
         "ExecutionDate":{"shape":"DateTime"},
         "Status":{"shape":"StatusName"},
         "DetailedStatus":{"shape":"StatusName"},
         "ExecutionSummary":{"shape":"InstanceAssociationExecutionSummary"},
         "ErrorCode":{"shape":"AgentErrorCode"},
-        "OutputUrl":{"shape":"InstanceAssociationOutputUrl"}
+        "OutputUrl":{"shape":"InstanceAssociationOutputUrl"},
+        "AssociationName":{"shape":"AssociationName"}
       }
     },
     "InstanceAssociationStatusInfos":{
@@ -3959,6 +4022,13 @@
       "type":"structure",
       "members":{
         "message":{"shape":"String"}
+      },
+      "exception":true
+    },
+    "InvalidAssociationVersion":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"String"}
       },
       "exception":true
     },
@@ -4415,6 +4485,25 @@
     },
     "LastResourceDataSyncTime":{"type":"timestamp"},
     "LastSuccessfulResourceDataSyncTime":{"type":"timestamp"},
+    "ListAssociationVersionsRequest":{
+      "type":"structure",
+      "required":["AssociationId"],
+      "members":{
+        "AssociationId":{"shape":"AssociationId"},
+        "MaxResults":{
+          "shape":"MaxResults",
+          "box":true
+        },
+        "NextToken":{"shape":"NextToken"}
+      }
+    },
+    "ListAssociationVersionsResult":{
+      "type":"structure",
+      "members":{
+        "AssociationVersions":{"shape":"AssociationVersionList"},
+        "NextToken":{"shape":"NextToken"}
+      }
+    },
     "ListAssociationsRequest":{
       "type":"structure",
       "members":{
@@ -6264,7 +6353,9 @@
         "ScheduleExpression":{"shape":"ScheduleExpression"},
         "OutputLocation":{"shape":"InstanceAssociationOutputLocation"},
         "Name":{"shape":"DocumentName"},
-        "Targets":{"shape":"Targets"}
+        "Targets":{"shape":"Targets"},
+        "AssociationName":{"shape":"AssociationName"},
+        "AssociationVersion":{"shape":"AssociationVersion"}
       }
     },
     "UpdateAssociationResult":{

--- a/models/apis/ssm/2014-11-06/docs-2.json
+++ b/models/apis/ssm/2014-11-06/docs-2.json
@@ -64,11 +64,12 @@
     "GetParametersByPath": "<p>Retrieve parameters in a specific hierarchy. For more information, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-working.html\">Working with Systems Manager Parameters</a>. </p> <p>Request results are returned on a best-effort basis. If you specify <code>MaxResults</code> in the request, the response includes information up to the limit specified. The number of items returned, however, can be between zero and the value of <code>MaxResults</code>. If the service reaches an internal limit while processing the results, it stops the operation and returns the matching values up to that point and a <code>NextToken</code>. You can specify the <code>NextToken</code> in a subsequent call to get the next set of results.</p>",
     "GetPatchBaseline": "<p>Retrieves information about a patch baseline.</p>",
     "GetPatchBaselineForPatchGroup": "<p>Retrieves the patch baseline that should be used for the specified patch group.</p>",
+    "ListAssociationVersions": "<p>Retrieves all versions of an association for a specific association ID.</p>",
     "ListAssociations": "<p>Lists the associations for the specified Systems Manager document or instance.</p>",
     "ListCommandInvocations": "<p>An invocation is copy of a command sent to a specific instance. A command can apply to one or more instances. A command invocation applies to one instance. For example, if a user executes SendCommand against three instances, then a command invocation is created for each requested instance ID. ListCommandInvocations provide status about command execution.</p>",
     "ListCommands": "<p>Lists the commands requested by users of the AWS account.</p>",
-    "ListComplianceItems": "<p>For a specified resource ID, this API returns a list of compliance statuses for different resource types. Currently, you can only specify one resource ID per call. List results depend on the criteria specified in the filter. </p>",
-    "ListComplianceSummaries": "<p>Returns a summary count of compliant and non-compliant resources for a compliance type. For example, this call can return State Manager associations, patches, or custom compliance types according to the filter criteria you specify. </p>",
+    "ListComplianceItems": "<p>For a specified resource ID, this API action returns a list of compliance statuses for different resource types. Currently, you can only specify one resource ID per call. List results depend on the criteria specified in the filter. </p>",
+    "ListComplianceSummaries": "<p>Returns a summary count of compliant and non-compliant resources for a compliance type. For example, this call can return State Manager associations, patches, or custom compliance types according to the filter criteria that you specify. </p>",
     "ListDocumentVersions": "<p>List all versions for a document.</p>",
     "ListDocuments": "<p>Describes one or more of your SSM documents.</p>",
     "ListInventoryEntries": "<p>A list of inventory items returned by the request.</p>",
@@ -76,7 +77,7 @@
     "ListResourceDataSync": "<p>Lists your resource data sync configurations. Includes information about the last time a sync attempted to start, the last sync status, and the last time a sync successfully completed.</p> <p>The number of sync configurations might be too large to return using a single call to <code>ListResourceDataSync</code>. You can limit the number of sync configurations returned by using the <code>MaxResults</code> parameter. To determine whether there are more sync configurations to list, check the value of <code>NextToken</code> in the output. If there are more sync configurations to list, you can request them by specifying the <code>NextToken</code> returned in the call to the parameter of a subsequent call. </p>",
     "ListTagsForResource": "<p>Returns a list of the tags assigned to the specified resource.</p>",
     "ModifyDocumentPermission": "<p>Shares a Systems Manager document publicly or privately. If you share a document privately, you must specify the AWS user account IDs for those people who can use the document. If you share a document publicly, you must specify <i>All</i> as the account ID.</p>",
-    "PutComplianceItems": "<p>Registers a compliance type and other compliance details on a designated resource. This API lets you register custom compliance details with a resource. This call overwrites existing compliance information on the resource, so you must provide a full list of compliance items each time you send the request.</p>",
+    "PutComplianceItems": "<p>Registers a compliance type and other compliance details on a designated resource. This action lets you register custom compliance details with a resource. This call overwrites existing compliance information on the resource, so you must provide a full list of compliance items each time that you send the request.</p>",
     "PutInventory": "<p>Bulk update custom inventory items on one more instance. The request adds an inventory item, if it doesn't already exist, or updates an inventory item, if it does exist.</p>",
     "PutParameter": "<p>Add one or more parameters to the system.</p>",
     "RegisterDefaultPatchBaseline": "<p>Defines the default patch baseline.</p>",
@@ -88,13 +89,13 @@
     "SendCommand": "<p>Executes commands on one or more managed instances.</p>",
     "StartAutomationExecution": "<p>Initiates execution of an Automation document.</p>",
     "StopAutomationExecution": "<p>Stop an Automation that is currently executing.</p>",
-    "UpdateAssociation": "<p>Updates an association. You can only update the document version, schedule, parameters, and Amazon S3 output of an association.</p>",
+    "UpdateAssociation": "<p>Updates an association. You can update the association name and version, the document version, schedule, parameters, and Amazon S3 output.</p>",
     "UpdateAssociationStatus": "<p>Updates the status of the Systems Manager document associated with the specified instance.</p>",
     "UpdateDocument": "<p>The document you want to update.</p>",
     "UpdateDocumentDefaultVersion": "<p>Set the default version of a document. </p>",
     "UpdateMaintenanceWindow": "<p>Updates an existing Maintenance Window. Only specified parameters are modified.</p>",
-    "UpdateMaintenanceWindowTarget": "<p>Modifies the target of an existing Maintenance Window. You can't change the target type, but you can change the following:</p> <p>The target from being an ID target to a Tag target, or a Tag target to an ID target.</p> <p>The IDs of an ID target.</p> <p>The tags of a Tag target.</p> <p>The Owner.</p> <p>The Name.</p> <p>The Description.</p> <p>Also note that if a parameter is null, then the corresponding field is not modified.</p>",
-    "UpdateMaintenanceWindowTask": "<p>Modifies a task assigned to a Maintenance Window. You can't change the task type, but you can change the following:</p> <p>The Task Arn. For example, you can change a RUN_COMMAND task from AWS-RunPowerShellScript to AWS-RunShellScript.</p> <p>The service role ARN.</p> <p>The task parameters.</p> <p>The task priority.</p> <p>The task MaxConcurrency and MaxErrors.</p> <p>The log location.</p> <p>If a parameter is null, then the corresponding field is not modified. Also, if you set Replace to true, then all fields required by the RegisterTaskWithMaintenanceWindow operation are required for this request. Optional fields that aren't specified are be set to null.</p>",
+    "UpdateMaintenanceWindowTarget": "<p>Modifies the target of an existing Maintenance Window. You can't change the target type, but you can change the following:</p> <p>The target from being an ID target to a Tag target, or a Tag target to an ID target.</p> <p>IDs for an ID target.</p> <p>Tags for a Tag target.</p> <p>Owner.</p> <p>Name.</p> <p>Description.</p> <p>If a parameter is null, then the corresponding field is not modified.</p>",
+    "UpdateMaintenanceWindowTask": "<p>Modifies a task assigned to a Maintenance Window. You can't change the task type, but you can change the following values:</p> <p>Task ARN. For example, you can change a RUN_COMMAND task from AWS-RunPowerShellScript to AWS-RunShellScript.</p> <p>Service role ARN.</p> <p>Task parameters.</p> <p>Task priority.</p> <p>Task MaxConcurrency and MaxErrors.</p> <p>Log location.</p> <p>If a parameter is null, then the corresponding field is not modified. Also, if you set Replace to true, then all fields required by the RegisterTaskWithMaintenanceWindow action are required for this request. Optional fields that aren't specified are set to null.</p>",
     "UpdateManagedInstanceRole": "<p>Assigns or changes an Amazon Identity and Access Management (IAM) role to the managed instance.</p>",
     "UpdatePatchBaseline": "<p>Modifies an existing patch baseline. Fields not specified in the request are left unchanged.</p>"
   },
@@ -248,10 +249,12 @@
       "refs": {
         "Association$AssociationId": "<p>The ID created by the system when you create an association. An association is a binding between a document and a set of targets with a schedule.</p>",
         "AssociationDescription$AssociationId": "<p>The association ID.</p>",
+        "AssociationVersionInfo$AssociationId": "<p>The ID created by the system when the association was created.</p>",
         "DeleteAssociationRequest$AssociationId": "<p>The association ID that you want to delete.</p>",
         "DescribeAssociationRequest$AssociationId": "<p>The association ID for which you want information.</p>",
         "InstanceAssociation$AssociationId": "<p>The association ID.</p>",
         "InstanceAssociationStatusInfo$AssociationId": "<p>The association ID.</p>",
+        "ListAssociationVersionsRequest$AssociationId": "<p>The association ID for which you want to view all versions.</p>",
         "UpdateAssociationRequest$AssociationId": "<p>The ID of the association you want to update. </p>"
       }
     },
@@ -264,6 +267,18 @@
       "base": null,
       "refs": {
         "ListAssociationsResult$Associations": "<p>The associations.</p>"
+      }
+    },
+    "AssociationName": {
+      "base": null,
+      "refs": {
+        "Association$AssociationName": "<p>The association name.</p>",
+        "AssociationDescription$AssociationName": "<p>The association name.</p>",
+        "AssociationVersionInfo$AssociationName": "<p>The name specified for the association version when the association version was created.</p>",
+        "CreateAssociationBatchRequestEntry$AssociationName": "<p>Specify a descriptive name for the association.</p>",
+        "CreateAssociationRequest$AssociationName": "<p>Specify a descriptive name for the association.</p>",
+        "InstanceAssociationStatusInfo$AssociationName": "<p>The name of the association applied to the instance.</p>",
+        "UpdateAssociationRequest$AssociationName": "<p>The name of the association that you want to update.</p>"
       }
     },
     "AssociationOverview": {
@@ -290,6 +305,35 @@
       "base": null,
       "refs": {
         "AssociationStatus$Name": "<p>The status.</p>"
+      }
+    },
+    "AssociationVersion": {
+      "base": null,
+      "refs": {
+        "Association$AssociationVersion": "<p>The association version.</p>",
+        "AssociationDescription$AssociationVersion": "<p>The association version.</p>",
+        "AssociationVersionInfo$AssociationVersion": "<p>The association version.</p>",
+        "DescribeAssociationRequest$AssociationVersion": "<p>Specify the association version to retrieve. To view the latest version, either specify <code>$LATEST</code> for this parameter, or omit this parameter. To view a list of all associations for an instance, use ListInstanceAssociations. To get a list of versions for a specific association, use ListAssociationVersions. </p>",
+        "InstanceAssociation$AssociationVersion": "<p>Version information for the association on the instance.</p>",
+        "InstanceAssociationStatusInfo$AssociationVersion": "<p>The version of the association applied to the instance.</p>",
+        "UpdateAssociationRequest$AssociationVersion": "<p>This parameter is provided for concurrency control purposes. You must specify the latest association version in the service. If you want to ensure that this request succeeds, either specify <code>$LATEST</code>, or omit this parameter.</p>"
+      }
+    },
+    "AssociationVersionInfo": {
+      "base": "<p>Information about the association version.</p>",
+      "refs": {
+        "AssociationVersionList$member": null
+      }
+    },
+    "AssociationVersionLimitExceeded": {
+      "base": "<p>You have reached the maximum number versions allowed for an association. Each association has a limit of 1,000 versions. </p>",
+      "refs": {
+      }
+    },
+    "AssociationVersionList": {
+      "base": null,
+      "refs": {
+        "ListAssociationVersionsResult$AssociationVersions": "<p>Information about all versions of the association for the specified association ID.</p>"
       }
     },
     "AttributeName": {
@@ -414,7 +458,7 @@
         "AutomationExecution$Outputs": "<p>The list of execution outputs as defined in the automation document.</p>",
         "AutomationExecutionMetadata$Outputs": "<p>The list of execution outputs as defined in the Automation document.</p>",
         "FailureDetails$Details": "<p>Detailed information about the Automation step failure.</p>",
-        "MaintenanceWindowAutomationParameters$Parameters": "<p>Parameters for the AUTOMATION task.</p>",
+        "MaintenanceWindowAutomationParameters$Parameters": "<p>The parameters for the AUTOMATION task.</p>",
         "SendAutomationSignalRequest$Payload": "<p>The data sent with the signal. The data schema depends on the type of signal used in the request. </p>",
         "StartAutomationExecutionRequest$Parameters": "<p>A key-value map of execution parameters, which match the declared parameters in the Automation document.</p>",
         "StepExecution$Outputs": "<p>Returned values from the execution of the step.</p>"
@@ -485,7 +529,7 @@
       "base": null,
       "refs": {
         "Activation$Expired": "<p>Whether or not the activation is expired.</p>",
-        "DeregisterTargetFromMaintenanceWindowRequest$Safe": "<p>The system checks if the target is being referenced by a task. If the target is being referenced, the system returns and error and does not deregister the target from the Maintenance Window.</p>",
+        "DeregisterTargetFromMaintenanceWindowRequest$Safe": "<p>The system checks if the target is being referenced by a task. If the target is being referenced, the system returns an error and does not deregister the target from the Maintenance Window.</p>",
         "DocumentVersionInfo$IsDefaultVersion": "<p>An identifier for the default version of the document.</p>",
         "GetParameterHistoryRequest$WithDecryption": "<p>Return decrypted values for secure string parameters. This flag is ignored for String and StringList parameter types.</p>",
         "GetParameterRequest$WithDecryption": "<p>Return decrypted values for secure string parameters. This flag is ignored for String and StringList parameter types.</p>",
@@ -495,9 +539,9 @@
         "InstanceInformation$IsLatestVersion": "<p>Indicates whether latest version of the SSM Agent is running on your instance. </p>",
         "ListCommandInvocationsRequest$Details": "<p>(Optional) If set this returns the response of the command executions and any command output. By default this is set to False. </p>",
         "PutParameterRequest$Overwrite": "<p>Overwrite an existing parameter. If not specified, will default to \"false\".</p>",
-        "UpdateMaintenanceWindowRequest$Replace": "<p>If you specify True, then all fields that are required by the CreateMaintenanceWindow API are also required for this API request. Optional fields that are not specified will be set to null. </p>",
-        "UpdateMaintenanceWindowTargetRequest$Replace": "<p>If you specify True, then all fields that are required by the RegisterTargetWithMaintenanceWindow API are also required for this API request. Optional fields that are not specified will be set to null.</p>",
-        "UpdateMaintenanceWindowTaskRequest$Replace": "<p>If you specify True, then all fields that are required by the RegisterTaskWithMaintenanceWndow API are also required for this API request. Optional fields that are not specified will be set to null.</p>"
+        "UpdateMaintenanceWindowRequest$Replace": "<p>If True, then all fields that are required by the CreateMaintenanceWindow action are also required for this API request. Optional fields that are not specified are set to null. </p>",
+        "UpdateMaintenanceWindowTargetRequest$Replace": "<p>If True, then all fields that are required by the RegisterTargetWithMaintenanceWindow action are also required for this API request. Optional fields that are not specified are set to null.</p>",
+        "UpdateMaintenanceWindowTaskRequest$Replace": "<p>If True, then all fields that are required by the RegisterTaskWithMaintenanceWndow action are also required for this API request. Optional fields that are not specified are set to null.</p>"
       }
     },
     "CancelCommandRequest": {
@@ -684,7 +728,7 @@
     "ComplianceItemContentHash": {
       "base": null,
       "refs": {
-        "PutComplianceItemsRequest$ItemContentHash": "<p>MD5 or Sha256 content hash. The content hash is used to determine if existing information should be overwritten or ignored. If the content hashes match, ,the request to put compliance information is ignored.</p>"
+        "PutComplianceItemsRequest$ItemContentHash": "<p>MD5 or SHA-256 content hash. The content hash is used to determine if existing information should be overwritten or ignored. If the content hashes match, the request to put compliance information is ignored.</p>"
       }
     },
     "ComplianceItemDetails": {
@@ -744,7 +788,7 @@
     "ComplianceResourceIdList": {
       "base": null,
       "refs": {
-        "ListComplianceItemsRequest$ResourceIds": "<p>The ID for the resources from which you want to get compliance information. Currently, you can only specify one resource ID.</p>"
+        "ListComplianceItemsRequest$ResourceIds": "<p>The ID for the resources from which to get compliance information. Currently, you can only specify one resource ID.</p>"
       }
     },
     "ComplianceResourceType": {
@@ -759,13 +803,13 @@
     "ComplianceResourceTypeList": {
       "base": null,
       "refs": {
-        "ListComplianceItemsRequest$ResourceTypes": "<p>The type of resource from which you want to get compliance information. Currently, the only supported resource type is <code>ManagedInstance</code>.</p>"
+        "ListComplianceItemsRequest$ResourceTypes": "<p>The type of resource from which to get compliance information. Currently, the only supported resource type is <code>ManagedInstance</code>.</p>"
       }
     },
     "ComplianceSeverity": {
       "base": null,
       "refs": {
-        "ComplianceItem$Severity": "<p>The severity of the compliance status. Severity can be one of the following: Critical, HIGH, Medium, Low, Informational, Unspecified.</p>",
+        "ComplianceItem$Severity": "<p>The severity of the compliance status. Severity can be one of the following: Critical, High, Medium, Low, Informational, Unspecified.</p>",
         "ComplianceItemEntry$Severity": "<p>The severity of the compliance status. Severity can be one of the following: Critical, High, Medium, Low, Informational, Unspecified.</p>",
         "ResourceComplianceSummaryItem$OverallSeverity": "<p>The highest severity item found for the resource. The resource is compliant for this item.</p>"
       }
@@ -801,7 +845,7 @@
     "ComplianceStringFilterValueList": {
       "base": null,
       "refs": {
-        "ComplianceStringFilter$Values": "<p>The value you want to search for.</p>"
+        "ComplianceStringFilter$Values": "<p>The value for which to search.</p>"
       }
     },
     "ComplianceSummaryCount": {
@@ -826,7 +870,7 @@
     "ComplianceSummaryItemList": {
       "base": null,
       "refs": {
-        "ListComplianceSummariesResult$ComplianceSummaryItems": "<p>A list of compliant and non-compliant summary counts based on compliance types. For example, this call returns State Manager associations, patches, or custom compliance types according to the filter criteria you specified.</p>"
+        "ListComplianceSummariesResult$ComplianceSummaryItems": "<p>A list of compliant and non-compliant summary counts based on compliance types. For example, this call returns State Manager associations, patches, or custom compliance types according to the filter criteria that you specified.</p>"
       }
     },
     "ComplianceTypeCountLimitExceededException": {
@@ -837,7 +881,7 @@
     "ComplianceTypeName": {
       "base": null,
       "refs": {
-        "ComplianceItem$ComplianceType": "<p>The compliance type. For example, Association (for a State Manager association), Patch, or Custom:<code>string</code> are all valide compliance types.</p>",
+        "ComplianceItem$ComplianceType": "<p>The compliance type. For example, Association (for a State Manager association), Patch, or Custom:<code>string</code> are all valid compliance types.</p>",
         "ComplianceSummaryItem$ComplianceType": "<p>The type of compliance item. For example, the compliance type can be Association, Patch, or Custom:string.</p>",
         "PutComplianceItemsRequest$ComplianceType": "<p>Specify the compliance type. For example, specify Association (for a State Manager association), Patch, or Custom:<code>string</code>.</p>",
         "ResourceComplianceSummaryItem$ComplianceType": "<p>The compliance type.</p>"
@@ -959,6 +1003,7 @@
         "AssociationDescription$LastExecutionDate": "<p>The date on which the association was last run.</p>",
         "AssociationDescription$LastSuccessfulExecutionDate": "<p>The last date on which the association was successfully run.</p>",
         "AssociationStatus$Date": "<p>The date when the status changed.</p>",
+        "AssociationVersionInfo$CreatedDate": "<p>The date the association version was created.</p>",
         "AutomationExecution$ExecutionStartTime": "<p>The time the execution started.</p>",
         "AutomationExecution$ExecutionEndTime": "<p>The time the execution finished.</p>",
         "AutomationExecutionMetadata$ExecutionStartTime": "<p>The time the execution started.&gt;</p>",
@@ -973,8 +1018,8 @@
         "DocumentVersionInfo$CreatedDate": "<p>The date the document was created.</p>",
         "GetMaintenanceWindowExecutionResult$StartTime": "<p>The time the Maintenance Window started executing.</p>",
         "GetMaintenanceWindowExecutionResult$EndTime": "<p>The time the Maintenance Window finished executing.</p>",
-        "GetMaintenanceWindowExecutionTaskInvocationResult$StartTime": "<p>The time the task started executing on the target.</p>",
-        "GetMaintenanceWindowExecutionTaskInvocationResult$EndTime": "<p>The time the task finished executing on the target.</p>",
+        "GetMaintenanceWindowExecutionTaskInvocationResult$StartTime": "<p>The time that the task started executing on the target.</p>",
+        "GetMaintenanceWindowExecutionTaskInvocationResult$EndTime": "<p>The time that the task finished executing on the target.</p>",
         "GetMaintenanceWindowExecutionTaskResult$StartTime": "<p>The time the task execution started.</p>",
         "GetMaintenanceWindowExecutionTaskResult$EndTime": "<p>The time the task execution completed.</p>",
         "GetMaintenanceWindowResult$CreatedDate": "<p>The date the Maintenance Window was created.</p>",
@@ -1460,7 +1505,7 @@
       "base": null,
       "refs": {
         "DocumentDescription$Hash": "<p>The Sha256 or Sha1 hash created by the system when the document was created. </p> <note> <p>Sha1 hashes have been deprecated.</p> </note>",
-        "MaintenanceWindowRunCommandParameters$DocumentHash": "<p>The Sha256 or Sha1 hash created by the system when the document was created. Sha1 hashes have been deprecated.</p>",
+        "MaintenanceWindowRunCommandParameters$DocumentHash": "<p>The SHA-256 or SHA-1 hash created by the system when the document was created. SHA-1 hashes have been deprecated.</p>",
         "SendCommandRequest$DocumentHash": "<p>The Sha256 or Sha1 hash created by the system when the document was created. </p> <note> <p>Sha1 hashes have been deprecated.</p> </note>"
       }
     },
@@ -1468,7 +1513,7 @@
       "base": null,
       "refs": {
         "DocumentDescription$HashType": "<p>Sha256 or Sha1.</p> <note> <p>Sha1 hashes have been deprecated.</p> </note>",
-        "MaintenanceWindowRunCommandParameters$DocumentHashType": "<p>Sha256 or Sha1. Sha1 hashes have been deprecated.</p>",
+        "MaintenanceWindowRunCommandParameters$DocumentHashType": "<p>SHA-256 or SHA-1. SHA-1 hashes have been deprecated.</p>",
         "SendCommandRequest$DocumentHashType": "<p>Sha256 or Sha1.</p> <note> <p>Sha1 hashes have been deprecated.</p> </note>"
       }
     },
@@ -1494,6 +1539,7 @@
       "refs": {
         "Association$Name": "<p>The name of the SSM document.</p>",
         "AssociationDescription$Name": "<p>The name of the SSM document.</p>",
+        "AssociationVersionInfo$Name": "<p>The name specified when the association was created.</p>",
         "AutomationExecution$DocumentName": "<p>The name of the Automation document used during the execution.</p>",
         "AutomationExecutionMetadata$DocumentName": "<p>The name of the Automation document used during execution.</p>",
         "Command$DocumentName": "<p>The name of the document requested for execution.</p>",
@@ -1605,6 +1651,7 @@
       "refs": {
         "Association$DocumentVersion": "<p>The version of the document used in the association.</p>",
         "AssociationDescription$DocumentVersion": "<p>The document version.</p>",
+        "AssociationVersionInfo$DocumentVersion": "<p>The version of an SSM document used when the association version was created.</p>",
         "AutomationExecution$DocumentVersion": "<p>The version of the document to use during execution.</p>",
         "AutomationExecutionMetadata$DocumentVersion": "<p>The document version used during the execution.</p>",
         "CreateAssociationBatchRequestEntry$DocumentVersion": "<p>The document version.</p>",
@@ -1619,7 +1666,7 @@
         "GetDocumentRequest$DocumentVersion": "<p>The document version for which you want information.</p>",
         "GetDocumentResult$DocumentVersion": "<p>The document version.</p>",
         "InstanceAssociationStatusInfo$DocumentVersion": "<p>The association document verions.</p>",
-        "MaintenanceWindowAutomationParameters$DocumentVersion": "<p>The version of an SSM Automation document to use during task execution.</p>",
+        "MaintenanceWindowAutomationParameters$DocumentVersion": "<p>The version of an Automation document to use during task execution.</p>",
         "StartAutomationExecutionRequest$DocumentVersion": "<p>The version of the Automation document to use for this execution.</p>",
         "UpdateAssociationRequest$DocumentVersion": "<p>The document version you want update for the association. </p>",
         "UpdateDocumentRequest$DocumentVersion": "<p>The version of the document that you want to update.</p>"
@@ -1719,7 +1766,7 @@
       }
     },
     "FeatureNotAvailableException": {
-      "base": "<p>You attempted to register a LAMBDA or STEP_FUNCTION task in a region where there corresponding service is not available. </p>",
+      "base": "<p>You attempted to register a LAMBDA or STEP_FUNCTION task in a region where the corresponding service is not available. </p>",
       "refs": {
       }
     },
@@ -1973,6 +2020,7 @@
       "base": "<p>An Amazon S3 bucket where you want to store the results of this request.</p>",
       "refs": {
         "AssociationDescription$OutputLocation": "<p>An Amazon S3 bucket where you want to store the output details of the request.</p>",
+        "AssociationVersionInfo$OutputLocation": "<p>The location in Amazon S3 specified for the association when the association version was created.</p>",
         "CreateAssociationBatchRequestEntry$OutputLocation": "<p>An Amazon S3 bucket where you want to store the results of this request.</p>",
         "CreateAssociationRequest$OutputLocation": "<p>An Amazon S3 bucket where you want to store the output details of the request.</p>",
         "UpdateAssociationRequest$OutputLocation": "<p>An Amazon S3 bucket where you want to store the results of this request.</p>"
@@ -2198,6 +2246,11 @@
     },
     "InvalidAllowedPatternException": {
       "base": "<p>The request does not meet the regular expression requirement.</p>",
+      "refs": {
+      }
+    },
+    "InvalidAssociationVersion": {
+      "base": "<p>The version you specified is not valid. Use ListAssociationVersions to view all versions of an association according to the association ID. Or, use the <code>$LATEST</code> parameter to view the latest version of the association.</p>",
       "refs": {
       }
     },
@@ -2598,6 +2651,16 @@
         "ResourceDataSyncItem$LastSuccessfulSyncTime": "<p>The last time the sync operations returned a status of <code>SUCCESSFUL</code> (UTC).</p>"
       }
     },
+    "ListAssociationVersionsRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListAssociationVersionsResult": {
+      "base": null,
+      "refs": {
+      }
+    },
     "ListAssociationsRequest": {
       "base": null,
       "refs": {
@@ -2711,26 +2774,26 @@
     "LoggingInfo": {
       "base": "<p>Information about an Amazon S3 bucket to write instance-level logs to.</p>",
       "refs": {
-        "GetMaintenanceWindowTaskResult$LoggingInfo": "<p>The location in Amazon S3 where the task results will be logged.</p>",
+        "GetMaintenanceWindowTaskResult$LoggingInfo": "<p>The location in Amazon S3 where the task results are logged.</p>",
         "MaintenanceWindowTask$LoggingInfo": "<p>Information about an Amazon S3 bucket to write task-level logs to.</p>",
         "RegisterTaskWithMaintenanceWindowRequest$LoggingInfo": "<p>A structure containing information about an Amazon S3 bucket to write instance-level logs to. </p>",
-        "UpdateMaintenanceWindowTaskRequest$LoggingInfo": "<p>The new logging location in Amazon S3 that you want to specify.</p>",
+        "UpdateMaintenanceWindowTaskRequest$LoggingInfo": "<p>The new logging location in Amazon S3 to specify.</p>",
         "UpdateMaintenanceWindowTaskResult$LoggingInfo": "<p>The updated logging information in Amazon S3.</p>"
       }
     },
     "MaintenanceWindowAllowUnassociatedTargets": {
       "base": null,
       "refs": {
-        "CreateMaintenanceWindowRequest$AllowUnassociatedTargets": "<p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>",
+        "CreateMaintenanceWindowRequest$AllowUnassociatedTargets": "<p>Enables a Maintenance Window task to execute on managed instances, even if you have not registered those instances as targets. If enabled, then you must specify the unregistered instances (by instance ID) when you register a task with the Maintenance Window </p> <p>If you don't enable this option, then you must specify previously-registered targets when you register a task with the Maintenance Window. </p>",
         "GetMaintenanceWindowResult$AllowUnassociatedTargets": "<p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>",
         "UpdateMaintenanceWindowRequest$AllowUnassociatedTargets": "<p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>",
         "UpdateMaintenanceWindowResult$AllowUnassociatedTargets": "<p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>"
       }
     },
     "MaintenanceWindowAutomationParameters": {
-      "base": "<p>Parameters for an AUTOMATION task type.</p>",
+      "base": "<p>The parameters for an AUTOMATION task type.</p>",
       "refs": {
-        "MaintenanceWindowTaskInvocationParameters$Automation": "<p>Parameters for a AUTOMATION task type.</p>"
+        "MaintenanceWindowTaskInvocationParameters$Automation": "<p>The parameters for a AUTOMATION task type.</p>"
       }
     },
     "MaintenanceWindowCutoff": {
@@ -2746,7 +2809,7 @@
     "MaintenanceWindowDescription": {
       "base": null,
       "refs": {
-        "CreateMaintenanceWindowRequest$Description": "<p>An optional description for the Maintenance Window. We recommend specifying a description to help your organize your Maintenance Windows. </p>",
+        "CreateMaintenanceWindowRequest$Description": "<p>An optional description for the Maintenance Window. We recommend specifying a description to help you organize your Maintenance Windows. </p>",
         "GetMaintenanceWindowResult$Description": "<p>The description of the Maintenance Window.</p>",
         "GetMaintenanceWindowTaskResult$Description": "<p>The retrieved task description.</p>",
         "MaintenanceWindowIdentity$Description": "<p>A description of the Maintenance Window.</p>",
@@ -2758,7 +2821,7 @@
         "UpdateMaintenanceWindowResult$Description": "<p>An optional description of the update.</p>",
         "UpdateMaintenanceWindowTargetRequest$Description": "<p>An optional description for the update.</p>",
         "UpdateMaintenanceWindowTargetResult$Description": "<p>The updated description.</p>",
-        "UpdateMaintenanceWindowTaskRequest$Description": "<p>The new task description that you want to specify.</p>",
+        "UpdateMaintenanceWindowTaskRequest$Description": "<p>The new task description to specify.</p>",
         "UpdateMaintenanceWindowTaskResult$Description": "<p>The updated task description.</p>"
       }
     },
@@ -2794,7 +2857,7 @@
         "DescribeMaintenanceWindowExecutionTasksRequest$WindowExecutionId": "<p>The ID of the Maintenance Window execution whose task executions should be retrieved.</p>",
         "GetMaintenanceWindowExecutionRequest$WindowExecutionId": "<p>The ID of the Maintenance Window execution that includes the task.</p>",
         "GetMaintenanceWindowExecutionResult$WindowExecutionId": "<p>The ID of the Maintenance Window execution.</p>",
-        "GetMaintenanceWindowExecutionTaskInvocationRequest$WindowExecutionId": "<p>The ID of the Maintenance Window execution the task is part of.</p>",
+        "GetMaintenanceWindowExecutionTaskInvocationRequest$WindowExecutionId": "<p>The ID of the Maintenance Window execution for which the task is a part.</p>",
         "GetMaintenanceWindowExecutionTaskInvocationResult$WindowExecutionId": "<p>The Maintenance Window execution ID.</p>",
         "GetMaintenanceWindowExecutionTaskRequest$WindowExecutionId": "<p>The ID of the Maintenance Window execution that includes the task.</p>",
         "GetMaintenanceWindowExecutionTaskResult$WindowExecutionId": "<p>The ID of the Maintenance Window execution that includes the task.</p>",
@@ -2892,7 +2955,7 @@
     "MaintenanceWindowExecutionTaskInvocationParameters": {
       "base": null,
       "refs": {
-        "GetMaintenanceWindowExecutionTaskInvocationResult$Parameters": "<p>The parameters used at the time the task executed.</p>",
+        "GetMaintenanceWindowExecutionTaskInvocationResult$Parameters": "<p>The parameters used at the time that the task executed.</p>",
         "MaintenanceWindowExecutionTaskInvocationIdentity$Parameters": "<p>The parameters that were provided for the invocation when it was executed.</p>"
       }
     },
@@ -2956,10 +3019,10 @@
         "RegisterTaskWithMaintenanceWindowRequest$WindowId": "<p>The id of the Maintenance Window the task should be added to.</p>",
         "UpdateMaintenanceWindowRequest$WindowId": "<p>The ID of the Maintenance Window to update.</p>",
         "UpdateMaintenanceWindowResult$WindowId": "<p>The ID of the created Maintenance Window.</p>",
-        "UpdateMaintenanceWindowTargetRequest$WindowId": "<p>The Maintenance Window ID for which you want to modify the target.</p>",
+        "UpdateMaintenanceWindowTargetRequest$WindowId": "<p>The Maintenance Window ID with which to modify the target.</p>",
         "UpdateMaintenanceWindowTargetResult$WindowId": "<p>The Maintenance Window ID specified in the update request.</p>",
-        "UpdateMaintenanceWindowTaskRequest$WindowId": "<p>The Maintenance Window ID that contains the task that you want to modify.</p>",
-        "UpdateMaintenanceWindowTaskResult$WindowId": "<p>The Maintenance Window ID that was updated.</p>"
+        "UpdateMaintenanceWindowTaskRequest$WindowId": "<p>The Maintenance Window ID that contains the task to modify.</p>",
+        "UpdateMaintenanceWindowTaskResult$WindowId": "<p>The ID of the Maintenance Window that was updated.</p>"
       }
     },
     "MaintenanceWindowIdentity": {
@@ -2977,25 +3040,25 @@
     "MaintenanceWindowLambdaClientContext": {
       "base": null,
       "refs": {
-        "MaintenanceWindowLambdaParameters$ClientContext": "<p>Using the ClientContext you can pass client-specific information to the Lambda function you are invoking. You can then process the client information in your Lambda function as you choose through the context variable.</p>"
+        "MaintenanceWindowLambdaParameters$ClientContext": "<p>Pass client-specific information to the Lambda function that you are invoking. You can then process the client information in your Lambda function as you choose through the context variable.</p>"
       }
     },
     "MaintenanceWindowLambdaParameters": {
-      "base": "<p>Parameters for a LAMBDA task type.</p>",
+      "base": "<p>The parameters for a LAMBDA task type.</p>",
       "refs": {
-        "MaintenanceWindowTaskInvocationParameters$Lambda": "<p>Parameters for a LAMBDA task type.</p>"
+        "MaintenanceWindowTaskInvocationParameters$Lambda": "<p>The parameters for a LAMBDA task type.</p>"
       }
     },
     "MaintenanceWindowLambdaPayload": {
       "base": null,
       "refs": {
-        "MaintenanceWindowLambdaParameters$Payload": "<p>JSON that you want to provide to your Lambda function as input.</p>"
+        "MaintenanceWindowLambdaParameters$Payload": "<p>JSON to provide to your Lambda function as input.</p>"
       }
     },
     "MaintenanceWindowLambdaQualifier": {
       "base": null,
       "refs": {
-        "MaintenanceWindowLambdaParameters$Qualifier": "<p>You can use this optional parameter to specify a Lambda function version or alias name. If you specify a function version, the API uses the qualified function ARN to invoke a specific Lambda function. If you specify an alias name, the API uses the alias ARN to invoke the Lambda function version to which the alias points.</p>"
+        "MaintenanceWindowLambdaParameters$Qualifier": "<p>(Optional) Specify a Lambda function version or alias name. If you specify a function version, the action uses the qualified function ARN to invoke a specific Lambda function. If you specify an alias name, the action uses the alias ARN to invoke the Lambda function version to which the alias points.</p>"
       }
     },
     "MaintenanceWindowMaxResults": {
@@ -3024,7 +3087,7 @@
         "UpdateMaintenanceWindowResult$Name": "<p>The name of the Maintenance Window.</p>",
         "UpdateMaintenanceWindowTargetRequest$Name": "<p>A name for the update.</p>",
         "UpdateMaintenanceWindowTargetResult$Name": "<p>The updated name.</p>",
-        "UpdateMaintenanceWindowTaskRequest$Name": "<p>The new task name that you want to specify.</p>",
+        "UpdateMaintenanceWindowTaskRequest$Name": "<p>The new task name to specify.</p>",
         "UpdateMaintenanceWindowTaskResult$Name": "<p>The updated task name.</p>"
       }
     },
@@ -3036,9 +3099,9 @@
       }
     },
     "MaintenanceWindowRunCommandParameters": {
-      "base": "<p>Parameters for a RUN_COMMAND task type.</p>",
+      "base": "<p>The parameters for a RUN_COMMAND task type.</p>",
       "refs": {
-        "MaintenanceWindowTaskInvocationParameters$RunCommand": "<p>Parameters for a RUN_COMMAND task type.</p>"
+        "MaintenanceWindowTaskInvocationParameters$RunCommand": "<p>The parameters for a RUN_COMMAND task type.</p>"
       }
     },
     "MaintenanceWindowSchedule": {
@@ -3063,9 +3126,9 @@
       }
     },
     "MaintenanceWindowStepFunctionsParameters": {
-      "base": "<p>Parameters for the STEP_FUNCTION execution.</p>",
+      "base": "<p>The parameters for the STEP_FUNCTION execution.</p>",
       "refs": {
-        "MaintenanceWindowTaskInvocationParameters$StepFunctions": "<p>Parameters for a STEP_FUNCTION task type.</p>"
+        "MaintenanceWindowTaskInvocationParameters$StepFunctions": "<p>The parameters for a STEP_FUNCTION task type.</p>"
       }
     },
     "MaintenanceWindowTarget": {
@@ -3081,7 +3144,7 @@
         "DeregisterTargetFromMaintenanceWindowResult$WindowTargetId": "<p>The ID of the removed target definition.</p>",
         "MaintenanceWindowTarget$WindowTargetId": "<p>The ID of the target.</p>",
         "RegisterTargetWithMaintenanceWindowResult$WindowTargetId": "<p>The ID of the target definition in this Maintenance Window.</p>",
-        "UpdateMaintenanceWindowTargetRequest$WindowTargetId": "<p>The target ID that you want to modify.</p>",
+        "UpdateMaintenanceWindowTargetRequest$WindowTargetId": "<p>The target ID to modify.</p>",
         "UpdateMaintenanceWindowTargetResult$WindowTargetId": "<p>The target ID specified in the update request.</p>"
       }
     },
@@ -3101,11 +3164,11 @@
       "base": null,
       "refs": {
         "GetMaintenanceWindowExecutionTaskResult$TaskArn": "<p>The ARN of the executed task.</p>",
-        "GetMaintenanceWindowTaskResult$TaskArn": "<p>TaskArn is the resource that the task used during execution. For RUN_COMMAND and AUTOMATION task types, the TaskArn is the SSM Document Name/ARN. For LAMBDA tasks, TaskArn is the Function Name/ARN. For STEP_FUNCTION tasks, the TaskArn is the State Machine ARN.</p>",
+        "GetMaintenanceWindowTaskResult$TaskArn": "<p>The resource that the task used during execution. For RUN_COMMAND and AUTOMATION task types, the TaskArn is the SSM Document name/ARN. For LAMBDA tasks, the value is the function name/ARN. For STEP_FUNCTION tasks, the value is the state machine ARN.</p>",
         "MaintenanceWindowExecutionTaskIdentity$TaskArn": "<p>The ARN of the executed task.</p>",
-        "MaintenanceWindowTask$TaskArn": "<p>TaskArn is the resource that the task uses during execution. For RUN_COMMAND and AUTOMATION task types, the TaskArn is the SSM Document Name/ARN. For LAMBDA tasks, it's the Function Name/ARN. For STEP_FUNCTION tasks, it's the State Machine ARN.</p>",
+        "MaintenanceWindowTask$TaskArn": "<p>The resource that the task uses during execution. For RUN_COMMAND and AUTOMATION task types, <code>TaskArn</code> is the SSM document name or ARN. For LAMBDA tasks, it's the function name or ARN. For STEP_FUNCTION tasks, it's the state machine ARN.</p>",
         "RegisterTaskWithMaintenanceWindowRequest$TaskArn": "<p>The ARN of the task to execute </p>",
-        "UpdateMaintenanceWindowTaskRequest$TaskArn": "<p>The task ARN that you want to modify.</p>",
+        "UpdateMaintenanceWindowTaskRequest$TaskArn": "<p>The task ARN to modify.</p>",
         "UpdateMaintenanceWindowTaskResult$TaskArn": "<p>The updated task ARN value.</p>"
       }
     },
@@ -3118,16 +3181,16 @@
         "GetMaintenanceWindowTaskResult$WindowTaskId": "<p>The retrieved Maintenance Window task ID.</p>",
         "MaintenanceWindowTask$WindowTaskId": "<p>The task ID.</p>",
         "RegisterTaskWithMaintenanceWindowResult$WindowTaskId": "<p>The id of the task in the Maintenance Window.</p>",
-        "UpdateMaintenanceWindowTaskRequest$WindowTaskId": "<p>The task ID that you want to modify.</p>",
-        "UpdateMaintenanceWindowTaskResult$WindowTaskId": "<p>The Maintenance Window task ID that was updated.</p>"
+        "UpdateMaintenanceWindowTaskRequest$WindowTaskId": "<p>The task ID to modify.</p>",
+        "UpdateMaintenanceWindowTaskResult$WindowTaskId": "<p>The task ID of the Maintenance Window that was updated.</p>"
       }
     },
     "MaintenanceWindowTaskInvocationParameters": {
-      "base": "<p>Parameters for task execution.</p>",
+      "base": "<p>The parameters for task execution.</p>",
       "refs": {
         "GetMaintenanceWindowTaskResult$TaskInvocationParameters": "<p>The parameters to pass to the task when it executes.</p>",
-        "RegisterTaskWithMaintenanceWindowRequest$TaskInvocationParameters": "<p>Parameters the task should use during execution. Populate only the fields that match the task type. All other fields should be empty. </p>",
-        "UpdateMaintenanceWindowTaskRequest$TaskInvocationParameters": "<p>Parameters the task should use during execution. Populate only the fields that match the task type. All other fields should be empty.</p>",
+        "RegisterTaskWithMaintenanceWindowRequest$TaskInvocationParameters": "<p>The parameters that the task should use during execution. Populate only the fields that match the task type. All other fields should be empty. </p>",
+        "UpdateMaintenanceWindowTaskRequest$TaskInvocationParameters": "<p>The parameters that the task should use during execution. Populate only the fields that match the task type. All other fields should be empty.</p>",
         "UpdateMaintenanceWindowTaskResult$TaskInvocationParameters": "<p>The updated parameter values.</p>"
       }
     },
@@ -3168,7 +3231,7 @@
         "MaintenanceWindowTask$TaskParameters": "<p>The parameters that should be passed to the task when it is executed.</p>",
         "MaintenanceWindowTaskParametersList$member": null,
         "RegisterTaskWithMaintenanceWindowRequest$TaskParameters": "<p>The parameters that should be passed to the task when it is executed.</p>",
-        "UpdateMaintenanceWindowTaskRequest$TaskParameters": "<p>The parameters that you want to modify. The map has the following format:</p> <p>Key: string, between 1 and 255 characters</p> <p>Value: an array of strings, each string is between 1 and 255 characters</p>",
+        "UpdateMaintenanceWindowTaskRequest$TaskParameters": "<p>The parameters to modify. The map has the following format:</p> <p>Key: string, between 1 and 255 characters</p> <p>Value: an array of strings, each string is between 1 and 255 characters</p>",
         "UpdateMaintenanceWindowTaskResult$TaskParameters": "<p>The updated parameter values.</p>"
       }
     },
@@ -3185,7 +3248,7 @@
         "GetMaintenanceWindowTaskResult$Priority": "<p>The priority of the task when it executes. The lower the number, the higher the priority. Tasks that have the same priority are scheduled in parallel.</p>",
         "MaintenanceWindowTask$Priority": "<p>The priority of the task in the Maintenance Window. The lower the number, the higher the priority. Tasks that have the same priority are scheduled in parallel.</p>",
         "RegisterTaskWithMaintenanceWindowRequest$Priority": "<p>The priority of the task in the Maintenance Window, the lower the number the higher the priority. Tasks in a Maintenance Window are scheduled in priority order with tasks that have the same priority scheduled in parallel.</p>",
-        "UpdateMaintenanceWindowTaskRequest$Priority": "<p>The new task priority that you want to specify. The lower the number, the higher the priority. Tasks that have the same priority are scheduled in parallel.</p>",
+        "UpdateMaintenanceWindowTaskRequest$Priority": "<p>The new task priority to specify. The lower the number, the higher the priority. Tasks that have the same priority are scheduled in parallel.</p>",
         "UpdateMaintenanceWindowTaskResult$Priority": "<p>The updated priority value.</p>"
       }
     },
@@ -3242,7 +3305,7 @@
         "MaintenanceWindowTask$MaxErrors": "<p>The maximum number of errors allowed before this task stops being scheduled.</p>",
         "RegisterTaskWithMaintenanceWindowRequest$MaxErrors": "<p>The maximum number of errors allowed before this task stops being scheduled.</p>",
         "SendCommandRequest$MaxErrors": "<p>The maximum number of errors allowed without the command failing. When the command fails one more time beyond the value of MaxErrors, the systems stops sending the command to additional targets. You can specify a number like 10 or a percentage like 10%. The default value is 50. For more information about how to use MaxErrors, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/send-commands-maxerrors.html\">Using Error Controls</a>.</p>",
-        "UpdateMaintenanceWindowTaskRequest$MaxErrors": "<p>The new <code>MaxErrors</code> value you want to specify. <code>MaxErrors</code> is the maximum number of errors that are allowed before the task stops being scheduled.</p>",
+        "UpdateMaintenanceWindowTaskRequest$MaxErrors": "<p>The new <code>MaxErrors</code> value to specify. <code>MaxErrors</code> is the maximum number of errors that are allowed before the task stops being scheduled.</p>",
         "UpdateMaintenanceWindowTaskResult$MaxErrors": "<p>The updated MaxErrors value.</p>"
       }
     },
@@ -3255,6 +3318,7 @@
         "DescribeParametersRequest$MaxResults": "<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>",
         "GetInventoryRequest$MaxResults": "<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>",
         "GetParameterHistoryRequest$MaxResults": "<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>",
+        "ListAssociationVersionsRequest$MaxResults": "<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>",
         "ListAssociationsRequest$MaxResults": "<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>",
         "ListComplianceItemsRequest$MaxResults": "<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>",
         "ListComplianceSummariesRequest$MaxResults": "<p>The maximum number of items to return for this call. Currently, you can specify null or 50. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>",
@@ -3330,6 +3394,8 @@
         "GetParameterHistoryResult$NextToken": "<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>",
         "GetParametersByPathRequest$NextToken": "<p>A token to start the list. Use this token to get the next set of results. </p>",
         "GetParametersByPathResult$NextToken": "<p>The token for the next set of items to return. Use this token to get the next set of results.</p>",
+        "ListAssociationVersionsRequest$NextToken": "<p>A token to start the list. Use this token to get the next set of results. </p>",
+        "ListAssociationVersionsResult$NextToken": "<p>The token for the next set of items to return. Use this token to get the next set of results.</p>",
         "ListAssociationsRequest$NextToken": "<p>The token for the next set of items to return. (You received this token from a previous call.)</p>",
         "ListAssociationsResult$NextToken": "<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>",
         "ListCommandInvocationsRequest$NextToken": "<p>(Optional) The token for the next set of items to return. (You received this token from a previous call.)</p>",
@@ -3376,7 +3442,7 @@
       "refs": {
         "Command$NotificationConfig": "<p>Configurations for sending notifications about command status changes. </p>",
         "CommandInvocation$NotificationConfig": "<p>Configurations for sending notifications about command status changes on a per instance basis.</p>",
-        "MaintenanceWindowRunCommandParameters$NotificationConfig": "<p>Configurations for sending notifications about command status changes on a per instance basis.</p>",
+        "MaintenanceWindowRunCommandParameters$NotificationConfig": "<p>Configurations for sending notifications about command status changes on a per-instance basis.</p>",
         "SendCommandRequest$NotificationConfig": "<p>Configurations for sending notifications.</p>"
       }
     },
@@ -3414,7 +3480,7 @@
     "OwnerInformation": {
       "base": null,
       "refs": {
-        "GetMaintenanceWindowExecutionTaskInvocationResult$OwnerInformation": "<p>User-provided value that will be included in any CloudWatch events raised while running tasks for these targets in this Maintenance Window. </p>",
+        "GetMaintenanceWindowExecutionTaskInvocationResult$OwnerInformation": "<p>User-provided value to be included in any CloudWatch events raised while running tasks for these targets in this Maintenance Window. </p>",
         "InstancePatchState$OwnerInformation": "<p>Placeholder information, this field will always be empty in the current release of the service.</p>",
         "MaintenanceWindowExecutionTaskInvocationIdentity$OwnerInformation": "<p>User-provided value that was specified when the target was registered with the Maintenance Window. This was also included in any CloudWatch events raised during the task invocation.</p>",
         "MaintenanceWindowTarget$OwnerInformation": "<p>User-provided value that will be included in any CloudWatch events raised while running tasks for these targets in this Maintenance Window.</p>",
@@ -3597,10 +3663,11 @@
       "base": null,
       "refs": {
         "AssociationDescription$Parameters": "<p>A description of the parameters for a document. </p>",
+        "AssociationVersionInfo$Parameters": "<p>Parameters specified when the association version was created.</p>",
         "Command$Parameters": "<p>The parameter values to be inserted in the document when executing the command.</p>",
         "CreateAssociationBatchRequestEntry$Parameters": "<p>A description of the parameters for a document. </p>",
         "CreateAssociationRequest$Parameters": "<p>The parameters for the documents runtime configuration. </p>",
-        "MaintenanceWindowRunCommandParameters$Parameters": "<p>Parameters for the RUN_COMMAND task execution.</p>",
+        "MaintenanceWindowRunCommandParameters$Parameters": "<p>The parameters for the RUN_COMMAND task execution.</p>",
         "SendCommandRequest$Parameters": "<p>The required and optional parameters specified in the document being executed.</p>",
         "UpdateAssociationRequest$Parameters": "<p>The parameters you want to update for the association. If you create a parameter using Parameter Store, you can reference the parameter using {{ssm:parameter-name}}</p>"
       }
@@ -4106,7 +4173,7 @@
     "ResourceComplianceSummaryItemList": {
       "base": null,
       "refs": {
-        "ListResourceComplianceSummariesResult$ResourceComplianceSummaryItems": "<p>A summary count for specified or targeted managed instances. Summary count includes information about compliant and non-compliant State Manager associations, patch statuses, or custom items according to the filter criteria you specify. </p>"
+        "ListResourceComplianceSummariesResult$ResourceComplianceSummaryItems": "<p>A summary count for specified or targeted managed instances. Summary count includes information about compliant and non-compliant State Manager associations, patch status, or custom items according to the filter criteria that you specify. </p>"
       }
     },
     "ResourceDataSyncAlreadyExistsException": {
@@ -4288,6 +4355,7 @@
       "refs": {
         "Association$ScheduleExpression": "<p>A cron expression that specifies a schedule when the association runs.</p>",
         "AssociationDescription$ScheduleExpression": "<p>A cron expression that specifies a schedule when the association runs.</p>",
+        "AssociationVersionInfo$ScheduleExpression": "<p>The cron or rate schedule specified for the association when the association version was created.</p>",
         "CreateAssociationBatchRequestEntry$ScheduleExpression": "<p>A cron expression that specifies a schedule when the association runs.</p>",
         "CreateAssociationRequest$ScheduleExpression": "<p>A cron expression when the association will be applied to the target(s).</p>",
         "UpdateAssociationRequest$ScheduleExpression": "<p>The cron expression used to schedule the association that you want to update.</p>"
@@ -4320,11 +4388,11 @@
         "CommandInvocation$ServiceRole": "<p>The IAM service role that Run Command uses to act on your behalf when sending notifications about command status changes on a per instance basis.</p>",
         "GetMaintenanceWindowExecutionTaskResult$ServiceRole": "<p>The role that was assumed when executing the task.</p>",
         "GetMaintenanceWindowTaskResult$ServiceRoleArn": "<p>The IAM service role to assume during task execution.</p>",
-        "MaintenanceWindowRunCommandParameters$ServiceRoleArn": "<p>The IAM service role that to assume during task execution.</p>",
+        "MaintenanceWindowRunCommandParameters$ServiceRoleArn": "<p>The IAM service role to assume during task execution.</p>",
         "MaintenanceWindowTask$ServiceRoleArn": "<p>The role that should be assumed when executing the task</p>",
         "RegisterTaskWithMaintenanceWindowRequest$ServiceRoleArn": "<p>The role that should be assumed when executing the task.</p>",
         "SendCommandRequest$ServiceRoleArn": "<p>The IAM role that Systems Manager uses to send notifications. </p>",
-        "UpdateMaintenanceWindowTaskRequest$ServiceRoleArn": "<p>The IAM service role ARN that you want to modify. The system assumes this role during task exectuion. </p>",
+        "UpdateMaintenanceWindowTaskRequest$ServiceRoleArn": "<p>The IAM service role ARN to modify. The system assumes this role during task execution. </p>",
         "UpdateMaintenanceWindowTaskResult$ServiceRoleArn": "<p>The updated service role ARN value.</p>"
       }
     },
@@ -4443,6 +4511,7 @@
       "refs": {
         "AlreadyExistsException$Message": null,
         "AssociationDoesNotExist$Message": null,
+        "AssociationVersionLimitExceeded$Message": null,
         "AutomationDefinitionNotFoundException$Message": null,
         "AutomationDefinitionVersionNotFoundException$Message": null,
         "AutomationExecution$FailureMessage": "<p>A message describing why an execution has failed, if the status is set to Failed.</p>",
@@ -4471,6 +4540,7 @@
         "InvalidActivation$Message": null,
         "InvalidActivationId$Message": null,
         "InvalidAllowedPatternException$message": "<p>The request does not meet the regular expression requirement.</p>",
+        "InvalidAssociationVersion$Message": null,
         "InvalidAutomationExecutionParametersException$Message": null,
         "InvalidAutomationSignalException$Message": null,
         "InvalidDocument$Message": "<p>The document does not exist or the document is not available to the user. This exception can be issued by CreateAssociation, CreateAssociationBatch, DeleteAssociation, DeleteDocument, DescribeAssociation, DescribeDocument, GetDocument, SendCommand, or UpdateAssociationStatus. </p>",
@@ -4612,6 +4682,7 @@
       "refs": {
         "Association$Targets": "<p>The instances targeted by the request to create an association. </p>",
         "AssociationDescription$Targets": "<p>The instances targeted by the request. </p>",
+        "AssociationVersionInfo$Targets": "<p>The targets specified for the association when the association version was created. </p>",
         "Command$Targets": "<p>An array of search criteria that targets instances using a Key,Value combination that you specify. Targets is required if you don't provide one or more instance IDs in the call.</p>",
         "CreateAssociationBatchRequestEntry$Targets": "<p>The instances targeted by the request.</p>",
         "CreateAssociationRequest$Targets": "<p>The targets (either instances or tags) for the association.</p>",
@@ -4622,16 +4693,16 @@
         "RegisterTaskWithMaintenanceWindowRequest$Targets": "<p>The targets (either instances or tags). Instances are specified using Key=instanceids,Values=&lt;instanceid1&gt;,&lt;instanceid2&gt;. Tags are specified using Key=&lt;tag name&gt;,Values=&lt;tag value&gt;.</p>",
         "SendCommandRequest$Targets": "<p>(Optional) An array of search criteria that targets instances using a Key,Value combination that you specify. Targets is required if you don't provide one or more instance IDs in the call. For more information about how to use Targets, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/send-commands-multiple.html\">Sending Commands to a Fleet</a>.</p>",
         "UpdateAssociationRequest$Targets": "<p>The targets of the association.</p>",
-        "UpdateMaintenanceWindowTargetRequest$Targets": "<p>The targets that you want to add or replace.</p>",
+        "UpdateMaintenanceWindowTargetRequest$Targets": "<p>The targets to add or replace.</p>",
         "UpdateMaintenanceWindowTargetResult$Targets": "<p>The updated targets.</p>",
-        "UpdateMaintenanceWindowTaskRequest$Targets": "<p>The targets (either instances or tags) that you want to modify. Instances are specified using Key=instanceids,Values=instanceID_1,instanceID_2. Tags are specified using Key=tag_name,Values=tag_value. </p>",
+        "UpdateMaintenanceWindowTaskRequest$Targets": "<p>The targets (either instances or tags) to modify. Instances are specified using Key=instanceids,Values=instanceID_1,instanceID_2. Tags are specified using Key=tag_name,Values=tag_value. </p>",
         "UpdateMaintenanceWindowTaskResult$Targets": "<p>The updated target values.</p>"
       }
     },
     "TimeoutSeconds": {
       "base": null,
       "refs": {
-        "MaintenanceWindowRunCommandParameters$TimeoutSeconds": "<p>If this time is reached and the command has not already started executing, it will not execute.</p>",
+        "MaintenanceWindowRunCommandParameters$TimeoutSeconds": "<p>If this time is reached and the command has not already started executing, it doesn not execute.</p>",
         "SendCommandRequest$TimeoutSeconds": "<p>If this time is reached and the command has not already started executing, it will not execute.</p>"
       }
     },
@@ -4651,7 +4722,7 @@
       }
     },
     "UnsupportedInventoryItemContextException": {
-      "base": "<p>The <code>Context</code> attribute you specified for the <code>InventoryItem</code> is not allowed for this inventory type. You can only use the <code>Context</code> attribute with inventory types like <code>AWS:ComplianceItem</code>.</p>",
+      "base": "<p>The <code>Context</code> attribute that you specified for the <code>InventoryItem</code> is not allowed for this inventory type. You can only use the <code>Context</code> attribute with inventory types like <code>AWS:ComplianceItem</code>.</p>",
       "refs": {
       }
     },

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -2191,6 +2191,11 @@ func (c *SSM) DescribeAssociationRequest(input *DescribeAssociationInput) (req *
 //   * ErrCodeAssociationDoesNotExist "AssociationDoesNotExist"
 //   The specified association does not exist.
 //
+//   * ErrCodeInvalidAssociationVersion "InvalidAssociationVersion"
+//   The version you specified is not valid. Use ListAssociationVersions to view
+//   all versions of an association according to the association ID. Or, use the
+//   $LATEST parameter to view the latest version of the association.
+//
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
 //
@@ -5852,6 +5857,91 @@ func (c *SSM) GetPatchBaselineForPatchGroupWithContext(ctx aws.Context, input *G
 	return out, req.Send()
 }
 
+const opListAssociationVersions = "ListAssociationVersions"
+
+// ListAssociationVersionsRequest generates a "aws/request.Request" representing the
+// client's request for the ListAssociationVersions operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListAssociationVersions for more information on using the ListAssociationVersions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListAssociationVersionsRequest method.
+//    req, resp := client.ListAssociationVersionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ListAssociationVersions
+func (c *SSM) ListAssociationVersionsRequest(input *ListAssociationVersionsInput) (req *request.Request, output *ListAssociationVersionsOutput) {
+	op := &request.Operation{
+		Name:       opListAssociationVersions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListAssociationVersionsInput{}
+	}
+
+	output = &ListAssociationVersionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListAssociationVersions API operation for Amazon Simple Systems Manager (SSM).
+//
+// Retrieves all versions of an association for a specific association ID.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Systems Manager (SSM)'s
+// API operation ListAssociationVersions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+//   * ErrCodeInvalidNextToken "InvalidNextToken"
+//   The specified token is not valid.
+//
+//   * ErrCodeAssociationDoesNotExist "AssociationDoesNotExist"
+//   The specified association does not exist.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ListAssociationVersions
+func (c *SSM) ListAssociationVersions(input *ListAssociationVersionsInput) (*ListAssociationVersionsOutput, error) {
+	req, out := c.ListAssociationVersionsRequest(input)
+	return out, req.Send()
+}
+
+// ListAssociationVersionsWithContext is the same as ListAssociationVersions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListAssociationVersions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SSM) ListAssociationVersionsWithContext(ctx aws.Context, input *ListAssociationVersionsInput, opts ...request.Option) (*ListAssociationVersionsOutput, error) {
+	req, out := c.ListAssociationVersionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListAssociations = "ListAssociations"
 
 // ListAssociationsRequest generates a "aws/request.Request" representing the
@@ -6354,9 +6444,10 @@ func (c *SSM) ListComplianceItemsRequest(input *ListComplianceItemsInput) (req *
 
 // ListComplianceItems API operation for Amazon Simple Systems Manager (SSM).
 //
-// For a specified resource ID, this API returns a list of compliance statuses
-// for different resource types. Currently, you can only specify one resource
-// ID per call. List results depend on the criteria specified in the filter.
+// For a specified resource ID, this API action returns a list of compliance
+// statuses for different resource types. Currently, you can only specify one
+// resource ID per call. List results depend on the criteria specified in the
+// filter.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6452,7 +6543,7 @@ func (c *SSM) ListComplianceSummariesRequest(input *ListComplianceSummariesInput
 //
 // Returns a summary count of compliant and non-compliant resources for a compliance
 // type. For example, this call can return State Manager associations, patches,
-// or custom compliance types according to the filter criteria you specify.
+// or custom compliance types according to the filter criteria that you specify.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -7232,9 +7323,10 @@ func (c *SSM) PutComplianceItemsRequest(input *PutComplianceItemsInput) (req *re
 // PutComplianceItems API operation for Amazon Simple Systems Manager (SSM).
 //
 // Registers a compliance type and other compliance details on a designated
-// resource. This API lets you register custom compliance details with a resource.
-// This call overwrites existing compliance information on the resource, so
-// you must provide a full list of compliance items each time you send the request.
+// resource. This action lets you register custom compliance details with a
+// resource. This call overwrites existing compliance information on the resource,
+// so you must provide a full list of compliance items each time that you send
+// the request.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -7389,7 +7481,7 @@ func (c *SSM) PutInventoryRequest(input *PutInventoryInput) (req *request.Reques
 //   for each type.
 //
 //   * ErrCodeUnsupportedInventoryItemContextException "UnsupportedInventoryItemContextException"
-//   The Context attribute you specified for the InventoryItem is not allowed
+//   The Context attribute that you specified for the InventoryItem is not allowed
 //   for this inventory type. You can only use the Context attribute with inventory
 //   types like AWS:ComplianceItem.
 //
@@ -7877,7 +7969,7 @@ func (c *SSM) RegisterTaskWithMaintenanceWindowRequest(input *RegisterTaskWithMa
 //
 //   * ErrCodeFeatureNotAvailableException "FeatureNotAvailableException"
 //   You attempted to register a LAMBDA or STEP_FUNCTION task in a region where
-//   there corresponding service is not available.
+//   the corresponding service is not available.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -8424,8 +8516,8 @@ func (c *SSM) UpdateAssociationRequest(input *UpdateAssociationInput) (req *requ
 
 // UpdateAssociation API operation for Amazon Simple Systems Manager (SSM).
 //
-// Updates an association. You can only update the document version, schedule,
-// parameters, and Amazon S3 output of an association.
+// Updates an association. You can update the association name and version,
+// the document version, schedule, parameters, and Amazon S3 output.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -8467,6 +8559,15 @@ func (c *SSM) UpdateAssociationRequest(input *UpdateAssociationInput) (req *requ
 //   * ErrCodeInvalidTarget "InvalidTarget"
 //   The target is not valid or does not exist. It might not be configured for
 //   EC2 Systems Manager or you might not have permission to perform the operation.
+//
+//   * ErrCodeInvalidAssociationVersion "InvalidAssociationVersion"
+//   The version you specified is not valid. Use ListAssociationVersions to view
+//   all versions of an association according to the association ID. Or, use the
+//   $LATEST parameter to view the latest version of the association.
+//
+//   * ErrCodeAssociationVersionLimitExceeded "AssociationVersionLimitExceeded"
+//   You have reached the maximum number versions allowed for an association.
+//   Each association has a limit of 1,000 versions.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/UpdateAssociation
 func (c *SSM) UpdateAssociation(input *UpdateAssociationInput) (*UpdateAssociationOutput, error) {
@@ -8921,18 +9022,17 @@ func (c *SSM) UpdateMaintenanceWindowTargetRequest(input *UpdateMaintenanceWindo
 // The target from being an ID target to a Tag target, or a Tag target to an
 // ID target.
 //
-// The IDs of an ID target.
+// IDs for an ID target.
 //
-// The tags of a Tag target.
+// Tags for a Tag target.
 //
-// The Owner.
+// Owner.
 //
-// The Name.
+// Name.
 //
-// The Description.
+// Description.
 //
-// Also note that if a parameter is null, then the corresponding field is not
-// modified.
+// If a parameter is null, then the corresponding field is not modified.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -9016,25 +9116,25 @@ func (c *SSM) UpdateMaintenanceWindowTaskRequest(input *UpdateMaintenanceWindowT
 // UpdateMaintenanceWindowTask API operation for Amazon Simple Systems Manager (SSM).
 //
 // Modifies a task assigned to a Maintenance Window. You can't change the task
-// type, but you can change the following:
+// type, but you can change the following values:
 //
-// The Task Arn. For example, you can change a RUN_COMMAND task from AWS-RunPowerShellScript
+// Task ARN. For example, you can change a RUN_COMMAND task from AWS-RunPowerShellScript
 // to AWS-RunShellScript.
 //
-// The service role ARN.
+// Service role ARN.
 //
-// The task parameters.
+// Task parameters.
 //
-// The task priority.
+// Task priority.
 //
-// The task MaxConcurrency and MaxErrors.
+// Task MaxConcurrency and MaxErrors.
 //
-// The log location.
+// Log location.
 //
 // If a parameter is null, then the corresponding field is not modified. Also,
 // if you set Replace to true, then all fields required by the RegisterTaskWithMaintenanceWindow
-// operation are required for this request. Optional fields that aren't specified
-// are be set to null.
+// action are required for this request. Optional fields that aren't specified
+// are set to null.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -9456,6 +9556,12 @@ type Association struct {
 	// is a binding between a document and a set of targets with a schedule.
 	AssociationId *string `type:"string"`
 
+	// The association name.
+	AssociationName *string `type:"string"`
+
+	// The association version.
+	AssociationVersion *string `type:"string"`
+
 	// The version of the document used in the association.
 	DocumentVersion *string `type:"string"`
 
@@ -9491,6 +9597,18 @@ func (s Association) GoString() string {
 // SetAssociationId sets the AssociationId field's value.
 func (s *Association) SetAssociationId(v string) *Association {
 	s.AssociationId = &v
+	return s
+}
+
+// SetAssociationName sets the AssociationName field's value.
+func (s *Association) SetAssociationName(v string) *Association {
+	s.AssociationName = &v
+	return s
+}
+
+// SetAssociationVersion sets the AssociationVersion field's value.
+func (s *Association) SetAssociationVersion(v string) *Association {
+	s.AssociationVersion = &v
 	return s
 }
 
@@ -9543,6 +9661,12 @@ type AssociationDescription struct {
 
 	// The association ID.
 	AssociationId *string `type:"string"`
+
+	// The association name.
+	AssociationName *string `type:"string"`
+
+	// The association version.
+	AssociationVersion *string `type:"string"`
 
 	// The date when the association was made.
 	Date *time.Time `type:"timestamp" timestampFormat:"unix"`
@@ -9597,6 +9721,18 @@ func (s AssociationDescription) GoString() string {
 // SetAssociationId sets the AssociationId field's value.
 func (s *AssociationDescription) SetAssociationId(v string) *AssociationDescription {
 	s.AssociationId = &v
+	return s
+}
+
+// SetAssociationName sets the AssociationName field's value.
+func (s *AssociationDescription) SetAssociationName(v string) *AssociationDescription {
+	s.AssociationName = &v
+	return s
+}
+
+// SetAssociationVersion sets the AssociationVersion field's value.
+func (s *AssociationDescription) SetAssociationVersion(v string) *AssociationDescription {
+	s.AssociationVersion = &v
 	return s
 }
 
@@ -9857,6 +9993,116 @@ func (s *AssociationStatus) SetMessage(v string) *AssociationStatus {
 // SetName sets the Name field's value.
 func (s *AssociationStatus) SetName(v string) *AssociationStatus {
 	s.Name = &v
+	return s
+}
+
+// Information about the association version.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/AssociationVersionInfo
+type AssociationVersionInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The ID created by the system when the association was created.
+	AssociationId *string `type:"string"`
+
+	// The name specified for the association version when the association version
+	// was created.
+	AssociationName *string `type:"string"`
+
+	// The association version.
+	AssociationVersion *string `type:"string"`
+
+	// The date the association version was created.
+	CreatedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The version of an SSM document used when the association version was created.
+	DocumentVersion *string `type:"string"`
+
+	// The name specified when the association was created.
+	Name *string `type:"string"`
+
+	// The location in Amazon S3 specified for the association when the association
+	// version was created.
+	OutputLocation *InstanceAssociationOutputLocation `type:"structure"`
+
+	// Parameters specified when the association version was created.
+	Parameters map[string][]*string `type:"map"`
+
+	// The cron or rate schedule specified for the association when the association
+	// version was created.
+	ScheduleExpression *string `min:"1" type:"string"`
+
+	// The targets specified for the association when the association version was
+	// created.
+	Targets []*Target `type:"list"`
+}
+
+// String returns the string representation
+func (s AssociationVersionInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociationVersionInfo) GoString() string {
+	return s.String()
+}
+
+// SetAssociationId sets the AssociationId field's value.
+func (s *AssociationVersionInfo) SetAssociationId(v string) *AssociationVersionInfo {
+	s.AssociationId = &v
+	return s
+}
+
+// SetAssociationName sets the AssociationName field's value.
+func (s *AssociationVersionInfo) SetAssociationName(v string) *AssociationVersionInfo {
+	s.AssociationName = &v
+	return s
+}
+
+// SetAssociationVersion sets the AssociationVersion field's value.
+func (s *AssociationVersionInfo) SetAssociationVersion(v string) *AssociationVersionInfo {
+	s.AssociationVersion = &v
+	return s
+}
+
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *AssociationVersionInfo) SetCreatedDate(v time.Time) *AssociationVersionInfo {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetDocumentVersion sets the DocumentVersion field's value.
+func (s *AssociationVersionInfo) SetDocumentVersion(v string) *AssociationVersionInfo {
+	s.DocumentVersion = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AssociationVersionInfo) SetName(v string) *AssociationVersionInfo {
+	s.Name = &v
+	return s
+}
+
+// SetOutputLocation sets the OutputLocation field's value.
+func (s *AssociationVersionInfo) SetOutputLocation(v *InstanceAssociationOutputLocation) *AssociationVersionInfo {
+	s.OutputLocation = v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *AssociationVersionInfo) SetParameters(v map[string][]*string) *AssociationVersionInfo {
+	s.Parameters = v
+	return s
+}
+
+// SetScheduleExpression sets the ScheduleExpression field's value.
+func (s *AssociationVersionInfo) SetScheduleExpression(v string) *AssociationVersionInfo {
+	s.ScheduleExpression = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *AssociationVersionInfo) SetTargets(v []*Target) *AssociationVersionInfo {
+	s.Targets = v
 	return s
 }
 
@@ -10966,7 +11212,7 @@ type ComplianceItem struct {
 	_ struct{} `type:"structure"`
 
 	// The compliance type. For example, Association (for a State Manager association),
-	// Patch, or Custom:string are all valide compliance types.
+	// Patch, or Custom:string are all valid compliance types.
 	ComplianceType *string `min:"1" type:"string"`
 
 	// A "Key": "Value" tag combination for the compliance item.
@@ -10988,7 +11234,7 @@ type ComplianceItem struct {
 	ResourceType *string `min:"1" type:"string"`
 
 	// The severity of the compliance status. Severity can be one of the following:
-	// Critical, HIGH, Medium, Low, Informational, Unspecified.
+	// Critical, High, Medium, Low, Informational, Unspecified.
 	Severity *string `type:"string" enum:"ComplianceSeverity"`
 
 	// The status of the compliance item. An item is either COMPLIANT or NON_COMPLIANT.
@@ -11164,7 +11410,7 @@ type ComplianceStringFilter struct {
 	// BeginWith, LessThan, or GreaterThan.
 	Type *string `type:"string" enum:"ComplianceQueryOperatorType"`
 
-	// The value you want to search for.
+	// The value for which to search.
 	Values []*string `locationNameList:"FilterValue" min:"1" type:"list"`
 }
 
@@ -11499,6 +11745,9 @@ func (s *CreateAssociationBatchOutput) SetSuccessful(v []*AssociationDescription
 type CreateAssociationBatchRequestEntry struct {
 	_ struct{} `type:"structure"`
 
+	// Specify a descriptive name for the association.
+	AssociationName *string `type:"string"`
+
 	// The document version.
 	DocumentVersion *string `type:"string"`
 
@@ -11564,6 +11813,12 @@ func (s *CreateAssociationBatchRequestEntry) Validate() error {
 	return nil
 }
 
+// SetAssociationName sets the AssociationName field's value.
+func (s *CreateAssociationBatchRequestEntry) SetAssociationName(v string) *CreateAssociationBatchRequestEntry {
+	s.AssociationName = &v
+	return s
+}
+
 // SetDocumentVersion sets the DocumentVersion field's value.
 func (s *CreateAssociationBatchRequestEntry) SetDocumentVersion(v string) *CreateAssociationBatchRequestEntry {
 	s.DocumentVersion = &v
@@ -11609,6 +11864,9 @@ func (s *CreateAssociationBatchRequestEntry) SetTargets(v []*Target) *CreateAsso
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/CreateAssociationRequest
 type CreateAssociationInput struct {
 	_ struct{} `type:"structure"`
+
+	// Specify a descriptive name for the association.
+	AssociationName *string `type:"string"`
 
 	// The document version you want to associate with the target(s). Can be a specific
 	// version or the default version.
@@ -11674,6 +11932,12 @@ func (s *CreateAssociationInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAssociationName sets the AssociationName field's value.
+func (s *CreateAssociationInput) SetAssociationName(v string) *CreateAssociationInput {
+	s.AssociationName = &v
+	return s
 }
 
 // SetDocumentVersion sets the DocumentVersion field's value.
@@ -11836,8 +12100,13 @@ func (s *CreateDocumentOutput) SetDocumentDescription(v *DocumentDescription) *C
 type CreateMaintenanceWindowInput struct {
 	_ struct{} `type:"structure"`
 
-	// Whether targets must be registered with the Maintenance Window before tasks
-	// can be defined for those targets.
+	// Enables a Maintenance Window task to execute on managed instances, even if
+	// you have not registered those instances as targets. If enabled, then you
+	// must specify the unregistered instances (by instance ID) when you register
+	// a task with the Maintenance Window
+	//
+	// If you don't enable this option, then you must specify previously-registered
+	// targets when you register a task with the Maintenance Window.
 	//
 	// AllowUnassociatedTargets is a required field
 	AllowUnassociatedTargets *bool `type:"boolean" required:"true"`
@@ -11852,7 +12121,7 @@ type CreateMaintenanceWindowInput struct {
 	Cutoff *int64 `type:"integer" required:"true"`
 
 	// An optional description for the Maintenance Window. We recommend specifying
-	// a description to help your organize your Maintenance Windows.
+	// a description to help you organize your Maintenance Windows.
 	Description *string `min:"1" type:"string"`
 
 	// The duration of the Maintenance Window in hours.
@@ -12861,7 +13130,7 @@ type DeregisterTargetFromMaintenanceWindowInput struct {
 	_ struct{} `type:"structure"`
 
 	// The system checks if the target is being referenced by a task. If the target
-	// is being referenced, the system returns and error and does not deregister
+	// is being referenced, the system returns an error and does not deregister
 	// the target from the Maintenance Window.
 	Safe *bool `type:"boolean"`
 
@@ -13183,6 +13452,12 @@ type DescribeAssociationInput struct {
 	// The association ID for which you want information.
 	AssociationId *string `type:"string"`
 
+	// Specify the association version to retrieve. To view the latest version,
+	// either specify $LATEST for this parameter, or omit this parameter. To view
+	// a list of all associations for an instance, use ListInstanceAssociations.
+	// To get a list of versions for a specific association, use ListAssociationVersions.
+	AssociationVersion *string `type:"string"`
+
 	// The instance ID.
 	InstanceId *string `type:"string"`
 
@@ -13203,6 +13478,12 @@ func (s DescribeAssociationInput) GoString() string {
 // SetAssociationId sets the AssociationId field's value.
 func (s *DescribeAssociationInput) SetAssociationId(v string) *DescribeAssociationInput {
 	s.AssociationId = &v
+	return s
+}
+
+// SetAssociationVersion sets the AssociationVersion field's value.
+func (s *DescribeAssociationInput) SetAssociationVersion(v string) *DescribeAssociationInput {
+	s.AssociationVersion = &v
 	return s
 }
 
@@ -17127,7 +17408,7 @@ type GetMaintenanceWindowExecutionTaskInvocationInput struct {
 	// TaskId is a required field
 	TaskId *string `min:"36" type:"string" required:"true"`
 
-	// The ID of the Maintenance Window execution the task is part of.
+	// The ID of the Maintenance Window execution for which the task is a part.
 	//
 	// WindowExecutionId is a required field
 	WindowExecutionId *string `min:"36" type:"string" required:"true"`
@@ -17193,7 +17474,7 @@ func (s *GetMaintenanceWindowExecutionTaskInvocationInput) SetWindowExecutionId(
 type GetMaintenanceWindowExecutionTaskInvocationOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The time the task finished executing on the target.
+	// The time that the task finished executing on the target.
 	EndTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// The execution ID.
@@ -17202,14 +17483,14 @@ type GetMaintenanceWindowExecutionTaskInvocationOutput struct {
 	// The invocation ID.
 	InvocationId *string `min:"36" type:"string"`
 
-	// User-provided value that will be included in any CloudWatch events raised
-	// while running tasks for these targets in this Maintenance Window.
+	// User-provided value to be included in any CloudWatch events raised while
+	// running tasks for these targets in this Maintenance Window.
 	OwnerInformation *string `min:"1" type:"string"`
 
-	// The parameters used at the time the task executed.
+	// The parameters used at the time that the task executed.
 	Parameters *string `type:"string"`
 
-	// The time the task started executing on the target.
+	// The time that the task started executing on the target.
 	StartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// The task status for an invocation.
@@ -17669,7 +17950,7 @@ type GetMaintenanceWindowTaskOutput struct {
 	// The retrieved task description.
 	Description *string `min:"1" type:"string"`
 
-	// The location in Amazon S3 where the task results will be logged.
+	// The location in Amazon S3 where the task results are logged.
 	LoggingInfo *LoggingInfo `type:"structure"`
 
 	// The maximum number of targets allowed to run this task in parallel.
@@ -17691,10 +17972,10 @@ type GetMaintenanceWindowTaskOutput struct {
 	// The targets where the task should execute.
 	Targets []*Target `type:"list"`
 
-	// TaskArn is the resource that the task used during execution. For RUN_COMMAND
-	// and AUTOMATION task types, the TaskArn is the SSM Document Name/ARN. For
-	// LAMBDA tasks, TaskArn is the Function Name/ARN. For STEP_FUNCTION tasks,
-	// the TaskArn is the State Machine ARN.
+	// The resource that the task used during execution. For RUN_COMMAND and AUTOMATION
+	// task types, the TaskArn is the SSM Document name/ARN. For LAMBDA tasks, the
+	// value is the function name/ARN. For STEP_FUNCTION tasks, the value is the
+	// state machine ARN.
 	TaskArn *string `min:"1" type:"string"`
 
 	// The parameters to pass to the task when it executes.
@@ -18522,6 +18803,9 @@ type InstanceAssociation struct {
 	// The association ID.
 	AssociationId *string `type:"string"`
 
+	// Version information for the association on the instance.
+	AssociationVersion *string `type:"string"`
+
 	// The content of the association document for the instance(s).
 	Content *string `min:"1" type:"string"`
 
@@ -18542,6 +18826,12 @@ func (s InstanceAssociation) GoString() string {
 // SetAssociationId sets the AssociationId field's value.
 func (s *InstanceAssociation) SetAssociationId(v string) *InstanceAssociation {
 	s.AssociationId = &v
+	return s
+}
+
+// SetAssociationVersion sets the AssociationVersion field's value.
+func (s *InstanceAssociation) SetAssociationVersion(v string) *InstanceAssociation {
+	s.AssociationVersion = &v
 	return s
 }
 
@@ -18630,6 +18920,12 @@ type InstanceAssociationStatusInfo struct {
 	// The association ID.
 	AssociationId *string `type:"string"`
 
+	// The name of the association applied to the instance.
+	AssociationName *string `type:"string"`
+
+	// The version of the association applied to the instance.
+	AssociationVersion *string `type:"string"`
+
 	// Detailed status information about the instance association.
 	DetailedStatus *string `type:"string"`
 
@@ -18672,6 +18968,18 @@ func (s InstanceAssociationStatusInfo) GoString() string {
 // SetAssociationId sets the AssociationId field's value.
 func (s *InstanceAssociationStatusInfo) SetAssociationId(v string) *InstanceAssociationStatusInfo {
 	s.AssociationId = &v
+	return s
+}
+
+// SetAssociationName sets the AssociationName field's value.
+func (s *InstanceAssociationStatusInfo) SetAssociationName(v string) *InstanceAssociationStatusInfo {
+	s.AssociationName = &v
+	return s
+}
+
+// SetAssociationVersion sets the AssociationVersion field's value.
+func (s *InstanceAssociationStatusInfo) SetAssociationVersion(v string) *InstanceAssociationStatusInfo {
+	s.AssociationVersion = &v
 	return s
 }
 
@@ -19646,6 +19954,103 @@ func (s *InventoryResultItem) SetTypeName(v string) *InventoryResultItem {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ListAssociationVersionsRequest
+type ListAssociationVersionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The association ID for which you want to view all versions.
+	//
+	// AssociationId is a required field
+	AssociationId *string `type:"string" required:"true"`
+
+	// The maximum number of items to return for this call. The call also returns
+	// a token that you can specify in a subsequent call to get the next set of
+	// results.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// A token to start the list. Use this token to get the next set of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListAssociationVersionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListAssociationVersionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAssociationVersionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAssociationVersionsInput"}
+	if s.AssociationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssociationId"))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAssociationId sets the AssociationId field's value.
+func (s *ListAssociationVersionsInput) SetAssociationId(v string) *ListAssociationVersionsInput {
+	s.AssociationId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListAssociationVersionsInput) SetMaxResults(v int64) *ListAssociationVersionsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssociationVersionsInput) SetNextToken(v string) *ListAssociationVersionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ListAssociationVersionsResult
+type ListAssociationVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about all versions of the association for the specified association
+	// ID.
+	AssociationVersions []*AssociationVersionInfo `min:"1" type:"list"`
+
+	// The token for the next set of items to return. Use this token to get the
+	// next set of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListAssociationVersionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListAssociationVersionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetAssociationVersions sets the AssociationVersions field's value.
+func (s *ListAssociationVersionsOutput) SetAssociationVersions(v []*AssociationVersionInfo) *ListAssociationVersionsOutput {
+	s.AssociationVersions = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAssociationVersionsOutput) SetNextToken(v string) *ListAssociationVersionsOutput {
+	s.NextToken = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ListAssociationsRequest
 type ListAssociationsInput struct {
 	_ struct{} `type:"structure"`
@@ -20031,11 +20436,11 @@ type ListComplianceItemsInput struct {
 	// A token to start the list. Use this token to get the next set of results.
 	NextToken *string `type:"string"`
 
-	// The ID for the resources from which you want to get compliance information.
-	// Currently, you can only specify one resource ID.
+	// The ID for the resources from which to get compliance information. Currently,
+	// you can only specify one resource ID.
 	ResourceIds []*string `min:"1" type:"list"`
 
-	// The type of resource from which you want to get compliance information. Currently,
+	// The type of resource from which to get compliance information. Currently,
 	// the only supported resource type is ManagedInstance.
 	ResourceTypes []*string `min:"1" type:"list"`
 }
@@ -20217,7 +20622,7 @@ type ListComplianceSummariesOutput struct {
 
 	// A list of compliant and non-compliant summary counts based on compliance
 	// types. For example, this call returns State Manager associations, patches,
-	// or custom compliance types according to the filter criteria you specified.
+	// or custom compliance types according to the filter criteria that you specified.
 	ComplianceSummaryItems []*ComplianceSummaryItem `locationNameList:"Item" type:"list"`
 
 	// The token for the next set of items to return. Use this token to get the
@@ -20698,7 +21103,7 @@ type ListResourceComplianceSummariesOutput struct {
 
 	// A summary count for specified or targeted managed instances. Summary count
 	// includes information about compliant and non-compliant State Manager associations,
-	// patch statuses, or custom items according to the filter criteria you specify.
+	// patch status, or custom items according to the filter criteria that you specify.
 	ResourceComplianceSummaryItems []*ResourceComplianceSummaryItem `locationNameList:"Item" type:"list"`
 }
 
@@ -20952,15 +21357,15 @@ func (s *LoggingInfo) SetS3Region(v string) *LoggingInfo {
 	return s
 }
 
-// Parameters for an AUTOMATION task type.
+// The parameters for an AUTOMATION task type.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/MaintenanceWindowAutomationParameters
 type MaintenanceWindowAutomationParameters struct {
 	_ struct{} `type:"structure"`
 
-	// The version of an SSM Automation document to use during task execution.
+	// The version of an Automation document to use during task execution.
 	DocumentVersion *string `type:"string"`
 
-	// Parameters for the AUTOMATION task.
+	// The parameters for the AUTOMATION task.
 	Parameters map[string][]*string `min:"1" type:"map"`
 }
 
@@ -21407,26 +21812,25 @@ func (s *MaintenanceWindowIdentity) SetWindowId(v string) *MaintenanceWindowIden
 	return s
 }
 
-// Parameters for a LAMBDA task type.
+// The parameters for a LAMBDA task type.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/MaintenanceWindowLambdaParameters
 type MaintenanceWindowLambdaParameters struct {
 	_ struct{} `type:"structure"`
 
-	// Using the ClientContext you can pass client-specific information to the Lambda
-	// function you are invoking. You can then process the client information in
-	// your Lambda function as you choose through the context variable.
+	// Pass client-specific information to the Lambda function that you are invoking.
+	// You can then process the client information in your Lambda function as you
+	// choose through the context variable.
 	ClientContext *string `min:"1" type:"string"`
 
-	// JSON that you want to provide to your Lambda function as input.
+	// JSON to provide to your Lambda function as input.
 	//
 	// Payload is automatically base64 encoded/decoded by the SDK.
 	Payload []byte `type:"blob"`
 
-	// You can use this optional parameter to specify a Lambda function version
-	// or alias name. If you specify a function version, the API uses the qualified
-	// function ARN to invoke a specific Lambda function. If you specify an alias
-	// name, the API uses the alias ARN to invoke the Lambda function version to
-	// which the alias points.
+	// (Optional) Specify a Lambda function version or alias name. If you specify
+	// a function version, the action uses the qualified function ARN to invoke
+	// a specific Lambda function. If you specify an alias name, the action uses
+	// the alias ARN to invoke the Lambda function version to which the alias points.
 	Qualifier *string `min:"1" type:"string"`
 }
 
@@ -21474,7 +21878,7 @@ func (s *MaintenanceWindowLambdaParameters) SetQualifier(v string) *MaintenanceW
 	return s
 }
 
-// Parameters for a RUN_COMMAND task type.
+// The parameters for a RUN_COMMAND task type.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/MaintenanceWindowRunCommandParameters
 type MaintenanceWindowRunCommandParameters struct {
 	_ struct{} `type:"structure"`
@@ -21482,15 +21886,15 @@ type MaintenanceWindowRunCommandParameters struct {
 	// Information about the command(s) to execute.
 	Comment *string `type:"string"`
 
-	// The Sha256 or Sha1 hash created by the system when the document was created.
-	// Sha1 hashes have been deprecated.
+	// The SHA-256 or SHA-1 hash created by the system when the document was created.
+	// SHA-1 hashes have been deprecated.
 	DocumentHash *string `type:"string"`
 
-	// Sha256 or Sha1. Sha1 hashes have been deprecated.
+	// SHA-256 or SHA-1. SHA-1 hashes have been deprecated.
 	DocumentHashType *string `type:"string" enum:"DocumentHashType"`
 
 	// Configurations for sending notifications about command status changes on
-	// a per instance basis.
+	// a per-instance basis.
 	NotificationConfig *NotificationConfig `type:"structure"`
 
 	// The name of the Amazon S3 bucket.
@@ -21499,14 +21903,14 @@ type MaintenanceWindowRunCommandParameters struct {
 	// The Amazon S3 bucket subfolder.
 	OutputS3KeyPrefix *string `type:"string"`
 
-	// Parameters for the RUN_COMMAND task execution.
+	// The parameters for the RUN_COMMAND task execution.
 	Parameters map[string][]*string `type:"map"`
 
-	// The IAM service role that to assume during task execution.
+	// The IAM service role to assume during task execution.
 	ServiceRoleArn *string `type:"string"`
 
 	// If this time is reached and the command has not already started executing,
-	// it will not execute.
+	// it doesn not execute.
 	TimeoutSeconds *int64 `min:"30" type:"integer"`
 }
 
@@ -21590,7 +21994,7 @@ func (s *MaintenanceWindowRunCommandParameters) SetTimeoutSeconds(v int64) *Main
 	return s
 }
 
-// Parameters for the STEP_FUNCTION execution.
+// The parameters for the STEP_FUNCTION execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/MaintenanceWindowStepFunctionsParameters
 type MaintenanceWindowStepFunctionsParameters struct {
 	_ struct{} `type:"structure"`
@@ -21750,10 +22154,10 @@ type MaintenanceWindowTask struct {
 	// Tags are specified using Key=<tag name>,Values=<tag value>.
 	Targets []*Target `type:"list"`
 
-	// TaskArn is the resource that the task uses during execution. For RUN_COMMAND
-	// and AUTOMATION task types, the TaskArn is the SSM Document Name/ARN. For
-	// LAMBDA tasks, it's the Function Name/ARN. For STEP_FUNCTION tasks, it's the
-	// State Machine ARN.
+	// The resource that the task uses during execution. For RUN_COMMAND and AUTOMATION
+	// task types, TaskArn is the SSM document name or ARN. For LAMBDA tasks, it's
+	// the function name or ARN. For STEP_FUNCTION tasks, it's the state machine
+	// ARN.
 	TaskArn *string `min:"1" type:"string"`
 
 	// The parameters that should be passed to the task when it is executed.
@@ -21858,21 +22262,21 @@ func (s *MaintenanceWindowTask) SetWindowTaskId(v string) *MaintenanceWindowTask
 	return s
 }
 
-// Parameters for task execution.
+// The parameters for task execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/MaintenanceWindowTaskInvocationParameters
 type MaintenanceWindowTaskInvocationParameters struct {
 	_ struct{} `type:"structure"`
 
-	// Parameters for a AUTOMATION task type.
+	// The parameters for a AUTOMATION task type.
 	Automation *MaintenanceWindowAutomationParameters `type:"structure"`
 
-	// Parameters for a LAMBDA task type.
+	// The parameters for a LAMBDA task type.
 	Lambda *MaintenanceWindowLambdaParameters `type:"structure"`
 
-	// Parameters for a RUN_COMMAND task type.
+	// The parameters for a RUN_COMMAND task type.
 	RunCommand *MaintenanceWindowRunCommandParameters `type:"structure"`
 
-	// Parameters for a STEP_FUNCTION task type.
+	// The parameters for a STEP_FUNCTION task type.
 	StepFunctions *MaintenanceWindowStepFunctionsParameters `type:"structure"`
 }
 
@@ -23138,9 +23542,9 @@ type PutComplianceItemsInput struct {
 	// ExecutionSummary is a required field
 	ExecutionSummary *ComplianceExecutionSummary `type:"structure" required:"true"`
 
-	// MD5 or Sha256 content hash. The content hash is used to determine if existing
+	// MD5 or SHA-256 content hash. The content hash is used to determine if existing
 	// information should be overwritten or ignored. If the content hashes match,
-	// ,the request to put compliance information is ignored.
+	// the request to put compliance information is ignored.
 	ItemContentHash *string `type:"string"`
 
 	// Information about the compliance as defined by the resource type. For example,
@@ -23848,8 +24252,8 @@ type RegisterTaskWithMaintenanceWindowInput struct {
 	// TaskArn is a required field
 	TaskArn *string `min:"1" type:"string" required:"true"`
 
-	// Parameters the task should use during execution. Populate only the fields
-	// that match the task type. All other fields should be empty.
+	// The parameters that the task should use during execution. Populate only the
+	// fields that match the task type. All other fields should be empty.
 	TaskInvocationParameters *MaintenanceWindowTaskInvocationParameters `type:"structure"`
 
 	// The parameters that should be passed to the task when it is executed.
@@ -25312,6 +25716,14 @@ type UpdateAssociationInput struct {
 	// AssociationId is a required field
 	AssociationId *string `type:"string" required:"true"`
 
+	// The name of the association that you want to update.
+	AssociationName *string `type:"string"`
+
+	// This parameter is provided for concurrency control purposes. You must specify
+	// the latest association version in the service. If you want to ensure that
+	// this request succeeds, either specify $LATEST, or omit this parameter.
+	AssociationVersion *string `type:"string"`
+
 	// The document version you want update for the association.
 	DocumentVersion *string `type:"string"`
 
@@ -25376,6 +25788,18 @@ func (s *UpdateAssociationInput) Validate() error {
 // SetAssociationId sets the AssociationId field's value.
 func (s *UpdateAssociationInput) SetAssociationId(v string) *UpdateAssociationInput {
 	s.AssociationId = &v
+	return s
+}
+
+// SetAssociationName sets the AssociationName field's value.
+func (s *UpdateAssociationInput) SetAssociationName(v string) *UpdateAssociationInput {
+	s.AssociationName = &v
+	return s
+}
+
+// SetAssociationVersion sets the AssociationVersion field's value.
+func (s *UpdateAssociationInput) SetAssociationVersion(v string) *UpdateAssociationInput {
+	s.AssociationVersion = &v
 	return s
 }
 
@@ -25726,9 +26150,9 @@ type UpdateMaintenanceWindowInput struct {
 	// The name of the Maintenance Window.
 	Name *string `min:"3" type:"string"`
 
-	// If you specify True, then all fields that are required by the CreateMaintenanceWindow
-	// API are also required for this API request. Optional fields that are not
-	// specified will be set to null.
+	// If True, then all fields that are required by the CreateMaintenanceWindow
+	// action are also required for this API request. Optional fields that are not
+	// specified are set to null.
 	Replace *bool `type:"boolean"`
 
 	// The schedule of the Maintenance Window in the form of a cron or rate expression.
@@ -25935,20 +26359,20 @@ type UpdateMaintenanceWindowTargetInput struct {
 	// while running tasks for these targets in this Maintenance Window.
 	OwnerInformation *string `min:"1" type:"string"`
 
-	// If you specify True, then all fields that are required by the RegisterTargetWithMaintenanceWindow
-	// API are also required for this API request. Optional fields that are not
-	// specified will be set to null.
+	// If True, then all fields that are required by the RegisterTargetWithMaintenanceWindow
+	// action are also required for this API request. Optional fields that are not
+	// specified are set to null.
 	Replace *bool `type:"boolean"`
 
-	// The targets that you want to add or replace.
+	// The targets to add or replace.
 	Targets []*Target `type:"list"`
 
-	// The Maintenance Window ID for which you want to modify the target.
+	// The Maintenance Window ID with which to modify the target.
 	//
 	// WindowId is a required field
 	WindowId *string `min:"20" type:"string" required:"true"`
 
-	// The target ID that you want to modify.
+	// The target ID to modify.
 	//
 	// WindowTargetId is a required field
 	WindowTargetId *string `min:"36" type:"string" required:"true"`
@@ -26120,61 +26544,61 @@ func (s *UpdateMaintenanceWindowTargetOutput) SetWindowTargetId(v string) *Updat
 type UpdateMaintenanceWindowTaskInput struct {
 	_ struct{} `type:"structure"`
 
-	// The new task description that you want to specify.
+	// The new task description to specify.
 	Description *string `min:"1" type:"string"`
 
-	// The new logging location in Amazon S3 that you want to specify.
+	// The new logging location in Amazon S3 to specify.
 	LoggingInfo *LoggingInfo `type:"structure"`
 
 	// The new MaxConcurrency value you want to specify. MaxConcurrency is the number
 	// of targets that are allowed to run this task in parallel.
 	MaxConcurrency *string `min:"1" type:"string"`
 
-	// The new MaxErrors value you want to specify. MaxErrors is the maximum number
-	// of errors that are allowed before the task stops being scheduled.
+	// The new MaxErrors value to specify. MaxErrors is the maximum number of errors
+	// that are allowed before the task stops being scheduled.
 	MaxErrors *string `min:"1" type:"string"`
 
-	// The new task name that you want to specify.
+	// The new task name to specify.
 	Name *string `min:"3" type:"string"`
 
-	// The new task priority that you want to specify. The lower the number, the
-	// higher the priority. Tasks that have the same priority are scheduled in parallel.
+	// The new task priority to specify. The lower the number, the higher the priority.
+	// Tasks that have the same priority are scheduled in parallel.
 	Priority *int64 `type:"integer"`
 
-	// If you specify True, then all fields that are required by the RegisterTaskWithMaintenanceWndow
-	// API are also required for this API request. Optional fields that are not
-	// specified will be set to null.
+	// If True, then all fields that are required by the RegisterTaskWithMaintenanceWndow
+	// action are also required for this API request. Optional fields that are not
+	// specified are set to null.
 	Replace *bool `type:"boolean"`
 
-	// The IAM service role ARN that you want to modify. The system assumes this
-	// role during task exectuion.
+	// The IAM service role ARN to modify. The system assumes this role during task
+	// execution.
 	ServiceRoleArn *string `type:"string"`
 
-	// The targets (either instances or tags) that you want to modify. Instances
-	// are specified using Key=instanceids,Values=instanceID_1,instanceID_2. Tags
-	// are specified using Key=tag_name,Values=tag_value.
+	// The targets (either instances or tags) to modify. Instances are specified
+	// using Key=instanceids,Values=instanceID_1,instanceID_2. Tags are specified
+	// using Key=tag_name,Values=tag_value.
 	Targets []*Target `type:"list"`
 
-	// The task ARN that you want to modify.
+	// The task ARN to modify.
 	TaskArn *string `min:"1" type:"string"`
 
-	// Parameters the task should use during execution. Populate only the fields
-	// that match the task type. All other fields should be empty.
+	// The parameters that the task should use during execution. Populate only the
+	// fields that match the task type. All other fields should be empty.
 	TaskInvocationParameters *MaintenanceWindowTaskInvocationParameters `type:"structure"`
 
-	// The parameters that you want to modify. The map has the following format:
+	// The parameters to modify. The map has the following format:
 	//
 	// Key: string, between 1 and 255 characters
 	//
 	// Value: an array of strings, each string is between 1 and 255 characters
 	TaskParameters map[string]*MaintenanceWindowTaskParameterValueExpression `type:"map"`
 
-	// The Maintenance Window ID that contains the task that you want to modify.
+	// The Maintenance Window ID that contains the task to modify.
 	//
 	// WindowId is a required field
 	WindowId *string `min:"20" type:"string" required:"true"`
 
-	// The task ID that you want to modify.
+	// The task ID to modify.
 	//
 	// WindowTaskId is a required field
 	WindowTaskId *string `min:"36" type:"string" required:"true"`
@@ -26368,10 +26792,10 @@ type UpdateMaintenanceWindowTaskOutput struct {
 	// The updated parameter values.
 	TaskParameters map[string]*MaintenanceWindowTaskParameterValueExpression `type:"map"`
 
-	// The Maintenance Window ID that was updated.
+	// The ID of the Maintenance Window that was updated.
 	WindowId *string `min:"20" type:"string"`
 
-	// The Maintenance Window task ID that was updated.
+	// The task ID of the Maintenance Window that was updated.
 	WindowTaskId *string `min:"36" type:"string"`
 }
 
@@ -26785,6 +27209,9 @@ const (
 
 	// AssociationFilterKeyLastExecutedAfter is a AssociationFilterKey enum value
 	AssociationFilterKeyLastExecutedAfter = "LastExecutedAfter"
+
+	// AssociationFilterKeyAssociationName is a AssociationFilterKey enum value
+	AssociationFilterKeyAssociationName = "AssociationName"
 )
 
 const (

--- a/service/ssm/errors.go
+++ b/service/ssm/errors.go
@@ -36,6 +36,13 @@ const (
 	// You can have at most 2,000 active associations.
 	ErrCodeAssociationLimitExceeded = "AssociationLimitExceeded"
 
+	// ErrCodeAssociationVersionLimitExceeded for service response error code
+	// "AssociationVersionLimitExceeded".
+	//
+	// You have reached the maximum number versions allowed for an association.
+	// Each association has a limit of 1,000 versions.
+	ErrCodeAssociationVersionLimitExceeded = "AssociationVersionLimitExceeded"
+
 	// ErrCodeAutomationDefinitionNotFoundException for service response error code
 	// "AutomationDefinitionNotFoundException".
 	//
@@ -127,7 +134,7 @@ const (
 	// "FeatureNotAvailableException".
 	//
 	// You attempted to register a LAMBDA or STEP_FUNCTION task in a region where
-	// there corresponding service is not available.
+	// the corresponding service is not available.
 	ErrCodeFeatureNotAvailableException = "FeatureNotAvailableException"
 
 	// ErrCodeHierarchyLevelLimitExceededException for service response error code
@@ -180,6 +187,14 @@ const (
 	//
 	// The request does not meet the regular expression requirement.
 	ErrCodeInvalidAllowedPatternException = "InvalidAllowedPatternException"
+
+	// ErrCodeInvalidAssociationVersion for service response error code
+	// "InvalidAssociationVersion".
+	//
+	// The version you specified is not valid. Use ListAssociationVersions to view
+	// all versions of an association according to the association ID. Or, use the
+	// $LATEST parameter to view the latest version of the association.
+	ErrCodeInvalidAssociationVersion = "InvalidAssociationVersion"
 
 	// ErrCodeInvalidAutomationExecutionParametersException for service response error code
 	// "InvalidAutomationExecutionParametersException".
@@ -529,7 +544,7 @@ const (
 	// ErrCodeUnsupportedInventoryItemContextException for service response error code
 	// "UnsupportedInventoryItemContextException".
 	//
-	// The Context attribute you specified for the InventoryItem is not allowed
+	// The Context attribute that you specified for the InventoryItem is not allowed
 	// for this inventory type. You can only use the Context attribute with inventory
 	// types like AWS:ComplianceItem.
 	ErrCodeUnsupportedInventoryItemContextException = "UnsupportedInventoryItemContextException"

--- a/service/ssm/ssmiface/interface.go
+++ b/service/ssm/ssmiface/interface.go
@@ -323,6 +323,10 @@ type SSMAPI interface {
 	GetPatchBaselineForPatchGroupWithContext(aws.Context, *ssm.GetPatchBaselineForPatchGroupInput, ...request.Option) (*ssm.GetPatchBaselineForPatchGroupOutput, error)
 	GetPatchBaselineForPatchGroupRequest(*ssm.GetPatchBaselineForPatchGroupInput) (*request.Request, *ssm.GetPatchBaselineForPatchGroupOutput)
 
+	ListAssociationVersions(*ssm.ListAssociationVersionsInput) (*ssm.ListAssociationVersionsOutput, error)
+	ListAssociationVersionsWithContext(aws.Context, *ssm.ListAssociationVersionsInput, ...request.Option) (*ssm.ListAssociationVersionsOutput, error)
+	ListAssociationVersionsRequest(*ssm.ListAssociationVersionsInput) (*request.Request, *ssm.ListAssociationVersionsOutput)
+
 	ListAssociations(*ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error)
 	ListAssociationsWithContext(aws.Context, *ssm.ListAssociationsInput, ...request.Option) (*ssm.ListAssociationsOutput, error)
 	ListAssociationsRequest(*ssm.ListAssociationsInput) (*request.Request, *ssm.ListAssociationsOutput)


### PR DESCRIPTION
Release v1.10.30 (2017-08-22)
===

### Service Client Updates
* `service/ssm`: Updates service API and documentation
  * Changes to associations in Systems Manager State Manager can now be recorded. Previously, when you edited associations, you could not go back and review older association settings. Now, associations are versioned, and can be named using human-readable strings, allowing you to see a trail of association changes. You can also perform rate-based scheduling, which allows you to schedule associations more granularly.

