### PR TITLE
Create EnvProviderName constant.

### DIFF
--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
+const EnvProviderName = "EnvConfigCredentials"
+
 // envConfig is a collection of environment values the SDK will read
 // setup config from. All environment values are optional. But some values
 // such as credentials require multiple values to be complete or the values
@@ -157,7 +159,7 @@ func envConfigLoad(enableSharedConfig bool) envConfig {
 	if len(cfg.Creds.AccessKeyID) == 0 || len(cfg.Creds.SecretAccessKey) == 0 {
 		cfg.Creds = credentials.Value{}
 	} else {
-		cfg.Creds.ProviderName = "EnvConfigCredentials"
+		cfg.Creds.ProviderName = EnvProviderName
 	}
 
 	regionKeys := regionEnvKeys

--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
+// EnvProviderName provides a name of the provider when config is loaded from environment.
 const EnvProviderName = "EnvConfigCredentials"
 
 // envConfig is a collection of environment values the SDK will read


### PR DESCRIPTION
Fixes #1444 by moving the `"EnvConfigCredentials" ` string literal into the `EnvProviderName` constant.