### PR TITLE
aws/signer/v4: Revert #1491, conflicts with undocumented spec test cases

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,5 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* `aws/signer/v4`: Revert [#1491](https://github.com/aws/aws-sdk-go/issues/1491) as change conflicts with AWS signature test suite, but is not documented.
+* `aws/signer/v4`: Revert [#1491](https://github.com/aws/aws-sdk-go/issues/1491) as change conflicts with an undocumented AWS v4 signature test case.
   * Related to: [#1495](https://github.com/aws/aws-sdk-go/issues/1495).

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/signer/v4`: Revert [#1491](https://github.com/aws/aws-sdk-go/issues/1491) as change conflicts with AWS signature test suite, but is not documented.
+  * Related to: [#1495](https://github.com/aws/aws-sdk-go/issues/1495).

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -324,6 +324,10 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 		unsignedPayload:        v4.UnsignedPayload,
 	}
 
+	for key := range ctx.Query {
+		sort.Strings(ctx.Query[key])
+	}
+
 	if ctx.isRequestSigned() {
 		ctx.Time = currentTimeFn()
 		ctx.handlePresignRemoval()

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -128,14 +128,14 @@ func TestPresignRequest(t *testing.T) {
 
 func TestPresignBodyWithArrayRequest(t *testing.T) {
 	req, body := buildRequest("dynamodb", "us-east-1", "{}")
-	req.URL.RawQuery = "FooB=a&FooA=b&FooA=a&FooB=b"
+	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
 
 	signer := buildSigner()
 	signer.Presign(req, body, "dynamodb", "us-east-1", 300*time.Second, time.Unix(0, 0))
 
 	expectedDate := "19700101T000000Z"
 	expectedHeaders := "content-length;content-type;host;x-amz-meta-other-header;x-amz-meta-other-header_with_underscore"
-	expectedSig := "60152079d308a87f036082a236c935261221a32d369ec4b6b75dbc9873d2ab9a"
+	expectedSig := "fef6002062400bbf526d70f1a6456abc0fb2e213fe1416012737eebd42a62924"
 	expectedCred := "AKID/19700101/us-east-1/dynamodb/aws4_request"
 	expectedTarget := "prefix.Operation"
 
@@ -519,7 +519,7 @@ func TestSignWithRequestBody_Overwrite(t *testing.T) {
 
 func TestBuildCanonicalRequest(t *testing.T) {
 	req, body := buildRequest("dynamodb", "us-east-1", "{}")
-	req.URL.RawQuery = "FooB=a&FooA=b&FooA=a&FooB=b"
+	req.URL.RawQuery = "Foo=z&Foo=o&Foo=m&Foo=a"
 	ctx := &signingCtx{
 		ServiceName: "dynamodb",
 		Region:      "us-east-1",
@@ -531,7 +531,7 @@ func TestBuildCanonicalRequest(t *testing.T) {
 	}
 
 	ctx.buildCanonicalString()
-	expected := "https://example.org/bucket/key-._~,!@#$%^&*()?FooA=b&FooA=a&FooB=a&FooB=b"
+	expected := "https://example.org/bucket/key-._~,!@#$%^&*()?Foo=z&Foo=o&Foo=m&Foo=a"
 	if e, a := expected, ctx.Request.URL.String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}


### PR DESCRIPTION
Reverts #1491 change since it conflicts with the AWS v4 signer test cases found in #1495. This case is not documented in the V4 spec. Additional research is needed before #1491 can be accepted. As either a implementation detail of the test cases, or an undocumented requirement of the spec.