### PR TITLE
v1.10.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+Release v1.10.50 (2017-09-21)
+===
+
+### Service Client Updates
+* `service/budgets`: Updates service API
+  * Including "DuplicateRecordException" in UpdateNotification and UpdateSubscriber.
+* `service/ec2`: Updates service API and documentation
+  * Add EC2 APIs to copy Amazon FPGA Images (AFIs) within the same region and across multiple regions, delete AFIs, and modify AFI attributes. AFI attributes include name, description and granting/denying other AWS accounts to load the AFI.
+* `service/logs`: Updates service API and documentation
+  * Adds support for associating LogGroups with KMS Keys.
+
+### SDK Bugs
+* Fix greengrass service model being duplicated with different casing. ([#1541](https://github.com/aws/aws-sdk-go/pull/1541))
+  * Fixes [#1540](https://github.com/aws/aws-sdk-go/issues/1540)
+  * Fixes [#1539](https://github.com/aws/aws-sdk-go/issues/1539)
 Release v1.10.49 (2017-09-20)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,3 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* Fix greengrass service model being duplicated with different casing. ([#1541](https://github.com/aws/aws-sdk-go/pull/1541))
-  * Fixes [#1540](https://github.com/aws/aws-sdk-go/issues/1540)
-  * Fixes [#1539](https://github.com/aws/aws-sdk-go/issues/1539)

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.10.49"
+const SDKVersion = "1.10.50"

--- a/models/apis/budgets/2016-10-20/api-2.json
+++ b/models/apis/budgets/2016-10-20/api-2.json
@@ -188,7 +188,8 @@
       "errors":[
         {"shape":"InternalErrorException"},
         {"shape":"InvalidParameterException"},
-        {"shape":"NotFoundException"}
+        {"shape":"NotFoundException"},
+        {"shape":"DuplicateRecordException"}
       ]
     },
     "UpdateSubscriber":{
@@ -202,7 +203,8 @@
       "errors":[
         {"shape":"InternalErrorException"},
         {"shape":"InvalidParameterException"},
-        {"shape":"NotFoundException"}
+        {"shape":"NotFoundException"},
+        {"shape":"DuplicateRecordException"}
       ]
     }
   },

--- a/models/apis/ec2/2016-11-15/api-2.json
+++ b/models/apis/ec2/2016-11-15/api-2.json
@@ -256,6 +256,15 @@
       "input":{"shape":"ConfirmProductInstanceRequest"},
       "output":{"shape":"ConfirmProductInstanceResult"}
     },
+    "CopyFpgaImage":{
+      "name":"CopyFpgaImage",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CopyFpgaImageRequest"},
+      "output":{"shape":"CopyFpgaImageResult"}
+    },
     "CopyImage":{
       "name":"CopyImage",
       "http":{
@@ -583,6 +592,15 @@
       "input":{"shape":"DeleteFlowLogsRequest"},
       "output":{"shape":"DeleteFlowLogsResult"}
     },
+    "DeleteFpgaImage":{
+      "name":"DeleteFpgaImage",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteFpgaImageRequest"},
+      "output":{"shape":"DeleteFpgaImageResult"}
+    },
     "DeleteInternetGateway":{
       "name":"DeleteInternetGateway",
       "http":{
@@ -878,6 +896,15 @@
       },
       "input":{"shape":"DescribeFlowLogsRequest"},
       "output":{"shape":"DescribeFlowLogsResult"}
+    },
+    "DescribeFpgaImageAttribute":{
+      "name":"DescribeFpgaImageAttribute",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeFpgaImageAttributeRequest"},
+      "output":{"shape":"DescribeFpgaImageAttributeResult"}
     },
     "DescribeFpgaImages":{
       "name":"DescribeFpgaImages",
@@ -1636,6 +1663,15 @@
       "input":{"shape":"ImportVolumeRequest"},
       "output":{"shape":"ImportVolumeResult"}
     },
+    "ModifyFpgaImageAttribute":{
+      "name":"ModifyFpgaImageAttribute",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ModifyFpgaImageAttributeRequest"},
+      "output":{"shape":"ModifyFpgaImageAttributeResult"}
+    },
     "ModifyHosts":{
       "name":"ModifyHosts",
       "http":{
@@ -1927,6 +1963,15 @@
       },
       "input":{"shape":"RequestSpotInstancesRequest"},
       "output":{"shape":"RequestSpotInstancesResult"}
+    },
+    "ResetFpgaImageAttribute":{
+      "name":"ResetFpgaImageAttribute",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ResetFpgaImageAttributeRequest"},
+      "output":{"shape":"ResetFpgaImageAttributeResult"}
     },
     "ResetImageAttribute":{
       "name":"ResetImageAttribute",
@@ -3458,6 +3503,30 @@
         "completed"
       ]
     },
+    "CopyFpgaImageRequest":{
+      "type":"structure",
+      "required":[
+        "SourceFpgaImageId",
+        "SourceRegion"
+      ],
+      "members":{
+        "DryRun":{"shape":"Boolean"},
+        "SourceFpgaImageId":{"shape":"String"},
+        "Description":{"shape":"String"},
+        "Name":{"shape":"String"},
+        "SourceRegion":{"shape":"String"},
+        "ClientToken":{"shape":"String"}
+      }
+    },
+    "CopyFpgaImageResult":{
+      "type":"structure",
+      "members":{
+        "FpgaImageId":{
+          "shape":"String",
+          "locationName":"fpgaImageId"
+        }
+      }
+    },
     "CopyImageRequest":{
       "type":"structure",
       "required":[
@@ -4527,6 +4596,23 @@
         }
       }
     },
+    "DeleteFpgaImageRequest":{
+      "type":"structure",
+      "required":["FpgaImageId"],
+      "members":{
+        "DryRun":{"shape":"Boolean"},
+        "FpgaImageId":{"shape":"String"}
+      }
+    },
+    "DeleteFpgaImageResult":{
+      "type":"structure",
+      "members":{
+        "Return":{
+          "shape":"Boolean",
+          "locationName":"return"
+        }
+      }
+    },
     "DeleteInternetGatewayRequest":{
       "type":"structure",
       "required":["InternetGatewayId"],
@@ -5180,6 +5266,27 @@
         "NextToken":{
           "shape":"String",
           "locationName":"nextToken"
+        }
+      }
+    },
+    "DescribeFpgaImageAttributeRequest":{
+      "type":"structure",
+      "required":[
+        "FpgaImageId",
+        "Attribute"
+      ],
+      "members":{
+        "DryRun":{"shape":"Boolean"},
+        "FpgaImageId":{"shape":"String"},
+        "Attribute":{"shape":"FpgaImageAttributeName"}
+      }
+    },
+    "DescribeFpgaImageAttributeResult":{
+      "type":"structure",
+      "members":{
+        "FpgaImageAttribute":{
+          "shape":"FpgaImageAttribute",
+          "locationName":"fpgaImageAttribute"
         }
       }
     },
@@ -7854,8 +7961,46 @@
         "Tags":{
           "shape":"TagList",
           "locationName":"tags"
+        },
+        "Public":{
+          "shape":"Boolean",
+          "locationName":"public"
         }
       }
+    },
+    "FpgaImageAttribute":{
+      "type":"structure",
+      "members":{
+        "FpgaImageId":{
+          "shape":"String",
+          "locationName":"fpgaImageId"
+        },
+        "Name":{
+          "shape":"String",
+          "locationName":"name"
+        },
+        "Description":{
+          "shape":"String",
+          "locationName":"description"
+        },
+        "LoadPermissions":{
+          "shape":"LoadPermissionList",
+          "locationName":"loadPermissions"
+        },
+        "ProductCodes":{
+          "shape":"ProductCodeList",
+          "locationName":"productCodes"
+        }
+      }
+    },
+    "FpgaImageAttributeName":{
+      "type":"string",
+      "enum":[
+        "description",
+        "name",
+        "loadPermission",
+        "productCodes"
+      ]
     },
     "FpgaImageIdList":{
       "type":"list",
@@ -10281,11 +10426,86 @@
         "closed"
       ]
     },
+    "LoadPermission":{
+      "type":"structure",
+      "members":{
+        "UserId":{
+          "shape":"String",
+          "locationName":"userId"
+        },
+        "Group":{
+          "shape":"PermissionGroup",
+          "locationName":"group"
+        }
+      }
+    },
+    "LoadPermissionList":{
+      "type":"list",
+      "member":{
+        "shape":"LoadPermission",
+        "locationName":"item"
+      }
+    },
+    "LoadPermissionListRequest":{
+      "type":"list",
+      "member":{
+        "shape":"LoadPermissionRequest",
+        "locationName":"item"
+      }
+    },
+    "LoadPermissionModifications":{
+      "type":"structure",
+      "members":{
+        "Add":{"shape":"LoadPermissionListRequest"},
+        "Remove":{"shape":"LoadPermissionListRequest"}
+      }
+    },
+    "LoadPermissionRequest":{
+      "type":"structure",
+      "members":{
+        "Group":{"shape":"PermissionGroup"},
+        "UserId":{"shape":"String"}
+      }
+    },
     "Long":{"type":"long"},
     "MaxResults":{
       "type":"integer",
       "max":255,
       "min":5
+    },
+    "ModifyFpgaImageAttributeRequest":{
+      "type":"structure",
+      "required":["FpgaImageId"],
+      "members":{
+        "DryRun":{"shape":"Boolean"},
+        "FpgaImageId":{"shape":"String"},
+        "Attribute":{"shape":"FpgaImageAttributeName"},
+        "OperationType":{"shape":"OperationType"},
+        "UserIds":{
+          "shape":"UserIdStringList",
+          "locationName":"UserId"
+        },
+        "UserGroups":{
+          "shape":"UserGroupStringList",
+          "locationName":"UserGroup"
+        },
+        "ProductCodes":{
+          "shape":"ProductCodeStringList",
+          "locationName":"ProductCode"
+        },
+        "LoadPermission":{"shape":"LoadPermissionModifications"},
+        "Description":{"shape":"String"},
+        "Name":{"shape":"String"}
+      }
+    },
+    "ModifyFpgaImageAttributeResult":{
+      "type":"structure",
+      "members":{
+        "FpgaImageAttribute":{
+          "shape":"FpgaImageAttribute",
+          "locationName":"fpgaImageAttribute"
+        }
+      }
     },
     "ModifyHostsRequest":{
       "type":"structure",
@@ -12941,6 +13161,28 @@
       "member":{
         "shape":"ReservedInstancesId",
         "locationName":"item"
+      }
+    },
+    "ResetFpgaImageAttributeName":{
+      "type":"string",
+      "enum":["loadPermission"]
+    },
+    "ResetFpgaImageAttributeRequest":{
+      "type":"structure",
+      "required":["FpgaImageId"],
+      "members":{
+        "DryRun":{"shape":"Boolean"},
+        "FpgaImageId":{"shape":"String"},
+        "Attribute":{"shape":"ResetFpgaImageAttributeName"}
+      }
+    },
+    "ResetFpgaImageAttributeResult":{
+      "type":"structure",
+      "members":{
+        "Return":{
+          "shape":"Boolean",
+          "locationName":"return"
+        }
       }
     },
     "ResetImageAttributeName":{

--- a/models/apis/ec2/2016-11-15/docs-2.json
+++ b/models/apis/ec2/2016-11-15/docs-2.json
@@ -30,6 +30,7 @@
     "CancelSpotFleetRequests": "<p>Cancels the specified Spot fleet requests.</p> <p>After you cancel a Spot fleet request, the Spot fleet launches no new Spot instances. You must specify whether the Spot fleet should also terminate its Spot instances. If you terminate the instances, the Spot fleet request enters the <code>cancelled_terminating</code> state. Otherwise, the Spot fleet request enters the <code>cancelled_running</code> state and the instances continue to run until they are interrupted or you terminate them manually.</p>",
     "CancelSpotInstanceRequests": "<p>Cancels one or more Spot instance requests. Spot instances are instances that Amazon EC2 starts on your behalf when the bid price that you specify exceeds the current Spot price. Amazon EC2 periodically sets the Spot price based on available Spot instance capacity and current Spot instance requests. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html\">Spot Instance Requests</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> <important> <p>Canceling a Spot instance request does not terminate running Spot instances associated with the request.</p> </important>",
     "ConfirmProductInstance": "<p>Determines whether a product code is associated with an instance. This action can only be used by the owner of the product code. It is useful when a product code owner needs to verify whether another user's instance is eligible for support.</p>",
+    "CopyFpgaImage": "<p>Copies the specified Amazon FPGA Image (AFI) to the current region.</p>",
     "CopyImage": "<p>Initiates the copy of an AMI from the specified source region to the current region. You specify the destination region by using its endpoint when making the request.</p> <p>For more information about the prerequisites and limits when copying an AMI, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/CopyingAMIs.html\">Copying an AMI</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>",
     "CopySnapshot": "<p>Copies a point-in-time snapshot of an EBS volume and stores it in Amazon S3. You can copy the snapshot within the same region or from one region to another. You can use the snapshot to create EBS volumes or Amazon Machine Images (AMIs). The snapshot is copied to the regional endpoint that you send the HTTP request to.</p> <p>Copies of encrypted EBS snapshots remain encrypted. Copies of unencrypted snapshots remain unencrypted, unless the <code>Encrypted</code> flag is specified during the snapshot copy operation. By default, encrypted snapshot copies use the default AWS Key Management Service (AWS KMS) customer master key (CMK); however, you can specify a non-default CMK with the <code>KmsKeyId</code> parameter. </p> <note> <p>To copy an encrypted snapshot that has been shared from another account, you must have permissions for the CMK used to encrypt the snapshot.</p> </note> <note> <p>Snapshots created by the CopySnapshot action have an arbitrary volume ID that should not be used for any purpose.</p> </note> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-copy-snapshot.html\">Copying an Amazon EBS Snapshot</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>",
     "CreateCustomerGateway": "<p>Provides information to AWS about your VPN customer gateway device. The customer gateway is the appliance at your end of the VPN connection. (The device on the AWS side of the VPN connection is the virtual private gateway.) You must provide the Internet-routable IP address of the customer gateway's external interface. The IP address must be static and may be behind a device performing network address translation (NAT).</p> <p>For devices that use Border Gateway Protocol (BGP), you can also provide the device's BGP Autonomous System Number (ASN). You can use an existing ASN assigned to your network. If you don't have an ASN already, you can use a private ASN (in the 64512 - 65534 range).</p> <note> <p>Amazon EC2 supports all 2-byte ASN numbers in the range of 1 - 65534, with the exception of 7224, which is reserved in the <code>us-east-1</code> region, and 9059, which is reserved in the <code>eu-west-1</code> region.</p> </note> <p>For more information about VPN customer gateways, see <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html\">Adding a Hardware Virtual Private Gateway to Your VPC</a> in the <i>Amazon Virtual Private Cloud User Guide</i>.</p> <important> <p>You cannot create more than one customer gateway with the same VPN type, IP address, and BGP ASN parameter values. If you run an identical request more than one time, the first request creates the customer gateway, and subsequent requests return information about the existing customer gateway. The subsequent requests do not create new customer gateway resources.</p> </important>",
@@ -67,6 +68,7 @@
     "DeleteDhcpOptions": "<p>Deletes the specified set of DHCP options. You must disassociate the set of DHCP options before you can delete it. You can disassociate the set of DHCP options by associating either a new set of options or the default set of options with the VPC.</p>",
     "DeleteEgressOnlyInternetGateway": "<p>Deletes an egress-only Internet gateway.</p>",
     "DeleteFlowLogs": "<p>Deletes one or more flow logs.</p>",
+    "DeleteFpgaImage": "<p>Deletes the specified Amazon FPGA Image (AFI).</p>",
     "DeleteInternetGateway": "<p>Deletes the specified Internet gateway. You must detach the Internet gateway from the VPC before you can delete it.</p>",
     "DeleteKeyPair": "<p>Deletes the specified key pair, by removing the public key from Amazon EC2.</p>",
     "DeleteNatGateway": "<p>Deletes the specified NAT gateway. Deleting a NAT gateway disassociates its Elastic IP address, but does not release the address from your account. Deleting a NAT gateway does not delete any NAT gateway routes in your route tables.</p>",
@@ -102,6 +104,7 @@
     "DescribeElasticGpus": "<p>Describes the Elastic GPUs associated with your instances. For more information about Elastic GPUs, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-gpus.html\">Amazon EC2 Elastic GPUs</a>.</p>",
     "DescribeExportTasks": "<p>Describes one or more of your export tasks.</p>",
     "DescribeFlowLogs": "<p>Describes one or more flow logs. To view the information in your flow logs (the log streams for the network interfaces), you must use the CloudWatch Logs console or the CloudWatch Logs API.</p>",
+    "DescribeFpgaImageAttribute": "<p>Describes the specified attribute of the specified Amazon FPGA Image (AFI).</p>",
     "DescribeFpgaImages": "<p>Describes one or more available Amazon FPGA Images (AFIs). These include public AFIs, private AFIs that you own, and AFIs owned by other AWS accounts for which you have load permissions.</p>",
     "DescribeHostReservationOfferings": "<p>Describes the Dedicated Host Reservations that are available to purchase.</p> <p>The results describe all the Dedicated Host Reservation offerings, including offerings that may not match the instance family and region of your Dedicated Hosts. When purchasing an offering, ensure that the the instance family and region of the offering matches that of the Dedicated Host/s it will be associated with. For an overview of supported instance types, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-hosts-overview.html\">Dedicated Hosts Overview</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>. </p>",
     "DescribeHostReservations": "<p>Describes Dedicated Host Reservations which are associated with Dedicated Hosts in your account.</p>",
@@ -180,13 +183,14 @@
     "GetConsoleOutput": "<p>Gets the console output for the specified instance.</p> <p>Instances do not have a physical monitor through which you can view their console output. They also lack physical controls that allow you to power up, reboot, or shut them down. To allow these actions, we provide them through the Amazon EC2 API and command line interface.</p> <p>Instance console output is buffered and posted shortly after instance boot, reboot, and termination. Amazon EC2 preserves the most recent 64 KB output which is available for at least one hour after the most recent post.</p> <p>For Linux instances, the instance console output displays the exact console output that would normally be displayed on a physical monitor attached to a computer. This output is buffered because the instance produces it and then posts it to a store where the instance's owner can retrieve it.</p> <p>For Windows instances, the instance console output includes output from the EC2Config service.</p>",
     "GetConsoleScreenshot": "<p>Retrieve a JPG-format screenshot of a running instance to help with troubleshooting.</p> <p>The returned content is Base64-encoded.</p>",
     "GetHostReservationPurchasePreview": "<p>Preview a reservation purchase with configurations that match those of your Dedicated Host. You must have active Dedicated Hosts in your account before you purchase a reservation.</p> <p>This is a preview of the <a>PurchaseHostReservation</a> action and does not result in the offering being purchased.</p>",
-    "GetPasswordData": "<p>Retrieves the encrypted administrator password for an instance running Windows.</p> <p>The Windows password is generated at boot if the <code>EC2Config</code> service plugin, <code>Ec2SetPassword</code>, is enabled. This usually only happens the first time an AMI is launched, and then <code>Ec2SetPassword</code> is automatically disabled. The password is not generated for rebundled AMIs unless <code>Ec2SetPassword</code> is enabled before bundling.</p> <p>The password is encrypted using the key pair that you specified when you launched the instance. You must provide the corresponding key pair file.</p> <p>Password generation and encryption takes a few moments. We recommend that you wait up to 15 minutes after launching an instance before trying to retrieve the generated password.</p>",
+    "GetPasswordData": "<p>Retrieves the encrypted administrator password for a running Windows instance.</p> <p>The Windows password is generated at boot by the <code>EC2Config</code> service or <code>EC2Launch</code> scripts (Windows Server 2016 and later). This usually only happens the first time an instance is launched. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/UsingConfig_WinAMI.html\">EC2Config</a> and <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html\">EC2Launch</a> in the Amazon Elastic Compute Cloud User Guide.</p> <p>For the <code>EC2Config</code> service, the password is not generated for rebundled AMIs unless <code>Ec2SetPassword</code> is enabled before bundling.</p> <p>The password is encrypted using the key pair that you specified when you launched the instance. You must provide the corresponding key pair file.</p> <p>When you launch an instance, password generation and encryption may take a few minutes. If you try to retrieve the password before it's available, the output returns an empty string. We recommend that you wait up to 15 minutes after launching an instance before trying to retrieve the generated password.</p>",
     "GetReservedInstancesExchangeQuote": "<p>Returns details about the values and term of your specified Convertible Reserved Instances. When a target configuration is specified, it returns information about whether the exchange is valid and can be performed.</p>",
     "ImportImage": "<p>Import single or multi-volume disk images or EBS snapshots into an Amazon Machine Image (AMI). For more information, see <a href=\"http://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html\">Importing a VM as an Image Using VM Import/Export</a> in the <i>VM Import/Export User Guide</i>.</p>",
     "ImportInstance": "<p>Creates an import instance task using metadata from the specified disk image. <code>ImportInstance</code> only supports single-volume VMs. To import multi-volume VMs, use <a>ImportImage</a>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ec2-cli-vmimport-export.html\">Importing a Virtual Machine Using the Amazon EC2 CLI</a>.</p> <p>For information about the import manifest referenced by this API action, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/manifest.html\">VM Import Manifest</a>.</p>",
     "ImportKeyPair": "<p>Imports the public key from an RSA key pair that you created with a third-party tool. Compare this with <a>CreateKeyPair</a>, in which AWS creates the key pair and gives the keys to you (AWS keeps a copy of the public key). With ImportKeyPair, you create the key pair and give AWS just the public key. The private key is never transferred between you and AWS.</p> <p>For more information about key pairs, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\">Key Pairs</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>",
     "ImportSnapshot": "<p>Imports a disk into an EBS snapshot.</p>",
     "ImportVolume": "<p>Creates an import volume task using metadata from the specified disk image.For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/importing-your-volumes-into-amazon-ebs.html\">Importing Disks to Amazon EBS</a>.</p> <p>For information about the import manifest referenced by this API action, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/manifest.html\">VM Import Manifest</a>.</p>",
+    "ModifyFpgaImageAttribute": "<p>Modifies the specified attribute of the specified Amazon FPGA Image (AFI).</p>",
     "ModifyHosts": "<p>Modify the auto-placement setting of a Dedicated Host. When auto-placement is enabled, AWS will place instances that you launch with a tenancy of <code>host</code>, but without targeting a specific host ID, onto any available Dedicated Host in your account which has auto-placement enabled. When auto-placement is disabled, you need to provide a host ID if you want the instance to launch onto a specific host. If no host ID is provided, the instance will be launched onto a suitable host which has auto-placement enabled.</p>",
     "ModifyIdFormat": "<p>Modifies the ID format for the specified resource on a per-region basis. You can specify that resources should receive longer IDs (17-character IDs) when they are created. The following resource types support longer IDs: <code>instance</code> | <code>reservation</code> | <code>snapshot</code> | <code>volume</code>.</p> <p>This setting applies to the IAM user who makes the request; it does not apply to the entire AWS account. By default, an IAM user defaults to the same settings as the root user. If you're using this action as the root user, then these settings apply to the entire account, unless an IAM user explicitly overrides these settings for themselves. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/resource-ids.html\">Resource IDs</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>. </p> <p>Resources created with longer IDs are visible to all IAM roles and users, regardless of these settings and provided that they have permission to use the relevant <code>Describe</code> command for the resource type.</p>",
     "ModifyIdentityIdFormat": "<p>Modifies the ID format of a resource for a specified IAM user, IAM role, or the root user for an account; or all IAM users, IAM roles, and the root user for an account. You can specify that resources should receive longer IDs (17-character IDs) when they are created. </p> <p>The following resource types support longer IDs: <code>instance</code> | <code>reservation</code> | <code>snapshot</code> | <code>volume</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/resource-ids.html\">Resource IDs</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>. </p> <p>This setting applies to the principal specified in the request; it does not apply to the principal that makes the request. </p> <p>Resources created with longer IDs are visible to all IAM roles and users, regardless of these settings and provided that they have permission to use the relevant <code>Describe</code> command for the resource type.</p>",
@@ -221,6 +225,7 @@
     "ReportInstanceStatus": "<p>Submits feedback about the status of an instance. The instance must be in the <code>running</code> state. If your experience with the instance differs from the instance status returned by <a>DescribeInstanceStatus</a>, use <a>ReportInstanceStatus</a> to report your experience with the instance. Amazon EC2 collects this information to improve the accuracy of status checks.</p> <p>Use of this action does not change the value returned by <a>DescribeInstanceStatus</a>.</p>",
     "RequestSpotFleet": "<p>Creates a Spot fleet request.</p> <p>You can submit a single request that includes multiple launch specifications that vary by instance type, AMI, Availability Zone, or subnet.</p> <p>By default, the Spot fleet requests Spot instances in the Spot pool where the price per unit is the lowest. Each launch specification can include its own instance weighting that reflects the value of the instance type to your application workload.</p> <p>Alternatively, you can specify that the Spot fleet distribute the target capacity across the Spot pools included in its launch specifications. By ensuring that the Spot instances in your Spot fleet are in different Spot pools, you can improve the availability of your fleet.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-requests.html\">Spot Fleet Requests</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>",
     "RequestSpotInstances": "<p>Creates a Spot instance request. Spot instances are instances that Amazon EC2 launches when the bid price that you specify exceeds the current Spot price. Amazon EC2 periodically sets the Spot price based on available Spot Instance capacity and current Spot instance requests. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html\">Spot Instance Requests</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>",
+    "ResetFpgaImageAttribute": "<p>Resets the specified attribute of the specified Amazon FPGA Image (AFI) to its default value. You can only reset the load permission attribute.</p>",
     "ResetImageAttribute": "<p>Resets an attribute of an AMI to its default value.</p> <note> <p>The productCodes attribute can't be reset.</p> </note>",
     "ResetInstanceAttribute": "<p>Resets an attribute of an instance to its default value. To reset the <code>kernel</code> or <code>ramdisk</code>, the instance must be in a stopped state. To reset the <code>sourceDestCheck</code>, the instance can be either running or stopped.</p> <p>The <code>sourceDestCheck</code> attribute controls whether source/destination checking is enabled. The default value is <code>true</code>, which means checking is enabled. This value must be <code>false</code> for a NAT instance to perform NAT. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_NAT_Instance.html\">NAT Instances</a> in the <i>Amazon Virtual Private Cloud User Guide</i>.</p>",
     "ResetNetworkInterfaceAttribute": "<p>Resets a network interface attribute. You can specify only one attribute at a time.</p>",
@@ -697,6 +702,7 @@
         "ClassicLinkDnsSupport$ClassicLinkDnsSupported": "<p>Indicates whether ClassicLink DNS support is enabled for the VPC.</p>",
         "ConfirmProductInstanceRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "ConfirmProductInstanceResult$Return": "<p>The return value of the request. Returns <code>true</code> if the specified product code is owned by the requester and associated with the specified instance.</p>",
+        "CopyFpgaImageRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "CopyImageRequest$Encrypted": "<p>Specifies whether the destination snapshots of the copied image should be encrypted. The default CMK for EBS is used unless a non-default AWS Key Management Service (AWS KMS) CMK is specified with <code>KmsKeyId</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html\">Amazon EBS Encryption</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>",
         "CopyImageRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "CopySnapshotRequest$Encrypted": "<p>Specifies whether the destination snapshot should be encrypted. You can encrypt a copy of an unencrypted snapshot using this flag, but you cannot use it to create an unencrypted copy from an encrypted snapshot. Your default CMK for EBS is used unless a non-default AWS Key Management Service (AWS KMS) CMK is specified with <code>KmsKeyId</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html\">Amazon EBS Encryption</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>",
@@ -736,6 +742,8 @@
         "DeleteDhcpOptionsRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DeleteEgressOnlyInternetGatewayRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DeleteEgressOnlyInternetGatewayResult$ReturnCode": "<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>",
+        "DeleteFpgaImageRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
+        "DeleteFpgaImageResult$Return": "<p>Is <code>true</code> if the request succeeds, and an error otherwise.</p>",
         "DeleteInternetGatewayRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DeleteKeyPairRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DeleteNetworkAclEntryRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
@@ -771,6 +779,7 @@
         "DescribeDhcpOptionsRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DescribeEgressOnlyInternetGatewaysRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DescribeElasticGpusRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
+        "DescribeFpgaImageAttributeRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DescribeFpgaImagesRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DescribeImageAttributeRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "DescribeImagesRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
@@ -841,6 +850,7 @@
         "EnableVpcClassicLinkDnsSupportResult$Return": "<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>",
         "EnableVpcClassicLinkRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "EnableVpcClassicLinkResult$Return": "<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>",
+        "FpgaImage$Public": "<p>Indicates whether the AFI is public.</p>",
         "GetConsoleOutputRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "GetConsoleScreenshotRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "GetConsoleScreenshotRequest$WakeUp": "<p>When set to <code>true</code>, acts as keystroke input and wakes up an instance that's in standby or \"sleep\" mode.</p>",
@@ -865,6 +875,7 @@
         "InstanceNetworkInterfaceSpecification$DeleteOnTermination": "<p>If set to <code>true</code>, the interface is deleted when the instance is terminated. You can specify <code>true</code> only if creating a new network interface when launching an instance.</p>",
         "InstancePrivateIpAddress$Primary": "<p>Indicates whether this IPv4 address is the primary private IP address of the network interface.</p>",
         "LaunchSpecification$EbsOptimized": "<p>Indicates whether the instance is optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal EBS I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS Optimized instance.</p> <p>Default: <code>false</code> </p>",
+        "ModifyFpgaImageAttributeRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "ModifyIdFormatRequest$UseLongIds": "<p>Indicate whether the resource should use longer IDs (17-character IDs).</p>",
         "ModifyIdentityIdFormatRequest$UseLongIds": "<p>Indicates whether the resource should use longer IDs (17-character IDs)</p>",
         "ModifyImageAttributeRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
@@ -914,6 +925,8 @@
         "RequestSpotInstancesRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "RequestSpotLaunchSpecification$EbsOptimized": "<p>Indicates whether the instance is optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal EBS I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS Optimized instance.</p> <p>Default: <code>false</code> </p>",
         "ReservedInstancesOffering$Marketplace": "<p>Indicates whether the offering is available through the Reserved Instance Marketplace (resale) or AWS. If it's a Reserved Instance Marketplace offering, this is <code>true</code>.</p>",
+        "ResetFpgaImageAttributeRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
+        "ResetFpgaImageAttributeResult$Return": "<p>Is <code>true</code> if the request succeeds, and an error otherwise.</p>",
         "ResetImageAttributeRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "ResetInstanceAttributeRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
         "ResetNetworkInterfaceAttributeRequest$DryRun": "<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>",
@@ -1198,6 +1211,16 @@
       "base": null,
       "refs": {
         "ConversionTask$State": "<p>The state of the conversion task.</p>"
+      }
+    },
+    "CopyFpgaImageRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "CopyFpgaImageResult": {
+      "base": null,
+      "refs": {
       }
     },
     "CopyImageRequest": {
@@ -1661,6 +1684,16 @@
       "refs": {
       }
     },
+    "DeleteFpgaImageRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DeleteFpgaImageResult": {
+      "base": null,
+      "refs": {
+      }
+    },
     "DeleteInternetGatewayRequest": {
       "base": "<p>Contains the parameters for DeleteInternetGateway.</p>",
       "refs": {
@@ -1919,6 +1952,16 @@
     },
     "DescribeFlowLogsResult": {
       "base": "<p>Contains the output of DescribeFlowLogs.</p>",
+      "refs": {
+      }
+    },
+    "DescribeFpgaImageAttributeRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeFpgaImageAttributeResult": {
+      "base": null,
       "refs": {
       }
     },
@@ -3007,6 +3050,20 @@
         "FpgaImageList$member": null
       }
     },
+    "FpgaImageAttribute": {
+      "base": "<p>Describes an Amazon FPGA image (AFI) attribute.</p>",
+      "refs": {
+        "DescribeFpgaImageAttributeResult$FpgaImageAttribute": "<p>Information about the attribute.</p>",
+        "ModifyFpgaImageAttributeResult$FpgaImageAttribute": "<p>Information about the attribute.</p>"
+      }
+    },
+    "FpgaImageAttributeName": {
+      "base": null,
+      "refs": {
+        "DescribeFpgaImageAttributeRequest$Attribute": "<p>The AFI attribute.</p>",
+        "ModifyFpgaImageAttributeRequest$Attribute": "<p>The name of the attribute.</p>"
+      }
+    },
     "FpgaImageIdList": {
       "base": null,
       "refs": {
@@ -4040,6 +4097,37 @@
         "ReservedInstancesListing$Status": "<p>The status of the Reserved Instance listing.</p>"
       }
     },
+    "LoadPermission": {
+      "base": "<p>Describes a load permission.</p>",
+      "refs": {
+        "LoadPermissionList$member": null
+      }
+    },
+    "LoadPermissionList": {
+      "base": null,
+      "refs": {
+        "FpgaImageAttribute$LoadPermissions": "<p>One or more load permissions.</p>"
+      }
+    },
+    "LoadPermissionListRequest": {
+      "base": null,
+      "refs": {
+        "LoadPermissionModifications$Add": "<p>The load permissions to add.</p>",
+        "LoadPermissionModifications$Remove": "<p>The load permissions to remove.</p>"
+      }
+    },
+    "LoadPermissionModifications": {
+      "base": "<p>Describes modifications to the load permissions of an Amazon FPGA image (AFI).</p>",
+      "refs": {
+        "ModifyFpgaImageAttributeRequest$LoadPermission": "<p>The load permission for the AFI.</p>"
+      }
+    },
+    "LoadPermissionRequest": {
+      "base": "<p>Describes a load permission.</p>",
+      "refs": {
+        "LoadPermissionListRequest$member": null
+      }
+    },
     "Long": {
       "base": null,
       "refs": {
@@ -4065,6 +4153,16 @@
         "DescribeIamInstanceProfileAssociationsRequest$MaxResults": "<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>",
         "DescribeStaleSecurityGroupsRequest$MaxResults": "<p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p>",
         "DescribeVpcClassicLinkDnsSupportRequest$MaxResults": "<p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p>"
+      }
+    },
+    "ModifyFpgaImageAttributeRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ModifyFpgaImageAttributeResult": {
+      "base": null,
+      "refs": {
       }
     },
     "ModifyHostsRequest": {
@@ -4471,6 +4569,7 @@
     "OperationType": {
       "base": null,
       "refs": {
+        "ModifyFpgaImageAttributeRequest$OperationType": "<p>The operation type.</p>",
         "ModifyImageAttributeRequest$OperationType": "<p>The operation type.</p>",
         "ModifySnapshotAttributeRequest$OperationType": "<p>The type of operation to perform to the attribute.</p>"
       }
@@ -4515,7 +4614,9 @@
       "base": null,
       "refs": {
         "CreateVolumePermission$Group": "<p>The specific group that is to be added or removed from a volume's list of create volume permissions.</p>",
-        "LaunchPermission$Group": "<p>The name of the group.</p>"
+        "LaunchPermission$Group": "<p>The name of the group.</p>",
+        "LoadPermission$Group": "<p>The name of the group.</p>",
+        "LoadPermissionRequest$Group": "<p>The name of the group.</p>"
       }
     },
     "Placement": {
@@ -4678,6 +4779,7 @@
         "DescribeSnapshotAttributeResult$ProductCodes": "<p>A list of product codes.</p>",
         "DescribeVolumeAttributeResult$ProductCodes": "<p>A list of product codes.</p>",
         "FpgaImage$ProductCodes": "<p>The product codes for the AFI.</p>",
+        "FpgaImageAttribute$ProductCodes": "<p>One or more product codes.</p>",
         "Image$ProductCodes": "<p>Any product codes associated with the AMI.</p>",
         "ImageAttribute$ProductCodes": "<p>One or more product codes.</p>",
         "Instance$ProductCodes": "<p>The product codes attached to this instance, if applicable.</p>",
@@ -4687,6 +4789,7 @@
     "ProductCodeStringList": {
       "base": null,
       "refs": {
+        "ModifyFpgaImageAttributeRequest$ProductCodes": "<p>One or more product codes. After you add a product code to an AFI, it can't be removed. This parameter is valid only when modifying the <code>productCodes</code> attribute.</p>",
         "ModifyImageAttributeRequest$ProductCodes": "<p>One or more product codes. After you add a product code to an AMI, it can't be removed. This is only valid when modifying the <code>productCodes</code> attribute.</p>"
       }
     },
@@ -5140,6 +5243,22 @@
       "base": null,
       "refs": {
         "ReservedInstancesModification$ReservedInstancesIds": "<p>The IDs of one or more Reserved Instances.</p>"
+      }
+    },
+    "ResetFpgaImageAttributeName": {
+      "base": null,
+      "refs": {
+        "ResetFpgaImageAttributeRequest$Attribute": "<p>The attribute.</p>"
+      }
+    },
+    "ResetFpgaImageAttributeRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ResetFpgaImageAttributeResult": {
+      "base": null,
+      "refs": {
       }
     },
     "ResetImageAttributeName": {
@@ -5868,6 +5987,12 @@
         "ConversionTask$ConversionTaskId": "<p>The ID of the conversion task.</p>",
         "ConversionTask$ExpirationTime": "<p>The time when the task expires. If the upload isn't complete before the expiration time, we automatically cancel the task.</p>",
         "ConversionTask$StatusMessage": "<p>The status message related to the conversion task.</p>",
+        "CopyFpgaImageRequest$SourceFpgaImageId": "<p>The ID of the source AFI.</p>",
+        "CopyFpgaImageRequest$Description": "<p>The description for the new AFI.</p>",
+        "CopyFpgaImageRequest$Name": "<p>The name for the new AFI. The default is the name of the source AFI.</p>",
+        "CopyFpgaImageRequest$SourceRegion": "<p>The region that contains the source AFI.</p>",
+        "CopyFpgaImageRequest$ClientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>",
+        "CopyFpgaImageResult$FpgaImageId": "<p>The ID of the new AFI.</p>",
         "CopyImageRequest$ClientToken": "<p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>",
         "CopyImageRequest$Description": "<p>A description for the new AMI in the destination region.</p>",
         "CopyImageRequest$KmsKeyId": "<p>The full ARN of the AWS Key Management Service (AWS KMS) CMK to use when encrypting the snapshots of an image during a copy operation. This parameter is only required if you want to use a non-default CMK; if this parameter is not specified, the default CMK for EBS is used. The ARN contains the <code>arn:aws:kms</code> namespace, followed by the region of the CMK, the AWS account ID of the CMK owner, the <code>key</code> namespace, and then the CMK ID. For example, arn:aws:kms:<i>us-east-1</i>:<i>012345678910</i>:key/<i>abcd1234-a123-456a-a12b-a123b4cd56ef</i>. The specified CMK must exist in the region that the snapshot is being copied to. If a <code>KmsKeyId</code> is specified, the <code>Encrypted</code> flag must also be set.</p>",
@@ -5969,6 +6094,7 @@
         "CustomerGatewayIdStringList$member": null,
         "DeleteCustomerGatewayRequest$CustomerGatewayId": "<p>The ID of the customer gateway.</p>",
         "DeleteDhcpOptionsRequest$DhcpOptionsId": "<p>The ID of the DHCP options set.</p>",
+        "DeleteFpgaImageRequest$FpgaImageId": "<p>The ID of the AFI.</p>",
         "DeleteInternetGatewayRequest$InternetGatewayId": "<p>The ID of the Internet gateway.</p>",
         "DeleteKeyPairRequest$KeyName": "<p>The name of the key pair.</p>",
         "DeleteNatGatewayRequest$NatGatewayId": "<p>The ID of the NAT gateway.</p>",
@@ -6002,6 +6128,7 @@
         "DescribeElasticGpusResult$NextToken": "<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>",
         "DescribeFlowLogsRequest$NextToken": "<p>The token to retrieve the next page of results.</p>",
         "DescribeFlowLogsResult$NextToken": "<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>",
+        "DescribeFpgaImageAttributeRequest$FpgaImageId": "<p>The ID of the AFI.</p>",
         "DescribeHostReservationOfferingsRequest$NextToken": "<p>The token to use to retrieve the next page of results.</p>",
         "DescribeHostReservationOfferingsRequest$OfferingId": "<p>The ID of the reservation offering.</p>",
         "DescribeHostReservationOfferingsResult$NextToken": "<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>",
@@ -6153,6 +6280,9 @@
         "FpgaImage$ShellVersion": "<p>The version of the AWS Shell that was used to create the bitstream.</p>",
         "FpgaImage$OwnerId": "<p>The AWS account ID of the AFI owner.</p>",
         "FpgaImage$OwnerAlias": "<p>The alias of the AFI owner. Possible values include <code>self</code>, <code>amazon</code>, and <code>aws-marketplace</code>.</p>",
+        "FpgaImageAttribute$FpgaImageId": "<p>The ID of the AFI.</p>",
+        "FpgaImageAttribute$Name": "<p>The name of the AFI.</p>",
+        "FpgaImageAttribute$Description": "<p>The description of the AFI.</p>",
         "FpgaImageIdList$member": null,
         "FpgaImageState$Message": "<p>If the state is <code>failed</code>, this is the error message.</p>",
         "GetConsoleOutputRequest$InstanceId": "<p>The ID of the instance.</p>",
@@ -6166,7 +6296,7 @@
         "GetHostReservationPurchasePreviewResult$TotalUpfrontPrice": "<p>The potential total upfront price. This is billed immediately.</p>",
         "GetPasswordDataRequest$InstanceId": "<p>The ID of the Windows instance.</p>",
         "GetPasswordDataResult$InstanceId": "<p>The ID of the Windows instance.</p>",
-        "GetPasswordDataResult$PasswordData": "<p>The password of the instance.</p>",
+        "GetPasswordDataResult$PasswordData": "<p>The password of the instance. Returns an empty string if the password is not available.</p>",
         "GetReservedInstancesExchangeQuoteResult$CurrencyCode": "<p>The currency of the transaction.</p>",
         "GetReservedInstancesExchangeQuoteResult$PaymentDue": "<p>The total true upfront charge for the exchange.</p>",
         "GetReservedInstancesExchangeQuoteResult$ValidationFailureReason": "<p>Describes the reason why the exchange cannot be completed.</p>",
@@ -6342,6 +6472,11 @@
         "LaunchSpecification$KeyName": "<p>The name of the key pair.</p>",
         "LaunchSpecification$RamdiskId": "<p>The ID of the RAM disk.</p>",
         "LaunchSpecification$SubnetId": "<p>The ID of the subnet in which to launch the instance.</p>",
+        "LoadPermission$UserId": "<p>The AWS account ID.</p>",
+        "LoadPermissionRequest$UserId": "<p>The AWS account ID.</p>",
+        "ModifyFpgaImageAttributeRequest$FpgaImageId": "<p>The ID of the AFI.</p>",
+        "ModifyFpgaImageAttributeRequest$Description": "<p>A description for the AFI.</p>",
+        "ModifyFpgaImageAttributeRequest$Name": "<p>A name for the AFI.</p>",
         "ModifyIdFormatRequest$Resource": "<p>The type of resource: <code>instance</code> | <code>reservation</code> | <code>snapshot</code> | <code>volume</code> </p>",
         "ModifyIdentityIdFormatRequest$PrincipalArn": "<p>The ARN of the principal, which can be an IAM user, IAM role, or the root user. Specify <code>all</code> to modify the ID format for all IAM users, IAM roles, and the root user of the account.</p>",
         "ModifyIdentityIdFormatRequest$Resource": "<p>The type of resource: <code>instance</code> | <code>reservation</code> | <code>snapshot</code> | <code>volume</code> </p>",
@@ -6532,6 +6667,7 @@
         "ReservedInstancesOffering$AvailabilityZone": "<p>The Availability Zone in which the Reserved Instance can be used.</p>",
         "ReservedInstancesOffering$ReservedInstancesOfferingId": "<p>The ID of the Reserved Instance offering. This is the offering ID used in <a>GetReservedInstancesExchangeQuote</a> to confirm that an exchange can be made.</p>",
         "ReservedInstancesOfferingIdStringList$member": null,
+        "ResetFpgaImageAttributeRequest$FpgaImageId": "<p>The ID of the AFI.</p>",
         "ResetImageAttributeRequest$ImageId": "<p>The ID of the AMI.</p>",
         "ResetInstanceAttributeRequest$InstanceId": "<p>The ID of the instance.</p>",
         "ResetNetworkInterfaceAttributeRequest$NetworkInterfaceId": "<p>The ID of the network interface.</p>",
@@ -7080,6 +7216,7 @@
     "UserGroupStringList": {
       "base": null,
       "refs": {
+        "ModifyFpgaImageAttributeRequest$UserGroups": "<p>One or more user groups. This parameter is valid only when modifying the <code>loadPermission</code> attribute.</p>",
         "ModifyImageAttributeRequest$UserGroups": "<p>One or more user groups. This is only valid when modifying the <code>launchPermission</code> attribute.</p>"
       }
     },
@@ -7105,6 +7242,7 @@
     "UserIdStringList": {
       "base": null,
       "refs": {
+        "ModifyFpgaImageAttributeRequest$UserIds": "<p>One or more AWS account IDs. This parameter is valid only when modifying the <code>loadPermission</code> attribute.</p>",
         "ModifyImageAttributeRequest$UserIds": "<p>One or more AWS account IDs. This is only valid when modifying the <code>launchPermission</code> attribute.</p>",
         "ModifySnapshotAttributeRequest$UserIds": "<p>The account ID to modify for the snapshot.</p>"
       }

--- a/models/apis/logs/2014-03-28/api-2.json
+++ b/models/apis/logs/2014-03-28/api-2.json
@@ -11,6 +11,20 @@
     "uid":"logs-2014-03-28"
   },
   "operations":{
+    "AssociateKmsKey":{
+      "name":"AssociateKmsKey",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"AssociateKmsKeyRequest"},
+      "errors":[
+        {"shape":"InvalidParameterException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"OperationAbortedException"},
+        {"shape":"ServiceUnavailableException"}
+      ]
+    },
     "CancelExportTask":{
       "name":"CancelExportTask",
       "http":{
@@ -262,6 +276,20 @@
         {"shape":"ServiceUnavailableException"}
       ]
     },
+    "DisassociateKmsKey":{
+      "name":"DisassociateKmsKey",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DisassociateKmsKeyRequest"},
+      "errors":[
+        {"shape":"InvalidParameterException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"OperationAbortedException"},
+        {"shape":"ServiceUnavailableException"}
+      ]
+    },
     "FilterLogEvents":{
       "name":"FilterLogEvents",
       "http":{
@@ -447,6 +475,17 @@
       "min":1
     },
     "Arn":{"type":"string"},
+    "AssociateKmsKeyRequest":{
+      "type":"structure",
+      "required":[
+        "logGroupName",
+        "kmsKeyId"
+      ],
+      "members":{
+        "logGroupName":{"shape":"LogGroupName"},
+        "kmsKeyId":{"shape":"KmsKeyId"}
+      }
+    },
     "CancelExportTaskRequest":{
       "type":"structure",
       "required":["taskId"],
@@ -483,6 +522,7 @@
       "required":["logGroupName"],
       "members":{
         "logGroupName":{"shape":"LogGroupName"},
+        "kmsKeyId":{"shape":"KmsKeyId"},
         "tags":{"shape":"Tags"}
       }
     },
@@ -711,6 +751,13 @@
       "type":"list",
       "member":{"shape":"Destination"}
     },
+    "DisassociateKmsKeyRequest":{
+      "type":"structure",
+      "required":["logGroupName"],
+      "members":{
+        "logGroupName":{"shape":"LogGroupName"}
+      }
+    },
     "Distribution":{
       "type":"string",
       "enum":[
@@ -909,6 +956,10 @@
       },
       "exception":true
     },
+    "KmsKeyId":{
+      "type":"string",
+      "max":256
+    },
     "LimitExceededException":{
       "type":"structure",
       "members":{
@@ -937,7 +988,8 @@
         "retentionInDays":{"shape":"Days"},
         "metricFilterCount":{"shape":"FilterCount"},
         "arn":{"shape":"Arn"},
-        "storedBytes":{"shape":"StoredBytes"}
+        "storedBytes":{"shape":"StoredBytes"},
+        "kmsKeyId":{"shape":"KmsKeyId"}
       }
     },
     "LogGroupName":{

--- a/models/apis/logs/2014-03-28/docs-2.json
+++ b/models/apis/logs/2014-03-28/docs-2.json
@@ -2,9 +2,10 @@
   "version": "2.0",
   "service": "<p>You can use Amazon CloudWatch Logs to monitor, store, and access your log files from Amazon EC2 instances, AWS CloudTrail, or other sources. You can then retrieve the associated log data from CloudWatch Logs using the CloudWatch console, CloudWatch Logs commands in the AWS CLI, CloudWatch Logs API, or CloudWatch Logs SDK.</p> <p>You can use CloudWatch Logs to:</p> <ul> <li> <p> <b>Monitor logs from EC2 instances in real-time</b>: You can use CloudWatch Logs to monitor applications and systems using log data. For example, CloudWatch Logs can track the number of errors that occur in your application logs and send you a notification whenever the rate of errors exceeds a threshold that you specify. CloudWatch Logs uses your log data for monitoring; so, no code changes are required. For example, you can monitor application logs for specific literal terms (such as \"NullReferenceException\") or count the number of occurrences of a literal term at a particular position in log data (such as \"404\" status codes in an Apache access log). When the term you are searching for is found, CloudWatch Logs reports the data to a CloudWatch metric that you specify.</p> </li> <li> <p> <b>Monitor AWS CloudTrail logged events</b>: You can create alarms in CloudWatch and receive notifications of particular API activity as captured by CloudTrail and use the notification to perform troubleshooting.</p> </li> <li> <p> <b>Archive log data</b>: You can use CloudWatch Logs to store your log data in highly durable storage. You can change the log retention setting so that any log events older than this setting are automatically deleted. The CloudWatch Logs agent makes it easy to quickly send both rotated and non-rotated log data off of a host and into the log service. You can then access the raw log data when you need it.</p> </li> </ul>",
   "operations": {
+    "AssociateKmsKey": "<p>Associates the specified AWS Key Management Service (AWS KMS) customer master key (CMK) with the specified log group.</p> <p>Associating an AWS KMS CMK with a log group overrides any existing associations between the log group and a CMK. After a CMK is associated with a log group, all newly ingested data for the log group is encrypted using the CMK. This association is stored as long as the data encrypted with the CMK is still within Amazon CloudWatch Logs. This enables Amazon CloudWatch Logs to decrypt this data whenever it is requested.</p> <p>Note that it can take up to 5 minutes for this operation to take effect.</p> <p>If you attempt to associate a CMK with a log group but the CMK does not exist or the CMK is disabled, you will receive an <code>InvalidParameterException</code> error. </p>",
     "CancelExportTask": "<p>Cancels the specified export task.</p> <p>The task must be in the <code>PENDING</code> or <code>RUNNING</code> state.</p>",
     "CreateExportTask": "<p>Creates an export task, which allows you to efficiently export data from a log group to an Amazon S3 bucket.</p> <p>This is an asynchronous call. If all the required information is provided, this operation initiates an export task and responds with the ID of the task. After the task has started, you can use <a>DescribeExportTasks</a> to get the status of the export task. Each account can only have one active (<code>RUNNING</code> or <code>PENDING</code>) export task at a time. To cancel an export task, use <a>CancelExportTask</a>.</p> <p>You can export logs from multiple log groups or multiple time ranges to the same S3 bucket. To separate out log data for each export task, you can specify a prefix to be used as the Amazon S3 key prefix for all exported objects.</p>",
-    "CreateLogGroup": "<p>Creates a log group with the specified name.</p> <p>You can create up to 5000 log groups per account.</p> <p>You must use the following guidelines when naming a log group:</p> <ul> <li> <p>Log group names must be unique within a region for an AWS account.</p> </li> <li> <p>Log group names can be between 1 and 512 characters long.</p> </li> <li> <p>Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), '/' (forward slash), and '.' (period).</p> </li> </ul>",
+    "CreateLogGroup": "<p>Creates a log group with the specified name.</p> <p>You can create up to 5000 log groups per account.</p> <p>You must use the following guidelines when naming a log group:</p> <ul> <li> <p>Log group names must be unique within a region for an AWS account.</p> </li> <li> <p>Log group names can be between 1 and 512 characters long.</p> </li> <li> <p>Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), '/' (forward slash), and '.' (period).</p> </li> </ul> <p>If you associate a AWS Key Management Service (AWS KMS) customer master key (CMK) with the log group, ingested data is encrypted using the CMK. This association is stored as long as the data encrypted with the CMK is still within Amazon CloudWatch Logs. This enables Amazon CloudWatch Logs to decrypt this data whenever it is requested.</p> <p>If you attempt to associate a CMK with the log group but the CMK does not exist or the CMK is disabled, you will receive an <code>InvalidParameterException</code> error. </p>",
     "CreateLogStream": "<p>Creates a log stream for the specified log group.</p> <p>There is no limit on the number of log streams that you can create for a log group.</p> <p>You must use the following guidelines when naming a log stream:</p> <ul> <li> <p>Log stream names must be unique within the log group.</p> </li> <li> <p>Log stream names can be between 1 and 512 characters long.</p> </li> <li> <p>The ':' (colon) and '*' (asterisk) characters are not allowed.</p> </li> </ul>",
     "DeleteDestination": "<p>Deletes the specified destination, and eventually disables all the subscription filters that publish to it. This operation does not delete the physical resource encapsulated by the destination.</p>",
     "DeleteLogGroup": "<p>Deletes the specified log group and permanently deletes all the archived log events associated with the log group.</p>",
@@ -17,12 +18,13 @@
     "DescribeExportTasks": "<p>Lists the specified export tasks. You can list all your export tasks or filter the results based on task ID or task status.</p>",
     "DescribeLogGroups": "<p>Lists the specified log groups. You can list all your log groups or filter the results by prefix. The results are ASCII-sorted by log group name.</p>",
     "DescribeLogStreams": "<p>Lists the log streams for the specified log group. You can list all the log streams or filter the results by prefix. You can also control how the results are ordered.</p> <p>This operation has a limit of five transactions per second, after which transactions are throttled.</p>",
-    "DescribeMetricFilters": "<p>Lists the specified metric filters. You can list all the metric filters or filter the results by log name, prefix, metric name, and metric namespace. The results are ASCII-sorted by filter name.</p>",
+    "DescribeMetricFilters": "<p>Lists the specified metric filters. You can list all the metric filters or filter the results by log name, prefix, metric name, or metric namespace. The results are ASCII-sorted by filter name.</p>",
     "DescribeResourcePolicies": "<p>Lists the resource policies in this account.</p>",
     "DescribeSubscriptionFilters": "<p>Lists the subscription filters for the specified log group. You can list all the subscription filters or filter the results by prefix. The results are ASCII-sorted by filter name.</p>",
+    "DisassociateKmsKey": "<p>Disassociates the associated AWS Key Management Service (AWS KMS) customer master key (CMK) from the specified log group.</p> <p>After the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested.</p> <p>Note that it can take up to 5 minutes for this operation to take effect.</p>",
     "FilterLogEvents": "<p>Lists log events from the specified log group. You can list all the log events or filter the results using a filter pattern, a time range, and the name of the log stream.</p> <p>By default, this operation returns as many log events as can fit in 1 MB (up to 10,000 log events), or all the events found within the time range that you specify. If the results include a token, then there are more log events available, and you can get additional results by specifying the token in a subsequent call.</p>",
-    "GetLogEvents": "<p>Lists log events from the specified log stream. You can list all the log events or filter using a time range.</p> <p>By default, this operation returns as many log events as can fit in a response size of 1 MB (up to 10,000 log events). You can get additional log events by specifying one of the tokens in a subsequent call.</p>",
-    "ListTagsLogGroup": "<p>Lists the tags for the specified log group.</p> <p>To add tags, use <a>TagLogGroup</a>. To remove tags, use <a>UntagLogGroup</a>.</p>",
+    "GetLogEvents": "<p>Lists log events from the specified log stream. You can list all the log events or filter using a time range.</p> <p>By default, this operation returns as many log events as can fit in a response size of 1MB (up to 10,000 log events). You can get additional log events by specifying one of the tokens in a subsequent call.</p>",
+    "ListTagsLogGroup": "<p>Lists the tags for the specified log group.</p>",
     "PutDestination": "<p>Creates or updates a destination. A destination encapsulates a physical resource (such as an Amazon Kinesis stream) and enables you to subscribe to a real-time stream of log events for a different account, ingested using <a>PutLogEvents</a>. Currently, the only supported physical resource is a Kinesis stream belonging to the same account as the destination.</p> <p>Through an access policy, a destination controls what is written to its Kinesis stream. By default, <code>PutDestination</code> does not set any access policy with the destination, which means a cross-account user cannot call <a>PutSubscriptionFilter</a> against this destination. To enable this, the destination owner must call <a>PutDestinationPolicy</a> after <code>PutDestination</code>.</p>",
     "PutDestinationPolicy": "<p>Creates or updates an access policy associated with an existing destination. An access policy is an <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies_overview.html\">IAM policy document</a> that is used to authorize claims to register a subscription filter against a given destination.</p>",
     "PutLogEvents": "<p>Uploads a batch of log events to the specified log stream.</p> <p>You must include the sequence token obtained from the response of the previous call. An upload in a newly created log stream does not require a sequence token. You can also get the sequence token using <a>DescribeLogStreams</a>. If you call <code>PutLogEvents</code> twice within a narrow time period using the same value for <code>sequenceToken</code>, both calls may be successful, or one may be rejected.</p> <p>The batch of events must satisfy the following constraints:</p> <ul> <li> <p>The maximum batch size is 1,048,576 bytes, and this size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.</p> </li> <li> <p>None of the log events in the batch can be more than 2 hours in the future.</p> </li> <li> <p>None of the log events in the batch can be older than 14 days or the retention period of the log group.</p> </li> <li> <p>The log events in the batch must be in chronological ordered by their time stamp (the time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC).</p> </li> <li> <p>The maximum number of log events in a batch is 10,000.</p> </li> <li> <p>A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.</p> </li> </ul>",
@@ -48,6 +50,11 @@
         "Destination$arn": "<p>The ARN of this destination.</p>",
         "LogGroup$arn": "<p>The Amazon Resource Name (ARN) of the log group.</p>",
         "LogStream$arn": "<p>The Amazon Resource Name (ARN) of the log stream.</p>"
+      }
+    },
+    "AssociateKmsKeyRequest": {
+      "base": null,
+      "refs": {
       }
     },
     "CancelExportTaskRequest": {
@@ -246,11 +253,16 @@
         "DescribeDestinationsResponse$destinations": "<p>The destinations.</p>"
       }
     },
-    "Distribution": {
+    "DisassociateKmsKeyRequest": {
       "base": null,
       "refs": {
-        "PutSubscriptionFilterRequest$distribution": "<p>The method used to distribute log data to the destination, when the destination is an Amazon Kinesis stream. By default, log data is grouped by log stream. For a more even distribution, you can group log data randomly.</p>",
-        "SubscriptionFilter$distribution": "<p>The method used to distribute log data to the destination, when the destination is an Amazon Kinesis stream.</p>"
+      }
+    },
+    "Distribution": {
+      "base": "<p>The method used to distribute log data to the destination, which can be either random or grouped by log stream.</p>",
+      "refs": {
+        "PutSubscriptionFilterRequest$distribution": "<p>The method used to distribute log data to the destination. By default log data is grouped by log stream, but the grouping can be set to random for a more even distribution. This property is only applicable when the destination is an Amazon Kinesis stream. </p>",
+        "SubscriptionFilter$distribution": null
       }
     },
     "EventId": {
@@ -456,6 +468,14 @@
       "refs": {
       }
     },
+    "KmsKeyId": {
+      "base": null,
+      "refs": {
+        "AssociateKmsKeyRequest$kmsKeyId": "<p>The Amazon Resource Name (ARN) of the CMK to use when encrypting log data. For more information, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms\">Amazon Resource Names - AWS Key Management Service (AWS KMS)</a>.</p>",
+        "CreateLogGroupRequest$kmsKeyId": "<p>The Amazon Resource Name (ARN) of the CMK to use when encrypting log data. For more information, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms\">Amazon Resource Names - AWS Key Management Service (AWS KMS)</a>.</p>",
+        "LogGroup$kmsKeyId": "<p>The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.</p>"
+      }
+    },
     "LimitExceededException": {
       "base": "<p>You have reached the maximum number of resources that can be created.</p>",
       "refs": {
@@ -488,6 +508,7 @@
     "LogGroupName": {
       "base": null,
       "refs": {
+        "AssociateKmsKeyRequest$logGroupName": "<p>The name of the log group.</p>",
         "CreateExportTaskRequest$logGroupName": "<p>The name of the log group.</p>",
         "CreateLogGroupRequest$logGroupName": "<p>The name of the log group.</p>",
         "CreateLogStreamRequest$logGroupName": "<p>The name of the log group.</p>",
@@ -500,6 +521,7 @@
         "DescribeLogStreamsRequest$logGroupName": "<p>The name of the log group.</p>",
         "DescribeMetricFiltersRequest$logGroupName": "<p>The name of the log group.</p>",
         "DescribeSubscriptionFiltersRequest$logGroupName": "<p>The name of the log group.</p>",
+        "DisassociateKmsKeyRequest$logGroupName": "<p>The name of the log group.</p>",
         "ExportTask$logGroupName": "<p>The name of the log group from which logs data was exported.</p>",
         "FilterLogEventsRequest$logGroupName": "<p>The name of the log group.</p>",
         "GetLogEventsRequest$logGroupName": "<p>The name of the log group.</p>",
@@ -581,7 +603,7 @@
     "MetricName": {
       "base": "<p>The name of the CloudWatch metric to which the monitored log information should be published. For example, you may publish to a metric called ErrorCount.</p>",
       "refs": {
-        "DescribeMetricFiltersRequest$metricName": "<p>The name of the CloudWatch metric.</p>",
+        "DescribeMetricFiltersRequest$metricName": null,
         "MetricTransformation$metricName": "<p>The name of the CloudWatch metric.</p>"
       }
     },
@@ -841,7 +863,7 @@
       "base": null,
       "refs": {
         "CreateLogGroupRequest$tags": "<p>The key-value pairs to use for the tags.</p>",
-        "ListTagsLogGroupResponse$tags": "<p>The tags.</p>",
+        "ListTagsLogGroupResponse$tags": "<p>The tags for the log group.</p>",
         "TagLogGroupRequest$tags": "<p>The key-value pairs to use for the tags.</p>"
       }
     },

--- a/service/budgets/api.go
+++ b/service/budgets/api.go
@@ -1039,6 +1039,10 @@ func (c *Budgets) UpdateNotificationRequest(input *UpdateNotificationInput) (req
 //   This exception is thrown if a requested entity is not found. E.g., if a budget
 //   id doesn't exist for an account ID.
 //
+//   * ErrCodeDuplicateRecordException "DuplicateRecordException"
+//   The exception is thrown when customer tries to create a record (e.g. budget)
+//   that already exists.
+//
 func (c *Budgets) UpdateNotification(input *UpdateNotificationInput) (*UpdateNotificationOutput, error) {
 	req, out := c.UpdateNotificationRequest(input)
 	return out, req.Send()
@@ -1122,6 +1126,10 @@ func (c *Budgets) UpdateSubscriberRequest(input *UpdateSubscriberInput) (req *re
 //   * ErrCodeNotFoundException "NotFoundException"
 //   This exception is thrown if a requested entity is not found. E.g., if a budget
 //   id doesn't exist for an account ID.
+//
+//   * ErrCodeDuplicateRecordException "DuplicateRecordException"
+//   The exception is thrown when customer tries to create a record (e.g. budget)
+//   that already exists.
 //
 func (c *Budgets) UpdateSubscriber(input *UpdateSubscriberInput) (*UpdateSubscriberOutput, error) {
 	req, out := c.UpdateSubscriberRequest(input)

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -12,6 +12,109 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 )
 
+const opAssociateKmsKey = "AssociateKmsKey"
+
+// AssociateKmsKeyRequest generates a "aws/request.Request" representing the
+// client's request for the AssociateKmsKey operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AssociateKmsKey for more information on using the AssociateKmsKey
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AssociateKmsKeyRequest method.
+//    req, resp := client.AssociateKmsKeyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/AssociateKmsKey
+func (c *CloudWatchLogs) AssociateKmsKeyRequest(input *AssociateKmsKeyInput) (req *request.Request, output *AssociateKmsKeyOutput) {
+	op := &request.Operation{
+		Name:       opAssociateKmsKey,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &AssociateKmsKeyInput{}
+	}
+
+	output = &AssociateKmsKeyOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// AssociateKmsKey API operation for Amazon CloudWatch Logs.
+//
+// Associates the specified AWS Key Management Service (AWS KMS) customer master
+// key (CMK) with the specified log group.
+//
+// Associating an AWS KMS CMK with a log group overrides any existing associations
+// between the log group and a CMK. After a CMK is associated with a log group,
+// all newly ingested data for the log group is encrypted using the CMK. This
+// association is stored as long as the data encrypted with the CMK is still
+// within Amazon CloudWatch Logs. This enables Amazon CloudWatch Logs to decrypt
+// this data whenever it is requested.
+//
+// Note that it can take up to 5 minutes for this operation to take effect.
+//
+// If you attempt to associate a CMK with a log group but the CMK does not exist
+// or the CMK is disabled, you will receive an InvalidParameterException error.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudWatch Logs's
+// API operation AssociateKmsKey for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   A parameter is specified incorrectly.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeOperationAbortedException "OperationAbortedException"
+//   Multiple requests to update the same resource were in conflict.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service cannot complete the request.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/AssociateKmsKey
+func (c *CloudWatchLogs) AssociateKmsKey(input *AssociateKmsKeyInput) (*AssociateKmsKeyOutput, error) {
+	req, out := c.AssociateKmsKeyRequest(input)
+	return out, req.Send()
+}
+
+// AssociateKmsKeyWithContext is the same as AssociateKmsKey with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AssociateKmsKey for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudWatchLogs) AssociateKmsKeyWithContext(ctx aws.Context, input *AssociateKmsKeyInput, opts ...request.Option) (*AssociateKmsKeyOutput, error) {
+	req, out := c.AssociateKmsKeyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCancelExportTask = "CancelExportTask"
 
 // CancelExportTaskRequest generates a "aws/request.Request" representing the
@@ -267,6 +370,16 @@ func (c *CloudWatchLogs) CreateLogGroupRequest(input *CreateLogGroupInput) (req 
 //
 //    * Log group names consist of the following characters: a-z, A-Z, 0-9,
 //    '_' (underscore), '-' (hyphen), '/' (forward slash), and '.' (period).
+//
+// If you associate a AWS Key Management Service (AWS KMS) customer master key
+// (CMK) with the log group, ingested data is encrypted using the CMK. This
+// association is stored as long as the data encrypted with the CMK is still
+// within Amazon CloudWatch Logs. This enables Amazon CloudWatch Logs to decrypt
+// this data whenever it is requested.
+//
+// If you attempt to associate a CMK with the log group but the CMK does not
+// exist or the CMK is disabled, you will receive an InvalidParameterException
+// error.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1607,7 +1720,7 @@ func (c *CloudWatchLogs) DescribeMetricFiltersRequest(input *DescribeMetricFilte
 // DescribeMetricFilters API operation for Amazon CloudWatch Logs.
 //
 // Lists the specified metric filters. You can list all the metric filters or
-// filter the results by log name, prefix, metric name, and metric namespace.
+// filter the results by log name, prefix, metric name, or metric namespace.
 // The results are ASCII-sorted by filter name.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1924,6 +2037,104 @@ func (c *CloudWatchLogs) DescribeSubscriptionFiltersPagesWithContext(ctx aws.Con
 	return p.Err()
 }
 
+const opDisassociateKmsKey = "DisassociateKmsKey"
+
+// DisassociateKmsKeyRequest generates a "aws/request.Request" representing the
+// client's request for the DisassociateKmsKey operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DisassociateKmsKey for more information on using the DisassociateKmsKey
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DisassociateKmsKeyRequest method.
+//    req, resp := client.DisassociateKmsKeyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/DisassociateKmsKey
+func (c *CloudWatchLogs) DisassociateKmsKeyRequest(input *DisassociateKmsKeyInput) (req *request.Request, output *DisassociateKmsKeyOutput) {
+	op := &request.Operation{
+		Name:       opDisassociateKmsKey,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DisassociateKmsKeyInput{}
+	}
+
+	output = &DisassociateKmsKeyOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DisassociateKmsKey API operation for Amazon CloudWatch Logs.
+//
+// Disassociates the associated AWS Key Management Service (AWS KMS) customer
+// master key (CMK) from the specified log group.
+//
+// After the AWS KMS CMK is disassociated from the log group, AWS CloudWatch
+// Logs stops encrypting newly ingested data for the log group. All previously
+// ingested data remains encrypted, and AWS CloudWatch Logs requires permissions
+// for the CMK whenever the encrypted data is requested.
+//
+// Note that it can take up to 5 minutes for this operation to take effect.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudWatch Logs's
+// API operation DisassociateKmsKey for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   A parameter is specified incorrectly.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeOperationAbortedException "OperationAbortedException"
+//   Multiple requests to update the same resource were in conflict.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service cannot complete the request.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/DisassociateKmsKey
+func (c *CloudWatchLogs) DisassociateKmsKey(input *DisassociateKmsKeyInput) (*DisassociateKmsKeyOutput, error) {
+	req, out := c.DisassociateKmsKeyRequest(input)
+	return out, req.Send()
+}
+
+// DisassociateKmsKeyWithContext is the same as DisassociateKmsKey with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DisassociateKmsKey for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudWatchLogs) DisassociateKmsKeyWithContext(ctx aws.Context, input *DisassociateKmsKeyInput, opts ...request.Option) (*DisassociateKmsKeyOutput, error) {
+	req, out := c.DisassociateKmsKeyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opFilterLogEvents = "FilterLogEvents"
 
 // FilterLogEventsRequest generates a "aws/request.Request" representing the
@@ -2127,7 +2338,7 @@ func (c *CloudWatchLogs) GetLogEventsRequest(input *GetLogEventsInput) (req *req
 // events or filter using a time range.
 //
 // By default, this operation returns as many log events as can fit in a response
-// size of 1 MB (up to 10,000 log events). You can get additional log events
+// size of 1MB (up to 10,000 log events). You can get additional log events
 // by specifying one of the tokens in a subsequent call.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2264,8 +2475,6 @@ func (c *CloudWatchLogs) ListTagsLogGroupRequest(input *ListTagsLogGroupInput) (
 // ListTagsLogGroup API operation for Amazon CloudWatch Logs.
 //
 // Lists the tags for the specified log group.
-//
-// To add tags, use TagLogGroup. To remove tags, use UntagLogGroup.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3255,6 +3464,79 @@ func (c *CloudWatchLogs) UntagLogGroupWithContext(ctx aws.Context, input *UntagL
 	return out, req.Send()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/AssociateKmsKeyRequest
+type AssociateKmsKeyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.
+	// For more information, see Amazon Resource Names - AWS Key Management Service
+	// (AWS KMS) (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms).
+	//
+	// KmsKeyId is a required field
+	KmsKeyId *string `locationName:"kmsKeyId" type:"string" required:"true"`
+
+	// The name of the log group.
+	//
+	// LogGroupName is a required field
+	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s AssociateKmsKeyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociateKmsKeyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociateKmsKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociateKmsKeyInput"}
+	if s.KmsKeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KmsKeyId"))
+	}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *AssociateKmsKeyInput) SetKmsKeyId(v string) *AssociateKmsKeyInput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *AssociateKmsKeyInput) SetLogGroupName(v string) *AssociateKmsKeyInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/AssociateKmsKeyOutput
+type AssociateKmsKeyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociateKmsKeyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociateKmsKeyOutput) GoString() string {
+	return s.String()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/CancelExportTaskRequest
 type CancelExportTaskInput struct {
 	_ struct{} `type:"structure"`
@@ -3467,6 +3749,11 @@ func (s *CreateExportTaskOutput) SetTaskId(v string) *CreateExportTaskOutput {
 type CreateLogGroupInput struct {
 	_ struct{} `type:"structure"`
 
+	// The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.
+	// For more information, see Amazon Resource Names - AWS Key Management Service
+	// (AWS KMS) (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms).
+	KmsKeyId *string `locationName:"kmsKeyId" type:"string"`
+
 	// The name of the log group.
 	//
 	// LogGroupName is a required field
@@ -3503,6 +3790,12 @@ func (s *CreateLogGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *CreateLogGroupInput) SetKmsKeyId(v string) *CreateLogGroupInput {
+	s.KmsKeyId = &v
+	return s
 }
 
 // SetLogGroupName sets the LogGroupName field's value.
@@ -4501,7 +4794,8 @@ type DescribeMetricFiltersInput struct {
 	// The name of the log group.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string"`
 
-	// The name of the CloudWatch metric.
+	// The name of the CloudWatch metric to which the monitored log information
+	// should be published. For example, you may publish to a metric called ErrorCount.
 	MetricName *string `locationName:"metricName" type:"string"`
 
 	// The namespace of the CloudWatch metric.
@@ -4884,6 +5178,63 @@ func (s *Destination) SetRoleArn(v string) *Destination {
 func (s *Destination) SetTargetArn(v string) *Destination {
 	s.TargetArn = &v
 	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/DisassociateKmsKeyRequest
+type DisassociateKmsKeyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the log group.
+	//
+	// LogGroupName is a required field
+	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DisassociateKmsKeyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateKmsKeyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DisassociateKmsKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DisassociateKmsKeyInput"}
+	if s.LogGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogGroupName"))
+	}
+	if s.LogGroupName != nil && len(*s.LogGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LogGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLogGroupName sets the LogGroupName field's value.
+func (s *DisassociateKmsKeyInput) SetLogGroupName(v string) *DisassociateKmsKeyInput {
+	s.LogGroupName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/logs-2014-03-28/DisassociateKmsKeyOutput
+type DisassociateKmsKeyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisassociateKmsKeyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateKmsKeyOutput) GoString() string {
+	return s.String()
 }
 
 // Represents an export task.
@@ -5553,7 +5904,7 @@ func (s *ListTagsLogGroupInput) SetLogGroupName(v string) *ListTagsLogGroupInput
 type ListTagsLogGroupOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The tags.
+	// The tags for the log group.
 	Tags map[string]*string `locationName:"tags" min:"1" type:"map"`
 }
 
@@ -5584,6 +5935,9 @@ type LogGroup struct {
 	// The creation time of the log group, expressed as the number of milliseconds
 	// after Jan 1, 1970 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
+
+	// The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.
+	KmsKeyId *string `locationName:"kmsKeyId" type:"string"`
 
 	// The name of the log group.
 	LogGroupName *string `locationName:"logGroupName" min:"1" type:"string"`
@@ -5619,6 +5973,12 @@ func (s *LogGroup) SetArn(v string) *LogGroup {
 // SetCreationTime sets the CreationTime field's value.
 func (s *LogGroup) SetCreationTime(v int64) *LogGroup {
 	s.CreationTime = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *LogGroup) SetKmsKeyId(v string) *LogGroup {
+	s.KmsKeyId = &v
 	return s
 }
 
@@ -6577,9 +6937,10 @@ type PutSubscriptionFilterInput struct {
 	// DestinationArn is a required field
 	DestinationArn *string `locationName:"destinationArn" min:"1" type:"string" required:"true"`
 
-	// The method used to distribute log data to the destination, when the destination
-	// is an Amazon Kinesis stream. By default, log data is grouped by log stream.
-	// For a more even distribution, you can group log data randomly.
+	// The method used to distribute log data to the destination. By default log
+	// data is grouped by log stream, but the grouping can be set to random for
+	// a more even distribution. This property is only applicable when the destination
+	// is an Amazon Kinesis stream.
 	Distribution *string `locationName:"distribution" type:"string" enum:"Distribution"`
 
 	// A name for the subscription filter. If you are updating an existing filter,
@@ -6836,8 +7197,8 @@ type SubscriptionFilter struct {
 	// The Amazon Resource Name (ARN) of the destination.
 	DestinationArn *string `locationName:"destinationArn" min:"1" type:"string"`
 
-	// The method used to distribute log data to the destination, when the destination
-	// is an Amazon Kinesis stream.
+	// The method used to distribute log data to the destination, which can be either
+	// random or grouped by log stream.
 	Distribution *string `locationName:"distribution" type:"string" enum:"Distribution"`
 
 	// The name of the subscription filter.
@@ -7138,6 +7499,8 @@ func (s UntagLogGroupOutput) GoString() string {
 	return s.String()
 }
 
+// The method used to distribute log data to the destination, which can be either
+// random or grouped by log stream.
 const (
 	// DistributionRandom is a Distribution enum value
 	DistributionRandom = "Random"

--- a/service/cloudwatchlogs/cloudwatchlogsiface/interface.go
+++ b/service/cloudwatchlogs/cloudwatchlogsiface/interface.go
@@ -26,7 +26,7 @@ import (
 //    // myFunc uses an SDK service client to make a request to
 //    // Amazon CloudWatch Logs.
 //    func myFunc(svc cloudwatchlogsiface.CloudWatchLogsAPI) bool {
-//        // Make svc.CancelExportTask request
+//        // Make svc.AssociateKmsKey request
 //    }
 //
 //    func main() {
@@ -42,7 +42,7 @@ import (
 //    type mockCloudWatchLogsClient struct {
 //        cloudwatchlogsiface.CloudWatchLogsAPI
 //    }
-//    func (m *mockCloudWatchLogsClient) CancelExportTask(input *cloudwatchlogs.CancelExportTaskInput) (*cloudwatchlogs.CancelExportTaskOutput, error) {
+//    func (m *mockCloudWatchLogsClient) AssociateKmsKey(input *cloudwatchlogs.AssociateKmsKeyInput) (*cloudwatchlogs.AssociateKmsKeyOutput, error) {
 //        // mock response/functionality
 //    }
 //
@@ -60,6 +60,10 @@ import (
 // and waiters. Its suggested to use the pattern above for testing, or using
 // tooling to generate mocks to satisfy the interfaces.
 type CloudWatchLogsAPI interface {
+	AssociateKmsKey(*cloudwatchlogs.AssociateKmsKeyInput) (*cloudwatchlogs.AssociateKmsKeyOutput, error)
+	AssociateKmsKeyWithContext(aws.Context, *cloudwatchlogs.AssociateKmsKeyInput, ...request.Option) (*cloudwatchlogs.AssociateKmsKeyOutput, error)
+	AssociateKmsKeyRequest(*cloudwatchlogs.AssociateKmsKeyInput) (*request.Request, *cloudwatchlogs.AssociateKmsKeyOutput)
+
 	CancelExportTask(*cloudwatchlogs.CancelExportTaskInput) (*cloudwatchlogs.CancelExportTaskOutput, error)
 	CancelExportTaskWithContext(aws.Context, *cloudwatchlogs.CancelExportTaskInput, ...request.Option) (*cloudwatchlogs.CancelExportTaskOutput, error)
 	CancelExportTaskRequest(*cloudwatchlogs.CancelExportTaskInput) (*request.Request, *cloudwatchlogs.CancelExportTaskOutput)
@@ -146,6 +150,10 @@ type CloudWatchLogsAPI interface {
 
 	DescribeSubscriptionFiltersPages(*cloudwatchlogs.DescribeSubscriptionFiltersInput, func(*cloudwatchlogs.DescribeSubscriptionFiltersOutput, bool) bool) error
 	DescribeSubscriptionFiltersPagesWithContext(aws.Context, *cloudwatchlogs.DescribeSubscriptionFiltersInput, func(*cloudwatchlogs.DescribeSubscriptionFiltersOutput, bool) bool, ...request.Option) error
+
+	DisassociateKmsKey(*cloudwatchlogs.DisassociateKmsKeyInput) (*cloudwatchlogs.DisassociateKmsKeyOutput, error)
+	DisassociateKmsKeyWithContext(aws.Context, *cloudwatchlogs.DisassociateKmsKeyInput, ...request.Option) (*cloudwatchlogs.DisassociateKmsKeyOutput, error)
+	DisassociateKmsKeyRequest(*cloudwatchlogs.DisassociateKmsKeyInput) (*request.Request, *cloudwatchlogs.DisassociateKmsKeyOutput)
 
 	FilterLogEvents(*cloudwatchlogs.FilterLogEventsInput) (*cloudwatchlogs.FilterLogEventsOutput, error)
 	FilterLogEventsWithContext(aws.Context, *cloudwatchlogs.FilterLogEventsInput, ...request.Option) (*cloudwatchlogs.FilterLogEventsOutput, error)

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -2306,6 +2306,80 @@ func (c *EC2) ConfirmProductInstanceWithContext(ctx aws.Context, input *ConfirmP
 	return out, req.Send()
 }
 
+const opCopyFpgaImage = "CopyFpgaImage"
+
+// CopyFpgaImageRequest generates a "aws/request.Request" representing the
+// client's request for the CopyFpgaImage operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CopyFpgaImage for more information on using the CopyFpgaImage
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CopyFpgaImageRequest method.
+//    req, resp := client.CopyFpgaImageRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CopyFpgaImage
+func (c *EC2) CopyFpgaImageRequest(input *CopyFpgaImageInput) (req *request.Request, output *CopyFpgaImageOutput) {
+	op := &request.Operation{
+		Name:       opCopyFpgaImage,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CopyFpgaImageInput{}
+	}
+
+	output = &CopyFpgaImageOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CopyFpgaImage API operation for Amazon Elastic Compute Cloud.
+//
+// Copies the specified Amazon FPGA Image (AFI) to the current region.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation CopyFpgaImage for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CopyFpgaImage
+func (c *EC2) CopyFpgaImage(input *CopyFpgaImageInput) (*CopyFpgaImageOutput, error) {
+	req, out := c.CopyFpgaImageRequest(input)
+	return out, req.Send()
+}
+
+// CopyFpgaImageWithContext is the same as CopyFpgaImage with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CopyFpgaImage for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) CopyFpgaImageWithContext(ctx aws.Context, input *CopyFpgaImageInput, opts ...request.Option) (*CopyFpgaImageOutput, error) {
+	req, out := c.CopyFpgaImageRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCopyImage = "CopyImage"
 
 // CopyImageRequest generates a "aws/request.Request" representing the
@@ -5466,6 +5540,80 @@ func (c *EC2) DeleteFlowLogsWithContext(ctx aws.Context, input *DeleteFlowLogsIn
 	return out, req.Send()
 }
 
+const opDeleteFpgaImage = "DeleteFpgaImage"
+
+// DeleteFpgaImageRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteFpgaImage operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteFpgaImage for more information on using the DeleteFpgaImage
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteFpgaImageRequest method.
+//    req, resp := client.DeleteFpgaImageRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteFpgaImage
+func (c *EC2) DeleteFpgaImageRequest(input *DeleteFpgaImageInput) (req *request.Request, output *DeleteFpgaImageOutput) {
+	op := &request.Operation{
+		Name:       opDeleteFpgaImage,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteFpgaImageInput{}
+	}
+
+	output = &DeleteFpgaImageOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteFpgaImage API operation for Amazon Elastic Compute Cloud.
+//
+// Deletes the specified Amazon FPGA Image (AFI).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DeleteFpgaImage for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteFpgaImage
+func (c *EC2) DeleteFpgaImage(input *DeleteFpgaImageInput) (*DeleteFpgaImageOutput, error) {
+	req, out := c.DeleteFpgaImageRequest(input)
+	return out, req.Send()
+}
+
+// DeleteFpgaImageWithContext is the same as DeleteFpgaImage with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteFpgaImage for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DeleteFpgaImageWithContext(ctx aws.Context, input *DeleteFpgaImageInput, opts ...request.Option) (*DeleteFpgaImageOutput, error) {
+	req, out := c.DeleteFpgaImageRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteInternetGateway = "DeleteInternetGateway"
 
 // DeleteInternetGatewayRequest generates a "aws/request.Request" representing the
@@ -8214,6 +8362,80 @@ func (c *EC2) DescribeFlowLogs(input *DescribeFlowLogsInput) (*DescribeFlowLogsO
 // for more information on using Contexts.
 func (c *EC2) DescribeFlowLogsWithContext(ctx aws.Context, input *DescribeFlowLogsInput, opts ...request.Option) (*DescribeFlowLogsOutput, error) {
 	req, out := c.DescribeFlowLogsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeFpgaImageAttribute = "DescribeFpgaImageAttribute"
+
+// DescribeFpgaImageAttributeRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeFpgaImageAttribute operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeFpgaImageAttribute for more information on using the DescribeFpgaImageAttribute
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeFpgaImageAttributeRequest method.
+//    req, resp := client.DescribeFpgaImageAttributeRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeFpgaImageAttribute
+func (c *EC2) DescribeFpgaImageAttributeRequest(input *DescribeFpgaImageAttributeInput) (req *request.Request, output *DescribeFpgaImageAttributeOutput) {
+	op := &request.Operation{
+		Name:       opDescribeFpgaImageAttribute,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeFpgaImageAttributeInput{}
+	}
+
+	output = &DescribeFpgaImageAttributeOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeFpgaImageAttribute API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the specified attribute of the specified Amazon FPGA Image (AFI).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeFpgaImageAttribute for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeFpgaImageAttribute
+func (c *EC2) DescribeFpgaImageAttribute(input *DescribeFpgaImageAttributeInput) (*DescribeFpgaImageAttributeOutput, error) {
+	req, out := c.DescribeFpgaImageAttributeRequest(input)
+	return out, req.Send()
+}
+
+// DescribeFpgaImageAttributeWithContext is the same as DescribeFpgaImageAttribute with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeFpgaImageAttribute for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeFpgaImageAttributeWithContext(ctx aws.Context, input *DescribeFpgaImageAttributeInput, opts ...request.Option) (*DescribeFpgaImageAttributeOutput, error) {
+	req, out := c.DescribeFpgaImageAttributeRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -15093,20 +15315,24 @@ func (c *EC2) GetPasswordDataRequest(input *GetPasswordDataInput) (req *request.
 
 // GetPasswordData API operation for Amazon Elastic Compute Cloud.
 //
-// Retrieves the encrypted administrator password for an instance running Windows.
+// Retrieves the encrypted administrator password for a running Windows instance.
 //
-// The Windows password is generated at boot if the EC2Config service plugin,
-// Ec2SetPassword, is enabled. This usually only happens the first time an AMI
-// is launched, and then Ec2SetPassword is automatically disabled. The password
-// is not generated for rebundled AMIs unless Ec2SetPassword is enabled before
-// bundling.
+// The Windows password is generated at boot by the EC2Config service or EC2Launch
+// scripts (Windows Server 2016 and later). This usually only happens the first
+// time an instance is launched. For more information, see EC2Config (http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/UsingConfig_WinAMI.html)
+// and EC2Launch (http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html)
+// in the Amazon Elastic Compute Cloud User Guide.
+//
+// For the EC2Config service, the password is not generated for rebundled AMIs
+// unless Ec2SetPassword is enabled before bundling.
 //
 // The password is encrypted using the key pair that you specified when you
 // launched the instance. You must provide the corresponding key pair file.
 //
-// Password generation and encryption takes a few moments. We recommend that
-// you wait up to 15 minutes after launching an instance before trying to retrieve
-// the generated password.
+// When you launch an instance, password generation and encryption may take
+// a few minutes. If you try to retrieve the password before it's available,
+// the output returns an empty string. We recommend that you wait up to 15 minutes
+// after launching an instance before trying to retrieve the generated password.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -15597,6 +15823,80 @@ func (c *EC2) ImportVolume(input *ImportVolumeInput) (*ImportVolumeOutput, error
 // for more information on using Contexts.
 func (c *EC2) ImportVolumeWithContext(ctx aws.Context, input *ImportVolumeInput, opts ...request.Option) (*ImportVolumeOutput, error) {
 	req, out := c.ImportVolumeRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opModifyFpgaImageAttribute = "ModifyFpgaImageAttribute"
+
+// ModifyFpgaImageAttributeRequest generates a "aws/request.Request" representing the
+// client's request for the ModifyFpgaImageAttribute operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ModifyFpgaImageAttribute for more information on using the ModifyFpgaImageAttribute
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ModifyFpgaImageAttributeRequest method.
+//    req, resp := client.ModifyFpgaImageAttributeRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyFpgaImageAttribute
+func (c *EC2) ModifyFpgaImageAttributeRequest(input *ModifyFpgaImageAttributeInput) (req *request.Request, output *ModifyFpgaImageAttributeOutput) {
+	op := &request.Operation{
+		Name:       opModifyFpgaImageAttribute,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ModifyFpgaImageAttributeInput{}
+	}
+
+	output = &ModifyFpgaImageAttributeOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ModifyFpgaImageAttribute API operation for Amazon Elastic Compute Cloud.
+//
+// Modifies the specified attribute of the specified Amazon FPGA Image (AFI).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation ModifyFpgaImageAttribute for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyFpgaImageAttribute
+func (c *EC2) ModifyFpgaImageAttribute(input *ModifyFpgaImageAttributeInput) (*ModifyFpgaImageAttributeOutput, error) {
+	req, out := c.ModifyFpgaImageAttributeRequest(input)
+	return out, req.Send()
+}
+
+// ModifyFpgaImageAttributeWithContext is the same as ModifyFpgaImageAttribute with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ModifyFpgaImageAttribute for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) ModifyFpgaImageAttributeWithContext(ctx aws.Context, input *ModifyFpgaImageAttributeInput, opts ...request.Option) (*ModifyFpgaImageAttributeOutput, error) {
+	req, out := c.ModifyFpgaImageAttributeRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -18460,6 +18760,81 @@ func (c *EC2) RequestSpotInstances(input *RequestSpotInstancesInput) (*RequestSp
 // for more information on using Contexts.
 func (c *EC2) RequestSpotInstancesWithContext(ctx aws.Context, input *RequestSpotInstancesInput, opts ...request.Option) (*RequestSpotInstancesOutput, error) {
 	req, out := c.RequestSpotInstancesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opResetFpgaImageAttribute = "ResetFpgaImageAttribute"
+
+// ResetFpgaImageAttributeRequest generates a "aws/request.Request" representing the
+// client's request for the ResetFpgaImageAttribute operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ResetFpgaImageAttribute for more information on using the ResetFpgaImageAttribute
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ResetFpgaImageAttributeRequest method.
+//    req, resp := client.ResetFpgaImageAttributeRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ResetFpgaImageAttribute
+func (c *EC2) ResetFpgaImageAttributeRequest(input *ResetFpgaImageAttributeInput) (req *request.Request, output *ResetFpgaImageAttributeOutput) {
+	op := &request.Operation{
+		Name:       opResetFpgaImageAttribute,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ResetFpgaImageAttributeInput{}
+	}
+
+	output = &ResetFpgaImageAttributeOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ResetFpgaImageAttribute API operation for Amazon Elastic Compute Cloud.
+//
+// Resets the specified attribute of the specified Amazon FPGA Image (AFI) to
+// its default value. You can only reset the load permission attribute.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation ResetFpgaImageAttribute for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ResetFpgaImageAttribute
+func (c *EC2) ResetFpgaImageAttribute(input *ResetFpgaImageAttributeInput) (*ResetFpgaImageAttributeOutput, error) {
+	req, out := c.ResetFpgaImageAttributeRequest(input)
+	return out, req.Send()
+}
+
+// ResetFpgaImageAttributeWithContext is the same as ResetFpgaImageAttribute with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ResetFpgaImageAttribute for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) ResetFpgaImageAttributeWithContext(ctx aws.Context, input *ResetFpgaImageAttributeInput, opts ...request.Option) (*ResetFpgaImageAttributeOutput, error) {
+	req, out := c.ResetFpgaImageAttributeRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -23511,6 +23886,123 @@ func (s *ConversionTask) SetTags(v []*Tag) *ConversionTask {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CopyFpgaImageRequest
+type CopyFpgaImageInput struct {
+	_ struct{} `type:"structure"`
+
+	// Unique, case-sensitive identifier that you provide to ensure the idempotency
+	// of the request. For more information, see Ensuring Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html).
+	ClientToken *string `type:"string"`
+
+	// The description for the new AFI.
+	Description *string `type:"string"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The name for the new AFI. The default is the name of the source AFI.
+	Name *string `type:"string"`
+
+	// The ID of the source AFI.
+	//
+	// SourceFpgaImageId is a required field
+	SourceFpgaImageId *string `type:"string" required:"true"`
+
+	// The region that contains the source AFI.
+	//
+	// SourceRegion is a required field
+	SourceRegion *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CopyFpgaImageInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CopyFpgaImageInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyFpgaImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyFpgaImageInput"}
+	if s.SourceFpgaImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceFpgaImageId"))
+	}
+	if s.SourceRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceRegion"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *CopyFpgaImageInput) SetClientToken(v string) *CopyFpgaImageInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CopyFpgaImageInput) SetDescription(v string) *CopyFpgaImageInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *CopyFpgaImageInput) SetDryRun(v bool) *CopyFpgaImageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CopyFpgaImageInput) SetName(v string) *CopyFpgaImageInput {
+	s.Name = &v
+	return s
+}
+
+// SetSourceFpgaImageId sets the SourceFpgaImageId field's value.
+func (s *CopyFpgaImageInput) SetSourceFpgaImageId(v string) *CopyFpgaImageInput {
+	s.SourceFpgaImageId = &v
+	return s
+}
+
+// SetSourceRegion sets the SourceRegion field's value.
+func (s *CopyFpgaImageInput) SetSourceRegion(v string) *CopyFpgaImageInput {
+	s.SourceRegion = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CopyFpgaImageResult
+type CopyFpgaImageOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the new AFI.
+	FpgaImageId *string `locationName:"fpgaImageId" type:"string"`
+}
+
+// String returns the string representation
+func (s CopyFpgaImageOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CopyFpgaImageOutput) GoString() string {
+	return s.String()
+}
+
+// SetFpgaImageId sets the FpgaImageId field's value.
+func (s *CopyFpgaImageOutput) SetFpgaImageId(v string) *CopyFpgaImageOutput {
+	s.FpgaImageId = &v
+	return s
+}
+
 // Contains the parameters for CopyImage.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/CopyImageRequest
 type CopyImageInput struct {
@@ -27471,6 +27963,81 @@ func (s *DeleteFlowLogsOutput) SetUnsuccessful(v []*UnsuccessfulItem) *DeleteFlo
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteFpgaImageRequest
+type DeleteFpgaImageInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the AFI.
+	//
+	// FpgaImageId is a required field
+	FpgaImageId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteFpgaImageInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteFpgaImageInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteFpgaImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteFpgaImageInput"}
+	if s.FpgaImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FpgaImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DeleteFpgaImageInput) SetDryRun(v bool) *DeleteFpgaImageInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFpgaImageId sets the FpgaImageId field's value.
+func (s *DeleteFpgaImageInput) SetFpgaImageId(v string) *DeleteFpgaImageInput {
+	s.FpgaImageId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteFpgaImageResult
+type DeleteFpgaImageOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Is true if the request succeeds, and an error otherwise.
+	Return *bool `locationName:"return" type:"boolean"`
+}
+
+// String returns the string representation
+func (s DeleteFpgaImageOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteFpgaImageOutput) GoString() string {
+	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *DeleteFpgaImageOutput) SetReturn(v bool) *DeleteFpgaImageOutput {
+	s.Return = &v
+	return s
+}
+
 // Contains the parameters for DeleteInternetGateway.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DeleteInternetGatewayRequest
 type DeleteInternetGatewayInput struct {
@@ -30171,6 +30738,95 @@ func (s *DescribeFlowLogsOutput) SetFlowLogs(v []*FlowLog) *DescribeFlowLogsOutp
 // SetNextToken sets the NextToken field's value.
 func (s *DescribeFlowLogsOutput) SetNextToken(v string) *DescribeFlowLogsOutput {
 	s.NextToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeFpgaImageAttributeRequest
+type DescribeFpgaImageAttributeInput struct {
+	_ struct{} `type:"structure"`
+
+	// The AFI attribute.
+	//
+	// Attribute is a required field
+	Attribute *string `type:"string" required:"true" enum:"FpgaImageAttributeName"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the AFI.
+	//
+	// FpgaImageId is a required field
+	FpgaImageId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeFpgaImageAttributeInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFpgaImageAttributeInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeFpgaImageAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeFpgaImageAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
+	if s.FpgaImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FpgaImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *DescribeFpgaImageAttributeInput) SetAttribute(v string) *DescribeFpgaImageAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeFpgaImageAttributeInput) SetDryRun(v bool) *DescribeFpgaImageAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFpgaImageId sets the FpgaImageId field's value.
+func (s *DescribeFpgaImageAttributeInput) SetFpgaImageId(v string) *DescribeFpgaImageAttributeInput {
+	s.FpgaImageId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeFpgaImageAttributeResult
+type DescribeFpgaImageAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the attribute.
+	FpgaImageAttribute *FpgaImageAttribute `locationName:"fpgaImageAttribute" type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeFpgaImageAttributeOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFpgaImageAttributeOutput) GoString() string {
+	return s.String()
+}
+
+// SetFpgaImageAttribute sets the FpgaImageAttribute field's value.
+func (s *DescribeFpgaImageAttributeOutput) SetFpgaImageAttribute(v *FpgaImageAttribute) *DescribeFpgaImageAttributeOutput {
+	s.FpgaImageAttribute = v
 	return s
 }
 
@@ -39763,6 +40419,9 @@ type FpgaImage struct {
 	// The product codes for the AFI.
 	ProductCodes []*ProductCode `locationName:"productCodes" locationNameList:"item" type:"list"`
 
+	// Indicates whether the AFI is public.
+	Public *bool `locationName:"public" type:"boolean"`
+
 	// The version of the AWS Shell that was used to create the bitstream.
 	ShellVersion *string `locationName:"shellVersion" type:"string"`
 
@@ -39840,6 +40499,12 @@ func (s *FpgaImage) SetProductCodes(v []*ProductCode) *FpgaImage {
 	return s
 }
 
+// SetPublic sets the Public field's value.
+func (s *FpgaImage) SetPublic(v bool) *FpgaImage {
+	s.Public = &v
+	return s
+}
+
 // SetShellVersion sets the ShellVersion field's value.
 func (s *FpgaImage) SetShellVersion(v string) *FpgaImage {
 	s.ShellVersion = &v
@@ -39861,6 +40526,67 @@ func (s *FpgaImage) SetTags(v []*Tag) *FpgaImage {
 // SetUpdateTime sets the UpdateTime field's value.
 func (s *FpgaImage) SetUpdateTime(v time.Time) *FpgaImage {
 	s.UpdateTime = &v
+	return s
+}
+
+// Describes an Amazon FPGA image (AFI) attribute.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/FpgaImageAttribute
+type FpgaImageAttribute struct {
+	_ struct{} `type:"structure"`
+
+	// The description of the AFI.
+	Description *string `locationName:"description" type:"string"`
+
+	// The ID of the AFI.
+	FpgaImageId *string `locationName:"fpgaImageId" type:"string"`
+
+	// One or more load permissions.
+	LoadPermissions []*LoadPermission `locationName:"loadPermissions" locationNameList:"item" type:"list"`
+
+	// The name of the AFI.
+	Name *string `locationName:"name" type:"string"`
+
+	// One or more product codes.
+	ProductCodes []*ProductCode `locationName:"productCodes" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s FpgaImageAttribute) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s FpgaImageAttribute) GoString() string {
+	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *FpgaImageAttribute) SetDescription(v string) *FpgaImageAttribute {
+	s.Description = &v
+	return s
+}
+
+// SetFpgaImageId sets the FpgaImageId field's value.
+func (s *FpgaImageAttribute) SetFpgaImageId(v string) *FpgaImageAttribute {
+	s.FpgaImageId = &v
+	return s
+}
+
+// SetLoadPermissions sets the LoadPermissions field's value.
+func (s *FpgaImageAttribute) SetLoadPermissions(v []*LoadPermission) *FpgaImageAttribute {
+	s.LoadPermissions = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *FpgaImageAttribute) SetName(v string) *FpgaImageAttribute {
+	s.Name = &v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *FpgaImageAttribute) SetProductCodes(v []*ProductCode) *FpgaImageAttribute {
+	s.ProductCodes = v
 	return s
 }
 
@@ -40266,7 +40992,8 @@ type GetPasswordDataOutput struct {
 	// The ID of the Windows instance.
 	InstanceId *string `locationName:"instanceId" type:"string"`
 
-	// The password of the instance.
+	// The password of the instance. Returns an empty string if the password is
+	// not available.
 	PasswordData *string `locationName:"passwordData" type:"string"`
 
 	// The time the data was last updated.
@@ -44638,6 +45365,259 @@ func (s *LaunchSpecification) SetSubnetId(v string) *LaunchSpecification {
 // SetUserData sets the UserData field's value.
 func (s *LaunchSpecification) SetUserData(v string) *LaunchSpecification {
 	s.UserData = &v
+	return s
+}
+
+// Describes a load permission.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/LoadPermission
+type LoadPermission struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the group.
+	Group *string `locationName:"group" type:"string" enum:"PermissionGroup"`
+
+	// The AWS account ID.
+	UserId *string `locationName:"userId" type:"string"`
+}
+
+// String returns the string representation
+func (s LoadPermission) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadPermission) GoString() string {
+	return s.String()
+}
+
+// SetGroup sets the Group field's value.
+func (s *LoadPermission) SetGroup(v string) *LoadPermission {
+	s.Group = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *LoadPermission) SetUserId(v string) *LoadPermission {
+	s.UserId = &v
+	return s
+}
+
+// Describes modifications to the load permissions of an Amazon FPGA image (AFI).
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/LoadPermissionModifications
+type LoadPermissionModifications struct {
+	_ struct{} `type:"structure"`
+
+	// The load permissions to add.
+	Add []*LoadPermissionRequest `locationNameList:"item" type:"list"`
+
+	// The load permissions to remove.
+	Remove []*LoadPermissionRequest `locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s LoadPermissionModifications) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadPermissionModifications) GoString() string {
+	return s.String()
+}
+
+// SetAdd sets the Add field's value.
+func (s *LoadPermissionModifications) SetAdd(v []*LoadPermissionRequest) *LoadPermissionModifications {
+	s.Add = v
+	return s
+}
+
+// SetRemove sets the Remove field's value.
+func (s *LoadPermissionModifications) SetRemove(v []*LoadPermissionRequest) *LoadPermissionModifications {
+	s.Remove = v
+	return s
+}
+
+// Describes a load permission.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/LoadPermissionRequest
+type LoadPermissionRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the group.
+	Group *string `type:"string" enum:"PermissionGroup"`
+
+	// The AWS account ID.
+	UserId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s LoadPermissionRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadPermissionRequest) GoString() string {
+	return s.String()
+}
+
+// SetGroup sets the Group field's value.
+func (s *LoadPermissionRequest) SetGroup(v string) *LoadPermissionRequest {
+	s.Group = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *LoadPermissionRequest) SetUserId(v string) *LoadPermissionRequest {
+	s.UserId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyFpgaImageAttributeRequest
+type ModifyFpgaImageAttributeInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the attribute.
+	Attribute *string `type:"string" enum:"FpgaImageAttributeName"`
+
+	// A description for the AFI.
+	Description *string `type:"string"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the AFI.
+	//
+	// FpgaImageId is a required field
+	FpgaImageId *string `type:"string" required:"true"`
+
+	// The load permission for the AFI.
+	LoadPermission *LoadPermissionModifications `type:"structure"`
+
+	// A name for the AFI.
+	Name *string `type:"string"`
+
+	// The operation type.
+	OperationType *string `type:"string" enum:"OperationType"`
+
+	// One or more product codes. After you add a product code to an AFI, it can't
+	// be removed. This parameter is valid only when modifying the productCodes
+	// attribute.
+	ProductCodes []*string `locationName:"ProductCode" locationNameList:"ProductCode" type:"list"`
+
+	// One or more user groups. This parameter is valid only when modifying the
+	// loadPermission attribute.
+	UserGroups []*string `locationName:"UserGroup" locationNameList:"UserGroup" type:"list"`
+
+	// One or more AWS account IDs. This parameter is valid only when modifying
+	// the loadPermission attribute.
+	UserIds []*string `locationName:"UserId" locationNameList:"UserId" type:"list"`
+}
+
+// String returns the string representation
+func (s ModifyFpgaImageAttributeInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyFpgaImageAttributeInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyFpgaImageAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyFpgaImageAttributeInput"}
+	if s.FpgaImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FpgaImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *ModifyFpgaImageAttributeInput) SetAttribute(v string) *ModifyFpgaImageAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *ModifyFpgaImageAttributeInput) SetDescription(v string) *ModifyFpgaImageAttributeInput {
+	s.Description = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyFpgaImageAttributeInput) SetDryRun(v bool) *ModifyFpgaImageAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFpgaImageId sets the FpgaImageId field's value.
+func (s *ModifyFpgaImageAttributeInput) SetFpgaImageId(v string) *ModifyFpgaImageAttributeInput {
+	s.FpgaImageId = &v
+	return s
+}
+
+// SetLoadPermission sets the LoadPermission field's value.
+func (s *ModifyFpgaImageAttributeInput) SetLoadPermission(v *LoadPermissionModifications) *ModifyFpgaImageAttributeInput {
+	s.LoadPermission = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *ModifyFpgaImageAttributeInput) SetName(v string) *ModifyFpgaImageAttributeInput {
+	s.Name = &v
+	return s
+}
+
+// SetOperationType sets the OperationType field's value.
+func (s *ModifyFpgaImageAttributeInput) SetOperationType(v string) *ModifyFpgaImageAttributeInput {
+	s.OperationType = &v
+	return s
+}
+
+// SetProductCodes sets the ProductCodes field's value.
+func (s *ModifyFpgaImageAttributeInput) SetProductCodes(v []*string) *ModifyFpgaImageAttributeInput {
+	s.ProductCodes = v
+	return s
+}
+
+// SetUserGroups sets the UserGroups field's value.
+func (s *ModifyFpgaImageAttributeInput) SetUserGroups(v []*string) *ModifyFpgaImageAttributeInput {
+	s.UserGroups = v
+	return s
+}
+
+// SetUserIds sets the UserIds field's value.
+func (s *ModifyFpgaImageAttributeInput) SetUserIds(v []*string) *ModifyFpgaImageAttributeInput {
+	s.UserIds = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyFpgaImageAttributeResult
+type ModifyFpgaImageAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the attribute.
+	FpgaImageAttribute *FpgaImageAttribute `locationName:"fpgaImageAttribute" type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyFpgaImageAttributeOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyFpgaImageAttributeOutput) GoString() string {
+	return s.String()
+}
+
+// SetFpgaImageAttribute sets the FpgaImageAttribute field's value.
+func (s *ModifyFpgaImageAttributeOutput) SetFpgaImageAttribute(v *FpgaImageAttribute) *ModifyFpgaImageAttributeOutput {
+	s.FpgaImageAttribute = v
 	return s
 }
 
@@ -51356,6 +52336,90 @@ func (s *ReservedInstancesOffering) SetScope(v string) *ReservedInstancesOfferin
 // SetUsagePrice sets the UsagePrice field's value.
 func (s *ReservedInstancesOffering) SetUsagePrice(v float64) *ReservedInstancesOffering {
 	s.UsagePrice = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ResetFpgaImageAttributeRequest
+type ResetFpgaImageAttributeInput struct {
+	_ struct{} `type:"structure"`
+
+	// The attribute.
+	Attribute *string `type:"string" enum:"ResetFpgaImageAttributeName"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the AFI.
+	//
+	// FpgaImageId is a required field
+	FpgaImageId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ResetFpgaImageAttributeInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResetFpgaImageAttributeInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResetFpgaImageAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResetFpgaImageAttributeInput"}
+	if s.FpgaImageId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FpgaImageId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttribute sets the Attribute field's value.
+func (s *ResetFpgaImageAttributeInput) SetAttribute(v string) *ResetFpgaImageAttributeInput {
+	s.Attribute = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ResetFpgaImageAttributeInput) SetDryRun(v bool) *ResetFpgaImageAttributeInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFpgaImageId sets the FpgaImageId field's value.
+func (s *ResetFpgaImageAttributeInput) SetFpgaImageId(v string) *ResetFpgaImageAttributeInput {
+	s.FpgaImageId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ResetFpgaImageAttributeResult
+type ResetFpgaImageAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Is true if the request succeeds, and an error otherwise.
+	Return *bool `locationName:"return" type:"boolean"`
+}
+
+// String returns the string representation
+func (s ResetFpgaImageAttributeOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResetFpgaImageAttributeOutput) GoString() string {
+	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *ResetFpgaImageAttributeOutput) SetReturn(v bool) *ResetFpgaImageAttributeOutput {
+	s.Return = &v
 	return s
 }
 
@@ -59133,6 +60197,20 @@ const (
 )
 
 const (
+	// FpgaImageAttributeNameDescription is a FpgaImageAttributeName enum value
+	FpgaImageAttributeNameDescription = "description"
+
+	// FpgaImageAttributeNameName is a FpgaImageAttributeName enum value
+	FpgaImageAttributeNameName = "name"
+
+	// FpgaImageAttributeNameLoadPermission is a FpgaImageAttributeName enum value
+	FpgaImageAttributeNameLoadPermission = "loadPermission"
+
+	// FpgaImageAttributeNameProductCodes is a FpgaImageAttributeName enum value
+	FpgaImageAttributeNameProductCodes = "productCodes"
+)
+
+const (
 	// FpgaImageStateCodePending is a FpgaImageStateCode enum value
 	FpgaImageStateCodePending = "pending"
 
@@ -59862,6 +60940,11 @@ const (
 
 	// ReservedInstanceStateRetired is a ReservedInstanceState enum value
 	ReservedInstanceStateRetired = "retired"
+)
+
+const (
+	// ResetFpgaImageAttributeNameLoadPermission is a ResetFpgaImageAttributeName enum value
+	ResetFpgaImageAttributeNameLoadPermission = "loadPermission"
 )
 
 const (

--- a/service/ec2/ec2iface/interface.go
+++ b/service/ec2/ec2iface/interface.go
@@ -172,6 +172,10 @@ type EC2API interface {
 	ConfirmProductInstanceWithContext(aws.Context, *ec2.ConfirmProductInstanceInput, ...request.Option) (*ec2.ConfirmProductInstanceOutput, error)
 	ConfirmProductInstanceRequest(*ec2.ConfirmProductInstanceInput) (*request.Request, *ec2.ConfirmProductInstanceOutput)
 
+	CopyFpgaImage(*ec2.CopyFpgaImageInput) (*ec2.CopyFpgaImageOutput, error)
+	CopyFpgaImageWithContext(aws.Context, *ec2.CopyFpgaImageInput, ...request.Option) (*ec2.CopyFpgaImageOutput, error)
+	CopyFpgaImageRequest(*ec2.CopyFpgaImageInput) (*request.Request, *ec2.CopyFpgaImageOutput)
+
 	CopyImage(*ec2.CopyImageInput) (*ec2.CopyImageOutput, error)
 	CopyImageWithContext(aws.Context, *ec2.CopyImageInput, ...request.Option) (*ec2.CopyImageOutput, error)
 	CopyImageRequest(*ec2.CopyImageInput) (*request.Request, *ec2.CopyImageOutput)
@@ -320,6 +324,10 @@ type EC2API interface {
 	DeleteFlowLogsWithContext(aws.Context, *ec2.DeleteFlowLogsInput, ...request.Option) (*ec2.DeleteFlowLogsOutput, error)
 	DeleteFlowLogsRequest(*ec2.DeleteFlowLogsInput) (*request.Request, *ec2.DeleteFlowLogsOutput)
 
+	DeleteFpgaImage(*ec2.DeleteFpgaImageInput) (*ec2.DeleteFpgaImageOutput, error)
+	DeleteFpgaImageWithContext(aws.Context, *ec2.DeleteFpgaImageInput, ...request.Option) (*ec2.DeleteFpgaImageOutput, error)
+	DeleteFpgaImageRequest(*ec2.DeleteFpgaImageInput) (*request.Request, *ec2.DeleteFpgaImageOutput)
+
 	DeleteInternetGateway(*ec2.DeleteInternetGatewayInput) (*ec2.DeleteInternetGatewayOutput, error)
 	DeleteInternetGatewayWithContext(aws.Context, *ec2.DeleteInternetGatewayInput, ...request.Option) (*ec2.DeleteInternetGatewayOutput, error)
 	DeleteInternetGatewayRequest(*ec2.DeleteInternetGatewayInput) (*request.Request, *ec2.DeleteInternetGatewayOutput)
@@ -459,6 +467,10 @@ type EC2API interface {
 	DescribeFlowLogs(*ec2.DescribeFlowLogsInput) (*ec2.DescribeFlowLogsOutput, error)
 	DescribeFlowLogsWithContext(aws.Context, *ec2.DescribeFlowLogsInput, ...request.Option) (*ec2.DescribeFlowLogsOutput, error)
 	DescribeFlowLogsRequest(*ec2.DescribeFlowLogsInput) (*request.Request, *ec2.DescribeFlowLogsOutput)
+
+	DescribeFpgaImageAttribute(*ec2.DescribeFpgaImageAttributeInput) (*ec2.DescribeFpgaImageAttributeOutput, error)
+	DescribeFpgaImageAttributeWithContext(aws.Context, *ec2.DescribeFpgaImageAttributeInput, ...request.Option) (*ec2.DescribeFpgaImageAttributeOutput, error)
+	DescribeFpgaImageAttributeRequest(*ec2.DescribeFpgaImageAttributeInput) (*request.Request, *ec2.DescribeFpgaImageAttributeOutput)
 
 	DescribeFpgaImages(*ec2.DescribeFpgaImagesInput) (*ec2.DescribeFpgaImagesOutput, error)
 	DescribeFpgaImagesWithContext(aws.Context, *ec2.DescribeFpgaImagesInput, ...request.Option) (*ec2.DescribeFpgaImagesOutput, error)
@@ -833,6 +845,10 @@ type EC2API interface {
 	ImportVolumeWithContext(aws.Context, *ec2.ImportVolumeInput, ...request.Option) (*ec2.ImportVolumeOutput, error)
 	ImportVolumeRequest(*ec2.ImportVolumeInput) (*request.Request, *ec2.ImportVolumeOutput)
 
+	ModifyFpgaImageAttribute(*ec2.ModifyFpgaImageAttributeInput) (*ec2.ModifyFpgaImageAttributeOutput, error)
+	ModifyFpgaImageAttributeWithContext(aws.Context, *ec2.ModifyFpgaImageAttributeInput, ...request.Option) (*ec2.ModifyFpgaImageAttributeOutput, error)
+	ModifyFpgaImageAttributeRequest(*ec2.ModifyFpgaImageAttributeInput) (*request.Request, *ec2.ModifyFpgaImageAttributeOutput)
+
 	ModifyHosts(*ec2.ModifyHostsInput) (*ec2.ModifyHostsOutput, error)
 	ModifyHostsWithContext(aws.Context, *ec2.ModifyHostsInput, ...request.Option) (*ec2.ModifyHostsOutput, error)
 	ModifyHostsRequest(*ec2.ModifyHostsInput) (*request.Request, *ec2.ModifyHostsOutput)
@@ -968,6 +984,10 @@ type EC2API interface {
 	RequestSpotInstances(*ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error)
 	RequestSpotInstancesWithContext(aws.Context, *ec2.RequestSpotInstancesInput, ...request.Option) (*ec2.RequestSpotInstancesOutput, error)
 	RequestSpotInstancesRequest(*ec2.RequestSpotInstancesInput) (*request.Request, *ec2.RequestSpotInstancesOutput)
+
+	ResetFpgaImageAttribute(*ec2.ResetFpgaImageAttributeInput) (*ec2.ResetFpgaImageAttributeOutput, error)
+	ResetFpgaImageAttributeWithContext(aws.Context, *ec2.ResetFpgaImageAttributeInput, ...request.Option) (*ec2.ResetFpgaImageAttributeOutput, error)
+	ResetFpgaImageAttributeRequest(*ec2.ResetFpgaImageAttributeInput) (*request.Request, *ec2.ResetFpgaImageAttributeOutput)
 
 	ResetImageAttribute(*ec2.ResetImageAttributeInput) (*ec2.ResetImageAttributeOutput, error)
 	ResetImageAttributeWithContext(aws.Context, *ec2.ResetImageAttributeInput, ...request.Option) (*ec2.ResetImageAttributeOutput, error)


### PR DESCRIPTION
Release v1.10.50 (2017-09-21)
===

### Service Client Updates
* `service/budgets`: Updates service API
  * Including "DuplicateRecordException" in UpdateNotification and UpdateSubscriber.
* `service/ec2`: Updates service API and documentation
  * Add EC2 APIs to copy Amazon FPGA Images (AFIs) within the same region and across multiple regions, delete AFIs, and modify AFI attributes. AFI attributes include name, description and granting/denying other AWS accounts to load the AFI.
* `service/logs`: Updates service API and documentation
  * Adds support for associating LogGroups with KMS Keys.

### SDK Bugs
* Fix greengrass service model being duplicated with different casing. ([#1541](https://github.com/aws/aws-sdk-go/pull/1541))
  * Fixes [#1540](https://github.com/aws/aws-sdk-go/issues/1540)
  * Fixes [#1539](https://github.com/aws/aws-sdk-go/issues/1539)
