### PR TITLE
service/s3/s3manager: Clarify S3 Upload manager Concurrency config

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -218,8 +218,11 @@ type Uploader struct {
 	// if this value is set to zero, the DefaultUploadPartSize value will be used.
 	PartSize int64
 
-	// The number of goroutines to spin up in parallel when sending parts.
-	// If this is set to zero, the DefaultUploadConcurrency value will be used.
+	// The number of goroutines to spin up in parallel per call to Upload when
+	// sending parts. If this is set to zero, the DefaultUploadConcurrency value
+	// will be used.
+	//
+	// The concurrency pool is not shared between calls to Upload.
 	Concurrency int
 
 	// Setting this value to true will cause the SDK to avoid calling


### PR DESCRIPTION
Clarifies the S3 Upload Managers concurrency configuration is per call
to Upload, not shared across the instance of the Upload manager.

Fix #1458
