### PR TITLE
v1.10.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Release v1.10.43 (2017-09-12)
+===
+
+### Service Client Updates
+* `service/ec2`: Updates service API
+  * Fixed bug in EC2 clients preventing HostOfferingSet from being set
+* `aws/endpoints`: Updated Regions and Endpoints metadata.
+
 Release v1.10.42 (2017-09-12)
 ===
 

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -2072,6 +2072,12 @@ var awscnPartition = partition{
 				"cn-north-1": endpoint{},
 			},
 		},
+		"snowball": service{
+
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{},
+			},
+		},
 		"sns": service{
 			Defaults: endpoint{
 				Protocols: []string{"http", "https"},

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.10.42"
+const SDKVersion = "1.10.43"

--- a/models/apis/ec2/2016-11-15/api-2.json
+++ b/models/apis/ec2/2016-11-15/api-2.json
@@ -8233,7 +8233,10 @@
     },
     "HostOfferingSet":{
       "type":"list",
-      "member":{"shape":"HostOffering"}
+      "member":{
+        "shape":"HostOffering",
+        "locationName":"item"
+      }
     },
     "HostProperties":{
       "type":"structure",

--- a/models/endpoints/endpoints.json
+++ b/models/endpoints/endpoints.json
@@ -1777,6 +1777,11 @@
           "cn-north-1" : { }
         }
       },
+      "snowball" : {
+        "endpoints" : {
+          "cn-north-1" : { }
+        }
+      },
       "sns" : {
         "defaults" : {
           "protocols" : [ "http", "https" ]

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -30425,7 +30425,7 @@ type DescribeHostReservationOfferingsOutput struct {
 	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// Information about the offerings.
-	OfferingSet []*HostOffering `locationName:"offeringSet" type:"list"`
+	OfferingSet []*HostOffering `locationName:"offeringSet" locationNameList:"item" type:"list"`
 }
 
 // String returns the string representation


### PR DESCRIPTION
Release v1.10.43 (2017-09-12)
===

### Service Client Updates
* `service/ec2`: Updates service API
  * Fixed bug in EC2 clients preventing HostOfferingSet from being set
* `aws/endpoints`: Updated Regions and Endpoints metadata.

