### PR TITLE
service/dynamodb/dynamodbattribute: Add support for time alias.

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -338,12 +338,12 @@ func (d *Decoder) decodeNumber(n *string, v reflect.Value, fieldTag tag) error {
 		}
 		v.SetFloat(i)
 	default:
-		if _, ok := v.Interface().(time.Time); ok && fieldTag.AsUnixTime {
+		if v.Type().ConvertibleTo(reflect.TypeOf(time.Time{})) && fieldTag.AsUnixTime {
 			t, err := decodeUnixTime(*n)
 			if err != nil {
 				return err
 			}
-			v.Set(reflect.ValueOf(t))
+			v.Set(reflect.ValueOf(t).Convert(v.Type()))
 			return nil
 		}
 		return &UnmarshalTypeError{Value: "number", Type: v.Type()}
@@ -502,12 +502,12 @@ func (d *Decoder) decodeString(s *string, v reflect.Value, fieldTag tag) error {
 
 	// To maintain backwards compatibility with ConvertFrom family of methods which
 	// converted strings to time.Time structs
-	if _, ok := v.Interface().(time.Time); ok {
+	if v.Type().ConvertibleTo(reflect.TypeOf(time.Time{})) {
 		t, err := time.Parse(time.RFC3339, *s)
 		if err != nil {
 			return err
 		}
-		v.Set(reflect.ValueOf(t))
+		v.Set(reflect.ValueOf(t).Convert(v.Type()))
 		return nil
 	}
 

--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -153,6 +153,7 @@ var stringInterfaceMapType = reflect.TypeOf(map[string]interface{}(nil))
 var byteSliceType = reflect.TypeOf([]byte(nil))
 var byteSliceSlicetype = reflect.TypeOf([][]byte(nil))
 var numberType = reflect.TypeOf(Number(""))
+var timeType = reflect.TypeOf(time.Time{})
 
 func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
 	var u Unmarshaler
@@ -338,7 +339,7 @@ func (d *Decoder) decodeNumber(n *string, v reflect.Value, fieldTag tag) error {
 		}
 		v.SetFloat(i)
 	default:
-		if v.Type().ConvertibleTo(reflect.TypeOf(time.Time{})) && fieldTag.AsUnixTime {
+		if v.Type().ConvertibleTo(timeType) && fieldTag.AsUnixTime {
 			t, err := decodeUnixTime(*n)
 			if err != nil {
 				return err
@@ -502,7 +503,7 @@ func (d *Decoder) decodeString(s *string, v reflect.Value, fieldTag tag) error {
 
 	// To maintain backwards compatibility with ConvertFrom family of methods which
 	// converted strings to time.Time structs
-	if v.Type().ConvertibleTo(reflect.TypeOf(time.Time{})) {
+	if v.Type().ConvertibleTo(timeType) {
 		t, err := time.Parse(time.RFC3339, *s)
 		if err != nil {
 			return err
@@ -564,7 +565,7 @@ func decodeUnixTime(n string) (time.Time, error) {
 	v, err := strconv.ParseInt(n, 10, 64)
 	if err != nil {
 		return time.Time{}, &UnmarshalError{
-			Err: err, Value: n, Type: reflect.TypeOf(time.Time{}),
+			Err: err, Value: n, Type: timeType,
 		}
 	}
 

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -527,3 +527,31 @@ func TestDecodeUnixTime(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expect, actual)
 }
+
+func TestDecodeAliasedUnixTime(t *testing.T) {
+	type A struct {
+		Normal AliasedTime
+		Tagged AliasedTime `dynamodbav:",unixtime"`
+	}
+
+	expect := A{
+		Normal: AliasedTime(time.Unix(123, 0).UTC()),
+		Tagged: AliasedTime(time.Unix(456, 0)),
+	}
+
+	input := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Normal": {
+				S: aws.String("1970-01-01T00:02:03Z"),
+			},
+			"Tagged": {
+				N: aws.String("456"),
+			},
+		},
+	}
+	actual := A{}
+
+	err := Unmarshal(input, &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expect, actual)
+}

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -285,7 +285,9 @@ func (e *Encoder) encode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 func (e *Encoder) encodeStruct(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
 	// To maintain backwards compatibility with ConvertTo family of methods which
 	// converted time.Time structs to strings
-	if t, ok := v.Interface().(time.Time); ok {
+	if v.Type().ConvertibleTo(reflect.TypeOf(time.Time{})) {
+		var t time.Time
+		t = v.Convert(reflect.TypeOf(time.Time{})).Interface().(time.Time)
 		if fieldTag.AsUnixTime {
 			return UnixTime(t).MarshalDynamoDBAttributeValue(av)
 		}

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -285,9 +285,9 @@ func (e *Encoder) encode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 func (e *Encoder) encodeStruct(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
 	// To maintain backwards compatibility with ConvertTo family of methods which
 	// converted time.Time structs to strings
-	if v.Type().ConvertibleTo(reflect.TypeOf(time.Time{})) {
+	if v.Type().ConvertibleTo(timeType) {
 		var t time.Time
-		t = v.Convert(reflect.TypeOf(time.Time{})).Interface().(time.Time)
+		t = v.Convert(timeType).Interface().(time.Time)
 		if fieldTag.AsUnixTime {
 			return UnixTime(t).MarshalDynamoDBAttributeValue(av)
 		}

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -207,3 +207,31 @@ func TestEncodeUnixTime(t *testing.T) {
 	}
 	assert.Equal(t, expect, actual)
 }
+
+type AliasedTime time.Time
+
+func TestEncodeAliasedUnixTime(t *testing.T) {
+	type A struct {
+		Normal AliasedTime
+		Tagged AliasedTime `dynamodbav:",unixtime"`
+	}
+
+	a := A{
+		Normal: AliasedTime(time.Unix(123, 0).UTC()),
+		Tagged: AliasedTime(time.Unix(456, 0)),
+	}
+
+	actual, err := Marshal(a)
+	assert.NoError(t, err)
+	expect := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Normal": {
+				S: aws.String("1970-01-01T00:02:03Z"),
+			},
+			"Tagged": {
+				N: aws.String("456"),
+			},
+		},
+	}
+	assert.Equal(t, expect, actual)
+}


### PR DESCRIPTION
The `dynamodbattribte` package handles aliases of builtin types (e.g. aliased strings, ints, etc.), but not `time.Time`. This PR adds support for aliased `time.Time` types. I added encode/decode tests that mirror the tests for non-aliased `time.Time`.

Modification of #1505