### PR TITLE
Add Go1.9 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
   - 1.6
   - 1.7
   - 1.8
+  - 1.9
   - tip
     
 # Use Go 1.5's vendoring experiment for 1.5 tests.

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ smoke-tests: get-deps-tests
 performance: get-deps-tests
 	AWS_TESTING_LOG_RESULTS=${log-detailed} AWS_TESTING_REGION=$(region) AWS_TESTING_DB_TABLE=$(table) gucumber -go-tags "integration" ./awstesting/performance
 
-sandbox-tests: sandbox-test-go15 sandbox-test-go15-novendorexp sandbox-test-go16 sandbox-test-go17 sandbox-test-go18 sandbox-test-gotip
+sandbox-tests: sandbox-test-go15 sandbox-test-go15-novendorexp sandbox-test-go16 sandbox-test-go17 sandbox-test-go18 sandbox-test-go19 sandbox-test-gotip
 
 sandbox-build-go15:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.5 -t "aws-sdk-go-1.5" .
@@ -110,6 +110,13 @@ sandbox-go18: sandbox-build-go18
 	docker run -i -t aws-sdk-go-1.8 bash
 sandbox-test-go18: sandbox-build-go18
 	docker run -t aws-sdk-go-1.8
+
+sandbox-build-go19:
+	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.8 -t "aws-sdk-go-1.9" .
+sandbox-go19: sandbox-build-go19
+	docker run -i -t aws-sdk-go-1.9 bash
+sandbox-test-go19: sandbox-build-go19
+	docker run -t aws-sdk-go-1.9
 
 sandbox-build-gotip:
 	@echo "Run make update-aws-golang-tip, if this test fails because missing aws-golang:tip container"

--- a/awstesting/sandbox/Dockerfile.test.go1.9
+++ b/awstesting/sandbox/Dockerfile.test.go1.9
@@ -1,0 +1,11 @@
+FROM ubuntu:12.04
+FROM golang:1.9
+
+ADD . /go/src/github.com/aws/aws-sdk-go
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		vim \
+	&& rm -rf /var/list/apt/lists/*
+
+WORKDIR /go/src/github.com/aws/aws-sdk-go
+CMD ["make", "unit"]

--- a/service/s3/s3crypto/envelope.go
+++ b/service/s3/s3crypto/envelope.go
@@ -26,7 +26,7 @@ type Envelope struct {
 	// IV is the randomly generated IV base64 encoded.
 	IV string `json:"x-amz-iv"`
 	// CipherKey is the randomly generated cipher key.
-	CipherKey string `json:"x-amz-key-v2, x-amz-key"`
+	CipherKey string `json:"x-amz-key-v2"`
 	// MaterialDesc is a description to distinguish from other envelopes.
 	MatDesc               string `json:"x-amz-matdesc"`
 	WrapAlg               string `json:"x-amz-wrap-alg"`


### PR DESCRIPTION
Adds Travis testing for Go 1.9, as well as fixes a bug in the S3 Crypto's Envelope struct tag