### PR TITLE
API Marshaler: Add generated marshalers for RESTJSON protocol

### DIFF
--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -59,7 +59,7 @@ func (a *API) EnableSelectGeneratedMarshalers() {
 
 	// Enable generated marshalers
 	switch a.Metadata.Protocol {
-	case "rest-xml":
+	case "rest-xml", "rest-json":
 		a.NoGenMarshalers = false
 	}
 }

--- a/private/model/api/shape_marshal.go
+++ b/private/model/api/shape_marshal.go
@@ -339,7 +339,7 @@ func (r marshalShapeRef) Location() string {
 		return "Headers"
 	case "uri":
 		return "Path"
-	case "StatusCode":
+	case "statusCode":
 		return "StatusCode"
 	default:
 		if len(loc) != 0 {
@@ -423,7 +423,7 @@ func (r marshalShapeRef) TimeFormat() string {
 	default:
 		switch r.Context.API.Metadata.Protocol {
 		case "json", "rest-json":
-			return "protocol.FormatUnixTime"
+			return "protocol.UnixTimeFormat"
 		case "rest-xml", "ec2", "query":
 			return "protocol.ISO8601TimeFormat"
 		default:

--- a/private/protocol/encode.go
+++ b/private/protocol/encode.go
@@ -146,3 +146,21 @@ func EncodeTimeMap(vs map[string]*time.Time) func(MapEncoder) {
 		}
 	}
 }
+
+// A FieldBuffer provides buffering of fields so the number of
+// allocations are reduced by providng a persistent buffer that is
+// used between fields.
+type FieldBuffer struct {
+	buf []byte
+}
+
+// GetValue will retrieve the ValueMarshaler's value by appending the
+// value to the buffer. Will return the buffer that was populated.
+//
+// This buffer is only valid until the next time GetValue is called.
+func (b *FieldBuffer) GetValue(m ValueMarshaler) ([]byte, error) {
+	v, err := m.MarshalValueBuf(b.buf)
+	b.buf = v
+	b.buf = b.buf[0:0]
+	return v, err
+}

--- a/private/protocol/json/encode.go
+++ b/private/protocol/json/encode.go
@@ -1,0 +1,271 @@
+package json
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+// An Encoder provides encoding of the AWS JSON protocol. This encoder will will
+// write all content to JSON. Only supports body and payload targets.
+type Encoder struct {
+	encoder
+	root bool
+}
+
+// NewEncoder creates a new encoder for encoding AWS JSON protocol. Only encodes
+// fields into the JSON body, and error is returned if target is anything other
+// than Body or Payload.
+func NewEncoder() *Encoder {
+	e := &Encoder{
+		encoder: encoder{
+			buf:      bytes.NewBuffer([]byte{'{'}),
+			fieldBuf: &protocol.FieldBuffer{},
+		},
+		root: true,
+	}
+
+	return e
+}
+
+// Encode returns the encoded XMl reader. An error will be returned if one was
+// encountered while building the JSON body.
+func (e *Encoder) Encode() (io.ReadSeeker, error) {
+	b, err := e.encode()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) == 2 {
+		// Account for first starting object in buffer
+		return nil, nil
+	}
+
+	return bytes.NewReader(b), nil
+}
+
+// SetValue sets an individual value to the JSON body.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeValue(v)
+}
+
+// SetStream is not supported for JSON protocol marshaling.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	e.err = fmt.Errorf("json encoder SetStream not supported, %s, %s", t, k)
+}
+
+// SetList creates an JSON list and calls the passed in fn callback with a list encoder.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeList(func(enc encoder) error {
+		nested := listEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// SetMap creates an JSON map and calls the passed in fn callback with a map encoder.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(me protocol.MapEncoder), meta protocol.Metadata) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeObject(func(enc encoder) error {
+		nested := mapEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// SetFields sets the nested fields to the JSON body.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	if t == protocol.PayloadTarget {
+		// Ignore payload key and only marshal body without wrapping in object first.
+		nested := Encoder{
+			encoder: encoder{
+				buf:      e.encoder.buf,
+				fieldBuf: e.encoder.fieldBuf,
+			},
+		}
+		m.MarshalFields(&nested)
+		e.err = nested.err
+		return
+	}
+
+	e.writeSep()
+	e.writeKey(k)
+	e.writeObject(func(enc encoder) error {
+		nested := Encoder{encoder: enc}
+		m.MarshalFields(&nested)
+		return nested.err
+	})
+}
+
+// A listEncoder encodes elements within a list for the JSON encoder.
+type listEncoder struct {
+	encoder
+}
+
+// ListAddValue will add the value to the list.
+func (e *listEncoder) ListAddValue(v protocol.ValueMarshaler) {
+	e.writeSep()
+	e.writeValue(v)
+}
+
+// ListAddList adds a list nested within another list.
+func (e *listEncoder) ListAddList(fn func(le protocol.ListEncoder)) {
+	e.writeSep()
+	e.writeList(func(enc encoder) error {
+		nested := listEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// ListAddMap adds a map nested within a list.
+func (e *listEncoder) ListAddMap(fn func(me protocol.MapEncoder)) {
+	e.writeSep()
+	e.writeObject(func(enc encoder) error {
+		nested := mapEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// ListAddFields will set the nested type's fields to the list.
+func (e *listEncoder) ListAddFields(m protocol.FieldMarshaler) {
+	e.writeSep()
+	e.writeObject(func(enc encoder) error {
+		nested := Encoder{encoder: enc}
+		m.MarshalFields(&nested)
+		return nested.err
+	})
+}
+
+// A mapEncoder encodes key values pair map values for the JSON encoder.
+type mapEncoder struct {
+	encoder
+}
+
+// MapSetValue sets a map value.
+func (e *mapEncoder) MapSetValue(k string, v protocol.ValueMarshaler) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeValue(v)
+}
+
+// MapSetList encodes a list nested within the map.
+func (e *mapEncoder) MapSetList(k string, fn func(le protocol.ListEncoder)) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeList(func(enc encoder) error {
+		nested := listEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// MapSetMap encodes a map nested within another map.
+func (e *mapEncoder) MapSetMap(k string, fn func(me protocol.MapEncoder)) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeObject(func(enc encoder) error {
+		nested := mapEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// MapSetFields will set the nested type's fields under the map.
+func (e *mapEncoder) MapSetFields(k string, m protocol.FieldMarshaler) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeObject(func(enc encoder) error {
+		nested := Encoder{encoder: enc}
+		m.MarshalFields(&nested)
+		return nested.err
+	})
+}
+
+type encoder struct {
+	buf      *bytes.Buffer
+	fieldBuf *protocol.FieldBuffer
+	started  bool
+	err      error
+}
+
+func (e encoder) encode() ([]byte, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+
+	// Close the root object
+	e.buf.WriteByte('}')
+
+	return e.buf.Bytes(), nil
+}
+
+func (e *encoder) writeSep() {
+	if e.started {
+		e.buf.WriteByte(',')
+	} else {
+		e.started = true
+	}
+
+}
+func (e *encoder) writeKey(k string) {
+	e.buf.WriteByte('"')
+	e.buf.WriteString(k) // TODO escape?
+	e.buf.WriteByte('"')
+	e.buf.WriteByte(':')
+}
+
+func (e *encoder) writeValue(v protocol.ValueMarshaler) {
+	if e.err != nil {
+		return
+	}
+
+	b, err := e.fieldBuf.GetValue(v)
+	if err != nil {
+		e.err = err
+		return
+	}
+
+	var asStr bool
+	switch v.(type) {
+	case protocol.StringValue, protocol.BytesValue:
+		asStr = true
+	}
+
+	if asStr {
+		escapeStringBytes(e.buf, b)
+	} else {
+		e.buf.Write(b)
+	}
+}
+
+func (e *encoder) writeList(fn func(encoder) error) {
+	if e.err != nil {
+		return
+	}
+
+	e.buf.WriteByte('[')
+	e.err = fn(encoder{buf: e.buf, fieldBuf: e.fieldBuf})
+	e.buf.WriteByte(']')
+}
+
+func (e *encoder) writeObject(fn func(encoder) error) {
+	if e.err != nil {
+		return
+	}
+
+	e.buf.WriteByte('{')
+	e.err = fn(encoder{buf: e.buf, fieldBuf: e.fieldBuf})
+	e.buf.WriteByte('}')
+}

--- a/private/protocol/json/encode_test.go
+++ b/private/protocol/json/encode_test.go
@@ -1,0 +1,303 @@
+package json
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+func TestEncodeNestedShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			Nested: &nestedShape{
+				Value: aws.String("expected value"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"nested":{"value":"expected value"}}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapString(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapStr: map[string]*string{
+				"abc": aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"mapstr":{"abc":"123"}}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapShape: map[string]*nestedShape{
+				"abc": {Value: aws.String("1")},
+				"123": {IntVal: aws.Int64(123)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"mapShape":{"abc":{"value":"1"},"123":{"intval":123}}}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListString(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListStr: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"liststr":["abc","123"]}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListFlatten(t *testing.T) {
+	// TODO no JSON flatten
+}
+func TestEncodeListFlattened(t *testing.T) {
+	// TODO No json flatten
+}
+func TestEncodeListNamed(t *testing.T) {
+	// TODO no json named
+}
+func TestEncodeListShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListShape: []*nestedShape{
+				{Value: aws.String("abc")},
+				{Value: aws.String("123")},
+				{IntVal: aws.Int64(123)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"listShape":[{"value":"abc"},{"value":"123"},{"intval":123}]}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+type baseShape struct {
+	Payload *payloadShape
+}
+
+func (s *baseShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		e.SetFields(protocol.PayloadTarget, "payload", s.Payload, protocol.Metadata{})
+	}
+	return nil
+}
+
+type payloadShape struct {
+	Value            *string
+	IntVal           *int64
+	TimeVal          *time.Time
+	Nested           *nestedShape
+	MapStr           map[string]*string
+	MapFlatten       map[string]*string
+	MapNamed         map[string]*string
+	MapShape         map[string]*nestedShape
+	MapFlattenShape  map[string]*nestedShape
+	MapNamedShape    map[string]*nestedShape
+	ListStr          []*string
+	ListFlatten      []*string
+	ListNamed        []*string
+	ListShape        []*nestedShape
+	ListFlattenShape []*nestedShape
+	ListNamedShape   []*nestedShape
+}
+
+func (s *payloadShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	if s.IntVal != nil {
+		e.SetValue(protocol.BodyTarget, "intval", protocol.Int64Value(*s.IntVal), protocol.Metadata{})
+	}
+	if s.TimeVal != nil {
+		e.SetValue(protocol.BodyTarget, "timeval", protocol.TimeValue{
+			V: *s.TimeVal, Format: protocol.UnixTimeFormat,
+		}, protocol.Metadata{})
+	}
+	if s.Nested != nil {
+		e.SetFields(protocol.BodyTarget, "nested", s.Nested, protocol.Metadata{})
+	}
+	if len(s.MapStr) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapstr", func(me protocol.MapEncoder) {
+			for k, v := range s.MapStr {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.MapFlatten) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapFlatten", func(me protocol.MapEncoder) {
+			for k, v := range s.MapFlatten {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.MapNamed) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapNamed", func(me protocol.MapEncoder) {
+			for k, v := range s.MapNamed {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			MapLocationNameKey: "namedKey", MapLocationNameValue: "namedValue",
+		})
+	}
+	if len(s.MapShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapShape", encodeNestedShapeMap(s.MapShape), protocol.Metadata{})
+	}
+	if len(s.MapFlattenShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapFlattenShape", encodeNestedShapeMap(s.MapFlattenShape), protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.MapNamedShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapNamedShape", encodeNestedShapeMap(s.MapNamedShape), protocol.Metadata{
+			MapLocationNameKey: "namedKey", MapLocationNameValue: "namedValue",
+		})
+	}
+	if len(s.ListStr) > 0 {
+		e.SetList(protocol.BodyTarget, "liststr", func(le protocol.ListEncoder) {
+			for _, v := range s.ListStr {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.ListFlatten) > 0 {
+		e.SetList(protocol.BodyTarget, "listFlatten", func(le protocol.ListEncoder) {
+			for _, v := range s.ListFlatten {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.ListNamed) > 0 {
+		e.SetList(protocol.BodyTarget, "listNamed", func(le protocol.ListEncoder) {
+			for _, v := range s.ListNamed {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			ListLocationName: "namedMember",
+		})
+	}
+	if len(s.ListShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listShape", encodeNestedShapeList(s.ListShape), protocol.Metadata{})
+	}
+	if len(s.ListFlattenShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listFlattenShape", encodeNestedShapeList(s.ListFlattenShape), protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.ListNamedShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listNamedShape", encodeNestedShapeList(s.ListNamedShape), protocol.Metadata{
+			ListLocationName: "namedMember",
+		})
+	}
+	return nil
+}
+
+type nestedShape struct {
+	Value    *string
+	IntVal   *int64
+	Prefixed *string
+}
+
+func (s *nestedShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	if s.IntVal != nil {
+		e.SetValue(protocol.BodyTarget, "intval", protocol.Int64Value(*s.IntVal), protocol.Metadata{})
+	}
+	if s.Prefixed != nil {
+		e.SetValue(protocol.BodyTarget, "prefixed", protocol.StringValue(*s.Prefixed), protocol.Metadata{})
+	}
+	return nil
+}
+func encodeNestedShapeMap(vs map[string]*nestedShape) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+func encodeNestedShapeList(vs []*nestedShape) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
+func encode(s baseShape) (io.ReadSeeker, error) {
+	e := NewEncoder()
+	s.MarshalFields(e)
+	return e.Encode()
+}

--- a/private/protocol/json/encode_test.go
+++ b/private/protocol/json/encode_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
@@ -76,9 +77,7 @@ func TestEncodeMapShape(t *testing.T) {
 
 	expect := `{"mapShape":{"abc":{"value":"1"},"123":{"intval":123}}}`
 
-	if e, a := expect, string(b); e != a {
-		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
-	}
+	awstesting.AssertJSON(t, expect, string(b), "expect bodies to match")
 }
 func TestEncodeListString(t *testing.T) {
 	r, err := encode(baseShape{

--- a/private/protocol/json/escape.go
+++ b/private/protocol/json/escape.go
@@ -1,0 +1,198 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied and modified from Go 1.8 stdlib's encoding/json/#safeSet
+
+package json
+
+import (
+	"bytes"
+	"unicode/utf8"
+)
+
+// safeSet holds the value true if the ASCII character with the given array
+// position can be represented inside a JSON string without any further
+// escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), and the backslash character ("\").
+var safeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      true,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      true,
+	'=':      true,
+	'>':      true,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
+}
+
+// copied from Go 1.8 stdlib's encoding/json/#hex
+var hex = "0123456789abcdef"
+
+// escapeStringBytes escapes and writes the passed in string bytes to the dst
+// buffer
+//
+// Copied and modifed from Go 1.8 stdlib's encodeing/json/#encodeState.stringBytes
+func escapeStringBytes(e *bytes.Buffer, s []byte) {
+	e.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if safeSet[b] {
+				i++
+				continue
+			}
+			if start < i {
+				e.Write(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				e.WriteByte('\\')
+				e.WriteByte(b)
+			case '\n':
+				e.WriteByte('\\')
+				e.WriteByte('n')
+			case '\r':
+				e.WriteByte('\\')
+				e.WriteByte('r')
+			case '\t':
+				e.WriteByte('\\')
+				e.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// If escapeHTML is set, it also escapes <, >, and &
+				// because they can lead to security holes when
+				// user-controlled strings are rendered into JSON
+				// and served to some browsers.
+				e.WriteString(`\u00`)
+				e.WriteByte(hex[b>>4])
+				e.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRune(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				e.Write(s[start:i])
+			}
+			e.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				e.Write(s[start:i])
+			}
+			e.WriteString(`\u202`)
+			e.WriteByte(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		e.Write(s[start:])
+	}
+	e.WriteByte('"')
+}

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -179,8 +179,20 @@ type InputService1TestShapeInputService1TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService2ProtocolTest provides the API operation methods for making requests to
@@ -325,8 +337,25 @@ func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetPipeline
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService3ProtocolTest provides the API operation methods for making requests to
@@ -471,8 +500,25 @@ func (s *InputService3TestShapeInputService3TestCaseOperation1Input) SetFoo(v st
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService4ProtocolTest provides the API operation methods for making requests to
@@ -617,8 +663,25 @@ func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetItems(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.QueryTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService5ProtocolTest provides the API operation methods for making requests to
@@ -771,8 +834,30 @@ func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetQueryDoc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryDoc) > 0 {
+		v := s.QueryDoc
+
+		e.SetMap(protocol.QueryTarget, "QueryDoc", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService6ProtocolTest provides the API operation methods for making requests to
@@ -925,8 +1010,35 @@ func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetQueryDoc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryDoc) > 0 {
+		v := s.QueryDoc
+
+		e.SetMap(protocol.QueryTarget, "QueryDoc", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService7ProtocolTest provides the API operation methods for making requests to
@@ -1134,6 +1246,12 @@ type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService7TestShapeInputService7TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -1146,8 +1264,25 @@ func (s *InputService7TestShapeInputService7TestCaseOperation2Input) SetBoolQuer
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BoolQuery != nil {
+		v := *s.BoolQuery
+
+		e.SetValue(protocol.QueryTarget, "bool-query", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService7TestShapeInputService7TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService8ProtocolTest provides the API operation methods for making requests to
@@ -1308,8 +1443,35 @@ func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetPipeline
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService9ProtocolTest provides the API operation methods for making requests to
@@ -1478,8 +1640,40 @@ func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetPipeline
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Config != nil {
+		v := s.Config
+
+		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService9TestShapeStructType struct {
@@ -1500,6 +1694,22 @@ func (s *InputService9TestShapeStructType) SetA(v string) *InputService9TestShap
 func (s *InputService9TestShapeStructType) SetB(v string) *InputService9TestShapeStructType {
 	s.B = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeStructType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.A != nil {
+		v := *s.A
+
+		e.SetValue(protocol.BodyTarget, "A", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.B != nil {
+		v := *s.B
+
+		e.SetValue(protocol.BodyTarget, "B", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService10ProtocolTest provides the API operation methods for making requests to
@@ -1676,8 +1886,45 @@ func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetPipeli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Config != nil {
+		v := s.Config
+
+		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService10TestShapeStructType struct {
@@ -1698,6 +1945,22 @@ func (s *InputService10TestShapeStructType) SetA(v string) *InputService10TestSh
 func (s *InputService10TestShapeStructType) SetB(v string) *InputService10TestShapeStructType {
 	s.B = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeStructType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.A != nil {
+		v := *s.A
+
+		e.SetValue(protocol.BodyTarget, "A", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.B != nil {
+		v := *s.B
+
+		e.SetValue(protocol.BodyTarget, "B", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService11ProtocolTest provides the API operation methods for making requests to
@@ -1872,8 +2135,35 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetVaultN
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService12ProtocolTest provides the API operation methods for making requests to
@@ -2041,8 +2331,30 @@ func (s *InputService12TestShapeInputService12TestCaseOperation1Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bar != nil {
+		v := s.Bar
+
+		e.SetValue(protocol.BodyTarget, "Bar", protocol.BytesValue(v), protocol.Metadata{})
+	}
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.PathTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService13ProtocolTest provides the API operation methods for making requests to
@@ -2250,6 +2562,12 @@ type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService13TestShapeInputService13TestCaseOperation2Input struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
@@ -2262,8 +2580,25 @@ func (s *InputService13TestShapeInputService13TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetStream(protocol.PayloadTarget, "foo", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService13TestShapeInputService13TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService14ProtocolTest provides the API operation methods for making requests to
@@ -2479,8 +2814,25 @@ func (s *InputService14TestShapeFooShape) SetBaz(v string) *InputService14TestSh
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeFooShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Baz != nil {
+		v := *s.Baz
+
+		e.SetValue(protocol.BodyTarget, "baz", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService14TestShapeInputService14TestCaseOperation2Input struct {
@@ -2495,8 +2847,25 @@ func (s *InputService14TestShapeInputService14TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetFields(protocol.PayloadTarget, "foo", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService14TestShapeInputService14TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService15ProtocolTest provides the API operation methods for making requests to
@@ -2704,6 +3073,12 @@ type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService15TestShapeInputService15TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -2716,8 +3091,25 @@ func (s *InputService15TestShapeInputService15TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.QueryTarget, "param-name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService15TestShapeInputService15TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService16ProtocolTest provides the API operation methods for making requests to
@@ -3209,20 +3601,50 @@ type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService16TestShapeInputService16TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation4Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation5Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation5Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService16TestShapeInputService16TestCaseOperation6Input struct {
@@ -3237,8 +3659,25 @@ func (s *InputService16TestShapeInputService16TestCaseOperation6Input) SetRecurs
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation6Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RecursiveStruct != nil {
+		v := s.RecursiveStruct
+
+		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation6Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation6Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService16TestShapeRecursiveStructType struct {
@@ -3275,6 +3714,48 @@ func (s *InputService16TestShapeRecursiveStructType) SetRecursiveMap(v map[strin
 func (s *InputService16TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService16TestShapeRecursiveStructType) *InputService16TestShapeRecursiveStructType {
 	s.RecursiveStruct = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeRecursiveStructType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NoRecurse != nil {
+		v := *s.NoRecurse
+
+		e.SetValue(protocol.BodyTarget, "NoRecurse", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RecursiveList) > 0 {
+		v := s.RecursiveList
+
+		e.SetList(protocol.BodyTarget, "RecursiveList", encodeInputService16TestShapeRecursiveStructTypeList(v), protocol.Metadata{})
+	}
+	if len(s.RecursiveMap) > 0 {
+		v := s.RecursiveMap
+
+		e.SetMap(protocol.BodyTarget, "RecursiveMap", encodeInputService16TestShapeRecursiveStructTypeMap(v), protocol.Metadata{})
+	}
+	if s.RecursiveStruct != nil {
+		v := s.RecursiveStruct
+
+		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputService16TestShapeRecursiveStructTypeList(vs []*InputService16TestShapeRecursiveStructType) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
+func encodeInputService16TestShapeRecursiveStructTypeMap(vs map[string]*InputService16TestShapeRecursiveStructType) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // InputService17ProtocolTest provides the API operation methods for making requests to
@@ -3482,6 +3963,12 @@ type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService17TestShapeInputService17TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -3502,8 +3989,30 @@ func (s *InputService17TestShapeInputService17TestCaseOperation2Input) SetTimeAr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TimeArg != nil {
+		v := *s.TimeArg
+
+		e.SetValue(protocol.BodyTarget, "TimeArg", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.TimeArgInHeader != nil {
+		v := *s.TimeArgInHeader
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-timearg", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService17TestShapeInputService17TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService18ProtocolTest provides the API operation methods for making requests to
@@ -3648,8 +4157,25 @@ func (s *InputService18TestShapeInputService18TestCaseOperation1Input) SetTimeAr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TimeArg != nil {
+		v := *s.TimeArg
+
+		e.SetValue(protocol.BodyTarget, "timestamp_location", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService19ProtocolTest provides the API operation methods for making requests to
@@ -3794,8 +4320,25 @@ func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetStream(protocol.PayloadTarget, "foo", protocol.StringStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService19TestShapeInputService19TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService20ProtocolTest provides the API operation methods for making requests to
@@ -4003,6 +4546,12 @@ type InputService20TestShapeInputService20TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService20TestShapeInputService20TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -4015,8 +4564,31 @@ func (s *InputService20TestShapeInputService20TestCaseOperation2Input) SetToken(
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	var Token string
+	if s.Token != nil {
+		Token = *s.Token
+	} else {
+		Token = protocol.GetIdempotencyToken()
+	}
+	{
+		v := Token
+
+		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService20TestShapeInputService20TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService21ProtocolTest provides the API operation methods for making requests to
@@ -4224,6 +4796,12 @@ type InputService21TestShapeInputService21TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -4236,8 +4814,25 @@ func (s *InputService21TestShapeInputService21TestCaseOperation2Input) SetAttr(v
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Attr != nil {
+		v := s.Attr
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Foo", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 //

--- a/private/protocol/restjson/encode.go
+++ b/private/protocol/restjson/encode.go
@@ -1,0 +1,162 @@
+package restjson
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/json"
+	"github.com/aws/aws-sdk-go/private/protocol/rest"
+)
+
+// An Encoder provides encoding of the AWS RESTJSON protocol. This encoder combindes
+// the JSON and REST encoders deligating to them for their associated targets.
+//
+// It is invalid to set a JSON and stream payload on the same encoder.
+type Encoder struct {
+	method      string
+	reqEncoder  *rest.Encoder
+	bodyEncoder *json.Encoder
+
+	buf *bytes.Buffer
+	err error
+}
+
+// NewEncoder creates a new encoder for encoding the AWS RESTJSON protocol.
+// The request passed in will be the base the path, query, and headers encoded
+// will be set on top of.
+func NewEncoder(req *http.Request) *Encoder {
+	e := &Encoder{
+		method:      req.Method,
+		reqEncoder:  rest.NewEncoder(req),
+		bodyEncoder: json.NewEncoder(),
+	}
+
+	return e
+}
+
+// Encode returns the encoded request, and body payload. If no payload body was
+// set nil will be returned.  If an error occurred while encoding the API an
+// error will be returned.
+func (e *Encoder) Encode() (*http.Request, io.ReadSeeker, error) {
+	req, payloadBody, err := e.reqEncoder.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jsonBody, err := e.bodyEncoder.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	havePayload := payloadBody != nil
+	haveJSON := jsonBody != nil
+
+	if havePayload == haveJSON && haveJSON {
+		return nil, nil, fmt.Errorf("unexpected JSON body and request payload for AWSMarshaler")
+	}
+
+	body := payloadBody
+	if body == nil {
+		body = jsonBody
+	}
+
+	return req, body, err
+}
+
+// SetValue will set a value to the header, path, query, or body.
+//
+// If the request's method is GET all BodyTarget values will be written to
+// the query string.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PathTarget:
+		fallthrough
+	case protocol.QueryTarget:
+		fallthrough
+	case protocol.HeaderTarget:
+		e.reqEncoder.SetValue(t, k, v, meta)
+	case protocol.BodyTarget:
+		fallthrough
+	case protocol.PayloadTarget:
+		if e.method == "GET" {
+			e.reqEncoder.SetValue(t, k, v, meta)
+		} else {
+			e.bodyEncoder.SetValue(t, k, v, meta)
+		}
+	default:
+		e.err = fmt.Errorf("unknown SetValue restjson encode target, %s, %s", t, k)
+	}
+}
+
+// SetStream will set the stream to the payload of the request.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		e.reqEncoder.SetStream(t, k, v, meta)
+	default:
+		e.err = fmt.Errorf("invalid target %s, for SetStream, must be PayloadTarget", t)
+	}
+}
+
+// SetList will set the nested list values to the header, query, or body.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.HeaderTarget:
+		fallthrough
+	case protocol.QueryTarget:
+		e.reqEncoder.SetList(t, k, fn, meta)
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetList(t, k, fn, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetList restjson encode target, %s, %s", t, k)
+	}
+}
+
+// SetMap will set the nested map values to the header, query, or body.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(me protocol.MapEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.QueryTarget:
+		fallthrough
+	case protocol.HeadersTarget:
+		e.reqEncoder.SetMap(t, k, fn, meta)
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetMap(t, k, fn, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetMap restjson encode target, %s, %s", t, k)
+	}
+}
+
+// SetFields will set the nested type's fields to the body.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		fallthrough
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetFields(t, k, m, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetMarshaler restjson encode target, %s, %s", t, k)
+	}
+}

--- a/private/protocol/restjson/encode_test.go
+++ b/private/protocol/restjson/encode_test.go
@@ -1,0 +1,111 @@
+package restjson
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+func TestEncodeNestedShape(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		NestedShape: &nestedShape{
+			Value: aws.String("some value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"nestedShape":{"value":"some value"}}`
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodePayloadShape(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		PayloadShape: &nestedShape{
+			Value: aws.String("some value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"value":"some value"}`
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodePayloadStream(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		PayloadStream: strings.NewReader("some value"),
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := "some value"
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+type shape struct {
+	NestedShape   *nestedShape
+	PayloadShape  *nestedShape
+	PayloadStream io.ReadSeeker
+}
+
+func (s *shape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NestedShape != nil {
+		e.SetFields(protocol.BodyTarget, "nestedShape", s.NestedShape, protocol.Metadata{})
+	}
+	if s.PayloadShape != nil {
+		e.SetFields(protocol.PayloadTarget, "payloadShape", s.PayloadShape, protocol.Metadata{})
+	}
+	if s.PayloadStream != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadReader", protocol.ReadSeekerStream{V: s.PayloadStream}, protocol.Metadata{})
+	}
+	return nil
+}
+
+type nestedShape struct {
+	Value *string
+}
+
+func (s *nestedShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	return nil
+}
+
+func encode(method, path string, s shape) (*http.Request, io.ReadSeeker, error) {
+	origReq, _ := http.NewRequest(method, "https://service.amazonaws.com"+path, nil)
+
+	e := NewEncoder(origReq)
+	s.MarshalFields(e)
+	return e.Encode()
+}

--- a/private/protocol/restjson/restjson.go
+++ b/private/protocol/restjson/restjson.go
@@ -7,11 +7,13 @@ package restjson
 
 import (
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
 )
@@ -30,6 +32,25 @@ var UnmarshalErrorHandler = request.NamedHandler{Name: "awssdk.restjson.Unmarsha
 
 // Build builds a request for the REST JSON protocol.
 func Build(r *request.Request) {
+	if m, ok := r.Params.(protocol.FieldMarshaler); ok {
+		e := NewEncoder(r.HTTPRequest)
+
+		m.MarshalFields(e)
+
+		var body io.ReadSeeker
+		var err error
+		r.HTTPRequest, body, err = e.Encode()
+		if err != nil {
+			r.Error = awserr.New(request.ErrCodeSerialization, "failed to encode rest JSON request", err)
+			return
+		}
+		if body != nil {
+			r.SetReaderBody(body)
+		}
+		return
+	}
+
+	// Fall back to old reflection based marshaler
 	rest.Build(r)
 
 	if t := rest.PayloadType(r.Params); t == "structure" || t == "" {

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -176,6 +176,12 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -266,6 +272,63 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetStr(v
 func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
 	s.TrueBool = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Char != nil {
+		v := *s.Char
+
+		e.SetValue(protocol.BodyTarget, "Char", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Double != nil {
+		v := *s.Double
+
+		e.SetValue(protocol.BodyTarget, "Double", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.FalseBool != nil {
+		v := *s.FalseBool
+
+		e.SetValue(protocol.BodyTarget, "FalseBool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Float != nil {
+		v := *s.Float
+
+		e.SetValue(protocol.BodyTarget, "Float", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.ImaHeader != nil {
+		v := *s.ImaHeader
+
+		e.SetValue(protocol.HeaderTarget, "ImaHeader", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImaHeaderLocation != nil {
+		v := *s.ImaHeaderLocation
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Long != nil {
+		v := *s.Long
+
+		e.SetValue(protocol.BodyTarget, "Long", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Num != nil {
+		v := *s.Num
+
+		e.SetValue(protocol.BodyTarget, "Num", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	// ignoring invalid encode state, StatusCode. Status
+	if s.Str != nil {
+		v := *s.Str
+
+		e.SetValue(protocol.BodyTarget, "Str", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrueBool != nil {
+		v := *s.TrueBool
+
+		e.SetValue(protocol.BodyTarget, "TrueBool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService2ProtocolTest provides the API operation methods for making requests to
@@ -408,8 +471,25 @@ func (s *OutputService2TestShapeBlobContainer) SetFoo(v []byte) *OutputService2T
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeBlobContainer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetValue(protocol.BodyTarget, "foo", protocol.BytesValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
@@ -431,6 +511,22 @@ func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetBlobM
 func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetStructMember(v *OutputService2TestShapeBlobContainer) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
 	s.StructMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BlobMember != nil {
+		v := s.BlobMember
+
+		e.SetValue(protocol.BodyTarget, "BlobMember", protocol.BytesValue(v), protocol.Metadata{})
+	}
+	if s.StructMember != nil {
+		v := s.StructMember
+
+		e.SetFields(protocol.BodyTarget, "StructMember", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService3ProtocolTest provides the API operation methods for making requests to
@@ -564,6 +660,12 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -584,6 +686,22 @@ func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetTimeM
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StructMember != nil {
+		v := s.StructMember
+
+		e.SetFields(protocol.BodyTarget, "StructMember", v, protocol.Metadata{})
+	}
+	if s.TimeMember != nil {
+		v := *s.TimeMember
+
+		e.SetValue(protocol.BodyTarget, "TimeMember", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService3TestShapeTimeContainer struct {
 	_ struct{} `type:"structure"`
 
@@ -594,6 +712,17 @@ type OutputService3TestShapeTimeContainer struct {
 func (s *OutputService3TestShapeTimeContainer) SetFoo(v time.Time) *OutputService3TestShapeTimeContainer {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeTimeContainer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "foo", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService4ProtocolTest provides the API operation methods for making requests to
@@ -727,6 +856,12 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -737,6 +872,17 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
 	s.ListMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService5ProtocolTest provides the API operation methods for making requests to
@@ -870,6 +1016,12 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -882,6 +1034,17 @@ func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetListM
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", encodeOutputService5TestShapeSingleStructList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService5TestShapeSingleStruct struct {
 	_ struct{} `type:"structure"`
 
@@ -892,6 +1055,25 @@ type OutputService5TestShapeSingleStruct struct {
 func (s *OutputService5TestShapeSingleStruct) SetFoo(v string) *OutputService5TestShapeSingleStruct {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeSingleStruct) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputService5TestShapeSingleStructList(vs []*OutputService5TestShapeSingleStruct) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // OutputService6ProtocolTest provides the API operation methods for making requests to
@@ -1025,6 +1207,12 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1035,6 +1223,22 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetMapMember(v map[string][]*int64) *OutputService6TestShapeOutputService6TestCaseOperation1Output {
 	s.MapMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.MapMember) > 0 {
+		v := s.MapMember
+
+		e.SetMap(protocol.BodyTarget, "MapMember", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeInt64List(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService7ProtocolTest provides the API operation methods for making requests to
@@ -1168,6 +1372,12 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1178,6 +1388,17 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) SetMapMember(v map[string]*time.Time) *OutputService7TestShapeOutputService7TestCaseOperation1Output {
 	s.MapMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.MapMember) > 0 {
+		v := s.MapMember
+
+		e.SetMap(protocol.BodyTarget, "MapMember", protocol.EncodeTimeMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService8ProtocolTest provides the API operation methods for making requests to
@@ -1311,6 +1532,12 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1321,6 +1548,17 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) SetStrType(v string) *OutputService8TestShapeOutputService8TestCaseOperation1Output {
 	s.StrType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StrType != nil {
+		v := *s.StrType
+
+		e.SetValue(protocol.BodyTarget, "StrType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService9ProtocolTest provides the API operation methods for making requests to
@@ -1454,6 +1692,12 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1472,6 +1716,22 @@ func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetAllHe
 func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetPrefixedHeaders(v map[string]*string) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
 	s.PrefixedHeaders = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AllHeaders) > 0 {
+		v := s.AllHeaders
+
+		e.SetMap(protocol.HeadersTarget, "AllHeaders", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.PrefixedHeaders) > 0 {
+		v := s.PrefixedHeaders
+
+		e.SetMap(protocol.HeadersTarget, "X-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService10ProtocolTest provides the API operation methods for making requests to
@@ -1613,8 +1873,25 @@ func (s *OutputService10TestShapeBodyStructure) SetFoo(v string) *OutputService1
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeBodyStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
@@ -1635,6 +1912,22 @@ func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetDat
 func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetHeader(v string) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
 	s.Header = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Data != nil {
+		v := s.Data
+
+		e.SetFields(protocol.PayloadTarget, "Data", v, protocol.Metadata{})
+	}
+	if s.Header != nil {
+		v := *s.Header
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService11ProtocolTest provides the API operation methods for making requests to
@@ -1768,6 +2061,12 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure" payload:"Stream"`
 
@@ -1778,6 +2077,17 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetStream(v []byte) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
 	s.Stream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Stream != nil {
+		v := s.Stream
+
+		e.SetStream(protocol.PayloadTarget, "Stream", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService12ProtocolTest provides the API operation methods for making requests to
@@ -1911,6 +2221,12 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1921,6 +2237,17 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetAttr(v aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
 	s.Attr = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Attr != nil {
+		v := s.Attr
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Foo", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 //

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -4056,7 +4056,6 @@ func (s *InputService19TestShapeGrant) MarshalFields(e protocol.FieldEncoder) er
 	if s.Grantee != nil {
 		v := s.Grantee
 		attrs := make([]protocol.Attribute, 0, 1)
-		// TODO only create array if an attribute value is set
 
 		if s.Grantee.Type != nil {
 			v := *s.Grantee.Type

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -10647,6 +10647,32 @@ func (s *Account) SetThrottleSettings(v *ThrottleSettings) *Account {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Account) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKeyVersion != nil {
+		v := *s.ApiKeyVersion
+
+		e.SetValue(protocol.BodyTarget, "apiKeyVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CloudwatchRoleArn != nil {
+		v := *s.CloudwatchRoleArn
+
+		e.SetValue(protocol.BodyTarget, "cloudwatchRoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Features) > 0 {
+		v := s.Features
+
+		e.SetList(protocol.BodyTarget, "features", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ThrottleSettings != nil {
+		v := s.ThrottleSettings
+
+		e.SetFields(protocol.BodyTarget, "throttleSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A resource that can be distributed to callers for executing Method resources
 // that require an API key. API keys can be mapped to any Stage on any RestApi,
 // which indicates that the callers with the API key can make requests to that
@@ -10749,6 +10775,65 @@ func (s *ApiKey) SetValue(v string) *ApiKey {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApiKey) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CustomerId != nil {
+		v := *s.CustomerId
+
+		e.SetValue(protocol.BodyTarget, "customerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageKeys) > 0 {
+		v := s.StageKeys
+
+		e.SetList(protocol.BodyTarget, "stageKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeApiKeyList(vs []*ApiKey) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // API stage name of the associated API stage in a usage plan.
 type ApiStage struct {
 	_ struct{} `type:"structure"`
@@ -10780,6 +10865,30 @@ func (s *ApiStage) SetApiId(v string) *ApiStage {
 func (s *ApiStage) SetStage(v string) *ApiStage {
 	s.Stage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApiStage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiId != nil {
+		v := *s.ApiId
+
+		e.SetValue(protocol.BodyTarget, "apiId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Stage != nil {
+		v := *s.Stage
+
+		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeApiStageList(vs []*ApiStage) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents an authorization layer for methods. If enabled on a method, API
@@ -10932,6 +11041,70 @@ func (s *Authorizer) SetType(v string) *Authorizer {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Authorizer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthType != nil {
+		v := *s.AuthType
+
+		e.SetValue(protocol.BodyTarget, "authType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerCredentials != nil {
+		v := *s.AuthorizerCredentials
+
+		e.SetValue(protocol.BodyTarget, "authorizerCredentials", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerResultTtlInSeconds != nil {
+		v := *s.AuthorizerResultTtlInSeconds
+
+		e.SetValue(protocol.BodyTarget, "authorizerResultTtlInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AuthorizerUri != nil {
+		v := *s.AuthorizerUri
+
+		e.SetValue(protocol.BodyTarget, "authorizerUri", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentitySource != nil {
+		v := *s.IdentitySource
+
+		e.SetValue(protocol.BodyTarget, "identitySource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityValidationExpression != nil {
+		v := *s.IdentityValidationExpression
+
+		e.SetValue(protocol.BodyTarget, "identityValidationExpression", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ProviderARNs) > 0 {
+		v := s.ProviderARNs
+
+		e.SetList(protocol.BodyTarget, "providerARNs", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAuthorizerList(vs []*Authorizer) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents the base path that callers of the API must provide as part of
 // the URL after the domain name.
 //
@@ -10978,6 +11151,35 @@ func (s *BasePathMapping) SetRestApiId(v string) *BasePathMapping {
 func (s *BasePathMapping) SetStage(v string) *BasePathMapping {
 	s.Stage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BasePathMapping) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.BodyTarget, "basePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.BodyTarget, "restApiId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Stage != nil {
+		v := *s.Stage
+
+		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBasePathMappingList(vs []*BasePathMapping) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents a client certificate used to configure client-side SSL authentication
@@ -11045,6 +11247,45 @@ func (s *ClientCertificate) SetExpirationDate(v time.Time) *ClientCertificate {
 func (s *ClientCertificate) SetPemEncodedCertificate(v string) *ClientCertificate {
 	s.PemEncodedCertificate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ClientCertificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.BodyTarget, "clientCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExpirationDate != nil {
+		v := *s.ExpirationDate
+
+		e.SetValue(protocol.BodyTarget, "expirationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.PemEncodedCertificate != nil {
+		v := *s.PemEncodedCertificate
+
+		e.SetValue(protocol.BodyTarget, "pemEncodedCertificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeClientCertificateList(vs []*ClientCertificate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Request to create an ApiKey resource.
@@ -11125,6 +11366,47 @@ func (s *CreateApiKeyInput) SetStageKeys(v []*StageKey) *CreateApiKeyInput {
 func (s *CreateApiKeyInput) SetValue(v string) *CreateApiKeyInput {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CustomerId != nil {
+		v := *s.CustomerId
+
+		e.SetValue(protocol.BodyTarget, "customerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.GenerateDistinctId != nil {
+		v := *s.GenerateDistinctId
+
+		e.SetValue(protocol.BodyTarget, "generateDistinctId", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageKeys) > 0 {
+		v := s.StageKeys
+
+		e.SetList(protocol.BodyTarget, "stageKeys", encodeStageKeyList(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to add a new Authorizer to an existing RestApi resource.
@@ -11299,6 +11581,62 @@ func (s *CreateAuthorizerInput) SetType(v string) *CreateAuthorizerInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthType != nil {
+		v := *s.AuthType
+
+		e.SetValue(protocol.BodyTarget, "authType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerCredentials != nil {
+		v := *s.AuthorizerCredentials
+
+		e.SetValue(protocol.BodyTarget, "authorizerCredentials", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerResultTtlInSeconds != nil {
+		v := *s.AuthorizerResultTtlInSeconds
+
+		e.SetValue(protocol.BodyTarget, "authorizerResultTtlInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AuthorizerUri != nil {
+		v := *s.AuthorizerUri
+
+		e.SetValue(protocol.BodyTarget, "authorizerUri", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentitySource != nil {
+		v := *s.IdentitySource
+
+		e.SetValue(protocol.BodyTarget, "identitySource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityValidationExpression != nil {
+		v := *s.IdentityValidationExpression
+
+		e.SetValue(protocol.BodyTarget, "identityValidationExpression", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ProviderARNs) > 0 {
+		v := s.ProviderARNs
+
+		e.SetList(protocol.BodyTarget, "providerARNs", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to create a new BasePathMapping resource.
 type CreateBasePathMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -11373,6 +11711,32 @@ func (s *CreateBasePathMappingInput) SetRestApiId(v string) *CreateBasePathMappi
 func (s *CreateBasePathMappingInput) SetStage(v string) *CreateBasePathMappingInput {
 	s.Stage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.BodyTarget, "basePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.BodyTarget, "restApiId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Stage != nil {
+		v := *s.Stage
+
+		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to create a Deployment resource.
@@ -11471,6 +11835,47 @@ func (s *CreateDeploymentInput) SetVariables(v map[string]*string) *CreateDeploy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CacheClusterEnabled != nil {
+		v := *s.CacheClusterEnabled
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CacheClusterSize != nil {
+		v := *s.CacheClusterSize
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterSize", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageDescription != nil {
+		v := *s.StageDescription
+
+		e.SetValue(protocol.BodyTarget, "stageDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Creates a new documentation part of a given API.
 type CreateDocumentationPartInput struct {
 	_ struct{} `type:"structure"`
@@ -11546,6 +11951,27 @@ func (s *CreateDocumentationPartInput) SetRestApiId(v string) *CreateDocumentati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "location", v, protocol.Metadata{})
+	}
+	if s.Properties != nil {
+		v := *s.Properties
+
+		e.SetValue(protocol.BodyTarget, "properties", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Creates a new documentation version of a given API.
 type CreateDocumentationVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -11615,6 +12041,32 @@ func (s *CreateDocumentationVersionInput) SetRestApiId(v string) *CreateDocument
 func (s *CreateDocumentationVersionInput) SetStageName(v string) *CreateDocumentationVersionInput {
 	s.StageName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.BodyTarget, "documentationVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to create a new domain name.
@@ -11708,6 +12160,42 @@ func (s *CreateDomainNameInput) SetDomainName(v string) *CreateDomainNameInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateBody != nil {
+		v := *s.CertificateBody
+
+		e.SetValue(protocol.BodyTarget, "certificateBody", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateChain != nil {
+		v := *s.CertificateChain
+
+		e.SetValue(protocol.BodyTarget, "certificateChain", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateName != nil {
+		v := *s.CertificateName
+
+		e.SetValue(protocol.BodyTarget, "certificateName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePrivateKey != nil {
+		v := *s.CertificatePrivateKey
+
+		e.SetValue(protocol.BodyTarget, "certificatePrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to add a new Model to an existing RestApi resource.
 type CreateModelInput struct {
 	_ struct{} `type:"structure"`
@@ -11794,6 +12282,37 @@ func (s *CreateModelInput) SetSchema(v string) *CreateModelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateModelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Schema != nil {
+		v := *s.Schema
+
+		e.SetValue(protocol.BodyTarget, "schema", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Creates a RequestValidator of a given RestApi.
 type CreateRequestValidatorInput struct {
 	_ struct{} `type:"structure"`
@@ -11862,6 +12381,32 @@ func (s *CreateRequestValidatorInput) SetValidateRequestParameters(v bool) *Crea
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValidateRequestBody != nil {
+		v := *s.ValidateRequestBody
+
+		e.SetValue(protocol.BodyTarget, "validateRequestBody", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ValidateRequestParameters != nil {
+		v := *s.ValidateRequestParameters
+
+		e.SetValue(protocol.BodyTarget, "validateRequestParameters", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to create a Resource resource.
 type CreateResourceInput struct {
 	_ struct{} `type:"structure"`
@@ -11927,6 +12472,27 @@ func (s *CreateResourceInput) SetPathPart(v string) *CreateResourceInput {
 func (s *CreateResourceInput) SetRestApiId(v string) *CreateResourceInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.PathTarget, "parent_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PathPart != nil {
+		v := *s.PathPart
+
+		e.SetValue(protocol.BodyTarget, "pathPart", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The POST Request to add a new RestApi resource to your collection.
@@ -12003,6 +12569,37 @@ func (s *CreateRestApiInput) SetName(v string) *CreateRestApiInput {
 func (s *CreateRestApiInput) SetVersion(v string) *CreateRestApiInput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BinaryMediaTypes) > 0 {
+		v := s.BinaryMediaTypes
+
+		e.SetList(protocol.BodyTarget, "binaryMediaTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.CloneFrom != nil {
+		v := *s.CloneFrom
+
+		e.SetValue(protocol.BodyTarget, "cloneFrom", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to create a Stage resource.
@@ -12119,6 +12716,52 @@ func (s *CreateStageInput) SetVariables(v map[string]*string) *CreateStageInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CacheClusterEnabled != nil {
+		v := *s.CacheClusterEnabled
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CacheClusterSize != nil {
+		v := *s.CacheClusterSize
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterSize", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "deploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.BodyTarget, "documentationVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The POST request to create a usage plan with the name, description, throttle
 // limits and quota limits, as well as the associated API stages, specified
 // in the payload.
@@ -12196,6 +12839,37 @@ func (s *CreateUsagePlanInput) SetThrottle(v *ThrottleSettings) *CreateUsagePlan
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ApiStages) > 0 {
+		v := s.ApiStages
+
+		e.SetList(protocol.BodyTarget, "apiStages", encodeApiStageList(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quota != nil {
+		v := s.Quota
+
+		e.SetFields(protocol.BodyTarget, "quota", v, protocol.Metadata{})
+	}
+	if s.Throttle != nil {
+		v := s.Throttle
+
+		e.SetFields(protocol.BodyTarget, "throttle", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The POST request to create a usage plan key for adding an existing API key
 // to a usage plan.
 type CreateUsagePlanKeyInput struct {
@@ -12265,6 +12939,27 @@ func (s *CreateUsagePlanKeyInput) SetUsagePlanId(v string) *CreateUsagePlanKeyIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.BodyTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyType != nil {
+		v := *s.KeyType
+
+		e.SetValue(protocol.BodyTarget, "keyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to delete the ApiKey resource.
 type DeleteApiKeyInput struct {
 	_ struct{} `type:"structure"`
@@ -12304,6 +12999,17 @@ func (s *DeleteApiKeyInput) SetApiKey(v string) *DeleteApiKeyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteApiKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12316,6 +13022,12 @@ func (s DeleteApiKeyOutput) String() string {
 // GoString returns the string representation
 func (s DeleteApiKeyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApiKeyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete an existing Authorizer resource.
@@ -12371,6 +13083,22 @@ func (s *DeleteAuthorizerInput) SetRestApiId(v string) *DeleteAuthorizerInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteAuthorizerOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12383,6 +13111,12 @@ func (s DeleteAuthorizerOutput) String() string {
 // GoString returns the string representation
 func (s DeleteAuthorizerOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAuthorizerOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete the BasePathMapping resource.
@@ -12438,6 +13172,22 @@ func (s *DeleteBasePathMappingInput) SetDomainName(v string) *DeleteBasePathMapp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.PathTarget, "base_path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteBasePathMappingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12450,6 +13200,12 @@ func (s DeleteBasePathMappingOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBasePathMappingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBasePathMappingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete the ClientCertificate resource.
@@ -12491,6 +13247,17 @@ func (s *DeleteClientCertificateInput) SetClientCertificateId(v string) *DeleteC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteClientCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12503,6 +13270,12 @@ func (s DeleteClientCertificateOutput) String() string {
 // GoString returns the string representation
 func (s DeleteClientCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteClientCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Requests Amazon API Gateway to delete a Deployment resource.
@@ -12558,6 +13331,22 @@ func (s *DeleteDeploymentInput) SetRestApiId(v string) *DeleteDeploymentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteDeploymentOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12570,6 +13359,12 @@ func (s DeleteDeploymentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDeploymentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDeploymentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Deletes an existing documentation part of an API.
@@ -12625,6 +13420,22 @@ func (s *DeleteDocumentationPartInput) SetRestApiId(v string) *DeleteDocumentati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationPartId != nil {
+		v := *s.DocumentationPartId
+
+		e.SetValue(protocol.PathTarget, "part_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteDocumentationPartOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12637,6 +13448,12 @@ func (s DeleteDocumentationPartOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDocumentationPartOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentationPartOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Deletes an existing documentation version of an API.
@@ -12692,6 +13509,22 @@ func (s *DeleteDocumentationVersionInput) SetRestApiId(v string) *DeleteDocument
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.PathTarget, "doc_version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteDocumentationVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12704,6 +13537,12 @@ func (s DeleteDocumentationVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDocumentationVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentationVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete the DomainName resource.
@@ -12745,6 +13584,17 @@ func (s *DeleteDomainNameInput) SetDomainName(v string) *DeleteDomainNameInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteDomainNameOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12757,6 +13607,12 @@ func (s DeleteDomainNameOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDomainNameOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDomainNameOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Clears any customization of a GatewayResponse of a specified response type
@@ -12833,6 +13689,22 @@ func (s *DeleteGatewayResponseInput) SetRestApiId(v string) *DeleteGatewayRespon
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.PathTarget, "response_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteGatewayResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12845,6 +13717,12 @@ func (s DeleteGatewayResponseOutput) String() string {
 // GoString returns the string representation
 func (s DeleteGatewayResponseOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGatewayResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents a delete integration request.
@@ -12914,6 +13792,27 @@ func (s *DeleteIntegrationInput) SetRestApiId(v string) *DeleteIntegrationInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteIntegrationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12926,6 +13825,12 @@ func (s DeleteIntegrationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIntegrationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntegrationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents a delete integration response request.
@@ -13009,6 +13914,32 @@ func (s *DeleteIntegrationResponseInput) SetStatusCode(v string) *DeleteIntegrat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteIntegrationResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13021,6 +13952,12 @@ func (s DeleteIntegrationResponseOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIntegrationResponseOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntegrationResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete an existing Method resource.
@@ -13090,6 +14027,27 @@ func (s *DeleteMethodInput) SetRestApiId(v string) *DeleteMethodInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteMethodOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13102,6 +14060,12 @@ func (s DeleteMethodOutput) String() string {
 // GoString returns the string representation
 func (s DeleteMethodOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMethodOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete an existing MethodResponse resource.
@@ -13185,6 +14149,32 @@ func (s *DeleteMethodResponseInput) SetStatusCode(v string) *DeleteMethodRespons
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteMethodResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13197,6 +14187,12 @@ func (s DeleteMethodResponseOutput) String() string {
 // GoString returns the string representation
 func (s DeleteMethodResponseOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMethodResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete an existing model in an existing RestApi resource.
@@ -13252,6 +14248,22 @@ func (s *DeleteModelInput) SetRestApiId(v string) *DeleteModelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteModelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteModelOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13264,6 +14276,12 @@ func (s DeleteModelOutput) String() string {
 // GoString returns the string representation
 func (s DeleteModelOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteModelOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Deletes a specified RequestValidator of a given RestApi.
@@ -13319,6 +14337,22 @@ func (s *DeleteRequestValidatorInput) SetRestApiId(v string) *DeleteRequestValid
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.PathTarget, "requestvalidator_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteRequestValidatorOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13331,6 +14365,12 @@ func (s DeleteRequestValidatorOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRequestValidatorOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRequestValidatorOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete a Resource.
@@ -13386,6 +14426,22 @@ func (s *DeleteResourceInput) SetRestApiId(v string) *DeleteResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13398,6 +14454,12 @@ func (s DeleteResourceOutput) String() string {
 // GoString returns the string representation
 func (s DeleteResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete the specified API from your collection.
@@ -13439,6 +14501,17 @@ func (s *DeleteRestApiInput) SetRestApiId(v string) *DeleteRestApiInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteRestApiOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13451,6 +14524,12 @@ func (s DeleteRestApiOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRestApiOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRestApiOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Requests Amazon API Gateway to delete a Stage resource.
@@ -13506,6 +14585,22 @@ func (s *DeleteStageInput) SetStageName(v string) *DeleteStageInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteStageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteStageOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13518,6 +14613,12 @@ func (s DeleteStageOutput) String() string {
 // GoString returns the string representation
 func (s DeleteStageOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteStageOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The DELETE request to delete a usage plan of a given plan Id.
@@ -13557,6 +14658,17 @@ func (s *DeleteUsagePlanInput) Validate() error {
 func (s *DeleteUsagePlanInput) SetUsagePlanId(v string) *DeleteUsagePlanInput {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The DELETE request to delete a usage plan key and remove the underlying API
@@ -13614,6 +14726,22 @@ func (s *DeleteUsagePlanKeyInput) SetUsagePlanId(v string) *DeleteUsagePlanKeyIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.PathTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteUsagePlanKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13628,6 +14756,12 @@ func (s DeleteUsagePlanKeyOutput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUsagePlanKeyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type DeleteUsagePlanOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13640,6 +14774,12 @@ func (s DeleteUsagePlanOutput) String() string {
 // GoString returns the string representation
 func (s DeleteUsagePlanOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUsagePlanOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // An immutable representation of a RestApi resource that can be called by users
@@ -13701,6 +14841,45 @@ func (s *Deployment) SetDescription(v string) *Deployment {
 func (s *Deployment) SetId(v string) *Deployment {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Deployment) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ApiSummary) > 0 {
+		v := s.ApiSummary
+
+		e.SetMap(protocol.BodyTarget, "apiSummary", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetMap(k, encodeMethodSnapshotMap(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeploymentList(vs []*Deployment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A documentation part for a targeted API entity.
@@ -13768,6 +14947,35 @@ func (s *DocumentationPart) SetLocation(v *DocumentationPartLocation) *Documenta
 func (s *DocumentationPart) SetProperties(v string) *DocumentationPart {
 	s.Properties = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentationPart) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "location", v, protocol.Metadata{})
+	}
+	if s.Properties != nil {
+		v := *s.Properties
+
+		e.SetValue(protocol.BodyTarget, "properties", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentationPartList(vs []*DocumentationPart) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Specifies the target API entity to which the documentation applies.
@@ -13870,6 +15078,37 @@ func (s *DocumentationPartLocation) SetType(v string) *DocumentationPartLocation
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentationPartLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Method != nil {
+		v := *s.Method
+
+		e.SetValue(protocol.BodyTarget, "method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A snapshot of the documentation of an API.
 //
 // Publishing API documentation involves creating a documentation version associated
@@ -13917,6 +15156,35 @@ func (s *DocumentationVersion) SetDescription(v string) *DocumentationVersion {
 func (s *DocumentationVersion) SetVersion(v string) *DocumentationVersion {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentationVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentationVersionList(vs []*DocumentationVersion) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents a domain name that is contained in a simpler, more intuitive URL
@@ -13984,6 +15252,45 @@ func (s *DomainName) SetDomainName(v string) *DomainName {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DomainName) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateName != nil {
+		v := *s.CertificateName
+
+		e.SetValue(protocol.BodyTarget, "certificateName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateUploadDate != nil {
+		v := *s.CertificateUploadDate
+
+		e.SetValue(protocol.BodyTarget, "certificateUploadDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.DistributionDomainName != nil {
+		v := *s.DistributionDomainName
+
+		e.SetValue(protocol.BodyTarget, "distributionDomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDomainNameList(vs []*DomainName) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Request to flush authorizer cache entries on a specified stage.
 type FlushStageAuthorizersCacheInput struct {
 	_ struct{} `type:"structure"`
@@ -14037,6 +15344,22 @@ func (s *FlushStageAuthorizersCacheInput) SetStageName(v string) *FlushStageAuth
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FlushStageAuthorizersCacheInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type FlushStageAuthorizersCacheOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -14049,6 +15372,12 @@ func (s FlushStageAuthorizersCacheOutput) String() string {
 // GoString returns the string representation
 func (s FlushStageAuthorizersCacheOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FlushStageAuthorizersCacheOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Requests Amazon API Gateway to flush a stage's cache.
@@ -14104,6 +15433,22 @@ func (s *FlushStageCacheInput) SetStageName(v string) *FlushStageCacheInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FlushStageCacheInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type FlushStageCacheOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -14116,6 +15461,12 @@ func (s FlushStageCacheOutput) String() string {
 // GoString returns the string representation
 func (s FlushStageCacheOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FlushStageCacheOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to generate a ClientCertificate resource.
@@ -14142,6 +15493,17 @@ func (s *GenerateClientCertificateInput) SetDescription(v string) *GenerateClien
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GenerateClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to get information about the current Account
 // resource.
 type GetAccountInput struct {
@@ -14156,6 +15518,12 @@ func (s GetAccountInput) String() string {
 // GoString returns the string representation
 func (s GetAccountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to get information about the current ApiKey resource.
@@ -14205,6 +15573,22 @@ func (s *GetApiKeyInput) SetApiKey(v string) *GetApiKeyInput {
 func (s *GetApiKeyInput) SetIncludeValue(v bool) *GetApiKeyInput {
 	s.IncludeValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeValue != nil {
+		v := *s.IncludeValue
+
+		e.SetValue(protocol.QueryTarget, "includeValue", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about the current ApiKeys resource.
@@ -14269,6 +15653,37 @@ func (s *GetApiKeysInput) SetPosition(v string) *GetApiKeysInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApiKeysInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CustomerId != nil {
+		v := *s.CustomerId
+
+		e.SetValue(protocol.QueryTarget, "customerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeValues != nil {
+		v := *s.IncludeValues
+
+		e.SetValue(protocol.QueryTarget, "includeValues", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameQuery != nil {
+		v := *s.NameQuery
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of API keys as represented by an ApiKeys resource.
 //
 // Use API Keys (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html)
@@ -14311,6 +15726,27 @@ func (s *GetApiKeysOutput) SetPosition(v string) *GetApiKeysOutput {
 func (s *GetApiKeysOutput) SetWarnings(v []*string) *GetApiKeysOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApiKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeApiKeyList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to describe an existing Authorizer resource.
@@ -14364,6 +15800,22 @@ func (s *GetAuthorizerInput) SetAuthorizerId(v string) *GetAuthorizerInput {
 func (s *GetAuthorizerInput) SetRestApiId(v string) *GetAuthorizerInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to describe an existing Authorizers resource.
@@ -14423,6 +15875,27 @@ func (s *GetAuthorizersInput) SetRestApiId(v string) *GetAuthorizersInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAuthorizersInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of Authorizer resources.
 //
 // Enable custom authorization (http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html)
@@ -14455,6 +15928,22 @@ func (s *GetAuthorizersOutput) SetItems(v []*Authorizer) *GetAuthorizersOutput {
 func (s *GetAuthorizersOutput) SetPosition(v string) *GetAuthorizersOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAuthorizersOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeAuthorizerList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to describe a BasePathMapping resource.
@@ -14511,6 +16000,22 @@ func (s *GetBasePathMappingInput) SetBasePath(v string) *GetBasePathMappingInput
 func (s *GetBasePathMappingInput) SetDomainName(v string) *GetBasePathMappingInput {
 	s.DomainName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.PathTarget, "base_path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about a collection of BasePathMapping resources.
@@ -14571,6 +16076,27 @@ func (s *GetBasePathMappingsInput) SetPosition(v string) *GetBasePathMappingsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBasePathMappingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of BasePathMapping resources.
 //
 // Use Custom Domain Names (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html)
@@ -14603,6 +16129,22 @@ func (s *GetBasePathMappingsOutput) SetItems(v []*BasePathMapping) *GetBasePathM
 func (s *GetBasePathMappingsOutput) SetPosition(v string) *GetBasePathMappingsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBasePathMappingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeBasePathMappingList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about the current ClientCertificate resource.
@@ -14644,6 +16186,17 @@ func (s *GetClientCertificateInput) SetClientCertificateId(v string) *GetClientC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to get information about a collection of ClientCertificate resources.
 type GetClientCertificatesInput struct {
 	_ struct{} `type:"structure"`
@@ -14678,6 +16231,22 @@ func (s *GetClientCertificatesInput) SetPosition(v string) *GetClientCertificate
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetClientCertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of ClientCertificate resources.
 //
 // Use Client-Side Certificate (http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html)
@@ -14710,6 +16279,22 @@ func (s *GetClientCertificatesOutput) SetItems(v []*ClientCertificate) *GetClien
 func (s *GetClientCertificatesOutput) SetPosition(v string) *GetClientCertificatesOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetClientCertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeClientCertificateList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to get information about a Deployment resource.
@@ -14780,6 +16365,27 @@ func (s *GetDeploymentInput) SetRestApiId(v string) *GetDeploymentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Embed) > 0 {
+		v := s.Embed
+
+		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to get information about a Deployments collection.
 type GetDeploymentsInput struct {
 	_ struct{} `type:"structure"`
@@ -14838,6 +16444,27 @@ func (s *GetDeploymentsInput) SetRestApiId(v string) *GetDeploymentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection resource that contains zero or more references to
 // your existing deployments, and links that guide you on how to interact with
 // your collection. The collection offers a paginated view of the contained
@@ -14879,6 +16506,22 @@ func (s *GetDeploymentsOutput) SetItems(v []*Deployment) *GetDeploymentsOutput {
 func (s *GetDeploymentsOutput) SetPosition(v string) *GetDeploymentsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeDeploymentList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets a specified documentation part of a given API.
@@ -14932,6 +16575,22 @@ func (s *GetDocumentationPartInput) SetDocumentationPartId(v string) *GetDocumen
 func (s *GetDocumentationPartInput) SetRestApiId(v string) *GetDocumentationPartInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationPartId != nil {
+		v := *s.DocumentationPartId
+
+		e.SetValue(protocol.PathTarget, "part_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets the documentation parts of an API. The result may be filtered by the
@@ -15019,6 +16678,42 @@ func (s *GetDocumentationPartsInput) SetType(v string) *GetDocumentationPartsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameQuery != nil {
+		v := *s.NameQuery
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.QueryTarget, "path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The collection of documentation parts of an API.
 //
 // Documenting an API (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html), DocumentationPart
@@ -15051,6 +16746,22 @@ func (s *GetDocumentationPartsOutput) SetItems(v []*DocumentationPart) *GetDocum
 func (s *GetDocumentationPartsOutput) SetPosition(v string) *GetDocumentationPartsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeDocumentationPartList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets a documentation snapshot of an API.
@@ -15104,6 +16815,22 @@ func (s *GetDocumentationVersionInput) SetDocumentationVersion(v string) *GetDoc
 func (s *GetDocumentationVersionInput) SetRestApiId(v string) *GetDocumentationVersionInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.PathTarget, "doc_version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets the documentation versions of an API.
@@ -15163,6 +16890,27 @@ func (s *GetDocumentationVersionsInput) SetRestApiId(v string) *GetDocumentation
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The collection of documentation snapshots of an API.
 //
 // Use the DocumentationVersions to manage documentation snapshots associated
@@ -15199,6 +16947,22 @@ func (s *GetDocumentationVersionsOutput) SetItems(v []*DocumentationVersion) *Ge
 func (s *GetDocumentationVersionsOutput) SetPosition(v string) *GetDocumentationVersionsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeDocumentationVersionList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to get the name of a DomainName resource.
@@ -15240,6 +17004,17 @@ func (s *GetDomainNameInput) SetDomainName(v string) *GetDomainNameInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to describe a collection of DomainName resources.
 type GetDomainNamesInput struct {
 	_ struct{} `type:"structure"`
@@ -15274,6 +17049,22 @@ func (s *GetDomainNamesInput) SetPosition(v string) *GetDomainNamesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDomainNamesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of DomainName resources.
 //
 // Use Client-Side Certificate (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html)
@@ -15306,6 +17097,22 @@ func (s *GetDomainNamesOutput) SetItems(v []*DomainName) *GetDomainNamesOutput {
 func (s *GetDomainNamesOutput) SetPosition(v string) *GetDomainNamesOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDomainNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeDomainNameList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request a new export of a RestApi for a particular Stage.
@@ -15401,6 +17208,37 @@ func (s *GetExportInput) SetStageName(v string) *GetExportInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetExportInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Accepts != nil {
+		v := *s.Accepts
+
+		e.SetValue(protocol.HeaderTarget, "Accept", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExportType != nil {
+		v := *s.ExportType
+
+		e.SetValue(protocol.PathTarget, "export_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The binary blob response to GetExport, which contains the generated SDK.
 type GetExportOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -15442,6 +17280,27 @@ func (s *GetExportOutput) SetContentDisposition(v string) *GetExportOutput {
 func (s *GetExportOutput) SetContentType(v string) *GetExportOutput {
 	s.ContentType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetExportOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets a GatewayResponse of a specified response type on the given RestApi.
@@ -15517,6 +17376,22 @@ func (s *GetGatewayResponseInput) SetRestApiId(v string) *GetGatewayResponseInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.PathTarget, "response_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Gets the GatewayResponses collection on the given RestApi. If an API developer
 // has not added any definitions for gateway responses, the result will be the
 // Amazon API Gateway-generated default GatewayResponses collection for the
@@ -15577,6 +17452,27 @@ func (s *GetGatewayResponsesInput) SetPosition(v string) *GetGatewayResponsesInp
 func (s *GetGatewayResponsesInput) SetRestApiId(v string) *GetGatewayResponsesInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGatewayResponsesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The collection of the GatewayResponse instances of a RestApi as a responseType-to-GatewayResponse
@@ -15770,6 +17666,22 @@ func (s *GetGatewayResponsesOutput) SetPosition(v string) *GetGatewayResponsesOu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGatewayResponsesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeUpdateGatewayResponseOutputList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a get integration request.
 type GetIntegrationInput struct {
 	_ struct{} `type:"structure"`
@@ -15835,6 +17747,27 @@ func (s *GetIntegrationInput) SetResourceId(v string) *GetIntegrationInput {
 func (s *GetIntegrationInput) SetRestApiId(v string) *GetIntegrationInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents a get integration response request.
@@ -15918,6 +17851,32 @@ func (s *GetIntegrationResponseInput) SetStatusCode(v string) *GetIntegrationRes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to describe an existing Method resource.
 type GetMethodInput struct {
 	_ struct{} `type:"structure"`
@@ -15983,6 +17942,27 @@ func (s *GetMethodInput) SetResourceId(v string) *GetMethodInput {
 func (s *GetMethodInput) SetRestApiId(v string) *GetMethodInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to describe a MethodResponse resource.
@@ -16066,6 +18046,32 @@ func (s *GetMethodResponseInput) SetStatusCode(v string) *GetMethodResponseInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to list information about a model in an existing RestApi resource.
 type GetModelInput struct {
 	_ struct{} `type:"structure"`
@@ -16130,6 +18136,27 @@ func (s *GetModelInput) SetRestApiId(v string) *GetModelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Flatten != nil {
+		v := *s.Flatten
+
+		e.SetValue(protocol.QueryTarget, "flatten", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to generate a sample mapping template used to transform the payload.
 type GetModelTemplateInput struct {
 	_ struct{} `type:"structure"`
@@ -16183,6 +18210,22 @@ func (s *GetModelTemplateInput) SetRestApiId(v string) *GetModelTemplateInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a mapping template used to transform a payload.
 //
 // Mapping Templates (http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings)
@@ -16208,6 +18251,17 @@ func (s GetModelTemplateOutput) GoString() string {
 func (s *GetModelTemplateOutput) SetValue(v string) *GetModelTemplateOutput {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to list existing Models defined for a RestApi resource.
@@ -16268,6 +18322,27 @@ func (s *GetModelsInput) SetRestApiId(v string) *GetModelsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of Model resources.
 //
 // Method, MethodResponse, Models and Mappings (http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html)
@@ -16300,6 +18375,22 @@ func (s *GetModelsOutput) SetItems(v []*Model) *GetModelsOutput {
 func (s *GetModelsOutput) SetPosition(v string) *GetModelsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeModelList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets a RequestValidator of a given RestApi.
@@ -16353,6 +18444,22 @@ func (s *GetRequestValidatorInput) SetRequestValidatorId(v string) *GetRequestVa
 func (s *GetRequestValidatorInput) SetRestApiId(v string) *GetRequestValidatorInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.PathTarget, "requestvalidator_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets the RequestValidators collection of a given RestApi.
@@ -16412,6 +18519,27 @@ func (s *GetRequestValidatorsInput) SetRestApiId(v string) *GetRequestValidators
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRequestValidatorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A collection of RequestValidator resources of a given RestApi.
 //
 // In Swagger, the RequestValidators of an API is defined by the x-amazon-apigateway-request-validators
@@ -16448,6 +18576,22 @@ func (s *GetRequestValidatorsOutput) SetItems(v []*UpdateRequestValidatorOutput)
 func (s *GetRequestValidatorsOutput) SetPosition(v string) *GetRequestValidatorsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRequestValidatorsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeUpdateRequestValidatorOutputList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to list information about a resource.
@@ -16515,6 +18659,27 @@ func (s *GetResourceInput) SetResourceId(v string) *GetResourceInput {
 func (s *GetResourceInput) SetRestApiId(v string) *GetResourceInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Embed) > 0 {
+		v := s.Embed
+
+		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to list information about a collection of resources.
@@ -16589,6 +18754,32 @@ func (s *GetResourcesInput) SetRestApiId(v string) *GetResourcesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetResourcesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Embed) > 0 {
+		v := s.Embed
+
+		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of Resource resources.
 //
 // Create an API (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html)
@@ -16621,6 +18812,22 @@ func (s *GetResourcesOutput) SetItems(v []*Resource) *GetResourcesOutput {
 func (s *GetResourcesOutput) SetPosition(v string) *GetResourcesOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetResourcesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeResourceList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to list an existing RestApi defined for your collection.
@@ -16662,6 +18869,17 @@ func (s *GetRestApiInput) SetRestApiId(v string) *GetRestApiInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The GET request to list existing RestApis defined for your collection.
 type GetRestApisInput struct {
 	_ struct{} `type:"structure"`
@@ -16694,6 +18912,22 @@ func (s *GetRestApisInput) SetLimit(v int64) *GetRestApisInput {
 func (s *GetRestApisInput) SetPosition(v string) *GetRestApisInput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRestApisInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains references to your APIs and links that guide you in how to interact
@@ -16729,6 +18963,22 @@ func (s *GetRestApisOutput) SetItems(v []*RestApi) *GetRestApisOutput {
 func (s *GetRestApisOutput) SetPosition(v string) *GetRestApisOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRestApisOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeRestApiList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request a new generated client SDK for a RestApi and Stage.
@@ -16812,6 +19062,32 @@ func (s *GetSdkInput) SetStageName(v string) *GetSdkInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SdkType != nil {
+		v := *s.SdkType
+
+		e.SetValue(protocol.PathTarget, "sdk_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The binary blob response to GetSdk, which contains the generated SDK.
 type GetSdkOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -16854,6 +19130,27 @@ func (s *GetSdkOutput) SetContentType(v string) *GetSdkOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Get an SdkType instance.
 type GetSdkTypeInput struct {
 	_ struct{} `type:"structure"`
@@ -16893,6 +19190,17 @@ func (s *GetSdkTypeInput) SetId(v string) *GetSdkTypeInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "sdktype_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Get the SdkTypes collection.
 type GetSdkTypesInput struct {
 	_ struct{} `type:"structure"`
@@ -16926,6 +19234,22 @@ func (s *GetSdkTypesInput) SetPosition(v string) *GetSdkTypesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The collection of SdkType instances.
 type GetSdkTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16956,6 +19280,22 @@ func (s *GetSdkTypesOutput) SetItems(v []*SdkType) *GetSdkTypesOutput {
 func (s *GetSdkTypesOutput) SetPosition(v string) *GetSdkTypesOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeSdkTypeList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to get information about a Stage resource.
@@ -17011,6 +19351,22 @@ func (s *GetStageInput) SetStageName(v string) *GetStageInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to get information about one or more Stage resources.
 type GetStagesInput struct {
 	_ struct{} `type:"structure"`
@@ -17059,6 +19415,22 @@ func (s *GetStagesInput) SetRestApiId(v string) *GetStagesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStagesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.QueryTarget, "deploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A list of Stage resources that are associated with the ApiKey resource.
 //
 // Deploying API in Stages (http://docs.aws.amazon.com/apigateway/latest/developerguide/stages.html)
@@ -17083,6 +19455,17 @@ func (s GetStagesOutput) GoString() string {
 func (s *GetStagesOutput) SetItem(v []*Stage) *GetStagesOutput {
 	s.Item = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStagesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "item", encodeStageList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to get the usage data of a usage plan in a specified time
@@ -17180,6 +19563,42 @@ func (s *GetUsageInput) SetUsagePlanId(v string) *GetUsageInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndDate != nil {
+		v := *s.EndDate
+
+		e.SetValue(protocol.QueryTarget, "endDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.QueryTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.QueryTarget, "startDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The GET request to get a usage plan of a given plan identifier.
 type GetUsagePlanInput struct {
 	_ struct{} `type:"structure"`
@@ -17217,6 +19636,17 @@ func (s *GetUsagePlanInput) Validate() error {
 func (s *GetUsagePlanInput) SetUsagePlanId(v string) *GetUsagePlanInput {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to get a usage plan key of a given key identifier.
@@ -17272,6 +19702,22 @@ func (s *GetUsagePlanKeyInput) SetKeyId(v string) *GetUsagePlanKeyInput {
 func (s *GetUsagePlanKeyInput) SetUsagePlanId(v string) *GetUsagePlanKeyInput {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.PathTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to get all the usage plan keys representing the API keys
@@ -17342,6 +19788,32 @@ func (s *GetUsagePlanKeysInput) SetUsagePlanId(v string) *GetUsagePlanKeysInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlanKeysInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameQuery != nil {
+		v := *s.NameQuery
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the collection of usage plan keys added to usage plans for the
 // associated API keys and, possibly, other types of keys.
 //
@@ -17375,6 +19847,22 @@ func (s *GetUsagePlanKeysOutput) SetItems(v []*UsagePlanKey) *GetUsagePlanKeysOu
 func (s *GetUsagePlanKeysOutput) SetPosition(v string) *GetUsagePlanKeysOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlanKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeUsagePlanKeyList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to get all the usage plans of the caller's account.
@@ -17419,6 +19907,27 @@ func (s *GetUsagePlansInput) SetPosition(v string) *GetUsagePlansInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlansInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.QueryTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of usage plans for an AWS account.
 //
 // Create and Use Usage Plans (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html)
@@ -17451,6 +19960,22 @@ func (s *GetUsagePlansOutput) SetItems(v []*UsagePlan) *GetUsagePlansOutput {
 func (s *GetUsagePlansOutput) SetPosition(v string) *GetUsagePlansOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlansOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeUsagePlanList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The POST request to import API keys from an external source, such as a CSV-formatted
@@ -17519,6 +20044,27 @@ func (s *ImportApiKeysInput) SetFormat(v string) *ImportApiKeysInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportApiKeysInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.FailOnWarnings != nil {
+		v := *s.FailOnWarnings
+
+		e.SetValue(protocol.QueryTarget, "failonwarnings", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.QueryTarget, "format", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The identifier of an ApiKey used in a UsagePlan.
 type ImportApiKeysOutput struct {
 	_ struct{} `type:"structure"`
@@ -17550,6 +20096,22 @@ func (s *ImportApiKeysOutput) SetIds(v []*string) *ImportApiKeysOutput {
 func (s *ImportApiKeysOutput) SetWarnings(v []*string) *ImportApiKeysOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportApiKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Ids) > 0 {
+		v := s.Ids
+
+		e.SetList(protocol.BodyTarget, "ids", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Import documentation parts from an external (e.g., Swagger) definition file.
@@ -17628,6 +20190,32 @@ func (s *ImportDocumentationPartsInput) SetRestApiId(v string) *ImportDocumentat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportDocumentationPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.FailOnWarnings != nil {
+		v := *s.FailOnWarnings
+
+		e.SetValue(protocol.QueryTarget, "failonwarnings", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.QueryTarget, "mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A collection of the imported DocumentationPart identifiers.
 //
 // This is used to return the result when documentation parts in an external
@@ -17665,6 +20253,22 @@ func (s *ImportDocumentationPartsOutput) SetIds(v []*string) *ImportDocumentatio
 func (s *ImportDocumentationPartsOutput) SetWarnings(v []*string) *ImportDocumentationPartsOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportDocumentationPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Ids) > 0 {
+		v := s.Ids
+
+		e.SetList(protocol.BodyTarget, "ids", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A POST request to import an API to Amazon API Gateway using an input of an
@@ -17729,6 +20333,27 @@ func (s *ImportRestApiInput) SetFailOnWarnings(v bool) *ImportRestApiInput {
 func (s *ImportRestApiInput) SetParameters(v map[string]*string) *ImportRestApiInput {
 	s.Parameters = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.FailOnWarnings != nil {
+		v := *s.FailOnWarnings
+
+		e.SetValue(protocol.QueryTarget, "failonwarnings", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents an HTTP, HTTP_PROXY, AWS, AWS_PROXY, or Mock integration.
@@ -17926,6 +20551,67 @@ func (s *Integration) SetUri(v string) *Integration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Integration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CacheKeyParameters) > 0 {
+		v := s.CacheKeyParameters
+
+		e.SetList(protocol.BodyTarget, "cacheKeyParameters", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.CacheNamespace != nil {
+		v := *s.CacheNamespace
+
+		e.SetValue(protocol.BodyTarget, "cacheNamespace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentHandling != nil {
+		v := *s.ContentHandling
+
+		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Credentials != nil {
+		v := *s.Credentials
+
+		e.SetValue(protocol.BodyTarget, "credentials", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.BodyTarget, "httpMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.IntegrationResponses) > 0 {
+		v := s.IntegrationResponses
+
+		e.SetMap(protocol.BodyTarget, "integrationResponses", encodeIntegrationResponseMap(v), protocol.Metadata{})
+	}
+	if s.PassthroughBehavior != nil {
+		v := *s.PassthroughBehavior
+
+		e.SetValue(protocol.BodyTarget, "passthroughBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestParameters) > 0 {
+		v := s.RequestParameters
+
+		e.SetMap(protocol.BodyTarget, "requestParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.RequestTemplates) > 0 {
+		v := s.RequestTemplates
+
+		e.SetMap(protocol.BodyTarget, "requestTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Uri != nil {
+		v := *s.Uri
+
+		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents an integration response. The status code must map to an existing
 // MethodResponse, and parameters and templates can be used to transform the
 // back-end response.
@@ -18017,6 +20703,45 @@ func (s *IntegrationResponse) SetSelectionPattern(v string) *IntegrationResponse
 func (s *IntegrationResponse) SetStatusCode(v string) *IntegrationResponse {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IntegrationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentHandling != nil {
+		v := *s.ContentHandling
+
+		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTemplates) > 0 {
+		v := s.ResponseTemplates
+
+		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.SelectionPattern != nil {
+		v := *s.SelectionPattern
+
+		e.SetValue(protocol.BodyTarget, "selectionPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIntegrationResponseMap(vs map[string]*IntegrationResponse) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Represents a client-facing interface by which the client calls the API to
@@ -18275,6 +21000,70 @@ func (s *Method) SetRequestValidatorId(v string) *Method {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Method) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKeyRequired != nil {
+		v := *s.ApiKeyRequired
+
+		e.SetValue(protocol.BodyTarget, "apiKeyRequired", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizationType != nil {
+		v := *s.AuthorizationType
+
+		e.SetValue(protocol.BodyTarget, "authorizationType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.BodyTarget, "authorizerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.BodyTarget, "httpMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MethodIntegration != nil {
+		v := s.MethodIntegration
+
+		e.SetFields(protocol.BodyTarget, "methodIntegration", v, protocol.Metadata{})
+	}
+	if len(s.MethodResponses) > 0 {
+		v := s.MethodResponses
+
+		e.SetMap(protocol.BodyTarget, "methodResponses", encodeMethodResponseMap(v), protocol.Metadata{})
+	}
+	if s.OperationName != nil {
+		v := *s.OperationName
+
+		e.SetValue(protocol.BodyTarget, "operationName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestModels) > 0 {
+		v := s.RequestModels
+
+		e.SetMap(protocol.BodyTarget, "requestModels", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.RequestParameters) > 0 {
+		v := s.RequestParameters
+
+		e.SetMap(protocol.BodyTarget, "requestParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.BodyTarget, "requestValidatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMethodMap(vs map[string]*Method) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Represents a method response of a given HTTP status code returned to the
 // client. The method response is passed from the back end through the associated
 // integration response that can be transformed using a mapping template.
@@ -18352,6 +21141,35 @@ func (s *MethodResponse) SetResponseParameters(v map[string]*bool) *MethodRespon
 func (s *MethodResponse) SetStatusCode(v string) *MethodResponse {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MethodResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ResponseModels) > 0 {
+		v := s.ResponseModels
+
+		e.SetMap(protocol.BodyTarget, "responseModels", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMethodResponseMap(vs map[string]*MethodResponse) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Specifies the method setting properties.
@@ -18480,6 +21298,70 @@ func (s *MethodSetting) SetUnauthorizedCacheControlHeaderStrategy(v string) *Met
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MethodSetting) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CacheDataEncrypted != nil {
+		v := *s.CacheDataEncrypted
+
+		e.SetValue(protocol.BodyTarget, "cacheDataEncrypted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CacheTtlInSeconds != nil {
+		v := *s.CacheTtlInSeconds
+
+		e.SetValue(protocol.BodyTarget, "cacheTtlInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CachingEnabled != nil {
+		v := *s.CachingEnabled
+
+		e.SetValue(protocol.BodyTarget, "cachingEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DataTraceEnabled != nil {
+		v := *s.DataTraceEnabled
+
+		e.SetValue(protocol.BodyTarget, "dataTraceEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LoggingLevel != nil {
+		v := *s.LoggingLevel
+
+		e.SetValue(protocol.BodyTarget, "loggingLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricsEnabled != nil {
+		v := *s.MetricsEnabled
+
+		e.SetValue(protocol.BodyTarget, "metricsEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RequireAuthorizationForCacheControl != nil {
+		v := *s.RequireAuthorizationForCacheControl
+
+		e.SetValue(protocol.BodyTarget, "requireAuthorizationForCacheControl", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ThrottlingBurstLimit != nil {
+		v := *s.ThrottlingBurstLimit
+
+		e.SetValue(protocol.BodyTarget, "throttlingBurstLimit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ThrottlingRateLimit != nil {
+		v := *s.ThrottlingRateLimit
+
+		e.SetValue(protocol.BodyTarget, "throttlingRateLimit", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.UnauthorizedCacheControlHeaderStrategy != nil {
+		v := *s.UnauthorizedCacheControlHeaderStrategy
+
+		e.SetValue(protocol.BodyTarget, "unauthorizedCacheControlHeaderStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMethodSettingMap(vs map[string]*MethodSetting) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Represents a summary of a Method resource, given a particular date and time.
 type MethodSnapshot struct {
 	_ struct{} `type:"structure"`
@@ -18513,6 +21395,30 @@ func (s *MethodSnapshot) SetApiKeyRequired(v bool) *MethodSnapshot {
 func (s *MethodSnapshot) SetAuthorizationType(v string) *MethodSnapshot {
 	s.AuthorizationType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MethodSnapshot) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKeyRequired != nil {
+		v := *s.ApiKeyRequired
+
+		e.SetValue(protocol.BodyTarget, "apiKeyRequired", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizationType != nil {
+		v := *s.AuthorizationType
+
+		e.SetValue(protocol.BodyTarget, "authorizationType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMethodSnapshotMap(vs map[string]*MethodSnapshot) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Represents the data structure of a method's request or response payload.
@@ -18590,6 +21496,45 @@ func (s *Model) SetSchema(v string) *Model {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Model) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Schema != nil {
+		v := *s.Schema
+
+		e.SetValue(protocol.BodyTarget, "schema", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeModelList(vs []*Model) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A single patch operation to apply to the specified resource. Please refer
 // to http://tools.ietf.org/html/rfc6902#section-4 for an explanation of how
 // each operation is used.
@@ -18655,6 +21600,40 @@ func (s *PatchOperation) SetPath(v string) *PatchOperation {
 func (s *PatchOperation) SetValue(v string) *PatchOperation {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PatchOperation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.From != nil {
+		v := *s.From
+
+		e.SetValue(protocol.BodyTarget, "from", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Op != nil {
+		v := *s.Op
+
+		e.SetValue(protocol.BodyTarget, "op", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePatchOperationList(vs []*PatchOperation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Creates a customization of a GatewayResponse of a specified response type
@@ -18758,6 +21737,37 @@ func (s *PutGatewayResponseInput) SetRestApiId(v string) *PutGatewayResponseInpu
 func (s *PutGatewayResponseInput) SetStatusCode(v string) *PutGatewayResponseInput {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTemplates) > 0 {
+		v := s.ResponseTemplates
+
+		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.PathTarget, "response_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Sets up a method's integration.
@@ -18964,6 +21974,77 @@ func (s *PutIntegrationInput) SetUri(v string) *PutIntegrationInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CacheKeyParameters) > 0 {
+		v := s.CacheKeyParameters
+
+		e.SetList(protocol.BodyTarget, "cacheKeyParameters", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.CacheNamespace != nil {
+		v := *s.CacheNamespace
+
+		e.SetValue(protocol.BodyTarget, "cacheNamespace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentHandling != nil {
+		v := *s.ContentHandling
+
+		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Credentials != nil {
+		v := *s.Credentials
+
+		e.SetValue(protocol.BodyTarget, "credentials", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntegrationHttpMethod != nil {
+		v := *s.IntegrationHttpMethod
+
+		e.SetValue(protocol.BodyTarget, "httpMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PassthroughBehavior != nil {
+		v := *s.PassthroughBehavior
+
+		e.SetValue(protocol.BodyTarget, "passthroughBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestParameters) > 0 {
+		v := s.RequestParameters
+
+		e.SetMap(protocol.BodyTarget, "requestParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.RequestTemplates) > 0 {
+		v := s.RequestTemplates
+
+		e.SetMap(protocol.BodyTarget, "requestTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Uri != nil {
+		v := *s.Uri
+
+		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a put integration response request.
 type PutIntegrationResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -19099,6 +22180,52 @@ func (s *PutIntegrationResponseInput) SetSelectionPattern(v string) *PutIntegrat
 func (s *PutIntegrationResponseInput) SetStatusCode(v string) *PutIntegrationResponseInput {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentHandling != nil {
+		v := *s.ContentHandling
+
+		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTemplates) > 0 {
+		v := s.ResponseTemplates
+
+		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SelectionPattern != nil {
+		v := *s.SelectionPattern
+
+		e.SetValue(protocol.BodyTarget, "selectionPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to add a method to an existing Resource resource.
@@ -19250,6 +22377,62 @@ func (s *PutMethodInput) SetRestApiId(v string) *PutMethodInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKeyRequired != nil {
+		v := *s.ApiKeyRequired
+
+		e.SetValue(protocol.BodyTarget, "apiKeyRequired", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizationType != nil {
+		v := *s.AuthorizationType
+
+		e.SetValue(protocol.BodyTarget, "authorizationType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.BodyTarget, "authorizerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OperationName != nil {
+		v := *s.OperationName
+
+		e.SetValue(protocol.BodyTarget, "operationName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestModels) > 0 {
+		v := s.RequestModels
+
+		e.SetMap(protocol.BodyTarget, "requestModels", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.RequestParameters) > 0 {
+		v := s.RequestParameters
+
+		e.SetMap(protocol.BodyTarget, "requestParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.BodyTarget, "requestValidatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to add a MethodResponse to an existing Method resource.
 type PutMethodResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -19361,6 +22544,42 @@ func (s *PutMethodResponseInput) SetStatusCode(v string) *PutMethodResponseInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResponseModels) > 0 {
+		v := s.ResponseModels
+
+		e.SetMap(protocol.BodyTarget, "responseModels", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A PUT request to update an existing API, with external API definitions specified
 // as the request body.
 type PutRestApiInput struct {
@@ -19449,6 +22668,37 @@ func (s *PutRestApiInput) SetRestApiId(v string) *PutRestApiInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.FailOnWarnings != nil {
+		v := *s.FailOnWarnings
+
+		e.SetValue(protocol.QueryTarget, "failonwarnings", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.QueryTarget, "mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Quotas configured for a usage plan.
 type QuotaSettings struct {
 	_ struct{} `type:"structure"`
@@ -19491,6 +22741,27 @@ func (s *QuotaSettings) SetOffset(v int64) *QuotaSettings {
 func (s *QuotaSettings) SetPeriod(v string) *QuotaSettings {
 	s.Period = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QuotaSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.BodyTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Offset != nil {
+		v := *s.Offset
+
+		e.SetValue(protocol.BodyTarget, "offset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Period != nil {
+		v := *s.Period
+
+		e.SetValue(protocol.BodyTarget, "period", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents an API resource.
@@ -19611,6 +22882,45 @@ func (s *Resource) SetResourceMethods(v map[string]*Method) *Resource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Resource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.BodyTarget, "parentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PathPart != nil {
+		v := *s.PathPart
+
+		e.SetValue(protocol.BodyTarget, "pathPart", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResourceMethods) > 0 {
+		v := s.ResourceMethods
+
+		e.SetMap(protocol.BodyTarget, "resourceMethods", encodeMethodMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourceList(vs []*Resource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents a REST API.
 //
 // Create an API (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html)
@@ -19694,6 +23004,55 @@ func (s *RestApi) SetWarnings(v []*string) *RestApi {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RestApi) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BinaryMediaTypes) > 0 {
+		v := s.BinaryMediaTypes
+
+		e.SetList(protocol.BodyTarget, "binaryMediaTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRestApiList(vs []*RestApi) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A configuration property of an SDK type.
 type SdkConfigurationProperty struct {
 	_ struct{} `type:"structure"`
@@ -19755,6 +23114,45 @@ func (s *SdkConfigurationProperty) SetRequired(v bool) *SdkConfigurationProperty
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SdkConfigurationProperty) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultValue != nil {
+		v := *s.DefaultValue
+
+		e.SetValue(protocol.BodyTarget, "defaultValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FriendlyName != nil {
+		v := *s.FriendlyName
+
+		e.SetValue(protocol.BodyTarget, "friendlyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Required != nil {
+		v := *s.Required
+
+		e.SetValue(protocol.BodyTarget, "required", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSdkConfigurationPropertyList(vs []*SdkConfigurationProperty) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A type of SDK that API Gateway can generate.
 type SdkType struct {
 	_ struct{} `type:"structure"`
@@ -19804,6 +23202,40 @@ func (s *SdkType) SetFriendlyName(v string) *SdkType {
 func (s *SdkType) SetId(v string) *SdkType {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SdkType) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ConfigurationProperties) > 0 {
+		v := s.ConfigurationProperties
+
+		e.SetList(protocol.BodyTarget, "configurationProperties", encodeSdkConfigurationPropertyList(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FriendlyName != nil {
+		v := *s.FriendlyName
+
+		e.SetValue(protocol.BodyTarget, "friendlyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSdkTypeList(vs []*SdkType) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents a unique identifier for a version of a deployed RestApi that is
@@ -19938,6 +23370,80 @@ func (s *Stage) SetVariables(v map[string]*string) *Stage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Stage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CacheClusterEnabled != nil {
+		v := *s.CacheClusterEnabled
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CacheClusterSize != nil {
+		v := *s.CacheClusterSize
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterSize", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheClusterStatus != nil {
+		v := *s.CacheClusterStatus
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.BodyTarget, "clientCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "deploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.BodyTarget, "documentationVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if len(s.MethodSettings) > 0 {
+		v := s.MethodSettings
+
+		e.SetMap(protocol.BodyTarget, "methodSettings", encodeMethodSettingMap(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStageList(vs []*Stage) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A reference to a unique stage identified in the format {restApiId}/{stage}.
 type StageKey struct {
 	_ struct{} `type:"structure"`
@@ -19969,6 +23475,30 @@ func (s *StageKey) SetRestApiId(v string) *StageKey {
 func (s *StageKey) SetStageName(v string) *StageKey {
 	s.StageName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StageKey) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.BodyTarget, "restApiId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStageKeyList(vs []*StageKey) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Make a request to simulate the execution of an Authorizer.
@@ -20073,6 +23603,47 @@ func (s *TestInvokeAuthorizerInput) SetStageVariables(v map[string]*string) *Tes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestInvokeAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdditionalContext) > 0 {
+		v := s.AdditionalContext
+
+		e.SetMap(protocol.BodyTarget, "additionalContext", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Headers) > 0 {
+		v := s.Headers
+
+		e.SetMap(protocol.BodyTarget, "headers", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.PathWithQueryString != nil {
+		v := *s.PathWithQueryString
+
+		e.SetValue(protocol.BodyTarget, "pathWithQueryString", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageVariables) > 0 {
+		v := s.StageVariables
+
+		e.SetMap(protocol.BodyTarget, "stageVariables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the response of the test invoke request for a custom Authorizer
 type TestInvokeAuthorizerOutput struct {
 	_ struct{} `type:"structure"`
@@ -20151,6 +23722,52 @@ func (s *TestInvokeAuthorizerOutput) SetPolicy(v string) *TestInvokeAuthorizerOu
 func (s *TestInvokeAuthorizerOutput) SetPrincipalId(v string) *TestInvokeAuthorizerOutput {
 	s.PrincipalId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestInvokeAuthorizerOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Authorization) > 0 {
+		v := s.Authorization
+
+		e.SetMap(protocol.BodyTarget, "authorization", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.Claims) > 0 {
+		v := s.Claims
+
+		e.SetMap(protocol.BodyTarget, "claims", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ClientStatus != nil {
+		v := *s.ClientStatus
+
+		e.SetValue(protocol.BodyTarget, "clientStatus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Latency != nil {
+		v := *s.Latency
+
+		e.SetValue(protocol.BodyTarget, "latency", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Log != nil {
+		v := *s.Log
+
+		e.SetValue(protocol.BodyTarget, "log", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrincipalId != nil {
+		v := *s.PrincipalId
+
+		e.SetValue(protocol.BodyTarget, "principalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Make a request to simulate the execution of a Method.
@@ -20269,6 +23886,52 @@ func (s *TestInvokeMethodInput) SetStageVariables(v map[string]*string) *TestInv
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestInvokeMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.BodyTarget, "clientCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Headers) > 0 {
+		v := s.Headers
+
+		e.SetMap(protocol.BodyTarget, "headers", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PathWithQueryString != nil {
+		v := *s.PathWithQueryString
+
+		e.SetValue(protocol.BodyTarget, "pathWithQueryString", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageVariables) > 0 {
+		v := s.StageVariables
+
+		e.SetMap(protocol.BodyTarget, "stageVariables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the response of the test invoke request in the HTTP method.
 //
 // Test API using the API Gateway console (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-test-method.html#how-to-test-method-console)
@@ -20331,6 +23994,37 @@ func (s *TestInvokeMethodOutput) SetStatus(v int64) *TestInvokeMethodOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestInvokeMethodOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Headers) > 0 {
+		v := s.Headers
+
+		e.SetMap(protocol.BodyTarget, "headers", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Latency != nil {
+		v := *s.Latency
+
+		e.SetValue(protocol.BodyTarget, "latency", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Log != nil {
+		v := *s.Log
+
+		e.SetValue(protocol.BodyTarget, "log", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The API request rate limits.
 type ThrottleSettings struct {
 	_ struct{} `type:"structure"`
@@ -20366,6 +24060,22 @@ func (s *ThrottleSettings) SetRateLimit(v float64) *ThrottleSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThrottleSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BurstLimit != nil {
+		v := *s.BurstLimit
+
+		e.SetValue(protocol.BodyTarget, "burstLimit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RateLimit != nil {
+		v := *s.RateLimit
+
+		e.SetValue(protocol.BodyTarget, "rateLimit", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to change information about the current Account
 // resource.
 type UpdateAccountInput struct {
@@ -20390,6 +24100,17 @@ func (s UpdateAccountInput) GoString() string {
 func (s *UpdateAccountInput) SetPatchOperations(v []*PatchOperation) *UpdateAccountInput {
 	s.PatchOperations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to change information about an ApiKey resource.
@@ -20439,6 +24160,22 @@ func (s *UpdateApiKeyInput) SetApiKey(v string) *UpdateApiKeyInput {
 func (s *UpdateApiKeyInput) SetPatchOperations(v []*PatchOperation) *UpdateApiKeyInput {
 	s.PatchOperations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to update an existing Authorizer resource.
@@ -20504,6 +24241,27 @@ func (s *UpdateAuthorizerInput) SetRestApiId(v string) *UpdateAuthorizerInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to change information about the BasePathMapping resource.
 type UpdateBasePathMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -20567,6 +24325,27 @@ func (s *UpdateBasePathMappingInput) SetPatchOperations(v []*PatchOperation) *Up
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.PathTarget, "base_path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to change information about an ClientCertificate resource.
 type UpdateClientCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -20614,6 +24393,22 @@ func (s *UpdateClientCertificateInput) SetClientCertificateId(v string) *UpdateC
 func (s *UpdateClientCertificateInput) SetPatchOperations(v []*PatchOperation) *UpdateClientCertificateInput {
 	s.PatchOperations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to change information about a Deployment resource.
@@ -20680,6 +24475,27 @@ func (s *UpdateDeploymentInput) SetRestApiId(v string) *UpdateDeploymentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Updates an existing documentation part of a given API.
 type UpdateDocumentationPartInput struct {
 	_ struct{} `type:"structure"`
@@ -20741,6 +24557,27 @@ func (s *UpdateDocumentationPartInput) SetPatchOperations(v []*PatchOperation) *
 func (s *UpdateDocumentationPartInput) SetRestApiId(v string) *UpdateDocumentationPartInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationPartId != nil {
+		v := *s.DocumentationPartId
+
+		e.SetValue(protocol.PathTarget, "part_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Updates an existing documentation version of an API.
@@ -20806,6 +24643,27 @@ func (s *UpdateDocumentationVersionInput) SetRestApiId(v string) *UpdateDocument
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.PathTarget, "doc_version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to change information about the DomainName resource.
 type UpdateDomainNameInput struct {
 	_ struct{} `type:"structure"`
@@ -20853,6 +24711,22 @@ func (s *UpdateDomainNameInput) SetDomainName(v string) *UpdateDomainNameInput {
 func (s *UpdateDomainNameInput) SetPatchOperations(v []*PatchOperation) *UpdateDomainNameInput {
 	s.PatchOperations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Updates a GatewayResponse of a specified response type on the given RestApi.
@@ -20936,6 +24810,27 @@ func (s *UpdateGatewayResponseInput) SetResponseType(v string) *UpdateGatewayRes
 func (s *UpdateGatewayResponseInput) SetRestApiId(v string) *UpdateGatewayResponseInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.PathTarget, "response_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A gateway response of a given response type and status code, with optional
@@ -21062,6 +24957,45 @@ func (s *UpdateGatewayResponseOutput) SetStatusCode(v string) *UpdateGatewayResp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGatewayResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultResponse != nil {
+		v := *s.DefaultResponse
+
+		e.SetValue(protocol.BodyTarget, "defaultResponse", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTemplates) > 0 {
+		v := s.ResponseTemplates
+
+		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.BodyTarget, "responseType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUpdateGatewayResponseOutputList(vs []*UpdateGatewayResponseOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents an update integration request.
 type UpdateIntegrationInput struct {
 	_ struct{} `type:"structure"`
@@ -21137,6 +25071,32 @@ func (s *UpdateIntegrationInput) SetResourceId(v string) *UpdateIntegrationInput
 func (s *UpdateIntegrationInput) SetRestApiId(v string) *UpdateIntegrationInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents an update integration response request.
@@ -21230,6 +25190,37 @@ func (s *UpdateIntegrationResponseInput) SetStatusCode(v string) *UpdateIntegrat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to update an existing Method resource.
 type UpdateMethodInput struct {
 	_ struct{} `type:"structure"`
@@ -21305,6 +25296,32 @@ func (s *UpdateMethodInput) SetResourceId(v string) *UpdateMethodInput {
 func (s *UpdateMethodInput) SetRestApiId(v string) *UpdateMethodInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to update an existing MethodResponse resource.
@@ -21398,6 +25415,37 @@ func (s *UpdateMethodResponseInput) SetStatusCode(v string) *UpdateMethodRespons
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to update an existing model in an existing RestApi resource.
 type UpdateModelInput struct {
 	_ struct{} `type:"structure"`
@@ -21459,6 +25507,27 @@ func (s *UpdateModelInput) SetPatchOperations(v []*PatchOperation) *UpdateModelI
 func (s *UpdateModelInput) SetRestApiId(v string) *UpdateModelInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateModelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Updates a RequestValidator of a given RestApi.
@@ -21524,6 +25593,27 @@ func (s *UpdateRequestValidatorInput) SetRestApiId(v string) *UpdateRequestValid
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.PathTarget, "requestvalidator_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A set of validation rules for incoming Method requests.
 //
 // In Swagger, a RequestValidator of an API is defined by the x-amazon-apigateway-request-validators.requestValidator
@@ -21583,6 +25673,40 @@ func (s *UpdateRequestValidatorOutput) SetValidateRequestBody(v bool) *UpdateReq
 func (s *UpdateRequestValidatorOutput) SetValidateRequestParameters(v bool) *UpdateRequestValidatorOutput {
 	s.ValidateRequestParameters = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRequestValidatorOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValidateRequestBody != nil {
+		v := *s.ValidateRequestBody
+
+		e.SetValue(protocol.BodyTarget, "validateRequestBody", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ValidateRequestParameters != nil {
+		v := *s.ValidateRequestParameters
+
+		e.SetValue(protocol.BodyTarget, "validateRequestParameters", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUpdateRequestValidatorOutputList(vs []*UpdateRequestValidatorOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Request to change information about a Resource resource.
@@ -21648,6 +25772,27 @@ func (s *UpdateResourceInput) SetRestApiId(v string) *UpdateResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to update an existing RestApi resource in your collection.
 type UpdateRestApiInput struct {
 	_ struct{} `type:"structure"`
@@ -21695,6 +25840,22 @@ func (s *UpdateRestApiInput) SetPatchOperations(v []*PatchOperation) *UpdateRest
 func (s *UpdateRestApiInput) SetRestApiId(v string) *UpdateRestApiInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to change information about a Stage resource.
@@ -21758,6 +25919,27 @@ func (s *UpdateStageInput) SetRestApiId(v string) *UpdateStageInput {
 func (s *UpdateStageInput) SetStageName(v string) *UpdateStageInput {
 	s.StageName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateStageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The PATCH request to grant a temporary extension to the remaining quota of
@@ -21825,6 +26007,27 @@ func (s *UpdateUsageInput) SetUsagePlanId(v string) *UpdateUsageInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.PathTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The PATCH request to update a usage plan of a given plan Id.
 type UpdateUsagePlanInput struct {
 	_ struct{} `type:"structure"`
@@ -21872,6 +26075,22 @@ func (s *UpdateUsagePlanInput) SetPatchOperations(v []*PatchOperation) *UpdateUs
 func (s *UpdateUsagePlanInput) SetUsagePlanId(v string) *UpdateUsagePlanInput {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the usage data of a usage plan.
@@ -21937,6 +26156,47 @@ func (s *Usage) SetStartDate(v string) *Usage {
 func (s *Usage) SetUsagePlanId(v string) *Usage {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Usage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndDate != nil {
+		v := *s.EndDate
+
+		e.SetValue(protocol.BodyTarget, "endDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetMap(protocol.BodyTarget, "values", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, func(le protocol.ListEncoder) {
+					for _, item := range v {
+						v := item
+						le.ListAddList(protocol.EncodeInt64List(v))
+					}
+				})
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.BodyTarget, "startDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.BodyTarget, "usagePlanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents a usage plan than can specify who can assess associated API stages
@@ -22025,6 +26285,55 @@ func (s *UsagePlan) SetThrottle(v *ThrottleSettings) *UsagePlan {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UsagePlan) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ApiStages) > 0 {
+		v := s.ApiStages
+
+		e.SetList(protocol.BodyTarget, "apiStages", encodeApiStageList(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProductCode != nil {
+		v := *s.ProductCode
+
+		e.SetValue(protocol.BodyTarget, "productCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quota != nil {
+		v := s.Quota
+
+		e.SetFields(protocol.BodyTarget, "quota", v, protocol.Metadata{})
+	}
+	if s.Throttle != nil {
+		v := s.Throttle
+
+		e.SetFields(protocol.BodyTarget, "throttle", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUsagePlanList(vs []*UsagePlan) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents a usage plan key to identify a plan customer.
 //
 // To associate an API stage with a selected API key in a usage plan, you must
@@ -22079,6 +26388,40 @@ func (s *UsagePlanKey) SetType(v string) *UsagePlanKey {
 func (s *UsagePlanKey) SetValue(v string) *UsagePlanKey {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UsagePlanKey) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUsagePlanKeyList(vs []*UsagePlanKey) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/batch/api.go
+++ b/service/batch/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCancelJob = "CancelJob"
@@ -1472,6 +1473,37 @@ func (s *AttemptContainerDetail) SetTaskArn(v string) *AttemptContainerDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttemptContainerDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerInstanceArn != nil {
+		v := *s.ContainerInstanceArn
+
+		e.SetValue(protocol.BodyTarget, "containerInstanceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExitCode != nil {
+		v := *s.ExitCode
+
+		e.SetValue(protocol.BodyTarget, "exitCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LogStreamName != nil {
+		v := *s.LogStreamName
+
+		e.SetValue(protocol.BodyTarget, "logStreamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Reason != nil {
+		v := *s.Reason
+
+		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TaskArn != nil {
+		v := *s.TaskArn
+
+		e.SetValue(protocol.BodyTarget, "taskArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An object representing a job attempt.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/AttemptDetail
 type AttemptDetail struct {
@@ -1525,6 +1557,40 @@ func (s *AttemptDetail) SetStatusReason(v string) *AttemptDetail {
 func (s *AttemptDetail) SetStoppedAt(v int64) *AttemptDetail {
 	s.StoppedAt = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttemptDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Container != nil {
+		v := s.Container
+
+		e.SetFields(protocol.BodyTarget, "container", v, protocol.Metadata{})
+	}
+	if s.StartedAt != nil {
+		v := *s.StartedAt
+
+		e.SetValue(protocol.BodyTarget, "startedAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StatusReason != nil {
+		v := *s.StatusReason
+
+		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StoppedAt != nil {
+		v := *s.StoppedAt
+
+		e.SetValue(protocol.BodyTarget, "stoppedAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttemptDetailList(vs []*AttemptDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CancelJobRequest
@@ -1582,6 +1648,22 @@ func (s *CancelJobInput) SetReason(v string) *CancelJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Reason != nil {
+		v := *s.Reason
+
+		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CancelJobResponse
 type CancelJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -1595,6 +1677,12 @@ func (s CancelJobOutput) String() string {
 // GoString returns the string representation
 func (s CancelJobOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // An object representing an AWS Batch compute environment.
@@ -1705,6 +1793,65 @@ func (s *ComputeEnvironmentDetail) SetType(v string) *ComputeEnvironmentDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ComputeEnvironmentDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironmentArn != nil {
+		v := *s.ComputeEnvironmentArn
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeEnvironmentName != nil {
+		v := *s.ComputeEnvironmentName
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeResources != nil {
+		v := s.ComputeResources
+
+		e.SetFields(protocol.BodyTarget, "computeResources", v, protocol.Metadata{})
+	}
+	if s.EcsClusterArn != nil {
+		v := *s.EcsClusterArn
+
+		e.SetValue(protocol.BodyTarget, "ecsClusterArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServiceRole != nil {
+		v := *s.ServiceRole
+
+		e.SetValue(protocol.BodyTarget, "serviceRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusReason != nil {
+		v := *s.StatusReason
+
+		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeComputeEnvironmentDetailList(vs []*ComputeEnvironmentDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The order in which compute environments are tried for job placement within
 // a queue. Compute environments are tried in ascending order. For example,
 // if two compute environments are associated with a job queue, the compute
@@ -1760,6 +1907,30 @@ func (s *ComputeEnvironmentOrder) SetComputeEnvironment(v string) *ComputeEnviro
 func (s *ComputeEnvironmentOrder) SetOrder(v int64) *ComputeEnvironmentOrder {
 	s.Order = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ComputeEnvironmentOrder) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironment != nil {
+		v := *s.ComputeEnvironment
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.BodyTarget, "order", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeComputeEnvironmentOrderList(vs []*ComputeEnvironmentOrder) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // An object representing an AWS Batch compute resource.
@@ -1951,6 +2122,77 @@ func (s *ComputeResource) SetType(v string) *ComputeResource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ComputeResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BidPercentage != nil {
+		v := *s.BidPercentage
+
+		e.SetValue(protocol.BodyTarget, "bidPercentage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DesiredvCpus != nil {
+		v := *s.DesiredvCpus
+
+		e.SetValue(protocol.BodyTarget, "desiredvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Ec2KeyPair != nil {
+		v := *s.Ec2KeyPair
+
+		e.SetValue(protocol.BodyTarget, "ec2KeyPair", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageId != nil {
+		v := *s.ImageId
+
+		e.SetValue(protocol.BodyTarget, "imageId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InstanceRole != nil {
+		v := *s.InstanceRole
+
+		e.SetValue(protocol.BodyTarget, "instanceRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InstanceTypes) > 0 {
+		v := s.InstanceTypes
+
+		e.SetList(protocol.BodyTarget, "instanceTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.MaxvCpus != nil {
+		v := *s.MaxvCpus
+
+		e.SetValue(protocol.BodyTarget, "maxvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinvCpus != nil {
+		v := *s.MinvCpus
+
+		e.SetValue(protocol.BodyTarget, "minvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroupIds) > 0 {
+		v := s.SecurityGroupIds
+
+		e.SetList(protocol.BodyTarget, "securityGroupIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.SpotIamFleetRole != nil {
+		v := *s.SpotIamFleetRole
+
+		e.SetValue(protocol.BodyTarget, "spotIamFleetRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Subnets) > 0 {
+		v := s.Subnets
+
+		e.SetList(protocol.BodyTarget, "subnets", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An object representing the attributes of a compute environment that can be
 // updated.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/ComputeResourceUpdate
@@ -1993,6 +2235,27 @@ func (s *ComputeResourceUpdate) SetMaxvCpus(v int64) *ComputeResourceUpdate {
 func (s *ComputeResourceUpdate) SetMinvCpus(v int64) *ComputeResourceUpdate {
 	s.MinvCpus = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ComputeResourceUpdate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DesiredvCpus != nil {
+		v := *s.DesiredvCpus
+
+		e.SetValue(protocol.BodyTarget, "desiredvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxvCpus != nil {
+		v := *s.MaxvCpus
+
+		e.SetValue(protocol.BodyTarget, "maxvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinvCpus != nil {
+		v := *s.MinvCpus
+
+		e.SetValue(protocol.BodyTarget, "minvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An object representing the details of a container that is part of a job.
@@ -2171,6 +2434,97 @@ func (s *ContainerDetail) SetVolumes(v []*Volume) *ContainerDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ContainerDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Command) > 0 {
+		v := s.Command
+
+		e.SetList(protocol.BodyTarget, "command", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ContainerInstanceArn != nil {
+		v := *s.ContainerInstanceArn
+
+		e.SetValue(protocol.BodyTarget, "containerInstanceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Environment) > 0 {
+		v := s.Environment
+
+		e.SetList(protocol.BodyTarget, "environment", encodeKeyValuePairList(v), protocol.Metadata{})
+	}
+	if s.ExitCode != nil {
+		v := *s.ExitCode
+
+		e.SetValue(protocol.BodyTarget, "exitCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Image != nil {
+		v := *s.Image
+
+		e.SetValue(protocol.BodyTarget, "image", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobRoleArn != nil {
+		v := *s.JobRoleArn
+
+		e.SetValue(protocol.BodyTarget, "jobRoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LogStreamName != nil {
+		v := *s.LogStreamName
+
+		e.SetValue(protocol.BodyTarget, "logStreamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Memory != nil {
+		v := *s.Memory
+
+		e.SetValue(protocol.BodyTarget, "memory", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.MountPoints) > 0 {
+		v := s.MountPoints
+
+		e.SetList(protocol.BodyTarget, "mountPoints", encodeMountPointList(v), protocol.Metadata{})
+	}
+	if s.Privileged != nil {
+		v := *s.Privileged
+
+		e.SetValue(protocol.BodyTarget, "privileged", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ReadonlyRootFilesystem != nil {
+		v := *s.ReadonlyRootFilesystem
+
+		e.SetValue(protocol.BodyTarget, "readonlyRootFilesystem", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Reason != nil {
+		v := *s.Reason
+
+		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TaskArn != nil {
+		v := *s.TaskArn
+
+		e.SetValue(protocol.BodyTarget, "taskArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Ulimits) > 0 {
+		v := s.Ulimits
+
+		e.SetList(protocol.BodyTarget, "ulimits", encodeUlimitList(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := *s.User
+
+		e.SetValue(protocol.BodyTarget, "user", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Vcpus != nil {
+		v := *s.Vcpus
+
+		e.SetValue(protocol.BodyTarget, "vcpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Volumes) > 0 {
+		v := s.Volumes
+
+		e.SetList(protocol.BodyTarget, "volumes", encodeVolumeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The overrides that should be sent to a container.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/ContainerOverrides
 type ContainerOverrides struct {
@@ -2226,6 +2580,32 @@ func (s *ContainerOverrides) SetMemory(v int64) *ContainerOverrides {
 func (s *ContainerOverrides) SetVcpus(v int64) *ContainerOverrides {
 	s.Vcpus = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ContainerOverrides) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Command) > 0 {
+		v := s.Command
+
+		e.SetList(protocol.BodyTarget, "command", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Environment) > 0 {
+		v := s.Environment
+
+		e.SetList(protocol.BodyTarget, "environment", encodeKeyValuePairList(v), protocol.Metadata{})
+	}
+	if s.Memory != nil {
+		v := *s.Memory
+
+		e.SetValue(protocol.BodyTarget, "memory", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Vcpus != nil {
+		v := *s.Vcpus
+
+		e.SetValue(protocol.BodyTarget, "vcpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container properties are used in job definitions to describe the container
@@ -2447,6 +2827,72 @@ func (s *ContainerProperties) SetVolumes(v []*Volume) *ContainerProperties {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ContainerProperties) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Command) > 0 {
+		v := s.Command
+
+		e.SetList(protocol.BodyTarget, "command", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Environment) > 0 {
+		v := s.Environment
+
+		e.SetList(protocol.BodyTarget, "environment", encodeKeyValuePairList(v), protocol.Metadata{})
+	}
+	if s.Image != nil {
+		v := *s.Image
+
+		e.SetValue(protocol.BodyTarget, "image", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobRoleArn != nil {
+		v := *s.JobRoleArn
+
+		e.SetValue(protocol.BodyTarget, "jobRoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Memory != nil {
+		v := *s.Memory
+
+		e.SetValue(protocol.BodyTarget, "memory", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.MountPoints) > 0 {
+		v := s.MountPoints
+
+		e.SetList(protocol.BodyTarget, "mountPoints", encodeMountPointList(v), protocol.Metadata{})
+	}
+	if s.Privileged != nil {
+		v := *s.Privileged
+
+		e.SetValue(protocol.BodyTarget, "privileged", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ReadonlyRootFilesystem != nil {
+		v := *s.ReadonlyRootFilesystem
+
+		e.SetValue(protocol.BodyTarget, "readonlyRootFilesystem", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Ulimits) > 0 {
+		v := s.Ulimits
+
+		e.SetList(protocol.BodyTarget, "ulimits", encodeUlimitList(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := *s.User
+
+		e.SetValue(protocol.BodyTarget, "user", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Vcpus != nil {
+		v := *s.Vcpus
+
+		e.SetValue(protocol.BodyTarget, "vcpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Volumes) > 0 {
+		v := s.Volumes
+
+		e.SetList(protocol.BodyTarget, "volumes", encodeVolumeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CreateComputeEnvironmentRequest
 type CreateComputeEnvironmentInput struct {
 	_ struct{} `type:"structure"`
@@ -2552,6 +2998,37 @@ func (s *CreateComputeEnvironmentInput) SetType(v string) *CreateComputeEnvironm
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironmentName != nil {
+		v := *s.ComputeEnvironmentName
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeResources != nil {
+		v := s.ComputeResources
+
+		e.SetFields(protocol.BodyTarget, "computeResources", v, protocol.Metadata{})
+	}
+	if s.ServiceRole != nil {
+		v := *s.ServiceRole
+
+		e.SetValue(protocol.BodyTarget, "serviceRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CreateComputeEnvironmentResponse
 type CreateComputeEnvironmentOutput struct {
 	_ struct{} `type:"structure"`
@@ -2583,6 +3060,22 @@ func (s *CreateComputeEnvironmentOutput) SetComputeEnvironmentArn(v string) *Cre
 func (s *CreateComputeEnvironmentOutput) SetComputeEnvironmentName(v string) *CreateComputeEnvironmentOutput {
 	s.ComputeEnvironmentName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironmentArn != nil {
+		v := *s.ComputeEnvironmentArn
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeEnvironmentName != nil {
+		v := *s.ComputeEnvironmentName
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CreateJobQueueRequest
@@ -2680,6 +3173,32 @@ func (s *CreateJobQueueInput) SetState(v string) *CreateJobQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironmentOrder) > 0 {
+		v := s.ComputeEnvironmentOrder
+
+		e.SetList(protocol.BodyTarget, "computeEnvironmentOrder", encodeComputeEnvironmentOrderList(v), protocol.Metadata{})
+	}
+	if s.JobQueueName != nil {
+		v := *s.JobQueueName
+
+		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "priority", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CreateJobQueueResponse
 type CreateJobQueueOutput struct {
 	_ struct{} `type:"structure"`
@@ -2715,6 +3234,22 @@ func (s *CreateJobQueueOutput) SetJobQueueArn(v string) *CreateJobQueueOutput {
 func (s *CreateJobQueueOutput) SetJobQueueName(v string) *CreateJobQueueOutput {
 	s.JobQueueName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobQueueArn != nil {
+		v := *s.JobQueueArn
+
+		e.SetValue(protocol.BodyTarget, "jobQueueArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueueName != nil {
+		v := *s.JobQueueName
+
+		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeleteComputeEnvironmentRequest
@@ -2756,6 +3291,17 @@ func (s *DeleteComputeEnvironmentInput) SetComputeEnvironment(v string) *DeleteC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironment != nil {
+		v := *s.ComputeEnvironment
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironment", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeleteComputeEnvironmentResponse
 type DeleteComputeEnvironmentOutput struct {
 	_ struct{} `type:"structure"`
@@ -2769,6 +3315,12 @@ func (s DeleteComputeEnvironmentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteComputeEnvironmentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeleteJobQueueRequest
@@ -2810,6 +3362,17 @@ func (s *DeleteJobQueueInput) SetJobQueue(v string) *DeleteJobQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeleteJobQueueResponse
 type DeleteJobQueueOutput struct {
 	_ struct{} `type:"structure"`
@@ -2823,6 +3386,12 @@ func (s DeleteJobQueueOutput) String() string {
 // GoString returns the string representation
 func (s DeleteJobQueueOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeregisterJobDefinitionRequest
@@ -2865,6 +3434,17 @@ func (s *DeregisterJobDefinitionInput) SetJobDefinition(v string) *DeregisterJob
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeregisterJobDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobDefinition != nil {
+		v := *s.JobDefinition
+
+		e.SetValue(protocol.BodyTarget, "jobDefinition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeregisterJobDefinitionResponse
 type DeregisterJobDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2878,6 +3458,12 @@ func (s DeregisterJobDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeregisterJobDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeregisterJobDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeComputeEnvironmentsRequest
@@ -2937,6 +3523,27 @@ func (s *DescribeComputeEnvironmentsInput) SetNextToken(v string) *DescribeCompu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeComputeEnvironmentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironments) > 0 {
+		v := s.ComputeEnvironments
+
+		e.SetList(protocol.BodyTarget, "computeEnvironments", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeComputeEnvironmentsResponse
 type DescribeComputeEnvironmentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2971,6 +3578,22 @@ func (s *DescribeComputeEnvironmentsOutput) SetComputeEnvironments(v []*ComputeE
 func (s *DescribeComputeEnvironmentsOutput) SetNextToken(v string) *DescribeComputeEnvironmentsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeComputeEnvironmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironments) > 0 {
+		v := s.ComputeEnvironments
+
+		e.SetList(protocol.BodyTarget, "computeEnvironments", encodeComputeEnvironmentDetailList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobDefinitionsRequest
@@ -3047,6 +3670,37 @@ func (s *DescribeJobDefinitionsInput) SetStatus(v string) *DescribeJobDefinition
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobDefinitionName != nil {
+		v := *s.JobDefinitionName
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.JobDefinitions) > 0 {
+		v := s.JobDefinitions
+
+		e.SetList(protocol.BodyTarget, "jobDefinitions", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobDefinitionsResponse
 type DescribeJobDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3081,6 +3735,22 @@ func (s *DescribeJobDefinitionsOutput) SetJobDefinitions(v []*JobDefinition) *De
 func (s *DescribeJobDefinitionsOutput) SetNextToken(v string) *DescribeJobDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobDefinitions) > 0 {
+		v := s.JobDefinitions
+
+		e.SetList(protocol.BodyTarget, "jobDefinitions", encodeJobDefinitionList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobQueuesRequest
@@ -3139,6 +3809,27 @@ func (s *DescribeJobQueuesInput) SetNextToken(v string) *DescribeJobQueuesInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobQueuesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobQueues) > 0 {
+		v := s.JobQueues
+
+		e.SetList(protocol.BodyTarget, "jobQueues", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobQueuesResponse
 type DescribeJobQueuesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3173,6 +3864,22 @@ func (s *DescribeJobQueuesOutput) SetJobQueues(v []*JobQueueDetail) *DescribeJob
 func (s *DescribeJobQueuesOutput) SetNextToken(v string) *DescribeJobQueuesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobQueuesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobQueues) > 0 {
+		v := s.JobQueues
+
+		e.SetList(protocol.BodyTarget, "jobQueues", encodeJobQueueDetailList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobsRequest
@@ -3214,6 +3921,17 @@ func (s *DescribeJobsInput) SetJobs(v []*string) *DescribeJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "jobs", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobsResponse
 type DescribeJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3236,6 +3954,17 @@ func (s DescribeJobsOutput) GoString() string {
 func (s *DescribeJobsOutput) SetJobs(v []*JobDetail) *DescribeJobsOutput {
 	s.Jobs = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "jobs", encodeJobDetailList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The contents of the host parameter determine whether your data volume persists
@@ -3271,6 +4000,17 @@ func (s Host) GoString() string {
 func (s *Host) SetSourcePath(v string) *Host {
 	s.SourcePath = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Host) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SourcePath != nil {
+		v := *s.SourcePath
+
+		e.SetValue(protocol.BodyTarget, "sourcePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An object representing an AWS Batch job definition.
@@ -3373,6 +4113,60 @@ func (s *JobDefinition) SetType(v string) *JobDefinition {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobDefinition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerProperties != nil {
+		v := s.ContainerProperties
+
+		e.SetFields(protocol.BodyTarget, "containerProperties", v, protocol.Metadata{})
+	}
+	if s.JobDefinitionArn != nil {
+		v := *s.JobDefinitionArn
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobDefinitionName != nil {
+		v := *s.JobDefinitionName
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RetryStrategy != nil {
+		v := s.RetryStrategy
+
+		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
+	}
+	if s.Revision != nil {
+		v := *s.Revision
+
+		e.SetValue(protocol.BodyTarget, "revision", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobDefinitionList(vs []*JobDefinition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // An object representing an AWS Batch job dependency.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/JobDependency
 type JobDependency struct {
@@ -3396,6 +4190,25 @@ func (s JobDependency) GoString() string {
 func (s *JobDependency) SetJobId(v string) *JobDependency {
 	s.JobId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobDependency) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobDependencyList(vs []*JobDependency) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // An object representing an AWS Batch job.
@@ -3559,6 +4372,90 @@ func (s *JobDetail) SetStoppedAt(v int64) *JobDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attempts) > 0 {
+		v := s.Attempts
+
+		e.SetList(protocol.BodyTarget, "attempts", encodeAttemptDetailList(v), protocol.Metadata{})
+	}
+	if s.Container != nil {
+		v := s.Container
+
+		e.SetFields(protocol.BodyTarget, "container", v, protocol.Metadata{})
+	}
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.DependsOn) > 0 {
+		v := s.DependsOn
+
+		e.SetList(protocol.BodyTarget, "dependsOn", encodeJobDependencyList(v), protocol.Metadata{})
+	}
+	if s.JobDefinition != nil {
+		v := *s.JobDefinition
+
+		e.SetValue(protocol.BodyTarget, "jobDefinition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobName != nil {
+		v := *s.JobName
+
+		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RetryStrategy != nil {
+		v := s.RetryStrategy
+
+		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
+	}
+	if s.StartedAt != nil {
+		v := *s.StartedAt
+
+		e.SetValue(protocol.BodyTarget, "startedAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusReason != nil {
+		v := *s.StatusReason
+
+		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StoppedAt != nil {
+		v := *s.StoppedAt
+
+		e.SetValue(protocol.BodyTarget, "stoppedAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobDetailList(vs []*JobDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // An object representing the details of an AWS Batch job queue.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/JobQueueDetail
 type JobQueueDetail struct {
@@ -3651,6 +4548,55 @@ func (s *JobQueueDetail) SetStatusReason(v string) *JobQueueDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobQueueDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironmentOrder) > 0 {
+		v := s.ComputeEnvironmentOrder
+
+		e.SetList(protocol.BodyTarget, "computeEnvironmentOrder", encodeComputeEnvironmentOrderList(v), protocol.Metadata{})
+	}
+	if s.JobQueueArn != nil {
+		v := *s.JobQueueArn
+
+		e.SetValue(protocol.BodyTarget, "jobQueueArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueueName != nil {
+		v := *s.JobQueueName
+
+		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "priority", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusReason != nil {
+		v := *s.StatusReason
+
+		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobQueueDetailList(vs []*JobQueueDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // An object representing summary details of a job.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/JobSummary
 type JobSummary struct {
@@ -3689,6 +4635,30 @@ func (s *JobSummary) SetJobName(v string) *JobSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobName != nil {
+		v := *s.JobName
+
+		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobSummaryList(vs []*JobSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A key-value pair object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/KeyValuePair
 type KeyValuePair struct {
@@ -3723,6 +4693,30 @@ func (s *KeyValuePair) SetName(v string) *KeyValuePair {
 func (s *KeyValuePair) SetValue(v string) *KeyValuePair {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyValuePair) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeKeyValuePairList(vs []*KeyValuePair) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/ListJobsRequest
@@ -3805,6 +4799,32 @@ func (s *ListJobsInput) SetNextToken(v string) *ListJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobStatus != nil {
+		v := *s.JobStatus
+
+		e.SetValue(protocol.BodyTarget, "jobStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/ListJobsResponse
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3841,6 +4861,22 @@ func (s *ListJobsOutput) SetJobSummaryList(v []*JobSummary) *ListJobsOutput {
 func (s *ListJobsOutput) SetNextToken(v string) *ListJobsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobSummaryList) > 0 {
+		v := s.JobSummaryList
+
+		e.SetList(protocol.BodyTarget, "jobSummaryList", encodeJobSummaryList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Details on a Docker volume mount point that is used in a job's container
@@ -3886,6 +4922,35 @@ func (s *MountPoint) SetReadOnly(v bool) *MountPoint {
 func (s *MountPoint) SetSourceVolume(v string) *MountPoint {
 	s.SourceVolume = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MountPoint) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerPath != nil {
+		v := *s.ContainerPath
+
+		e.SetValue(protocol.BodyTarget, "containerPath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ReadOnly != nil {
+		v := *s.ReadOnly
+
+		e.SetValue(protocol.BodyTarget, "readOnly", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SourceVolume != nil {
+		v := *s.SourceVolume
+
+		e.SetValue(protocol.BodyTarget, "sourceVolume", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMountPointList(vs []*MountPoint) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/RegisterJobDefinitionRequest
@@ -3979,6 +5044,37 @@ func (s *RegisterJobDefinitionInput) SetType(v string) *RegisterJobDefinitionInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterJobDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerProperties != nil {
+		v := s.ContainerProperties
+
+		e.SetFields(protocol.BodyTarget, "containerProperties", v, protocol.Metadata{})
+	}
+	if s.JobDefinitionName != nil {
+		v := *s.JobDefinitionName
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RetryStrategy != nil {
+		v := s.RetryStrategy
+
+		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/RegisterJobDefinitionResponse
 type RegisterJobDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4027,6 +5123,27 @@ func (s *RegisterJobDefinitionOutput) SetRevision(v int64) *RegisterJobDefinitio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterJobDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobDefinitionArn != nil {
+		v := *s.JobDefinitionArn
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobDefinitionName != nil {
+		v := *s.JobDefinitionName
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Revision != nil {
+		v := *s.Revision
+
+		e.SetValue(protocol.BodyTarget, "revision", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The retry strategy associated with a job.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/RetryStrategy
 type RetryStrategy struct {
@@ -4052,6 +5169,17 @@ func (s RetryStrategy) GoString() string {
 func (s *RetryStrategy) SetAttempts(v int64) *RetryStrategy {
 	s.Attempts = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RetryStrategy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Attempts != nil {
+		v := *s.Attempts
+
+		e.SetValue(protocol.BodyTarget, "attempts", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/SubmitJobRequest
@@ -4173,6 +5301,47 @@ func (s *SubmitJobInput) SetRetryStrategy(v *RetryStrategy) *SubmitJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubmitJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerOverrides != nil {
+		v := s.ContainerOverrides
+
+		e.SetFields(protocol.BodyTarget, "containerOverrides", v, protocol.Metadata{})
+	}
+	if len(s.DependsOn) > 0 {
+		v := s.DependsOn
+
+		e.SetList(protocol.BodyTarget, "dependsOn", encodeJobDependencyList(v), protocol.Metadata{})
+	}
+	if s.JobDefinition != nil {
+		v := *s.JobDefinition
+
+		e.SetValue(protocol.BodyTarget, "jobDefinition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobName != nil {
+		v := *s.JobName
+
+		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RetryStrategy != nil {
+		v := s.RetryStrategy
+
+		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/SubmitJobResponse
 type SubmitJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -4208,6 +5377,22 @@ func (s *SubmitJobOutput) SetJobId(v string) *SubmitJobOutput {
 func (s *SubmitJobOutput) SetJobName(v string) *SubmitJobOutput {
 	s.JobName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubmitJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobName != nil {
+		v := *s.JobName
+
+		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/TerminateJobRequest
@@ -4265,6 +5450,22 @@ func (s *TerminateJobInput) SetReason(v string) *TerminateJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TerminateJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Reason != nil {
+		v := *s.Reason
+
+		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/TerminateJobResponse
 type TerminateJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -4278,6 +5479,12 @@ func (s TerminateJobOutput) String() string {
 // GoString returns the string representation
 func (s TerminateJobOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TerminateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The ulimit settings to pass to the container.
@@ -4346,6 +5553,35 @@ func (s *Ulimit) SetName(v string) *Ulimit {
 func (s *Ulimit) SetSoftLimit(v int64) *Ulimit {
 	s.SoftLimit = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Ulimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HardLimit != nil {
+		v := *s.HardLimit
+
+		e.SetValue(protocol.BodyTarget, "hardLimit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SoftLimit != nil {
+		v := *s.SoftLimit
+
+		e.SetValue(protocol.BodyTarget, "softLimit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUlimitList(vs []*Ulimit) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/UpdateComputeEnvironmentRequest
@@ -4429,6 +5665,32 @@ func (s *UpdateComputeEnvironmentInput) SetState(v string) *UpdateComputeEnviron
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironment != nil {
+		v := *s.ComputeEnvironment
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeResources != nil {
+		v := s.ComputeResources
+
+		e.SetFields(protocol.BodyTarget, "computeResources", v, protocol.Metadata{})
+	}
+	if s.ServiceRole != nil {
+		v := *s.ServiceRole
+
+		e.SetValue(protocol.BodyTarget, "serviceRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/UpdateComputeEnvironmentResponse
 type UpdateComputeEnvironmentOutput struct {
 	_ struct{} `type:"structure"`
@@ -4460,6 +5722,22 @@ func (s *UpdateComputeEnvironmentOutput) SetComputeEnvironmentArn(v string) *Upd
 func (s *UpdateComputeEnvironmentOutput) SetComputeEnvironmentName(v string) *UpdateComputeEnvironmentOutput {
 	s.ComputeEnvironmentName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironmentArn != nil {
+		v := *s.ComputeEnvironmentArn
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeEnvironmentName != nil {
+		v := *s.ComputeEnvironmentName
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/UpdateJobQueueRequest
@@ -4544,6 +5822,32 @@ func (s *UpdateJobQueueInput) SetState(v string) *UpdateJobQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironmentOrder) > 0 {
+		v := s.ComputeEnvironmentOrder
+
+		e.SetList(protocol.BodyTarget, "computeEnvironmentOrder", encodeComputeEnvironmentOrderList(v), protocol.Metadata{})
+	}
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "priority", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/UpdateJobQueueResponse
 type UpdateJobQueueOutput struct {
 	_ struct{} `type:"structure"`
@@ -4575,6 +5879,22 @@ func (s *UpdateJobQueueOutput) SetJobQueueArn(v string) *UpdateJobQueueOutput {
 func (s *UpdateJobQueueOutput) SetJobQueueName(v string) *UpdateJobQueueOutput {
 	s.JobQueueName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobQueueArn != nil {
+		v := *s.JobQueueArn
+
+		e.SetValue(protocol.BodyTarget, "jobQueueArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueueName != nil {
+		v := *s.JobQueueName
+
+		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A data volume used in a job's container properties.
@@ -4615,6 +5935,30 @@ func (s *Volume) SetHost(v *Host) *Volume {
 func (s *Volume) SetName(v string) *Volume {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Volume) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Host != nil {
+		v := s.Host
+
+		e.SetFields(protocol.BodyTarget, "host", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVolumeList(vs []*Volume) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -7903,6 +7903,32 @@ func (s *AddFacetToObjectInput) SetSchemaFacet(v *SchemaFacet) *AddFacetToObject
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddFacetToObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectAttributeList) > 0 {
+		v := s.ObjectAttributeList
+
+		e.SetList(protocol.BodyTarget, "ObjectAttributeList", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.SchemaFacet != nil {
+		v := s.SchemaFacet
+
+		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AddFacetToObjectResponse
 type AddFacetToObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -7916,6 +7942,12 @@ func (s AddFacetToObjectOutput) String() string {
 // GoString returns the string representation
 func (s AddFacetToObjectOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddFacetToObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ApplySchemaRequest
@@ -7973,6 +8005,22 @@ func (s *ApplySchemaInput) SetPublishedSchemaArn(v string) *ApplySchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplySchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PublishedSchemaArn != nil {
+		v := *s.PublishedSchemaArn
+
+		e.SetValue(protocol.BodyTarget, "PublishedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ApplySchemaResponse
 type ApplySchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -8007,6 +8055,22 @@ func (s *ApplySchemaOutput) SetAppliedSchemaArn(v string) *ApplySchemaOutput {
 func (s *ApplySchemaOutput) SetDirectoryArn(v string) *ApplySchemaOutput {
 	s.DirectoryArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplySchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AppliedSchemaArn != nil {
+		v := *s.AppliedSchemaArn
+
+		e.SetValue(protocol.BodyTarget, "AppliedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachObjectRequest
@@ -8094,6 +8158,32 @@ func (s *AttachObjectInput) SetParentReference(v *ObjectReference) *AttachObject
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChildReference != nil {
+		v := s.ChildReference
+
+		e.SetFields(protocol.BodyTarget, "ChildReference", v, protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachObjectResponse
 type AttachObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -8116,6 +8206,17 @@ func (s AttachObjectOutput) GoString() string {
 func (s *AttachObjectOutput) SetAttachedObjectIdentifier(v string) *AttachObjectOutput {
 	s.AttachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachedObjectIdentifier != nil {
+		v := *s.AttachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachPolicyRequest
@@ -8181,6 +8282,27 @@ func (s *AttachPolicyInput) SetPolicyReference(v *ObjectReference) *AttachPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachPolicyResponse
 type AttachPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -8194,6 +8316,12 @@ func (s AttachPolicyOutput) String() string {
 // GoString returns the string representation
 func (s AttachPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachToIndexRequest
@@ -8264,6 +8392,27 @@ func (s *AttachToIndexInput) SetTargetReference(v *ObjectReference) *AttachToInd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachToIndexInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachToIndexResponse
 type AttachToIndexOutput struct {
 	_ struct{} `type:"structure"`
@@ -8286,6 +8435,17 @@ func (s AttachToIndexOutput) GoString() string {
 func (s *AttachToIndexOutput) SetAttachedObjectIdentifier(v string) *AttachToIndexOutput {
 	s.AttachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachToIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachedObjectIdentifier != nil {
+		v := *s.AttachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachTypedLinkRequest
@@ -8399,6 +8559,37 @@ func (s *AttachTypedLinkInput) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachTypedLinkInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeNameAndValueList(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceObjectReference != nil {
+		v := s.SourceObjectReference
+
+		e.SetFields(protocol.BodyTarget, "SourceObjectReference", v, protocol.Metadata{})
+	}
+	if s.TargetObjectReference != nil {
+		v := s.TargetObjectReference
+
+		e.SetFields(protocol.BodyTarget, "TargetObjectReference", v, protocol.Metadata{})
+	}
+	if s.TypedLinkFacet != nil {
+		v := s.TypedLinkFacet
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachTypedLinkResponse
 type AttachTypedLinkOutput struct {
 	_ struct{} `type:"structure"`
@@ -8421,6 +8612,17 @@ func (s AttachTypedLinkOutput) GoString() string {
 func (s *AttachTypedLinkOutput) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *AttachTypedLinkOutput {
 	s.TypedLinkSpecifier = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachTypedLinkOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TypedLinkSpecifier != nil {
+		v := s.TypedLinkSpecifier
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A unique identifier for an attribute.
@@ -8498,6 +8700,35 @@ func (s *AttributeKey) SetSchemaArn(v string) *AttributeKey {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributeKey) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FacetName != nil {
+		v := *s.FacetName
+
+		e.SetValue(protocol.BodyTarget, "FacetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttributeKeyList(vs []*AttributeKey) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The combination of an attribute key and an attribute value.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttributeKeyAndValue
 type AttributeKeyAndValue struct {
@@ -8557,6 +8788,30 @@ func (s *AttributeKeyAndValue) SetValue(v *TypedAttributeValue) *AttributeKeyAnd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributeKeyAndValue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := s.Key
+
+		e.SetFields(protocol.BodyTarget, "Key", v, protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := s.Value
+
+		e.SetFields(protocol.BodyTarget, "Value", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttributeKeyAndValueList(vs []*AttributeKeyAndValue) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Identifies the attribute name and value for a typed link.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttributeNameAndValue
 type AttributeNameAndValue struct {
@@ -8612,6 +8867,30 @@ func (s *AttributeNameAndValue) SetAttributeName(v string) *AttributeNameAndValu
 func (s *AttributeNameAndValue) SetValue(v *TypedAttributeValue) *AttributeNameAndValue {
 	s.Value = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributeNameAndValue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeName != nil {
+		v := *s.AttributeName
+
+		e.SetValue(protocol.BodyTarget, "AttributeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := s.Value
+
+		e.SetFields(protocol.BodyTarget, "Value", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttributeNameAndValueList(vs []*AttributeNameAndValue) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents the output of a batch add facet to object operation.
@@ -8697,6 +8976,27 @@ func (s *BatchAddFacetToObject) SetSchemaFacet(v *SchemaFacet) *BatchAddFacetToO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAddFacetToObject) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ObjectAttributeList) > 0 {
+		v := s.ObjectAttributeList
+
+		e.SetList(protocol.BodyTarget, "ObjectAttributeList", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.SchemaFacet != nil {
+		v := s.SchemaFacet
+
+		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a batch add facet to object operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAddFacetToObjectResponse
 type BatchAddFacetToObjectResponse struct {
@@ -8711,6 +9011,12 @@ func (s BatchAddFacetToObjectResponse) String() string {
 // GoString returns the string representation
 func (s BatchAddFacetToObjectResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAddFacetToObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents the output of an AttachObject operation.
@@ -8784,6 +9090,27 @@ func (s *BatchAttachObject) SetParentReference(v *ObjectReference) *BatchAttachO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChildReference != nil {
+		v := s.ChildReference
+
+		e.SetFields(protocol.BodyTarget, "ChildReference", v, protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output batch AttachObject response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAttachObjectResponse
 type BatchAttachObjectResponse struct {
@@ -8807,6 +9134,17 @@ func (s BatchAttachObjectResponse) GoString() string {
 func (s *BatchAttachObjectResponse) SetAttachedObjectIdentifier(v string) *BatchAttachObjectResponse {
 	s.AttachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachedObjectIdentifier != nil {
+		v := *s.AttachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "attachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Attaches a policy object to a regular object inside a BatchRead operation. For
@@ -8864,6 +9202,22 @@ func (s *BatchAttachPolicy) SetPolicyReference(v *ObjectReference) *BatchAttachP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of an AttachPolicy response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAttachPolicyResponse
 type BatchAttachPolicyResponse struct {
@@ -8878,6 +9232,12 @@ func (s BatchAttachPolicyResponse) String() string {
 // GoString returns the string representation
 func (s BatchAttachPolicyResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachPolicyResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Attaches the specified object to the specified index inside a BatchRead operation.
@@ -8935,6 +9295,22 @@ func (s *BatchAttachToIndex) SetTargetReference(v *ObjectReference) *BatchAttach
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachToIndex) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a AttachToIndex response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAttachToIndexResponse
 type BatchAttachToIndexResponse struct {
@@ -8958,6 +9334,17 @@ func (s BatchAttachToIndexResponse) GoString() string {
 func (s *BatchAttachToIndexResponse) SetAttachedObjectIdentifier(v string) *BatchAttachToIndexResponse {
 	s.AttachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachToIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachedObjectIdentifier != nil {
+		v := *s.AttachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Attaches a typed link to a specified source and target object inside a BatchRead
@@ -9058,6 +9445,32 @@ func (s *BatchAttachTypedLink) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachTypedLink) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeNameAndValueList(v), protocol.Metadata{})
+	}
+	if s.SourceObjectReference != nil {
+		v := s.SourceObjectReference
+
+		e.SetFields(protocol.BodyTarget, "SourceObjectReference", v, protocol.Metadata{})
+	}
+	if s.TargetObjectReference != nil {
+		v := s.TargetObjectReference
+
+		e.SetFields(protocol.BodyTarget, "TargetObjectReference", v, protocol.Metadata{})
+	}
+	if s.TypedLinkFacet != nil {
+		v := s.TypedLinkFacet
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a AttachTypedLink response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAttachTypedLinkResponse
 type BatchAttachTypedLinkResponse struct {
@@ -9081,6 +9494,17 @@ func (s BatchAttachTypedLinkResponse) GoString() string {
 func (s *BatchAttachTypedLinkResponse) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *BatchAttachTypedLinkResponse {
 	s.TypedLinkSpecifier = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachTypedLinkResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TypedLinkSpecifier != nil {
+		v := s.TypedLinkSpecifier
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Creates an index object inside of a BatchRead operation. For more information,
@@ -9181,6 +9605,37 @@ func (s *BatchCreateIndex) SetParentReference(v *ObjectReference) *BatchCreateIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchCreateIndex) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchReferenceName != nil {
+		v := *s.BatchReferenceName
+
+		e.SetValue(protocol.BodyTarget, "BatchReferenceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsUnique != nil {
+		v := *s.IsUnique
+
+		e.SetValue(protocol.BodyTarget, "IsUnique", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OrderedIndexedAttributeList) > 0 {
+		v := s.OrderedIndexedAttributeList
+
+		e.SetList(protocol.BodyTarget, "OrderedIndexedAttributeList", encodeAttributeKeyList(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a CreateIndex response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchCreateIndexResponse
 type BatchCreateIndexResponse struct {
@@ -9204,6 +9659,17 @@ func (s BatchCreateIndexResponse) GoString() string {
 func (s *BatchCreateIndexResponse) SetObjectIdentifier(v string) *BatchCreateIndexResponse {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchCreateIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a CreateObject operation.
@@ -9328,6 +9794,37 @@ func (s *BatchCreateObject) SetSchemaFacet(v []*SchemaFacet) *BatchCreateObject 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchCreateObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchReferenceName != nil {
+		v := *s.BatchReferenceName
+
+		e.SetValue(protocol.BodyTarget, "BatchReferenceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectAttributeList) > 0 {
+		v := s.ObjectAttributeList
+
+		e.SetList(protocol.BodyTarget, "ObjectAttributeList", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+	if len(s.SchemaFacet) > 0 {
+		v := s.SchemaFacet
+
+		e.SetList(protocol.BodyTarget, "SchemaFacet", encodeSchemaFacetList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a CreateObject response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchCreateObjectResponse
 type BatchCreateObjectResponse struct {
@@ -9351,6 +9848,17 @@ func (s BatchCreateObjectResponse) GoString() string {
 func (s *BatchCreateObjectResponse) SetObjectIdentifier(v string) *BatchCreateObjectResponse {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchCreateObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a DeleteObject operation.
@@ -9393,6 +9901,17 @@ func (s *BatchDeleteObject) SetObjectReference(v *ObjectReference) *BatchDeleteO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDeleteObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DeleteObject response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDeleteObjectResponse
 type BatchDeleteObjectResponse struct {
@@ -9407,6 +9926,12 @@ func (s BatchDeleteObjectResponse) String() string {
 // GoString returns the string representation
 func (s BatchDeleteObjectResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDeleteObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Detaches the specified object from the specified index inside a BatchRead
@@ -9464,6 +9989,22 @@ func (s *BatchDetachFromIndex) SetTargetReference(v *ObjectReference) *BatchDeta
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachFromIndex) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DetachFromIndex response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDetachFromIndexResponse
 type BatchDetachFromIndexResponse struct {
@@ -9487,6 +10028,17 @@ func (s BatchDetachFromIndexResponse) GoString() string {
 func (s *BatchDetachFromIndexResponse) SetDetachedObjectIdentifier(v string) *BatchDetachFromIndexResponse {
 	s.DetachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachFromIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetachedObjectIdentifier != nil {
+		v := *s.DetachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a DetachObject operation.
@@ -9561,6 +10113,27 @@ func (s *BatchDetachObject) SetParentReference(v *ObjectReference) *BatchDetachO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchReferenceName != nil {
+		v := *s.BatchReferenceName
+
+		e.SetValue(protocol.BodyTarget, "BatchReferenceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DetachObject response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDetachObjectResponse
 type BatchDetachObjectResponse struct {
@@ -9584,6 +10157,17 @@ func (s BatchDetachObjectResponse) GoString() string {
 func (s *BatchDetachObjectResponse) SetDetachedObjectIdentifier(v string) *BatchDetachObjectResponse {
 	s.DetachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetachedObjectIdentifier != nil {
+		v := *s.DetachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "detachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Detaches the specified policy from the specified directory inside a BatchRead
@@ -9641,6 +10225,22 @@ func (s *BatchDetachPolicy) SetPolicyReference(v *ObjectReference) *BatchDetachP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DetachPolicy response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDetachPolicyResponse
 type BatchDetachPolicyResponse struct {
@@ -9655,6 +10255,12 @@ func (s BatchDetachPolicyResponse) String() string {
 // GoString returns the string representation
 func (s BatchDetachPolicyResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachPolicyResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Detaches a typed link from a specified source and target object inside a
@@ -9703,6 +10309,17 @@ func (s *BatchDetachTypedLink) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *Bat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachTypedLink) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TypedLinkSpecifier != nil {
+		v := s.TypedLinkSpecifier
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DetachTypedLink response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDetachTypedLinkResponse
 type BatchDetachTypedLinkResponse struct {
@@ -9717,6 +10334,12 @@ func (s BatchDetachTypedLinkResponse) String() string {
 // GoString returns the string representation
 func (s BatchDetachTypedLinkResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachTypedLinkResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Retrieves metadata about an object inside a BatchRead operation. For more
@@ -9760,6 +10383,17 @@ func (s *BatchGetObjectInformation) SetObjectReference(v *ObjectReference) *Batc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchGetObjectInformation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a GetObjectInformation response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchGetObjectInformationResponse
 type BatchGetObjectInformationResponse struct {
@@ -9792,6 +10426,22 @@ func (s *BatchGetObjectInformationResponse) SetObjectIdentifier(v string) *Batch
 func (s *BatchGetObjectInformationResponse) SetSchemaFacets(v []*SchemaFacet) *BatchGetObjectInformationResponse {
 	s.SchemaFacets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchGetObjectInformationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaFacets) > 0 {
+		v := s.SchemaFacets
+
+		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Lists indices attached to an object inside a BatchRead operation. For more
@@ -9856,6 +10506,27 @@ func (s *BatchListAttachedIndices) SetTargetReference(v *ObjectReference) *Batch
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListAttachedIndices) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListAttachedIndices response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListAttachedIndicesResponse
 type BatchListAttachedIndicesResponse struct {
@@ -9888,6 +10559,22 @@ func (s *BatchListAttachedIndicesResponse) SetIndexAttachments(v []*IndexAttachm
 func (s *BatchListAttachedIndicesResponse) SetNextToken(v string) *BatchListAttachedIndicesResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListAttachedIndicesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexAttachments) > 0 {
+		v := s.IndexAttachments
+
+		e.SetList(protocol.BodyTarget, "IndexAttachments", encodeIndexAttachmentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returns a paginated list of all the incoming TypedLinkSpecifier information
@@ -9990,6 +10677,37 @@ func (s *BatchListIncomingTypedLinks) SetObjectReference(v *ObjectReference) *Ba
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListIncomingTypedLinks) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FilterAttributeRanges) > 0 {
+		v := s.FilterAttributeRanges
+
+		e.SetList(protocol.BodyTarget, "FilterAttributeRanges", encodeTypedLinkAttributeRangeList(v), protocol.Metadata{})
+	}
+	if s.FilterTypedLink != nil {
+		v := s.FilterTypedLink
+
+		e.SetFields(protocol.BodyTarget, "FilterTypedLink", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListIncomingTypedLinks response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListIncomingTypedLinksResponse
 type BatchListIncomingTypedLinksResponse struct {
@@ -10022,6 +10740,22 @@ func (s *BatchListIncomingTypedLinksResponse) SetLinkSpecifiers(v []*TypedLinkSp
 func (s *BatchListIncomingTypedLinksResponse) SetNextToken(v string) *BatchListIncomingTypedLinksResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListIncomingTypedLinksResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LinkSpecifiers) > 0 {
+		v := s.LinkSpecifiers
+
+		e.SetList(protocol.BodyTarget, "LinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Lists objects attached to the specified index inside a BatchRead operation.
@@ -10105,6 +10839,32 @@ func (s *BatchListIndex) SetRangesOnIndexedValues(v []*ObjectAttributeRange) *Ba
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListIndex) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RangesOnIndexedValues) > 0 {
+		v := s.RangesOnIndexedValues
+
+		e.SetList(protocol.BodyTarget, "RangesOnIndexedValues", encodeObjectAttributeRangeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListIndex response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListIndexResponse
 type BatchListIndexResponse struct {
@@ -10137,6 +10897,22 @@ func (s *BatchListIndexResponse) SetIndexAttachments(v []*IndexAttachment) *Batc
 func (s *BatchListIndexResponse) SetNextToken(v string) *BatchListIndexResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexAttachments) > 0 {
+		v := s.IndexAttachments
+
+		e.SetList(protocol.BodyTarget, "IndexAttachments", encodeIndexAttachmentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a ListObjectAttributes operation.
@@ -10216,6 +10992,32 @@ func (s *BatchListObjectAttributes) SetObjectReference(v *ObjectReference) *Batc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectAttributes) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FacetFilter != nil {
+		v := s.FacetFilter
+
+		e.SetFields(protocol.BodyTarget, "FacetFilter", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListObjectAttributes response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListObjectAttributesResponse
 type BatchListObjectAttributesResponse struct {
@@ -10249,6 +11051,22 @@ func (s *BatchListObjectAttributesResponse) SetAttributes(v []*AttributeKeyAndVa
 func (s *BatchListObjectAttributesResponse) SetNextToken(v string) *BatchListObjectAttributesResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectAttributesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a ListObjectChildren operation.
@@ -10313,6 +11131,27 @@ func (s *BatchListObjectChildren) SetObjectReference(v *ObjectReference) *BatchL
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectChildren) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListObjectChildren response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListObjectChildrenResponse
 type BatchListObjectChildrenResponse struct {
@@ -10346,6 +11185,22 @@ func (s *BatchListObjectChildrenResponse) SetChildren(v map[string]*string) *Bat
 func (s *BatchListObjectChildrenResponse) SetNextToken(v string) *BatchListObjectChildrenResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectChildrenResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Children) > 0 {
+		v := s.Children
+
+		e.SetMap(protocol.BodyTarget, "Children", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Retrieves all available parent paths for any object type such as node, leaf
@@ -10411,6 +11266,27 @@ func (s *BatchListObjectParentPaths) SetObjectReference(v *ObjectReference) *Bat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectParentPaths) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListObjectParentPaths response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListObjectParentPathsResponse
 type BatchListObjectParentPathsResponse struct {
@@ -10443,6 +11319,22 @@ func (s *BatchListObjectParentPathsResponse) SetNextToken(v string) *BatchListOb
 func (s *BatchListObjectParentPathsResponse) SetPathToObjectIdentifiersList(v []*PathToObjectIdentifiers) *BatchListObjectParentPathsResponse {
 	s.PathToObjectIdentifiersList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectParentPathsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PathToObjectIdentifiersList) > 0 {
+		v := s.PathToObjectIdentifiersList
+
+		e.SetList(protocol.BodyTarget, "PathToObjectIdentifiersList", encodePathToObjectIdentifiersList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returns policies attached to an object in pagination fashion inside a BatchRead
@@ -10507,6 +11399,27 @@ func (s *BatchListObjectPolicies) SetObjectReference(v *ObjectReference) *BatchL
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectPolicies) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListObjectPolicies response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListObjectPoliciesResponse
 type BatchListObjectPoliciesResponse struct {
@@ -10539,6 +11452,22 @@ func (s *BatchListObjectPoliciesResponse) SetAttachedPolicyIds(v []*string) *Bat
 func (s *BatchListObjectPoliciesResponse) SetNextToken(v string) *BatchListObjectPoliciesResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectPoliciesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttachedPolicyIds) > 0 {
+		v := s.AttachedPolicyIds
+
+		e.SetList(protocol.BodyTarget, "AttachedPolicyIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returns a paginated list of all the outgoing TypedLinkSpecifier information
@@ -10641,6 +11570,37 @@ func (s *BatchListOutgoingTypedLinks) SetObjectReference(v *ObjectReference) *Ba
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListOutgoingTypedLinks) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FilterAttributeRanges) > 0 {
+		v := s.FilterAttributeRanges
+
+		e.SetList(protocol.BodyTarget, "FilterAttributeRanges", encodeTypedLinkAttributeRangeList(v), protocol.Metadata{})
+	}
+	if s.FilterTypedLink != nil {
+		v := s.FilterTypedLink
+
+		e.SetFields(protocol.BodyTarget, "FilterTypedLink", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListOutgoingTypedLinks response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListOutgoingTypedLinksResponse
 type BatchListOutgoingTypedLinksResponse struct {
@@ -10673,6 +11633,22 @@ func (s *BatchListOutgoingTypedLinksResponse) SetNextToken(v string) *BatchListO
 func (s *BatchListOutgoingTypedLinksResponse) SetTypedLinkSpecifiers(v []*TypedLinkSpecifier) *BatchListOutgoingTypedLinksResponse {
 	s.TypedLinkSpecifiers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListOutgoingTypedLinksResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TypedLinkSpecifiers) > 0 {
+		v := s.TypedLinkSpecifiers
+
+		e.SetList(protocol.BodyTarget, "TypedLinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returns all of the ObjectIdentifiers to which a given policy is attached
@@ -10738,6 +11714,27 @@ func (s *BatchListPolicyAttachments) SetPolicyReference(v *ObjectReference) *Bat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListPolicyAttachments) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListPolicyAttachments response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListPolicyAttachmentsResponse
 type BatchListPolicyAttachmentsResponse struct {
@@ -10770,6 +11767,22 @@ func (s *BatchListPolicyAttachmentsResponse) SetNextToken(v string) *BatchListPo
 func (s *BatchListPolicyAttachmentsResponse) SetObjectIdentifiers(v []*string) *BatchListPolicyAttachmentsResponse {
 	s.ObjectIdentifiers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListPolicyAttachmentsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectIdentifiers) > 0 {
+		v := s.ObjectIdentifiers
+
+		e.SetList(protocol.BodyTarget, "ObjectIdentifiers", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Lists all policies from the root of the Directory to the object specified
@@ -10835,6 +11848,27 @@ func (s *BatchLookupPolicy) SetObjectReference(v *ObjectReference) *BatchLookupP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchLookupPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a LookupPolicy response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchLookupPolicyResponse
 type BatchLookupPolicyResponse struct {
@@ -10870,6 +11904,22 @@ func (s *BatchLookupPolicyResponse) SetPolicyToPathList(v []*PolicyToPath) *Batc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchLookupPolicyResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PolicyToPathList) > 0 {
+		v := s.PolicyToPathList
+
+		e.SetList(protocol.BodyTarget, "PolicyToPathList", encodePolicyToPathList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The batch read exception structure, which contains the exception type and
 // message.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadException
@@ -10903,6 +11953,22 @@ func (s *BatchReadException) SetMessage(v string) *BatchReadException {
 func (s *BatchReadException) SetType(v string) *BatchReadException {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadException) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadRequest
@@ -10977,6 +12043,27 @@ func (s *BatchReadInput) SetDirectoryArn(v string) *BatchReadInput {
 func (s *BatchReadInput) SetOperations(v []*BatchReadOperation) *BatchReadInput {
 	s.Operations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Operations) > 0 {
+		v := s.Operations
+
+		e.SetList(protocol.BodyTarget, "Operations", encodeBatchReadOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a BatchRead operation.
@@ -11172,6 +12259,75 @@ func (s *BatchReadOperation) SetLookupPolicy(v *BatchLookupPolicy) *BatchReadOpe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadOperation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GetObjectInformation != nil {
+		v := s.GetObjectInformation
+
+		e.SetFields(protocol.BodyTarget, "GetObjectInformation", v, protocol.Metadata{})
+	}
+	if s.ListAttachedIndices != nil {
+		v := s.ListAttachedIndices
+
+		e.SetFields(protocol.BodyTarget, "ListAttachedIndices", v, protocol.Metadata{})
+	}
+	if s.ListIncomingTypedLinks != nil {
+		v := s.ListIncomingTypedLinks
+
+		e.SetFields(protocol.BodyTarget, "ListIncomingTypedLinks", v, protocol.Metadata{})
+	}
+	if s.ListIndex != nil {
+		v := s.ListIndex
+
+		e.SetFields(protocol.BodyTarget, "ListIndex", v, protocol.Metadata{})
+	}
+	if s.ListObjectAttributes != nil {
+		v := s.ListObjectAttributes
+
+		e.SetFields(protocol.BodyTarget, "ListObjectAttributes", v, protocol.Metadata{})
+	}
+	if s.ListObjectChildren != nil {
+		v := s.ListObjectChildren
+
+		e.SetFields(protocol.BodyTarget, "ListObjectChildren", v, protocol.Metadata{})
+	}
+	if s.ListObjectParentPaths != nil {
+		v := s.ListObjectParentPaths
+
+		e.SetFields(protocol.BodyTarget, "ListObjectParentPaths", v, protocol.Metadata{})
+	}
+	if s.ListObjectPolicies != nil {
+		v := s.ListObjectPolicies
+
+		e.SetFields(protocol.BodyTarget, "ListObjectPolicies", v, protocol.Metadata{})
+	}
+	if s.ListOutgoingTypedLinks != nil {
+		v := s.ListOutgoingTypedLinks
+
+		e.SetFields(protocol.BodyTarget, "ListOutgoingTypedLinks", v, protocol.Metadata{})
+	}
+	if s.ListPolicyAttachments != nil {
+		v := s.ListPolicyAttachments
+
+		e.SetFields(protocol.BodyTarget, "ListPolicyAttachments", v, protocol.Metadata{})
+	}
+	if s.LookupPolicy != nil {
+		v := s.LookupPolicy
+
+		e.SetFields(protocol.BodyTarget, "LookupPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBatchReadOperationList(vs []*BatchReadOperation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents the output of a BatchRead response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadOperationResponse
 type BatchReadOperationResponse struct {
@@ -11206,6 +12362,30 @@ func (s *BatchReadOperationResponse) SetSuccessfulResponse(v *BatchReadSuccessfu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadOperationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ExceptionResponse != nil {
+		v := s.ExceptionResponse
+
+		e.SetFields(protocol.BodyTarget, "ExceptionResponse", v, protocol.Metadata{})
+	}
+	if s.SuccessfulResponse != nil {
+		v := s.SuccessfulResponse
+
+		e.SetFields(protocol.BodyTarget, "SuccessfulResponse", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBatchReadOperationResponseList(vs []*BatchReadOperationResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadResponse
 type BatchReadOutput struct {
 	_ struct{} `type:"structure"`
@@ -11228,6 +12408,17 @@ func (s BatchReadOutput) GoString() string {
 func (s *BatchReadOutput) SetResponses(v []*BatchReadOperationResponse) *BatchReadOutput {
 	s.Responses = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Responses) > 0 {
+		v := s.Responses
+
+		e.SetList(protocol.BodyTarget, "Responses", encodeBatchReadOperationResponseList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a BatchRead success response operation.
@@ -11358,6 +12549,67 @@ func (s *BatchReadSuccessfulResponse) SetLookupPolicy(v *BatchLookupPolicyRespon
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadSuccessfulResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GetObjectInformation != nil {
+		v := s.GetObjectInformation
+
+		e.SetFields(protocol.BodyTarget, "GetObjectInformation", v, protocol.Metadata{})
+	}
+	if s.ListAttachedIndices != nil {
+		v := s.ListAttachedIndices
+
+		e.SetFields(protocol.BodyTarget, "ListAttachedIndices", v, protocol.Metadata{})
+	}
+	if s.ListIncomingTypedLinks != nil {
+		v := s.ListIncomingTypedLinks
+
+		e.SetFields(protocol.BodyTarget, "ListIncomingTypedLinks", v, protocol.Metadata{})
+	}
+	if s.ListIndex != nil {
+		v := s.ListIndex
+
+		e.SetFields(protocol.BodyTarget, "ListIndex", v, protocol.Metadata{})
+	}
+	if s.ListObjectAttributes != nil {
+		v := s.ListObjectAttributes
+
+		e.SetFields(protocol.BodyTarget, "ListObjectAttributes", v, protocol.Metadata{})
+	}
+	if s.ListObjectChildren != nil {
+		v := s.ListObjectChildren
+
+		e.SetFields(protocol.BodyTarget, "ListObjectChildren", v, protocol.Metadata{})
+	}
+	if s.ListObjectParentPaths != nil {
+		v := s.ListObjectParentPaths
+
+		e.SetFields(protocol.BodyTarget, "ListObjectParentPaths", v, protocol.Metadata{})
+	}
+	if s.ListObjectPolicies != nil {
+		v := s.ListObjectPolicies
+
+		e.SetFields(protocol.BodyTarget, "ListObjectPolicies", v, protocol.Metadata{})
+	}
+	if s.ListOutgoingTypedLinks != nil {
+		v := s.ListOutgoingTypedLinks
+
+		e.SetFields(protocol.BodyTarget, "ListOutgoingTypedLinks", v, protocol.Metadata{})
+	}
+	if s.ListPolicyAttachments != nil {
+		v := s.ListPolicyAttachments
+
+		e.SetFields(protocol.BodyTarget, "ListPolicyAttachments", v, protocol.Metadata{})
+	}
+	if s.LookupPolicy != nil {
+		v := s.LookupPolicy
+
+		e.SetFields(protocol.BodyTarget, "LookupPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A batch operation to remove a facet from an object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchRemoveFacetFromObject
 type BatchRemoveFacetFromObject struct {
@@ -11417,6 +12669,22 @@ func (s *BatchRemoveFacetFromObject) SetSchemaFacet(v *SchemaFacet) *BatchRemove
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchRemoveFacetFromObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.SchemaFacet != nil {
+		v := s.SchemaFacet
+
+		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An empty result that represents success.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchRemoveFacetFromObjectResponse
 type BatchRemoveFacetFromObjectResponse struct {
@@ -11431,6 +12699,12 @@ func (s BatchRemoveFacetFromObjectResponse) String() string {
 // GoString returns the string representation
 func (s BatchRemoveFacetFromObjectResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchRemoveFacetFromObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents the output of a BatchUpdate operation.
@@ -11497,6 +12771,22 @@ func (s *BatchUpdateObjectAttributes) SetObjectReference(v *ObjectReference) *Ba
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchUpdateObjectAttributes) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttributeUpdates) > 0 {
+		v := s.AttributeUpdates
+
+		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeObjectAttributeUpdateList(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a BatchUpdate response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchUpdateObjectAttributesResponse
 type BatchUpdateObjectAttributesResponse struct {
@@ -11520,6 +12810,17 @@ func (s BatchUpdateObjectAttributesResponse) GoString() string {
 func (s *BatchUpdateObjectAttributesResponse) SetObjectIdentifier(v string) *BatchUpdateObjectAttributesResponse {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchUpdateObjectAttributesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchWriteRequest
@@ -11584,6 +12885,22 @@ func (s *BatchWriteInput) SetDirectoryArn(v string) *BatchWriteInput {
 func (s *BatchWriteInput) SetOperations(v []*BatchWriteOperation) *BatchWriteInput {
 	s.Operations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchWriteInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Operations) > 0 {
+		v := s.Operations
+
+		e.SetList(protocol.BodyTarget, "Operations", encodeBatchWriteOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a BatchWrite operation.
@@ -11812,6 +13129,90 @@ func (s *BatchWriteOperation) SetUpdateObjectAttributes(v *BatchUpdateObjectAttr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchWriteOperation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AddFacetToObject != nil {
+		v := s.AddFacetToObject
+
+		e.SetFields(protocol.BodyTarget, "AddFacetToObject", v, protocol.Metadata{})
+	}
+	if s.AttachObject != nil {
+		v := s.AttachObject
+
+		e.SetFields(protocol.BodyTarget, "AttachObject", v, protocol.Metadata{})
+	}
+	if s.AttachPolicy != nil {
+		v := s.AttachPolicy
+
+		e.SetFields(protocol.BodyTarget, "AttachPolicy", v, protocol.Metadata{})
+	}
+	if s.AttachToIndex != nil {
+		v := s.AttachToIndex
+
+		e.SetFields(protocol.BodyTarget, "AttachToIndex", v, protocol.Metadata{})
+	}
+	if s.AttachTypedLink != nil {
+		v := s.AttachTypedLink
+
+		e.SetFields(protocol.BodyTarget, "AttachTypedLink", v, protocol.Metadata{})
+	}
+	if s.CreateIndex != nil {
+		v := s.CreateIndex
+
+		e.SetFields(protocol.BodyTarget, "CreateIndex", v, protocol.Metadata{})
+	}
+	if s.CreateObject != nil {
+		v := s.CreateObject
+
+		e.SetFields(protocol.BodyTarget, "CreateObject", v, protocol.Metadata{})
+	}
+	if s.DeleteObject != nil {
+		v := s.DeleteObject
+
+		e.SetFields(protocol.BodyTarget, "DeleteObject", v, protocol.Metadata{})
+	}
+	if s.DetachFromIndex != nil {
+		v := s.DetachFromIndex
+
+		e.SetFields(protocol.BodyTarget, "DetachFromIndex", v, protocol.Metadata{})
+	}
+	if s.DetachObject != nil {
+		v := s.DetachObject
+
+		e.SetFields(protocol.BodyTarget, "DetachObject", v, protocol.Metadata{})
+	}
+	if s.DetachPolicy != nil {
+		v := s.DetachPolicy
+
+		e.SetFields(protocol.BodyTarget, "DetachPolicy", v, protocol.Metadata{})
+	}
+	if s.DetachTypedLink != nil {
+		v := s.DetachTypedLink
+
+		e.SetFields(protocol.BodyTarget, "DetachTypedLink", v, protocol.Metadata{})
+	}
+	if s.RemoveFacetFromObject != nil {
+		v := s.RemoveFacetFromObject
+
+		e.SetFields(protocol.BodyTarget, "RemoveFacetFromObject", v, protocol.Metadata{})
+	}
+	if s.UpdateObjectAttributes != nil {
+		v := s.UpdateObjectAttributes
+
+		e.SetFields(protocol.BodyTarget, "UpdateObjectAttributes", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBatchWriteOperationList(vs []*BatchWriteOperation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents the output of a BatchWrite response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchWriteOperationResponse
 type BatchWriteOperationResponse struct {
@@ -11958,6 +13359,90 @@ func (s *BatchWriteOperationResponse) SetUpdateObjectAttributes(v *BatchUpdateOb
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchWriteOperationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AddFacetToObject != nil {
+		v := s.AddFacetToObject
+
+		e.SetFields(protocol.BodyTarget, "AddFacetToObject", v, protocol.Metadata{})
+	}
+	if s.AttachObject != nil {
+		v := s.AttachObject
+
+		e.SetFields(protocol.BodyTarget, "AttachObject", v, protocol.Metadata{})
+	}
+	if s.AttachPolicy != nil {
+		v := s.AttachPolicy
+
+		e.SetFields(protocol.BodyTarget, "AttachPolicy", v, protocol.Metadata{})
+	}
+	if s.AttachToIndex != nil {
+		v := s.AttachToIndex
+
+		e.SetFields(protocol.BodyTarget, "AttachToIndex", v, protocol.Metadata{})
+	}
+	if s.AttachTypedLink != nil {
+		v := s.AttachTypedLink
+
+		e.SetFields(protocol.BodyTarget, "AttachTypedLink", v, protocol.Metadata{})
+	}
+	if s.CreateIndex != nil {
+		v := s.CreateIndex
+
+		e.SetFields(protocol.BodyTarget, "CreateIndex", v, protocol.Metadata{})
+	}
+	if s.CreateObject != nil {
+		v := s.CreateObject
+
+		e.SetFields(protocol.BodyTarget, "CreateObject", v, protocol.Metadata{})
+	}
+	if s.DeleteObject != nil {
+		v := s.DeleteObject
+
+		e.SetFields(protocol.BodyTarget, "DeleteObject", v, protocol.Metadata{})
+	}
+	if s.DetachFromIndex != nil {
+		v := s.DetachFromIndex
+
+		e.SetFields(protocol.BodyTarget, "DetachFromIndex", v, protocol.Metadata{})
+	}
+	if s.DetachObject != nil {
+		v := s.DetachObject
+
+		e.SetFields(protocol.BodyTarget, "DetachObject", v, protocol.Metadata{})
+	}
+	if s.DetachPolicy != nil {
+		v := s.DetachPolicy
+
+		e.SetFields(protocol.BodyTarget, "DetachPolicy", v, protocol.Metadata{})
+	}
+	if s.DetachTypedLink != nil {
+		v := s.DetachTypedLink
+
+		e.SetFields(protocol.BodyTarget, "DetachTypedLink", v, protocol.Metadata{})
+	}
+	if s.RemoveFacetFromObject != nil {
+		v := s.RemoveFacetFromObject
+
+		e.SetFields(protocol.BodyTarget, "RemoveFacetFromObject", v, protocol.Metadata{})
+	}
+	if s.UpdateObjectAttributes != nil {
+		v := s.UpdateObjectAttributes
+
+		e.SetFields(protocol.BodyTarget, "UpdateObjectAttributes", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBatchWriteOperationResponseList(vs []*BatchWriteOperationResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchWriteResponse
 type BatchWriteOutput struct {
 	_ struct{} `type:"structure"`
@@ -11980,6 +13465,17 @@ func (s BatchWriteOutput) GoString() string {
 func (s *BatchWriteOutput) SetResponses(v []*BatchWriteOperationResponse) *BatchWriteOutput {
 	s.Responses = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchWriteOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Responses) > 0 {
+		v := s.Responses
+
+		e.SetList(protocol.BodyTarget, "Responses", encodeBatchWriteOperationResponseList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateDirectoryRequest
@@ -12037,6 +13533,22 @@ func (s *CreateDirectoryInput) SetName(v string) *CreateDirectoryInput {
 func (s *CreateDirectoryInput) SetSchemaArn(v string) *CreateDirectoryInput {
 	s.SchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateDirectoryResponse
@@ -12099,6 +13611,32 @@ func (s *CreateDirectoryOutput) SetName(v string) *CreateDirectoryOutput {
 func (s *CreateDirectoryOutput) SetObjectIdentifier(v string) *CreateDirectoryOutput {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AppliedSchemaArn != nil {
+		v := *s.AppliedSchemaArn
+
+		e.SetValue(protocol.BodyTarget, "AppliedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateFacetRequest
@@ -12201,6 +13739,32 @@ func (s *CreateFacetInput) SetSchemaArn(v string) *CreateFacetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeFacetAttributeList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectType != nil {
+		v := *s.ObjectType
+
+		e.SetValue(protocol.BodyTarget, "ObjectType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateFacetResponse
 type CreateFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -12214,6 +13778,12 @@ func (s CreateFacetOutput) String() string {
 // GoString returns the string representation
 func (s CreateFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateIndexRequest
@@ -12316,6 +13886,37 @@ func (s *CreateIndexInput) SetParentReference(v *ObjectReference) *CreateIndexIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateIndexInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsUnique != nil {
+		v := *s.IsUnique
+
+		e.SetValue(protocol.BodyTarget, "IsUnique", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OrderedIndexedAttributeList) > 0 {
+		v := s.OrderedIndexedAttributeList
+
+		e.SetList(protocol.BodyTarget, "OrderedIndexedAttributeList", encodeAttributeKeyList(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateIndexResponse
 type CreateIndexOutput struct {
 	_ struct{} `type:"structure"`
@@ -12338,6 +13939,17 @@ func (s CreateIndexOutput) GoString() string {
 func (s *CreateIndexOutput) SetObjectIdentifier(v string) *CreateIndexOutput {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateObjectRequest
@@ -12446,6 +14058,37 @@ func (s *CreateObjectInput) SetSchemaFacets(v []*SchemaFacet) *CreateObjectInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectAttributeList) > 0 {
+		v := s.ObjectAttributeList
+
+		e.SetList(protocol.BodyTarget, "ObjectAttributeList", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+	if len(s.SchemaFacets) > 0 {
+		v := s.SchemaFacets
+
+		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateObjectResponse
 type CreateObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -12468,6 +14111,17 @@ func (s CreateObjectOutput) GoString() string {
 func (s *CreateObjectOutput) SetObjectIdentifier(v string) *CreateObjectOutput {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateSchemaRequest
@@ -12513,6 +14167,17 @@ func (s *CreateSchemaInput) SetName(v string) *CreateSchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateSchemaResponse
 type CreateSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -12536,6 +14201,17 @@ func (s CreateSchemaOutput) GoString() string {
 func (s *CreateSchemaOutput) SetSchemaArn(v string) *CreateSchemaOutput {
 	s.SchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateTypedLinkFacetRequest
@@ -12597,6 +14273,22 @@ func (s *CreateTypedLinkFacetInput) SetSchemaArn(v string) *CreateTypedLinkFacet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Facet != nil {
+		v := s.Facet
+
+		e.SetFields(protocol.BodyTarget, "Facet", v, protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateTypedLinkFacetResponse
 type CreateTypedLinkFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -12610,6 +14302,12 @@ func (s CreateTypedLinkFacetOutput) String() string {
 // GoString returns the string representation
 func (s CreateTypedLinkFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteDirectoryRequest
@@ -12651,6 +14349,17 @@ func (s *DeleteDirectoryInput) SetDirectoryArn(v string) *DeleteDirectoryInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteDirectoryResponse
 type DeleteDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -12675,6 +14384,17 @@ func (s DeleteDirectoryOutput) GoString() string {
 func (s *DeleteDirectoryOutput) SetDirectoryArn(v string) *DeleteDirectoryOutput {
 	s.DirectoryArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteFacetRequest
@@ -12734,6 +14454,22 @@ func (s *DeleteFacetInput) SetSchemaArn(v string) *DeleteFacetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteFacetResponse
 type DeleteFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -12747,6 +14483,12 @@ func (s DeleteFacetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteObjectRequest
@@ -12803,6 +14545,22 @@ func (s *DeleteObjectInput) SetObjectReference(v *ObjectReference) *DeleteObject
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteObjectResponse
 type DeleteObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -12816,6 +14574,12 @@ func (s DeleteObjectOutput) String() string {
 // GoString returns the string representation
 func (s DeleteObjectOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteSchemaRequest
@@ -12858,6 +14622,17 @@ func (s *DeleteSchemaInput) SetSchemaArn(v string) *DeleteSchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteSchemaResponse
 type DeleteSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -12881,6 +14656,17 @@ func (s DeleteSchemaOutput) GoString() string {
 func (s *DeleteSchemaOutput) SetSchemaArn(v string) *DeleteSchemaOutput {
 	s.SchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteTypedLinkFacetRequest
@@ -12937,6 +14723,22 @@ func (s *DeleteTypedLinkFacetInput) SetSchemaArn(v string) *DeleteTypedLinkFacet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteTypedLinkFacetResponse
 type DeleteTypedLinkFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -12950,6 +14752,12 @@ func (s DeleteTypedLinkFacetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTypedLinkFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachFromIndexRequest
@@ -13020,6 +14828,27 @@ func (s *DetachFromIndexInput) SetTargetReference(v *ObjectReference) *DetachFro
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachFromIndexInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachFromIndexResponse
 type DetachFromIndexOutput struct {
 	_ struct{} `type:"structure"`
@@ -13042,6 +14871,17 @@ func (s DetachFromIndexOutput) GoString() string {
 func (s *DetachFromIndexOutput) SetDetachedObjectIdentifier(v string) *DetachFromIndexOutput {
 	s.DetachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachFromIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetachedObjectIdentifier != nil {
+		v := *s.DetachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachObjectRequest
@@ -13116,6 +14956,27 @@ func (s *DetachObjectInput) SetParentReference(v *ObjectReference) *DetachObject
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachObjectResponse
 type DetachObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -13138,6 +14999,17 @@ func (s DetachObjectOutput) GoString() string {
 func (s *DetachObjectOutput) SetDetachedObjectIdentifier(v string) *DetachObjectOutput {
 	s.DetachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetachedObjectIdentifier != nil {
+		v := *s.DetachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachPolicyRequest
@@ -13208,6 +15080,27 @@ func (s *DetachPolicyInput) SetPolicyReference(v *ObjectReference) *DetachPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachPolicyResponse
 type DetachPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -13221,6 +15114,12 @@ func (s DetachPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DetachPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachTypedLinkRequest
@@ -13282,6 +15181,22 @@ func (s *DetachTypedLinkInput) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *Det
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachTypedLinkInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TypedLinkSpecifier != nil {
+		v := s.TypedLinkSpecifier
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachTypedLinkOutput
 type DetachTypedLinkOutput struct {
 	_ struct{} `type:"structure"`
@@ -13295,6 +15210,12 @@ func (s DetachTypedLinkOutput) String() string {
 // GoString returns the string representation
 func (s DetachTypedLinkOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachTypedLinkOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Directory structure that includes the directory name and directory ARN.
@@ -13350,6 +15271,40 @@ func (s *Directory) SetState(v string) *Directory {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Directory) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDateTime != nil {
+		v := *s.CreationDateTime
+
+		e.SetValue(protocol.BodyTarget, "CreationDateTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDirectoryList(vs []*Directory) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DisableDirectoryRequest
 type DisableDirectoryInput struct {
 	_ struct{} `type:"structure"`
@@ -13389,6 +15344,17 @@ func (s *DisableDirectoryInput) SetDirectoryArn(v string) *DisableDirectoryInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisableDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DisableDirectoryResponse
 type DisableDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -13413,6 +15379,17 @@ func (s DisableDirectoryOutput) GoString() string {
 func (s *DisableDirectoryOutput) SetDirectoryArn(v string) *DisableDirectoryOutput {
 	s.DirectoryArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisableDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/EnableDirectoryRequest
@@ -13454,6 +15431,17 @@ func (s *EnableDirectoryInput) SetDirectoryArn(v string) *EnableDirectoryInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnableDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/EnableDirectoryResponse
 type EnableDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -13478,6 +15466,17 @@ func (s EnableDirectoryOutput) GoString() string {
 func (s *EnableDirectoryOutput) SetDirectoryArn(v string) *EnableDirectoryOutput {
 	s.DirectoryArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnableDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A structure that contains Name, ARN, Attributes, Rules, and ObjectTypes.
@@ -13513,6 +15512,22 @@ func (s *Facet) SetName(v string) *Facet {
 func (s *Facet) SetObjectType(v string) *Facet {
 	s.ObjectType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Facet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectType != nil {
+		v := *s.ObjectType
+
+		e.SetValue(protocol.BodyTarget, "ObjectType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An attribute that is associated with the Facet.
@@ -13599,6 +15614,40 @@ func (s *FacetAttribute) SetRequiredBehavior(v string) *FacetAttribute {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FacetAttribute) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeDefinition != nil {
+		v := s.AttributeDefinition
+
+		e.SetFields(protocol.BodyTarget, "AttributeDefinition", v, protocol.Metadata{})
+	}
+	if s.AttributeReference != nil {
+		v := s.AttributeReference
+
+		e.SetFields(protocol.BodyTarget, "AttributeReference", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequiredBehavior != nil {
+		v := *s.RequiredBehavior
+
+		e.SetValue(protocol.BodyTarget, "RequiredBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFacetAttributeList(vs []*FacetAttribute) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A facet attribute definition. See Attribute References (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences)
 // for more information.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/FacetAttributeDefinition
@@ -13667,6 +15716,32 @@ func (s *FacetAttributeDefinition) SetType(v string) *FacetAttributeDefinition {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FacetAttributeDefinition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultValue != nil {
+		v := s.DefaultValue
+
+		e.SetFields(protocol.BodyTarget, "DefaultValue", v, protocol.Metadata{})
+	}
+	if s.IsImmutable != nil {
+		v := *s.IsImmutable
+
+		e.SetValue(protocol.BodyTarget, "IsImmutable", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetMap(protocol.BodyTarget, "Rules", encodeRuleMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The facet attribute reference that specifies the attribute definition that
 // contains the attribute facet name and attribute name.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/FacetAttributeReference
@@ -13732,6 +15807,22 @@ func (s *FacetAttributeReference) SetTargetFacetName(v string) *FacetAttributeRe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FacetAttributeReference) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TargetAttributeName != nil {
+		v := *s.TargetAttributeName
+
+		e.SetValue(protocol.BodyTarget, "TargetAttributeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetFacetName != nil {
+		v := *s.TargetFacetName
+
+		e.SetValue(protocol.BodyTarget, "TargetFacetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A structure that contains information used to update an attribute.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/FacetAttributeUpdate
 type FacetAttributeUpdate struct {
@@ -13781,6 +15872,30 @@ func (s *FacetAttributeUpdate) SetAttribute(v *FacetAttribute) *FacetAttributeUp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FacetAttributeUpdate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Attribute != nil {
+		v := s.Attribute
+
+		e.SetFields(protocol.BodyTarget, "Attribute", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFacetAttributeUpdateList(vs []*FacetAttributeUpdate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetDirectoryRequest
 type GetDirectoryInput struct {
 	_ struct{} `type:"structure"`
@@ -13820,6 +15935,17 @@ func (s *GetDirectoryInput) SetDirectoryArn(v string) *GetDirectoryInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetDirectoryResponse
 type GetDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -13844,6 +15970,17 @@ func (s GetDirectoryOutput) GoString() string {
 func (s *GetDirectoryOutput) SetDirectory(v *Directory) *GetDirectoryOutput {
 	s.Directory = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Directory != nil {
+		v := s.Directory
+
+		e.SetFields(protocol.BodyTarget, "Directory", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetFacetRequest
@@ -13903,6 +16040,22 @@ func (s *GetFacetInput) SetSchemaArn(v string) *GetFacetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetFacetResponse
 type GetFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -13925,6 +16078,17 @@ func (s GetFacetOutput) GoString() string {
 func (s *GetFacetOutput) SetFacet(v *Facet) *GetFacetOutput {
 	s.Facet = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Facet != nil {
+		v := s.Facet
+
+		e.SetFields(protocol.BodyTarget, "Facet", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetObjectInformationRequest
@@ -13989,6 +16153,27 @@ func (s *GetObjectInformationInput) SetObjectReference(v *ObjectReference) *GetO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectInformationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetObjectInformationResponse
 type GetObjectInformationOutput struct {
 	_ struct{} `type:"structure"`
@@ -14020,6 +16205,22 @@ func (s *GetObjectInformationOutput) SetObjectIdentifier(v string) *GetObjectInf
 func (s *GetObjectInformationOutput) SetSchemaFacets(v []*SchemaFacet) *GetObjectInformationOutput {
 	s.SchemaFacets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectInformationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaFacets) > 0 {
+		v := s.SchemaFacets
+
+		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetSchemaAsJsonRequest
@@ -14061,6 +16262,17 @@ func (s *GetSchemaAsJsonInput) SetSchemaArn(v string) *GetSchemaAsJsonInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSchemaAsJsonInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetSchemaAsJsonResponse
 type GetSchemaAsJsonOutput struct {
 	_ struct{} `type:"structure"`
@@ -14092,6 +16304,22 @@ func (s *GetSchemaAsJsonOutput) SetDocument(v string) *GetSchemaAsJsonOutput {
 func (s *GetSchemaAsJsonOutput) SetName(v string) *GetSchemaAsJsonOutput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSchemaAsJsonOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetTypedLinkFacetInformationRequest
@@ -14148,6 +16376,22 @@ func (s *GetTypedLinkFacetInformationInput) SetSchemaArn(v string) *GetTypedLink
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTypedLinkFacetInformationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetTypedLinkFacetInformationResponse
 type GetTypedLinkFacetInformationOutput struct {
 	_ struct{} `type:"structure"`
@@ -14177,6 +16421,17 @@ func (s GetTypedLinkFacetInformationOutput) GoString() string {
 func (s *GetTypedLinkFacetInformationOutput) SetIdentityAttributeOrder(v []*string) *GetTypedLinkFacetInformationOutput {
 	s.IdentityAttributeOrder = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTypedLinkFacetInformationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IdentityAttributeOrder) > 0 {
+		v := s.IdentityAttributeOrder
+
+		e.SetList(protocol.BodyTarget, "IdentityAttributeOrder", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents an index and an attached object.
@@ -14211,6 +16466,30 @@ func (s *IndexAttachment) SetIndexedAttributes(v []*AttributeKeyAndValue) *Index
 func (s *IndexAttachment) SetObjectIdentifier(v string) *IndexAttachment {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IndexAttachment) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexedAttributes) > 0 {
+		v := s.IndexedAttributes
+
+		e.SetList(protocol.BodyTarget, "IndexedAttributes", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIndexAttachmentList(vs []*IndexAttachment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListAppliedSchemaArnsRequest
@@ -14273,6 +16552,27 @@ func (s *ListAppliedSchemaArnsInput) SetNextToken(v string) *ListAppliedSchemaAr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAppliedSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListAppliedSchemaArnsResponse
 type ListAppliedSchemaArnsOutput struct {
 	_ struct{} `type:"structure"`
@@ -14304,6 +16604,22 @@ func (s *ListAppliedSchemaArnsOutput) SetNextToken(v string) *ListAppliedSchemaA
 func (s *ListAppliedSchemaArnsOutput) SetSchemaArns(v []*string) *ListAppliedSchemaArnsOutput {
 	s.SchemaArns = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAppliedSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaArns) > 0 {
+		v := s.SchemaArns
+
+		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListAttachedIndicesRequest
@@ -14389,6 +16705,37 @@ func (s *ListAttachedIndicesInput) SetTargetReference(v *ObjectReference) *ListA
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAttachedIndicesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListAttachedIndicesResponse
 type ListAttachedIndicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14420,6 +16767,22 @@ func (s *ListAttachedIndicesOutput) SetIndexAttachments(v []*IndexAttachment) *L
 func (s *ListAttachedIndicesOutput) SetNextToken(v string) *ListAttachedIndicesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAttachedIndicesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexAttachments) > 0 {
+		v := s.IndexAttachments
+
+		e.SetList(protocol.BodyTarget, "IndexAttachments", encodeIndexAttachmentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListDevelopmentSchemaArnsRequest
@@ -14468,6 +16831,22 @@ func (s *ListDevelopmentSchemaArnsInput) SetNextToken(v string) *ListDevelopment
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDevelopmentSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListDevelopmentSchemaArnsResponse
 type ListDevelopmentSchemaArnsOutput struct {
 	_ struct{} `type:"structure"`
@@ -14499,6 +16878,22 @@ func (s *ListDevelopmentSchemaArnsOutput) SetNextToken(v string) *ListDevelopmen
 func (s *ListDevelopmentSchemaArnsOutput) SetSchemaArns(v []*string) *ListDevelopmentSchemaArnsOutput {
 	s.SchemaArns = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDevelopmentSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaArns) > 0 {
+		v := s.SchemaArns
+
+		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListDirectoriesRequest
@@ -14557,6 +16952,27 @@ func (s *ListDirectoriesInput) SetState(v string) *ListDirectoriesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDirectoriesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListDirectoriesResponse
 type ListDirectoriesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14591,6 +17007,22 @@ func (s *ListDirectoriesOutput) SetDirectories(v []*Directory) *ListDirectoriesO
 func (s *ListDirectoriesOutput) SetNextToken(v string) *ListDirectoriesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDirectoriesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Directories) > 0 {
+		v := s.Directories
+
+		e.SetList(protocol.BodyTarget, "Directories", encodeDirectoryList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListFacetAttributesRequest
@@ -14670,6 +17102,32 @@ func (s *ListFacetAttributesInput) SetSchemaArn(v string) *ListFacetAttributesIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFacetAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListFacetAttributesResponse
 type ListFacetAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14701,6 +17159,22 @@ func (s *ListFacetAttributesOutput) SetAttributes(v []*FacetAttribute) *ListFace
 func (s *ListFacetAttributesOutput) SetNextToken(v string) *ListFacetAttributesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFacetAttributesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeFacetAttributeList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListFacetNamesRequest
@@ -14763,6 +17237,27 @@ func (s *ListFacetNamesInput) SetSchemaArn(v string) *ListFacetNamesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFacetNamesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListFacetNamesResponse
 type ListFacetNamesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14794,6 +17289,22 @@ func (s *ListFacetNamesOutput) SetFacetNames(v []*string) *ListFacetNamesOutput 
 func (s *ListFacetNamesOutput) SetNextToken(v string) *ListFacetNamesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFacetNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FacetNames) > 0 {
+		v := s.FacetNames
+
+		e.SetList(protocol.BodyTarget, "FacetNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIncomingTypedLinksRequest
@@ -14917,6 +17428,47 @@ func (s *ListIncomingTypedLinksInput) SetObjectReference(v *ObjectReference) *Li
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIncomingTypedLinksInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.BodyTarget, "ConsistencyLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.FilterAttributeRanges) > 0 {
+		v := s.FilterAttributeRanges
+
+		e.SetList(protocol.BodyTarget, "FilterAttributeRanges", encodeTypedLinkAttributeRangeList(v), protocol.Metadata{})
+	}
+	if s.FilterTypedLink != nil {
+		v := s.FilterTypedLink
+
+		e.SetFields(protocol.BodyTarget, "FilterTypedLink", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIncomingTypedLinksResponse
 type ListIncomingTypedLinksOutput struct {
 	_ struct{} `type:"structure"`
@@ -14948,6 +17500,22 @@ func (s *ListIncomingTypedLinksOutput) SetLinkSpecifiers(v []*TypedLinkSpecifier
 func (s *ListIncomingTypedLinksOutput) SetNextToken(v string) *ListIncomingTypedLinksOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIncomingTypedLinksOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LinkSpecifiers) > 0 {
+		v := s.LinkSpecifiers
+
+		e.SetList(protocol.BodyTarget, "LinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIndexRequest
@@ -15052,6 +17620,42 @@ func (s *ListIndexInput) SetRangesOnIndexedValues(v []*ObjectAttributeRange) *Li
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIndexInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RangesOnIndexedValues) > 0 {
+		v := s.RangesOnIndexedValues
+
+		e.SetList(protocol.BodyTarget, "RangesOnIndexedValues", encodeObjectAttributeRangeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIndexResponse
 type ListIndexOutput struct {
 	_ struct{} `type:"structure"`
@@ -15083,6 +17687,22 @@ func (s *ListIndexOutput) SetIndexAttachments(v []*IndexAttachment) *ListIndexOu
 func (s *ListIndexOutput) SetNextToken(v string) *ListIndexOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexAttachments) > 0 {
+		v := s.IndexAttachments
+
+		e.SetList(protocol.BodyTarget, "IndexAttachments", encodeIndexAttachmentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectAttributesRequest
@@ -15186,6 +17806,42 @@ func (s *ListObjectAttributesInput) SetObjectReference(v *ObjectReference) *List
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FacetFilter != nil {
+		v := s.FacetFilter
+
+		e.SetFields(protocol.BodyTarget, "FacetFilter", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectAttributesResponse
 type ListObjectAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15218,6 +17874,22 @@ func (s *ListObjectAttributesOutput) SetAttributes(v []*AttributeKeyAndValue) *L
 func (s *ListObjectAttributesOutput) SetNextToken(v string) *ListObjectAttributesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectAttributesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectChildrenRequest
@@ -15307,6 +17979,37 @@ func (s *ListObjectChildrenInput) SetObjectReference(v *ObjectReference) *ListOb
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectChildrenInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectChildrenResponse
 type ListObjectChildrenOutput struct {
 	_ struct{} `type:"structure"`
@@ -15339,6 +18042,22 @@ func (s *ListObjectChildrenOutput) SetChildren(v map[string]*string) *ListObject
 func (s *ListObjectChildrenOutput) SetNextToken(v string) *ListObjectChildrenOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectChildrenOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Children) > 0 {
+		v := s.Children
+
+		e.SetMap(protocol.BodyTarget, "Children", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectParentPathsRequest
@@ -15416,6 +18135,32 @@ func (s *ListObjectParentPathsInput) SetObjectReference(v *ObjectReference) *Lis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectParentPathsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectParentPathsResponse
 type ListObjectParentPathsOutput struct {
 	_ struct{} `type:"structure"`
@@ -15447,6 +18192,22 @@ func (s *ListObjectParentPathsOutput) SetNextToken(v string) *ListObjectParentPa
 func (s *ListObjectParentPathsOutput) SetPathToObjectIdentifiersList(v []*PathToObjectIdentifiers) *ListObjectParentPathsOutput {
 	s.PathToObjectIdentifiersList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectParentPathsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PathToObjectIdentifiersList) > 0 {
+		v := s.PathToObjectIdentifiersList
+
+		e.SetList(protocol.BodyTarget, "PathToObjectIdentifiersList", encodePathToObjectIdentifiersList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectParentsRequest
@@ -15536,6 +18297,37 @@ func (s *ListObjectParentsInput) SetObjectReference(v *ObjectReference) *ListObj
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectParentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectParentsResponse
 type ListObjectParentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -15568,6 +18360,22 @@ func (s *ListObjectParentsOutput) SetNextToken(v string) *ListObjectParentsOutpu
 func (s *ListObjectParentsOutput) SetParents(v map[string]*string) *ListObjectParentsOutput {
 	s.Parents = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectParentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parents) > 0 {
+		v := s.Parents
+
+		e.SetMap(protocol.BodyTarget, "Parents", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectPoliciesRequest
@@ -15656,6 +18464,37 @@ func (s *ListObjectPoliciesInput) SetObjectReference(v *ObjectReference) *ListOb
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectPoliciesResponse
 type ListObjectPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15687,6 +18526,22 @@ func (s *ListObjectPoliciesOutput) SetAttachedPolicyIds(v []*string) *ListObject
 func (s *ListObjectPoliciesOutput) SetNextToken(v string) *ListObjectPoliciesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttachedPolicyIds) > 0 {
+		v := s.AttachedPolicyIds
+
+		e.SetList(protocol.BodyTarget, "AttachedPolicyIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListOutgoingTypedLinksRequest
@@ -15810,6 +18665,47 @@ func (s *ListOutgoingTypedLinksInput) SetObjectReference(v *ObjectReference) *Li
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOutgoingTypedLinksInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.BodyTarget, "ConsistencyLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.FilterAttributeRanges) > 0 {
+		v := s.FilterAttributeRanges
+
+		e.SetList(protocol.BodyTarget, "FilterAttributeRanges", encodeTypedLinkAttributeRangeList(v), protocol.Metadata{})
+	}
+	if s.FilterTypedLink != nil {
+		v := s.FilterTypedLink
+
+		e.SetFields(protocol.BodyTarget, "FilterTypedLink", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListOutgoingTypedLinksResponse
 type ListOutgoingTypedLinksOutput struct {
 	_ struct{} `type:"structure"`
@@ -15841,6 +18737,22 @@ func (s *ListOutgoingTypedLinksOutput) SetNextToken(v string) *ListOutgoingTyped
 func (s *ListOutgoingTypedLinksOutput) SetTypedLinkSpecifiers(v []*TypedLinkSpecifier) *ListOutgoingTypedLinksOutput {
 	s.TypedLinkSpecifiers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOutgoingTypedLinksOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TypedLinkSpecifiers) > 0 {
+		v := s.TypedLinkSpecifiers
+
+		e.SetList(protocol.BodyTarget, "TypedLinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPolicyAttachmentsRequest
@@ -15929,6 +18841,37 @@ func (s *ListPolicyAttachmentsInput) SetPolicyReference(v *ObjectReference) *Lis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyAttachmentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPolicyAttachmentsResponse
 type ListPolicyAttachmentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -15960,6 +18903,22 @@ func (s *ListPolicyAttachmentsOutput) SetNextToken(v string) *ListPolicyAttachme
 func (s *ListPolicyAttachmentsOutput) SetObjectIdentifiers(v []*string) *ListPolicyAttachmentsOutput {
 	s.ObjectIdentifiers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyAttachmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectIdentifiers) > 0 {
+		v := s.ObjectIdentifiers
+
+		e.SetList(protocol.BodyTarget, "ObjectIdentifiers", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPublishedSchemaArnsRequest
@@ -16008,6 +18967,22 @@ func (s *ListPublishedSchemaArnsInput) SetNextToken(v string) *ListPublishedSche
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPublishedSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPublishedSchemaArnsResponse
 type ListPublishedSchemaArnsOutput struct {
 	_ struct{} `type:"structure"`
@@ -16039,6 +19014,22 @@ func (s *ListPublishedSchemaArnsOutput) SetNextToken(v string) *ListPublishedSch
 func (s *ListPublishedSchemaArnsOutput) SetSchemaArns(v []*string) *ListPublishedSchemaArnsOutput {
 	s.SchemaArns = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPublishedSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaArns) > 0 {
+		v := s.SchemaArns
+
+		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTagsForResourceRequest
@@ -16104,6 +19095,27 @@ func (s *ListTagsForResourceInput) SetResourceArn(v string) *ListTagsForResource
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceArn != nil {
+		v := *s.ResourceArn
+
+		e.SetValue(protocol.BodyTarget, "ResourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTagsForResourceResponse
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -16136,6 +19148,22 @@ func (s *ListTagsForResourceOutput) SetNextToken(v string) *ListTagsForResourceO
 func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetAttributesRequest
@@ -16213,6 +19241,32 @@ func (s *ListTypedLinkFacetAttributesInput) SetSchemaArn(v string) *ListTypedLin
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTypedLinkFacetAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetAttributesResponse
 type ListTypedLinkFacetAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16244,6 +19298,22 @@ func (s *ListTypedLinkFacetAttributesOutput) SetAttributes(v []*TypedLinkAttribu
 func (s *ListTypedLinkFacetAttributesOutput) SetNextToken(v string) *ListTypedLinkFacetAttributesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTypedLinkFacetAttributesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeTypedLinkAttributeDefinitionList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetNamesRequest
@@ -16307,6 +19377,27 @@ func (s *ListTypedLinkFacetNamesInput) SetSchemaArn(v string) *ListTypedLinkFace
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTypedLinkFacetNamesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetNamesResponse
 type ListTypedLinkFacetNamesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16338,6 +19429,22 @@ func (s *ListTypedLinkFacetNamesOutput) SetFacetNames(v []*string) *ListTypedLin
 func (s *ListTypedLinkFacetNamesOutput) SetNextToken(v string) *ListTypedLinkFacetNamesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTypedLinkFacetNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FacetNames) > 0 {
+		v := s.FacetNames
+
+		e.SetList(protocol.BodyTarget, "FacetNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/LookupPolicyRequest
@@ -16416,6 +19523,32 @@ func (s *LookupPolicyInput) SetObjectReference(v *ObjectReference) *LookupPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LookupPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/LookupPolicyResponse
 type LookupPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -16450,6 +19583,22 @@ func (s *LookupPolicyOutput) SetPolicyToPathList(v []*PolicyToPath) *LookupPolic
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LookupPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PolicyToPathList) > 0 {
+		v := s.PolicyToPathList
+
+		e.SetList(protocol.BodyTarget, "PolicyToPathList", encodePolicyToPathList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The action to take on the object attribute.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ObjectAttributeAction
 type ObjectAttributeAction struct {
@@ -16482,6 +19631,22 @@ func (s *ObjectAttributeAction) SetObjectAttributeActionType(v string) *ObjectAt
 func (s *ObjectAttributeAction) SetObjectAttributeUpdateValue(v *TypedAttributeValue) *ObjectAttributeAction {
 	s.ObjectAttributeUpdateValue = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectAttributeAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectAttributeActionType != nil {
+		v := *s.ObjectAttributeActionType
+
+		e.SetValue(protocol.BodyTarget, "ObjectAttributeActionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectAttributeUpdateValue != nil {
+		v := s.ObjectAttributeUpdateValue
+
+		e.SetFields(protocol.BodyTarget, "ObjectAttributeUpdateValue", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A range of attributes.
@@ -16538,6 +19703,30 @@ func (s *ObjectAttributeRange) SetRange(v *TypedAttributeValueRange) *ObjectAttr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectAttributeRange) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeKey != nil {
+		v := s.AttributeKey
+
+		e.SetFields(protocol.BodyTarget, "AttributeKey", v, protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := s.Range
+
+		e.SetFields(protocol.BodyTarget, "Range", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectAttributeRangeList(vs []*ObjectAttributeRange) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Structure that contains attribute update information.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ObjectAttributeUpdate
 type ObjectAttributeUpdate struct {
@@ -16587,6 +19776,30 @@ func (s *ObjectAttributeUpdate) SetObjectAttributeKey(v *AttributeKey) *ObjectAt
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectAttributeUpdate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectAttributeAction != nil {
+		v := s.ObjectAttributeAction
+
+		e.SetFields(protocol.BodyTarget, "ObjectAttributeAction", v, protocol.Metadata{})
+	}
+	if s.ObjectAttributeKey != nil {
+		v := s.ObjectAttributeKey
+
+		e.SetFields(protocol.BodyTarget, "ObjectAttributeKey", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectAttributeUpdateList(vs []*ObjectAttributeUpdate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The reference that identifies an object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ObjectReference
 type ObjectReference struct {
@@ -16626,6 +19839,17 @@ func (s *ObjectReference) SetSelector(v string) *ObjectReference {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectReference) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Selector != nil {
+		v := *s.Selector
+
+		e.SetValue(protocol.BodyTarget, "Selector", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Returns the path to the ObjectIdentifiers that is associated with the directory.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PathToObjectIdentifiers
 type PathToObjectIdentifiers struct {
@@ -16659,6 +19883,30 @@ func (s *PathToObjectIdentifiers) SetObjectIdentifiers(v []*string) *PathToObjec
 func (s *PathToObjectIdentifiers) SetPath(v string) *PathToObjectIdentifiers {
 	s.Path = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PathToObjectIdentifiers) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ObjectIdentifiers) > 0 {
+		v := s.ObjectIdentifiers
+
+		e.SetList(protocol.BodyTarget, "ObjectIdentifiers", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePathToObjectIdentifiersList(vs []*PathToObjectIdentifiers) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Contains the PolicyType, PolicyId, and the ObjectIdentifier to which it is
@@ -16705,6 +19953,35 @@ func (s *PolicyAttachment) SetPolicyType(v string) *PolicyAttachment {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PolicyAttachment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyId != nil {
+		v := *s.PolicyId
+
+		e.SetValue(protocol.BodyTarget, "PolicyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyType != nil {
+		v := *s.PolicyType
+
+		e.SetValue(protocol.BodyTarget, "PolicyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePolicyAttachmentList(vs []*PolicyAttachment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Used when a regular object exists in a Directory and you want to find all
 // of the policies that are associated with that object and the parent to that
 // object.
@@ -16739,6 +20016,30 @@ func (s *PolicyToPath) SetPath(v string) *PolicyToPath {
 func (s *PolicyToPath) SetPolicies(v []*PolicyAttachment) *PolicyToPath {
 	s.Policies = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PolicyToPath) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Policies) > 0 {
+		v := s.Policies
+
+		e.SetList(protocol.BodyTarget, "Policies", encodePolicyAttachmentList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePolicyToPathList(vs []*PolicyToPath) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PublishSchemaRequest
@@ -16811,6 +20112,27 @@ func (s *PublishSchemaInput) SetVersion(v string) *PublishSchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DevelopmentSchemaArn != nil {
+		v := *s.DevelopmentSchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PublishSchemaResponse
 type PublishSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -16834,6 +20156,17 @@ func (s PublishSchemaOutput) GoString() string {
 func (s *PublishSchemaOutput) SetPublishedSchemaArn(v string) *PublishSchemaOutput {
 	s.PublishedSchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PublishedSchemaArn != nil {
+		v := *s.PublishedSchemaArn
+
+		e.SetValue(protocol.BodyTarget, "PublishedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PutSchemaFromJsonRequest
@@ -16889,6 +20222,22 @@ func (s *PutSchemaFromJsonInput) SetSchemaArn(v string) *PutSchemaFromJsonInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutSchemaFromJsonInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PutSchemaFromJsonResponse
 type PutSchemaFromJsonOutput struct {
 	_ struct{} `type:"structure"`
@@ -16911,6 +20260,17 @@ func (s PutSchemaFromJsonOutput) GoString() string {
 func (s *PutSchemaFromJsonOutput) SetArn(v string) *PutSchemaFromJsonOutput {
 	s.Arn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutSchemaFromJsonOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/RemoveFacetFromObjectRequest
@@ -16985,6 +20345,27 @@ func (s *RemoveFacetFromObjectInput) SetSchemaFacet(v *SchemaFacet) *RemoveFacet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveFacetFromObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.SchemaFacet != nil {
+		v := s.SchemaFacet
+
+		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/RemoveFacetFromObjectResponse
 type RemoveFacetFromObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -16998,6 +20379,12 @@ func (s RemoveFacetFromObjectOutput) String() string {
 // GoString returns the string representation
 func (s RemoveFacetFromObjectOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveFacetFromObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Contains an Amazon Resource Name (ARN) and parameters that are associated
@@ -17033,6 +20420,30 @@ func (s *Rule) SetParameters(v map[string]*string) *Rule {
 func (s *Rule) SetType(v string) *Rule {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Rule) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "Parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRuleMap(vs map[string]*Rule) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // A facet.
@@ -17082,6 +20493,30 @@ func (s *SchemaFacet) SetSchemaArn(v string) *SchemaFacet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SchemaFacet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FacetName != nil {
+		v := *s.FacetName
+
+		e.SetValue(protocol.BodyTarget, "FacetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSchemaFacetList(vs []*SchemaFacet) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The tag structure that contains a tag key and value.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/Tag
 type Tag struct {
@@ -17114,6 +20549,30 @@ func (s *Tag) SetKey(v string) *Tag {
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TagResourceRequest
@@ -17170,6 +20629,22 @@ func (s *TagResourceInput) SetTags(v []*Tag) *TagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceArn != nil {
+		v := *s.ResourceArn
+
+		e.SetValue(protocol.BodyTarget, "ResourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TagResourceResponse
 type TagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -17183,6 +20658,12 @@ func (s TagResourceOutput) String() string {
 // GoString returns the string representation
 func (s TagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents the data for a typed attribute. You can set one, and only one,
@@ -17248,6 +20729,37 @@ func (s *TypedAttributeValue) SetNumberValue(v string) *TypedAttributeValue {
 func (s *TypedAttributeValue) SetStringValue(v string) *TypedAttributeValue {
 	s.StringValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedAttributeValue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BinaryValue != nil {
+		v := s.BinaryValue
+
+		e.SetValue(protocol.BodyTarget, "BinaryValue", protocol.BytesValue(v), protocol.Metadata{})
+	}
+	if s.BooleanValue != nil {
+		v := *s.BooleanValue
+
+		e.SetValue(protocol.BodyTarget, "BooleanValue", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DatetimeValue != nil {
+		v := *s.DatetimeValue
+
+		e.SetValue(protocol.BodyTarget, "DatetimeValue", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NumberValue != nil {
+		v := *s.NumberValue
+
+		e.SetValue(protocol.BodyTarget, "NumberValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StringValue != nil {
+		v := *s.StringValue
+
+		e.SetValue(protocol.BodyTarget, "StringValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A range of attribute values.
@@ -17320,6 +20832,32 @@ func (s *TypedAttributeValueRange) SetStartMode(v string) *TypedAttributeValueRa
 func (s *TypedAttributeValueRange) SetStartValue(v *TypedAttributeValue) *TypedAttributeValueRange {
 	s.StartValue = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedAttributeValueRange) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndMode != nil {
+		v := *s.EndMode
+
+		e.SetValue(protocol.BodyTarget, "EndMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndValue != nil {
+		v := s.EndValue
+
+		e.SetFields(protocol.BodyTarget, "EndValue", v, protocol.Metadata{})
+	}
+	if s.StartMode != nil {
+		v := *s.StartMode
+
+		e.SetValue(protocol.BodyTarget, "StartMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartValue != nil {
+		v := s.StartValue
+
+		e.SetFields(protocol.BodyTarget, "StartValue", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A typed link attribute definition.
@@ -17420,6 +20958,50 @@ func (s *TypedLinkAttributeDefinition) SetType(v string) *TypedLinkAttributeDefi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkAttributeDefinition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultValue != nil {
+		v := s.DefaultValue
+
+		e.SetFields(protocol.BodyTarget, "DefaultValue", v, protocol.Metadata{})
+	}
+	if s.IsImmutable != nil {
+		v := *s.IsImmutable
+
+		e.SetValue(protocol.BodyTarget, "IsImmutable", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequiredBehavior != nil {
+		v := *s.RequiredBehavior
+
+		e.SetValue(protocol.BodyTarget, "RequiredBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetMap(protocol.BodyTarget, "Rules", encodeRuleMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTypedLinkAttributeDefinitionList(vs []*TypedLinkAttributeDefinition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Identifies the range of attributes that are used by a specified filter.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkAttributeRange
 type TypedLinkAttributeRange struct {
@@ -17475,6 +21057,30 @@ func (s *TypedLinkAttributeRange) SetAttributeName(v string) *TypedLinkAttribute
 func (s *TypedLinkAttributeRange) SetRange(v *TypedAttributeValueRange) *TypedLinkAttributeRange {
 	s.Range = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkAttributeRange) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeName != nil {
+		v := *s.AttributeName
+
+		e.SetValue(protocol.BodyTarget, "AttributeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := s.Range
+
+		e.SetFields(protocol.BodyTarget, "Range", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTypedLinkAttributeRangeList(vs []*TypedLinkAttributeRange) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Defines the typed links structure and its attributes. To create a typed link
@@ -17562,6 +21168,27 @@ func (s *TypedLinkFacet) SetName(v string) *TypedLinkFacet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkFacet) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeTypedLinkAttributeDefinitionList(v), protocol.Metadata{})
+	}
+	if len(s.IdentityAttributeOrder) > 0 {
+		v := s.IdentityAttributeOrder
+
+		e.SetList(protocol.BodyTarget, "IdentityAttributeOrder", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A typed link facet attribute update.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkFacetAttributeUpdate
 type TypedLinkFacetAttributeUpdate struct {
@@ -17621,6 +21248,30 @@ func (s *TypedLinkFacetAttributeUpdate) SetAttribute(v *TypedLinkAttributeDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkFacetAttributeUpdate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Attribute != nil {
+		v := s.Attribute
+
+		e.SetFields(protocol.BodyTarget, "Attribute", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTypedLinkFacetAttributeUpdateList(vs []*TypedLinkFacetAttributeUpdate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Identifies the schema Amazon Resource Name (ARN) and facet name for the typed
 // link.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkSchemaAndFacetName
@@ -17675,6 +21326,22 @@ func (s *TypedLinkSchemaAndFacetName) SetSchemaArn(v string) *TypedLinkSchemaAnd
 func (s *TypedLinkSchemaAndFacetName) SetTypedLinkName(v string) *TypedLinkSchemaAndFacetName {
 	s.TypedLinkName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkSchemaAndFacetName) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TypedLinkName != nil {
+		v := *s.TypedLinkName
+
+		e.SetValue(protocol.BodyTarget, "TypedLinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains all the information that is used to uniquely identify a typed link.
@@ -17779,6 +21446,40 @@ func (s *TypedLinkSpecifier) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkSpecifier) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IdentityAttributeValues) > 0 {
+		v := s.IdentityAttributeValues
+
+		e.SetList(protocol.BodyTarget, "IdentityAttributeValues", encodeAttributeNameAndValueList(v), protocol.Metadata{})
+	}
+	if s.SourceObjectReference != nil {
+		v := s.SourceObjectReference
+
+		e.SetFields(protocol.BodyTarget, "SourceObjectReference", v, protocol.Metadata{})
+	}
+	if s.TargetObjectReference != nil {
+		v := s.TargetObjectReference
+
+		e.SetFields(protocol.BodyTarget, "TargetObjectReference", v, protocol.Metadata{})
+	}
+	if s.TypedLinkFacet != nil {
+		v := s.TypedLinkFacet
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTypedLinkSpecifierList(vs []*TypedLinkSpecifier) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UntagResourceRequest
 type UntagResourceInput struct {
 	_ struct{} `type:"structure"`
@@ -17833,6 +21534,22 @@ func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceArn != nil {
+		v := *s.ResourceArn
+
+		e.SetValue(protocol.BodyTarget, "ResourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UntagResourceResponse
 type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -17846,6 +21563,12 @@ func (s UntagResourceOutput) String() string {
 // GoString returns the string representation
 func (s UntagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateFacetRequest
@@ -17936,6 +21659,32 @@ func (s *UpdateFacetInput) SetSchemaArn(v string) *UpdateFacetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttributeUpdates) > 0 {
+		v := s.AttributeUpdates
+
+		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeFacetAttributeUpdateList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectType != nil {
+		v := *s.ObjectType
+
+		e.SetValue(protocol.BodyTarget, "ObjectType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateFacetResponse
 type UpdateFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -17949,6 +21698,12 @@ func (s UpdateFacetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateObjectAttributesRequest
@@ -18029,6 +21784,27 @@ func (s *UpdateObjectAttributesInput) SetObjectReference(v *ObjectReference) *Up
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateObjectAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttributeUpdates) > 0 {
+		v := s.AttributeUpdates
+
+		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeObjectAttributeUpdateList(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateObjectAttributesResponse
 type UpdateObjectAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -18051,6 +21827,17 @@ func (s UpdateObjectAttributesOutput) GoString() string {
 func (s *UpdateObjectAttributesOutput) SetObjectIdentifier(v string) *UpdateObjectAttributesOutput {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateObjectAttributesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateSchemaRequest
@@ -18110,6 +21897,22 @@ func (s *UpdateSchemaInput) SetSchemaArn(v string) *UpdateSchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateSchemaResponse
 type UpdateSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -18133,6 +21936,17 @@ func (s UpdateSchemaOutput) GoString() string {
 func (s *UpdateSchemaOutput) SetSchemaArn(v string) *UpdateSchemaOutput {
 	s.SchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateTypedLinkFacetRequest
@@ -18234,6 +22048,32 @@ func (s *UpdateTypedLinkFacetInput) SetSchemaArn(v string) *UpdateTypedLinkFacet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttributeUpdates) > 0 {
+		v := s.AttributeUpdates
+
+		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeTypedLinkFacetAttributeUpdateList(v), protocol.Metadata{})
+	}
+	if len(s.IdentityAttributeOrder) > 0 {
+		v := s.IdentityAttributeOrder
+
+		e.SetList(protocol.BodyTarget, "IdentityAttributeOrder", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateTypedLinkFacetResponse
 type UpdateTypedLinkFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -18247,6 +22087,12 @@ func (s UpdateTypedLinkFacetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateTypedLinkFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 const (

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opSearch = "Search"
@@ -328,6 +329,30 @@ func (s *Bucket) SetValue(v string) *Bucket {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Bucket) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBucketList(vs []*Bucket) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A container for the calculated facet values and counts.
 type BucketInfo struct {
 	_ struct{} `type:"structure"`
@@ -350,6 +375,25 @@ func (s BucketInfo) GoString() string {
 func (s *BucketInfo) SetBuckets(v []*Bucket) *BucketInfo {
 	s.Buckets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BucketInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Buckets) > 0 {
+		v := s.Buckets
+
+		e.SetList(protocol.BodyTarget, "buckets", encodeBucketList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBucketInfoMap(vs map[string]*BucketInfo) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // A warning returned by the document service when an issue is discovered while
@@ -375,6 +419,25 @@ func (s DocumentServiceWarning) GoString() string {
 func (s *DocumentServiceWarning) SetMessage(v string) *DocumentServiceWarning {
 	s.Message = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentServiceWarning) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentServiceWarningList(vs []*DocumentServiceWarning) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The statistics for a field calculated in the request.
@@ -486,6 +549,60 @@ func (s *FieldStats) SetSumOfSquares(v float64) *FieldStats {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FieldStats) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Max != nil {
+		v := *s.Max
+
+		e.SetValue(protocol.BodyTarget, "max", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Mean != nil {
+		v := *s.Mean
+
+		e.SetValue(protocol.BodyTarget, "mean", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Min != nil {
+		v := *s.Min
+
+		e.SetValue(protocol.BodyTarget, "min", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Missing != nil {
+		v := *s.Missing
+
+		e.SetValue(protocol.BodyTarget, "missing", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Stddev != nil {
+		v := *s.Stddev
+
+		e.SetValue(protocol.BodyTarget, "stddev", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Sum != nil {
+		v := *s.Sum
+
+		e.SetValue(protocol.BodyTarget, "sum", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.SumOfSquares != nil {
+		v := *s.SumOfSquares
+
+		e.SetValue(protocol.BodyTarget, "sumOfSquares", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFieldStatsMap(vs map[string]*FieldStats) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Information about a document that matches the search request.
 type Hit struct {
 	_ struct{} `type:"structure"`
@@ -535,6 +652,45 @@ func (s *Hit) SetHighlights(v map[string]*string) *Hit {
 func (s *Hit) SetId(v string) *Hit {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Hit) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Exprs) > 0 {
+		v := s.Exprs
+
+		e.SetMap(protocol.BodyTarget, "exprs", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.Fields) > 0 {
+		v := s.Fields
+
+		e.SetMap(protocol.BodyTarget, "fields", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.Highlights) > 0 {
+		v := s.Highlights
+
+		e.SetMap(protocol.BodyTarget, "highlights", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHitList(vs []*Hit) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The collection of documents that match the search request.
@@ -587,6 +743,32 @@ func (s *Hits) SetHit(v []*Hit) *Hits {
 func (s *Hits) SetStart(v int64) *Hits {
 	s.Start = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Hits) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Cursor != nil {
+		v := *s.Cursor
+
+		e.SetValue(protocol.BodyTarget, "cursor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Found != nil {
+		v := *s.Found
+
+		e.SetValue(protocol.BodyTarget, "found", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Hit) > 0 {
+		v := s.Hit
+
+		e.SetList(protocol.BodyTarget, "hit", encodeHitList(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.BodyTarget, "start", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the Search request.
@@ -1000,6 +1182,82 @@ func (s *SearchInput) SetStats(v string) *SearchInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SearchInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Cursor != nil {
+		v := *s.Cursor
+
+		e.SetValue(protocol.QueryTarget, "cursor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expr != nil {
+		v := *s.Expr
+
+		e.SetValue(protocol.QueryTarget, "expr", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Facet != nil {
+		v := *s.Facet
+
+		e.SetValue(protocol.QueryTarget, "facet", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilterQuery != nil {
+		v := *s.FilterQuery
+
+		e.SetValue(protocol.QueryTarget, "fq", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Highlight != nil {
+		v := *s.Highlight
+
+		e.SetValue(protocol.QueryTarget, "highlight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Partial != nil {
+		v := *s.Partial
+
+		e.SetValue(protocol.QueryTarget, "partial", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Query != nil {
+		v := *s.Query
+
+		e.SetValue(protocol.QueryTarget, "q", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.QueryOptions != nil {
+		v := *s.QueryOptions
+
+		e.SetValue(protocol.QueryTarget, "q.options", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.QueryParser != nil {
+		v := *s.QueryParser
+
+		e.SetValue(protocol.QueryTarget, "q.parser", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Return != nil {
+		v := *s.Return
+
+		e.SetValue(protocol.QueryTarget, "return", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.QueryTarget, "size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Sort != nil {
+		v := *s.Sort
+
+		e.SetValue(protocol.QueryTarget, "sort", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.QueryTarget, "start", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Stats != nil {
+		v := *s.Stats
+
+		e.SetValue(protocol.QueryTarget, "stats", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a Search request. Contains the documents that match the specified
 // search criteria and any requested fields, highlights, and facet information.
 type SearchOutput struct {
@@ -1052,6 +1310,32 @@ func (s *SearchOutput) SetStatus(v *SearchStatus) *SearchOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SearchOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Facets) > 0 {
+		v := s.Facets
+
+		e.SetMap(protocol.BodyTarget, "facets", encodeBucketInfoMap(v), protocol.Metadata{})
+	}
+	if s.Hits != nil {
+		v := s.Hits
+
+		e.SetFields(protocol.BodyTarget, "hits", v, protocol.Metadata{})
+	}
+	if len(s.Stats) > 0 {
+		v := s.Stats
+
+		e.SetMap(protocol.BodyTarget, "stats", encodeFieldStatsMap(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "status", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SearchStatus struct {
@@ -1084,6 +1368,22 @@ func (s *SearchStatus) SetRid(v string) *SearchStatus {
 func (s *SearchStatus) SetTimems(v int64) *SearchStatus {
 	s.Timems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SearchStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Rid != nil {
+		v := *s.Rid
+
+		e.SetValue(protocol.BodyTarget, "rid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timems != nil {
+		v := *s.Timems
+
+		e.SetValue(protocol.BodyTarget, "timems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the Suggest request.
@@ -1148,6 +1448,27 @@ func (s *SuggestInput) SetSuggester(v string) *SuggestInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Query != nil {
+		v := *s.Query
+
+		e.SetValue(protocol.QueryTarget, "q", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.QueryTarget, "size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Suggester != nil {
+		v := *s.Suggester
+
+		e.SetValue(protocol.QueryTarget, "suggester", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the suggestion information returned in a SuggestResponse.
 type SuggestModel struct {
 	_ struct{} `type:"structure"`
@@ -1190,6 +1511,27 @@ func (s *SuggestModel) SetSuggestions(v []*SuggestionMatch) *SuggestModel {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestModel) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Found != nil {
+		v := *s.Found
+
+		e.SetValue(protocol.BodyTarget, "found", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Query != nil {
+		v := *s.Query
+
+		e.SetValue(protocol.BodyTarget, "query", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Suggestions) > 0 {
+		v := s.Suggestions
+
+		e.SetList(protocol.BodyTarget, "suggestions", encodeSuggestionMatchList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the response to a Suggest request.
 type SuggestOutput struct {
 	_ struct{} `type:"structure"`
@@ -1224,6 +1566,22 @@ func (s *SuggestOutput) SetSuggest(v *SuggestModel) *SuggestOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "status", v, protocol.Metadata{})
+	}
+	if s.Suggest != nil {
+		v := s.Suggest
+
+		e.SetFields(protocol.BodyTarget, "suggest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SuggestStatus struct {
@@ -1256,6 +1614,22 @@ func (s *SuggestStatus) SetRid(v string) *SuggestStatus {
 func (s *SuggestStatus) SetTimems(v int64) *SuggestStatus {
 	s.Timems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Rid != nil {
+		v := *s.Rid
+
+		e.SetValue(protocol.BodyTarget, "rid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timems != nil {
+		v := *s.Timems
+
+		e.SetValue(protocol.BodyTarget, "timems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An autocomplete suggestion that matches the query string specified in a SuggestRequest.
@@ -1298,6 +1672,35 @@ func (s *SuggestionMatch) SetScore(v int64) *SuggestionMatch {
 func (s *SuggestionMatch) SetSuggestion(v string) *SuggestionMatch {
 	s.Suggestion = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestionMatch) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Score != nil {
+		v := *s.Score
+
+		e.SetValue(protocol.BodyTarget, "score", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Suggestion != nil {
+		v := *s.Suggestion
+
+		e.SetValue(protocol.BodyTarget, "suggestion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSuggestionMatchList(vs []*SuggestionMatch) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for the parameters to the UploadDocuments request.
@@ -1357,6 +1760,22 @@ func (s *UploadDocumentsInput) SetDocuments(v io.ReadSeeker) *UploadDocumentsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadDocumentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Documents != nil {
+		v := s.Documents
+
+		e.SetStream(protocol.PayloadTarget, "documents", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the response to an UploadDocuments request.
 type UploadDocumentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1406,6 +1825,32 @@ func (s *UploadDocumentsOutput) SetStatus(v string) *UploadDocumentsOutput {
 func (s *UploadDocumentsOutput) SetWarnings(v []*DocumentServiceWarning) *UploadDocumentsOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadDocumentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Adds != nil {
+		v := *s.Adds
+
+		e.SetValue(protocol.BodyTarget, "adds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Deletes != nil {
+		v := *s.Deletes
+
+		e.SetValue(protocol.BodyTarget, "deletes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", encodeDocumentServiceWarningList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -1713,6 +1713,17 @@ func (s *BulkPublishInput) SetIdentityPoolId(v string) *BulkPublishInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BulkPublishInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the BulkPublish operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/BulkPublishResponse
 type BulkPublishOutput struct {
@@ -1737,6 +1748,17 @@ func (s BulkPublishOutput) GoString() string {
 func (s *BulkPublishOutput) SetIdentityPoolId(v string) *BulkPublishOutput {
 	s.IdentityPoolId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BulkPublishOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Configuration options for configure Cognito streams.
@@ -1803,6 +1825,27 @@ func (s *CognitoStreams) SetStreamName(v string) *CognitoStreams {
 func (s *CognitoStreams) SetStreamingStatus(v string) *CognitoStreams {
 	s.StreamingStatus = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CognitoStreams) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamName != nil {
+		v := *s.StreamName
+
+		e.SetValue(protocol.BodyTarget, "StreamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingStatus != nil {
+		v := *s.StreamingStatus
+
+		e.SetValue(protocol.BodyTarget, "StreamingStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A collection of data for an identity pool. An identity pool can have multiple
@@ -1890,6 +1933,55 @@ func (s *Dataset) SetNumRecords(v int64) *Dataset {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Dataset) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.DataStorage != nil {
+		v := *s.DataStorage
+
+		e.SetValue(protocol.BodyTarget, "DataStorage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.BodyTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.BodyTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NumRecords != nil {
+		v := *s.NumRecords
+
+		e.SetValue(protocol.BodyTarget, "NumRecords", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDatasetList(vs []*Dataset) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A request to delete the specific dataset.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DeleteDatasetRequest
 type DeleteDatasetInput struct {
@@ -1970,6 +2062,27 @@ func (s *DeleteDatasetInput) SetIdentityPoolId(v string) *DeleteDatasetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a successful DeleteDataset request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DeleteDatasetResponse
 type DeleteDatasetOutput struct {
@@ -1997,6 +2110,17 @@ func (s DeleteDatasetOutput) GoString() string {
 func (s *DeleteDatasetOutput) SetDataset(v *Dataset) *DeleteDatasetOutput {
 	s.Dataset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Dataset != nil {
+		v := s.Dataset
+
+		e.SetFields(protocol.BodyTarget, "Dataset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for meta data about a dataset (creation date, number of records,
@@ -2080,6 +2204,27 @@ func (s *DescribeDatasetInput) SetIdentityPoolId(v string) *DescribeDatasetInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a successful DescribeDataset request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DescribeDatasetResponse
 type DescribeDatasetOutput struct {
@@ -2107,6 +2252,17 @@ func (s DescribeDatasetOutput) GoString() string {
 func (s *DescribeDatasetOutput) SetDataset(v *Dataset) *DescribeDatasetOutput {
 	s.Dataset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Dataset != nil {
+		v := s.Dataset
+
+		e.SetFields(protocol.BodyTarget, "Dataset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for usage information about the identity pool.
@@ -2153,6 +2309,17 @@ func (s *DescribeIdentityPoolUsageInput) SetIdentityPoolId(v string) *DescribeId
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeIdentityPoolUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a successful DescribeIdentityPoolUsage request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DescribeIdentityPoolUsageResponse
 type DescribeIdentityPoolUsageOutput struct {
@@ -2176,6 +2343,17 @@ func (s DescribeIdentityPoolUsageOutput) GoString() string {
 func (s *DescribeIdentityPoolUsageOutput) SetIdentityPoolUsage(v *IdentityPoolUsage) *DescribeIdentityPoolUsageOutput {
 	s.IdentityPoolUsage = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeIdentityPoolUsageOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolUsage != nil {
+		v := s.IdentityPoolUsage
+
+		e.SetFields(protocol.BodyTarget, "IdentityPoolUsage", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for information about the usage of an identity pool.
@@ -2240,6 +2418,22 @@ func (s *DescribeIdentityUsageInput) SetIdentityPoolId(v string) *DescribeIdenti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeIdentityUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The response to a successful DescribeIdentityUsage request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DescribeIdentityUsageResponse
 type DescribeIdentityUsageOutput struct {
@@ -2263,6 +2457,17 @@ func (s DescribeIdentityUsageOutput) GoString() string {
 func (s *DescribeIdentityUsageOutput) SetIdentityUsage(v *IdentityUsage) *DescribeIdentityUsageOutput {
 	s.IdentityUsage = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeIdentityUsageOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityUsage != nil {
+		v := s.IdentityUsage
+
+		e.SetFields(protocol.BodyTarget, "IdentityUsage", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetBulkPublishDetails operation.
@@ -2307,6 +2512,17 @@ func (s *GetBulkPublishDetailsInput) Validate() error {
 func (s *GetBulkPublishDetailsInput) SetIdentityPoolId(v string) *GetBulkPublishDetailsInput {
 	s.IdentityPoolId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBulkPublishDetailsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output for the GetBulkPublishDetails operation.
@@ -2382,6 +2598,37 @@ func (s *GetBulkPublishDetailsOutput) SetIdentityPoolId(v string) *GetBulkPublis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBulkPublishDetailsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BulkPublishCompleteTime != nil {
+		v := *s.BulkPublishCompleteTime
+
+		e.SetValue(protocol.BodyTarget, "BulkPublishCompleteTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.BulkPublishStartTime != nil {
+		v := *s.BulkPublishStartTime
+
+		e.SetValue(protocol.BodyTarget, "BulkPublishStartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.BulkPublishStatus != nil {
+		v := *s.BulkPublishStatus
+
+		e.SetValue(protocol.BodyTarget, "BulkPublishStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureMessage != nil {
+		v := *s.FailureMessage
+
+		e.SetValue(protocol.BodyTarget, "FailureMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request for a list of the configured Cognito Events
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/GetCognitoEventsRequest
 type GetCognitoEventsInput struct {
@@ -2425,6 +2672,17 @@ func (s *GetCognitoEventsInput) SetIdentityPoolId(v string) *GetCognitoEventsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCognitoEventsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The response from the GetCognitoEvents request
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/GetCognitoEventsResponse
 type GetCognitoEventsOutput struct {
@@ -2448,6 +2706,17 @@ func (s GetCognitoEventsOutput) GoString() string {
 func (s *GetCognitoEventsOutput) SetEvents(v map[string]*string) *GetCognitoEventsOutput {
 	s.Events = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCognitoEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetMap(protocol.BodyTarget, "Events", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetIdentityPoolConfiguration operation.
@@ -2495,6 +2764,17 @@ func (s *GetIdentityPoolConfigurationInput) SetIdentityPoolId(v string) *GetIden
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIdentityPoolConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the GetIdentityPoolConfiguration operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/GetIdentityPoolConfigurationResponse
 type GetIdentityPoolConfigurationOutput struct {
@@ -2537,6 +2817,27 @@ func (s *GetIdentityPoolConfigurationOutput) SetIdentityPoolId(v string) *GetIde
 func (s *GetIdentityPoolConfigurationOutput) SetPushSync(v *PushSync) *GetIdentityPoolConfigurationOutput {
 	s.PushSync = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIdentityPoolConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CognitoStreams != nil {
+		v := s.CognitoStreams
+
+		e.SetFields(protocol.BodyTarget, "CognitoStreams", v, protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PushSync != nil {
+		v := s.PushSync
+
+		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Usage information for the identity pool.
@@ -2590,6 +2891,40 @@ func (s *IdentityPoolUsage) SetLastModifiedDate(v time.Time) *IdentityPoolUsage 
 func (s *IdentityPoolUsage) SetSyncSessionsCount(v int64) *IdentityPoolUsage {
 	s.SyncSessionsCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IdentityPoolUsage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DataStorage != nil {
+		v := *s.DataStorage
+
+		e.SetValue(protocol.BodyTarget, "DataStorage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.SyncSessionsCount != nil {
+		v := *s.SyncSessionsCount
+
+		e.SetValue(protocol.BodyTarget, "SyncSessionsCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIdentityPoolUsageList(vs []*IdentityPoolUsage) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Usage information for the identity.
@@ -2653,6 +2988,37 @@ func (s *IdentityUsage) SetIdentityPoolId(v string) *IdentityUsage {
 func (s *IdentityUsage) SetLastModifiedDate(v time.Time) *IdentityUsage {
 	s.LastModifiedDate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IdentityUsage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DataStorage != nil {
+		v := *s.DataStorage
+
+		e.SetValue(protocol.BodyTarget, "DataStorage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DatasetCount != nil {
+		v := *s.DatasetCount
+
+		e.SetValue(protocol.BodyTarget, "DatasetCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.BodyTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request for a list of datasets for an identity.
@@ -2735,6 +3101,32 @@ func (s *ListDatasetsInput) SetNextToken(v string) *ListDatasetsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDatasetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Returned for a successful ListDatasets request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/ListDatasetsResponse
 type ListDatasetsOutput struct {
@@ -2778,6 +3170,27 @@ func (s *ListDatasetsOutput) SetNextToken(v string) *ListDatasetsOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDatasetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Datasets) > 0 {
+		v := s.Datasets
+
+		e.SetList(protocol.BodyTarget, "Datasets", encodeDatasetList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request for usage information on an identity pool.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/ListIdentityPoolUsageRequest
 type ListIdentityPoolUsageInput struct {
@@ -2810,6 +3223,22 @@ func (s *ListIdentityPoolUsageInput) SetMaxResults(v int64) *ListIdentityPoolUsa
 func (s *ListIdentityPoolUsageInput) SetNextToken(v string) *ListIdentityPoolUsageInput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIdentityPoolUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returned for a successful ListIdentityPoolUsage request.
@@ -2862,6 +3291,32 @@ func (s *ListIdentityPoolUsageOutput) SetMaxResults(v int64) *ListIdentityPoolUs
 func (s *ListIdentityPoolUsageOutput) SetNextToken(v string) *ListIdentityPoolUsageOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIdentityPoolUsageOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.IdentityPoolUsages) > 0 {
+		v := s.IdentityPoolUsages
+
+		e.SetList(protocol.BodyTarget, "IdentityPoolUsages", encodeIdentityPoolUsageList(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for a list of records.
@@ -2980,6 +3435,47 @@ func (s *ListRecordsInput) SetSyncSessionToken(v string) *ListRecordsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastSyncCount != nil {
+		v := *s.LastSyncCount
+
+		e.SetValue(protocol.QueryTarget, "lastSyncCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncSessionToken != nil {
+		v := *s.SyncSessionToken
+
+		e.SetValue(protocol.QueryTarget, "syncSessionToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Returned for a successful ListRecordsRequest.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/ListRecordsResponse
 type ListRecordsOutput struct {
@@ -3077,6 +3573,57 @@ func (s *ListRecordsOutput) SetSyncSessionToken(v string) *ListRecordsOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DatasetDeletedAfterRequestedSyncCount != nil {
+		v := *s.DatasetDeletedAfterRequestedSyncCount
+
+		e.SetValue(protocol.BodyTarget, "DatasetDeletedAfterRequestedSyncCount", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DatasetExists != nil {
+		v := *s.DatasetExists
+
+		e.SetValue(protocol.BodyTarget, "DatasetExists", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DatasetSyncCount != nil {
+		v := *s.DatasetSyncCount
+
+		e.SetValue(protocol.BodyTarget, "DatasetSyncCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.MergedDatasetNames) > 0 {
+		v := s.MergedDatasetNames
+
+		e.SetList(protocol.BodyTarget, "MergedDatasetNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Records) > 0 {
+		v := s.Records
+
+		e.SetList(protocol.BodyTarget, "Records", encodeRecordList(v), protocol.Metadata{})
+	}
+	if s.SyncSessionToken != nil {
+		v := *s.SyncSessionToken
+
+		e.SetValue(protocol.BodyTarget, "SyncSessionToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Configuration options to be applied to the identity pool.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/PushSync
 type PushSync struct {
@@ -3122,6 +3669,22 @@ func (s *PushSync) SetApplicationArns(v []*string) *PushSync {
 func (s *PushSync) SetRoleArn(v string) *PushSync {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PushSync) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ApplicationArns) > 0 {
+		v := s.ApplicationArns
+
+		e.SetList(protocol.BodyTarget, "ApplicationArns", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The basic data structure of a dataset.
@@ -3192,6 +3755,50 @@ func (s *Record) SetSyncCount(v int64) *Record {
 func (s *Record) SetValue(v string) *Record {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Record) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceLastModifiedDate != nil {
+		v := *s.DeviceLastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "DeviceLastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.SyncCount != nil {
+		v := *s.SyncCount
+
+		e.SetValue(protocol.BodyTarget, "SyncCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRecordList(vs []*Record) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // An update operation for a record.
@@ -3281,6 +3888,45 @@ func (s *RecordPatch) SetSyncCount(v int64) *RecordPatch {
 func (s *RecordPatch) SetValue(v string) *RecordPatch {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RecordPatch) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceLastModifiedDate != nil {
+		v := *s.DeviceLastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "DeviceLastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Op != nil {
+		v := *s.Op
+
+		e.SetValue(protocol.BodyTarget, "Op", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncCount != nil {
+		v := *s.SyncCount
+
+		e.SetValue(protocol.BodyTarget, "SyncCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRecordPatchList(vs []*RecordPatch) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A request to RegisterDevice.
@@ -3373,6 +4019,32 @@ func (s *RegisterDeviceInput) SetToken(v string) *RegisterDeviceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterDeviceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a RegisterDevice request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/RegisterDeviceResponse
 type RegisterDeviceOutput struct {
@@ -3396,6 +4068,17 @@ func (s RegisterDeviceOutput) GoString() string {
 func (s *RegisterDeviceOutput) SetDeviceId(v string) *RegisterDeviceOutput {
 	s.DeviceId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterDeviceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceId != nil {
+		v := *s.DeviceId
+
+		e.SetValue(protocol.BodyTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to configure Cognito Events"
@@ -3455,6 +4138,22 @@ func (s *SetCognitoEventsInput) SetIdentityPoolId(v string) *SetCognitoEventsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetCognitoEventsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetMap(protocol.BodyTarget, "Events", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/SetCognitoEventsOutput
 type SetCognitoEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3468,6 +4167,12 @@ func (s SetCognitoEventsOutput) String() string {
 // GoString returns the string representation
 func (s SetCognitoEventsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetCognitoEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the SetIdentityPoolConfiguration operation.
@@ -3542,6 +4247,27 @@ func (s *SetIdentityPoolConfigurationInput) SetPushSync(v *PushSync) *SetIdentit
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetIdentityPoolConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CognitoStreams != nil {
+		v := s.CognitoStreams
+
+		e.SetFields(protocol.BodyTarget, "CognitoStreams", v, protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PushSync != nil {
+		v := s.PushSync
+
+		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the SetIdentityPoolConfiguration operation
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/SetIdentityPoolConfigurationResponse
 type SetIdentityPoolConfigurationOutput struct {
@@ -3584,6 +4310,27 @@ func (s *SetIdentityPoolConfigurationOutput) SetIdentityPoolId(v string) *SetIde
 func (s *SetIdentityPoolConfigurationOutput) SetPushSync(v *PushSync) *SetIdentityPoolConfigurationOutput {
 	s.PushSync = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetIdentityPoolConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CognitoStreams != nil {
+		v := s.CognitoStreams
+
+		e.SetFields(protocol.BodyTarget, "CognitoStreams", v, protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PushSync != nil {
+		v := s.PushSync
+
+		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to SubscribeToDatasetRequest.
@@ -3681,6 +4428,32 @@ func (s *SubscribeToDatasetInput) SetIdentityPoolId(v string) *SubscribeToDatase
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubscribeToDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceId != nil {
+		v := *s.DeviceId
+
+		e.SetValue(protocol.PathTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a SubscribeToDataset request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/SubscribeToDatasetResponse
 type SubscribeToDatasetOutput struct {
@@ -3695,6 +4468,12 @@ func (s SubscribeToDatasetOutput) String() string {
 // GoString returns the string representation
 func (s SubscribeToDatasetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubscribeToDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to UnsubscribeFromDataset.
@@ -3792,6 +4571,32 @@ func (s *UnsubscribeFromDatasetInput) SetIdentityPoolId(v string) *UnsubscribeFr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UnsubscribeFromDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceId != nil {
+		v := *s.DeviceId
+
+		e.SetValue(protocol.PathTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to an UnsubscribeFromDataset request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/UnsubscribeFromDatasetResponse
 type UnsubscribeFromDatasetOutput struct {
@@ -3806,6 +4611,12 @@ func (s UnsubscribeFromDatasetOutput) String() string {
 // GoString returns the string representation
 func (s UnsubscribeFromDatasetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UnsubscribeFromDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to post updates to records or add and delete records for a dataset
@@ -3945,6 +4756,47 @@ func (s *UpdateRecordsInput) SetSyncSessionToken(v string) *UpdateRecordsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientContext != nil {
+		v := *s.ClientContext
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceId != nil {
+		v := *s.DeviceId
+
+		e.SetValue(protocol.BodyTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RecordPatches) > 0 {
+		v := s.RecordPatches
+
+		e.SetList(protocol.BodyTarget, "RecordPatches", encodeRecordPatchList(v), protocol.Metadata{})
+	}
+	if s.SyncSessionToken != nil {
+		v := *s.SyncSessionToken
+
+		e.SetValue(protocol.BodyTarget, "SyncSessionToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Returned for a successful UpdateRecordsRequest.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/UpdateRecordsResponse
 type UpdateRecordsOutput struct {
@@ -3968,6 +4820,17 @@ func (s UpdateRecordsOutput) GoString() string {
 func (s *UpdateRecordsOutput) SetRecords(v []*Record) *UpdateRecordsOutput {
 	s.Records = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Records) > 0 {
+		v := s.Records
+
+		e.SetList(protocol.BodyTarget, "Records", encodeRecordList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -1393,6 +1393,32 @@ func (s *CreateFileSystemInput) SetPerformanceMode(v string) *CreateFileSystemIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFileSystemInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationToken != nil {
+		v := *s.CreationToken
+
+		e.SetValue(protocol.BodyTarget, "CreationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encrypted != nil {
+		v := *s.Encrypted
+
+		e.SetValue(protocol.BodyTarget, "Encrypted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.KmsKeyId != nil {
+		v := *s.KmsKeyId
+
+		e.SetValue(protocol.BodyTarget, "KmsKeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PerformanceMode != nil {
+		v := *s.PerformanceMode
+
+		e.SetValue(protocol.BodyTarget, "PerformanceMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/CreateMountTargetRequest
 type CreateMountTargetInput struct {
 	_ struct{} `type:"structure"`
@@ -1465,6 +1491,32 @@ func (s *CreateMountTargetInput) SetSubnetId(v string) *CreateMountTargetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateMountTargetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.BodyTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IpAddress != nil {
+		v := *s.IpAddress
+
+		e.SetValue(protocol.BodyTarget, "IpAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroups) > 0 {
+		v := s.SecurityGroups
+
+		e.SetList(protocol.BodyTarget, "SecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.SubnetId != nil {
+		v := *s.SubnetId
+
+		e.SetValue(protocol.BodyTarget, "SubnetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/CreateTagsRequest
 type CreateTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -1529,6 +1581,22 @@ func (s *CreateTagsInput) SetTags(v []*Tag) *CreateTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/CreateTagsOutput
 type CreateTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1542,6 +1610,12 @@ func (s CreateTagsOutput) String() string {
 // GoString returns the string representation
 func (s CreateTagsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteFileSystemRequest
@@ -1583,6 +1657,17 @@ func (s *DeleteFileSystemInput) SetFileSystemId(v string) *DeleteFileSystemInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFileSystemInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteFileSystemOutput
 type DeleteFileSystemOutput struct {
 	_ struct{} `type:"structure"`
@@ -1596,6 +1681,12 @@ func (s DeleteFileSystemOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFileSystemOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFileSystemOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteMountTargetRequest
@@ -1637,6 +1728,17 @@ func (s *DeleteMountTargetInput) SetMountTargetId(v string) *DeleteMountTargetIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMountTargetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteMountTargetOutput
 type DeleteMountTargetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1650,6 +1752,12 @@ func (s DeleteMountTargetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteMountTargetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMountTargetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteTagsRequest
@@ -1705,6 +1813,22 @@ func (s *DeleteTagsInput) SetTagKeys(v []*string) *DeleteTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteTagsOutput
 type DeleteTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1718,6 +1842,12 @@ func (s DeleteTagsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTagsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeFileSystemsRequest
@@ -1795,6 +1925,32 @@ func (s *DescribeFileSystemsInput) SetMaxItems(v int64) *DescribeFileSystemsInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeFileSystemsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationToken != nil {
+		v := *s.CreationToken
+
+		e.SetValue(protocol.QueryTarget, "CreationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.QueryTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeFileSystemsResponse
 type DescribeFileSystemsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1838,6 +1994,27 @@ func (s *DescribeFileSystemsOutput) SetNextMarker(v string) *DescribeFileSystems
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeFileSystemsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FileSystems) > 0 {
+		v := s.FileSystems
+
+		e.SetList(protocol.BodyTarget, "FileSystems", encodeFileSystemDescriptionList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeMountTargetSecurityGroupsRequest
 type DescribeMountTargetSecurityGroupsInput struct {
 	_ struct{} `type:"structure"`
@@ -1877,6 +2054,17 @@ func (s *DescribeMountTargetSecurityGroupsInput) SetMountTargetId(v string) *Des
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeMountTargetSecurityGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeMountTargetSecurityGroupsResponse
 type DescribeMountTargetSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1901,6 +2089,17 @@ func (s DescribeMountTargetSecurityGroupsOutput) GoString() string {
 func (s *DescribeMountTargetSecurityGroupsOutput) SetSecurityGroups(v []*string) *DescribeMountTargetSecurityGroupsOutput {
 	s.SecurityGroups = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeMountTargetSecurityGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SecurityGroups) > 0 {
+		v := s.SecurityGroups
+
+		e.SetList(protocol.BodyTarget, "SecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeMountTargetsRequest
@@ -1972,6 +2171,32 @@ func (s *DescribeMountTargetsInput) SetMountTargetId(v string) *DescribeMountTar
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeMountTargetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.QueryTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.QueryTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeMountTargetsResponse
 type DescribeMountTargetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2016,6 +2241,27 @@ func (s *DescribeMountTargetsOutput) SetMountTargets(v []*MountTargetDescription
 func (s *DescribeMountTargetsOutput) SetNextMarker(v string) *DescribeMountTargetsOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeMountTargetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.MountTargets) > 0 {
+		v := s.MountTargets
+
+		e.SetList(protocol.BodyTarget, "MountTargets", encodeMountTargetDescriptionList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeTagsRequest
@@ -2081,6 +2327,27 @@ func (s *DescribeTagsInput) SetMaxItems(v int64) *DescribeTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeTagsResponse
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2126,6 +2393,27 @@ func (s *DescribeTagsOutput) SetNextMarker(v string) *DescribeTagsOutput {
 func (s *DescribeTagsOutput) SetTags(v []*Tag) *DescribeTagsOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Description of the file system.
@@ -2272,6 +2560,75 @@ func (s *FileSystemDescription) SetSizeInBytes(v *FileSystemSize) *FileSystemDes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FileSystemDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationTime != nil {
+		v := *s.CreationTime
+
+		e.SetValue(protocol.BodyTarget, "CreationTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CreationToken != nil {
+		v := *s.CreationToken
+
+		e.SetValue(protocol.BodyTarget, "CreationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encrypted != nil {
+		v := *s.Encrypted
+
+		e.SetValue(protocol.BodyTarget, "Encrypted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.BodyTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KmsKeyId != nil {
+		v := *s.KmsKeyId
+
+		e.SetValue(protocol.BodyTarget, "KmsKeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LifeCycleState != nil {
+		v := *s.LifeCycleState
+
+		e.SetValue(protocol.BodyTarget, "LifeCycleState", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NumberOfMountTargets != nil {
+		v := *s.NumberOfMountTargets
+
+		e.SetValue(protocol.BodyTarget, "NumberOfMountTargets", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OwnerId != nil {
+		v := *s.OwnerId
+
+		e.SetValue(protocol.BodyTarget, "OwnerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PerformanceMode != nil {
+		v := *s.PerformanceMode
+
+		e.SetValue(protocol.BodyTarget, "PerformanceMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizeInBytes != nil {
+		v := s.SizeInBytes
+
+		e.SetFields(protocol.BodyTarget, "SizeInBytes", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFileSystemDescriptionList(vs []*FileSystemDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Latest known metered size (in bytes) of data stored in the file system, in
 // its Value field, and the time at which that size was determined in its Timestamp
 // field. Note that the value does not represent the size of a consistent snapshot
@@ -2314,6 +2671,22 @@ func (s *FileSystemSize) SetTimestamp(v time.Time) *FileSystemSize {
 func (s *FileSystemSize) SetValue(v int64) *FileSystemSize {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FileSystemSize) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.BodyTarget, "Timestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/ModifyMountTargetSecurityGroupsRequest
@@ -2364,6 +2737,22 @@ func (s *ModifyMountTargetSecurityGroupsInput) SetSecurityGroups(v []*string) *M
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ModifyMountTargetSecurityGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroups) > 0 {
+		v := s.SecurityGroups
+
+		e.SetList(protocol.BodyTarget, "SecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/ModifyMountTargetSecurityGroupsOutput
 type ModifyMountTargetSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2377,6 +2766,12 @@ func (s ModifyMountTargetSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s ModifyMountTargetSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ModifyMountTargetSecurityGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides a description of a mount target.
@@ -2467,6 +2862,55 @@ func (s *MountTargetDescription) SetSubnetId(v string) *MountTargetDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MountTargetDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.BodyTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IpAddress != nil {
+		v := *s.IpAddress
+
+		e.SetValue(protocol.BodyTarget, "IpAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LifeCycleState != nil {
+		v := *s.LifeCycleState
+
+		e.SetValue(protocol.BodyTarget, "LifeCycleState", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.BodyTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NetworkInterfaceId != nil {
+		v := *s.NetworkInterfaceId
+
+		e.SetValue(protocol.BodyTarget, "NetworkInterfaceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OwnerId != nil {
+		v := *s.OwnerId
+
+		e.SetValue(protocol.BodyTarget, "OwnerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubnetId != nil {
+		v := *s.SubnetId
+
+		e.SetValue(protocol.BodyTarget, "SubnetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMountTargetDescriptionList(vs []*MountTargetDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A tag is a key-value pair. Allowed characters: letters, whitespace, and numbers,
 // representable in UTF-8, and the following characters: + - = . _ : /
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/Tag
@@ -2523,6 +2967,30 @@ func (s *Tag) SetKey(v string) *Tag {
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -1352,6 +1352,22 @@ func (s *AccessPoliciesStatus) SetStatus(v *OptionStatus) *AccessPoliciesStatus 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccessPoliciesStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := *s.Options
+
+		e.SetValue(protocol.BodyTarget, "Options", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters to the AddTags operation. Specify the tags that
 // you want to attach to the Elasticsearch domain.
 type AddTagsInput struct {
@@ -1416,6 +1432,22 @@ func (s *AddTagsInput) SetTagList(v []*Tag) *AddTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagList) > 0 {
+		v := s.TagList
+
+		e.SetList(protocol.BodyTarget, "TagList", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1428,6 +1460,12 @@ func (s AddTagsOutput) String() string {
 // GoString returns the string representation
 func (s AddTagsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // List of limits that are specific to a given InstanceType and for each of
@@ -1467,6 +1505,30 @@ func (s *AdditionalLimit) SetLimitName(v string) *AdditionalLimit {
 func (s *AdditionalLimit) SetLimitValues(v []*string) *AdditionalLimit {
 	s.LimitValues = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AdditionalLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LimitName != nil {
+		v := *s.LimitName
+
+		e.SetValue(protocol.BodyTarget, "LimitName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.LimitValues) > 0 {
+		v := s.LimitValues
+
+		e.SetList(protocol.BodyTarget, "LimitValues", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAdditionalLimitList(vs []*AdditionalLimit) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Status of the advanced options for the specified Elasticsearch domain. Currently,
@@ -1515,6 +1577,22 @@ func (s *AdvancedOptionsStatus) SetOptions(v map[string]*string) *AdvancedOption
 func (s *AdvancedOptionsStatus) SetStatus(v *OptionStatus) *AdvancedOptionsStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AdvancedOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Options) > 0 {
+		v := s.Options
+
+		e.SetMap(protocol.BodyTarget, "Options", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type CreateElasticsearchDomainInput struct {
@@ -1623,6 +1701,47 @@ func (s *CreateElasticsearchDomainInput) SetSnapshotOptions(v *SnapshotOptions) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccessPolicies != nil {
+		v := *s.AccessPolicies
+
+		e.SetValue(protocol.BodyTarget, "AccessPolicies", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.AdvancedOptions) > 0 {
+		v := s.AdvancedOptions
+
+		e.SetMap(protocol.BodyTarget, "AdvancedOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EBSOptions != nil {
+		v := s.EBSOptions
+
+		e.SetFields(protocol.BodyTarget, "EBSOptions", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchClusterConfig != nil {
+		v := s.ElasticsearchClusterConfig
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchClusterConfig", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := *s.ElasticsearchVersion
+
+		e.SetValue(protocol.BodyTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SnapshotOptions != nil {
+		v := s.SnapshotOptions
+
+		e.SetFields(protocol.BodyTarget, "SnapshotOptions", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a CreateElasticsearchDomain operation. Contains the status
 // of the newly created Elasticsearch domain.
 type CreateElasticsearchDomainOutput struct {
@@ -1646,6 +1765,17 @@ func (s CreateElasticsearchDomainOutput) GoString() string {
 func (s *CreateElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomainStatus) *CreateElasticsearchDomainOutput {
 	s.DomainStatus = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainStatus != nil {
+		v := s.DomainStatus
+
+		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the DeleteElasticsearchDomain operation.
@@ -1691,6 +1821,17 @@ func (s *DeleteElasticsearchDomainInput) SetDomainName(v string) *DeleteElastics
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a DeleteElasticsearchDomain request. Contains the status of
 // the pending deletion, or no status if the domain and all of its resources
 // have been deleted.
@@ -1715,6 +1856,17 @@ func (s DeleteElasticsearchDomainOutput) GoString() string {
 func (s *DeleteElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomainStatus) *DeleteElasticsearchDomainOutput {
 	s.DomainStatus = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainStatus != nil {
+		v := s.DomainStatus
+
+		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the DescribeElasticsearchDomainConfig operation.
@@ -1760,6 +1912,17 @@ func (s *DescribeElasticsearchDomainConfigInput) SetDomainName(v string) *Descri
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a DescribeElasticsearchDomainConfig request. Contains the configuration
 // information of the requested domain.
 type DescribeElasticsearchDomainConfigOutput struct {
@@ -1786,6 +1949,17 @@ func (s DescribeElasticsearchDomainConfigOutput) GoString() string {
 func (s *DescribeElasticsearchDomainConfigOutput) SetDomainConfig(v *ElasticsearchDomainConfig) *DescribeElasticsearchDomainConfigOutput {
 	s.DomainConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainConfig != nil {
+		v := s.DomainConfig
+
+		e.SetFields(protocol.BodyTarget, "DomainConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the DescribeElasticsearchDomain operation.
@@ -1830,6 +2004,17 @@ func (s *DescribeElasticsearchDomainInput) SetDomainName(v string) *DescribeElas
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a DescribeElasticsearchDomain request. Contains the status
 // of the domain specified in the request.
 type DescribeElasticsearchDomainOutput struct {
@@ -1855,6 +2040,17 @@ func (s DescribeElasticsearchDomainOutput) GoString() string {
 func (s *DescribeElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomainStatus) *DescribeElasticsearchDomainOutput {
 	s.DomainStatus = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainStatus != nil {
+		v := s.DomainStatus
+
+		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the DescribeElasticsearchDomains operation.
@@ -1897,6 +2093,17 @@ func (s *DescribeElasticsearchDomainsInput) SetDomainNames(v []*string) *Describ
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DomainNames) > 0 {
+		v := s.DomainNames
+
+		e.SetList(protocol.BodyTarget, "DomainNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a DescribeElasticsearchDomains request. Contains the status
 // of the specified domains or all domains owned by the account.
 type DescribeElasticsearchDomainsOutput struct {
@@ -1922,6 +2129,17 @@ func (s DescribeElasticsearchDomainsOutput) GoString() string {
 func (s *DescribeElasticsearchDomainsOutput) SetDomainStatusList(v []*ElasticsearchDomainStatus) *DescribeElasticsearchDomainsOutput {
 	s.DomainStatusList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DomainStatusList) > 0 {
+		v := s.DomainStatusList
+
+		e.SetList(protocol.BodyTarget, "DomainStatusList", encodeElasticsearchDomainStatusList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to DescribeElasticsearchInstanceTypeLimits operation.
@@ -1992,6 +2210,27 @@ func (s *DescribeElasticsearchInstanceTypeLimitsInput) SetInstanceType(v string)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchInstanceTypeLimitsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.QueryTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := *s.ElasticsearchVersion
+
+		e.SetValue(protocol.PathTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InstanceType != nil {
+		v := *s.InstanceType
+
+		e.SetValue(protocol.PathTarget, "InstanceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters received from DescribeElasticsearchInstanceTypeLimits
 // operation.
 type DescribeElasticsearchInstanceTypeLimitsOutput struct {
@@ -2020,6 +2259,17 @@ func (s *DescribeElasticsearchInstanceTypeLimitsOutput) SetLimitsByRole(v map[st
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchInstanceTypeLimitsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LimitsByRole) > 0 {
+		v := s.LimitsByRole
+
+		e.SetMap(protocol.BodyTarget, "LimitsByRole", encodeLimitsMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DomainInfo struct {
 	_ struct{} `type:"structure"`
 
@@ -2041,6 +2291,25 @@ func (s DomainInfo) GoString() string {
 func (s *DomainInfo) SetDomainName(v string) *DomainInfo {
 	s.DomainName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DomainInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDomainInfoList(vs []*DomainInfo) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Options to enable, disable, and specify the properties of EBS storage volumes.
@@ -2095,6 +2364,32 @@ func (s *EBSOptions) SetVolumeType(v string) *EBSOptions {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EBSOptions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EBSEnabled != nil {
+		v := *s.EBSEnabled
+
+		e.SetValue(protocol.BodyTarget, "EBSEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Iops != nil {
+		v := *s.Iops
+
+		e.SetValue(protocol.BodyTarget, "Iops", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VolumeSize != nil {
+		v := *s.VolumeSize
+
+		e.SetValue(protocol.BodyTarget, "VolumeSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VolumeType != nil {
+		v := *s.VolumeType
+
+		e.SetValue(protocol.BodyTarget, "VolumeType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Status of the EBS options for the specified Elasticsearch domain.
 type EBSOptionsStatus struct {
 	_ struct{} `type:"structure"`
@@ -2130,6 +2425,22 @@ func (s *EBSOptionsStatus) SetOptions(v *EBSOptions) *EBSOptionsStatus {
 func (s *EBSOptionsStatus) SetStatus(v *OptionStatus) *EBSOptionsStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EBSOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := s.Options
+
+		e.SetFields(protocol.BodyTarget, "Options", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Specifies the configuration for the domain cluster, such as the type and
@@ -2206,6 +2517,42 @@ func (s *ElasticsearchClusterConfig) SetZoneAwarenessEnabled(v bool) *Elasticsea
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchClusterConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DedicatedMasterCount != nil {
+		v := *s.DedicatedMasterCount
+
+		e.SetValue(protocol.BodyTarget, "DedicatedMasterCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DedicatedMasterEnabled != nil {
+		v := *s.DedicatedMasterEnabled
+
+		e.SetValue(protocol.BodyTarget, "DedicatedMasterEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DedicatedMasterType != nil {
+		v := *s.DedicatedMasterType
+
+		e.SetValue(protocol.BodyTarget, "DedicatedMasterType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InstanceCount != nil {
+		v := *s.InstanceCount
+
+		e.SetValue(protocol.BodyTarget, "InstanceCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InstanceType != nil {
+		v := *s.InstanceType
+
+		e.SetValue(protocol.BodyTarget, "InstanceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ZoneAwarenessEnabled != nil {
+		v := *s.ZoneAwarenessEnabled
+
+		e.SetValue(protocol.BodyTarget, "ZoneAwarenessEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Specifies the configuration status for the specified Elasticsearch domain.
 type ElasticsearchClusterConfigStatus struct {
 	_ struct{} `type:"structure"`
@@ -2242,6 +2589,22 @@ func (s *ElasticsearchClusterConfigStatus) SetOptions(v *ElasticsearchClusterCon
 func (s *ElasticsearchClusterConfigStatus) SetStatus(v *OptionStatus) *ElasticsearchClusterConfigStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchClusterConfigStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := s.Options
+
+		e.SetFields(protocol.BodyTarget, "Options", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The configuration of an Elasticsearch domain.
@@ -2313,6 +2676,42 @@ func (s *ElasticsearchDomainConfig) SetElasticsearchVersion(v *ElasticsearchVers
 func (s *ElasticsearchDomainConfig) SetSnapshotOptions(v *SnapshotOptionsStatus) *ElasticsearchDomainConfig {
 	s.SnapshotOptions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchDomainConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccessPolicies != nil {
+		v := s.AccessPolicies
+
+		e.SetFields(protocol.BodyTarget, "AccessPolicies", v, protocol.Metadata{})
+	}
+	if s.AdvancedOptions != nil {
+		v := s.AdvancedOptions
+
+		e.SetFields(protocol.BodyTarget, "AdvancedOptions", v, protocol.Metadata{})
+	}
+	if s.EBSOptions != nil {
+		v := s.EBSOptions
+
+		e.SetFields(protocol.BodyTarget, "EBSOptions", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchClusterConfig != nil {
+		v := s.ElasticsearchClusterConfig
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchClusterConfig", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := s.ElasticsearchVersion
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchVersion", v, protocol.Metadata{})
+	}
+	if s.SnapshotOptions != nil {
+		v := s.SnapshotOptions
+
+		e.SetFields(protocol.BodyTarget, "SnapshotOptions", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The current status of an Elasticsearch domain.
@@ -2468,6 +2867,85 @@ func (s *ElasticsearchDomainStatus) SetSnapshotOptions(v *SnapshotOptions) *Elas
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchDomainStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccessPolicies != nil {
+		v := *s.AccessPolicies
+
+		e.SetValue(protocol.BodyTarget, "AccessPolicies", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.AdvancedOptions) > 0 {
+		v := s.AdvancedOptions
+
+		e.SetMap(protocol.BodyTarget, "AdvancedOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Created != nil {
+		v := *s.Created
+
+		e.SetValue(protocol.BodyTarget, "Created", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Deleted != nil {
+		v := *s.Deleted
+
+		e.SetValue(protocol.BodyTarget, "Deleted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DomainId != nil {
+		v := *s.DomainId
+
+		e.SetValue(protocol.BodyTarget, "DomainId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EBSOptions != nil {
+		v := s.EBSOptions
+
+		e.SetFields(protocol.BodyTarget, "EBSOptions", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchClusterConfig != nil {
+		v := s.ElasticsearchClusterConfig
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchClusterConfig", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := *s.ElasticsearchVersion
+
+		e.SetValue(protocol.BodyTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Endpoint != nil {
+		v := *s.Endpoint
+
+		e.SetValue(protocol.BodyTarget, "Endpoint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Processing != nil {
+		v := *s.Processing
+
+		e.SetValue(protocol.BodyTarget, "Processing", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SnapshotOptions != nil {
+		v := s.SnapshotOptions
+
+		e.SetFields(protocol.BodyTarget, "SnapshotOptions", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeElasticsearchDomainStatusList(vs []*ElasticsearchDomainStatus) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Status of the Elasticsearch version options for the specified Elasticsearch
 // domain.
 type ElasticsearchVersionStatus struct {
@@ -2507,6 +2985,22 @@ func (s *ElasticsearchVersionStatus) SetStatus(v *OptionStatus) *ElasticsearchVe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchVersionStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := *s.Options
+
+		e.SetValue(protocol.BodyTarget, "Options", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // InstanceCountLimits represents the limits on number of instances that be
 // created in Amazon Elasticsearch for given InstanceType.
 type InstanceCountLimits struct {
@@ -2541,6 +3035,22 @@ func (s *InstanceCountLimits) SetMinimumInstanceCount(v int64) *InstanceCountLim
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InstanceCountLimits) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaximumInstanceCount != nil {
+		v := *s.MaximumInstanceCount
+
+		e.SetValue(protocol.BodyTarget, "MaximumInstanceCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinimumInstanceCount != nil {
+		v := *s.MinimumInstanceCount
+
+		e.SetValue(protocol.BodyTarget, "MinimumInstanceCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // InstanceLimits represents the list of instance related attributes that are
 // available for given InstanceType.
 type InstanceLimits struct {
@@ -2565,6 +3075,17 @@ func (s InstanceLimits) GoString() string {
 func (s *InstanceLimits) SetInstanceCountLimits(v *InstanceCountLimits) *InstanceLimits {
 	s.InstanceCountLimits = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InstanceLimits) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InstanceCountLimits != nil {
+		v := s.InstanceCountLimits
+
+		e.SetFields(protocol.BodyTarget, "InstanceCountLimits", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Limits for given InstanceType and for each of it's role. Limits contains following StorageTypes,   InstanceLimitsand AdditionalLimits
@@ -2612,6 +3133,35 @@ func (s *Limits) SetStorageTypes(v []*StorageType) *Limits {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Limits) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdditionalLimits) > 0 {
+		v := s.AdditionalLimits
+
+		e.SetList(protocol.BodyTarget, "AdditionalLimits", encodeAdditionalLimitList(v), protocol.Metadata{})
+	}
+	if s.InstanceLimits != nil {
+		v := s.InstanceLimits
+
+		e.SetFields(protocol.BodyTarget, "InstanceLimits", v, protocol.Metadata{})
+	}
+	if len(s.StorageTypes) > 0 {
+		v := s.StorageTypes
+
+		e.SetList(protocol.BodyTarget, "StorageTypes", encodeStorageTypeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLimitsMap(vs map[string]*Limits) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 type ListDomainNamesInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2624,6 +3174,12 @@ func (s ListDomainNamesInput) String() string {
 // GoString returns the string representation
 func (s ListDomainNamesInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDomainNamesInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The result of a ListDomainNames operation. Contains the names of all Elasticsearch
@@ -2649,6 +3205,17 @@ func (s ListDomainNamesOutput) GoString() string {
 func (s *ListDomainNamesOutput) SetDomainNames(v []*DomainInfo) *ListDomainNamesOutput {
 	s.DomainNames = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDomainNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DomainNames) > 0 {
+		v := s.DomainNames
+
+		e.SetList(protocol.BodyTarget, "DomainNames", encodeDomainInfoList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the ListElasticsearchInstanceTypes operation.
@@ -2725,6 +3292,32 @@ func (s *ListElasticsearchInstanceTypesInput) SetNextToken(v string) *ListElasti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListElasticsearchInstanceTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.QueryTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := *s.ElasticsearchVersion
+
+		e.SetValue(protocol.PathTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters returned by ListElasticsearchInstanceTypes operation.
 type ListElasticsearchInstanceTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2759,6 +3352,22 @@ func (s *ListElasticsearchInstanceTypesOutput) SetElasticsearchInstanceTypes(v [
 func (s *ListElasticsearchInstanceTypesOutput) SetNextToken(v string) *ListElasticsearchInstanceTypesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListElasticsearchInstanceTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ElasticsearchInstanceTypes) > 0 {
+		v := s.ElasticsearchInstanceTypes
+
+		e.SetList(protocol.BodyTarget, "ElasticsearchInstanceTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the ListElasticsearchVersions operation.
@@ -2802,6 +3411,22 @@ func (s *ListElasticsearchVersionsInput) SetNextToken(v string) *ListElasticsear
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListElasticsearchVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters for response received from ListElasticsearchVersions
 // operation.
 type ListElasticsearchVersionsOutput struct {
@@ -2836,6 +3461,22 @@ func (s *ListElasticsearchVersionsOutput) SetElasticsearchVersions(v []*string) 
 func (s *ListElasticsearchVersionsOutput) SetNextToken(v string) *ListElasticsearchVersionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListElasticsearchVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ElasticsearchVersions) > 0 {
+		v := s.ElasticsearchVersions
+
+		e.SetList(protocol.BodyTarget, "ElasticsearchVersions", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the ListTags operation. Specify the ARN for
@@ -2880,6 +3521,17 @@ func (s *ListTagsInput) SetARN(v string) *ListTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.QueryTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a ListTags operation. Contains tags for all requested Elasticsearch
 // domains.
 type ListTagsOutput struct {
@@ -2903,6 +3555,17 @@ func (s ListTagsOutput) GoString() string {
 func (s *ListTagsOutput) SetTagList(v []*Tag) *ListTagsOutput {
 	s.TagList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TagList) > 0 {
+		v := s.TagList
+
+		e.SetList(protocol.BodyTarget, "TagList", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides the current status of the entity.
@@ -2971,6 +3634,37 @@ func (s *OptionStatus) SetUpdateVersion(v int64) *OptionStatus {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OptionStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.PendingDeletion != nil {
+		v := *s.PendingDeletion
+
+		e.SetValue(protocol.BodyTarget, "PendingDeletion", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UpdateDate != nil {
+		v := *s.UpdateDate
+
+		e.SetValue(protocol.BodyTarget, "UpdateDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.UpdateVersion != nil {
+		v := *s.UpdateVersion
+
+		e.SetValue(protocol.BodyTarget, "UpdateVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters to the RemoveTags operation. Specify the ARN
 // for the Elasticsearch domain from which you want to remove the specified
 // TagKey.
@@ -3028,6 +3722,22 @@ func (s *RemoveTagsInput) SetTagKeys(v []*string) *RemoveTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type RemoveTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3040,6 +3750,12 @@ func (s RemoveTagsOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Specifies the time, in UTC format, when the service takes a daily automated
@@ -3066,6 +3782,17 @@ func (s SnapshotOptions) GoString() string {
 func (s *SnapshotOptions) SetAutomatedSnapshotStartHour(v int64) *SnapshotOptions {
 	s.AutomatedSnapshotStartHour = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SnapshotOptions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AutomatedSnapshotStartHour != nil {
+		v := *s.AutomatedSnapshotStartHour
+
+		e.SetValue(protocol.BodyTarget, "AutomatedSnapshotStartHour", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Status of a daily automated snapshot.
@@ -3103,6 +3830,22 @@ func (s *SnapshotOptionsStatus) SetOptions(v *SnapshotOptions) *SnapshotOptionsS
 func (s *SnapshotOptionsStatus) SetStatus(v *OptionStatus) *SnapshotOptionsStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SnapshotOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := s.Options
+
+		e.SetFields(protocol.BodyTarget, "Options", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // StorageTypes represents the list of storage related types and their attributes
@@ -3155,6 +3898,35 @@ func (s *StorageType) SetStorageTypeName(v string) *StorageType {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StorageSubTypeName != nil {
+		v := *s.StorageSubTypeName
+
+		e.SetValue(protocol.BodyTarget, "StorageSubTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StorageTypeLimits) > 0 {
+		v := s.StorageTypeLimits
+
+		e.SetList(protocol.BodyTarget, "StorageTypeLimits", encodeStorageTypeLimitList(v), protocol.Metadata{})
+	}
+	if s.StorageTypeName != nil {
+		v := *s.StorageTypeName
+
+		e.SetValue(protocol.BodyTarget, "StorageTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStorageTypeList(vs []*StorageType) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Limits that are applicable for given storage type.
 type StorageTypeLimit struct {
 	_ struct{} `type:"structure"`
@@ -3195,6 +3967,30 @@ func (s *StorageTypeLimit) SetLimitName(v string) *StorageTypeLimit {
 func (s *StorageTypeLimit) SetLimitValues(v []*string) *StorageTypeLimit {
 	s.LimitValues = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageTypeLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LimitName != nil {
+		v := *s.LimitName
+
+		e.SetValue(protocol.BodyTarget, "LimitName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.LimitValues) > 0 {
+		v := s.LimitValues
+
+		e.SetList(protocol.BodyTarget, "LimitValues", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStorageTypeLimitList(vs []*StorageTypeLimit) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Specifies a key value pair for a resource tag.
@@ -3255,6 +4051,30 @@ func (s *Tag) SetKey(v string) *Tag {
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for the parameters to the UpdateElasticsearchDomain operation.
@@ -3349,6 +4169,42 @@ func (s *UpdateElasticsearchDomainConfigInput) SetSnapshotOptions(v *SnapshotOpt
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateElasticsearchDomainConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccessPolicies != nil {
+		v := *s.AccessPolicies
+
+		e.SetValue(protocol.BodyTarget, "AccessPolicies", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.AdvancedOptions) > 0 {
+		v := s.AdvancedOptions
+
+		e.SetMap(protocol.BodyTarget, "AdvancedOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EBSOptions != nil {
+		v := s.EBSOptions
+
+		e.SetFields(protocol.BodyTarget, "EBSOptions", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchClusterConfig != nil {
+		v := s.ElasticsearchClusterConfig
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchClusterConfig", v, protocol.Metadata{})
+	}
+	if s.SnapshotOptions != nil {
+		v := s.SnapshotOptions
+
+		e.SetFields(protocol.BodyTarget, "SnapshotOptions", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of an UpdateElasticsearchDomain request. Contains the status of
 // the Elasticsearch domain being updated.
 type UpdateElasticsearchDomainConfigOutput struct {
@@ -3374,6 +4230,17 @@ func (s UpdateElasticsearchDomainConfigOutput) GoString() string {
 func (s *UpdateElasticsearchDomainConfigOutput) SetDomainConfig(v *ElasticsearchDomainConfig) *UpdateElasticsearchDomainConfigOutput {
 	s.DomainConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateElasticsearchDomainConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainConfig != nil {
+		v := s.DomainConfig
+
+		e.SetFields(protocol.BodyTarget, "DomainConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCancelJob = "CancelJob"
@@ -1986,6 +1987,55 @@ func (s *Artwork) SetSizingPolicy(v string) *Artwork {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Artwork) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlbumArtFormat != nil {
+		v := *s.AlbumArtFormat
+
+		e.SetValue(protocol.BodyTarget, "AlbumArtFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.InputKey != nil {
+		v := *s.InputKey
+
+		e.SetValue(protocol.BodyTarget, "InputKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxHeight != nil {
+		v := *s.MaxHeight
+
+		e.SetValue(protocol.BodyTarget, "MaxHeight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxWidth != nil {
+		v := *s.MaxWidth
+
+		e.SetValue(protocol.BodyTarget, "MaxWidth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PaddingPolicy != nil {
+		v := *s.PaddingPolicy
+
+		e.SetValue(protocol.BodyTarget, "PaddingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizingPolicy != nil {
+		v := *s.SizingPolicy
+
+		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeArtworkList(vs []*Artwork) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Options associated with your audio codec.
 type AudioCodecOptions struct {
 	_ struct{} `type:"structure"`
@@ -2077,6 +2127,32 @@ func (s *AudioCodecOptions) SetProfile(v string) *AudioCodecOptions {
 func (s *AudioCodecOptions) SetSigned(v string) *AudioCodecOptions {
 	s.Signed = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioCodecOptions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BitDepth != nil {
+		v := *s.BitDepth
+
+		e.SetValue(protocol.BodyTarget, "BitDepth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BitOrder != nil {
+		v := *s.BitOrder
+
+		e.SetValue(protocol.BodyTarget, "BitOrder", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Profile != nil {
+		v := *s.Profile
+
+		e.SetValue(protocol.BodyTarget, "Profile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Signed != nil {
+		v := *s.Signed
+
+		e.SetValue(protocol.BodyTarget, "Signed", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Parameters required for transcoding audio.
@@ -2289,6 +2365,42 @@ func (s *AudioParameters) SetSampleRate(v string) *AudioParameters {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioParameters) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioPackingMode != nil {
+		v := *s.AudioPackingMode
+
+		e.SetValue(protocol.BodyTarget, "AudioPackingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BitRate != nil {
+		v := *s.BitRate
+
+		e.SetValue(protocol.BodyTarget, "BitRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Channels != nil {
+		v := *s.Channels
+
+		e.SetValue(protocol.BodyTarget, "Channels", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Codec != nil {
+		v := *s.Codec
+
+		e.SetValue(protocol.BodyTarget, "Codec", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecOptions != nil {
+		v := s.CodecOptions
+
+		e.SetFields(protocol.BodyTarget, "CodecOptions", v, protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "SampleRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The CancelJobRequest structure.
 type CancelJobInput struct {
 	_ struct{} `type:"structure"`
@@ -2331,6 +2443,17 @@ func (s *CancelJobInput) SetId(v string) *CancelJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The response body contains a JSON object. If the job is successfully canceled,
 // the value of Success is true.
 type CancelJobOutput struct {
@@ -2345,6 +2468,12 @@ func (s CancelJobOutput) String() string {
 // GoString returns the string representation
 func (s CancelJobOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The file format of the output captions. If you leave this value blank, Elastic
@@ -2429,6 +2558,35 @@ func (s *CaptionFormat) SetFormat(v string) *CaptionFormat {
 func (s *CaptionFormat) SetPattern(v string) *CaptionFormat {
 	s.Pattern = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionFormat) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Pattern != nil {
+		v := *s.Pattern
+
+		e.SetValue(protocol.BodyTarget, "Pattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionFormatList(vs []*CaptionFormat) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A source file for the input sidecar captions used during the transcoding
@@ -2529,6 +2687,45 @@ func (s *CaptionSource) SetTimeOffset(v string) *CaptionSource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionSource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Label != nil {
+		v := *s.Label
+
+		e.SetValue(protocol.BodyTarget, "Label", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Language != nil {
+		v := *s.Language
+
+		e.SetValue(protocol.BodyTarget, "Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeOffset != nil {
+		v := *s.TimeOffset
+
+		e.SetValue(protocol.BodyTarget, "TimeOffset", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionSourceList(vs []*CaptionSource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The captions to be created, if any.
 type Captions struct {
 	_ struct{} `type:"structure"`
@@ -2611,6 +2808,27 @@ func (s *Captions) SetMergePolicy(v string) *Captions {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Captions) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CaptionFormats) > 0 {
+		v := s.CaptionFormats
+
+		e.SetList(protocol.BodyTarget, "CaptionFormats", encodeCaptionFormatList(v), protocol.Metadata{})
+	}
+	if len(s.CaptionSources) > 0 {
+		v := s.CaptionSources
+
+		e.SetList(protocol.BodyTarget, "CaptionSources", encodeCaptionSourceList(v), protocol.Metadata{})
+	}
+	if s.MergePolicy != nil {
+		v := *s.MergePolicy
+
+		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for one clip in a composition. All jobs in a playlist must have
 // the same clip settings.
 type Clip struct {
@@ -2634,6 +2852,25 @@ func (s Clip) GoString() string {
 func (s *Clip) SetTimeSpan(v *TimeSpan) *Clip {
 	s.TimeSpan = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Clip) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TimeSpan != nil {
+		v := s.TimeSpan
+
+		e.SetFields(protocol.BodyTarget, "TimeSpan", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeClipList(vs []*Clip) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The CreateJobRequest structure.
@@ -2797,6 +3034,52 @@ func (s *CreateJobInput) SetPlaylists(v []*CreateJobPlaylist) *CreateJobInput {
 func (s *CreateJobInput) SetUserMetadata(v map[string]*string) *CreateJobInput {
 	s.UserMetadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Input != nil {
+		v := s.Input
+
+		e.SetFields(protocol.BodyTarget, "Input", v, protocol.Metadata{})
+	}
+	if len(s.Inputs) > 0 {
+		v := s.Inputs
+
+		e.SetList(protocol.BodyTarget, "Inputs", encodeJobInputList(v), protocol.Metadata{})
+	}
+	if s.Output != nil {
+		v := s.Output
+
+		e.SetFields(protocol.BodyTarget, "Output", v, protocol.Metadata{})
+	}
+	if s.OutputKeyPrefix != nil {
+		v := *s.OutputKeyPrefix
+
+		e.SetValue(protocol.BodyTarget, "OutputKeyPrefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Outputs) > 0 {
+		v := s.Outputs
+
+		e.SetList(protocol.BodyTarget, "Outputs", encodeCreateJobOutputList(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.BodyTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Playlists) > 0 {
+		v := s.Playlists
+
+		e.SetList(protocol.BodyTarget, "Playlists", encodeCreateJobPlaylistList(v), protocol.Metadata{})
+	}
+	if len(s.UserMetadata) > 0 {
+		v := s.UserMetadata
+
+		e.SetMap(protocol.BodyTarget, "UserMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The CreateJobOutput structure.
@@ -3054,6 +3337,75 @@ func (s *CreateJobOutput) SetWatermarks(v []*JobWatermark) *CreateJobOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlbumArt != nil {
+		v := s.AlbumArt
+
+		e.SetFields(protocol.BodyTarget, "AlbumArt", v, protocol.Metadata{})
+	}
+	if s.Captions != nil {
+		v := s.Captions
+
+		e.SetFields(protocol.BodyTarget, "Captions", v, protocol.Metadata{})
+	}
+	if len(s.Composition) > 0 {
+		v := s.Composition
+
+		e.SetList(protocol.BodyTarget, "Composition", encodeClipList(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PresetId != nil {
+		v := *s.PresetId
+
+		e.SetValue(protocol.BodyTarget, "PresetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Rotate != nil {
+		v := *s.Rotate
+
+		e.SetValue(protocol.BodyTarget, "Rotate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentDuration != nil {
+		v := *s.SegmentDuration
+
+		e.SetValue(protocol.BodyTarget, "SegmentDuration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailEncryption != nil {
+		v := s.ThumbnailEncryption
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailEncryption", v, protocol.Metadata{})
+	}
+	if s.ThumbnailPattern != nil {
+		v := *s.ThumbnailPattern
+
+		e.SetValue(protocol.BodyTarget, "ThumbnailPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Watermarks) > 0 {
+		v := s.Watermarks
+
+		e.SetList(protocol.BodyTarget, "Watermarks", encodeJobWatermarkList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCreateJobOutputList(vs []*CreateJobOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information about the master playlist.
 type CreateJobPlaylist struct {
 	_ struct{} `type:"structure"`
@@ -3179,6 +3531,45 @@ func (s *CreateJobPlaylist) SetPlayReadyDrm(v *PlayReadyDrm) *CreateJobPlaylist 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobPlaylist) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsContentProtection != nil {
+		v := s.HlsContentProtection
+
+		e.SetFields(protocol.BodyTarget, "HlsContentProtection", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OutputKeys) > 0 {
+		v := s.OutputKeys
+
+		e.SetList(protocol.BodyTarget, "OutputKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.PlayReadyDrm != nil {
+		v := s.PlayReadyDrm
+
+		e.SetFields(protocol.BodyTarget, "PlayReadyDrm", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCreateJobPlaylistList(vs []*CreateJobPlaylist) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The CreateJobResponse structure.
 type CreateJobResponse struct {
 	_ struct{} `type:"structure"`
@@ -3202,6 +3593,17 @@ func (s CreateJobResponse) GoString() string {
 func (s *CreateJobResponse) SetJob(v *Job) *CreateJobResponse {
 	s.Job = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Job != nil {
+		v := s.Job
+
+		e.SetFields(protocol.BodyTarget, "Job", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The CreatePipelineRequest structure.
@@ -3511,6 +3913,52 @@ func (s *CreatePipelineInput) SetThumbnailConfig(v *PipelineOutputConfig) *Creat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AwsKmsKeyArn != nil {
+		v := *s.AwsKmsKeyArn
+
+		e.SetValue(protocol.BodyTarget, "AwsKmsKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentConfig != nil {
+		v := s.ContentConfig
+
+		e.SetFields(protocol.BodyTarget, "ContentConfig", v, protocol.Metadata{})
+	}
+	if s.InputBucket != nil {
+		v := *s.InputBucket
+
+		e.SetValue(protocol.BodyTarget, "InputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Notifications != nil {
+		v := s.Notifications
+
+		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
+	}
+	if s.OutputBucket != nil {
+		v := *s.OutputBucket
+
+		e.SetValue(protocol.BodyTarget, "OutputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailConfig != nil {
+		v := s.ThumbnailConfig
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // When you create a pipeline, Elastic Transcoder returns the values that you
 // specified in the request.
 type CreatePipelineOutput struct {
@@ -3549,6 +3997,22 @@ func (s *CreatePipelineOutput) SetPipeline(v *Pipeline) *CreatePipelineOutput {
 func (s *CreatePipelineOutput) SetWarnings(v []*Warning) *CreatePipelineOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The CreatePresetRequest structure.
@@ -3651,6 +4115,42 @@ func (s *CreatePresetInput) SetVideo(v *VideoParameters) *CreatePresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Audio != nil {
+		v := s.Audio
+
+		e.SetFields(protocol.BodyTarget, "Audio", v, protocol.Metadata{})
+	}
+	if s.Container != nil {
+		v := *s.Container
+
+		e.SetValue(protocol.BodyTarget, "Container", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Thumbnails != nil {
+		v := s.Thumbnails
+
+		e.SetFields(protocol.BodyTarget, "Thumbnails", v, protocol.Metadata{})
+	}
+	if s.Video != nil {
+		v := s.Video
+
+		e.SetFields(protocol.BodyTarget, "Video", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The CreatePresetResponse structure.
 type CreatePresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -3686,6 +4186,22 @@ func (s *CreatePresetOutput) SetPreset(v *Preset) *CreatePresetOutput {
 func (s *CreatePresetOutput) SetWarning(v string) *CreatePresetOutput {
 	s.Warning = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Preset != nil {
+		v := s.Preset
+
+		e.SetFields(protocol.BodyTarget, "Preset", v, protocol.Metadata{})
+	}
+	if s.Warning != nil {
+		v := *s.Warning
+
+		e.SetValue(protocol.BodyTarget, "Warning", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The DeletePipelineRequest structure.
@@ -3727,6 +4243,17 @@ func (s *DeletePipelineInput) SetId(v string) *DeletePipelineInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The DeletePipelineResponse structure.
 type DeletePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -3740,6 +4267,12 @@ func (s DeletePipelineOutput) String() string {
 // GoString returns the string representation
 func (s DeletePipelineOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The DeletePresetRequest structure.
@@ -3781,6 +4314,17 @@ func (s *DeletePresetInput) SetId(v string) *DeletePresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The DeletePresetResponse structure.
 type DeletePresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -3794,6 +4338,12 @@ func (s DeletePresetOutput) String() string {
 // GoString returns the string representation
 func (s DeletePresetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The detected properties of the input file. Elastic Transcoder identifies
@@ -3855,6 +4405,37 @@ func (s *DetectedProperties) SetHeight(v int64) *DetectedProperties {
 func (s *DetectedProperties) SetWidth(v int64) *DetectedProperties {
 	s.Width = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetectedProperties) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DurationMillis != nil {
+		v := *s.DurationMillis
+
+		e.SetValue(protocol.BodyTarget, "DurationMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FileSize != nil {
+		v := *s.FileSize
+
+		e.SetValue(protocol.BodyTarget, "FileSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FrameRate != nil {
+		v := *s.FrameRate
+
+		e.SetValue(protocol.BodyTarget, "FrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Height != nil {
+		v := *s.Height
+
+		e.SetValue(protocol.BodyTarget, "Height", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Width != nil {
+		v := *s.Width
+
+		e.SetValue(protocol.BodyTarget, "Width", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The encryption settings, if any, that are used for decrypting your input
@@ -3960,6 +4541,32 @@ func (s *Encryption) SetMode(v string) *Encryption {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Encryption) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InitializationVector != nil {
+		v := *s.InitializationVector
+
+		e.SetValue(protocol.BodyTarget, "InitializationVector", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMd5 != nil {
+		v := *s.KeyMd5
+
+		e.SetValue(protocol.BodyTarget, "KeyMd5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The HLS content protection settings, if any, that you want Elastic Transcoder
 // to apply to your output files.
 type HlsContentProtection struct {
@@ -4057,6 +4664,42 @@ func (s *HlsContentProtection) SetMethod(v string) *HlsContentProtection {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsContentProtection) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InitializationVector != nil {
+		v := *s.InitializationVector
+
+		e.SetValue(protocol.BodyTarget, "InitializationVector", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMd5 != nil {
+		v := *s.KeyMd5
+
+		e.SetValue(protocol.BodyTarget, "KeyMd5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyStoragePolicy != nil {
+		v := *s.KeyStoragePolicy
+
+		e.SetValue(protocol.BodyTarget, "KeyStoragePolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LicenseAcquisitionUrl != nil {
+		v := *s.LicenseAcquisitionUrl
+
+		e.SetValue(protocol.BodyTarget, "LicenseAcquisitionUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Method != nil {
+		v := *s.Method
+
+		e.SetValue(protocol.BodyTarget, "Method", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The captions to be created, if any.
 type InputCaptions struct {
 	_ struct{} `type:"structure"`
@@ -4127,6 +4770,22 @@ func (s *InputCaptions) SetCaptionSources(v []*CaptionSource) *InputCaptions {
 func (s *InputCaptions) SetMergePolicy(v string) *InputCaptions {
 	s.MergePolicy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputCaptions) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CaptionSources) > 0 {
+		v := s.CaptionSources
+
+		e.SetList(protocol.BodyTarget, "CaptionSources", encodeCaptionSourceList(v), protocol.Metadata{})
+	}
+	if s.MergePolicy != nil {
+		v := *s.MergePolicy
+
+		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A section of the response body that provides information about the job that
@@ -4296,6 +4955,80 @@ func (s *Job) SetUserMetadata(v map[string]*string) *Job {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Job) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Input != nil {
+		v := s.Input
+
+		e.SetFields(protocol.BodyTarget, "Input", v, protocol.Metadata{})
+	}
+	if len(s.Inputs) > 0 {
+		v := s.Inputs
+
+		e.SetList(protocol.BodyTarget, "Inputs", encodeJobInputList(v), protocol.Metadata{})
+	}
+	if s.Output != nil {
+		v := s.Output
+
+		e.SetFields(protocol.BodyTarget, "Output", v, protocol.Metadata{})
+	}
+	if s.OutputKeyPrefix != nil {
+		v := *s.OutputKeyPrefix
+
+		e.SetValue(protocol.BodyTarget, "OutputKeyPrefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Outputs) > 0 {
+		v := s.Outputs
+
+		e.SetList(protocol.BodyTarget, "Outputs", encodeJobOutputList(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.BodyTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Playlists) > 0 {
+		v := s.Playlists
+
+		e.SetList(protocol.BodyTarget, "Playlists", encodePlaylistList(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timing != nil {
+		v := s.Timing
+
+		e.SetFields(protocol.BodyTarget, "Timing", v, protocol.Metadata{})
+	}
+	if len(s.UserMetadata) > 0 {
+		v := s.UserMetadata
+
+		e.SetMap(protocol.BodyTarget, "UserMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobList(vs []*Job) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The .jpg or .png file associated with an audio file.
 type JobAlbumArt struct {
 	_ struct{} `type:"structure"`
@@ -4360,6 +5093,22 @@ func (s *JobAlbumArt) SetArtwork(v []*Artwork) *JobAlbumArt {
 func (s *JobAlbumArt) SetMergePolicy(v string) *JobAlbumArt {
 	s.MergePolicy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobAlbumArt) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Artwork) > 0 {
+		v := s.Artwork
+
+		e.SetList(protocol.BodyTarget, "Artwork", encodeArtworkList(v), protocol.Metadata{})
+	}
+	if s.MergePolicy != nil {
+		v := *s.MergePolicy
+
+		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information about the file that you're transcoding.
@@ -4562,6 +5311,70 @@ func (s *JobInput) SetResolution(v string) *JobInput {
 func (s *JobInput) SetTimeSpan(v *TimeSpan) *JobInput {
 	s.TimeSpan = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AspectRatio != nil {
+		v := *s.AspectRatio
+
+		e.SetValue(protocol.BodyTarget, "AspectRatio", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Container != nil {
+		v := *s.Container
+
+		e.SetValue(protocol.BodyTarget, "Container", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DetectedProperties != nil {
+		v := s.DetectedProperties
+
+		e.SetFields(protocol.BodyTarget, "DetectedProperties", v, protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.FrameRate != nil {
+		v := *s.FrameRate
+
+		e.SetValue(protocol.BodyTarget, "FrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputCaptions != nil {
+		v := s.InputCaptions
+
+		e.SetFields(protocol.BodyTarget, "InputCaptions", v, protocol.Metadata{})
+	}
+	if s.Interlaced != nil {
+		v := *s.Interlaced
+
+		e.SetValue(protocol.BodyTarget, "Interlaced", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Resolution != nil {
+		v := *s.Resolution
+
+		e.SetValue(protocol.BodyTarget, "Resolution", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeSpan != nil {
+		v := s.TimeSpan
+
+		e.SetFields(protocol.BodyTarget, "TimeSpan", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobInputList(vs []*JobInput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Outputs recommended instead.
@@ -4918,6 +5731,125 @@ func (s *JobOutput) SetWidth(v int64) *JobOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlbumArt != nil {
+		v := s.AlbumArt
+
+		e.SetFields(protocol.BodyTarget, "AlbumArt", v, protocol.Metadata{})
+	}
+	if s.AppliedColorSpaceConversion != nil {
+		v := *s.AppliedColorSpaceConversion
+
+		e.SetValue(protocol.BodyTarget, "AppliedColorSpaceConversion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Captions != nil {
+		v := s.Captions
+
+		e.SetFields(protocol.BodyTarget, "Captions", v, protocol.Metadata{})
+	}
+	if len(s.Composition) > 0 {
+		v := s.Composition
+
+		e.SetList(protocol.BodyTarget, "Composition", encodeClipList(v), protocol.Metadata{})
+	}
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DurationMillis != nil {
+		v := *s.DurationMillis
+
+		e.SetValue(protocol.BodyTarget, "DurationMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.FileSize != nil {
+		v := *s.FileSize
+
+		e.SetValue(protocol.BodyTarget, "FileSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FrameRate != nil {
+		v := *s.FrameRate
+
+		e.SetValue(protocol.BodyTarget, "FrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Height != nil {
+		v := *s.Height
+
+		e.SetValue(protocol.BodyTarget, "Height", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PresetId != nil {
+		v := *s.PresetId
+
+		e.SetValue(protocol.BodyTarget, "PresetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Rotate != nil {
+		v := *s.Rotate
+
+		e.SetValue(protocol.BodyTarget, "Rotate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentDuration != nil {
+		v := *s.SegmentDuration
+
+		e.SetValue(protocol.BodyTarget, "SegmentDuration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusDetail != nil {
+		v := *s.StatusDetail
+
+		e.SetValue(protocol.BodyTarget, "StatusDetail", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailEncryption != nil {
+		v := s.ThumbnailEncryption
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailEncryption", v, protocol.Metadata{})
+	}
+	if s.ThumbnailPattern != nil {
+		v := *s.ThumbnailPattern
+
+		e.SetValue(protocol.BodyTarget, "ThumbnailPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Watermarks) > 0 {
+		v := s.Watermarks
+
+		e.SetList(protocol.BodyTarget, "Watermarks", encodeJobWatermarkList(v), protocol.Metadata{})
+	}
+	if s.Width != nil {
+		v := *s.Width
+
+		e.SetValue(protocol.BodyTarget, "Width", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobOutputList(vs []*JobOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Watermarks can be in .png or .jpg format. If you want to display a watermark
 // that is not rectangular, use the .png format, which supports transparency.
 type JobWatermark struct {
@@ -4988,6 +5920,35 @@ func (s *JobWatermark) SetPresetWatermarkId(v string) *JobWatermark {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobWatermark) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.InputKey != nil {
+		v := *s.InputKey
+
+		e.SetValue(protocol.BodyTarget, "InputKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PresetWatermarkId != nil {
+		v := *s.PresetWatermarkId
+
+		e.SetValue(protocol.BodyTarget, "PresetWatermarkId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobWatermarkList(vs []*JobWatermark) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The ListJobsByPipelineRequest structure.
 type ListJobsByPipelineInput struct {
 	_ struct{} `type:"structure"`
@@ -5047,6 +6008,27 @@ func (s *ListJobsByPipelineInput) SetPipelineId(v string) *ListJobsByPipelineInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsByPipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ListJobsByPipelineResponse structure.
 type ListJobsByPipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -5080,6 +6062,22 @@ func (s *ListJobsByPipelineOutput) SetJobs(v []*Job) *ListJobsByPipelineOutput {
 func (s *ListJobsByPipelineOutput) SetNextPageToken(v string) *ListJobsByPipelineOutput {
 	s.NextPageToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsByPipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "Jobs", encodeJobList(v), protocol.Metadata{})
+	}
+	if s.NextPageToken != nil {
+		v := *s.NextPageToken
+
+		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ListJobsByStatusRequest structure.
@@ -5143,6 +6141,27 @@ func (s *ListJobsByStatusInput) SetStatus(v string) *ListJobsByStatusInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsByStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.PathTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ListJobsByStatusResponse structure.
 type ListJobsByStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -5176,6 +6195,22 @@ func (s *ListJobsByStatusOutput) SetJobs(v []*Job) *ListJobsByStatusOutput {
 func (s *ListJobsByStatusOutput) SetNextPageToken(v string) *ListJobsByStatusOutput {
 	s.NextPageToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsByStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "Jobs", encodeJobList(v), protocol.Metadata{})
+	}
+	if s.NextPageToken != nil {
+		v := *s.NextPageToken
+
+		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ListPipelineRequest structure.
@@ -5214,6 +6249,22 @@ func (s *ListPipelinesInput) SetPageToken(v string) *ListPipelinesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPipelinesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A list of the pipelines associated with the current AWS account.
 type ListPipelinesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5247,6 +6298,22 @@ func (s *ListPipelinesOutput) SetNextPageToken(v string) *ListPipelinesOutput {
 func (s *ListPipelinesOutput) SetPipelines(v []*Pipeline) *ListPipelinesOutput {
 	s.Pipelines = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPipelinesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextPageToken != nil {
+		v := *s.NextPageToken
+
+		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Pipelines) > 0 {
+		v := s.Pipelines
+
+		e.SetList(protocol.BodyTarget, "Pipelines", encodePipelineList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ListPresetsRequest structure.
@@ -5285,6 +6352,22 @@ func (s *ListPresetsInput) SetPageToken(v string) *ListPresetsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPresetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ListPresetsResponse structure.
 type ListPresetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5318,6 +6401,22 @@ func (s *ListPresetsOutput) SetNextPageToken(v string) *ListPresetsOutput {
 func (s *ListPresetsOutput) SetPresets(v []*Preset) *ListPresetsOutput {
 	s.Presets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPresetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextPageToken != nil {
+		v := *s.NextPageToken
+
+		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Presets) > 0 {
+		v := s.Presets
+
+		e.SetList(protocol.BodyTarget, "Presets", encodePresetList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The Amazon Simple Notification Service (Amazon SNS) topic or topics to notify
@@ -5377,6 +6476,32 @@ func (s *Notifications) SetProgressing(v string) *Notifications {
 func (s *Notifications) SetWarning(v string) *Notifications {
 	s.Warning = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Notifications) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Completed != nil {
+		v := *s.Completed
+
+		e.SetValue(protocol.BodyTarget, "Completed", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Error != nil {
+		v := *s.Error
+
+		e.SetValue(protocol.BodyTarget, "Error", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Progressing != nil {
+		v := *s.Progressing
+
+		e.SetValue(protocol.BodyTarget, "Progressing", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Warning != nil {
+		v := *s.Warning
+
+		e.SetValue(protocol.BodyTarget, "Warning", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The Permission structure.
@@ -5459,6 +6584,35 @@ func (s *Permission) SetGrantee(v string) *Permission {
 func (s *Permission) SetGranteeType(v string) *Permission {
 	s.GranteeType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Permission) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Access) > 0 {
+		v := s.Access
+
+		e.SetList(protocol.BodyTarget, "Access", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Grantee != nil {
+		v := *s.Grantee
+
+		e.SetValue(protocol.BodyTarget, "Grantee", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GranteeType != nil {
+		v := *s.GranteeType
+
+		e.SetValue(protocol.BodyTarget, "GranteeType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePermissionList(vs []*Permission) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The pipeline (queue) that is used to manage jobs.
@@ -5696,6 +6850,75 @@ func (s *Pipeline) SetThumbnailConfig(v *PipelineOutputConfig) *Pipeline {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Pipeline) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AwsKmsKeyArn != nil {
+		v := *s.AwsKmsKeyArn
+
+		e.SetValue(protocol.BodyTarget, "AwsKmsKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentConfig != nil {
+		v := s.ContentConfig
+
+		e.SetFields(protocol.BodyTarget, "ContentConfig", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputBucket != nil {
+		v := *s.InputBucket
+
+		e.SetValue(protocol.BodyTarget, "InputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Notifications != nil {
+		v := s.Notifications
+
+		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
+	}
+	if s.OutputBucket != nil {
+		v := *s.OutputBucket
+
+		e.SetValue(protocol.BodyTarget, "OutputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailConfig != nil {
+		v := s.ThumbnailConfig
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePipelineList(vs []*Pipeline) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The PipelineOutputConfig structure.
 type PipelineOutputConfig struct {
 	_ struct{} `type:"structure"`
@@ -5788,6 +7011,27 @@ func (s *PipelineOutputConfig) SetPermissions(v []*Permission) *PipelineOutputCo
 func (s *PipelineOutputConfig) SetStorageClass(v string) *PipelineOutputConfig {
 	s.StorageClass = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PipelineOutputConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Permissions) > 0 {
+		v := s.Permissions
+
+		e.SetList(protocol.BodyTarget, "Permissions", encodePermissionList(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The PlayReady DRM settings, if any, that you want Elastic Transcoder to apply
@@ -5899,6 +7143,42 @@ func (s *PlayReadyDrm) SetKeyMd5(v string) *PlayReadyDrm {
 func (s *PlayReadyDrm) SetLicenseAcquisitionUrl(v string) *PlayReadyDrm {
 	s.LicenseAcquisitionUrl = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PlayReadyDrm) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitializationVector != nil {
+		v := *s.InitializationVector
+
+		e.SetValue(protocol.BodyTarget, "InitializationVector", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.BodyTarget, "KeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMd5 != nil {
+		v := *s.KeyMd5
+
+		e.SetValue(protocol.BodyTarget, "KeyMd5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LicenseAcquisitionUrl != nil {
+		v := *s.LicenseAcquisitionUrl
+
+		e.SetValue(protocol.BodyTarget, "LicenseAcquisitionUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for
@@ -6030,6 +7310,55 @@ func (s *Playlist) SetStatusDetail(v string) *Playlist {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Playlist) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsContentProtection != nil {
+		v := s.HlsContentProtection
+
+		e.SetFields(protocol.BodyTarget, "HlsContentProtection", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OutputKeys) > 0 {
+		v := s.OutputKeys
+
+		e.SetList(protocol.BodyTarget, "OutputKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.PlayReadyDrm != nil {
+		v := s.PlayReadyDrm
+
+		e.SetFields(protocol.BodyTarget, "PlayReadyDrm", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusDetail != nil {
+		v := *s.StatusDetail
+
+		e.SetValue(protocol.BodyTarget, "StatusDetail", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePlaylistList(vs []*Playlist) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Presets are templates that contain most of the settings for transcoding media
 // files from one format to another. Elastic Transcoder includes some default
 // presets for common formats, for example, several iPod and iPhone versions.
@@ -6135,6 +7464,65 @@ func (s *Preset) SetType(v string) *Preset {
 func (s *Preset) SetVideo(v *VideoParameters) *Preset {
 	s.Video = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Preset) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Audio != nil {
+		v := s.Audio
+
+		e.SetFields(protocol.BodyTarget, "Audio", v, protocol.Metadata{})
+	}
+	if s.Container != nil {
+		v := *s.Container
+
+		e.SetValue(protocol.BodyTarget, "Container", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Thumbnails != nil {
+		v := s.Thumbnails
+
+		e.SetFields(protocol.BodyTarget, "Thumbnails", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Video != nil {
+		v := s.Video
+
+		e.SetFields(protocol.BodyTarget, "Video", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePresetList(vs []*Preset) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Settings for the size, location, and opacity of graphics that you want Elastic
@@ -6385,6 +7773,70 @@ func (s *PresetWatermark) SetVerticalOffset(v string) *PresetWatermark {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PresetWatermark) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HorizontalAlign != nil {
+		v := *s.HorizontalAlign
+
+		e.SetValue(protocol.BodyTarget, "HorizontalAlign", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HorizontalOffset != nil {
+		v := *s.HorizontalOffset
+
+		e.SetValue(protocol.BodyTarget, "HorizontalOffset", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxHeight != nil {
+		v := *s.MaxHeight
+
+		e.SetValue(protocol.BodyTarget, "MaxHeight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxWidth != nil {
+		v := *s.MaxWidth
+
+		e.SetValue(protocol.BodyTarget, "MaxWidth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Opacity != nil {
+		v := *s.Opacity
+
+		e.SetValue(protocol.BodyTarget, "Opacity", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizingPolicy != nil {
+		v := *s.SizingPolicy
+
+		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Target != nil {
+		v := *s.Target
+
+		e.SetValue(protocol.BodyTarget, "Target", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VerticalAlign != nil {
+		v := *s.VerticalAlign
+
+		e.SetValue(protocol.BodyTarget, "VerticalAlign", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VerticalOffset != nil {
+		v := *s.VerticalOffset
+
+		e.SetValue(protocol.BodyTarget, "VerticalOffset", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePresetWatermarkList(vs []*PresetWatermark) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The ReadJobRequest structure.
 type ReadJobInput struct {
 	_ struct{} `type:"structure"`
@@ -6424,6 +7876,17 @@ func (s *ReadJobInput) SetId(v string) *ReadJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ReadJobResponse structure.
 type ReadJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -6446,6 +7909,17 @@ func (s ReadJobOutput) GoString() string {
 func (s *ReadJobOutput) SetJob(v *Job) *ReadJobOutput {
 	s.Job = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Job != nil {
+		v := s.Job
+
+		e.SetFields(protocol.BodyTarget, "Job", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ReadPipelineRequest structure.
@@ -6487,6 +7961,17 @@ func (s *ReadPipelineInput) SetId(v string) *ReadPipelineInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadPipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ReadPipelineResponse structure.
 type ReadPipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -6523,6 +8008,22 @@ func (s *ReadPipelineOutput) SetPipeline(v *Pipeline) *ReadPipelineOutput {
 func (s *ReadPipelineOutput) SetWarnings(v []*Warning) *ReadPipelineOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadPipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ReadPresetRequest structure.
@@ -6564,6 +8065,17 @@ func (s *ReadPresetInput) SetId(v string) *ReadPresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadPresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ReadPresetResponse structure.
 type ReadPresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -6586,6 +8098,17 @@ func (s ReadPresetOutput) GoString() string {
 func (s *ReadPresetOutput) SetPreset(v *Preset) *ReadPresetOutput {
 	s.Preset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadPresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Preset != nil {
+		v := s.Preset
+
+		e.SetFields(protocol.BodyTarget, "Preset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The TestRoleRequest structure.
@@ -6673,6 +8196,32 @@ func (s *TestRoleInput) SetTopics(v []*string) *TestRoleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestRoleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InputBucket != nil {
+		v := *s.InputBucket
+
+		e.SetValue(protocol.BodyTarget, "InputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutputBucket != nil {
+		v := *s.OutputBucket
+
+		e.SetValue(protocol.BodyTarget, "OutputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Topics) > 0 {
+		v := s.Topics
+
+		e.SetList(protocol.BodyTarget, "Topics", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The TestRoleResponse structure.
 type TestRoleOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -6706,6 +8255,22 @@ func (s *TestRoleOutput) SetMessages(v []*string) *TestRoleOutput {
 func (s *TestRoleOutput) SetSuccess(v string) *TestRoleOutput {
 	s.Success = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Messages) > 0 {
+		v := s.Messages
+
+		e.SetList(protocol.BodyTarget, "Messages", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Success != nil {
+		v := *s.Success
+
+		e.SetValue(protocol.BodyTarget, "Success", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Thumbnails for videos.
@@ -6851,6 +8416,52 @@ func (s *Thumbnails) SetSizingPolicy(v string) *Thumbnails {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Thumbnails) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AspectRatio != nil {
+		v := *s.AspectRatio
+
+		e.SetValue(protocol.BodyTarget, "AspectRatio", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Interval != nil {
+		v := *s.Interval
+
+		e.SetValue(protocol.BodyTarget, "Interval", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxHeight != nil {
+		v := *s.MaxHeight
+
+		e.SetValue(protocol.BodyTarget, "MaxHeight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxWidth != nil {
+		v := *s.MaxWidth
+
+		e.SetValue(protocol.BodyTarget, "MaxWidth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PaddingPolicy != nil {
+		v := *s.PaddingPolicy
+
+		e.SetValue(protocol.BodyTarget, "PaddingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Resolution != nil {
+		v := *s.Resolution
+
+		e.SetValue(protocol.BodyTarget, "Resolution", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizingPolicy != nil {
+		v := *s.SizingPolicy
+
+		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings that determine when a clip begins and how long it lasts.
 type TimeSpan struct {
 	_ struct{} `type:"structure"`
@@ -6893,6 +8504,22 @@ func (s *TimeSpan) SetStartTime(v string) *TimeSpan {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TimeSpan) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Details about the timing of a job.
 type Timing struct {
 	_ struct{} `type:"structure"`
@@ -6933,6 +8560,27 @@ func (s *Timing) SetStartTimeMillis(v int64) *Timing {
 func (s *Timing) SetSubmitTimeMillis(v int64) *Timing {
 	s.SubmitTimeMillis = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Timing) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FinishTimeMillis != nil {
+		v := *s.FinishTimeMillis
+
+		e.SetValue(protocol.BodyTarget, "FinishTimeMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StartTimeMillis != nil {
+		v := *s.StartTimeMillis
+
+		e.SetValue(protocol.BodyTarget, "StartTimeMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SubmitTimeMillis != nil {
+		v := *s.SubmitTimeMillis
+
+		e.SetValue(protocol.BodyTarget, "SubmitTimeMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The UpdatePipelineRequest structure.
@@ -7204,6 +8852,52 @@ func (s *UpdatePipelineInput) SetThumbnailConfig(v *PipelineOutputConfig) *Updat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AwsKmsKeyArn != nil {
+		v := *s.AwsKmsKeyArn
+
+		e.SetValue(protocol.BodyTarget, "AwsKmsKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentConfig != nil {
+		v := s.ContentConfig
+
+		e.SetFields(protocol.BodyTarget, "ContentConfig", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputBucket != nil {
+		v := *s.InputBucket
+
+		e.SetValue(protocol.BodyTarget, "InputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Notifications != nil {
+		v := s.Notifications
+
+		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailConfig != nil {
+		v := s.ThumbnailConfig
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The UpdatePipelineNotificationsRequest structure.
 type UpdatePipelineNotificationsInput struct {
 	_ struct{} `type:"structure"`
@@ -7279,6 +8973,22 @@ func (s *UpdatePipelineNotificationsInput) SetNotifications(v *Notifications) *U
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Notifications != nil {
+		v := s.Notifications
+
+		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The UpdatePipelineNotificationsResponse structure.
 type UpdatePipelineNotificationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7302,6 +9012,17 @@ func (s UpdatePipelineNotificationsOutput) GoString() string {
 func (s *UpdatePipelineNotificationsOutput) SetPipeline(v *Pipeline) *UpdatePipelineNotificationsOutput {
 	s.Pipeline = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // When you update a pipeline, Elastic Transcoder returns the values that you
@@ -7341,6 +9062,22 @@ func (s *UpdatePipelineOutput) SetPipeline(v *Pipeline) *UpdatePipelineOutput {
 func (s *UpdatePipelineOutput) SetWarnings(v []*Warning) *UpdatePipelineOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The UpdatePipelineStatusRequest structure.
@@ -7400,6 +9137,22 @@ func (s *UpdatePipelineStatusInput) SetStatus(v string) *UpdatePipelineStatusInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // When you update status for a pipeline, Elastic Transcoder returns the values
 // that you specified in the request.
 type UpdatePipelineStatusOutput struct {
@@ -7423,6 +9176,17 @@ func (s UpdatePipelineStatusOutput) GoString() string {
 func (s *UpdatePipelineStatusOutput) SetPipeline(v *Pipeline) *UpdatePipelineStatusOutput {
 	s.Pipeline = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The VideoParameters structure.
@@ -7962,6 +9726,87 @@ func (s *VideoParameters) SetWatermarks(v []*PresetWatermark) *VideoParameters {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoParameters) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AspectRatio != nil {
+		v := *s.AspectRatio
+
+		e.SetValue(protocol.BodyTarget, "AspectRatio", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BitRate != nil {
+		v := *s.BitRate
+
+		e.SetValue(protocol.BodyTarget, "BitRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Codec != nil {
+		v := *s.Codec
+
+		e.SetValue(protocol.BodyTarget, "Codec", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.CodecOptions) > 0 {
+		v := s.CodecOptions
+
+		e.SetMap(protocol.BodyTarget, "CodecOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.DisplayAspectRatio != nil {
+		v := *s.DisplayAspectRatio
+
+		e.SetValue(protocol.BodyTarget, "DisplayAspectRatio", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FixedGOP != nil {
+		v := *s.FixedGOP
+
+		e.SetValue(protocol.BodyTarget, "FixedGOP", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FrameRate != nil {
+		v := *s.FrameRate
+
+		e.SetValue(protocol.BodyTarget, "FrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyframesMaxDist != nil {
+		v := *s.KeyframesMaxDist
+
+		e.SetValue(protocol.BodyTarget, "KeyframesMaxDist", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxFrameRate != nil {
+		v := *s.MaxFrameRate
+
+		e.SetValue(protocol.BodyTarget, "MaxFrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxHeight != nil {
+		v := *s.MaxHeight
+
+		e.SetValue(protocol.BodyTarget, "MaxHeight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxWidth != nil {
+		v := *s.MaxWidth
+
+		e.SetValue(protocol.BodyTarget, "MaxWidth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PaddingPolicy != nil {
+		v := *s.PaddingPolicy
+
+		e.SetValue(protocol.BodyTarget, "PaddingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Resolution != nil {
+		v := *s.Resolution
+
+		e.SetValue(protocol.BodyTarget, "Resolution", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizingPolicy != nil {
+		v := *s.SizingPolicy
+
+		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Watermarks) > 0 {
+		v := s.Watermarks
+
+		e.SetList(protocol.BodyTarget, "Watermarks", encodePresetWatermarkList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Elastic Transcoder returns a warning if the resources used by your pipeline
 // are not in the same region as the pipeline.
 //
@@ -8001,4 +9846,28 @@ func (s *Warning) SetCode(v string) *Warning {
 func (s *Warning) SetMessage(v string) *Warning {
 	s.Message = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Warning) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Code != nil {
+		v := *s.Code
+
+		e.SetValue(protocol.BodyTarget, "Code", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeWarningList(vs []*Warning) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -3931,6 +3931,27 @@ func (s *AbortMultipartUploadInput) SetVaultName(v string) *AbortMultipartUpload
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.PathTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3943,6 +3964,12 @@ func (s AbortMultipartUploadOutput) String() string {
 // GoString returns the string representation
 func (s AbortMultipartUploadOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input values for AbortVaultLock.
@@ -4003,6 +4030,22 @@ func (s *AbortVaultLockInput) SetVaultName(v string) *AbortVaultLockInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AbortVaultLockOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4015,6 +4058,12 @@ func (s AbortVaultLockOutput) String() string {
 // GoString returns the string representation
 func (s AbortVaultLockOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input values for AddTagsToVault.
@@ -4084,6 +4133,27 @@ func (s *AddTagsToVaultInput) SetVaultName(v string) *AddTagsToVaultInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddTagsToVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AddTagsToVaultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4096,6 +4166,12 @@ func (s AddTagsToVaultOutput) String() string {
 // GoString returns the string representation
 func (s AddTagsToVaultOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddTagsToVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -4141,6 +4217,27 @@ func (s *ArchiveCreationOutput) SetChecksum(v string) *ArchiveCreationOutput {
 func (s *ArchiveCreationOutput) SetLocation(v string) *ArchiveCreationOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ArchiveCreationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveId != nil {
+		v := *s.ArchiveId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options to complete a multipart upload operation. This informs Amazon
@@ -4240,6 +4337,37 @@ func (s *CompleteMultipartUploadInput) SetVaultName(v string) *CompleteMultipart
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveSize != nil {
+		v := *s.ArchiveSize
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.PathTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input values for CompleteVaultLock.
 type CompleteVaultLockInput struct {
 	_ struct{} `type:"structure"`
@@ -4312,6 +4440,27 @@ func (s *CompleteVaultLockInput) SetVaultName(v string) *CompleteVaultLockInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LockId != nil {
+		v := *s.LockId
+
+		e.SetValue(protocol.PathTarget, "lockId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CompleteVaultLockOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4324,6 +4473,12 @@ func (s CompleteVaultLockOutput) String() string {
 // GoString returns the string representation
 func (s CompleteVaultLockOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options to create a vault.
@@ -4384,6 +4539,22 @@ func (s *CreateVaultInput) SetVaultName(v string) *CreateVaultInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type CreateVaultOutput struct {
 	_ struct{} `type:"structure"`
@@ -4406,6 +4577,17 @@ func (s CreateVaultOutput) GoString() string {
 func (s *CreateVaultOutput) SetLocation(v string) *CreateVaultOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Data retrieval policy.
@@ -4431,6 +4613,17 @@ func (s DataRetrievalPolicy) GoString() string {
 func (s *DataRetrievalPolicy) SetRules(v []*DataRetrievalRule) *DataRetrievalPolicy {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DataRetrievalPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rules", encodeDataRetrievalRuleList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Data retrieval policy rule.
@@ -4470,6 +4663,30 @@ func (s *DataRetrievalRule) SetBytesPerHour(v int64) *DataRetrievalRule {
 func (s *DataRetrievalRule) SetStrategy(v string) *DataRetrievalRule {
 	s.Strategy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DataRetrievalRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BytesPerHour != nil {
+		v := *s.BytesPerHour
+
+		e.SetValue(protocol.BodyTarget, "BytesPerHour", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Strategy != nil {
+		v := *s.Strategy
+
+		e.SetValue(protocol.BodyTarget, "Strategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDataRetrievalRuleList(vs []*DataRetrievalRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Provides options for deleting an archive from an Amazon Glacier vault.
@@ -4543,6 +4760,27 @@ func (s *DeleteArchiveInput) SetVaultName(v string) *DeleteArchiveInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteArchiveInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveId != nil {
+		v := *s.ArchiveId
+
+		e.SetValue(protocol.PathTarget, "archiveId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteArchiveOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4555,6 +4793,12 @@ func (s DeleteArchiveOutput) String() string {
 // GoString returns the string representation
 func (s DeleteArchiveOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteArchiveOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // DeleteVaultAccessPolicy input.
@@ -4614,6 +4858,22 @@ func (s *DeleteVaultAccessPolicyInput) SetVaultName(v string) *DeleteVaultAccess
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4626,6 +4886,12 @@ func (s DeleteVaultAccessPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVaultAccessPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options for deleting a vault from Amazon Glacier.
@@ -4683,6 +4949,22 @@ func (s *DeleteVaultInput) SetAccountId(v string) *DeleteVaultInput {
 func (s *DeleteVaultInput) SetVaultName(v string) *DeleteVaultInput {
 	s.VaultName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for deleting a vault notification configuration from an
@@ -4743,6 +5025,22 @@ func (s *DeleteVaultNotificationsInput) SetVaultName(v string) *DeleteVaultNotif
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteVaultNotificationsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4757,6 +5055,12 @@ func (s DeleteVaultNotificationsOutput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type DeleteVaultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4769,6 +5073,12 @@ func (s DeleteVaultOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVaultOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options for retrieving a job description.
@@ -4842,6 +5152,27 @@ func (s *DescribeJobInput) SetVaultName(v string) *DescribeJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.PathTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides options for retrieving metadata for a specific vault in Amazon Glacier.
 type DescribeVaultInput struct {
 	_ struct{} `type:"structure"`
@@ -4897,6 +5228,22 @@ func (s *DescribeVaultInput) SetAccountId(v string) *DescribeVaultInput {
 func (s *DescribeVaultInput) SetVaultName(v string) *DescribeVaultInput {
 	s.VaultName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -4975,6 +5322,50 @@ func (s *DescribeVaultOutput) SetVaultName(v string) *DescribeVaultOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastInventoryDate != nil {
+		v := *s.LastInventoryDate
+
+		e.SetValue(protocol.BodyTarget, "LastInventoryDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NumberOfArchives != nil {
+		v := *s.NumberOfArchives
+
+		e.SetValue(protocol.BodyTarget, "NumberOfArchives", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SizeInBytes != nil {
+		v := *s.SizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "SizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VaultARN != nil {
+		v := *s.VaultARN
+
+		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.BodyTarget, "VaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDescribeVaultOutputList(vs []*DescribeVaultOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Input for GetDataRetrievalPolicy.
 type GetDataRetrievalPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -5019,6 +5410,17 @@ func (s *GetDataRetrievalPolicyInput) SetAccountId(v string) *GetDataRetrievalPo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDataRetrievalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to the GetDataRetrievalPolicy request.
 type GetDataRetrievalPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -5041,6 +5443,17 @@ func (s GetDataRetrievalPolicyOutput) GoString() string {
 func (s *GetDataRetrievalPolicyOutput) SetPolicy(v *DataRetrievalPolicy) *GetDataRetrievalPolicyOutput {
 	s.Policy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDataRetrievalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.BodyTarget, "Policy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for downloading output of an Amazon Glacier job.
@@ -5151,6 +5564,32 @@ func (s *GetJobOutputInput) SetVaultName(v string) *GetJobOutputInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetJobOutputInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.PathTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetJobOutputOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -5251,6 +5690,39 @@ func (s *GetJobOutputOutput) SetStatus(v int64) *GetJobOutputOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetJobOutputOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcceptRanges != nil {
+		v := *s.AcceptRanges
+
+		e.SetValue(protocol.HeaderTarget, "Accept-Ranges", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// Skipping Body Output type's body not valid.
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentRange != nil {
+		v := *s.ContentRange
+
+		e.SetValue(protocol.HeaderTarget, "Content-Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// ignoring invalid encode state, StatusCode. Status
+
+	return nil
+}
+
 // Input for GetVaultAccessPolicy.
 type GetVaultAccessPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -5308,6 +5780,22 @@ func (s *GetVaultAccessPolicyInput) SetVaultName(v string) *GetVaultAccessPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Output for GetVaultAccessPolicy.
 type GetVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure" payload:"Policy"`
@@ -5330,6 +5818,17 @@ func (s GetVaultAccessPolicyOutput) GoString() string {
 func (s *GetVaultAccessPolicyOutput) SetPolicy(v *VaultAccessPolicy) *GetVaultAccessPolicyOutput {
 	s.Policy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input values for GetVaultLock.
@@ -5389,6 +5888,22 @@ func (s *GetVaultLockInput) SetVaultName(v string) *GetVaultLockInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetVaultLockOutput struct {
 	_ struct{} `type:"structure"`
@@ -5440,6 +5955,32 @@ func (s *GetVaultLockOutput) SetPolicy(v string) *GetVaultLockOutput {
 func (s *GetVaultLockOutput) SetState(v string) *GetVaultLockOutput {
 	s.State = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExpirationDate != nil {
+		v := *s.ExpirationDate
+
+		e.SetValue(protocol.BodyTarget, "ExpirationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for retrieving the notification configuration set on an
@@ -5500,6 +6041,22 @@ func (s *GetVaultNotificationsInput) SetVaultName(v string) *GetVaultNotificatio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetVaultNotificationsOutput struct {
 	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
@@ -5522,6 +6079,17 @@ func (s GetVaultNotificationsOutput) GoString() string {
 func (s *GetVaultNotificationsOutput) SetVaultNotificationConfig(v *VaultNotificationConfig) *GetVaultNotificationsOutput {
 	s.VaultNotificationConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VaultNotificationConfig != nil {
+		v := s.VaultNotificationConfig
+
+		e.SetFields(protocol.PayloadTarget, "vaultNotificationConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for initiating an Amazon Glacier job.
@@ -5590,6 +6158,27 @@ func (s *InitiateJobInput) SetVaultName(v string) *InitiateJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobParameters != nil {
+		v := s.JobParameters
+
+		e.SetFields(protocol.PayloadTarget, "jobParameters", v, protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type InitiateJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -5621,6 +6210,22 @@ func (s *InitiateJobOutput) SetJobId(v string) *InitiateJobOutput {
 func (s *InitiateJobOutput) SetLocation(v string) *InitiateJobOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-job-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for initiating a multipart upload to an Amazon Glacier vault.
@@ -5704,6 +6309,32 @@ func (s *InitiateMultipartUploadInput) SetVaultName(v string) *InitiateMultipart
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartSize != nil {
+		v := *s.PartSize
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-part-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The Amazon Glacier response to your request.
 type InitiateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -5736,6 +6367,22 @@ func (s *InitiateMultipartUploadOutput) SetLocation(v string) *InitiateMultipart
 func (s *InitiateMultipartUploadOutput) SetUploadId(v string) *InitiateMultipartUploadOutput {
 	s.UploadId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-multipart-upload-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input values for InitiateVaultLock.
@@ -5805,6 +6452,27 @@ func (s *InitiateVaultLockInput) SetVaultName(v string) *InitiateVaultLockInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type InitiateVaultLockOutput struct {
 	_ struct{} `type:"structure"`
@@ -5827,6 +6495,17 @@ func (s InitiateVaultLockOutput) GoString() string {
 func (s *InitiateVaultLockOutput) SetLockId(v string) *InitiateVaultLockOutput {
 	s.LockId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LockId != nil {
+		v := *s.LockId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lock-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the options for a range inventory retrieval job.
@@ -5901,6 +6580,37 @@ func (s *InventoryRetrievalJobDescription) SetStartDate(v string) *InventoryRetr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryRetrievalJobDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndDate != nil {
+		v := *s.EndDate
+
+		e.SetValue(protocol.BodyTarget, "EndDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.BodyTarget, "Limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides options for specifying a range inventory retrieval job.
 type InventoryRetrievalJobInput struct {
 	_ struct{} `type:"structure"`
@@ -5958,6 +6668,32 @@ func (s *InventoryRetrievalJobInput) SetMarker(v string) *InventoryRetrievalJobI
 func (s *InventoryRetrievalJobInput) SetStartDate(v string) *InventoryRetrievalJobInput {
 	s.StartDate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryRetrievalJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndDate != nil {
+		v := *s.EndDate
+
+		e.SetValue(protocol.BodyTarget, "EndDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.BodyTarget, "Limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an Amazon Glacier job.
@@ -6166,6 +6902,110 @@ func (s *JobDescription) SetVaultARN(v string) *JobDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveId != nil {
+		v := *s.ArchiveId
+
+		e.SetValue(protocol.BodyTarget, "ArchiveId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveSHA256TreeHash != nil {
+		v := *s.ArchiveSHA256TreeHash
+
+		e.SetValue(protocol.BodyTarget, "ArchiveSHA256TreeHash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveSizeInBytes != nil {
+		v := *s.ArchiveSizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "ArchiveSizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Completed != nil {
+		v := *s.Completed
+
+		e.SetValue(protocol.BodyTarget, "Completed", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CompletionDate != nil {
+		v := *s.CompletionDate
+
+		e.SetValue(protocol.BodyTarget, "CompletionDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InventoryRetrievalParameters != nil {
+		v := s.InventoryRetrievalParameters
+
+		e.SetFields(protocol.BodyTarget, "InventoryRetrievalParameters", v, protocol.Metadata{})
+	}
+	if s.InventorySizeInBytes != nil {
+		v := *s.InventorySizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "InventorySizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.JobDescription != nil {
+		v := *s.JobDescription
+
+		e.SetValue(protocol.BodyTarget, "JobDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "JobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RetrievalByteRange != nil {
+		v := *s.RetrievalByteRange
+
+		e.SetValue(protocol.BodyTarget, "RetrievalByteRange", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SHA256TreeHash != nil {
+		v := *s.SHA256TreeHash
+
+		e.SetValue(protocol.BodyTarget, "SHA256TreeHash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SNSTopic != nil {
+		v := *s.SNSTopic
+
+		e.SetValue(protocol.BodyTarget, "SNSTopic", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "StatusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusMessage != nil {
+		v := *s.StatusMessage
+
+		e.SetValue(protocol.BodyTarget, "StatusMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tier != nil {
+		v := *s.Tier
+
+		e.SetValue(protocol.BodyTarget, "Tier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultARN != nil {
+		v := *s.VaultARN
+
+		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobDescriptionList(vs []*JobDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides options for defining a job.
 type JobParameters struct {
 	_ struct{} `type:"structure"`
@@ -6273,6 +7113,52 @@ func (s *JobParameters) SetType(v string) *JobParameters {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobParameters) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveId != nil {
+		v := *s.ArchiveId
+
+		e.SetValue(protocol.BodyTarget, "ArchiveId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InventoryRetrievalParameters != nil {
+		v := s.InventoryRetrievalParameters
+
+		e.SetFields(protocol.BodyTarget, "InventoryRetrievalParameters", v, protocol.Metadata{})
+	}
+	if s.RetrievalByteRange != nil {
+		v := *s.RetrievalByteRange
+
+		e.SetValue(protocol.BodyTarget, "RetrievalByteRange", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SNSTopic != nil {
+		v := *s.SNSTopic
+
+		e.SetValue(protocol.BodyTarget, "SNSTopic", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tier != nil {
+		v := *s.Tier
+
+		e.SetValue(protocol.BodyTarget, "Tier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides options for retrieving a job list for an Amazon Glacier vault.
 type ListJobsInput struct {
 	_ struct{} `type:"structure"`
@@ -6372,6 +7258,42 @@ func (s *ListJobsInput) SetVaultName(v string) *ListJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Completed != nil {
+		v := *s.Completed
+
+		e.SetValue(protocol.QueryTarget, "completed", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Statuscode != nil {
+		v := *s.Statuscode
+
+		e.SetValue(protocol.QueryTarget, "statuscode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6406,6 +7328,22 @@ func (s *ListJobsOutput) SetJobList(v []*JobDescription) *ListJobsOutput {
 func (s *ListJobsOutput) SetMarker(v string) *ListJobsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobList) > 0 {
+		v := s.JobList
+
+		e.SetList(protocol.BodyTarget, "JobList", encodeJobDescriptionList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for retrieving list of in-progress multipart uploads for
@@ -6489,6 +7427,32 @@ func (s *ListMultipartUploadsInput) SetVaultName(v string) *ListMultipartUploads
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListMultipartUploadsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListMultipartUploadsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6522,6 +7486,22 @@ func (s *ListMultipartUploadsOutput) SetMarker(v string) *ListMultipartUploadsOu
 func (s *ListMultipartUploadsOutput) SetUploadsList(v []*UploadListElement) *ListMultipartUploadsOutput {
 	s.UploadsList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListMultipartUploadsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.UploadsList) > 0 {
+		v := s.UploadsList
+
+		e.SetList(protocol.BodyTarget, "UploadsList", encodeUploadListElementList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for retrieving a list of parts of an archive that have been
@@ -6620,6 +7600,37 @@ func (s *ListPartsInput) SetVaultName(v string) *ListPartsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.PathTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListPartsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6704,6 +7715,47 @@ func (s *ListPartsOutput) SetVaultARN(v string) *ListPartsOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.BodyTarget, "ArchiveDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MultipartUploadId != nil {
+		v := *s.MultipartUploadId
+
+		e.SetValue(protocol.BodyTarget, "MultipartUploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartSizeInBytes != nil {
+		v := *s.PartSizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "PartSizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Parts) > 0 {
+		v := s.Parts
+
+		e.SetList(protocol.BodyTarget, "Parts", encodePartListElementList(v), protocol.Metadata{})
+	}
+	if s.VaultARN != nil {
+		v := *s.VaultARN
+
+		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type ListProvisionedCapacityInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6746,6 +7798,17 @@ func (s *ListProvisionedCapacityInput) SetAccountId(v string) *ListProvisionedCa
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListProvisionedCapacityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type ListProvisionedCapacityOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6767,6 +7830,17 @@ func (s ListProvisionedCapacityOutput) GoString() string {
 func (s *ListProvisionedCapacityOutput) SetProvisionedCapacityList(v []*ProvisionedCapacityDescription) *ListProvisionedCapacityOutput {
 	s.ProvisionedCapacityList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListProvisionedCapacityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ProvisionedCapacityList) > 0 {
+		v := s.ProvisionedCapacityList
+
+		e.SetList(protocol.BodyTarget, "ProvisionedCapacityList", encodeProvisionedCapacityDescriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input value for ListTagsForVaultInput.
@@ -6826,6 +7900,22 @@ func (s *ListTagsForVaultInput) SetVaultName(v string) *ListTagsForVaultInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListTagsForVaultOutput struct {
 	_ struct{} `type:"structure"`
@@ -6848,6 +7938,17 @@ func (s ListTagsForVaultOutput) GoString() string {
 func (s *ListTagsForVaultOutput) SetTags(v map[string]*string) *ListTagsForVaultOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options to retrieve the vault list owned by the calling user's account.
@@ -6916,6 +8017,27 @@ func (s *ListVaultsInput) SetMarker(v string) *ListVaultsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVaultsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListVaultsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6950,6 +8072,22 @@ func (s *ListVaultsOutput) SetVaultList(v []*DescribeVaultOutput) *ListVaultsOut
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVaultsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.VaultList) > 0 {
+		v := s.VaultList
+
+		e.SetList(protocol.BodyTarget, "VaultList", encodeDescribeVaultOutputList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A list of the part sizes of the multipart upload.
 type PartListElement struct {
 	_ struct{} `type:"structure"`
@@ -6982,6 +8120,30 @@ func (s *PartListElement) SetRangeInBytes(v string) *PartListElement {
 func (s *PartListElement) SetSHA256TreeHash(v string) *PartListElement {
 	s.SHA256TreeHash = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PartListElement) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RangeInBytes != nil {
+		v := *s.RangeInBytes
+
+		e.SetValue(protocol.BodyTarget, "RangeInBytes", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SHA256TreeHash != nil {
+		v := *s.SHA256TreeHash
+
+		e.SetValue(protocol.BodyTarget, "SHA256TreeHash", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePartListElementList(vs []*PartListElement) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The definition for a provisioned capacity unit.
@@ -7028,6 +8190,35 @@ func (s *ProvisionedCapacityDescription) SetStartDate(v string) *ProvisionedCapa
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ProvisionedCapacityDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CapacityId != nil {
+		v := *s.CapacityId
+
+		e.SetValue(protocol.BodyTarget, "CapacityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExpirationDate != nil {
+		v := *s.ExpirationDate
+
+		e.SetValue(protocol.BodyTarget, "ExpirationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeProvisionedCapacityDescriptionList(vs []*ProvisionedCapacityDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 type PurchaseProvisionedCapacityInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7070,6 +8261,17 @@ func (s *PurchaseProvisionedCapacityInput) SetAccountId(v string) *PurchaseProvi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PurchaseProvisionedCapacityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type PurchaseProvisionedCapacityOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7091,6 +8293,17 @@ func (s PurchaseProvisionedCapacityOutput) GoString() string {
 func (s *PurchaseProvisionedCapacityOutput) SetCapacityId(v string) *PurchaseProvisionedCapacityOutput {
 	s.CapacityId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PurchaseProvisionedCapacityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CapacityId != nil {
+		v := *s.CapacityId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-capacity-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input value for RemoveTagsFromVaultInput.
@@ -7159,6 +8372,27 @@ func (s *RemoveTagsFromVaultInput) SetVaultName(v string) *RemoveTagsFromVaultIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveTagsFromVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type RemoveTagsFromVaultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7171,6 +8405,12 @@ func (s RemoveTagsFromVaultOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromVaultOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveTagsFromVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // SetDataRetrievalPolicy input.
@@ -7226,6 +8466,22 @@ func (s *SetDataRetrievalPolicyInput) SetPolicy(v *DataRetrievalPolicy) *SetData
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDataRetrievalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.BodyTarget, "Policy", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetDataRetrievalPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7238,6 +8494,12 @@ func (s SetDataRetrievalPolicyOutput) String() string {
 // GoString returns the string representation
 func (s SetDataRetrievalPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDataRetrievalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // SetVaultAccessPolicy input.
@@ -7306,6 +8568,27 @@ func (s *SetVaultAccessPolicyInput) SetVaultName(v string) *SetVaultAccessPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7318,6 +8601,12 @@ func (s SetVaultAccessPolicyOutput) String() string {
 // GoString returns the string representation
 func (s SetVaultAccessPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options to configure notifications that will be sent when specific
@@ -7387,6 +8676,27 @@ func (s *SetVaultNotificationsInput) SetVaultNotificationConfig(v *VaultNotifica
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultNotificationConfig != nil {
+		v := s.VaultNotificationConfig
+
+		e.SetFields(protocol.PayloadTarget, "vaultNotificationConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetVaultNotificationsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7399,6 +8709,12 @@ func (s SetVaultNotificationsOutput) String() string {
 // GoString returns the string representation
 func (s SetVaultNotificationsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options to add an archive to a vault.
@@ -7485,6 +8801,37 @@ func (s *UploadArchiveInput) SetVaultName(v string) *UploadArchiveInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadArchiveInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A list of in-progress multipart uploads for a vault.
 type UploadListElement struct {
 	_ struct{} `type:"structure"`
@@ -7546,6 +8893,45 @@ func (s *UploadListElement) SetPartSizeInBytes(v int64) *UploadListElement {
 func (s *UploadListElement) SetVaultARN(v string) *UploadListElement {
 	s.VaultARN = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadListElement) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.BodyTarget, "ArchiveDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MultipartUploadId != nil {
+		v := *s.MultipartUploadId
+
+		e.SetValue(protocol.BodyTarget, "MultipartUploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartSizeInBytes != nil {
+		v := *s.PartSizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "PartSizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VaultARN != nil {
+		v := *s.VaultARN
+
+		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUploadListElementList(vs []*UploadListElement) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Provides options to upload a part of an archive in a multipart upload operation.
@@ -7649,6 +9035,42 @@ func (s *UploadMultipartPartInput) SetVaultName(v string) *UploadMultipartPartIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadMultipartPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Content-Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.PathTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type UploadMultipartPartOutput struct {
 	_ struct{} `type:"structure"`
@@ -7671,6 +9093,17 @@ func (s UploadMultipartPartOutput) GoString() string {
 func (s *UploadMultipartPartOutput) SetChecksum(v string) *UploadMultipartPartOutput {
 	s.Checksum = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadMultipartPartOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains the vault access policy.
@@ -7697,6 +9130,17 @@ func (s *VaultAccessPolicy) SetPolicy(v string) *VaultAccessPolicy {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VaultAccessPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the vault lock policy.
 type VaultLockPolicy struct {
 	_ struct{} `type:"structure"`
@@ -7719,6 +9163,17 @@ func (s VaultLockPolicy) GoString() string {
 func (s *VaultLockPolicy) SetPolicy(v string) *VaultLockPolicy {
 	s.Policy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VaultLockPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents a vault's notification configuration.
@@ -7754,6 +9209,22 @@ func (s *VaultNotificationConfig) SetEvents(v []*string) *VaultNotificationConfi
 func (s *VaultNotificationConfig) SetSNSTopic(v string) *VaultNotificationConfig {
 	s.SNSTopic = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VaultNotificationConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Events", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.SNSTopic != nil {
+		v := *s.SNSTopic
+
+		e.SetValue(protocol.BodyTarget, "SNSTopic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opAssociateRoleToGroup = "AssociateRoleToGroup"
@@ -5221,6 +5222,22 @@ func (s *AssociateRoleToGroupInput) SetRoleArn(v string) *AssociateRoleToGroupIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateRoleToGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/AssociateRoleToGroupResponse
 type AssociateRoleToGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -5243,6 +5260,17 @@ func (s AssociateRoleToGroupOutput) GoString() string {
 func (s *AssociateRoleToGroupOutput) SetAssociatedAt(v string) *AssociateRoleToGroupOutput {
 	s.AssociatedAt = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateRoleToGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AssociatedAt != nil {
+		v := *s.AssociatedAt
+
+		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/AssociateServiceRoleToAccountRequest
@@ -5269,6 +5297,17 @@ func (s *AssociateServiceRoleToAccountInput) SetRoleArn(v string) *AssociateServ
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateServiceRoleToAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/AssociateServiceRoleToAccountResponse
 type AssociateServiceRoleToAccountOutput struct {
 	_ struct{} `type:"structure"`
@@ -5291,6 +5330,17 @@ func (s AssociateServiceRoleToAccountOutput) GoString() string {
 func (s *AssociateServiceRoleToAccountOutput) SetAssociatedAt(v string) *AssociateServiceRoleToAccountOutput {
 	s.AssociatedAt = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateServiceRoleToAccountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AssociatedAt != nil {
+		v := *s.AssociatedAt
+
+		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Connectivity Info
@@ -5343,6 +5393,40 @@ func (s *ConnectivityInfo) SetMetadata(v string) *ConnectivityInfo {
 func (s *ConnectivityInfo) SetPortNumber(v int64) *ConnectivityInfo {
 	s.PortNumber = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ConnectivityInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostAddress != nil {
+		v := *s.HostAddress
+
+		e.SetValue(protocol.BodyTarget, "HostAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Metadata != nil {
+		v := *s.Metadata
+
+		e.SetValue(protocol.BodyTarget, "Metadata", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PortNumber != nil {
+		v := *s.PortNumber
+
+		e.SetValue(protocol.BodyTarget, "PortNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeConnectivityInfoList(vs []*ConnectivityInfo) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information on the core
@@ -5398,6 +5482,40 @@ func (s *Core) SetThingArn(v string) *Core {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Core) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "CertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncShadow != nil {
+		v := *s.SyncShadow
+
+		e.SetValue(protocol.BodyTarget, "SyncShadow", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ThingArn != nil {
+		v := *s.ThingArn
+
+		e.SetValue(protocol.BodyTarget, "ThingArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCoreList(vs []*Core) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on core definition version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CoreDefinitionVersion
 type CoreDefinitionVersion struct {
@@ -5421,6 +5539,17 @@ func (s CoreDefinitionVersion) GoString() string {
 func (s *CoreDefinitionVersion) SetCores(v []*Core) *CoreDefinitionVersion {
 	s.Cores = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CoreDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Cores) > 0 {
+		v := s.Cores
+
+		e.SetList(protocol.BodyTarget, "Cores", encodeCoreList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateCoreDefinitionRequest
@@ -5461,6 +5590,27 @@ func (s *CreateCoreDefinitionInput) SetInitialVersion(v *CoreDefinitionVersion) 
 func (s *CreateCoreDefinitionInput) SetName(v string) *CreateCoreDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateCoreDefinitionResponse
@@ -5534,6 +5684,47 @@ func (s *CreateCoreDefinitionOutput) SetName(v string) *CreateCoreDefinitionOutp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateCoreDefinitionVersionRequest
 type CreateCoreDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -5587,6 +5778,27 @@ func (s *CreateCoreDefinitionVersionInput) SetCores(v []*Core) *CreateCoreDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCoreDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Cores) > 0 {
+		v := s.Cores
+
+		e.SetList(protocol.BodyTarget, "Cores", encodeCoreList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateCoreDefinitionVersionResponse
 type CreateCoreDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5632,6 +5844,32 @@ func (s *CreateCoreDefinitionVersionOutput) SetId(v string) *CreateCoreDefinitio
 func (s *CreateCoreDefinitionVersionOutput) SetVersion(v string) *CreateCoreDefinitionVersionOutput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCoreDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on Deployment
@@ -5708,6 +5946,37 @@ func (s *CreateDeploymentInput) SetGroupVersionId(v string) *CreateDeploymentInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentType != nil {
+		v := *s.DeploymentType
+
+		e.SetValue(protocol.BodyTarget, "DeploymentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupVersionId != nil {
+		v := *s.GroupVersionId
+
+		e.SetValue(protocol.BodyTarget, "GroupVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeploymentResponse
 type CreateDeploymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5739,6 +6008,22 @@ func (s *CreateDeploymentOutput) SetDeploymentArn(v string) *CreateDeploymentOut
 func (s *CreateDeploymentOutput) SetDeploymentId(v string) *CreateDeploymentOutput {
 	s.DeploymentId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeploymentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentArn != nil {
+		v := *s.DeploymentArn
+
+		e.SetValue(protocol.BodyTarget, "DeploymentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeviceDefinitionRequest
@@ -5779,6 +6064,27 @@ func (s *CreateDeviceDefinitionInput) SetInitialVersion(v *DeviceDefinitionVersi
 func (s *CreateDeviceDefinitionInput) SetName(v string) *CreateDeviceDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeviceDefinitionResponse
@@ -5852,6 +6158,47 @@ func (s *CreateDeviceDefinitionOutput) SetName(v string) *CreateDeviceDefinition
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeviceDefinitionVersionRequest
 type CreateDeviceDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -5905,6 +6252,27 @@ func (s *CreateDeviceDefinitionVersionInput) SetDevices(v []*Device) *CreateDevi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeviceDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Devices) > 0 {
+		v := s.Devices
+
+		e.SetList(protocol.BodyTarget, "Devices", encodeDeviceList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeviceDefinitionVersionResponse
 type CreateDeviceDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5952,6 +6320,32 @@ func (s *CreateDeviceDefinitionVersionOutput) SetVersion(v string) *CreateDevice
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeviceDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateFunctionDefinitionRequest
 type CreateFunctionDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -5990,6 +6384,27 @@ func (s *CreateFunctionDefinitionInput) SetInitialVersion(v *FunctionDefinitionV
 func (s *CreateFunctionDefinitionInput) SetName(v string) *CreateFunctionDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateFunctionDefinitionResponse
@@ -6063,6 +6478,47 @@ func (s *CreateFunctionDefinitionOutput) SetName(v string) *CreateFunctionDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateFunctionDefinitionVersionRequest
 type CreateFunctionDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -6116,6 +6572,27 @@ func (s *CreateFunctionDefinitionVersionInput) SetFunctions(v []*Function) *Crea
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Functions) > 0 {
+		v := s.Functions
+
+		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateFunctionDefinitionVersionResponse
 type CreateFunctionDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6163,6 +6640,32 @@ func (s *CreateFunctionDefinitionVersionOutput) SetVersion(v string) *CreateFunc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupCertificateAuthorityRequest
 type CreateGroupCertificateAuthorityInput struct {
 	_ struct{} `type:"structure"`
@@ -6208,6 +6711,22 @@ func (s *CreateGroupCertificateAuthorityInput) SetGroupId(v string) *CreateGroup
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupCertificateAuthorityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupCertificateAuthorityResponse
 type CreateGroupCertificateAuthorityOutput struct {
 	_ struct{} `type:"structure"`
@@ -6230,6 +6749,17 @@ func (s CreateGroupCertificateAuthorityOutput) GoString() string {
 func (s *CreateGroupCertificateAuthorityOutput) SetGroupCertificateAuthorityArn(v string) *CreateGroupCertificateAuthorityOutput {
 	s.GroupCertificateAuthorityArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupCertificateAuthorityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupCertificateAuthorityArn != nil {
+		v := *s.GroupCertificateAuthorityArn
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupRequest
@@ -6270,6 +6800,27 @@ func (s *CreateGroupInput) SetInitialVersion(v *GroupVersion) *CreateGroupInput 
 func (s *CreateGroupInput) SetName(v string) *CreateGroupInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupResponse
@@ -6341,6 +6892,47 @@ func (s *CreateGroupOutput) SetLatestVersionArn(v string) *CreateGroupOutput {
 func (s *CreateGroupOutput) SetName(v string) *CreateGroupOutput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupVersionRequest
@@ -6428,6 +7020,47 @@ func (s *CreateGroupVersionInput) SetSubscriptionDefinitionVersionArn(v string) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CoreDefinitionVersionArn != nil {
+		v := *s.CoreDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "CoreDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceDefinitionVersionArn != nil {
+		v := *s.DeviceDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "DeviceDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionDefinitionVersionArn != nil {
+		v := *s.FunctionDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoggerDefinitionVersionArn != nil {
+		v := *s.LoggerDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LoggerDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionVersionArn != nil {
+		v := *s.SubscriptionDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "SubscriptionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupVersionResponse
 type CreateGroupVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6475,6 +7108,32 @@ func (s *CreateGroupVersionOutput) SetVersion(v string) *CreateGroupVersionOutpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateLoggerDefinitionRequest
 type CreateLoggerDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -6513,6 +7172,27 @@ func (s *CreateLoggerDefinitionInput) SetInitialVersion(v *LoggerDefinitionVersi
 func (s *CreateLoggerDefinitionInput) SetName(v string) *CreateLoggerDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateLoggerDefinitionResponse
@@ -6586,6 +7266,47 @@ func (s *CreateLoggerDefinitionOutput) SetName(v string) *CreateLoggerDefinition
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateLoggerDefinitionVersionRequest
 type CreateLoggerDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -6639,6 +7360,27 @@ func (s *CreateLoggerDefinitionVersionInput) SetLoggers(v []*Logger) *CreateLogg
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLoggerDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Loggers) > 0 {
+		v := s.Loggers
+
+		e.SetList(protocol.BodyTarget, "Loggers", encodeLoggerList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateLoggerDefinitionVersionResponse
 type CreateLoggerDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6686,6 +7428,32 @@ func (s *CreateLoggerDefinitionVersionOutput) SetVersion(v string) *CreateLogger
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLoggerDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateSubscriptionDefinitionRequest
 type CreateSubscriptionDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -6724,6 +7492,27 @@ func (s *CreateSubscriptionDefinitionInput) SetInitialVersion(v *SubscriptionDef
 func (s *CreateSubscriptionDefinitionInput) SetName(v string) *CreateSubscriptionDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateSubscriptionDefinitionResponse
@@ -6797,6 +7586,47 @@ func (s *CreateSubscriptionDefinitionOutput) SetName(v string) *CreateSubscripti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateSubscriptionDefinitionVersionRequest
 type CreateSubscriptionDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -6850,6 +7680,27 @@ func (s *CreateSubscriptionDefinitionVersionInput) SetSubscriptions(v []*Subscri
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSubscriptionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Subscriptions) > 0 {
+		v := s.Subscriptions
+
+		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateSubscriptionDefinitionVersionResponse
 type CreateSubscriptionDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6895,6 +7746,32 @@ func (s *CreateSubscriptionDefinitionVersionOutput) SetId(v string) *CreateSubsc
 func (s *CreateSubscriptionDefinitionVersionOutput) SetVersion(v string) *CreateSubscriptionDefinitionVersionOutput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSubscriptionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the Definition
@@ -6976,6 +7853,55 @@ func (s *DefinitionInformation) SetName(v string) *DefinitionInformation {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DefinitionInformation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDefinitionInformationList(vs []*DefinitionInformation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteCoreDefinitionRequest
 type DeleteCoreDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -7013,6 +7939,17 @@ func (s *DeleteCoreDefinitionInput) SetCoreDefinitionId(v string) *DeleteCoreDef
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteCoreDefinitionResponse
 type DeleteCoreDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7026,6 +7963,12 @@ func (s DeleteCoreDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCoreDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteDeviceDefinitionRequest
@@ -7065,6 +8008,17 @@ func (s *DeleteDeviceDefinitionInput) SetDeviceDefinitionId(v string) *DeleteDev
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteDeviceDefinitionResponse
 type DeleteDeviceDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7078,6 +8032,12 @@ func (s DeleteDeviceDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDeviceDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteFunctionDefinitionRequest
@@ -7117,6 +8077,17 @@ func (s *DeleteFunctionDefinitionInput) SetFunctionDefinitionId(v string) *Delet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteFunctionDefinitionResponse
 type DeleteFunctionDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7130,6 +8101,12 @@ func (s DeleteFunctionDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFunctionDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteGroupRequest
@@ -7169,6 +8146,17 @@ func (s *DeleteGroupInput) SetGroupId(v string) *DeleteGroupInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteGroupResponse
 type DeleteGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -7182,6 +8170,12 @@ func (s DeleteGroupOutput) String() string {
 // GoString returns the string representation
 func (s DeleteGroupOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteLoggerDefinitionRequest
@@ -7221,6 +8215,17 @@ func (s *DeleteLoggerDefinitionInput) SetLoggerDefinitionId(v string) *DeleteLog
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteLoggerDefinitionResponse
 type DeleteLoggerDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7234,6 +8239,12 @@ func (s DeleteLoggerDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteLoggerDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteSubscriptionDefinitionRequest
@@ -7273,6 +8284,17 @@ func (s *DeleteSubscriptionDefinitionInput) SetSubscriptionDefinitionId(v string
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteSubscriptionDefinitionResponse
 type DeleteSubscriptionDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7286,6 +8308,12 @@ func (s DeleteSubscriptionDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSubscriptionDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Information on the deployment
@@ -7349,6 +8377,45 @@ func (s *Deployment) SetGroupArn(v string) *Deployment {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Deployment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "CreatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentArn != nil {
+		v := *s.DeploymentArn
+
+		e.SetValue(protocol.BodyTarget, "DeploymentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentType != nil {
+		v := *s.DeploymentType
+
+		e.SetValue(protocol.BodyTarget, "DeploymentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupArn != nil {
+		v := *s.GroupArn
+
+		e.SetValue(protocol.BodyTarget, "GroupArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeploymentList(vs []*Deployment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on a Device
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/Device
 type Device struct {
@@ -7402,6 +8469,40 @@ func (s *Device) SetThingArn(v string) *Device {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Device) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "CertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncShadow != nil {
+		v := *s.SyncShadow
+
+		e.SetValue(protocol.BodyTarget, "SyncShadow", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ThingArn != nil {
+		v := *s.ThingArn
+
+		e.SetValue(protocol.BodyTarget, "ThingArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeviceList(vs []*Device) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on device definition version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeviceDefinitionVersion
 type DeviceDefinitionVersion struct {
@@ -7425,6 +8526,17 @@ func (s DeviceDefinitionVersion) GoString() string {
 func (s *DeviceDefinitionVersion) SetDevices(v []*Device) *DeviceDefinitionVersion {
 	s.Devices = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeviceDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Devices) > 0 {
+		v := s.Devices
+
+		e.SetList(protocol.BodyTarget, "Devices", encodeDeviceList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DisassociateRoleFromGroupRequest
@@ -7464,6 +8576,17 @@ func (s *DisassociateRoleFromGroupInput) SetGroupId(v string) *DisassociateRoleF
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateRoleFromGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DisassociateRoleFromGroupResponse
 type DisassociateRoleFromGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -7488,6 +8611,17 @@ func (s *DisassociateRoleFromGroupOutput) SetDisassociatedAt(v string) *Disassoc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateRoleFromGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisassociatedAt != nil {
+		v := *s.DisassociatedAt
+
+		e.SetValue(protocol.BodyTarget, "DisassociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DisassociateServiceRoleFromAccountRequest
 type DisassociateServiceRoleFromAccountInput struct {
 	_ struct{} `type:"structure"`
@@ -7501,6 +8635,12 @@ func (s DisassociateServiceRoleFromAccountInput) String() string {
 // GoString returns the string representation
 func (s DisassociateServiceRoleFromAccountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateServiceRoleFromAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DisassociateServiceRoleFromAccountResponse
@@ -7525,6 +8665,17 @@ func (s DisassociateServiceRoleFromAccountOutput) GoString() string {
 func (s *DisassociateServiceRoleFromAccountOutput) SetDisassociatedAt(v string) *DisassociateServiceRoleFromAccountOutput {
 	s.DisassociatedAt = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateServiceRoleFromAccountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisassociatedAt != nil {
+		v := *s.DisassociatedAt
+
+		e.SetValue(protocol.BodyTarget, "DisassociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // ErrorDetail
@@ -7559,6 +8710,30 @@ func (s *ErrorDetail) SetDetailedErrorCode(v string) *ErrorDetail {
 func (s *ErrorDetail) SetDetailedErrorMessage(v string) *ErrorDetail {
 	s.DetailedErrorMessage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ErrorDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetailedErrorCode != nil {
+		v := *s.DetailedErrorCode
+
+		e.SetValue(protocol.BodyTarget, "DetailedErrorCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DetailedErrorMessage != nil {
+		v := *s.DetailedErrorMessage
+
+		e.SetValue(protocol.BodyTarget, "DetailedErrorMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeErrorDetailList(vs []*ErrorDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information on function
@@ -7602,6 +8777,35 @@ func (s *Function) SetFunctionConfiguration(v *FunctionConfiguration) *Function 
 func (s *Function) SetId(v string) *Function {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Function) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionArn != nil {
+		v := *s.FunctionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionConfiguration != nil {
+		v := s.FunctionConfiguration
+
+		e.SetFields(protocol.BodyTarget, "FunctionConfiguration", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFunctionList(vs []*Function) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Configuration of the function
@@ -7676,6 +8880,42 @@ func (s *FunctionConfiguration) SetTimeout(v int64) *FunctionConfiguration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Environment != nil {
+		v := s.Environment
+
+		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
+	}
+	if s.ExecArgs != nil {
+		v := *s.ExecArgs
+
+		e.SetValue(protocol.BodyTarget, "ExecArgs", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Executable != nil {
+		v := *s.Executable
+
+		e.SetValue(protocol.BodyTarget, "Executable", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MemorySize != nil {
+		v := *s.MemorySize
+
+		e.SetValue(protocol.BodyTarget, "MemorySize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Pinned != nil {
+		v := *s.Pinned
+
+		e.SetValue(protocol.BodyTarget, "Pinned", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Timeout != nil {
+		v := *s.Timeout
+
+		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Environment of the function configuration
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/FunctionConfigurationEnvironment
 type FunctionConfigurationEnvironment struct {
@@ -7698,6 +8938,17 @@ func (s FunctionConfigurationEnvironment) GoString() string {
 func (s *FunctionConfigurationEnvironment) SetVariables(v map[string]*string) *FunctionConfigurationEnvironment {
 	s.Variables = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionConfigurationEnvironment) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the function definition version
@@ -7723,6 +8974,17 @@ func (s FunctionDefinitionVersion) GoString() string {
 func (s *FunctionDefinitionVersion) SetFunctions(v []*Function) *FunctionDefinitionVersion {
 	s.Functions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Functions) > 0 {
+		v := s.Functions
+
+		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetAssociatedRoleRequest
@@ -7762,6 +9024,17 @@ func (s *GetAssociatedRoleInput) SetGroupId(v string) *GetAssociatedRoleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAssociatedRoleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetAssociatedRoleResponse
 type GetAssociatedRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -7793,6 +9066,22 @@ func (s *GetAssociatedRoleOutput) SetAssociatedAt(v string) *GetAssociatedRoleOu
 func (s *GetAssociatedRoleOutput) SetRoleArn(v string) *GetAssociatedRoleOutput {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAssociatedRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AssociatedAt != nil {
+		v := *s.AssociatedAt
+
+		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetConnectivityInfoRequest
@@ -7832,6 +9121,17 @@ func (s *GetConnectivityInfoInput) SetThingName(v string) *GetConnectivityInfoIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetConnectivityInfoInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "ThingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // connectivity info response
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetConnectivityInfoResponse
 type GetConnectivityInfoOutput struct {
@@ -7863,6 +9163,22 @@ func (s *GetConnectivityInfoOutput) SetConnectivityInfo(v []*ConnectivityInfo) *
 func (s *GetConnectivityInfoOutput) SetMessage(v string) *GetConnectivityInfoOutput {
 	s.Message = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetConnectivityInfoOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ConnectivityInfo) > 0 {
+		v := s.ConnectivityInfo
+
+		e.SetList(protocol.BodyTarget, "ConnectivityInfo", encodeConnectivityInfoList(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetCoreDefinitionRequest
@@ -7900,6 +9216,17 @@ func (s *GetCoreDefinitionInput) Validate() error {
 func (s *GetCoreDefinitionInput) SetCoreDefinitionId(v string) *GetCoreDefinitionInput {
 	s.CoreDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetCoreDefinitionResponse
@@ -7973,6 +9300,47 @@ func (s *GetCoreDefinitionOutput) SetName(v string) *GetCoreDefinitionOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetCoreDefinitionVersionRequest
 type GetCoreDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8020,6 +9388,22 @@ func (s *GetCoreDefinitionVersionInput) SetCoreDefinitionId(v string) *GetCoreDe
 func (s *GetCoreDefinitionVersionInput) SetCoreDefinitionVersionId(v string) *GetCoreDefinitionVersionInput {
 	s.CoreDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCoreDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CoreDefinitionVersionId != nil {
+		v := *s.CoreDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetCoreDefinitionVersionResponse
@@ -8082,6 +9466,37 @@ func (s *GetCoreDefinitionVersionOutput) SetVersion(v string) *GetCoreDefinition
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCoreDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeploymentStatusRequest
 type GetDeploymentStatusInput struct {
 	_ struct{} `type:"structure"`
@@ -8129,6 +9544,22 @@ func (s *GetDeploymentStatusInput) SetDeploymentId(v string) *GetDeploymentStatu
 func (s *GetDeploymentStatusInput) SetGroupId(v string) *GetDeploymentStatusInput {
 	s.GroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The response body contains the status of a deployment for a group.
@@ -8192,6 +9623,37 @@ func (s *GetDeploymentStatusOutput) SetUpdatedAt(v string) *GetDeploymentStatusO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentStatus != nil {
+		v := *s.DeploymentStatus
+
+		e.SetValue(protocol.BodyTarget, "DeploymentStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentType != nil {
+		v := *s.DeploymentType
+
+		e.SetValue(protocol.BodyTarget, "DeploymentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ErrorDetails) > 0 {
+		v := s.ErrorDetails
+
+		e.SetList(protocol.BodyTarget, "ErrorDetails", encodeErrorDetailList(v), protocol.Metadata{})
+	}
+	if s.ErrorMessage != nil {
+		v := *s.ErrorMessage
+
+		e.SetValue(protocol.BodyTarget, "ErrorMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UpdatedAt != nil {
+		v := *s.UpdatedAt
+
+		e.SetValue(protocol.BodyTarget, "UpdatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeviceDefinitionRequest
 type GetDeviceDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -8227,6 +9689,17 @@ func (s *GetDeviceDefinitionInput) Validate() error {
 func (s *GetDeviceDefinitionInput) SetDeviceDefinitionId(v string) *GetDeviceDefinitionInput {
 	s.DeviceDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeviceDefinitionResponse
@@ -8300,6 +9773,47 @@ func (s *GetDeviceDefinitionOutput) SetName(v string) *GetDeviceDefinitionOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeviceDefinitionVersionRequest
 type GetDeviceDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8347,6 +9861,22 @@ func (s *GetDeviceDefinitionVersionInput) SetDeviceDefinitionId(v string) *GetDe
 func (s *GetDeviceDefinitionVersionInput) SetDeviceDefinitionVersionId(v string) *GetDeviceDefinitionVersionInput {
 	s.DeviceDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeviceDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceDefinitionVersionId != nil {
+		v := *s.DeviceDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeviceDefinitionVersionResponse
@@ -8409,6 +9939,37 @@ func (s *GetDeviceDefinitionVersionOutput) SetVersion(v string) *GetDeviceDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeviceDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetFunctionDefinitionRequest
 type GetFunctionDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -8444,6 +10005,17 @@ func (s *GetFunctionDefinitionInput) Validate() error {
 func (s *GetFunctionDefinitionInput) SetFunctionDefinitionId(v string) *GetFunctionDefinitionInput {
 	s.FunctionDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetFunctionDefinitionResponse
@@ -8517,6 +10089,47 @@ func (s *GetFunctionDefinitionOutput) SetName(v string) *GetFunctionDefinitionOu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetFunctionDefinitionVersionRequest
 type GetFunctionDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8564,6 +10177,22 @@ func (s *GetFunctionDefinitionVersionInput) SetFunctionDefinitionId(v string) *G
 func (s *GetFunctionDefinitionVersionInput) SetFunctionDefinitionVersionId(v string) *GetFunctionDefinitionVersionInput {
 	s.FunctionDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionDefinitionVersionId != nil {
+		v := *s.FunctionDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Function definition version
@@ -8627,6 +10256,37 @@ func (s *GetFunctionDefinitionVersionOutput) SetVersion(v string) *GetFunctionDe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupCertificateAuthorityRequest
 type GetGroupCertificateAuthorityInput struct {
 	_ struct{} `type:"structure"`
@@ -8676,6 +10336,22 @@ func (s *GetGroupCertificateAuthorityInput) SetGroupId(v string) *GetGroupCertif
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupCertificateAuthorityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateAuthorityId != nil {
+		v := *s.CertificateAuthorityId
+
+		e.SetValue(protocol.PathTarget, "CertificateAuthorityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Certificate authority for the group.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupCertificateAuthorityResponse
 type GetGroupCertificateAuthorityOutput struct {
@@ -8719,6 +10395,27 @@ func (s *GetGroupCertificateAuthorityOutput) SetPemEncodedCertificate(v string) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupCertificateAuthorityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupCertificateAuthorityArn != nil {
+		v := *s.GroupCertificateAuthorityArn
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupCertificateAuthorityId != nil {
+		v := *s.GroupCertificateAuthorityId
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PemEncodedCertificate != nil {
+		v := *s.PemEncodedCertificate
+
+		e.SetValue(protocol.BodyTarget, "PemEncodedCertificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupCertificateConfigurationRequest
 type GetGroupCertificateConfigurationInput struct {
 	_ struct{} `type:"structure"`
@@ -8754,6 +10451,17 @@ func (s *GetGroupCertificateConfigurationInput) Validate() error {
 func (s *GetGroupCertificateConfigurationInput) SetGroupId(v string) *GetGroupCertificateConfigurationInput {
 	s.GroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupCertificateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupCertificateConfigurationResponse
@@ -8795,6 +10503,27 @@ func (s *GetGroupCertificateConfigurationOutput) SetGroupId(v string) *GetGroupC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupCertificateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateAuthorityExpiryInMilliseconds != nil {
+		v := *s.CertificateAuthorityExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateAuthorityExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateExpiryInMilliseconds != nil {
+		v := *s.CertificateExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.BodyTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupRequest
 type GetGroupInput struct {
 	_ struct{} `type:"structure"`
@@ -8830,6 +10559,17 @@ func (s *GetGroupInput) Validate() error {
 func (s *GetGroupInput) SetGroupId(v string) *GetGroupInput {
 	s.GroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupResponse
@@ -8903,6 +10643,47 @@ func (s *GetGroupOutput) SetName(v string) *GetGroupOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupVersionRequest
 type GetGroupVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8950,6 +10731,22 @@ func (s *GetGroupVersionInput) SetGroupId(v string) *GetGroupVersionInput {
 func (s *GetGroupVersionInput) SetGroupVersionId(v string) *GetGroupVersionInput {
 	s.GroupVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupVersionId != nil {
+		v := *s.GroupVersionId
+
+		e.SetValue(protocol.PathTarget, "GroupVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the group version
@@ -9013,6 +10810,37 @@ func (s *GetGroupVersionOutput) SetVersion(v string) *GetGroupVersionOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetLoggerDefinitionRequest
 type GetLoggerDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -9048,6 +10876,17 @@ func (s *GetLoggerDefinitionInput) Validate() error {
 func (s *GetLoggerDefinitionInput) SetLoggerDefinitionId(v string) *GetLoggerDefinitionInput {
 	s.LoggerDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetLoggerDefinitionResponse
@@ -9121,6 +10960,47 @@ func (s *GetLoggerDefinitionOutput) SetName(v string) *GetLoggerDefinitionOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetLoggerDefinitionVersionRequest
 type GetLoggerDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -9168,6 +11048,22 @@ func (s *GetLoggerDefinitionVersionInput) SetLoggerDefinitionId(v string) *GetLo
 func (s *GetLoggerDefinitionVersionInput) SetLoggerDefinitionVersionId(v string) *GetLoggerDefinitionVersionInput {
 	s.LoggerDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggerDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoggerDefinitionVersionId != nil {
+		v := *s.LoggerDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on logger definition version response
@@ -9231,6 +11127,37 @@ func (s *GetLoggerDefinitionVersionOutput) SetVersion(v string) *GetLoggerDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggerDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetServiceRoleForAccountRequest
 type GetServiceRoleForAccountInput struct {
 	_ struct{} `type:"structure"`
@@ -9244,6 +11171,12 @@ func (s GetServiceRoleForAccountInput) String() string {
 // GoString returns the string representation
 func (s GetServiceRoleForAccountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetServiceRoleForAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetServiceRoleForAccountResponse
@@ -9277,6 +11210,22 @@ func (s *GetServiceRoleForAccountOutput) SetAssociatedAt(v string) *GetServiceRo
 func (s *GetServiceRoleForAccountOutput) SetRoleArn(v string) *GetServiceRoleForAccountOutput {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetServiceRoleForAccountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AssociatedAt != nil {
+		v := *s.AssociatedAt
+
+		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetSubscriptionDefinitionRequest
@@ -9314,6 +11263,17 @@ func (s *GetSubscriptionDefinitionInput) Validate() error {
 func (s *GetSubscriptionDefinitionInput) SetSubscriptionDefinitionId(v string) *GetSubscriptionDefinitionInput {
 	s.SubscriptionDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetSubscriptionDefinitionResponse
@@ -9387,6 +11347,47 @@ func (s *GetSubscriptionDefinitionOutput) SetName(v string) *GetSubscriptionDefi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetSubscriptionDefinitionVersionRequest
 type GetSubscriptionDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -9434,6 +11435,22 @@ func (s *GetSubscriptionDefinitionVersionInput) SetSubscriptionDefinitionId(v st
 func (s *GetSubscriptionDefinitionVersionInput) SetSubscriptionDefinitionVersionId(v string) *GetSubscriptionDefinitionVersionInput {
 	s.SubscriptionDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSubscriptionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionVersionId != nil {
+		v := *s.SubscriptionDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the Subscription Definition Version
@@ -9497,6 +11514,37 @@ func (s *GetSubscriptionDefinitionVersionOutput) SetVersion(v string) *GetSubscr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSubscriptionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Information on group certificate authority properties
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GroupCertificateAuthorityProperties
 type GroupCertificateAuthorityProperties struct {
@@ -9529,6 +11577,30 @@ func (s *GroupCertificateAuthorityProperties) SetGroupCertificateAuthorityArn(v 
 func (s *GroupCertificateAuthorityProperties) SetGroupCertificateAuthorityId(v string) *GroupCertificateAuthorityProperties {
 	s.GroupCertificateAuthorityId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GroupCertificateAuthorityProperties) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupCertificateAuthorityArn != nil {
+		v := *s.GroupCertificateAuthorityArn
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupCertificateAuthorityId != nil {
+		v := *s.GroupCertificateAuthorityId
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGroupCertificateAuthorityPropertiesList(vs []*GroupCertificateAuthorityProperties) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information on the group
@@ -9610,6 +11682,55 @@ func (s *GroupInformation) SetName(v string) *GroupInformation {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GroupInformation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGroupInformationList(vs []*GroupInformation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on group version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GroupVersion
 type GroupVersion struct {
@@ -9671,6 +11792,37 @@ func (s *GroupVersion) SetSubscriptionDefinitionVersionArn(v string) *GroupVersi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GroupVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionVersionArn != nil {
+		v := *s.CoreDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "CoreDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceDefinitionVersionArn != nil {
+		v := *s.DeviceDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "DeviceDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionDefinitionVersionArn != nil {
+		v := *s.FunctionDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoggerDefinitionVersionArn != nil {
+		v := *s.LoggerDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LoggerDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionVersionArn != nil {
+		v := *s.SubscriptionDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "SubscriptionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListCoreDefinitionVersionsRequest
 type ListCoreDefinitionVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -9724,6 +11876,27 @@ func (s *ListCoreDefinitionVersionsInput) SetNextToken(v string) *ListCoreDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCoreDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListCoreDefinitionVersionsResponse
 type ListCoreDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9753,6 +11926,22 @@ func (s *ListCoreDefinitionVersionsOutput) SetNextToken(v string) *ListCoreDefin
 func (s *ListCoreDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListCoreDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCoreDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListCoreDefinitionsRequest
@@ -9786,6 +11975,22 @@ func (s *ListCoreDefinitionsInput) SetNextToken(v string) *ListCoreDefinitionsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCoreDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListCoreDefinitionsResponse
 type ListCoreDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9815,6 +12020,22 @@ func (s *ListCoreDefinitionsOutput) SetDefinitions(v []*DefinitionInformation) *
 func (s *ListCoreDefinitionsOutput) SetNextToken(v string) *ListCoreDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCoreDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeploymentsRequest
@@ -9870,6 +12091,27 @@ func (s *ListDeploymentsInput) SetNextToken(v string) *ListDeploymentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeploymentsResponse
 type ListDeploymentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9902,6 +12144,22 @@ func (s *ListDeploymentsOutput) SetDeployments(v []*Deployment) *ListDeployments
 func (s *ListDeploymentsOutput) SetNextToken(v string) *ListDeploymentsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Deployments) > 0 {
+		v := s.Deployments
+
+		e.SetList(protocol.BodyTarget, "Deployments", encodeDeploymentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeviceDefinitionVersionsRequest
@@ -9957,6 +12215,27 @@ func (s *ListDeviceDefinitionVersionsInput) SetNextToken(v string) *ListDeviceDe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeviceDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeviceDefinitionVersionsResponse
 type ListDeviceDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9986,6 +12265,22 @@ func (s *ListDeviceDefinitionVersionsOutput) SetNextToken(v string) *ListDeviceD
 func (s *ListDeviceDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListDeviceDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeviceDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeviceDefinitionsRequest
@@ -10019,6 +12314,22 @@ func (s *ListDeviceDefinitionsInput) SetNextToken(v string) *ListDeviceDefinitio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeviceDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeviceDefinitionsResponse
 type ListDeviceDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10048,6 +12359,22 @@ func (s *ListDeviceDefinitionsOutput) SetDefinitions(v []*DefinitionInformation)
 func (s *ListDeviceDefinitionsOutput) SetNextToken(v string) *ListDeviceDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeviceDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListFunctionDefinitionVersionsRequest
@@ -10103,6 +12430,27 @@ func (s *ListFunctionDefinitionVersionsInput) SetNextToken(v string) *ListFuncti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListFunctionDefinitionVersionsResponse
 type ListFunctionDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10132,6 +12480,22 @@ func (s *ListFunctionDefinitionVersionsOutput) SetNextToken(v string) *ListFunct
 func (s *ListFunctionDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListFunctionDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListFunctionDefinitionsRequest
@@ -10165,6 +12529,22 @@ func (s *ListFunctionDefinitionsInput) SetNextToken(v string) *ListFunctionDefin
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListFunctionDefinitionsResponse
 type ListFunctionDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10194,6 +12574,22 @@ func (s *ListFunctionDefinitionsOutput) SetDefinitions(v []*DefinitionInformatio
 func (s *ListFunctionDefinitionsOutput) SetNextToken(v string) *ListFunctionDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupCertificateAuthoritiesRequest
@@ -10233,6 +12629,17 @@ func (s *ListGroupCertificateAuthoritiesInput) SetGroupId(v string) *ListGroupCe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupCertificateAuthoritiesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupCertificateAuthoritiesResponse
 type ListGroupCertificateAuthoritiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -10255,6 +12662,17 @@ func (s ListGroupCertificateAuthoritiesOutput) GoString() string {
 func (s *ListGroupCertificateAuthoritiesOutput) SetGroupCertificateAuthorities(v []*GroupCertificateAuthorityProperties) *ListGroupCertificateAuthoritiesOutput {
 	s.GroupCertificateAuthorities = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupCertificateAuthoritiesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.GroupCertificateAuthorities) > 0 {
+		v := s.GroupCertificateAuthorities
+
+		e.SetList(protocol.BodyTarget, "GroupCertificateAuthorities", encodeGroupCertificateAuthorityPropertiesList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupVersionsRequest
@@ -10310,6 +12728,27 @@ func (s *ListGroupVersionsInput) SetNextToken(v string) *ListGroupVersionsInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupVersionsResponse
 type ListGroupVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10341,6 +12780,22 @@ func (s *ListGroupVersionsOutput) SetVersions(v []*VersionInformation) *ListGrou
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupsRequest
 type ListGroupsInput struct {
 	_ struct{} `type:"structure"`
@@ -10370,6 +12825,22 @@ func (s *ListGroupsInput) SetMaxResults(v string) *ListGroupsInput {
 func (s *ListGroupsInput) SetNextToken(v string) *ListGroupsInput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupsResponse
@@ -10404,6 +12875,22 @@ func (s *ListGroupsOutput) SetGroups(v []*GroupInformation) *ListGroupsOutput {
 func (s *ListGroupsOutput) SetNextToken(v string) *ListGroupsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Groups) > 0 {
+		v := s.Groups
+
+		e.SetList(protocol.BodyTarget, "Groups", encodeGroupInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListLoggerDefinitionVersionsRequest
@@ -10459,6 +12946,27 @@ func (s *ListLoggerDefinitionVersionsInput) SetNextToken(v string) *ListLoggerDe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLoggerDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListLoggerDefinitionVersionsResponse
 type ListLoggerDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10488,6 +12996,22 @@ func (s *ListLoggerDefinitionVersionsOutput) SetNextToken(v string) *ListLoggerD
 func (s *ListLoggerDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListLoggerDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLoggerDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListLoggerDefinitionsRequest
@@ -10521,6 +13045,22 @@ func (s *ListLoggerDefinitionsInput) SetNextToken(v string) *ListLoggerDefinitio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLoggerDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListLoggerDefinitionsResponse
 type ListLoggerDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10550,6 +13090,22 @@ func (s *ListLoggerDefinitionsOutput) SetDefinitions(v []*DefinitionInformation)
 func (s *ListLoggerDefinitionsOutput) SetNextToken(v string) *ListLoggerDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLoggerDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListSubscriptionDefinitionVersionsRequest
@@ -10605,6 +13161,27 @@ func (s *ListSubscriptionDefinitionVersionsInput) SetSubscriptionDefinitionId(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListSubscriptionDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListSubscriptionDefinitionVersionsResponse
 type ListSubscriptionDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10634,6 +13211,22 @@ func (s *ListSubscriptionDefinitionVersionsOutput) SetNextToken(v string) *ListS
 func (s *ListSubscriptionDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListSubscriptionDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListSubscriptionDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListSubscriptionDefinitionsRequest
@@ -10667,6 +13260,22 @@ func (s *ListSubscriptionDefinitionsInput) SetNextToken(v string) *ListSubscript
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListSubscriptionDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListSubscriptionDefinitionsResponse
 type ListSubscriptionDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10696,6 +13305,22 @@ func (s *ListSubscriptionDefinitionsOutput) SetDefinitions(v []*DefinitionInform
 func (s *ListSubscriptionDefinitionsOutput) SetNextToken(v string) *ListSubscriptionDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListSubscriptionDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the Logger
@@ -10760,6 +13385,45 @@ func (s *Logger) SetType(v string) *Logger {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Logger) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Component != nil {
+		v := *s.Component
+
+		e.SetValue(protocol.BodyTarget, "Component", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Level != nil {
+		v := *s.Level
+
+		e.SetValue(protocol.BodyTarget, "Level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Space != nil {
+		v := *s.Space
+
+		e.SetValue(protocol.BodyTarget, "Space", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLoggerList(vs []*Logger) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on logger definition version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/LoggerDefinitionVersion
 type LoggerDefinitionVersion struct {
@@ -10783,6 +13447,17 @@ func (s LoggerDefinitionVersion) GoString() string {
 func (s *LoggerDefinitionVersion) SetLoggers(v []*Logger) *LoggerDefinitionVersion {
 	s.Loggers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LoggerDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Loggers) > 0 {
+		v := s.Loggers
+
+		e.SetList(protocol.BodyTarget, "Loggers", encodeLoggerList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information needed to perform a reset of a group's deployments.
@@ -10840,6 +13515,27 @@ func (s *ResetDeploymentsInput) SetGroupId(v string) *ResetDeploymentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResetDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Force != nil {
+		v := *s.Force
+
+		e.SetValue(protocol.BodyTarget, "Force", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ResetDeploymentsResponse
 type ResetDeploymentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10871,6 +13567,22 @@ func (s *ResetDeploymentsOutput) SetDeploymentArn(v string) *ResetDeploymentsOut
 func (s *ResetDeploymentsOutput) SetDeploymentId(v string) *ResetDeploymentsOutput {
 	s.DeploymentId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResetDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentArn != nil {
+		v := *s.DeploymentArn
+
+		e.SetValue(protocol.BodyTarget, "DeploymentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on subscription
@@ -10925,6 +13637,40 @@ func (s *Subscription) SetTarget(v string) *Subscription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Subscription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Source != nil {
+		v := *s.Source
+
+		e.SetValue(protocol.BodyTarget, "Source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Subject != nil {
+		v := *s.Subject
+
+		e.SetValue(protocol.BodyTarget, "Subject", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Target != nil {
+		v := *s.Target
+
+		e.SetValue(protocol.BodyTarget, "Target", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSubscriptionList(vs []*Subscription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on subscription definition version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/SubscriptionDefinitionVersion
 type SubscriptionDefinitionVersion struct {
@@ -10948,6 +13694,17 @@ func (s SubscriptionDefinitionVersion) GoString() string {
 func (s *SubscriptionDefinitionVersion) SetSubscriptions(v []*Subscription) *SubscriptionDefinitionVersion {
 	s.Subscriptions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubscriptionDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Subscriptions) > 0 {
+		v := s.Subscriptions
+
+		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on connectivity info
@@ -10997,6 +13754,22 @@ func (s *UpdateConnectivityInfoInput) SetThingName(v string) *UpdateConnectivity
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateConnectivityInfoInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ConnectivityInfo) > 0 {
+		v := s.ConnectivityInfo
+
+		e.SetList(protocol.BodyTarget, "ConnectivityInfo", encodeConnectivityInfoList(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "ThingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateConnectivityInfoResponse
 type UpdateConnectivityInfoOutput struct {
 	_ struct{} `type:"structure"`
@@ -11027,6 +13800,22 @@ func (s *UpdateConnectivityInfoOutput) SetMessage(v string) *UpdateConnectivityI
 func (s *UpdateConnectivityInfoOutput) SetVersion(v string) *UpdateConnectivityInfoOutput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateConnectivityInfoOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateCoreDefinitionRequest
@@ -11074,6 +13863,22 @@ func (s *UpdateCoreDefinitionInput) SetName(v string) *UpdateCoreDefinitionInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateCoreDefinitionResponse
 type UpdateCoreDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11087,6 +13892,12 @@ func (s UpdateCoreDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateCoreDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateDeviceDefinitionRequest
@@ -11134,6 +13945,22 @@ func (s *UpdateDeviceDefinitionInput) SetName(v string) *UpdateDeviceDefinitionI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateDeviceDefinitionResponse
 type UpdateDeviceDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11147,6 +13974,12 @@ func (s UpdateDeviceDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDeviceDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateFunctionDefinitionRequest
@@ -11194,6 +14027,22 @@ func (s *UpdateFunctionDefinitionInput) SetName(v string) *UpdateFunctionDefinit
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateFunctionDefinitionResponse
 type UpdateFunctionDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11207,6 +14056,12 @@ func (s UpdateFunctionDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFunctionDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateGroupCertificateConfigurationRequest
@@ -11255,6 +14110,22 @@ func (s *UpdateGroupCertificateConfigurationInput) SetGroupId(v string) *UpdateG
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGroupCertificateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateExpiryInMilliseconds != nil {
+		v := *s.CertificateExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateGroupCertificateConfigurationResponse
 type UpdateGroupCertificateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -11292,6 +14163,27 @@ func (s *UpdateGroupCertificateConfigurationOutput) SetCertificateExpiryInMillis
 func (s *UpdateGroupCertificateConfigurationOutput) SetGroupId(v string) *UpdateGroupCertificateConfigurationOutput {
 	s.GroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGroupCertificateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateAuthorityExpiryInMilliseconds != nil {
+		v := *s.CertificateAuthorityExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateAuthorityExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateExpiryInMilliseconds != nil {
+		v := *s.CertificateExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.BodyTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateGroupRequest
@@ -11339,6 +14231,22 @@ func (s *UpdateGroupInput) SetName(v string) *UpdateGroupInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateGroupResponse
 type UpdateGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -11352,6 +14260,12 @@ func (s UpdateGroupOutput) String() string {
 // GoString returns the string representation
 func (s UpdateGroupOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateLoggerDefinitionRequest
@@ -11399,6 +14313,22 @@ func (s *UpdateLoggerDefinitionInput) SetName(v string) *UpdateLoggerDefinitionI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateLoggerDefinitionResponse
 type UpdateLoggerDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11412,6 +14342,12 @@ func (s UpdateLoggerDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateLoggerDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateSubscriptionDefinitionRequest
@@ -11459,6 +14395,22 @@ func (s *UpdateSubscriptionDefinitionInput) SetSubscriptionDefinitionId(v string
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateSubscriptionDefinitionResponse
 type UpdateSubscriptionDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11472,6 +14424,12 @@ func (s UpdateSubscriptionDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateSubscriptionDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Information on the version
@@ -11524,6 +14482,40 @@ func (s *VersionInformation) SetId(v string) *VersionInformation {
 func (s *VersionInformation) SetVersion(v string) *VersionInformation {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VersionInformation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVersionInformationList(vs []*VersionInformation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -5410,6 +5410,22 @@ func (s *AcceptCertificateTransferInput) SetSetAsActive(v bool) *AcceptCertifica
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AcceptCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AcceptCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5422,6 +5438,12 @@ func (s AcceptCertificateTransferOutput) String() string {
 // GoString returns the string representation
 func (s AcceptCertificateTransferOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AcceptCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes the actions associated with a rule.
@@ -5633,6 +5655,85 @@ func (s *Action) SetSqs(v *SqsAction) *Action {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Action) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudwatchAlarm != nil {
+		v := s.CloudwatchAlarm
+
+		e.SetFields(protocol.BodyTarget, "cloudwatchAlarm", v, protocol.Metadata{})
+	}
+	if s.CloudwatchMetric != nil {
+		v := s.CloudwatchMetric
+
+		e.SetFields(protocol.BodyTarget, "cloudwatchMetric", v, protocol.Metadata{})
+	}
+	if s.DynamoDB != nil {
+		v := s.DynamoDB
+
+		e.SetFields(protocol.BodyTarget, "dynamoDB", v, protocol.Metadata{})
+	}
+	if s.DynamoDBv2 != nil {
+		v := s.DynamoDBv2
+
+		e.SetFields(protocol.BodyTarget, "dynamoDBv2", v, protocol.Metadata{})
+	}
+	if s.Elasticsearch != nil {
+		v := s.Elasticsearch
+
+		e.SetFields(protocol.BodyTarget, "elasticsearch", v, protocol.Metadata{})
+	}
+	if s.Firehose != nil {
+		v := s.Firehose
+
+		e.SetFields(protocol.BodyTarget, "firehose", v, protocol.Metadata{})
+	}
+	if s.Kinesis != nil {
+		v := s.Kinesis
+
+		e.SetFields(protocol.BodyTarget, "kinesis", v, protocol.Metadata{})
+	}
+	if s.Lambda != nil {
+		v := s.Lambda
+
+		e.SetFields(protocol.BodyTarget, "lambda", v, protocol.Metadata{})
+	}
+	if s.Republish != nil {
+		v := s.Republish
+
+		e.SetFields(protocol.BodyTarget, "republish", v, protocol.Metadata{})
+	}
+	if s.S3 != nil {
+		v := s.S3
+
+		e.SetFields(protocol.BodyTarget, "s3", v, protocol.Metadata{})
+	}
+	if s.Salesforce != nil {
+		v := s.Salesforce
+
+		e.SetFields(protocol.BodyTarget, "salesforce", v, protocol.Metadata{})
+	}
+	if s.Sns != nil {
+		v := s.Sns
+
+		e.SetFields(protocol.BodyTarget, "sns", v, protocol.Metadata{})
+	}
+	if s.Sqs != nil {
+		v := s.Sqs
+
+		e.SetFields(protocol.BodyTarget, "sqs", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeActionList(vs []*Action) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The input for the AttachPrincipalPolicy operation.
 type AttachPrincipalPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -5690,6 +5791,22 @@ func (s *AttachPrincipalPolicyInput) SetPrincipal(v string) *AttachPrincipalPoli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachPrincipalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AttachPrincipalPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5702,6 +5819,12 @@ func (s AttachPrincipalPolicyOutput) String() string {
 // GoString returns the string representation
 func (s AttachPrincipalPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachPrincipalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the AttachThingPrincipal operation.
@@ -5760,6 +5883,22 @@ func (s *AttachThingPrincipalInput) SetThingName(v string) *AttachThingPrincipal
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachThingPrincipalInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the AttachThingPrincipal operation.
 type AttachThingPrincipalOutput struct {
 	_ struct{} `type:"structure"`
@@ -5773,6 +5912,12 @@ func (s AttachThingPrincipalOutput) String() string {
 // GoString returns the string representation
 func (s AttachThingPrincipalOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachThingPrincipalOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The attribute payload.
@@ -5814,6 +5959,22 @@ func (s *AttributePayload) SetAttributes(v map[string]*string) *AttributePayload
 func (s *AttributePayload) SetMerge(v bool) *AttributePayload {
 	s.Merge = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributePayload) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Merge != nil {
+		v := *s.Merge
+
+		e.SetValue(protocol.BodyTarget, "merge", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A CA certificate.
@@ -5867,6 +6028,40 @@ func (s *CACertificate) SetCreationDate(v time.Time) *CACertificate {
 func (s *CACertificate) SetStatus(v string) *CACertificate {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CACertificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCACertificateList(vs []*CACertificate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a CA certificate.
@@ -5948,6 +6143,47 @@ func (s *CACertificateDescription) SetStatus(v string) *CACertificateDescription
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CACertificateDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AutoRegistrationStatus != nil {
+		v := *s.AutoRegistrationStatus
+
+		e.SetValue(protocol.BodyTarget, "autoRegistrationStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.OwnedBy != nil {
+		v := *s.OwnedBy
+
+		e.SetValue(protocol.BodyTarget, "ownedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the CancelCertificateTransfer operation.
 type CancelCertificateTransferInput struct {
 	_ struct{} `type:"structure"`
@@ -5990,6 +6226,17 @@ func (s *CancelCertificateTransferInput) SetCertificateId(v string) *CancelCerti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CancelCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6002,6 +6249,12 @@ func (s CancelCertificateTransferOutput) String() string {
 // GoString returns the string representation
 func (s CancelCertificateTransferOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Information about a certificate.
@@ -6055,6 +6308,40 @@ func (s *Certificate) SetCreationDate(v time.Time) *Certificate {
 func (s *Certificate) SetStatus(v string) *Certificate {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Certificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCertificateList(vs []*Certificate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a certificate.
@@ -6162,6 +6449,62 @@ func (s *CertificateDescription) SetTransferData(v *TransferData) *CertificateDe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CertificateDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CaCertificateId != nil {
+		v := *s.CaCertificateId
+
+		e.SetValue(protocol.BodyTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "lastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.OwnedBy != nil {
+		v := *s.OwnedBy
+
+		e.SetValue(protocol.BodyTarget, "ownedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PreviousOwnedBy != nil {
+		v := *s.PreviousOwnedBy
+
+		e.SetValue(protocol.BodyTarget, "previousOwnedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransferData != nil {
+		v := s.TransferData
+
+		e.SetFields(protocol.BodyTarget, "transferData", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action that updates a CloudWatch alarm.
 type CloudwatchAlarmAction struct {
 	_ struct{} `type:"structure"`
@@ -6241,6 +6584,32 @@ func (s *CloudwatchAlarmAction) SetStateReason(v string) *CloudwatchAlarmAction 
 func (s *CloudwatchAlarmAction) SetStateValue(v string) *CloudwatchAlarmAction {
 	s.StateValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CloudwatchAlarmAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlarmName != nil {
+		v := *s.AlarmName
+
+		e.SetValue(protocol.BodyTarget, "alarmName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StateReason != nil {
+		v := *s.StateReason
+
+		e.SetValue(protocol.BodyTarget, "stateReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StateValue != nil {
+		v := *s.StateValue
+
+		e.SetValue(protocol.BodyTarget, "stateValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an action that captures a CloudWatch metric.
@@ -6348,6 +6717,42 @@ func (s *CloudwatchMetricAction) SetRoleArn(v string) *CloudwatchMetricAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CloudwatchMetricAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MetricName != nil {
+		v := *s.MetricName
+
+		e.SetValue(protocol.BodyTarget, "metricName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricNamespace != nil {
+		v := *s.MetricNamespace
+
+		e.SetValue(protocol.BodyTarget, "metricNamespace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricTimestamp != nil {
+		v := *s.MetricTimestamp
+
+		e.SetValue(protocol.BodyTarget, "metricTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricUnit != nil {
+		v := *s.MetricUnit
+
+		e.SetValue(protocol.BodyTarget, "metricUnit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricValue != nil {
+		v := *s.MetricValue
+
+		e.SetValue(protocol.BodyTarget, "metricValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrInput struct {
 	_ struct{} `type:"structure"`
@@ -6399,6 +6804,22 @@ func (s *CreateCertificateFromCsrInput) SetSetAsActive(v bool) *CreateCertificat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCertificateFromCsrInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateSigningRequest != nil {
+		v := *s.CertificateSigningRequest
+
+		e.SetValue(protocol.BodyTarget, "certificateSigningRequest", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrOutput struct {
 	_ struct{} `type:"structure"`
@@ -6443,6 +6864,27 @@ func (s *CreateCertificateFromCsrOutput) SetCertificatePem(v string) *CreateCert
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCertificateFromCsrOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the CreateKeysAndCertificate operation.
 type CreateKeysAndCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -6465,6 +6907,17 @@ func (s CreateKeysAndCertificateInput) GoString() string {
 func (s *CreateKeysAndCertificateInput) SetSetAsActive(v bool) *CreateKeysAndCertificateInput {
 	s.SetAsActive = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateKeysAndCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output of the CreateKeysAndCertificate operation.
@@ -6517,6 +6970,32 @@ func (s *CreateKeysAndCertificateOutput) SetCertificatePem(v string) *CreateKeys
 func (s *CreateKeysAndCertificateOutput) SetKeyPair(v *KeyPair) *CreateKeysAndCertificateOutput {
 	s.KeyPair = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateKeysAndCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyPair != nil {
+		v := s.KeyPair
+
+		e.SetFields(protocol.BodyTarget, "keyPair", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreatePolicy operation.
@@ -6576,6 +7055,22 @@ func (s *CreatePolicyInput) SetPolicyName(v string) *CreatePolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the CreatePolicy operation.
 type CreatePolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -6625,6 +7120,32 @@ func (s *CreatePolicyOutput) SetPolicyName(v string) *CreatePolicyOutput {
 func (s *CreatePolicyOutput) SetPolicyVersionId(v string) *CreatePolicyOutput {
 	s.PolicyVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreatePolicyVersion operation.
@@ -6695,6 +7216,27 @@ func (s *CreatePolicyVersionInput) SetSetAsDefault(v bool) *CreatePolicyVersionI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsDefault != nil {
+		v := *s.SetAsDefault
+
+		e.SetValue(protocol.QueryTarget, "setAsDefault", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the CreatePolicyVersion operation.
 type CreatePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6744,6 +7286,32 @@ func (s *CreatePolicyVersionOutput) SetPolicyDocument(v string) *CreatePolicyVer
 func (s *CreatePolicyVersionOutput) SetPolicyVersionId(v string) *CreatePolicyVersionOutput {
 	s.PolicyVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsDefaultVersion != nil {
+		v := *s.IsDefaultVersion
+
+		e.SetValue(protocol.BodyTarget, "isDefaultVersion", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreateThing operation.
@@ -6812,6 +7380,27 @@ func (s *CreateThingInput) SetThingTypeName(v string) *CreateThingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateThingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributePayload != nil {
+		v := s.AttributePayload
+
+		e.SetFields(protocol.BodyTarget, "attributePayload", v, protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the CreateThing operation.
 type CreateThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -6843,6 +7432,22 @@ func (s *CreateThingOutput) SetThingArn(v string) *CreateThingOutput {
 func (s *CreateThingOutput) SetThingName(v string) *CreateThingOutput {
 	s.ThingName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateThingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingArn != nil {
+		v := *s.ThingArn
+
+		e.SetValue(protocol.BodyTarget, "thingArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.BodyTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreateThingType operation.
@@ -6898,6 +7503,22 @@ func (s *CreateThingTypeInput) SetThingTypeProperties(v *ThingTypeProperties) *C
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeProperties != nil {
+		v := s.ThingTypeProperties
+
+		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the CreateThingType operation.
 type CreateThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -6929,6 +7550,22 @@ func (s *CreateThingTypeOutput) SetThingTypeArn(v string) *CreateThingTypeOutput
 func (s *CreateThingTypeOutput) SetThingTypeName(v string) *CreateThingTypeOutput {
 	s.ThingTypeName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeArn != nil {
+		v := *s.ThingTypeArn
+
+		e.SetValue(protocol.BodyTarget, "thingTypeArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreateTopicRule operation.
@@ -6992,6 +7629,22 @@ func (s *CreateTopicRuleInput) SetTopicRulePayload(v *TopicRulePayload) *CreateT
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TopicRulePayload != nil {
+		v := s.TopicRulePayload
+
+		e.SetFields(protocol.PayloadTarget, "topicRulePayload", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CreateTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7004,6 +7657,12 @@ func (s CreateTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s CreateTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Input for the DeleteCACertificate operation.
@@ -7048,6 +7707,17 @@ func (s *DeleteCACertificateInput) SetCertificateId(v string) *DeleteCACertifica
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the DeleteCACertificate operation.
 type DeleteCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -7061,6 +7731,12 @@ func (s DeleteCACertificateOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCACertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteCertificate operation.
@@ -7105,6 +7781,17 @@ func (s *DeleteCertificateInput) SetCertificateId(v string) *DeleteCertificateIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7117,6 +7804,12 @@ func (s DeleteCertificateOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeletePolicy operation.
@@ -7161,6 +7854,17 @@ func (s *DeletePolicyInput) SetPolicyName(v string) *DeletePolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeletePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7173,6 +7877,12 @@ func (s DeletePolicyOutput) String() string {
 // GoString returns the string representation
 func (s DeletePolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeletePolicyVersion operation.
@@ -7231,6 +7941,22 @@ func (s *DeletePolicyVersionInput) SetPolicyVersionId(v string) *DeletePolicyVer
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeletePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7243,6 +7969,12 @@ func (s DeletePolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeletePolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteRegistrationCode operation.
@@ -7260,6 +7992,12 @@ func (s DeleteRegistrationCodeInput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRegistrationCodeInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 // The output for the DeleteRegistrationCode operation.
 type DeleteRegistrationCodeOutput struct {
 	_ struct{} `type:"structure"`
@@ -7273,6 +8011,12 @@ func (s DeleteRegistrationCodeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRegistrationCodeOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRegistrationCodeOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteThing operation.
@@ -7328,6 +8072,22 @@ func (s *DeleteThingInput) SetThingName(v string) *DeleteThingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ExpectedVersion != nil {
+		v := *s.ExpectedVersion
+
+		e.SetValue(protocol.QueryTarget, "expectedVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the DeleteThing operation.
 type DeleteThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -7341,6 +8101,12 @@ func (s DeleteThingOutput) String() string {
 // GoString returns the string representation
 func (s DeleteThingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteThingType operation.
@@ -7385,6 +8151,17 @@ func (s *DeleteThingTypeInput) SetThingTypeName(v string) *DeleteThingTypeInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the DeleteThingType operation.
 type DeleteThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -7398,6 +8175,12 @@ func (s DeleteThingTypeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteThingTypeOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteTopicRule operation.
@@ -7442,6 +8225,17 @@ func (s *DeleteTopicRuleInput) SetRuleName(v string) *DeleteTopicRuleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7454,6 +8248,12 @@ func (s DeleteTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeprecateThingType operation.
@@ -7508,6 +8308,22 @@ func (s *DeprecateThingTypeInput) SetUndoDeprecate(v bool) *DeprecateThingTypeIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeprecateThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UndoDeprecate != nil {
+		v := *s.UndoDeprecate
+
+		e.SetValue(protocol.BodyTarget, "undoDeprecate", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the DeprecateThingType operation.
 type DeprecateThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -7521,6 +8337,12 @@ func (s DeprecateThingTypeOutput) String() string {
 // GoString returns the string representation
 func (s DeprecateThingTypeOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeprecateThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DescribeCACertificate operation.
@@ -7565,6 +8387,17 @@ func (s *DescribeCACertificateInput) SetCertificateId(v string) *DescribeCACerti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the DescribeCACertificate operation.
 type DescribeCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -7587,6 +8420,17 @@ func (s DescribeCACertificateOutput) GoString() string {
 func (s *DescribeCACertificateOutput) SetCertificateDescription(v *CACertificateDescription) *DescribeCACertificateOutput {
 	s.CertificateDescription = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateDescription != nil {
+		v := s.CertificateDescription
+
+		e.SetFields(protocol.BodyTarget, "certificateDescription", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the DescribeCertificate operation.
@@ -7631,6 +8475,17 @@ func (s *DescribeCertificateInput) SetCertificateId(v string) *DescribeCertifica
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the DescribeCertificate operation.
 type DescribeCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -7655,6 +8510,17 @@ func (s *DescribeCertificateOutput) SetCertificateDescription(v *CertificateDesc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateDescription != nil {
+		v := s.CertificateDescription
+
+		e.SetFields(protocol.BodyTarget, "certificateDescription", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the DescribeEndpoint operation.
 type DescribeEndpointInput struct {
 	_ struct{} `type:"structure"`
@@ -7668,6 +8534,12 @@ func (s DescribeEndpointInput) String() string {
 // GoString returns the string representation
 func (s DescribeEndpointInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The output from the DescribeEndpoint operation.
@@ -7692,6 +8564,17 @@ func (s DescribeEndpointOutput) GoString() string {
 func (s *DescribeEndpointOutput) SetEndpointAddress(v string) *DescribeEndpointOutput {
 	s.EndpointAddress = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndpointAddress != nil {
+		v := *s.EndpointAddress
+
+		e.SetValue(protocol.BodyTarget, "endpointAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the DescribeThing operation.
@@ -7734,6 +8617,17 @@ func (s *DescribeThingInput) Validate() error {
 func (s *DescribeThingInput) SetThingName(v string) *DescribeThingInput {
 	s.ThingName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeThingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output from the DescribeThing operation.
@@ -7800,6 +8694,37 @@ func (s *DescribeThingOutput) SetVersion(v int64) *DescribeThingOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeThingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.DefaultClientId != nil {
+		v := *s.DefaultClientId
+
+		e.SetValue(protocol.BodyTarget, "defaultClientId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.BodyTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the DescribeThingType operation.
 type DescribeThingTypeInput struct {
 	_ struct{} `type:"structure"`
@@ -7840,6 +8765,17 @@ func (s *DescribeThingTypeInput) Validate() error {
 func (s *DescribeThingTypeInput) SetThingTypeName(v string) *DescribeThingTypeInput {
 	s.ThingTypeName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output for the DescribeThingType operation.
@@ -7885,6 +8821,27 @@ func (s *DescribeThingTypeOutput) SetThingTypeName(v string) *DescribeThingTypeO
 func (s *DescribeThingTypeOutput) SetThingTypeProperties(v *ThingTypeProperties) *DescribeThingTypeOutput {
 	s.ThingTypeProperties = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeMetadata != nil {
+		v := s.ThingTypeMetadata
+
+		e.SetFields(protocol.BodyTarget, "thingTypeMetadata", v, protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeProperties != nil {
+		v := s.ThingTypeProperties
+
+		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the DetachPrincipalPolicy operation.
@@ -7946,6 +8903,22 @@ func (s *DetachPrincipalPolicyInput) SetPrincipal(v string) *DetachPrincipalPoli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachPrincipalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DetachPrincipalPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7958,6 +8931,12 @@ func (s DetachPrincipalPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DetachPrincipalPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachPrincipalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DetachThingPrincipal operation.
@@ -8018,6 +8997,22 @@ func (s *DetachThingPrincipalInput) SetThingName(v string) *DetachThingPrincipal
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachThingPrincipalInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the DetachThingPrincipal operation.
 type DetachThingPrincipalOutput struct {
 	_ struct{} `type:"structure"`
@@ -8031,6 +9026,12 @@ func (s DetachThingPrincipalOutput) String() string {
 // GoString returns the string representation
 func (s DetachThingPrincipalOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachThingPrincipalOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DisableTopicRuleRequest operation.
@@ -8075,6 +9076,17 @@ func (s *DisableTopicRuleInput) SetRuleName(v string) *DisableTopicRuleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisableTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DisableTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8087,6 +9099,12 @@ func (s DisableTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s DisableTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisableTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes an action to write to a DynamoDB table.
@@ -8242,6 +9260,62 @@ func (s *DynamoDBAction) SetTableName(v string) *DynamoDBAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DynamoDBAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HashKeyField != nil {
+		v := *s.HashKeyField
+
+		e.SetValue(protocol.BodyTarget, "hashKeyField", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HashKeyType != nil {
+		v := *s.HashKeyType
+
+		e.SetValue(protocol.BodyTarget, "hashKeyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HashKeyValue != nil {
+		v := *s.HashKeyValue
+
+		e.SetValue(protocol.BodyTarget, "hashKeyValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Operation != nil {
+		v := *s.Operation
+
+		e.SetValue(protocol.BodyTarget, "operation", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PayloadField != nil {
+		v := *s.PayloadField
+
+		e.SetValue(protocol.BodyTarget, "payloadField", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RangeKeyField != nil {
+		v := *s.RangeKeyField
+
+		e.SetValue(protocol.BodyTarget, "rangeKeyField", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RangeKeyType != nil {
+		v := *s.RangeKeyType
+
+		e.SetValue(protocol.BodyTarget, "rangeKeyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RangeKeyValue != nil {
+		v := *s.RangeKeyValue
+
+		e.SetValue(protocol.BodyTarget, "rangeKeyValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TableName != nil {
+		v := *s.TableName
+
+		e.SetValue(protocol.BodyTarget, "tableName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action to write to a DynamoDB table.
 //
 // This DynamoDB action writes each attribute in the message payload into it's
@@ -8298,6 +9372,22 @@ func (s *DynamoDBv2Action) SetPutItem(v *PutItemInput) *DynamoDBv2Action {
 func (s *DynamoDBv2Action) SetRoleArn(v string) *DynamoDBv2Action {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DynamoDBv2Action) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PutItem != nil {
+		v := s.PutItem
+
+		e.SetFields(protocol.BodyTarget, "putItem", v, protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an action that writes data to an Amazon Elasticsearch Service domain.
@@ -8395,6 +9485,37 @@ func (s *ElasticsearchAction) SetType(v string) *ElasticsearchAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Endpoint != nil {
+		v := *s.Endpoint
+
+		e.SetValue(protocol.BodyTarget, "endpoint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Index != nil {
+		v := *s.Index
+
+		e.SetValue(protocol.BodyTarget, "index", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the EnableTopicRuleRequest operation.
 type EnableTopicRuleInput struct {
 	_ struct{} `type:"structure"`
@@ -8437,6 +9558,17 @@ func (s *EnableTopicRuleInput) SetRuleName(v string) *EnableTopicRuleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnableTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type EnableTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8449,6 +9581,12 @@ func (s EnableTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s EnableTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnableTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes an action that writes data to an Amazon Kinesis Firehose stream.
@@ -8515,6 +9653,27 @@ func (s *FirehoseAction) SetSeparator(v string) *FirehoseAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FirehoseAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeliveryStreamName != nil {
+		v := *s.DeliveryStreamName
+
+		e.SetValue(protocol.BodyTarget, "deliveryStreamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Separator != nil {
+		v := *s.Separator
+
+		e.SetValue(protocol.BodyTarget, "separator", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the GetLoggingOptions operation.
 type GetLoggingOptionsInput struct {
 	_ struct{} `type:"structure"`
@@ -8528,6 +9687,12 @@ func (s GetLoggingOptionsInput) String() string {
 // GoString returns the string representation
 func (s GetLoggingOptionsInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggingOptionsInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The output from the GetLoggingOptions operation.
@@ -8561,6 +9726,22 @@ func (s *GetLoggingOptionsOutput) SetLogLevel(v string) *GetLoggingOptionsOutput
 func (s *GetLoggingOptionsOutput) SetRoleArn(v string) *GetLoggingOptionsOutput {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggingOptionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LogLevel != nil {
+		v := *s.LogLevel
+
+		e.SetValue(protocol.BodyTarget, "logLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetPolicy operation.
@@ -8603,6 +9784,17 @@ func (s *GetPolicyInput) Validate() error {
 func (s *GetPolicyInput) SetPolicyName(v string) *GetPolicyInput {
 	s.PolicyName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output from the GetPolicy operation.
@@ -8654,6 +9846,32 @@ func (s *GetPolicyOutput) SetPolicyDocument(v string) *GetPolicyOutput {
 func (s *GetPolicyOutput) SetPolicyName(v string) *GetPolicyOutput {
 	s.PolicyName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultVersionId != nil {
+		v := *s.DefaultVersionId
+
+		e.SetValue(protocol.BodyTarget, "defaultVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetPolicyVersion operation.
@@ -8710,6 +9928,22 @@ func (s *GetPolicyVersionInput) SetPolicyName(v string) *GetPolicyVersionInput {
 func (s *GetPolicyVersionInput) SetPolicyVersionId(v string) *GetPolicyVersionInput {
 	s.PolicyVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output from the GetPolicyVersion operation.
@@ -8772,6 +10006,37 @@ func (s *GetPolicyVersionOutput) SetPolicyVersionId(v string) *GetPolicyVersionO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsDefaultVersion != nil {
+		v := *s.IsDefaultVersion
+
+		e.SetValue(protocol.BodyTarget, "isDefaultVersion", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input to the GetRegistrationCode operation.
 type GetRegistrationCodeInput struct {
 	_ struct{} `type:"structure"`
@@ -8785,6 +10050,12 @@ func (s GetRegistrationCodeInput) String() string {
 // GoString returns the string representation
 func (s GetRegistrationCodeInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRegistrationCodeInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The output from the GetRegistrationCode operation.
@@ -8809,6 +10080,17 @@ func (s GetRegistrationCodeOutput) GoString() string {
 func (s *GetRegistrationCodeOutput) SetRegistrationCode(v string) *GetRegistrationCodeOutput {
 	s.RegistrationCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRegistrationCodeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RegistrationCode != nil {
+		v := *s.RegistrationCode
+
+		e.SetValue(protocol.BodyTarget, "registrationCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetTopicRule operation.
@@ -8853,6 +10135,17 @@ func (s *GetTopicRuleInput) SetRuleName(v string) *GetTopicRuleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the GetTopicRule operation.
 type GetTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -8886,6 +10179,22 @@ func (s *GetTopicRuleOutput) SetRuleArn(v string) *GetTopicRuleOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Rule != nil {
+		v := s.Rule
+
+		e.SetFields(protocol.BodyTarget, "rule", v, protocol.Metadata{})
+	}
+	if s.RuleArn != nil {
+		v := *s.RuleArn
+
+		e.SetValue(protocol.BodyTarget, "ruleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes a key pair.
 type KeyPair struct {
 	_ struct{} `type:"structure"`
@@ -8917,6 +10226,22 @@ func (s *KeyPair) SetPrivateKey(v string) *KeyPair {
 func (s *KeyPair) SetPublicKey(v string) *KeyPair {
 	s.PublicKey = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyPair) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PrivateKey != nil {
+		v := *s.PrivateKey
+
+		e.SetValue(protocol.BodyTarget, "PrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PublicKey != nil {
+		v := *s.PublicKey
+
+		e.SetValue(protocol.BodyTarget, "PublicKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an action to write data to an Amazon Kinesis stream.
@@ -8981,6 +10306,27 @@ func (s *KinesisAction) SetStreamName(v string) *KinesisAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KinesisAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PartitionKey != nil {
+		v := *s.PartitionKey
+
+		e.SetValue(protocol.BodyTarget, "partitionKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamName != nil {
+		v := *s.StreamName
+
+		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action to invoke a Lambda function.
 type LambdaAction struct {
 	_ struct{} `type:"structure"`
@@ -9018,6 +10364,17 @@ func (s *LambdaAction) Validate() error {
 func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
 	s.FunctionArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LambdaAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionArn != nil {
+		v := *s.FunctionArn
+
+		e.SetValue(protocol.BodyTarget, "functionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Input for the ListCACertificates operation.
@@ -9075,6 +10432,27 @@ func (s *ListCACertificatesInput) SetPageSize(v int64) *ListCACertificatesInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCACertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListCACertificates operation.
 type ListCACertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9106,6 +10484,22 @@ func (s *ListCACertificatesOutput) SetCertificates(v []*CACertificate) *ListCACe
 func (s *ListCACertificatesOutput) SetNextMarker(v string) *ListCACertificatesOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCACertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Certificates) > 0 {
+		v := s.Certificates
+
+		e.SetList(protocol.BodyTarget, "certificates", encodeCACertificateList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the ListCertificatesByCA operation.
@@ -9182,6 +10576,32 @@ func (s *ListCertificatesByCAInput) SetPageSize(v int64) *ListCertificatesByCAIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCertificatesByCAInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CaCertificateId != nil {
+		v := *s.CaCertificateId
+
+		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the ListCertificatesByCA operation.
 type ListCertificatesByCAOutput struct {
 	_ struct{} `type:"structure"`
@@ -9214,6 +10634,22 @@ func (s *ListCertificatesByCAOutput) SetCertificates(v []*Certificate) *ListCert
 func (s *ListCertificatesByCAOutput) SetNextMarker(v string) *ListCertificatesByCAOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCertificatesByCAOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Certificates) > 0 {
+		v := s.Certificates
+
+		e.SetList(protocol.BodyTarget, "certificates", encodeCertificateList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListCertificates operation.
@@ -9272,6 +10708,27 @@ func (s *ListCertificatesInput) SetPageSize(v int64) *ListCertificatesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the ListCertificates operation.
 type ListCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9304,6 +10761,22 @@ func (s *ListCertificatesOutput) SetCertificates(v []*Certificate) *ListCertific
 func (s *ListCertificatesOutput) SetNextMarker(v string) *ListCertificatesOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Certificates) > 0 {
+		v := s.Certificates
+
+		e.SetList(protocol.BodyTarget, "certificates", encodeCertificateList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the ListOutgoingCertificates operation.
@@ -9362,6 +10835,27 @@ func (s *ListOutgoingCertificatesInput) SetPageSize(v int64) *ListOutgoingCertif
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOutgoingCertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListOutgoingCertificates operation.
 type ListOutgoingCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9393,6 +10887,22 @@ func (s *ListOutgoingCertificatesOutput) SetNextMarker(v string) *ListOutgoingCe
 func (s *ListOutgoingCertificatesOutput) SetOutgoingCertificates(v []*OutgoingCertificate) *ListOutgoingCertificatesOutput {
 	s.OutgoingCertificates = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOutgoingCertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OutgoingCertificates) > 0 {
+		v := s.OutgoingCertificates
+
+		e.SetList(protocol.BodyTarget, "outgoingCertificates", encodeOutgoingCertificateList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPolicies operation.
@@ -9451,6 +10961,27 @@ func (s *ListPoliciesInput) SetPageSize(v int64) *ListPoliciesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPolicies operation.
 type ListPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9483,6 +11014,22 @@ func (s *ListPoliciesOutput) SetNextMarker(v string) *ListPoliciesOutput {
 func (s *ListPoliciesOutput) SetPolicies(v []*Policy) *ListPoliciesOutput {
 	s.Policies = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Policies) > 0 {
+		v := s.Policies
+
+		e.SetList(protocol.BodyTarget, "policies", encodePolicyList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPolicyPrincipals operation.
@@ -9558,6 +11105,32 @@ func (s *ListPolicyPrincipalsInput) SetPolicyName(v string) *ListPolicyPrincipal
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyPrincipalsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPolicyPrincipals operation.
 type ListPolicyPrincipalsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9590,6 +11163,22 @@ func (s *ListPolicyPrincipalsOutput) SetNextMarker(v string) *ListPolicyPrincipa
 func (s *ListPolicyPrincipalsOutput) SetPrincipals(v []*string) *ListPolicyPrincipalsOutput {
 	s.Principals = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyPrincipalsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Principals) > 0 {
+		v := s.Principals
+
+		e.SetList(protocol.BodyTarget, "principals", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPolicyVersions operation.
@@ -9634,6 +11223,17 @@ func (s *ListPolicyVersionsInput) SetPolicyName(v string) *ListPolicyVersionsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPolicyVersions operation.
 type ListPolicyVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9656,6 +11256,17 @@ func (s ListPolicyVersionsOutput) GoString() string {
 func (s *ListPolicyVersionsOutput) SetPolicyVersions(v []*PolicyVersion) *ListPolicyVersionsOutput {
 	s.PolicyVersions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PolicyVersions) > 0 {
+		v := s.PolicyVersions
+
+		e.SetList(protocol.BodyTarget, "policyVersions", encodePolicyVersionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPrincipalPolicies operation.
@@ -9728,6 +11339,32 @@ func (s *ListPrincipalPoliciesInput) SetPrincipal(v string) *ListPrincipalPolici
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPrincipalPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPrincipalPolicies operation.
 type ListPrincipalPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9760,6 +11397,22 @@ func (s *ListPrincipalPoliciesOutput) SetNextMarker(v string) *ListPrincipalPoli
 func (s *ListPrincipalPoliciesOutput) SetPolicies(v []*Policy) *ListPrincipalPoliciesOutput {
 	s.Policies = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPrincipalPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Policies) > 0 {
+		v := s.Policies
+
+		e.SetList(protocol.BodyTarget, "policies", encodePolicyList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPrincipalThings operation.
@@ -9823,6 +11476,27 @@ func (s *ListPrincipalThingsInput) SetPrincipal(v string) *ListPrincipalThingsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPrincipalThingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPrincipalThings operation.
 type ListPrincipalThingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9855,6 +11529,22 @@ func (s *ListPrincipalThingsOutput) SetNextToken(v string) *ListPrincipalThingsO
 func (s *ListPrincipalThingsOutput) SetThings(v []*string) *ListPrincipalThingsOutput {
 	s.Things = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPrincipalThingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Things) > 0 {
+		v := s.Things
+
+		e.SetList(protocol.BodyTarget, "things", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListThingPrincipal operation.
@@ -9899,6 +11589,17 @@ func (s *ListThingPrincipalsInput) SetThingName(v string) *ListThingPrincipalsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingPrincipalsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListThingPrincipals operation.
 type ListThingPrincipalsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9921,6 +11622,17 @@ func (s ListThingPrincipalsOutput) GoString() string {
 func (s *ListThingPrincipalsOutput) SetPrincipals(v []*string) *ListThingPrincipalsOutput {
 	s.Principals = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingPrincipalsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Principals) > 0 {
+		v := s.Principals
+
+		e.SetList(protocol.BodyTarget, "principals", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListThingTypes operation.
@@ -9982,6 +11694,27 @@ func (s *ListThingTypesInput) SetThingTypeName(v string) *ListThingTypesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.QueryTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the ListThingTypes operation.
 type ListThingTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -10014,6 +11747,22 @@ func (s *ListThingTypesOutput) SetNextToken(v string) *ListThingTypesOutput {
 func (s *ListThingTypesOutput) SetThingTypes(v []*ThingTypeDefinition) *ListThingTypesOutput {
 	s.ThingTypes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ThingTypes) > 0 {
+		v := s.ThingTypes
+
+		e.SetList(protocol.BodyTarget, "thingTypes", encodeThingTypeDefinitionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListThings operation.
@@ -10093,6 +11842,37 @@ func (s *ListThingsInput) SetThingTypeName(v string) *ListThingsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeName != nil {
+		v := *s.AttributeName
+
+		e.SetValue(protocol.QueryTarget, "attributeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AttributeValue != nil {
+		v := *s.AttributeValue
+
+		e.SetValue(protocol.QueryTarget, "attributeValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.QueryTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListThings operation.
 type ListThingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10125,6 +11905,22 @@ func (s *ListThingsOutput) SetNextToken(v string) *ListThingsOutput {
 func (s *ListThingsOutput) SetThings(v []*ThingAttribute) *ListThingsOutput {
 	s.Things = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Things) > 0 {
+		v := s.Things
+
+		e.SetList(protocol.BodyTarget, "things", encodeThingAttributeList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListTopicRules operation.
@@ -10191,6 +11987,32 @@ func (s *ListTopicRulesInput) SetTopic(v string) *ListTopicRulesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTopicRulesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RuleDisabled != nil {
+		v := *s.RuleDisabled
+
+		e.SetValue(protocol.QueryTarget, "ruleDisabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.QueryTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListTopicRules operation.
 type ListTopicRulesOutput struct {
 	_ struct{} `type:"structure"`
@@ -10222,6 +12044,22 @@ func (s *ListTopicRulesOutput) SetNextToken(v string) *ListTopicRulesOutput {
 func (s *ListTopicRulesOutput) SetRules(v []*TopicRuleListItem) *ListTopicRulesOutput {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTopicRulesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "rules", encodeTopicRuleListItemList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the logging options payload.
@@ -10270,6 +12108,22 @@ func (s *LoggingOptionsPayload) SetLogLevel(v string) *LoggingOptionsPayload {
 func (s *LoggingOptionsPayload) SetRoleArn(v string) *LoggingOptionsPayload {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LoggingOptionsPayload) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LogLevel != nil {
+		v := *s.LogLevel
+
+		e.SetValue(protocol.BodyTarget, "logLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A certificate that has been transfered but not yet accepted.
@@ -10341,6 +12195,50 @@ func (s *OutgoingCertificate) SetTransferredTo(v string) *OutgoingCertificate {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutgoingCertificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.TransferDate != nil {
+		v := *s.TransferDate
+
+		e.SetValue(protocol.BodyTarget, "transferDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.TransferMessage != nil {
+		v := *s.TransferMessage
+
+		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransferredTo != nil {
+		v := *s.TransferredTo
+
+		e.SetValue(protocol.BodyTarget, "transferredTo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutgoingCertificateList(vs []*OutgoingCertificate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes an AWS IoT policy.
 type Policy struct {
 	_ struct{} `type:"structure"`
@@ -10372,6 +12270,30 @@ func (s *Policy) SetPolicyArn(v string) *Policy {
 func (s *Policy) SetPolicyName(v string) *Policy {
 	s.PolicyName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Policy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePolicyList(vs []*Policy) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a policy version.
@@ -10416,6 +12338,35 @@ func (s *PolicyVersion) SetVersionId(v string) *PolicyVersion {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PolicyVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreateDate != nil {
+		v := *s.CreateDate
+
+		e.SetValue(protocol.BodyTarget, "createDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.IsDefaultVersion != nil {
+		v := *s.IsDefaultVersion
+
+		e.SetValue(protocol.BodyTarget, "isDefaultVersion", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePolicyVersionList(vs []*PolicyVersion) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The input for the DynamoActionVS action that specifies the DynamoDB table
 // to which the message data will be written.
 type PutItemInput struct {
@@ -10454,6 +12405,17 @@ func (s *PutItemInput) Validate() error {
 func (s *PutItemInput) SetTableName(v string) *PutItemInput {
 	s.TableName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutItemInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TableName != nil {
+		v := *s.TableName
+
+		e.SetValue(protocol.BodyTarget, "tableName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the RegisterCACertificate operation.
@@ -10533,6 +12495,32 @@ func (s *RegisterCACertificateInput) SetVerificationCertificate(v string) *Regis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AllowAutoRegistration != nil {
+		v := *s.AllowAutoRegistration
+
+		e.SetValue(protocol.QueryTarget, "allowAutoRegistration", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CaCertificate != nil {
+		v := *s.CaCertificate
+
+		e.SetValue(protocol.BodyTarget, "caCertificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.VerificationCertificate != nil {
+		v := *s.VerificationCertificate
+
+		e.SetValue(protocol.BodyTarget, "verificationCertificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the RegisterCACertificateResponse operation.
 type RegisterCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -10564,6 +12552,22 @@ func (s *RegisterCACertificateOutput) SetCertificateArn(v string) *RegisterCACer
 func (s *RegisterCACertificateOutput) SetCertificateId(v string) *RegisterCACertificateOutput {
 	s.CertificateId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the RegisterCertificate operation.
@@ -10638,6 +12642,32 @@ func (s *RegisterCertificateInput) SetStatus(v string) *RegisterCertificateInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CaCertificatePem != nil {
+		v := *s.CaCertificatePem
+
+		e.SetValue(protocol.BodyTarget, "caCertificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the RegisterCertificate operation.
 type RegisterCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -10669,6 +12699,22 @@ func (s *RegisterCertificateOutput) SetCertificateArn(v string) *RegisterCertifi
 func (s *RegisterCertificateOutput) SetCertificateId(v string) *RegisterCertificateOutput {
 	s.CertificateId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the RejectCertificateTransfer operation.
@@ -10722,6 +12768,22 @@ func (s *RejectCertificateTransferInput) SetRejectReason(v string) *RejectCertif
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RejectCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectReason != nil {
+		v := *s.RejectReason
+
+		e.SetValue(protocol.BodyTarget, "rejectReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type RejectCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10734,6 +12796,12 @@ func (s RejectCertificateTransferOutput) String() string {
 // GoString returns the string representation
 func (s RejectCertificateTransferOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RejectCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the ReplaceTopicRule operation.
@@ -10797,6 +12865,22 @@ func (s *ReplaceTopicRuleInput) SetTopicRulePayload(v *TopicRulePayload) *Replac
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReplaceTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TopicRulePayload != nil {
+		v := s.TopicRulePayload
+
+		e.SetFields(protocol.PayloadTarget, "topicRulePayload", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type ReplaceTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10809,6 +12893,12 @@ func (s ReplaceTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s ReplaceTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReplaceTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes an action to republish to another topic.
@@ -10862,6 +12952,22 @@ func (s *RepublishAction) SetRoleArn(v string) *RepublishAction {
 func (s *RepublishAction) SetTopic(v string) *RepublishAction {
 	s.Topic = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RepublishAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.BodyTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an action to write data to an Amazon S3 bucket.
@@ -10941,6 +13047,32 @@ func (s *S3Action) SetRoleArn(v string) *S3Action {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *S3Action) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BucketName != nil {
+		v := *s.BucketName
+
+		e.SetValue(protocol.BodyTarget, "bucketName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CannedAcl != nil {
+		v := *s.CannedAcl
+
+		e.SetValue(protocol.BodyTarget, "cannedAcl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action to write a message to a Salesforce IoT Cloud Input Stream.
 type SalesforceAction struct {
 	_ struct{} `type:"structure"`
@@ -11000,6 +13132,22 @@ func (s *SalesforceAction) SetUrl(v string) *SalesforceAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SalesforceAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.BodyTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the SetDefaultPolicyVersion operation.
 type SetDefaultPolicyVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -11056,6 +13204,22 @@ func (s *SetDefaultPolicyVersionInput) SetPolicyVersionId(v string) *SetDefaultP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDefaultPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetDefaultPolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11068,6 +13232,12 @@ func (s SetDefaultPolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s SetDefaultPolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDefaultPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the SetLoggingOptions operation.
@@ -11114,6 +13284,17 @@ func (s *SetLoggingOptionsInput) SetLoggingOptionsPayload(v *LoggingOptionsPaylo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetLoggingOptionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggingOptionsPayload != nil {
+		v := s.LoggingOptionsPayload
+
+		e.SetFields(protocol.PayloadTarget, "loggingOptionsPayload", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetLoggingOptionsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11126,6 +13307,12 @@ func (s SetLoggingOptionsOutput) String() string {
 // GoString returns the string representation
 func (s SetLoggingOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetLoggingOptionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes an action to publish to an Amazon SNS topic.
@@ -11195,6 +13382,27 @@ func (s *SnsAction) SetTargetArn(v string) *SnsAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SnsAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageFormat != nil {
+		v := *s.MessageFormat
+
+		e.SetValue(protocol.BodyTarget, "messageFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetArn != nil {
+		v := *s.TargetArn
+
+		e.SetValue(protocol.BodyTarget, "targetArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action to publish data to an Amazon SQS queue.
 type SqsAction struct {
 	_ struct{} `type:"structure"`
@@ -11257,6 +13465,27 @@ func (s *SqsAction) SetUseBase64(v bool) *SqsAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SqsAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.QueueUrl != nil {
+		v := *s.QueueUrl
+
+		e.SetValue(protocol.BodyTarget, "queueUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UseBase64 != nil {
+		v := *s.UseBase64
+
+		e.SetValue(protocol.BodyTarget, "useBase64", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The properties of the thing, including thing name, thing type name, and a
 // list of thing attributes.
 type ThingAttribute struct {
@@ -11309,6 +13538,40 @@ func (s *ThingAttribute) SetVersion(v int64) *ThingAttribute {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThingAttribute) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.BodyTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeThingAttributeList(vs []*ThingAttribute) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The definition of the thing type, including thing type name and description.
 type ThingTypeDefinition struct {
 	_ struct{} `type:"structure"`
@@ -11351,6 +13614,35 @@ func (s *ThingTypeDefinition) SetThingTypeName(v string) *ThingTypeDefinition {
 func (s *ThingTypeDefinition) SetThingTypeProperties(v *ThingTypeProperties) *ThingTypeDefinition {
 	s.ThingTypeProperties = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThingTypeDefinition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeMetadata != nil {
+		v := s.ThingTypeMetadata
+
+		e.SetFields(protocol.BodyTarget, "thingTypeMetadata", v, protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeProperties != nil {
+		v := s.ThingTypeProperties
+
+		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeThingTypeDefinitionList(vs []*ThingTypeDefinition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The ThingTypeMetadata contains additional information about the thing type
@@ -11398,6 +13690,27 @@ func (s *ThingTypeMetadata) SetDeprecationDate(v time.Time) *ThingTypeMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThingTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Deprecated != nil {
+		v := *s.Deprecated
+
+		e.SetValue(protocol.BodyTarget, "deprecated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DeprecationDate != nil {
+		v := *s.DeprecationDate
+
+		e.SetValue(protocol.BodyTarget, "deprecationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ThingTypeProperties contains information about the thing type including:
 // a thing type description, and a list of searchable thing attribute names.
 type ThingTypeProperties struct {
@@ -11430,6 +13743,22 @@ func (s *ThingTypeProperties) SetSearchableAttributes(v []*string) *ThingTypePro
 func (s *ThingTypeProperties) SetThingTypeDescription(v string) *ThingTypeProperties {
 	s.ThingTypeDescription = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThingTypeProperties) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SearchableAttributes) > 0 {
+		v := s.SearchableAttributes
+
+		e.SetList(protocol.BodyTarget, "searchableAttributes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ThingTypeDescription != nil {
+		v := *s.ThingTypeDescription
+
+		e.SetValue(protocol.BodyTarget, "thingTypeDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes a rule.
@@ -11511,6 +13840,47 @@ func (s *TopicRule) SetSql(v string) *TopicRule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicRule) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Actions) > 0 {
+		v := s.Actions
+
+		e.SetList(protocol.BodyTarget, "actions", encodeActionList(v), protocol.Metadata{})
+	}
+	if s.AwsIotSqlVersion != nil {
+		v := *s.AwsIotSqlVersion
+
+		e.SetValue(protocol.BodyTarget, "awsIotSqlVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RuleDisabled != nil {
+		v := *s.RuleDisabled
+
+		e.SetValue(protocol.BodyTarget, "ruleDisabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.BodyTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sql != nil {
+		v := *s.Sql
+
+		e.SetValue(protocol.BodyTarget, "sql", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes a rule.
 type TopicRuleListItem struct {
 	_ struct{} `type:"structure"`
@@ -11569,6 +13939,45 @@ func (s *TopicRuleListItem) SetRuleName(v string) *TopicRuleListItem {
 func (s *TopicRuleListItem) SetTopicPattern(v string) *TopicRuleListItem {
 	s.TopicPattern = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicRuleListItem) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.RuleArn != nil {
+		v := *s.RuleArn
+
+		e.SetValue(protocol.BodyTarget, "ruleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RuleDisabled != nil {
+		v := *s.RuleDisabled
+
+		e.SetValue(protocol.BodyTarget, "ruleDisabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.BodyTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TopicPattern != nil {
+		v := *s.TopicPattern
+
+		e.SetValue(protocol.BodyTarget, "topicPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTopicRuleListItemList(vs []*TopicRuleListItem) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a rule.
@@ -11663,6 +14072,37 @@ func (s *TopicRulePayload) SetSql(v string) *TopicRulePayload {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicRulePayload) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Actions) > 0 {
+		v := s.Actions
+
+		e.SetList(protocol.BodyTarget, "actions", encodeActionList(v), protocol.Metadata{})
+	}
+	if s.AwsIotSqlVersion != nil {
+		v := *s.AwsIotSqlVersion
+
+		e.SetValue(protocol.BodyTarget, "awsIotSqlVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RuleDisabled != nil {
+		v := *s.RuleDisabled
+
+		e.SetValue(protocol.BodyTarget, "ruleDisabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Sql != nil {
+		v := *s.Sql
+
+		e.SetValue(protocol.BodyTarget, "sql", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the TransferCertificate operation.
 type TransferCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -11728,6 +14168,27 @@ func (s *TransferCertificateInput) SetTransferMessage(v string) *TransferCertifi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TransferCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetAwsAccount != nil {
+		v := *s.TargetAwsAccount
+
+		e.SetValue(protocol.QueryTarget, "targetAwsAccount", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransferMessage != nil {
+		v := *s.TransferMessage
+
+		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the TransferCertificate operation.
 type TransferCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -11750,6 +14211,17 @@ func (s TransferCertificateOutput) GoString() string {
 func (s *TransferCertificateOutput) SetTransferredCertificateArn(v string) *TransferCertificateOutput {
 	s.TransferredCertificateArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TransferCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TransferredCertificateArn != nil {
+		v := *s.TransferredCertificateArn
+
+		e.SetValue(protocol.BodyTarget, "transferredCertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Data used to transfer a certificate to an AWS account.
@@ -11810,6 +14282,37 @@ func (s *TransferData) SetTransferDate(v time.Time) *TransferData {
 func (s *TransferData) SetTransferMessage(v string) *TransferData {
 	s.TransferMessage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TransferData) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcceptDate != nil {
+		v := *s.AcceptDate
+
+		e.SetValue(protocol.BodyTarget, "acceptDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.RejectDate != nil {
+		v := *s.RejectDate
+
+		e.SetValue(protocol.BodyTarget, "rejectDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.RejectReason != nil {
+		v := *s.RejectReason
+
+		e.SetValue(protocol.BodyTarget, "rejectReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransferDate != nil {
+		v := *s.TransferDate
+
+		e.SetValue(protocol.BodyTarget, "transferDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.TransferMessage != nil {
+		v := *s.TransferMessage
+
+		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the UpdateCACertificate operation.
@@ -11876,6 +14379,27 @@ func (s *UpdateCACertificateInput) SetNewStatus(v string) *UpdateCACertificateIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NewAutoRegistrationStatus != nil {
+		v := *s.NewAutoRegistrationStatus
+
+		e.SetValue(protocol.QueryTarget, "newAutoRegistrationStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NewStatus != nil {
+		v := *s.NewStatus
+
+		e.SetValue(protocol.QueryTarget, "newStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateCACertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11888,6 +14412,12 @@ func (s UpdateCACertificateOutput) String() string {
 // GoString returns the string representation
 func (s UpdateCACertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the UpdateCertificate operation.
@@ -11953,6 +14483,22 @@ func (s *UpdateCertificateInput) SetNewStatus(v string) *UpdateCertificateInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NewStatus != nil {
+		v := *s.NewStatus
+
+		e.SetValue(protocol.QueryTarget, "newStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11965,6 +14511,12 @@ func (s UpdateCertificateOutput) String() string {
 // GoString returns the string representation
 func (s UpdateCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the UpdateThing operation.
@@ -12055,6 +14607,37 @@ func (s *UpdateThingInput) SetThingTypeName(v string) *UpdateThingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateThingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributePayload != nil {
+		v := s.AttributePayload
+
+		e.SetFields(protocol.BodyTarget, "attributePayload", v, protocol.Metadata{})
+	}
+	if s.ExpectedVersion != nil {
+		v := *s.ExpectedVersion
+
+		e.SetValue(protocol.BodyTarget, "expectedVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RemoveThingType != nil {
+		v := *s.RemoveThingType
+
+		e.SetValue(protocol.BodyTarget, "removeThingType", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the UpdateThing operation.
 type UpdateThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -12068,6 +14651,12 @@ func (s UpdateThingOutput) String() string {
 // GoString returns the string representation
 func (s UpdateThingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateThingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 const (

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -445,6 +445,17 @@ func (s *DeleteThingShadowInput) SetThingName(v string) *DeleteThingShadowInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the DeleteThingShadow operation.
 type DeleteThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -469,6 +480,17 @@ func (s DeleteThingShadowOutput) GoString() string {
 func (s *DeleteThingShadowOutput) SetPayload(v []byte) *DeleteThingShadowOutput {
 	s.Payload = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetThingShadow operation.
@@ -513,6 +535,17 @@ func (s *GetThingShadowInput) SetThingName(v string) *GetThingShadowInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the GetThingShadow operation.
 type GetThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -535,6 +568,17 @@ func (s GetThingShadowOutput) GoString() string {
 func (s *GetThingShadowOutput) SetPayload(v []byte) *GetThingShadowOutput {
 	s.Payload = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the Publish operation.
@@ -594,6 +638,27 @@ func (s *PublishInput) SetTopic(v string) *PublishInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.Qos != nil {
+		v := *s.Qos
+
+		e.SetValue(protocol.QueryTarget, "qos", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.PathTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type PublishOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -606,6 +671,12 @@ func (s PublishOutput) String() string {
 // GoString returns the string representation
 func (s PublishOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the UpdateThingShadow operation.
@@ -664,6 +735,22 @@ func (s *UpdateThingShadowInput) SetThingName(v string) *UpdateThingShadowInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the UpdateThingShadow operation.
 type UpdateThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -686,4 +773,15 @@ func (s UpdateThingShadowOutput) GoString() string {
 func (s *UpdateThingShadowOutput) SetPayload(v []byte) *UpdateThingShadowOutput {
 	s.Payload = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -3058,6 +3058,32 @@ func (s *AccountLimit) SetTotalCodeSize(v int64) *AccountLimit {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccountLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodeSizeUnzipped != nil {
+		v := *s.CodeSizeUnzipped
+
+		e.SetValue(protocol.BodyTarget, "CodeSizeUnzipped", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CodeSizeZipped != nil {
+		v := *s.CodeSizeZipped
+
+		e.SetValue(protocol.BodyTarget, "CodeSizeZipped", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ConcurrentExecutions != nil {
+		v := *s.ConcurrentExecutions
+
+		e.SetValue(protocol.BodyTarget, "ConcurrentExecutions", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCodeSize != nil {
+		v := *s.TotalCodeSize
+
+		e.SetValue(protocol.BodyTarget, "TotalCodeSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides code size usage and function count associated with the current account
 // and region.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/AccountUsage
@@ -3091,6 +3117,22 @@ func (s *AccountUsage) SetFunctionCount(v int64) *AccountUsage {
 func (s *AccountUsage) SetTotalCodeSize(v int64) *AccountUsage {
 	s.TotalCodeSize = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccountUsage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionCount != nil {
+		v := *s.FunctionCount
+
+		e.SetValue(protocol.BodyTarget, "FunctionCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCodeSize != nil {
+		v := *s.TotalCodeSize
+
+		e.SetValue(protocol.BodyTarget, "TotalCodeSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/AddPermissionRequest
@@ -3264,6 +3306,52 @@ func (s *AddPermissionInput) SetStatementId(v string) *AddPermissionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddPermissionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EventSourceToken != nil {
+		v := *s.EventSourceToken
+
+		e.SetValue(protocol.BodyTarget, "EventSourceToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.BodyTarget, "Principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceAccount != nil {
+		v := *s.SourceAccount
+
+		e.SetValue(protocol.BodyTarget, "SourceAccount", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceArn != nil {
+		v := *s.SourceArn
+
+		e.SetValue(protocol.BodyTarget, "SourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatementId != nil {
+		v := *s.StatementId
+
+		e.SetValue(protocol.BodyTarget, "StatementId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/AddPermissionResponse
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
@@ -3288,6 +3376,17 @@ func (s AddPermissionOutput) GoString() string {
 func (s *AddPermissionOutput) SetStatement(v string) *AddPermissionOutput {
 	s.Statement = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddPermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Statement != nil {
+		v := *s.Statement
+
+		e.SetValue(protocol.BodyTarget, "Statement", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides configuration information about a Lambda function version alias.
@@ -3342,6 +3441,40 @@ func (s *AliasConfiguration) SetFunctionVersion(v string) *AliasConfiguration {
 func (s *AliasConfiguration) SetName(v string) *AliasConfiguration {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AliasConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AliasArn != nil {
+		v := *s.AliasArn
+
+		e.SetValue(protocol.BodyTarget, "AliasArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.BodyTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAliasConfigurationList(vs []*AliasConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/CreateAliasRequest
@@ -3429,6 +3562,32 @@ func (s *CreateAliasInput) SetFunctionVersion(v string) *CreateAliasInput {
 func (s *CreateAliasInput) SetName(v string) *CreateAliasInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.BodyTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/CreateEventSourceMappingRequest
@@ -3557,6 +3716,42 @@ func (s *CreateEventSourceMappingInput) SetStartingPosition(v string) *CreateEve
 func (s *CreateEventSourceMappingInput) SetStartingPositionTimestamp(v time.Time) *CreateEventSourceMappingInput {
 	s.StartingPositionTimestamp = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchSize != nil {
+		v := *s.BatchSize
+
+		e.SetValue(protocol.BodyTarget, "BatchSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.EventSourceArn != nil {
+		v := *s.EventSourceArn
+
+		e.SetValue(protocol.BodyTarget, "EventSourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.BodyTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartingPosition != nil {
+		v := *s.StartingPosition
+
+		e.SetValue(protocol.BodyTarget, "StartingPosition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartingPositionTimestamp != nil {
+		v := *s.StartingPositionTimestamp
+
+		e.SetValue(protocol.BodyTarget, "StartingPositionTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/CreateFunctionRequest
@@ -3795,6 +3990,87 @@ func (s *CreateFunctionInput) SetVpcConfig(v *VpcConfig) *CreateFunctionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Code != nil {
+		v := s.Code
+
+		e.SetFields(protocol.BodyTarget, "Code", v, protocol.Metadata{})
+	}
+	if s.DeadLetterConfig != nil {
+		v := s.DeadLetterConfig
+
+		e.SetFields(protocol.BodyTarget, "DeadLetterConfig", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Environment != nil {
+		v := s.Environment
+
+		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.BodyTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Handler != nil {
+		v := *s.Handler
+
+		e.SetValue(protocol.BodyTarget, "Handler", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KMSKeyArn != nil {
+		v := *s.KMSKeyArn
+
+		e.SetValue(protocol.BodyTarget, "KMSKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MemorySize != nil {
+		v := *s.MemorySize
+
+		e.SetValue(protocol.BodyTarget, "MemorySize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Publish != nil {
+		v := *s.Publish
+
+		e.SetValue(protocol.BodyTarget, "Publish", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Runtime != nil {
+		v := *s.Runtime
+
+		e.SetValue(protocol.BodyTarget, "Runtime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Timeout != nil {
+		v := *s.Timeout
+
+		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TracingConfig != nil {
+		v := s.TracingConfig
+
+		e.SetFields(protocol.BodyTarget, "TracingConfig", v, protocol.Metadata{})
+	}
+	if s.VpcConfig != nil {
+		v := s.VpcConfig
+
+		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The parent object that contains the target ARN (Amazon Resource Name) of
 // an Amazon SQS queue or Amazon SNS topic.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeadLetterConfig
@@ -3820,6 +4096,17 @@ func (s DeadLetterConfig) GoString() string {
 func (s *DeadLetterConfig) SetTargetArn(v string) *DeadLetterConfig {
 	s.TargetArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeadLetterConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TargetArn != nil {
+		v := *s.TargetArn
+
+		e.SetValue(protocol.BodyTarget, "TargetArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteAliasRequest
@@ -3884,6 +4171,22 @@ func (s *DeleteAliasInput) SetName(v string) *DeleteAliasInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteAliasOutput
 type DeleteAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -3897,6 +4200,12 @@ func (s DeleteAliasOutput) String() string {
 // GoString returns the string representation
 func (s DeleteAliasOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteEventSourceMappingRequest
@@ -3936,6 +4245,17 @@ func (s *DeleteEventSourceMappingInput) Validate() error {
 func (s *DeleteEventSourceMappingInput) SetUUID(v string) *DeleteEventSourceMappingInput {
 	s.UUID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UUID != nil {
+		v := *s.UUID
+
+		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteFunctionRequest
@@ -4013,6 +4333,22 @@ func (s *DeleteFunctionInput) SetQualifier(v string) *DeleteFunctionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteFunctionOutput
 type DeleteFunctionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4026,6 +4362,12 @@ func (s DeleteFunctionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFunctionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFunctionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The parent object that contains your environment's configuration settings.
@@ -4051,6 +4393,17 @@ func (s Environment) GoString() string {
 func (s *Environment) SetVariables(v map[string]*string) *Environment {
 	s.Variables = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Environment) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The parent object that contains error information associated with your configuration
@@ -4088,6 +4441,22 @@ func (s *EnvironmentError) SetMessage(v string) *EnvironmentError {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnvironmentError) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorCode != nil {
+		v := *s.ErrorCode
+
+		e.SetValue(protocol.BodyTarget, "ErrorCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The parent object returned that contains your environment's configuration
 // settings or any error information associated with your configuration settings.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/EnvironmentResponse
@@ -4123,6 +4492,22 @@ func (s *EnvironmentResponse) SetError(v *EnvironmentError) *EnvironmentResponse
 func (s *EnvironmentResponse) SetVariables(v map[string]*string) *EnvironmentResponse {
 	s.Variables = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnvironmentResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Error != nil {
+		v := s.Error
+
+		e.SetFields(protocol.BodyTarget, "Error", v, protocol.Metadata{})
+	}
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes mapping between an Amazon Kinesis stream and a Lambda function.
@@ -4218,6 +4603,60 @@ func (s *EventSourceMappingConfiguration) SetUUID(v string) *EventSourceMappingC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EventSourceMappingConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchSize != nil {
+		v := *s.BatchSize
+
+		e.SetValue(protocol.BodyTarget, "BatchSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.EventSourceArn != nil {
+		v := *s.EventSourceArn
+
+		e.SetValue(protocol.BodyTarget, "EventSourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionArn != nil {
+		v := *s.FunctionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LastProcessingResult != nil {
+		v := *s.LastProcessingResult
+
+		e.SetValue(protocol.BodyTarget, "LastProcessingResult", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StateTransitionReason != nil {
+		v := *s.StateTransitionReason
+
+		e.SetValue(protocol.BodyTarget, "StateTransitionReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UUID != nil {
+		v := *s.UUID
+
+		e.SetValue(protocol.BodyTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEventSourceMappingConfigurationList(vs []*EventSourceMappingConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The code for the Lambda function.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/FunctionCode
 type FunctionCode struct {
@@ -4298,6 +4737,32 @@ func (s *FunctionCode) SetZipFile(v []byte) *FunctionCode {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionCode) MarshalFields(e protocol.FieldEncoder) error {
+	if s.S3Bucket != nil {
+		v := *s.S3Bucket
+
+		e.SetValue(protocol.BodyTarget, "S3Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Key != nil {
+		v := *s.S3Key
+
+		e.SetValue(protocol.BodyTarget, "S3Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3ObjectVersion != nil {
+		v := *s.S3ObjectVersion
+
+		e.SetValue(protocol.BodyTarget, "S3ObjectVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ZipFile != nil {
+		v := s.ZipFile
+
+		e.SetValue(protocol.BodyTarget, "ZipFile", protocol.BytesValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The object for the Lambda function location.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/FunctionCodeLocation
 type FunctionCodeLocation struct {
@@ -4331,6 +4796,22 @@ func (s *FunctionCodeLocation) SetLocation(v string) *FunctionCodeLocation {
 func (s *FunctionCodeLocation) SetRepositoryType(v string) *FunctionCodeLocation {
 	s.RepositoryType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionCodeLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.BodyTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RepositoryType != nil {
+		v := *s.RepositoryType
+
+		e.SetValue(protocol.BodyTarget, "RepositoryType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes function metadata.
@@ -4523,6 +5004,110 @@ func (s *FunctionConfiguration) SetVpcConfig(v *VpcConfigResponse) *FunctionConf
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodeSha256 != nil {
+		v := *s.CodeSha256
+
+		e.SetValue(protocol.BodyTarget, "CodeSha256", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodeSize != nil {
+		v := *s.CodeSize
+
+		e.SetValue(protocol.BodyTarget, "CodeSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DeadLetterConfig != nil {
+		v := s.DeadLetterConfig
+
+		e.SetFields(protocol.BodyTarget, "DeadLetterConfig", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Environment != nil {
+		v := s.Environment
+
+		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
+	}
+	if s.FunctionArn != nil {
+		v := *s.FunctionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.BodyTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Handler != nil {
+		v := *s.Handler
+
+		e.SetValue(protocol.BodyTarget, "Handler", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KMSKeyArn != nil {
+		v := *s.KMSKeyArn
+
+		e.SetValue(protocol.BodyTarget, "KMSKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MasterArn != nil {
+		v := *s.MasterArn
+
+		e.SetValue(protocol.BodyTarget, "MasterArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MemorySize != nil {
+		v := *s.MemorySize
+
+		e.SetValue(protocol.BodyTarget, "MemorySize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Runtime != nil {
+		v := *s.Runtime
+
+		e.SetValue(protocol.BodyTarget, "Runtime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timeout != nil {
+		v := *s.Timeout
+
+		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TracingConfig != nil {
+		v := s.TracingConfig
+
+		e.SetFields(protocol.BodyTarget, "TracingConfig", v, protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VpcConfig != nil {
+		v := s.VpcConfig
+
+		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFunctionConfigurationList(vs []*FunctionConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetAccountSettingsRequest
 type GetAccountSettingsInput struct {
 	_ struct{} `type:"structure"`
@@ -4536,6 +5121,12 @@ func (s GetAccountSettingsInput) String() string {
 // GoString returns the string representation
 func (s GetAccountSettingsInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAccountSettingsInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetAccountSettingsResponse
@@ -4571,6 +5162,22 @@ func (s *GetAccountSettingsOutput) SetAccountLimit(v *AccountLimit) *GetAccountS
 func (s *GetAccountSettingsOutput) SetAccountUsage(v *AccountUsage) *GetAccountSettingsOutput {
 	s.AccountUsage = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAccountSettingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountLimit != nil {
+		v := s.AccountLimit
+
+		e.SetFields(protocol.BodyTarget, "AccountLimit", v, protocol.Metadata{})
+	}
+	if s.AccountUsage != nil {
+		v := s.AccountUsage
+
+		e.SetFields(protocol.BodyTarget, "AccountUsage", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetAliasRequest
@@ -4636,6 +5243,22 @@ func (s *GetAliasInput) SetName(v string) *GetAliasInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetEventSourceMappingRequest
 type GetEventSourceMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -4673,6 +5296,17 @@ func (s *GetEventSourceMappingInput) Validate() error {
 func (s *GetEventSourceMappingInput) SetUUID(v string) *GetEventSourceMappingInput {
 	s.UUID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UUID != nil {
+		v := *s.UUID
+
+		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetFunctionConfigurationRequest
@@ -4743,6 +5377,22 @@ func (s *GetFunctionConfigurationInput) SetQualifier(v string) *GetFunctionConfi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetFunctionRequest
 type GetFunctionInput struct {
 	_ struct{} `type:"structure"`
@@ -4809,6 +5459,22 @@ func (s *GetFunctionInput) SetQualifier(v string) *GetFunctionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // This response contains the object for the Lambda function location (see FunctionCodeLocation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetFunctionResponse
 type GetFunctionOutput struct {
@@ -4850,6 +5516,27 @@ func (s *GetFunctionOutput) SetConfiguration(v *FunctionConfiguration) *GetFunct
 func (s *GetFunctionOutput) SetTags(v map[string]*string) *GetFunctionOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Code != nil {
+		v := s.Code
+
+		e.SetFields(protocol.BodyTarget, "Code", v, protocol.Metadata{})
+	}
+	if s.Configuration != nil {
+		v := s.Configuration
+
+		e.SetFields(protocol.BodyTarget, "Configuration", v, protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetPolicyRequest
@@ -4918,6 +5605,22 @@ func (s *GetPolicyInput) SetQualifier(v string) *GetPolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetPolicyResponse
 type GetPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -4942,6 +5645,17 @@ func (s GetPolicyOutput) GoString() string {
 func (s *GetPolicyOutput) SetPolicy(v string) *GetPolicyOutput {
 	s.Policy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/InvokeAsyncRequest
@@ -5002,6 +5716,22 @@ func (s *InvokeAsyncInput) SetInvokeArgs(v io.ReadSeeker) *InvokeAsyncInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvokeAsyncInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvokeArgs != nil {
+		v := s.InvokeArgs
+
+		e.SetStream(protocol.PayloadTarget, "InvokeArgs", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Upon success, it returns empty response. Otherwise, throws an exception.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/InvokeAsyncResponse
 type InvokeAsyncOutput struct {
@@ -5025,6 +5755,13 @@ func (s InvokeAsyncOutput) GoString() string {
 func (s *InvokeAsyncOutput) SetStatus(v int64) *InvokeAsyncOutput {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvokeAsyncOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// ignoring invalid encode state, StatusCode. Status
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/InvocationRequest
@@ -5145,6 +5882,42 @@ func (s *InvokeInput) SetQualifier(v string) *InvokeInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvokeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientContext != nil {
+		v := *s.ClientContext
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvocationType != nil {
+		v := *s.InvocationType
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Invocation-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LogType != nil {
+		v := *s.LogType
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Log-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "Payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Upon success, returns an empty response. Otherwise, throws an exception.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/InvocationResponse
 type InvokeOutput struct {
@@ -5210,6 +5983,28 @@ func (s *InvokeOutput) SetPayload(v []byte) *InvokeOutput {
 func (s *InvokeOutput) SetStatusCode(v int64) *InvokeOutput {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvokeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionError != nil {
+		v := *s.FunctionError
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Function-Error", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LogResult != nil {
+		v := *s.LogResult
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Log-Result", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "Payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	// ignoring invalid encode state, StatusCode. StatusCode
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListAliasesRequest
@@ -5293,6 +6088,32 @@ func (s *ListAliasesInput) SetMaxItems(v int64) *ListAliasesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAliasesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.QueryTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListAliasesResponse
 type ListAliasesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5324,6 +6145,22 @@ func (s *ListAliasesOutput) SetAliases(v []*AliasConfiguration) *ListAliasesOutp
 func (s *ListAliasesOutput) SetNextMarker(v string) *ListAliasesOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAliasesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Aliases) > 0 {
+		v := s.Aliases
+
+		e.SetList(protocol.BodyTarget, "Aliases", encodeAliasConfigurationList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListEventSourceMappingsRequest
@@ -5406,6 +6243,32 @@ func (s *ListEventSourceMappingsInput) SetMaxItems(v int64) *ListEventSourceMapp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListEventSourceMappingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventSourceArn != nil {
+		v := *s.EventSourceArn
+
+		e.SetValue(protocol.QueryTarget, "EventSourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.QueryTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains a list of event sources (see EventSourceMappingConfiguration)
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListEventSourceMappingsResponse
 type ListEventSourceMappingsOutput struct {
@@ -5438,6 +6301,22 @@ func (s *ListEventSourceMappingsOutput) SetEventSourceMappings(v []*EventSourceM
 func (s *ListEventSourceMappingsOutput) SetNextMarker(v string) *ListEventSourceMappingsOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListEventSourceMappingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.EventSourceMappings) > 0 {
+		v := s.EventSourceMappings
+
+		e.SetList(protocol.BodyTarget, "EventSourceMappings", encodeEventSourceMappingConfigurationList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListFunctionsRequest
@@ -5521,6 +6400,32 @@ func (s *ListFunctionsInput) SetMaxItems(v int64) *ListFunctionsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.QueryTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MasterRegion != nil {
+		v := *s.MasterRegion
+
+		e.SetValue(protocol.QueryTarget, "MasterRegion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains a list of AWS Lambda function configurations (see FunctionConfiguration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListFunctionsResponse
 type ListFunctionsOutput struct {
@@ -5553,6 +6458,22 @@ func (s *ListFunctionsOutput) SetFunctions(v []*FunctionConfiguration) *ListFunc
 func (s *ListFunctionsOutput) SetNextMarker(v string) *ListFunctionsOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Functions) > 0 {
+		v := s.Functions
+
+		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionConfigurationList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListTagsRequest
@@ -5594,6 +6515,17 @@ func (s *ListTagsInput) SetResource(v string) *ListTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListTagsResponse
 type ListTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5616,6 +6548,17 @@ func (s ListTagsOutput) GoString() string {
 func (s *ListTagsOutput) SetTags(v map[string]*string) *ListTagsOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListVersionsByFunctionRequest
@@ -5688,6 +6631,27 @@ func (s *ListVersionsByFunctionInput) SetMaxItems(v int64) *ListVersionsByFuncti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVersionsByFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListVersionsByFunctionResponse
 type ListVersionsByFunctionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5719,6 +6683,22 @@ func (s *ListVersionsByFunctionOutput) SetNextMarker(v string) *ListVersionsByFu
 func (s *ListVersionsByFunctionOutput) SetVersions(v []*FunctionConfiguration) *ListVersionsByFunctionOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVersionsByFunctionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeFunctionConfigurationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/PublishVersionRequest
@@ -5788,6 +6768,27 @@ func (s *PublishVersionInput) SetDescription(v string) *PublishVersionInput {
 func (s *PublishVersionInput) SetFunctionName(v string) *PublishVersionInput {
 	s.FunctionName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodeSha256 != nil {
+		v := *s.CodeSha256
+
+		e.SetValue(protocol.BodyTarget, "CodeSha256", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/RemovePermissionRequest
@@ -5870,6 +6871,27 @@ func (s *RemovePermissionInput) SetStatementId(v string) *RemovePermissionInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemovePermissionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatementId != nil {
+		v := *s.StatementId
+
+		e.SetValue(protocol.PathTarget, "StatementId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/RemovePermissionOutput
 type RemovePermissionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5883,6 +6905,12 @@ func (s RemovePermissionOutput) String() string {
 // GoString returns the string representation
 func (s RemovePermissionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemovePermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/TagResourceRequest
@@ -5938,6 +6966,22 @@ func (s *TagResourceInput) SetTags(v map[string]*string) *TagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/TagResourceOutput
 type TagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -5951,6 +6995,12 @@ func (s TagResourceOutput) String() string {
 // GoString returns the string representation
 func (s TagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The parent object that contains your function's tracing settings.
@@ -5982,6 +7032,17 @@ func (s *TracingConfig) SetMode(v string) *TracingConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TracingConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Parent object of the tracing information associated with your Lambda function.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/TracingConfigResponse
 type TracingConfigResponse struct {
@@ -6005,6 +7066,17 @@ func (s TracingConfigResponse) GoString() string {
 func (s *TracingConfigResponse) SetMode(v string) *TracingConfigResponse {
 	s.Mode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TracingConfigResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UntagResourceRequest
@@ -6060,6 +7132,22 @@ func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.QueryTarget, "tagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UntagResourceOutput
 type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -6073,6 +7161,12 @@ func (s UntagResourceOutput) String() string {
 // GoString returns the string representation
 func (s UntagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UpdateAliasRequest
@@ -6156,6 +7250,32 @@ func (s *UpdateAliasInput) SetFunctionVersion(v string) *UpdateAliasInput {
 func (s *UpdateAliasInput) SetName(v string) *UpdateAliasInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.BodyTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UpdateEventSourceMappingRequest
@@ -6244,6 +7364,32 @@ func (s *UpdateEventSourceMappingInput) SetFunctionName(v string) *UpdateEventSo
 func (s *UpdateEventSourceMappingInput) SetUUID(v string) *UpdateEventSourceMappingInput {
 	s.UUID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchSize != nil {
+		v := *s.BatchSize
+
+		e.SetValue(protocol.BodyTarget, "BatchSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.BodyTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UUID != nil {
+		v := *s.UUID
+
+		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UpdateFunctionCodeRequest
@@ -6370,6 +7516,47 @@ func (s *UpdateFunctionCodeInput) SetS3ObjectVersion(v string) *UpdateFunctionCo
 func (s *UpdateFunctionCodeInput) SetZipFile(v []byte) *UpdateFunctionCodeInput {
 	s.ZipFile = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFunctionCodeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DryRun != nil {
+		v := *s.DryRun
+
+		e.SetValue(protocol.BodyTarget, "DryRun", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Publish != nil {
+		v := *s.Publish
+
+		e.SetValue(protocol.BodyTarget, "Publish", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.S3Bucket != nil {
+		v := *s.S3Bucket
+
+		e.SetValue(protocol.BodyTarget, "S3Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Key != nil {
+		v := *s.S3Key
+
+		e.SetValue(protocol.BodyTarget, "S3Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3ObjectVersion != nil {
+		v := *s.S3ObjectVersion
+
+		e.SetValue(protocol.BodyTarget, "S3ObjectVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ZipFile != nil {
+		v := s.ZipFile
+
+		e.SetValue(protocol.BodyTarget, "ZipFile", protocol.BytesValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UpdateFunctionConfigurationRequest
@@ -6555,6 +7742,72 @@ func (s *UpdateFunctionConfigurationInput) SetVpcConfig(v *VpcConfig) *UpdateFun
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFunctionConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeadLetterConfig != nil {
+		v := s.DeadLetterConfig
+
+		e.SetFields(protocol.BodyTarget, "DeadLetterConfig", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Environment != nil {
+		v := s.Environment
+
+		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Handler != nil {
+		v := *s.Handler
+
+		e.SetValue(protocol.BodyTarget, "Handler", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KMSKeyArn != nil {
+		v := *s.KMSKeyArn
+
+		e.SetValue(protocol.BodyTarget, "KMSKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MemorySize != nil {
+		v := *s.MemorySize
+
+		e.SetValue(protocol.BodyTarget, "MemorySize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Runtime != nil {
+		v := *s.Runtime
+
+		e.SetValue(protocol.BodyTarget, "Runtime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timeout != nil {
+		v := *s.Timeout
+
+		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TracingConfig != nil {
+		v := s.TracingConfig
+
+		e.SetFields(protocol.BodyTarget, "TracingConfig", v, protocol.Metadata{})
+	}
+	if s.VpcConfig != nil {
+		v := s.VpcConfig
+
+		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // If your Lambda function accesses resources in a VPC, you provide this parameter
 // identifying the list of security group IDs and subnet IDs. These must belong
 // to the same VPC. You must provide at least one security group and one subnet
@@ -6590,6 +7843,22 @@ func (s *VpcConfig) SetSecurityGroupIds(v []*string) *VpcConfig {
 func (s *VpcConfig) SetSubnetIds(v []*string) *VpcConfig {
 	s.SubnetIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VpcConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SecurityGroupIds) > 0 {
+		v := s.SecurityGroupIds
+
+		e.SetList(protocol.BodyTarget, "SecurityGroupIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.SubnetIds) > 0 {
+		v := s.SubnetIds
+
+		e.SetList(protocol.BodyTarget, "SubnetIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // VPC configuration associated with your Lambda function.
@@ -6633,6 +7902,27 @@ func (s *VpcConfigResponse) SetSubnetIds(v []*string) *VpcConfigResponse {
 func (s *VpcConfigResponse) SetVpcId(v string) *VpcConfigResponse {
 	s.VpcId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VpcConfigResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SecurityGroupIds) > 0 {
+		v := s.SecurityGroupIds
+
+		e.SetList(protocol.BodyTarget, "SecurityGroupIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.SubnetIds) > 0 {
+		v := s.SubnetIds
+
+		e.SetList(protocol.BodyTarget, "SubnetIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.VpcId != nil {
+		v := *s.VpcId
+
+		e.SetValue(protocol.BodyTarget, "VpcId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -4137,6 +4137,55 @@ func (s *BotAliasMetadata) SetName(v string) *BotAliasMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BotAliasMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBotAliasMetadataList(vs []*BotAliasMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents an association between an Amazon Lex bot and an external messaging
 // platform.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/BotChannelAssociation
@@ -4223,6 +4272,55 @@ func (s *BotChannelAssociation) SetType(v string) *BotChannelAssociation {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BotChannelAssociation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.BodyTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.BotConfiguration) > 0 {
+		v := s.BotConfiguration
+
+		e.SetMap(protocol.BodyTarget, "botConfiguration", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBotChannelAssociationList(vs []*BotChannelAssociation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides information about a bot. .
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/BotMetadata
 type BotMetadata struct {
@@ -4294,6 +4392,50 @@ func (s *BotMetadata) SetVersion(v string) *BotMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BotMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBotMetadataList(vs []*BotMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides metadata for a built-in intent.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/BuiltinIntentMetadata
 type BuiltinIntentMetadata struct {
@@ -4330,6 +4472,30 @@ func (s *BuiltinIntentMetadata) SetSupportedLocales(v []*string) *BuiltinIntentM
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BuiltinIntentMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SupportedLocales) > 0 {
+		v := s.SupportedLocales
+
+		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBuiltinIntentMetadataList(vs []*BuiltinIntentMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides information about a slot used in a built-in intent.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/BuiltinIntentSlot
 type BuiltinIntentSlot struct {
@@ -4353,6 +4519,25 @@ func (s BuiltinIntentSlot) GoString() string {
 func (s *BuiltinIntentSlot) SetName(v string) *BuiltinIntentSlot {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BuiltinIntentSlot) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBuiltinIntentSlotList(vs []*BuiltinIntentSlot) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Provides information about a built in slot type.
@@ -4389,6 +4574,30 @@ func (s *BuiltinSlotTypeMetadata) SetSignature(v string) *BuiltinSlotTypeMetadat
 func (s *BuiltinSlotTypeMetadata) SetSupportedLocales(v []*string) *BuiltinSlotTypeMetadata {
 	s.SupportedLocales = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BuiltinSlotTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SupportedLocales) > 0 {
+		v := s.SupportedLocales
+
+		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBuiltinSlotTypeMetadataList(vs []*BuiltinSlotTypeMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Specifies a Lambda function that verifies requests to a bot or fulfills the
@@ -4453,6 +4662,22 @@ func (s *CodeHook) SetUri(v string) *CodeHook {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CodeHook) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageVersion != nil {
+		v := *s.MessageVersion
+
+		e.SetValue(protocol.BodyTarget, "messageVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Uri != nil {
+		v := *s.Uri
+
+		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateBotVersionRequest
 type CreateBotVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -4507,6 +4732,22 @@ func (s *CreateBotVersionInput) SetChecksum(v string) *CreateBotVersionInput {
 func (s *CreateBotVersionInput) SetName(v string) *CreateBotVersionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBotVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateBotVersionResponse
@@ -4689,6 +4930,87 @@ func (s *CreateBotVersionOutput) SetVoiceId(v string) *CreateBotVersionOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBotVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortStatement != nil {
+		v := s.AbortStatement
+
+		e.SetFields(protocol.BodyTarget, "abortStatement", v, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChildDirected != nil {
+		v := *s.ChildDirected
+
+		e.SetValue(protocol.BodyTarget, "childDirected", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ClarificationPrompt != nil {
+		v := s.ClarificationPrompt
+
+		e.SetFields(protocol.BodyTarget, "clarificationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureReason != nil {
+		v := *s.FailureReason
+
+		e.SetValue(protocol.BodyTarget, "failureReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdleSessionTTLInSeconds != nil {
+		v := *s.IdleSessionTTLInSeconds
+
+		e.SetValue(protocol.BodyTarget, "idleSessionTTLInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateIntentVersionRequest
 type CreateIntentVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -4743,6 +5065,22 @@ func (s *CreateIntentVersionInput) SetChecksum(v string) *CreateIntentVersionInp
 func (s *CreateIntentVersionInput) SetName(v string) *CreateIntentVersionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateIntentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateIntentVersionResponse
@@ -4900,6 +5238,87 @@ func (s *CreateIntentVersionOutput) SetVersion(v string) *CreateIntentVersionOut
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateIntentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConclusionStatement != nil {
+		v := s.ConclusionStatement
+
+		e.SetFields(protocol.BodyTarget, "conclusionStatement", v, protocol.Metadata{})
+	}
+	if s.ConfirmationPrompt != nil {
+		v := s.ConfirmationPrompt
+
+		e.SetFields(protocol.BodyTarget, "confirmationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogCodeHook != nil {
+		v := s.DialogCodeHook
+
+		e.SetFields(protocol.BodyTarget, "dialogCodeHook", v, protocol.Metadata{})
+	}
+	if s.FollowUpPrompt != nil {
+		v := s.FollowUpPrompt
+
+		e.SetFields(protocol.BodyTarget, "followUpPrompt", v, protocol.Metadata{})
+	}
+	if s.FulfillmentActivity != nil {
+		v := s.FulfillmentActivity
+
+		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentIntentSignature != nil {
+		v := *s.ParentIntentSignature
+
+		e.SetValue(protocol.BodyTarget, "parentIntentSignature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateSlotTypeVersionRequest
 type CreateSlotTypeVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -4954,6 +5373,22 @@ func (s *CreateSlotTypeVersionInput) SetChecksum(v string) *CreateSlotTypeVersio
 func (s *CreateSlotTypeVersionInput) SetName(v string) *CreateSlotTypeVersionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSlotTypeVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateSlotTypeVersionResponse
@@ -5046,6 +5481,52 @@ func (s *CreateSlotTypeVersionOutput) SetVersion(v string) *CreateSlotTypeVersio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSlotTypeVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EnumerationValues) > 0 {
+		v := s.EnumerationValues
+
+		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueSelectionStrategy != nil {
+		v := *s.ValueSelectionStrategy
+
+		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotAliasRequest
 type DeleteBotAliasInput struct {
 	_ struct{} `type:"structure"`
@@ -5105,6 +5586,22 @@ func (s *DeleteBotAliasInput) SetName(v string) *DeleteBotAliasInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotAliasOutput
 type DeleteBotAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -5118,6 +5615,12 @@ func (s DeleteBotAliasOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBotAliasOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotChannelAssociationRequest
@@ -5197,6 +5700,27 @@ func (s *DeleteBotChannelAssociationInput) SetName(v string) *DeleteBotChannelAs
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotChannelAssociationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "aliasName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotChannelAssociationOutput
 type DeleteBotChannelAssociationOutput struct {
 	_ struct{} `type:"structure"`
@@ -5210,6 +5734,12 @@ func (s DeleteBotChannelAssociationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBotChannelAssociationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotChannelAssociationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotRequest
@@ -5254,6 +5784,17 @@ func (s *DeleteBotInput) SetName(v string) *DeleteBotInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotOutput
 type DeleteBotOutput struct {
 	_ struct{} `type:"structure"`
@@ -5267,6 +5808,12 @@ func (s DeleteBotOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBotOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotVersionRequest
@@ -5329,6 +5876,22 @@ func (s *DeleteBotVersionInput) SetVersion(v string) *DeleteBotVersionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotVersionOutput
 type DeleteBotVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5342,6 +5905,12 @@ func (s DeleteBotVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBotVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteIntentRequest
@@ -5386,6 +5955,17 @@ func (s *DeleteIntentInput) SetName(v string) *DeleteIntentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteIntentOutput
 type DeleteIntentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5399,6 +5979,12 @@ func (s DeleteIntentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIntentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteIntentVersionRequest
@@ -5461,6 +6047,22 @@ func (s *DeleteIntentVersionInput) SetVersion(v string) *DeleteIntentVersionInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteIntentVersionOutput
 type DeleteIntentVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5474,6 +6076,12 @@ func (s DeleteIntentVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIntentVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteSlotTypeRequest
@@ -5518,6 +6126,17 @@ func (s *DeleteSlotTypeInput) SetName(v string) *DeleteSlotTypeInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteSlotTypeOutput
 type DeleteSlotTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -5531,6 +6150,12 @@ func (s DeleteSlotTypeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSlotTypeOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteSlotTypeVersionRequest
@@ -5593,6 +6218,22 @@ func (s *DeleteSlotTypeVersionInput) SetVersion(v string) *DeleteSlotTypeVersion
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSlotTypeVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteSlotTypeVersionOutput
 type DeleteSlotTypeVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5606,6 +6247,12 @@ func (s DeleteSlotTypeVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSlotTypeVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSlotTypeVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteUtterancesRequest
@@ -5670,6 +6317,22 @@ func (s *DeleteUtterancesInput) SetUserId(v string) *DeleteUtterancesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUtterancesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteUtterancesOutput
 type DeleteUtterancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5683,6 +6346,12 @@ func (s DeleteUtterancesOutput) String() string {
 // GoString returns the string representation
 func (s DeleteUtterancesOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUtterancesOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Each slot type can have a set of values. Each enumeration value represents
@@ -5746,6 +6415,30 @@ func (s *EnumerationValue) SetSynonyms(v []*string) *EnumerationValue {
 func (s *EnumerationValue) SetValue(v string) *EnumerationValue {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnumerationValue) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Synonyms) > 0 {
+		v := s.Synonyms
+
+		e.SetList(protocol.BodyTarget, "synonyms", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEnumerationValueList(vs []*EnumerationValue) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A prompt for additional activity after an intent is fulfilled. For example,
@@ -5813,6 +6506,22 @@ func (s *FollowUpPrompt) SetPrompt(v *Prompt) *FollowUpPrompt {
 func (s *FollowUpPrompt) SetRejectionStatement(v *Statement) *FollowUpPrompt {
 	s.RejectionStatement = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FollowUpPrompt) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prompt != nil {
+		v := s.Prompt
+
+		e.SetFields(protocol.BodyTarget, "prompt", v, protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes how the intent is fulfilled after the user provides all of the
@@ -5887,6 +6596,22 @@ func (s *FulfillmentActivity) SetType(v string) *FulfillmentActivity {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FulfillmentActivity) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodeHook != nil {
+		v := s.CodeHook
+
+		e.SetFields(protocol.BodyTarget, "codeHook", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotAliasRequest
 type GetBotAliasInput struct {
 	_ struct{} `type:"structure"`
@@ -5944,6 +6669,22 @@ func (s *GetBotAliasInput) SetBotName(v string) *GetBotAliasInput {
 func (s *GetBotAliasInput) SetName(v string) *GetBotAliasInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotAliasResponse
@@ -6023,6 +6764,47 @@ func (s *GetBotAliasOutput) SetLastUpdatedDate(v time.Time) *GetBotAliasOutput {
 func (s *GetBotAliasOutput) SetName(v string) *GetBotAliasOutput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotAliasesRequest
@@ -6106,6 +6888,32 @@ func (s *GetBotAliasesInput) SetNextToken(v string) *GetBotAliasesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotAliasesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotAliasesResponse
 type GetBotAliasesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6140,6 +6948,22 @@ func (s *GetBotAliasesOutput) SetBotAliases(v []*BotAliasMetadata) *GetBotAliase
 func (s *GetBotAliasesOutput) SetNextToken(v string) *GetBotAliasesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotAliasesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BotAliases) > 0 {
+		v := s.BotAliases
+
+		e.SetList(protocol.BodyTarget, "BotAliases", encodeBotAliasMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotChannelAssociationRequest
@@ -6220,6 +7044,27 @@ func (s *GetBotChannelAssociationInput) SetName(v string) *GetBotChannelAssociat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotChannelAssociationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "aliasName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotChannelAssociationResponse
 type GetBotChannelAssociationOutput struct {
 	_ struct{} `type:"structure"`
@@ -6298,6 +7143,47 @@ func (s *GetBotChannelAssociationOutput) SetName(v string) *GetBotChannelAssocia
 func (s *GetBotChannelAssociationOutput) SetType(v string) *GetBotChannelAssociationOutput {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotChannelAssociationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.BodyTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.BotConfiguration) > 0 {
+		v := s.BotConfiguration
+
+		e.SetMap(protocol.BodyTarget, "botConfiguration", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotChannelAssociationsRequest
@@ -6400,6 +7286,37 @@ func (s *GetBotChannelAssociationsInput) SetNextToken(v string) *GetBotChannelAs
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotChannelAssociationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "aliasName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotChannelAssociationsResponse
 type GetBotChannelAssociationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6435,6 +7352,22 @@ func (s *GetBotChannelAssociationsOutput) SetBotChannelAssociations(v []*BotChan
 func (s *GetBotChannelAssociationsOutput) SetNextToken(v string) *GetBotChannelAssociationsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotChannelAssociationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BotChannelAssociations) > 0 {
+		v := s.BotChannelAssociations
+
+		e.SetList(protocol.BodyTarget, "botChannelAssociations", encodeBotChannelAssociationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotRequest
@@ -6491,6 +7424,22 @@ func (s *GetBotInput) SetName(v string) *GetBotInput {
 func (s *GetBotInput) SetVersionOrAlias(v string) *GetBotInput {
 	s.VersionOrAlias = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionOrAlias != nil {
+		v := *s.VersionOrAlias
+
+		e.SetValue(protocol.PathTarget, "versionoralias", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotResponse
@@ -6674,6 +7623,87 @@ func (s *GetBotOutput) SetVoiceId(v string) *GetBotOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortStatement != nil {
+		v := s.AbortStatement
+
+		e.SetFields(protocol.BodyTarget, "abortStatement", v, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChildDirected != nil {
+		v := *s.ChildDirected
+
+		e.SetValue(protocol.BodyTarget, "childDirected", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ClarificationPrompt != nil {
+		v := s.ClarificationPrompt
+
+		e.SetFields(protocol.BodyTarget, "clarificationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureReason != nil {
+		v := *s.FailureReason
+
+		e.SetValue(protocol.BodyTarget, "failureReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdleSessionTTLInSeconds != nil {
+		v := *s.IdleSessionTTLInSeconds
+
+		e.SetValue(protocol.BodyTarget, "idleSessionTTLInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotVersionsRequest
 type GetBotVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -6741,6 +7771,27 @@ func (s *GetBotVersionsInput) SetNextToken(v string) *GetBotVersionsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotVersionsResponse
 type GetBotVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6776,6 +7827,22 @@ func (s *GetBotVersionsOutput) SetBots(v []*BotMetadata) *GetBotVersionsOutput {
 func (s *GetBotVersionsOutput) SetNextToken(v string) *GetBotVersionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Bots) > 0 {
+		v := s.Bots
+
+		e.SetList(protocol.BodyTarget, "bots", encodeBotMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotsRequest
@@ -6842,6 +7909,27 @@ func (s *GetBotsInput) SetNextToken(v string) *GetBotsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotsResponse
 type GetBotsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6874,6 +7962,22 @@ func (s *GetBotsOutput) SetBots(v []*BotMetadata) *GetBotsOutput {
 func (s *GetBotsOutput) SetNextToken(v string) *GetBotsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Bots) > 0 {
+		v := s.Bots
+
+		e.SetList(protocol.BodyTarget, "bots", encodeBotMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinIntentRequest
@@ -6917,6 +8021,17 @@ func (s *GetBuiltinIntentInput) SetSignature(v string) *GetBuiltinIntentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinIntentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.PathTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinIntentResponse
 type GetBuiltinIntentOutput struct {
 	_ struct{} `type:"structure"`
@@ -6958,6 +8073,27 @@ func (s *GetBuiltinIntentOutput) SetSlots(v []*BuiltinIntentSlot) *GetBuiltinInt
 func (s *GetBuiltinIntentOutput) SetSupportedLocales(v []*string) *GetBuiltinIntentOutput {
 	s.SupportedLocales = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeBuiltinIntentSlotList(v), protocol.Metadata{})
+	}
+	if len(s.SupportedLocales) > 0 {
+		v := s.SupportedLocales
+
+		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinIntentsRequest
@@ -7030,6 +8166,32 @@ func (s *GetBuiltinIntentsInput) SetSignatureContains(v string) *GetBuiltinInten
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinIntentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.QueryTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SignatureContains != nil {
+		v := *s.SignatureContains
+
+		e.SetValue(protocol.QueryTarget, "signatureContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinIntentsResponse
 type GetBuiltinIntentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7064,6 +8226,22 @@ func (s *GetBuiltinIntentsOutput) SetIntents(v []*BuiltinIntentMetadata) *GetBui
 func (s *GetBuiltinIntentsOutput) SetNextToken(v string) *GetBuiltinIntentsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinIntentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeBuiltinIntentMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinSlotTypesRequest
@@ -7136,6 +8314,32 @@ func (s *GetBuiltinSlotTypesInput) SetSignatureContains(v string) *GetBuiltinSlo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinSlotTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.QueryTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SignatureContains != nil {
+		v := *s.SignatureContains
+
+		e.SetValue(protocol.QueryTarget, "signatureContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinSlotTypesResponse
 type GetBuiltinSlotTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7169,6 +8373,22 @@ func (s *GetBuiltinSlotTypesOutput) SetNextToken(v string) *GetBuiltinSlotTypesO
 func (s *GetBuiltinSlotTypesOutput) SetSlotTypes(v []*BuiltinSlotTypeMetadata) *GetBuiltinSlotTypesOutput {
 	s.SlotTypes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinSlotTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SlotTypes) > 0 {
+		v := s.SlotTypes
+
+		e.SetList(protocol.BodyTarget, "slotTypes", encodeBuiltinSlotTypeMetadataList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetExportRequest
@@ -7256,6 +8476,32 @@ func (s *GetExportInput) SetResourceType(v string) *GetExportInput {
 func (s *GetExportInput) SetVersion(v string) *GetExportInput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetExportInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ExportType != nil {
+		v := *s.ExportType
+
+		e.SetValue(protocol.QueryTarget, "exportType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.QueryTarget, "resourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.QueryTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetExportResponse
@@ -7346,6 +8592,47 @@ func (s *GetExportOutput) SetVersion(v string) *GetExportOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetExportOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ExportStatus != nil {
+		v := *s.ExportStatus
+
+		e.SetValue(protocol.BodyTarget, "exportStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExportType != nil {
+		v := *s.ExportType
+
+		e.SetValue(protocol.BodyTarget, "exportType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureReason != nil {
+		v := *s.FailureReason
+
+		e.SetValue(protocol.BodyTarget, "failureReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.BodyTarget, "resourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentRequest
 type GetIntentInput struct {
 	_ struct{} `type:"structure"`
@@ -7403,6 +8690,22 @@ func (s *GetIntentInput) SetName(v string) *GetIntentInput {
 func (s *GetIntentInput) SetVersion(v string) *GetIntentInput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentResponse
@@ -7561,6 +8864,87 @@ func (s *GetIntentOutput) SetVersion(v string) *GetIntentOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConclusionStatement != nil {
+		v := s.ConclusionStatement
+
+		e.SetFields(protocol.BodyTarget, "conclusionStatement", v, protocol.Metadata{})
+	}
+	if s.ConfirmationPrompt != nil {
+		v := s.ConfirmationPrompt
+
+		e.SetFields(protocol.BodyTarget, "confirmationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogCodeHook != nil {
+		v := s.DialogCodeHook
+
+		e.SetFields(protocol.BodyTarget, "dialogCodeHook", v, protocol.Metadata{})
+	}
+	if s.FollowUpPrompt != nil {
+		v := s.FollowUpPrompt
+
+		e.SetFields(protocol.BodyTarget, "followUpPrompt", v, protocol.Metadata{})
+	}
+	if s.FulfillmentActivity != nil {
+		v := s.FulfillmentActivity
+
+		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentIntentSignature != nil {
+		v := *s.ParentIntentSignature
+
+		e.SetValue(protocol.BodyTarget, "parentIntentSignature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentVersionsRequest
 type GetIntentVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -7628,6 +9012,27 @@ func (s *GetIntentVersionsInput) SetNextToken(v string) *GetIntentVersionsInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentVersionsResponse
 type GetIntentVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7663,6 +9068,22 @@ func (s *GetIntentVersionsOutput) SetIntents(v []*IntentMetadata) *GetIntentVers
 func (s *GetIntentVersionsOutput) SetNextToken(v string) *GetIntentVersionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentsRequest
@@ -7728,6 +9149,27 @@ func (s *GetIntentsInput) SetNextToken(v string) *GetIntentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentsResponse
 type GetIntentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7760,6 +9202,22 @@ func (s *GetIntentsOutput) SetIntents(v []*IntentMetadata) *GetIntentsOutput {
 func (s *GetIntentsOutput) SetNextToken(v string) *GetIntentsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypeRequest
@@ -7819,6 +9277,22 @@ func (s *GetSlotTypeInput) SetName(v string) *GetSlotTypeInput {
 func (s *GetSlotTypeInput) SetVersion(v string) *GetSlotTypeInput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypeResponse
@@ -7911,6 +9385,52 @@ func (s *GetSlotTypeOutput) SetVersion(v string) *GetSlotTypeOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EnumerationValues) > 0 {
+		v := s.EnumerationValues
+
+		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueSelectionStrategy != nil {
+		v := *s.ValueSelectionStrategy
+
+		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypeVersionsRequest
 type GetSlotTypeVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -7978,6 +9498,27 @@ func (s *GetSlotTypeVersionsInput) SetNextToken(v string) *GetSlotTypeVersionsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypeVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypeVersionsResponse
 type GetSlotTypeVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8013,6 +9554,22 @@ func (s *GetSlotTypeVersionsOutput) SetNextToken(v string) *GetSlotTypeVersionsO
 func (s *GetSlotTypeVersionsOutput) SetSlotTypes(v []*SlotTypeMetadata) *GetSlotTypeVersionsOutput {
 	s.SlotTypes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypeVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SlotTypes) > 0 {
+		v := s.SlotTypes
+
+		e.SetList(protocol.BodyTarget, "slotTypes", encodeSlotTypeMetadataList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypesRequest
@@ -8079,6 +9636,27 @@ func (s *GetSlotTypesInput) SetNextToken(v string) *GetSlotTypesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypesResponse
 type GetSlotTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8112,6 +9690,22 @@ func (s *GetSlotTypesOutput) SetNextToken(v string) *GetSlotTypesOutput {
 func (s *GetSlotTypesOutput) SetSlotTypes(v []*SlotTypeMetadata) *GetSlotTypesOutput {
 	s.SlotTypes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SlotTypes) > 0 {
+		v := s.SlotTypes
+
+		e.SetList(protocol.BodyTarget, "slotTypes", encodeSlotTypeMetadataList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetUtterancesViewRequest
@@ -8189,6 +9783,27 @@ func (s *GetUtterancesViewInput) SetStatusType(v string) *GetUtterancesViewInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUtterancesViewInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.BotVersions) > 0 {
+		v := s.BotVersions
+
+		e.SetList(protocol.QueryTarget, "bot_versions", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.StatusType != nil {
+		v := *s.StatusType
+
+		e.SetValue(protocol.QueryTarget, "status_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetUtterancesViewResponse
 type GetUtterancesViewOutput struct {
 	_ struct{} `type:"structure"`
@@ -8222,6 +9837,22 @@ func (s *GetUtterancesViewOutput) SetBotName(v string) *GetUtterancesViewOutput 
 func (s *GetUtterancesViewOutput) SetUtterances(v []*UtteranceList) *GetUtterancesViewOutput {
 	s.Utterances = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUtterancesViewOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Utterances) > 0 {
+		v := s.Utterances
+
+		e.SetList(protocol.BodyTarget, "utterances", encodeUtteranceListList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Identifies the specific version of an intent.
@@ -8282,6 +9913,30 @@ func (s *Intent) SetIntentName(v string) *Intent {
 func (s *Intent) SetIntentVersion(v string) *Intent {
 	s.IntentVersion = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Intent) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IntentName != nil {
+		v := *s.IntentName
+
+		e.SetValue(protocol.BodyTarget, "intentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntentVersion != nil {
+		v := *s.IntentVersion
+
+		e.SetValue(protocol.BodyTarget, "intentVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIntentList(vs []*Intent) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Provides information about an intent.
@@ -8346,6 +10001,45 @@ func (s *IntentMetadata) SetVersion(v string) *IntentMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IntentMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIntentMetadataList(vs []*IntentMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The message object that provides the message text and its type.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/Message
 type Message struct {
@@ -8401,6 +10095,30 @@ func (s *Message) SetContent(v string) *Message {
 func (s *Message) SetContentType(v string) *Message {
 	s.ContentType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Message) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Content != nil {
+		v := *s.Content
+
+		e.SetValue(protocol.BodyTarget, "content", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMessageList(vs []*Message) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Obtains information from the user. To define a prompt, provide one or more
@@ -8490,6 +10208,27 @@ func (s *Prompt) SetMessages(v []*Message) *Prompt {
 func (s *Prompt) SetResponseCard(v string) *Prompt {
 	s.ResponseCard = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Prompt) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxAttempts != nil {
+		v := *s.MaxAttempts
+
+		e.SetValue(protocol.BodyTarget, "maxAttempts", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Messages) > 0 {
+		v := s.Messages
+
+		e.SetList(protocol.BodyTarget, "messages", encodeMessageList(v), protocol.Metadata{})
+	}
+	if s.ResponseCard != nil {
+		v := *s.ResponseCard
+
+		e.SetValue(protocol.BodyTarget, "responseCard", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutBotAliasRequest
@@ -8594,6 +10333,37 @@ func (s *PutBotAliasInput) SetName(v string) *PutBotAliasInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutBotAliasResponse
 type PutBotAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -8671,6 +10441,47 @@ func (s *PutBotAliasOutput) SetLastUpdatedDate(v time.Time) *PutBotAliasOutput {
 func (s *PutBotAliasOutput) SetName(v string) *PutBotAliasOutput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutBotRequest
@@ -8917,6 +10728,67 @@ func (s *PutBotInput) SetVoiceId(v string) *PutBotInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBotInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortStatement != nil {
+		v := s.AbortStatement
+
+		e.SetFields(protocol.BodyTarget, "abortStatement", v, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChildDirected != nil {
+		v := *s.ChildDirected
+
+		e.SetValue(protocol.BodyTarget, "childDirected", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ClarificationPrompt != nil {
+		v := s.ClarificationPrompt
+
+		e.SetFields(protocol.BodyTarget, "clarificationPrompt", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdleSessionTTLInSeconds != nil {
+		v := *s.IdleSessionTTLInSeconds
+
+		e.SetValue(protocol.BodyTarget, "idleSessionTTLInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentList(v), protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProcessBehavior != nil {
+		v := *s.ProcessBehavior
+
+		e.SetValue(protocol.BodyTarget, "processBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutBotResponse
 type PutBotOutput struct {
 	_ struct{} `type:"structure"`
@@ -9100,6 +10972,87 @@ func (s *PutBotOutput) SetVersion(v string) *PutBotOutput {
 func (s *PutBotOutput) SetVoiceId(v string) *PutBotOutput {
 	s.VoiceId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBotOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortStatement != nil {
+		v := s.AbortStatement
+
+		e.SetFields(protocol.BodyTarget, "abortStatement", v, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChildDirected != nil {
+		v := *s.ChildDirected
+
+		e.SetValue(protocol.BodyTarget, "childDirected", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ClarificationPrompt != nil {
+		v := s.ClarificationPrompt
+
+		e.SetFields(protocol.BodyTarget, "clarificationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureReason != nil {
+		v := *s.FailureReason
+
+		e.SetValue(protocol.BodyTarget, "failureReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdleSessionTTLInSeconds != nil {
+		v := *s.IdleSessionTTLInSeconds
+
+		e.SetValue(protocol.BodyTarget, "idleSessionTTLInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutIntentRequest
@@ -9360,6 +11313,72 @@ func (s *PutIntentInput) SetSlots(v []*Slot) *PutIntentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutIntentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConclusionStatement != nil {
+		v := s.ConclusionStatement
+
+		e.SetFields(protocol.BodyTarget, "conclusionStatement", v, protocol.Metadata{})
+	}
+	if s.ConfirmationPrompt != nil {
+		v := s.ConfirmationPrompt
+
+		e.SetFields(protocol.BodyTarget, "confirmationPrompt", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogCodeHook != nil {
+		v := s.DialogCodeHook
+
+		e.SetFields(protocol.BodyTarget, "dialogCodeHook", v, protocol.Metadata{})
+	}
+	if s.FollowUpPrompt != nil {
+		v := s.FollowUpPrompt
+
+		e.SetFields(protocol.BodyTarget, "followUpPrompt", v, protocol.Metadata{})
+	}
+	if s.FulfillmentActivity != nil {
+		v := s.FulfillmentActivity
+
+		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentIntentSignature != nil {
+		v := *s.ParentIntentSignature
+
+		e.SetValue(protocol.BodyTarget, "parentIntentSignature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutIntentResponse
 type PutIntentOutput struct {
 	_ struct{} `type:"structure"`
@@ -9518,6 +11537,87 @@ func (s *PutIntentOutput) SetVersion(v string) *PutIntentOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConclusionStatement != nil {
+		v := s.ConclusionStatement
+
+		e.SetFields(protocol.BodyTarget, "conclusionStatement", v, protocol.Metadata{})
+	}
+	if s.ConfirmationPrompt != nil {
+		v := s.ConfirmationPrompt
+
+		e.SetFields(protocol.BodyTarget, "confirmationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogCodeHook != nil {
+		v := s.DialogCodeHook
+
+		e.SetFields(protocol.BodyTarget, "dialogCodeHook", v, protocol.Metadata{})
+	}
+	if s.FollowUpPrompt != nil {
+		v := s.FollowUpPrompt
+
+		e.SetFields(protocol.BodyTarget, "followUpPrompt", v, protocol.Metadata{})
+	}
+	if s.FulfillmentActivity != nil {
+		v := s.FulfillmentActivity
+
+		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentIntentSignature != nil {
+		v := *s.ParentIntentSignature
+
+		e.SetValue(protocol.BodyTarget, "parentIntentSignature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutSlotTypeRequest
 type PutSlotTypeInput struct {
 	_ struct{} `type:"structure"`
@@ -9644,6 +11744,37 @@ func (s *PutSlotTypeInput) SetValueSelectionStrategy(v string) *PutSlotTypeInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EnumerationValues) > 0 {
+		v := s.EnumerationValues
+
+		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueSelectionStrategy != nil {
+		v := *s.ValueSelectionStrategy
+
+		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutSlotTypeResponse
 type PutSlotTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -9735,6 +11866,52 @@ func (s *PutSlotTypeOutput) SetVersion(v string) *PutSlotTypeOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EnumerationValues) > 0 {
+		v := s.EnumerationValues
+
+		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueSelectionStrategy != nil {
+		v := *s.ValueSelectionStrategy
+
+		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the resource that refers to the resource that you are attempting
 // to delete. This object is returned as part of the ResourceInUseException
 // exception.
@@ -9771,6 +11948,22 @@ func (s *ResourceReference) SetName(v string) *ResourceReference {
 func (s *ResourceReference) SetVersion(v string) *ResourceReference {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceReference) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Identifies the version of a specific slot.
@@ -9918,6 +12111,65 @@ func (s *Slot) SetValueElicitationPrompt(v *Prompt) *Slot {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Slot) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "priority", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ResponseCard != nil {
+		v := *s.ResponseCard
+
+		e.SetValue(protocol.BodyTarget, "responseCard", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.SlotConstraint != nil {
+		v := *s.SlotConstraint
+
+		e.SetValue(protocol.BodyTarget, "slotConstraint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SlotType != nil {
+		v := *s.SlotType
+
+		e.SetValue(protocol.BodyTarget, "slotType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SlotTypeVersion != nil {
+		v := *s.SlotTypeVersion
+
+		e.SetValue(protocol.BodyTarget, "slotTypeVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueElicitationPrompt != nil {
+		v := s.ValueElicitationPrompt
+
+		e.SetFields(protocol.BodyTarget, "valueElicitationPrompt", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSlotList(vs []*Slot) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides information about a slot type..
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/SlotTypeMetadata
 type SlotTypeMetadata struct {
@@ -9978,6 +12230,45 @@ func (s *SlotTypeMetadata) SetName(v string) *SlotTypeMetadata {
 func (s *SlotTypeMetadata) SetVersion(v string) *SlotTypeMetadata {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SlotTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSlotTypeMetadataList(vs []*SlotTypeMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A collection of messages that convey information to the user. At runtime,
@@ -10049,6 +12340,22 @@ func (s *Statement) SetResponseCard(v string) *Statement {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Statement) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Messages) > 0 {
+		v := s.Messages
+
+		e.SetList(protocol.BodyTarget, "messages", encodeMessageList(v), protocol.Metadata{})
+	}
+	if s.ResponseCard != nil {
+		v := *s.ResponseCard
+
+		e.SetValue(protocol.BodyTarget, "responseCard", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides information about a single utterance that was made to your bot.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/UtteranceData
 type UtteranceData struct {
@@ -10111,6 +12418,45 @@ func (s *UtteranceData) SetUtteranceString(v string) *UtteranceData {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UtteranceData) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DistinctUsers != nil {
+		v := *s.DistinctUsers
+
+		e.SetValue(protocol.BodyTarget, "distinctUsers", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FirstUtteredDate != nil {
+		v := *s.FirstUtteredDate
+
+		e.SetValue(protocol.BodyTarget, "firstUtteredDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LastUtteredDate != nil {
+		v := *s.LastUtteredDate
+
+		e.SetValue(protocol.BodyTarget, "lastUtteredDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.UtteranceString != nil {
+		v := *s.UtteranceString
+
+		e.SetValue(protocol.BodyTarget, "utteranceString", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUtteranceDataList(vs []*UtteranceData) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides a list of utterances that have been made to a specific version of
 // your bot. The list contains a maximum of 100 utterances.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/UtteranceList
@@ -10145,6 +12491,30 @@ func (s *UtteranceList) SetBotVersion(v string) *UtteranceList {
 func (s *UtteranceList) SetUtterances(v []*UtteranceData) *UtteranceList {
 	s.Utterances = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UtteranceList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Utterances) > 0 {
+		v := s.Utterances
+
+		e.SetList(protocol.BodyTarget, "utterances", encodeUtteranceDataList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUtteranceListList(vs []*UtteranceList) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opPostContent = "PostContent"
@@ -390,6 +391,30 @@ func (s *Button) SetValue(v string) *Button {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Button) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Text != nil {
+		v := *s.Text
+
+		e.SetValue(protocol.BodyTarget, "text", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeButtonList(vs []*Button) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents an option rendered to the user when a prompt is shown. It could
 // be an image, a button, a link, or text.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/GenericAttachment
@@ -450,6 +475,45 @@ func (s *GenericAttachment) SetSubTitle(v string) *GenericAttachment {
 func (s *GenericAttachment) SetTitle(v string) *GenericAttachment {
 	s.Title = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GenericAttachment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachmentLinkUrl != nil {
+		v := *s.AttachmentLinkUrl
+
+		e.SetValue(protocol.BodyTarget, "attachmentLinkUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Buttons) > 0 {
+		v := s.Buttons
+
+		e.SetList(protocol.BodyTarget, "buttons", encodeButtonList(v), protocol.Metadata{})
+	}
+	if s.ImageUrl != nil {
+		v := *s.ImageUrl
+
+		e.SetValue(protocol.BodyTarget, "imageUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubTitle != nil {
+		v := *s.SubTitle
+
+		e.SetValue(protocol.BodyTarget, "subTitle", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "title", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGenericAttachmentList(vs []*GenericAttachment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/PostContentRequest
@@ -664,6 +728,52 @@ func (s *PostContentInput) SetUserId(v string) *PostContentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PostContentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Accept != nil {
+		v := *s.Accept
+
+		e.SetValue(protocol.HeaderTarget, "Accept", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputStream != nil {
+		v := s.InputStream
+
+		e.SetStream(protocol.PayloadTarget, "inputStream", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.RequestAttributes != nil {
+		v := s.RequestAttributes
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-request-attributes", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+	if s.SessionAttributes != nil {
+		v := s.SessionAttributes
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-session-attributes", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/PostContentResponse
 type PostContentOutput struct {
 	_ struct{} `type:"structure" payload:"AudioStream"`
@@ -833,6 +943,53 @@ func (s *PostContentOutput) SetSlots(v aws.JSONValue) *PostContentOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PostContentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// Skipping AudioStream Output type's body not valid.
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogState != nil {
+		v := *s.DialogState
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-dialog-state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputTranscript != nil {
+		v := *s.InputTranscript
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-input-transcript", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntentName != nil {
+		v := *s.IntentName
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-intent-name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SessionAttributes != nil {
+		v := s.SessionAttributes
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-session-attributes", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+	if s.SlotToElicit != nil {
+		v := *s.SlotToElicit
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-slot-to-elicit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Slots != nil {
+		v := s.Slots
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-slots", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/PostTextRequest
 type PostTextInput struct {
 	_ struct{} `type:"structure"`
@@ -965,6 +1122,42 @@ func (s *PostTextInput) SetSessionAttributes(v map[string]*string) *PostTextInpu
 func (s *PostTextInput) SetUserId(v string) *PostTextInput {
 	s.UserId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PostTextInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputText != nil {
+		v := *s.InputText
+
+		e.SetValue(protocol.BodyTarget, "inputText", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestAttributes) > 0 {
+		v := s.RequestAttributes
+
+		e.SetMap(protocol.BodyTarget, "requestAttributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.SessionAttributes) > 0 {
+		v := s.SessionAttributes
+
+		e.SetMap(protocol.BodyTarget, "sessionAttributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/PostTextResponse
@@ -1109,6 +1302,47 @@ func (s *PostTextOutput) SetSlots(v map[string]*string) *PostTextOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PostTextOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DialogState != nil {
+		v := *s.DialogState
+
+		e.SetValue(protocol.BodyTarget, "dialogState", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntentName != nil {
+		v := *s.IntentName
+
+		e.SetValue(protocol.BodyTarget, "intentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseCard != nil {
+		v := s.ResponseCard
+
+		e.SetFields(protocol.BodyTarget, "responseCard", v, protocol.Metadata{})
+	}
+	if len(s.SessionAttributes) > 0 {
+		v := s.SessionAttributes
+
+		e.SetMap(protocol.BodyTarget, "sessionAttributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.SlotToElicit != nil {
+		v := *s.SlotToElicit
+
+		e.SetValue(protocol.BodyTarget, "slotToElicit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetMap(protocol.BodyTarget, "slots", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // If you configure a response card when creating your bots, Amazon Lex substitutes
 // the session attributes and slot values that are available, and then returns
 // it. The response card can also come from a Lambda function ( dialogCodeHook
@@ -1153,6 +1387,27 @@ func (s *ResponseCard) SetGenericAttachments(v []*GenericAttachment) *ResponseCa
 func (s *ResponseCard) SetVersion(v string) *ResponseCard {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResponseCard) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.GenericAttachments) > 0 {
+		v := s.GenericAttachments
+
+		e.SetList(protocol.BodyTarget, "genericAttachments", encodeGenericAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/mobile/api.go
+++ b/service/mobile/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCreateProject = "CreateProject"
@@ -1082,6 +1083,50 @@ func (s *BundleDetails) SetVersion(v string) *BundleDetails {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BundleDetails) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AvailablePlatforms) > 0 {
+		v := s.AvailablePlatforms
+
+		e.SetList(protocol.BodyTarget, "availablePlatforms", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.BodyTarget, "bundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IconUrl != nil {
+		v := *s.IconUrl
+
+		e.SetValue(protocol.BodyTarget, "iconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBundleDetailsList(vs []*BundleDetails) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Request structure used to request a project be created.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/CreateProjectRequest
 type CreateProjectInput struct {
@@ -1137,6 +1182,32 @@ func (s *CreateProjectInput) SetSnapshotId(v string) *CreateProjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Contents != nil {
+		v := s.Contents
+
+		e.SetStream(protocol.PayloadTarget, "contents", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.QueryTarget, "region", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SnapshotId != nil {
+		v := *s.SnapshotId
+
+		e.SetValue(protocol.QueryTarget, "snapshotId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used in response to a request to create a project.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/CreateProjectResult
 type CreateProjectOutput struct {
@@ -1160,6 +1231,17 @@ func (s CreateProjectOutput) GoString() string {
 func (s *CreateProjectOutput) SetDetails(v *ProjectDetails) *CreateProjectOutput {
 	s.Details = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Details != nil {
+		v := s.Details
+
+		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used to request a project be deleted.
@@ -1202,6 +1284,17 @@ func (s *DeleteProjectInput) SetProjectId(v string) *DeleteProjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.PathTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used in response to request to delete a project.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/DeleteProjectResult
 type DeleteProjectOutput struct {
@@ -1235,6 +1328,22 @@ func (s *DeleteProjectOutput) SetDeletedResources(v []*Resource) *DeleteProjectO
 func (s *DeleteProjectOutput) SetOrphanedResources(v []*Resource) *DeleteProjectOutput {
 	s.OrphanedResources = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DeletedResources) > 0 {
+		v := s.DeletedResources
+
+		e.SetList(protocol.BodyTarget, "deletedResources", encodeResourceList(v), protocol.Metadata{})
+	}
+	if len(s.OrphanedResources) > 0 {
+		v := s.OrphanedResources
+
+		e.SetList(protocol.BodyTarget, "orphanedResources", encodeResourceList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure to request the details of a specific bundle.
@@ -1277,6 +1386,17 @@ func (s *DescribeBundleInput) SetBundleId(v string) *DescribeBundleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeBundleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.PathTarget, "bundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure contains the details of the bundle.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/DescribeBundleResult
 type DescribeBundleOutput struct {
@@ -1300,6 +1420,17 @@ func (s DescribeBundleOutput) GoString() string {
 func (s *DescribeBundleOutput) SetDetails(v *BundleDetails) *DescribeBundleOutput {
 	s.Details = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeBundleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Details != nil {
+		v := s.Details
+
+		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used to request details about a project.
@@ -1353,6 +1484,22 @@ func (s *DescribeProjectInput) SetSyncFromResources(v bool) *DescribeProjectInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.QueryTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncFromResources != nil {
+		v := *s.SyncFromResources
+
+		e.SetValue(protocol.QueryTarget, "syncFromResources", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used for requests of project details.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/DescribeProjectResult
 type DescribeProjectOutput struct {
@@ -1376,6 +1523,17 @@ func (s DescribeProjectOutput) GoString() string {
 func (s *DescribeProjectOutput) SetDetails(v *ProjectDetails) *DescribeProjectOutput {
 	s.Details = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Details != nil {
+		v := s.Details
+
+		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used to request generation of custom SDK and tool packages
@@ -1437,6 +1595,27 @@ func (s *ExportBundleInput) SetProjectId(v string) *ExportBundleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ExportBundleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.PathTarget, "bundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.QueryTarget, "platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.QueryTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure which contains link to download custom-generated SDK and
 // tool packages used to integrate mobile web or app clients with backed AWS
 // resources.
@@ -1464,6 +1643,17 @@ func (s ExportBundleOutput) GoString() string {
 func (s *ExportBundleOutput) SetDownloadUrl(v string) *ExportBundleOutput {
 	s.DownloadUrl = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ExportBundleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DownloadUrl != nil {
+		v := *s.DownloadUrl
+
+		e.SetValue(protocol.BodyTarget, "downloadUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used in requests to export project configuration details.
@@ -1504,6 +1694,17 @@ func (s *ExportProjectInput) Validate() error {
 func (s *ExportProjectInput) SetProjectId(v string) *ExportProjectInput {
 	s.ProjectId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ExportProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.PathTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Result structure used for requests to export project configuration details.
@@ -1555,6 +1756,27 @@ func (s *ExportProjectOutput) SetSnapshotId(v string) *ExportProjectOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ExportProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DownloadUrl != nil {
+		v := *s.DownloadUrl
+
+		e.SetValue(protocol.BodyTarget, "downloadUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShareUrl != nil {
+		v := *s.ShareUrl
+
+		e.SetValue(protocol.BodyTarget, "shareUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SnapshotId != nil {
+		v := *s.SnapshotId
+
+		e.SetValue(protocol.BodyTarget, "snapshotId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request structure to request all available bundles.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/ListBundlesRequest
 type ListBundlesInput struct {
@@ -1591,6 +1813,22 @@ func (s *ListBundlesInput) SetNextToken(v string) *ListBundlesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBundlesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure contains a list of all available bundles with details.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/ListBundlesResult
 type ListBundlesOutput struct {
@@ -1624,6 +1862,22 @@ func (s *ListBundlesOutput) SetBundleList(v []*BundleDetails) *ListBundlesOutput
 func (s *ListBundlesOutput) SetNextToken(v string) *ListBundlesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBundlesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BundleList) > 0 {
+		v := s.BundleList
+
+		e.SetList(protocol.BodyTarget, "bundleList", encodeBundleDetailsList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used to request projects list in AWS Mobile Hub.
@@ -1662,6 +1916,22 @@ func (s *ListProjectsInput) SetNextToken(v string) *ListProjectsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListProjectsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used for requests to list projects in AWS Mobile Hub.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/ListProjectsResult
 type ListProjectsOutput struct {
@@ -1696,6 +1966,22 @@ func (s *ListProjectsOutput) SetNextToken(v string) *ListProjectsOutput {
 func (s *ListProjectsOutput) SetProjects(v []*ProjectSummary) *ListProjectsOutput {
 	s.Projects = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListProjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Projects) > 0 {
+		v := s.Projects
+
+		e.SetList(protocol.BodyTarget, "projects", encodeProjectSummaryList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Detailed information about an AWS Mobile Hub project.
@@ -1786,6 +2072,52 @@ func (s *ProjectDetails) SetState(v string) *ProjectDetails {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ProjectDetails) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsoleUrl != nil {
+		v := *s.ConsoleUrl
+
+		e.SetValue(protocol.BodyTarget, "consoleUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.BodyTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "region", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Resources) > 0 {
+		v := s.Resources
+
+		e.SetList(protocol.BodyTarget, "resources", encodeResourceList(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Summary information about an AWS Mobile Hub project.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/ProjectSummary
 type ProjectSummary struct {
@@ -1818,6 +2150,30 @@ func (s *ProjectSummary) SetName(v string) *ProjectSummary {
 func (s *ProjectSummary) SetProjectId(v string) *ProjectSummary {
 	s.ProjectId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ProjectSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.BodyTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeProjectSummaryList(vs []*ProjectSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about an instance of an AWS resource associated with a project.
@@ -1882,6 +2238,45 @@ func (s *Resource) SetType(v string) *Resource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Resource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Feature != nil {
+		v := *s.Feature
+
+		e.SetValue(protocol.BodyTarget, "feature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourceList(vs []*Resource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Request structure used for requests to update project configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/UpdateProjectRequest
 type UpdateProjectInput struct {
@@ -1933,6 +2328,22 @@ func (s *UpdateProjectInput) SetProjectId(v string) *UpdateProjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Contents != nil {
+		v := s.Contents
+
+		e.SetStream(protocol.PayloadTarget, "contents", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.QueryTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used for requests to updated project configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/UpdateProjectResult
 type UpdateProjectOutput struct {
@@ -1956,6 +2367,17 @@ func (s UpdateProjectOutput) GoString() string {
 func (s *UpdateProjectOutput) SetDetails(v *ProjectDetails) *UpdateProjectOutput {
 	s.Details = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Details != nil {
+		v := s.Details
+
+		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Developer desktop or target mobile app or website platform.

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -200,6 +200,50 @@ func (s *Event) SetVersion(v string) *Event {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Event) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.EventType != nil {
+		v := *s.EventType
+
+		e.SetValue(protocol.BodyTarget, "eventType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Metrics) > 0 {
+		v := s.Metrics
+
+		e.SetMap(protocol.BodyTarget, "metrics", protocol.EncodeFloat64Map(v), protocol.Metadata{})
+	}
+	if s.Session != nil {
+		v := s.Session
+
+		e.SetFields(protocol.BodyTarget, "session", v, protocol.Metadata{})
+	}
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.BodyTarget, "timestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEventList(vs []*Event) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A container for the data needed for a PutEvent operation
 type PutEventsInput struct {
 	_ struct{} `type:"structure"`
@@ -273,6 +317,27 @@ func (s *PutEventsInput) SetEvents(v []*Event) *PutEventsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutEventsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientContext != nil {
+		v := *s.ClientContext
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientContextEncoding != nil {
+		v := *s.ClientContextEncoding
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "events", encodeEventList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type PutEventsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -285,6 +350,12 @@ func (s PutEventsOutput) String() string {
 // GoString returns the string representation
 func (s PutEventsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes the session. Session information is required on ALL events.
@@ -351,4 +422,30 @@ func (s *Session) SetStartTimestamp(v string) *Session {
 func (s *Session) SetStopTimestamp(v string) *Session {
 	s.StopTimestamp = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Session) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "duration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTimestamp != nil {
+		v := *s.StartTimestamp
+
+		e.SetValue(protocol.BodyTarget, "startTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StopTimestamp != nil {
+		v := *s.StopTimestamp
+
+		e.SetValue(protocol.BodyTarget, "stopTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCreateApp = "CreateApp"
@@ -4045,6 +4046,27 @@ func (s *APNSChannelRequest) SetPrivateKey(v string) *APNSChannelRequest {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Certificate != nil {
+		v := *s.Certificate
+
+		e.SetValue(protocol.BodyTarget, "Certificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PrivateKey != nil {
+		v := *s.PrivateKey
+
+		e.SetValue(protocol.BodyTarget, "PrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Apple Distribution Push Notification Service channel definition.
 type APNSChannelResponse struct {
 	_ struct{} `type:"structure"`
@@ -4139,6 +4161,57 @@ func (s *APNSChannelResponse) SetPlatform(v string) *APNSChannelResponse {
 func (s *APNSChannelResponse) SetVersion(v int64) *APNSChannelResponse {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // APNS Message.
@@ -4289,6 +4362,82 @@ func (s *APNSMessage) SetUrl(v string) *APNSMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Badge != nil {
+		v := *s.Badge
+
+		e.SetValue(protocol.BodyTarget, "Badge", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.BodyTarget, "Category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Data) > 0 {
+		v := s.Data
+
+		e.SetMap(protocol.BodyTarget, "Data", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MediaUrl != nil {
+		v := *s.MediaUrl
+
+		e.SetValue(protocol.BodyTarget, "MediaUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Sound != nil {
+		v := *s.Sound
+
+		e.SetValue(protocol.BodyTarget, "Sound", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.ThreadId != nil {
+		v := *s.ThreadId
+
+		e.SetValue(protocol.BodyTarget, "ThreadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Apple Development Push Notification Service channel definition.
 type APNSSandboxChannelRequest struct {
 	_ struct{} `type:"structure"`
@@ -4329,6 +4478,27 @@ func (s *APNSSandboxChannelRequest) SetEnabled(v bool) *APNSSandboxChannelReques
 func (s *APNSSandboxChannelRequest) SetPrivateKey(v string) *APNSSandboxChannelRequest {
 	s.PrivateKey = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSSandboxChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Certificate != nil {
+		v := *s.Certificate
+
+		e.SetValue(protocol.BodyTarget, "Certificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PrivateKey != nil {
+		v := *s.PrivateKey
+
+		e.SetValue(protocol.BodyTarget, "PrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Apple Development Push Notification Service channel definition.
@@ -4427,6 +4597,57 @@ func (s *APNSSandboxChannelResponse) SetVersion(v int64) *APNSSandboxChannelResp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSSandboxChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Activities for campaign.
 type ActivitiesResponse struct {
 	_ struct{} `type:"structure"`
@@ -4449,6 +4670,17 @@ func (s ActivitiesResponse) GoString() string {
 func (s *ActivitiesResponse) SetItem(v []*ActivityResponse) *ActivitiesResponse {
 	s.Item = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActivitiesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeActivityResponseList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Activity definition
@@ -4586,6 +4818,85 @@ func (s *ActivityResponse) SetTreatmentId(v string) *ActivityResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActivityResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.BodyTarget, "CampaignId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.End != nil {
+		v := *s.End
+
+		e.SetValue(protocol.BodyTarget, "End", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Result != nil {
+		v := *s.Result
+
+		e.SetValue(protocol.BodyTarget, "Result", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ScheduledStart != nil {
+		v := *s.ScheduledStart
+
+		e.SetValue(protocol.BodyTarget, "ScheduledStart", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.BodyTarget, "Start", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SuccessfulEndpointCount != nil {
+		v := *s.SuccessfulEndpointCount
+
+		e.SetValue(protocol.BodyTarget, "SuccessfulEndpointCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimezonesCompletedCount != nil {
+		v := *s.TimezonesCompletedCount
+
+		e.SetValue(protocol.BodyTarget, "TimezonesCompletedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimezonesTotalCount != nil {
+		v := *s.TimezonesTotalCount
+
+		e.SetValue(protocol.BodyTarget, "TimezonesTotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalEndpointCount != nil {
+		v := *s.TotalEndpointCount
+
+		e.SetValue(protocol.BodyTarget, "TotalEndpointCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TreatmentId != nil {
+		v := *s.TreatmentId
+
+		e.SetValue(protocol.BodyTarget, "TreatmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeActivityResponseList(vs []*ActivityResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Address configuration.
 type AddressConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -4654,6 +4965,55 @@ func (s *AddressConfiguration) SetTitleOverride(v string) *AddressConfiguration 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddressConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BodyOverride != nil {
+		v := *s.BodyOverride
+
+		e.SetValue(protocol.BodyTarget, "BodyOverride", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChannelType != nil {
+		v := *s.ChannelType
+
+		e.SetValue(protocol.BodyTarget, "ChannelType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Context) > 0 {
+		v := s.Context
+
+		e.SetMap(protocol.BodyTarget, "Context", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.TitleOverride != nil {
+		v := *s.TitleOverride
+
+		e.SetValue(protocol.BodyTarget, "TitleOverride", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAddressConfigurationMap(vs map[string]*AddressConfiguration) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Application Response.
 type ApplicationResponse struct {
 	_ struct{} `type:"structure"`
@@ -4685,6 +5045,30 @@ func (s *ApplicationResponse) SetId(v string) *ApplicationResponse {
 func (s *ApplicationResponse) SetName(v string) *ApplicationResponse {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplicationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeApplicationResponseList(vs []*ApplicationResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Application settings.
@@ -4742,6 +5126,32 @@ func (s *ApplicationSettingsResource) SetQuietTime(v *QuietTime) *ApplicationSet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplicationSettingsResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limits != nil {
+		v := s.Limits
+
+		e.SetFields(protocol.BodyTarget, "Limits", v, protocol.Metadata{})
+	}
+	if s.QuietTime != nil {
+		v := s.QuietTime
+
+		e.SetFields(protocol.BodyTarget, "QuietTime", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Get Applications Result.
 type ApplicationsResponse struct {
 	_ struct{} `type:"structure"`
@@ -4776,6 +5186,22 @@ func (s *ApplicationsResponse) SetNextToken(v string) *ApplicationsResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplicationsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeApplicationResponseList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Custom attibute dimension
 type AttributeDimension struct {
 	_ struct{} `type:"structure"`
@@ -4808,6 +5234,30 @@ func (s *AttributeDimension) SetAttributeType(v string) *AttributeDimension {
 func (s *AttributeDimension) SetValues(v []*string) *AttributeDimension {
 	s.Values = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributeDimension) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeType != nil {
+		v := *s.AttributeType
+
+		e.SetValue(protocol.BodyTarget, "AttributeType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Values) > 0 {
+		v := s.Values
+
+		e.SetList(protocol.BodyTarget, "Values", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttributeDimensionMap(vs map[string]*AttributeDimension) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // The email message configuration.
@@ -4862,6 +5312,32 @@ func (s *CampaignEmailMessage) SetTitle(v string) *CampaignEmailMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignEmailMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FromAddress != nil {
+		v := *s.FromAddress
+
+		e.SetValue(protocol.BodyTarget, "FromAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HtmlBody != nil {
+		v := *s.HtmlBody
+
+		e.SetValue(protocol.BodyTarget, "HtmlBody", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Campaign Limits are used to limit the number of messages that can be sent
 // to a user.
 type CampaignLimits struct {
@@ -4894,6 +5370,22 @@ func (s *CampaignLimits) SetDaily(v int64) *CampaignLimits {
 func (s *CampaignLimits) SetTotal(v int64) *CampaignLimits {
 	s.Total = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignLimits) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Daily != nil {
+		v := *s.Daily
+
+		e.SetValue(protocol.BodyTarget, "Daily", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Total != nil {
+		v := *s.Total
+
+		e.SetValue(protocol.BodyTarget, "Total", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Campaign definition
@@ -5086,6 +5578,115 @@ func (s *CampaignResponse) SetVersion(v int64) *CampaignResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdditionalTreatments) > 0 {
+		v := s.AdditionalTreatments
+
+		e.SetList(protocol.BodyTarget, "AdditionalTreatments", encodeTreatmentResourceList(v), protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultState != nil {
+		v := s.DefaultState
+
+		e.SetFields(protocol.BodyTarget, "DefaultState", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HoldoutPercent != nil {
+		v := *s.HoldoutPercent
+
+		e.SetValue(protocol.BodyTarget, "HoldoutPercent", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsPaused != nil {
+		v := *s.IsPaused
+
+		e.SetValue(protocol.BodyTarget, "IsPaused", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limits != nil {
+		v := s.Limits
+
+		e.SetFields(protocol.BodyTarget, "Limits", v, protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.BodyTarget, "SegmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentVersion != nil {
+		v := *s.SegmentVersion
+
+		e.SetValue(protocol.BodyTarget, "SegmentVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := s.State
+
+		e.SetFields(protocol.BodyTarget, "State", v, protocol.Metadata{})
+	}
+	if s.TreatmentDescription != nil {
+		v := *s.TreatmentDescription
+
+		e.SetValue(protocol.BodyTarget, "TreatmentDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TreatmentName != nil {
+		v := *s.TreatmentName
+
+		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCampaignResponseList(vs []*CampaignResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // SMS message configuration.
 type CampaignSmsMessage struct {
 	_ struct{} `type:"structure"`
@@ -5128,6 +5729,27 @@ func (s *CampaignSmsMessage) SetSenderId(v string) *CampaignSmsMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignSmsMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MessageType != nil {
+		v := *s.MessageType
+
+		e.SetValue(protocol.BodyTarget, "MessageType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SenderId != nil {
+		v := *s.SenderId
+
+		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // State of the Campaign
 type CampaignState struct {
 	_ struct{} `type:"structure"`
@@ -5152,6 +5774,17 @@ func (s CampaignState) GoString() string {
 func (s *CampaignState) SetCampaignStatus(v string) *CampaignState {
 	s.CampaignStatus = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignState) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignStatus != nil {
+		v := *s.CampaignStatus
+
+		e.SetValue(protocol.BodyTarget, "CampaignStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // List of available campaigns.
@@ -5186,6 +5819,22 @@ func (s *CampaignsResponse) SetItem(v []*CampaignResponse) *CampaignsResponse {
 func (s *CampaignsResponse) SetNextToken(v string) *CampaignsResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeCampaignResponseList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type CreateAppInput struct {
@@ -5226,6 +5875,17 @@ func (s *CreateAppInput) SetCreateApplicationRequest(v *CreateApplicationRequest
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateAppInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreateApplicationRequest != nil {
+		v := s.CreateApplicationRequest
+
+		e.SetFields(protocol.PayloadTarget, "CreateApplicationRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CreateAppOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationResponse"`
 
@@ -5251,6 +5911,17 @@ func (s *CreateAppOutput) SetApplicationResponse(v *ApplicationResponse) *Create
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateAppOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationResponse != nil {
+		v := s.ApplicationResponse
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Application Request.
 type CreateApplicationRequest struct {
 	_ struct{} `type:"structure"`
@@ -5273,6 +5944,17 @@ func (s CreateApplicationRequest) GoString() string {
 func (s *CreateApplicationRequest) SetName(v string) *CreateApplicationRequest {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateApplicationRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type CreateCampaignInput struct {
@@ -5325,6 +6007,22 @@ func (s *CreateCampaignInput) SetWriteCampaignRequest(v *WriteCampaignRequest) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteCampaignRequest != nil {
+		v := s.WriteCampaignRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteCampaignRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CreateCampaignOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
 
@@ -5348,6 +6046,17 @@ func (s CreateCampaignOutput) GoString() string {
 func (s *CreateCampaignOutput) SetCampaignResponse(v *CampaignResponse) *CreateCampaignOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type CreateImportJobInput struct {
@@ -5398,6 +6107,22 @@ func (s *CreateImportJobInput) SetImportJobRequest(v *ImportJobRequest) *CreateI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateImportJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImportJobRequest != nil {
+		v := s.ImportJobRequest
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CreateImportJobOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobResponse"`
 
@@ -5419,6 +6144,17 @@ func (s CreateImportJobOutput) GoString() string {
 func (s *CreateImportJobOutput) SetImportJobResponse(v *ImportJobResponse) *CreateImportJobOutput {
 	s.ImportJobResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateImportJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ImportJobResponse != nil {
+		v := s.ImportJobResponse
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type CreateSegmentInput struct {
@@ -5471,6 +6207,22 @@ func (s *CreateSegmentInput) SetWriteSegmentRequest(v *WriteSegmentRequest) *Cre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteSegmentRequest != nil {
+		v := s.WriteSegmentRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteSegmentRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CreateSegmentOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
 
@@ -5494,6 +6246,17 @@ func (s CreateSegmentOutput) GoString() string {
 func (s *CreateSegmentOutput) SetSegmentResponse(v *SegmentResponse) *CreateSegmentOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Default Message across push notification, email, and sms.
@@ -5526,6 +6289,27 @@ func (s *DefaultMessage) SetBody(v string) *DefaultMessage {
 func (s *DefaultMessage) SetSubstitutions(v map[string][]*string) *DefaultMessage {
 	s.Substitutions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DefaultMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Default Push Notification Message.
@@ -5612,6 +6396,52 @@ func (s *DefaultPushNotificationMessage) SetUrl(v string) *DefaultPushNotificati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DefaultPushNotificationMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Data) > 0 {
+		v := s.Data
+
+		e.SetMap(protocol.BodyTarget, "Data", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteApnsChannelInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5648,6 +6478,17 @@ func (s *DeleteApnsChannelInput) SetApplicationId(v string) *DeleteApnsChannelIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteApnsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSChannelResponse"`
 
@@ -5671,6 +6512,17 @@ func (s DeleteApnsChannelOutput) GoString() string {
 func (s *DeleteApnsChannelOutput) SetAPNSChannelResponse(v *APNSChannelResponse) *DeleteApnsChannelOutput {
 	s.APNSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSChannelResponse != nil {
+		v := s.APNSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type DeleteApnsSandboxChannelInput struct {
@@ -5709,6 +6561,17 @@ func (s *DeleteApnsSandboxChannelInput) SetApplicationId(v string) *DeleteApnsSa
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteApnsSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSSandboxChannelResponse"`
 
@@ -5732,6 +6595,17 @@ func (s DeleteApnsSandboxChannelOutput) GoString() string {
 func (s *DeleteApnsSandboxChannelOutput) SetAPNSSandboxChannelResponse(v *APNSSandboxChannelResponse) *DeleteApnsSandboxChannelOutput {
 	s.APNSSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSSandboxChannelResponse != nil {
+		v := s.APNSSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type DeleteAppInput struct {
@@ -5770,6 +6644,17 @@ func (s *DeleteAppInput) SetApplicationId(v string) *DeleteAppInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAppInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteAppOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationResponse"`
 
@@ -5793,6 +6678,17 @@ func (s DeleteAppOutput) GoString() string {
 func (s *DeleteAppOutput) SetApplicationResponse(v *ApplicationResponse) *DeleteAppOutput {
 	s.ApplicationResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAppOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationResponse != nil {
+		v := s.ApplicationResponse
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type DeleteCampaignInput struct {
@@ -5843,6 +6739,22 @@ func (s *DeleteCampaignInput) SetCampaignId(v string) *DeleteCampaignInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteCampaignOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
 
@@ -5866,6 +6778,17 @@ func (s DeleteCampaignOutput) GoString() string {
 func (s *DeleteCampaignOutput) SetCampaignResponse(v *CampaignResponse) *DeleteCampaignOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type DeleteEmailChannelInput struct {
@@ -5904,6 +6827,17 @@ func (s *DeleteEmailChannelInput) SetApplicationId(v string) *DeleteEmailChannel
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteEmailChannelOutput struct {
 	_ struct{} `type:"structure" payload:"EmailChannelResponse"`
 
@@ -5927,6 +6861,17 @@ func (s DeleteEmailChannelOutput) GoString() string {
 func (s *DeleteEmailChannelOutput) SetEmailChannelResponse(v *EmailChannelResponse) *DeleteEmailChannelOutput {
 	s.EmailChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailChannelResponse != nil {
+		v := s.EmailChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type DeleteEventStreamInput struct {
@@ -5967,6 +6912,17 @@ func (s *DeleteEventStreamInput) SetApplicationId(v string) *DeleteEventStreamIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteEventStreamOutput struct {
 	_ struct{} `type:"structure" payload:"EventStream"`
 
@@ -5990,6 +6946,17 @@ func (s DeleteEventStreamOutput) GoString() string {
 func (s *DeleteEventStreamOutput) SetEventStream(v *EventStream) *DeleteEventStreamOutput {
 	s.EventStream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventStream != nil {
+		v := s.EventStream
+
+		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type DeleteGcmChannelInput struct {
@@ -6028,6 +6995,17 @@ func (s *DeleteGcmChannelInput) SetApplicationId(v string) *DeleteGcmChannelInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteGcmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"GCMChannelResponse"`
 
@@ -6051,6 +7029,17 @@ func (s DeleteGcmChannelOutput) GoString() string {
 func (s *DeleteGcmChannelOutput) SetGCMChannelResponse(v *GCMChannelResponse) *DeleteGcmChannelOutput {
 	s.GCMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GCMChannelResponse != nil {
+		v := s.GCMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type DeleteSegmentInput struct {
@@ -6101,6 +7090,22 @@ func (s *DeleteSegmentInput) SetSegmentId(v string) *DeleteSegmentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteSegmentOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
 
@@ -6124,6 +7129,17 @@ func (s DeleteSegmentOutput) GoString() string {
 func (s *DeleteSegmentOutput) SetSegmentResponse(v *SegmentResponse) *DeleteSegmentOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type DeleteSmsChannelInput struct {
@@ -6162,6 +7178,17 @@ func (s *DeleteSmsChannelInput) SetApplicationId(v string) *DeleteSmsChannelInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteSmsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"SMSChannelResponse"`
 
@@ -6185,6 +7212,17 @@ func (s DeleteSmsChannelOutput) GoString() string {
 func (s *DeleteSmsChannelOutput) SetSMSChannelResponse(v *SMSChannelResponse) *DeleteSmsChannelOutput {
 	s.SMSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SMSChannelResponse != nil {
+		v := s.SMSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The message configuration.
@@ -6247,6 +7285,37 @@ func (s *DirectMessageConfiguration) SetSMSMessage(v *SMSMessage) *DirectMessage
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DirectMessageConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSMessage != nil {
+		v := s.APNSMessage
+
+		e.SetFields(protocol.BodyTarget, "APNSMessage", v, protocol.Metadata{})
+	}
+	if s.DefaultMessage != nil {
+		v := s.DefaultMessage
+
+		e.SetFields(protocol.BodyTarget, "DefaultMessage", v, protocol.Metadata{})
+	}
+	if s.DefaultPushNotificationMessage != nil {
+		v := s.DefaultPushNotificationMessage
+
+		e.SetFields(protocol.BodyTarget, "DefaultPushNotificationMessage", v, protocol.Metadata{})
+	}
+	if s.GCMMessage != nil {
+		v := s.GCMMessage
+
+		e.SetFields(protocol.BodyTarget, "GCMMessage", v, protocol.Metadata{})
+	}
+	if s.SMSMessage != nil {
+		v := s.SMSMessage
+
+		e.SetFields(protocol.BodyTarget, "SMSMessage", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Email Channel Request
 type EmailChannelRequest struct {
 	_ struct{} `type:"structure"`
@@ -6297,6 +7366,32 @@ func (s *EmailChannelRequest) SetIdentity(v string) *EmailChannelRequest {
 func (s *EmailChannelRequest) SetRoleArn(v string) *EmailChannelRequest {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EmailChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FromAddress != nil {
+		v := *s.FromAddress
+
+		e.SetValue(protocol.BodyTarget, "FromAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Identity != nil {
+		v := *s.Identity
+
+		e.SetValue(protocol.BodyTarget, "Identity", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Email Channel Response.
@@ -6421,6 +7516,72 @@ func (s *EmailChannelResponse) SetRoleArn(v string) *EmailChannelResponse {
 func (s *EmailChannelResponse) SetVersion(v int64) *EmailChannelResponse {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EmailChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FromAddress != nil {
+		v := *s.FromAddress
+
+		e.SetValue(protocol.BodyTarget, "FromAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Identity != nil {
+		v := *s.Identity
+
+		e.SetValue(protocol.BodyTarget, "Identity", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Endpoint update request
@@ -6548,6 +7709,85 @@ func (s *EndpointBatchItem) SetUser(v *EndpointUser) *EndpointBatchItem {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointBatchItem) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Address != nil {
+		v := *s.Address
+
+		e.SetValue(protocol.BodyTarget, "Address", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "Attributes", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.ChannelType != nil {
+		v := *s.ChannelType
+
+		e.SetValue(protocol.BodyTarget, "ChannelType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Demographic != nil {
+		v := s.Demographic
+
+		e.SetFields(protocol.BodyTarget, "Demographic", v, protocol.Metadata{})
+	}
+	if s.EffectiveDate != nil {
+		v := *s.EffectiveDate
+
+		e.SetValue(protocol.BodyTarget, "EffectiveDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointStatus != nil {
+		v := *s.EndpointStatus
+
+		e.SetValue(protocol.BodyTarget, "EndpointStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "Location", v, protocol.Metadata{})
+	}
+	if len(s.Metrics) > 0 {
+		v := s.Metrics
+
+		e.SetMap(protocol.BodyTarget, "Metrics", protocol.EncodeFloat64Map(v), protocol.Metadata{})
+	}
+	if s.OptOut != nil {
+		v := *s.OptOut
+
+		e.SetValue(protocol.BodyTarget, "OptOut", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEndpointBatchItemList(vs []*EndpointBatchItem) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Endpoint batch update request.
 type EndpointBatchRequest struct {
 	_ struct{} `type:"structure"`
@@ -6570,6 +7810,17 @@ func (s EndpointBatchRequest) GoString() string {
 func (s *EndpointBatchRequest) SetItem(v []*EndpointBatchItem) *EndpointBatchRequest {
 	s.Item = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointBatchRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeEndpointBatchItemList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Endpoint demographic data
@@ -6660,6 +7911,52 @@ func (s *EndpointDemographic) SetTimezone(v string) *EndpointDemographic {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointDemographic) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AppVersion != nil {
+		v := *s.AppVersion
+
+		e.SetValue(protocol.BodyTarget, "AppVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "Locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Make != nil {
+		v := *s.Make
+
+		e.SetValue(protocol.BodyTarget, "Make", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Model != nil {
+		v := *s.Model
+
+		e.SetValue(protocol.BodyTarget, "Model", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ModelVersion != nil {
+		v := *s.ModelVersion
+
+		e.SetValue(protocol.BodyTarget, "ModelVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PlatformVersion != nil {
+		v := *s.PlatformVersion
+
+		e.SetValue(protocol.BodyTarget, "PlatformVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timezone != nil {
+		v := *s.Timezone
+
+		e.SetValue(protocol.BodyTarget, "Timezone", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Endpoint location data
 type EndpointLocation struct {
 	_ struct{} `type:"structure"`
@@ -6730,6 +8027,42 @@ func (s *EndpointLocation) SetPostalCode(v string) *EndpointLocation {
 func (s *EndpointLocation) SetRegion(v string) *EndpointLocation {
 	s.Region = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.City != nil {
+		v := *s.City
+
+		e.SetValue(protocol.BodyTarget, "City", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Country != nil {
+		v := *s.Country
+
+		e.SetValue(protocol.BodyTarget, "Country", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Latitude != nil {
+		v := *s.Latitude
+
+		e.SetValue(protocol.BodyTarget, "Latitude", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Longitude != nil {
+		v := *s.Longitude
+
+		e.SetValue(protocol.BodyTarget, "Longitude", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.PostalCode != nil {
+		v := *s.PostalCode
+
+		e.SetValue(protocol.BodyTarget, "PostalCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Endpoint update request
@@ -6846,6 +8179,72 @@ func (s *EndpointRequest) SetRequestId(v string) *EndpointRequest {
 func (s *EndpointRequest) SetUser(v *EndpointUser) *EndpointRequest {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Address != nil {
+		v := *s.Address
+
+		e.SetValue(protocol.BodyTarget, "Address", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "Attributes", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.ChannelType != nil {
+		v := *s.ChannelType
+
+		e.SetValue(protocol.BodyTarget, "ChannelType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Demographic != nil {
+		v := s.Demographic
+
+		e.SetFields(protocol.BodyTarget, "Demographic", v, protocol.Metadata{})
+	}
+	if s.EffectiveDate != nil {
+		v := *s.EffectiveDate
+
+		e.SetValue(protocol.BodyTarget, "EffectiveDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointStatus != nil {
+		v := *s.EndpointStatus
+
+		e.SetValue(protocol.BodyTarget, "EndpointStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "Location", v, protocol.Metadata{})
+	}
+	if len(s.Metrics) > 0 {
+		v := s.Metrics
+
+		e.SetMap(protocol.BodyTarget, "Metrics", protocol.EncodeFloat64Map(v), protocol.Metadata{})
+	}
+	if s.OptOut != nil {
+		v := *s.OptOut
+
+		e.SetValue(protocol.BodyTarget, "OptOut", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Endpoint response
@@ -7013,6 +8412,97 @@ func (s *EndpointResponse) SetUser(v *EndpointUser) *EndpointResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Address != nil {
+		v := *s.Address
+
+		e.SetValue(protocol.BodyTarget, "Address", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "Attributes", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.ChannelType != nil {
+		v := *s.ChannelType
+
+		e.SetValue(protocol.BodyTarget, "ChannelType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CohortId != nil {
+		v := *s.CohortId
+
+		e.SetValue(protocol.BodyTarget, "CohortId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Demographic != nil {
+		v := s.Demographic
+
+		e.SetFields(protocol.BodyTarget, "Demographic", v, protocol.Metadata{})
+	}
+	if s.EffectiveDate != nil {
+		v := *s.EffectiveDate
+
+		e.SetValue(protocol.BodyTarget, "EffectiveDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointStatus != nil {
+		v := *s.EndpointStatus
+
+		e.SetValue(protocol.BodyTarget, "EndpointStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "Location", v, protocol.Metadata{})
+	}
+	if len(s.Metrics) > 0 {
+		v := s.Metrics
+
+		e.SetMap(protocol.BodyTarget, "Metrics", protocol.EncodeFloat64Map(v), protocol.Metadata{})
+	}
+	if s.OptOut != nil {
+		v := *s.OptOut
+
+		e.SetValue(protocol.BodyTarget, "OptOut", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShardId != nil {
+		v := *s.ShardId
+
+		e.SetValue(protocol.BodyTarget, "ShardId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Endpoint user specific custom userAttributes
 type EndpointUser struct {
 	_ struct{} `type:"structure"`
@@ -7043,6 +8533,27 @@ func (s *EndpointUser) SetUserAttributes(v map[string][]*string) *EndpointUser {
 func (s *EndpointUser) SetUserId(v string) *EndpointUser {
 	s.UserId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointUser) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.UserAttributes) > 0 {
+		v := s.UserAttributes
+
+		e.SetMap(protocol.BodyTarget, "UserAttributes", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.BodyTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Model for an event publishing subscription export.
@@ -7118,6 +8629,42 @@ func (s *EventStream) SetRoleArn(v string) *EventStream {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EventStream) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DestinationStreamArn != nil {
+		v := *s.DestinationStreamArn
+
+		e.SetValue(protocol.BodyTarget, "DestinationStreamArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExternalId != nil {
+		v := *s.ExternalId
+
+		e.SetValue(protocol.BodyTarget, "ExternalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedBy != nil {
+		v := *s.LastUpdatedBy
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Google Cloud Messaging credentials
 type GCMChannelRequest struct {
 	_ struct{} `type:"structure"`
@@ -7149,6 +8696,22 @@ func (s *GCMChannelRequest) SetApiKey(v string) *GCMChannelRequest {
 func (s *GCMChannelRequest) SetEnabled(v bool) *GCMChannelRequest {
 	s.Enabled = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GCMChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.BodyTarget, "ApiKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Google Cloud Messaging channel definition
@@ -7254,6 +8817,62 @@ func (s *GCMChannelResponse) SetPlatform(v string) *GCMChannelResponse {
 func (s *GCMChannelResponse) SetVersion(v int64) *GCMChannelResponse {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GCMChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Credential != nil {
+		v := *s.Credential
+
+		e.SetValue(protocol.BodyTarget, "Credential", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // GCM Message.
@@ -7422,6 +9041,92 @@ func (s *GCMMessage) SetUrl(v string) *GCMMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GCMMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CollapseKey != nil {
+		v := *s.CollapseKey
+
+		e.SetValue(protocol.BodyTarget, "CollapseKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Data) > 0 {
+		v := s.Data
+
+		e.SetMap(protocol.BodyTarget, "Data", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.IconReference != nil {
+		v := *s.IconReference
+
+		e.SetValue(protocol.BodyTarget, "IconReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageIconUrl != nil {
+		v := *s.ImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageUrl != nil {
+		v := *s.ImageUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestrictedPackageName != nil {
+		v := *s.RestrictedPackageName
+
+		e.SetValue(protocol.BodyTarget, "RestrictedPackageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SmallImageIconUrl != nil {
+		v := *s.SmallImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "SmallImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sound != nil {
+		v := *s.Sound
+
+		e.SetValue(protocol.BodyTarget, "Sound", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetApnsChannelInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7458,6 +9163,17 @@ func (s *GetApnsChannelInput) SetApplicationId(v string) *GetApnsChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetApnsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSChannelResponse"`
 
@@ -7481,6 +9197,17 @@ func (s GetApnsChannelOutput) GoString() string {
 func (s *GetApnsChannelOutput) SetAPNSChannelResponse(v *APNSChannelResponse) *GetApnsChannelOutput {
 	s.APNSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSChannelResponse != nil {
+		v := s.APNSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetApnsSandboxChannelInput struct {
@@ -7519,6 +9246,17 @@ func (s *GetApnsSandboxChannelInput) SetApplicationId(v string) *GetApnsSandboxC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetApnsSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSSandboxChannelResponse"`
 
@@ -7542,6 +9280,17 @@ func (s GetApnsSandboxChannelOutput) GoString() string {
 func (s *GetApnsSandboxChannelOutput) SetAPNSSandboxChannelResponse(v *APNSSandboxChannelResponse) *GetApnsSandboxChannelOutput {
 	s.APNSSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSSandboxChannelResponse != nil {
+		v := s.APNSSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetAppInput struct {
@@ -7580,6 +9329,17 @@ func (s *GetAppInput) SetApplicationId(v string) *GetAppInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAppInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetAppOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationResponse"`
 
@@ -7603,6 +9363,17 @@ func (s GetAppOutput) GoString() string {
 func (s *GetAppOutput) SetApplicationResponse(v *ApplicationResponse) *GetAppOutput {
 	s.ApplicationResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAppOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationResponse != nil {
+		v := s.ApplicationResponse
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetApplicationSettingsInput struct {
@@ -7641,6 +9412,17 @@ func (s *GetApplicationSettingsInput) SetApplicationId(v string) *GetApplication
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApplicationSettingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetApplicationSettingsOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationSettingsResource"`
 
@@ -7664,6 +9446,17 @@ func (s GetApplicationSettingsOutput) GoString() string {
 func (s *GetApplicationSettingsOutput) SetApplicationSettingsResource(v *ApplicationSettingsResource) *GetApplicationSettingsOutput {
 	s.ApplicationSettingsResource = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApplicationSettingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationSettingsResource != nil {
+		v := s.ApplicationSettingsResource
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationSettingsResource", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetAppsInput struct {
@@ -7696,6 +9489,22 @@ func (s *GetAppsInput) SetToken(v string) *GetAppsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAppsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetAppsOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationsResponse"`
 
@@ -7719,6 +9528,17 @@ func (s GetAppsOutput) GoString() string {
 func (s *GetAppsOutput) SetApplicationsResponse(v *ApplicationsResponse) *GetAppsOutput {
 	s.ApplicationsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAppsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationsResponse != nil {
+		v := s.ApplicationsResponse
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetCampaignActivitiesInput struct {
@@ -7785,6 +9605,32 @@ func (s *GetCampaignActivitiesInput) SetToken(v string) *GetCampaignActivitiesIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignActivitiesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetCampaignActivitiesOutput struct {
 	_ struct{} `type:"structure" payload:"ActivitiesResponse"`
 
@@ -7808,6 +9654,17 @@ func (s GetCampaignActivitiesOutput) GoString() string {
 func (s *GetCampaignActivitiesOutput) SetActivitiesResponse(v *ActivitiesResponse) *GetCampaignActivitiesOutput {
 	s.ActivitiesResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignActivitiesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ActivitiesResponse != nil {
+		v := s.ActivitiesResponse
+
+		e.SetFields(protocol.PayloadTarget, "ActivitiesResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetCampaignInput struct {
@@ -7858,6 +9715,22 @@ func (s *GetCampaignInput) SetCampaignId(v string) *GetCampaignInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetCampaignOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
 
@@ -7881,6 +9754,17 @@ func (s GetCampaignOutput) GoString() string {
 func (s *GetCampaignOutput) SetCampaignResponse(v *CampaignResponse) *GetCampaignOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetCampaignVersionInput struct {
@@ -7943,6 +9827,27 @@ func (s *GetCampaignVersionInput) SetVersion(v string) *GetCampaignVersionInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetCampaignVersionOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
 
@@ -7966,6 +9871,17 @@ func (s GetCampaignVersionOutput) GoString() string {
 func (s *GetCampaignVersionOutput) SetCampaignResponse(v *CampaignResponse) *GetCampaignVersionOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetCampaignVersionsInput struct {
@@ -8032,6 +9948,32 @@ func (s *GetCampaignVersionsInput) SetToken(v string) *GetCampaignVersionsInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetCampaignVersionsOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignsResponse"`
 
@@ -8055,6 +9997,17 @@ func (s GetCampaignVersionsOutput) GoString() string {
 func (s *GetCampaignVersionsOutput) SetCampaignsResponse(v *CampaignsResponse) *GetCampaignVersionsOutput {
 	s.CampaignsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignsResponse != nil {
+		v := s.CampaignsResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetCampaignsInput struct {
@@ -8109,6 +10062,27 @@ func (s *GetCampaignsInput) SetToken(v string) *GetCampaignsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetCampaignsOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignsResponse"`
 
@@ -8132,6 +10106,17 @@ func (s GetCampaignsOutput) GoString() string {
 func (s *GetCampaignsOutput) SetCampaignsResponse(v *CampaignsResponse) *GetCampaignsOutput {
 	s.CampaignsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignsResponse != nil {
+		v := s.CampaignsResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetEmailChannelInput struct {
@@ -8170,6 +10155,17 @@ func (s *GetEmailChannelInput) SetApplicationId(v string) *GetEmailChannelInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetEmailChannelOutput struct {
 	_ struct{} `type:"structure" payload:"EmailChannelResponse"`
 
@@ -8193,6 +10189,17 @@ func (s GetEmailChannelOutput) GoString() string {
 func (s *GetEmailChannelOutput) SetEmailChannelResponse(v *EmailChannelResponse) *GetEmailChannelOutput {
 	s.EmailChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailChannelResponse != nil {
+		v := s.EmailChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetEndpointInput struct {
@@ -8243,6 +10250,22 @@ func (s *GetEndpointInput) SetEndpointId(v string) *GetEndpointInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointId != nil {
+		v := *s.EndpointId
+
+		e.SetValue(protocol.PathTarget, "endpoint-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetEndpointOutput struct {
 	_ struct{} `type:"structure" payload:"EndpointResponse"`
 
@@ -8266,6 +10289,17 @@ func (s GetEndpointOutput) GoString() string {
 func (s *GetEndpointOutput) SetEndpointResponse(v *EndpointResponse) *GetEndpointOutput {
 	s.EndpointResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndpointResponse != nil {
+		v := s.EndpointResponse
+
+		e.SetFields(protocol.PayloadTarget, "EndpointResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetEventStreamInput struct {
@@ -8306,6 +10340,17 @@ func (s *GetEventStreamInput) SetApplicationId(v string) *GetEventStreamInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetEventStreamOutput struct {
 	_ struct{} `type:"structure" payload:"EventStream"`
 
@@ -8329,6 +10374,17 @@ func (s GetEventStreamOutput) GoString() string {
 func (s *GetEventStreamOutput) SetEventStream(v *EventStream) *GetEventStreamOutput {
 	s.EventStream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventStream != nil {
+		v := s.EventStream
+
+		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetGcmChannelInput struct {
@@ -8367,6 +10423,17 @@ func (s *GetGcmChannelInput) SetApplicationId(v string) *GetGcmChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetGcmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"GCMChannelResponse"`
 
@@ -8390,6 +10457,17 @@ func (s GetGcmChannelOutput) GoString() string {
 func (s *GetGcmChannelOutput) SetGCMChannelResponse(v *GCMChannelResponse) *GetGcmChannelOutput {
 	s.GCMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GCMChannelResponse != nil {
+		v := s.GCMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetImportJobInput struct {
@@ -8440,6 +10518,22 @@ func (s *GetImportJobInput) SetJobId(v string) *GetImportJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetImportJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.PathTarget, "job-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetImportJobOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobResponse"`
 
@@ -8461,6 +10555,17 @@ func (s GetImportJobOutput) GoString() string {
 func (s *GetImportJobOutput) SetImportJobResponse(v *ImportJobResponse) *GetImportJobOutput {
 	s.ImportJobResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetImportJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ImportJobResponse != nil {
+		v := s.ImportJobResponse
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetImportJobsInput struct {
@@ -8515,6 +10620,27 @@ func (s *GetImportJobsInput) SetToken(v string) *GetImportJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetImportJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetImportJobsOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobsResponse"`
 
@@ -8538,6 +10664,17 @@ func (s GetImportJobsOutput) GoString() string {
 func (s *GetImportJobsOutput) SetImportJobsResponse(v *ImportJobsResponse) *GetImportJobsOutput {
 	s.ImportJobsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetImportJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ImportJobsResponse != nil {
+		v := s.ImportJobsResponse
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetSegmentImportJobsInput struct {
@@ -8604,6 +10741,32 @@ func (s *GetSegmentImportJobsInput) SetToken(v string) *GetSegmentImportJobsInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentImportJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetSegmentImportJobsOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobsResponse"`
 
@@ -8627,6 +10790,17 @@ func (s GetSegmentImportJobsOutput) GoString() string {
 func (s *GetSegmentImportJobsOutput) SetImportJobsResponse(v *ImportJobsResponse) *GetSegmentImportJobsOutput {
 	s.ImportJobsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentImportJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ImportJobsResponse != nil {
+		v := s.ImportJobsResponse
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetSegmentInput struct {
@@ -8677,6 +10851,22 @@ func (s *GetSegmentInput) SetSegmentId(v string) *GetSegmentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetSegmentOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
 
@@ -8700,6 +10890,17 @@ func (s GetSegmentOutput) GoString() string {
 func (s *GetSegmentOutput) SetSegmentResponse(v *SegmentResponse) *GetSegmentOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetSegmentVersionInput struct {
@@ -8762,6 +10963,27 @@ func (s *GetSegmentVersionInput) SetVersion(v string) *GetSegmentVersionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetSegmentVersionOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
 
@@ -8785,6 +11007,17 @@ func (s GetSegmentVersionOutput) GoString() string {
 func (s *GetSegmentVersionOutput) SetSegmentResponse(v *SegmentResponse) *GetSegmentVersionOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetSegmentVersionsInput struct {
@@ -8851,6 +11084,32 @@ func (s *GetSegmentVersionsInput) SetToken(v string) *GetSegmentVersionsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetSegmentVersionsOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentsResponse"`
 
@@ -8874,6 +11133,17 @@ func (s GetSegmentVersionsOutput) GoString() string {
 func (s *GetSegmentVersionsOutput) SetSegmentsResponse(v *SegmentsResponse) *GetSegmentVersionsOutput {
 	s.SegmentsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentsResponse != nil {
+		v := s.SegmentsResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetSegmentsInput struct {
@@ -8928,6 +11198,27 @@ func (s *GetSegmentsInput) SetToken(v string) *GetSegmentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetSegmentsOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentsResponse"`
 
@@ -8951,6 +11242,17 @@ func (s GetSegmentsOutput) GoString() string {
 func (s *GetSegmentsOutput) SetSegmentsResponse(v *SegmentsResponse) *GetSegmentsOutput {
 	s.SegmentsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentsResponse != nil {
+		v := s.SegmentsResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type GetSmsChannelInput struct {
@@ -8989,6 +11291,17 @@ func (s *GetSmsChannelInput) SetApplicationId(v string) *GetSmsChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type GetSmsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"SMSChannelResponse"`
 
@@ -9012,6 +11325,17 @@ func (s GetSmsChannelOutput) GoString() string {
 func (s *GetSmsChannelOutput) SetSMSChannelResponse(v *SMSChannelResponse) *GetSmsChannelOutput {
 	s.SMSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SMSChannelResponse != nil {
+		v := s.SMSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type ImportJobRequest struct {
@@ -9109,6 +11433,52 @@ func (s *ImportJobRequest) SetSegmentName(v string) *ImportJobRequest {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportJobRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefineSegment != nil {
+		v := *s.DefineSegment
+
+		e.SetValue(protocol.BodyTarget, "DefineSegment", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ExternalId != nil {
+		v := *s.ExternalId
+
+		e.SetValue(protocol.BodyTarget, "ExternalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RegisterEndpoints != nil {
+		v := *s.RegisterEndpoints
+
+		e.SetValue(protocol.BodyTarget, "RegisterEndpoints", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Url != nil {
+		v := *s.S3Url
+
+		e.SetValue(protocol.BodyTarget, "S3Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.BodyTarget, "SegmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentName != nil {
+		v := *s.SegmentName
+
+		e.SetValue(protocol.BodyTarget, "SegmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type ImportJobResource struct {
 	_ struct{} `type:"structure"`
 
@@ -9202,6 +11572,52 @@ func (s *ImportJobResource) SetSegmentId(v string) *ImportJobResource {
 func (s *ImportJobResource) SetSegmentName(v string) *ImportJobResource {
 	s.SegmentName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportJobResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefineSegment != nil {
+		v := *s.DefineSegment
+
+		e.SetValue(protocol.BodyTarget, "DefineSegment", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ExternalId != nil {
+		v := *s.ExternalId
+
+		e.SetValue(protocol.BodyTarget, "ExternalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RegisterEndpoints != nil {
+		v := *s.RegisterEndpoints
+
+		e.SetValue(protocol.BodyTarget, "RegisterEndpoints", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Url != nil {
+		v := *s.S3Url
+
+		e.SetValue(protocol.BodyTarget, "S3Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.BodyTarget, "SegmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentName != nil {
+		v := *s.SegmentName
+
+		e.SetValue(protocol.BodyTarget, "SegmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type ImportJobResponse struct {
@@ -9339,6 +11755,85 @@ func (s *ImportJobResponse) SetType(v string) *ImportJobResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportJobResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CompletedPieces != nil {
+		v := *s.CompletedPieces
+
+		e.SetValue(protocol.BodyTarget, "CompletedPieces", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CompletionDate != nil {
+		v := *s.CompletionDate
+
+		e.SetValue(protocol.BodyTarget, "CompletionDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.FailedPieces != nil {
+		v := *s.FailedPieces
+
+		e.SetValue(protocol.BodyTarget, "FailedPieces", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Failures) > 0 {
+		v := s.Failures
+
+		e.SetList(protocol.BodyTarget, "Failures", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobStatus != nil {
+		v := *s.JobStatus
+
+		e.SetValue(protocol.BodyTarget, "JobStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TotalFailures != nil {
+		v := *s.TotalFailures
+
+		e.SetValue(protocol.BodyTarget, "TotalFailures", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalPieces != nil {
+		v := *s.TotalPieces
+
+		e.SetValue(protocol.BodyTarget, "TotalPieces", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalProcessed != nil {
+		v := *s.TotalProcessed
+
+		e.SetValue(protocol.BodyTarget, "TotalProcessed", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeImportJobResponseList(vs []*ImportJobResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Import job list.
 type ImportJobsResponse struct {
 	_ struct{} `type:"structure"`
@@ -9371,6 +11866,22 @@ func (s *ImportJobsResponse) SetItem(v []*ImportJobResponse) *ImportJobsResponse
 func (s *ImportJobsResponse) SetNextToken(v string) *ImportJobsResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportJobsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeImportJobResponseList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type Message struct {
@@ -9496,6 +12007,67 @@ func (s *Message) SetUrl(v string) *Message {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Message) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageIconUrl != nil {
+		v := *s.ImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageSmallIconUrl != nil {
+		v := *s.ImageSmallIconUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageSmallIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageUrl != nil {
+		v := *s.ImageUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JsonBody != nil {
+		v := *s.JsonBody
+
+		e.SetValue(protocol.BodyTarget, "JsonBody", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MediaUrl != nil {
+		v := *s.MediaUrl
+
+		e.SetValue(protocol.BodyTarget, "MediaUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Simple message object.
 type MessageBody struct {
 	_ struct{} `type:"structure"`
@@ -9527,6 +12099,22 @@ func (s *MessageBody) SetMessage(v string) *MessageBody {
 func (s *MessageBody) SetRequestID(v string) *MessageBody {
 	s.RequestID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageBody) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestID != nil {
+		v := *s.RequestID
+
+		e.SetValue(protocol.BodyTarget, "RequestID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Message configuration for a campaign.
@@ -9591,6 +12179,37 @@ func (s *MessageConfiguration) SetSMSMessage(v *CampaignSmsMessage) *MessageConf
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSMessage != nil {
+		v := s.APNSMessage
+
+		e.SetFields(protocol.BodyTarget, "APNSMessage", v, protocol.Metadata{})
+	}
+	if s.DefaultMessage != nil {
+		v := s.DefaultMessage
+
+		e.SetFields(protocol.BodyTarget, "DefaultMessage", v, protocol.Metadata{})
+	}
+	if s.EmailMessage != nil {
+		v := s.EmailMessage
+
+		e.SetFields(protocol.BodyTarget, "EmailMessage", v, protocol.Metadata{})
+	}
+	if s.GCMMessage != nil {
+		v := s.GCMMessage
+
+		e.SetFields(protocol.BodyTarget, "GCMMessage", v, protocol.Metadata{})
+	}
+	if s.SMSMessage != nil {
+		v := s.SMSMessage
+
+		e.SetFields(protocol.BodyTarget, "SMSMessage", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Send message request.
 type MessageRequest struct {
 	_ struct{} `type:"structure"`
@@ -9631,6 +12250,27 @@ func (s *MessageRequest) SetContext(v map[string]*string) *MessageRequest {
 func (s *MessageRequest) SetMessageConfiguration(v *DirectMessageConfiguration) *MessageRequest {
 	s.MessageConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Addresses) > 0 {
+		v := s.Addresses
+
+		e.SetMap(protocol.BodyTarget, "Addresses", encodeAddressConfigurationMap(v), protocol.Metadata{})
+	}
+	if len(s.Context) > 0 {
+		v := s.Context
+
+		e.SetMap(protocol.BodyTarget, "Context", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Send message response.
@@ -9675,6 +12315,27 @@ func (s *MessageResponse) SetRequestId(v string) *MessageResponse {
 func (s *MessageResponse) SetResult(v map[string]*MessageResult) *MessageResponse {
 	s.Result = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Result) > 0 {
+		v := s.Result
+
+		e.SetMap(protocol.BodyTarget, "Result", encodeMessageResultMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The result from sending a message to an address.
@@ -9726,6 +12387,40 @@ func (s *MessageResult) SetStatusMessage(v string) *MessageResult {
 func (s *MessageResult) SetUpdatedToken(v string) *MessageResult {
 	s.UpdatedToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeliveryStatus != nil {
+		v := *s.DeliveryStatus
+
+		e.SetValue(protocol.BodyTarget, "DeliveryStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "StatusCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StatusMessage != nil {
+		v := *s.StatusMessage
+
+		e.SetValue(protocol.BodyTarget, "StatusMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UpdatedToken != nil {
+		v := *s.UpdatedToken
+
+		e.SetValue(protocol.BodyTarget, "UpdatedToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMessageResultMap(vs map[string]*MessageResult) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 type PutEventStreamInput struct {
@@ -9780,6 +12475,22 @@ func (s *PutEventStreamInput) SetWriteEventStream(v *WriteEventStream) *PutEvent
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteEventStream != nil {
+		v := s.WriteEventStream
+
+		e.SetFields(protocol.PayloadTarget, "WriteEventStream", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type PutEventStreamOutput struct {
 	_ struct{} `type:"structure" payload:"EventStream"`
 
@@ -9803,6 +12514,17 @@ func (s PutEventStreamOutput) GoString() string {
 func (s *PutEventStreamOutput) SetEventStream(v *EventStream) *PutEventStreamOutput {
 	s.EventStream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventStream != nil {
+		v := s.EventStream
+
+		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Quiet Time
@@ -9836,6 +12558,22 @@ func (s *QuietTime) SetEnd(v string) *QuietTime {
 func (s *QuietTime) SetStart(v string) *QuietTime {
 	s.Start = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QuietTime) MarshalFields(e protocol.FieldEncoder) error {
+	if s.End != nil {
+		v := *s.End
+
+		e.SetValue(protocol.BodyTarget, "End", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.BodyTarget, "Start", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Define how a segment based on recency of use.
@@ -9874,6 +12612,22 @@ func (s *RecencyDimension) SetRecencyType(v string) *RecencyDimension {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RecencyDimension) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecencyType != nil {
+		v := *s.RecencyType
+
+		e.SetValue(protocol.BodyTarget, "RecencyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // SMS Channel Request
 type SMSChannelRequest struct {
 	_ struct{} `type:"structure"`
@@ -9905,6 +12659,22 @@ func (s *SMSChannelRequest) SetEnabled(v bool) *SMSChannelRequest {
 func (s *SMSChannelRequest) SetSenderId(v string) *SMSChannelRequest {
 	s.SenderId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SMSChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SenderId != nil {
+		v := *s.SenderId
+
+		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // SMS Channel Response.
@@ -10021,6 +12791,67 @@ func (s *SMSChannelResponse) SetVersion(v int64) *SMSChannelResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SMSChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SenderId != nil {
+		v := *s.SenderId
+
+		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShortCode != nil {
+		v := *s.ShortCode
+
+		e.SetValue(protocol.BodyTarget, "ShortCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // SMS Message.
 type SMSMessage struct {
 	_ struct{} `type:"structure"`
@@ -10069,6 +12900,37 @@ func (s *SMSMessage) SetSenderId(v string) *SMSMessage {
 func (s *SMSMessage) SetSubstitutions(v map[string][]*string) *SMSMessage {
 	s.Substitutions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SMSMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MessageType != nil {
+		v := *s.MessageType
+
+		e.SetValue(protocol.BodyTarget, "MessageType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SenderId != nil {
+		v := *s.SenderId
+
+		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Shcedule that defines when a campaign is run.
@@ -10143,6 +13005,42 @@ func (s *Schedule) SetTimezone(v string) *Schedule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Schedule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Frequency != nil {
+		v := *s.Frequency
+
+		e.SetValue(protocol.BodyTarget, "Frequency", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsLocalTime != nil {
+		v := *s.IsLocalTime
+
+		e.SetValue(protocol.BodyTarget, "IsLocalTime", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.QuietTime != nil {
+		v := s.QuietTime
+
+		e.SetFields(protocol.BodyTarget, "QuietTime", v, protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timezone != nil {
+		v := *s.Timezone
+
+		e.SetValue(protocol.BodyTarget, "Timezone", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Segment behavior dimensions
 type SegmentBehaviors struct {
 	_ struct{} `type:"structure"`
@@ -10165,6 +13063,17 @@ func (s SegmentBehaviors) GoString() string {
 func (s *SegmentBehaviors) SetRecency(v *RecencyDimension) *SegmentBehaviors {
 	s.Recency = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentBehaviors) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Recency != nil {
+		v := s.Recency
+
+		e.SetFields(protocol.BodyTarget, "Recency", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Segment demographic dimensions
@@ -10236,6 +13145,42 @@ func (s *SegmentDemographics) SetPlatform(v *SetDimension) *SegmentDemographics 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentDemographics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AppVersion != nil {
+		v := s.AppVersion
+
+		e.SetFields(protocol.BodyTarget, "AppVersion", v, protocol.Metadata{})
+	}
+	if s.Channel != nil {
+		v := s.Channel
+
+		e.SetFields(protocol.BodyTarget, "Channel", v, protocol.Metadata{})
+	}
+	if s.DeviceType != nil {
+		v := s.DeviceType
+
+		e.SetFields(protocol.BodyTarget, "DeviceType", v, protocol.Metadata{})
+	}
+	if s.Make != nil {
+		v := s.Make
+
+		e.SetFields(protocol.BodyTarget, "Make", v, protocol.Metadata{})
+	}
+	if s.Model != nil {
+		v := s.Model
+
+		e.SetFields(protocol.BodyTarget, "Model", v, protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := s.Platform
+
+		e.SetFields(protocol.BodyTarget, "Platform", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Segment dimensions
 type SegmentDimensions struct {
 	_ struct{} `type:"structure"`
@@ -10294,6 +13239,37 @@ func (s *SegmentDimensions) SetLocation(v *SegmentLocation) *SegmentDimensions {
 func (s *SegmentDimensions) SetUserAttributes(v map[string]*AttributeDimension) *SegmentDimensions {
 	s.UserAttributes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentDimensions) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "Attributes", encodeAttributeDimensionMap(v), protocol.Metadata{})
+	}
+	if s.Behavior != nil {
+		v := s.Behavior
+
+		e.SetFields(protocol.BodyTarget, "Behavior", v, protocol.Metadata{})
+	}
+	if s.Demographic != nil {
+		v := s.Demographic
+
+		e.SetFields(protocol.BodyTarget, "Demographic", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "Location", v, protocol.Metadata{})
+	}
+	if len(s.UserAttributes) > 0 {
+		v := s.UserAttributes
+
+		e.SetMap(protocol.BodyTarget, "UserAttributes", encodeAttributeDimensionMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Segment import definition.
@@ -10368,6 +13344,42 @@ func (s *SegmentImportResource) SetSize(v int64) *SegmentImportResource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentImportResource) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ChannelCounts) > 0 {
+		v := s.ChannelCounts
+
+		e.SetMap(protocol.BodyTarget, "ChannelCounts", protocol.EncodeInt64Map(v), protocol.Metadata{})
+	}
+	if s.ExternalId != nil {
+		v := *s.ExternalId
+
+		e.SetValue(protocol.BodyTarget, "ExternalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Url != nil {
+		v := *s.S3Url
+
+		e.SetValue(protocol.BodyTarget, "S3Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Segment location dimensions
 type SegmentLocation struct {
 	_ struct{} `type:"structure"`
@@ -10390,6 +13402,17 @@ func (s SegmentLocation) GoString() string {
 func (s *SegmentLocation) SetCountry(v *SetDimension) *SegmentLocation {
 	s.Country = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Country != nil {
+		v := s.Country
+
+		e.SetFields(protocol.BodyTarget, "Country", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Segment definition.
@@ -10494,6 +13517,65 @@ func (s *SegmentResponse) SetVersion(v int64) *SegmentResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Dimensions != nil {
+		v := s.Dimensions
+
+		e.SetFields(protocol.BodyTarget, "Dimensions", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImportDefinition != nil {
+		v := s.ImportDefinition
+
+		e.SetFields(protocol.BodyTarget, "ImportDefinition", v, protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentType != nil {
+		v := *s.SegmentType
+
+		e.SetValue(protocol.BodyTarget, "SegmentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSegmentResponseList(vs []*SegmentResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Segments in your account.
 type SegmentsResponse struct {
 	_ struct{} `type:"structure"`
@@ -10526,6 +13608,22 @@ func (s *SegmentsResponse) SetItem(v []*SegmentResponse) *SegmentsResponse {
 func (s *SegmentsResponse) SetNextToken(v string) *SegmentsResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeSegmentResponseList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type SendMessagesInput struct {
@@ -10578,6 +13676,22 @@ func (s *SendMessagesInput) SetMessageRequest(v *MessageRequest) *SendMessagesIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SendMessagesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MessageRequest != nil {
+		v := s.MessageRequest
+
+		e.SetFields(protocol.PayloadTarget, "MessageRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SendMessagesOutput struct {
 	_ struct{} `type:"structure" payload:"MessageResponse"`
 
@@ -10601,6 +13715,17 @@ func (s SendMessagesOutput) GoString() string {
 func (s *SendMessagesOutput) SetMessageResponse(v *MessageResponse) *SendMessagesOutput {
 	s.MessageResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SendMessagesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageResponse != nil {
+		v := s.MessageResponse
+
+		e.SetFields(protocol.PayloadTarget, "MessageResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Dimension specification of a segment.
@@ -10635,6 +13760,22 @@ func (s *SetDimension) SetDimensionType(v string) *SetDimension {
 func (s *SetDimension) SetValues(v []*string) *SetDimension {
 	s.Values = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDimension) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DimensionType != nil {
+		v := *s.DimensionType
+
+		e.SetValue(protocol.BodyTarget, "DimensionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Values) > 0 {
+		v := s.Values
+
+		e.SetList(protocol.BodyTarget, "Values", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Treatment resource
@@ -10715,6 +13856,55 @@ func (s *TreatmentResource) SetTreatmentName(v string) *TreatmentResource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TreatmentResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+	if s.SizePercent != nil {
+		v := *s.SizePercent
+
+		e.SetValue(protocol.BodyTarget, "SizePercent", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := s.State
+
+		e.SetFields(protocol.BodyTarget, "State", v, protocol.Metadata{})
+	}
+	if s.TreatmentDescription != nil {
+		v := *s.TreatmentDescription
+
+		e.SetValue(protocol.BodyTarget, "TreatmentDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TreatmentName != nil {
+		v := *s.TreatmentName
+
+		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTreatmentResourceList(vs []*TreatmentResource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 type UpdateApnsChannelInput struct {
 	_ struct{} `type:"structure" payload:"APNSChannelRequest"`
 
@@ -10765,6 +13955,22 @@ func (s *UpdateApnsChannelInput) SetApplicationId(v string) *UpdateApnsChannelIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSChannelRequest != nil {
+		v := s.APNSChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "APNSChannelRequest", v, protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateApnsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSChannelResponse"`
 
@@ -10788,6 +13994,17 @@ func (s UpdateApnsChannelOutput) GoString() string {
 func (s *UpdateApnsChannelOutput) SetAPNSChannelResponse(v *APNSChannelResponse) *UpdateApnsChannelOutput {
 	s.APNSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSChannelResponse != nil {
+		v := s.APNSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateApnsSandboxChannelInput struct {
@@ -10840,6 +14057,22 @@ func (s *UpdateApnsSandboxChannelInput) SetApplicationId(v string) *UpdateApnsSa
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSSandboxChannelRequest != nil {
+		v := s.APNSSandboxChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelRequest", v, protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateApnsSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSSandboxChannelResponse"`
 
@@ -10863,6 +14096,17 @@ func (s UpdateApnsSandboxChannelOutput) GoString() string {
 func (s *UpdateApnsSandboxChannelOutput) SetAPNSSandboxChannelResponse(v *APNSSandboxChannelResponse) *UpdateApnsSandboxChannelOutput {
 	s.APNSSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSSandboxChannelResponse != nil {
+		v := s.APNSSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateApplicationSettingsInput struct {
@@ -10915,6 +14159,22 @@ func (s *UpdateApplicationSettingsInput) SetWriteApplicationSettingsRequest(v *W
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApplicationSettingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteApplicationSettingsRequest != nil {
+		v := s.WriteApplicationSettingsRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteApplicationSettingsRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateApplicationSettingsOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationSettingsResource"`
 
@@ -10938,6 +14198,17 @@ func (s UpdateApplicationSettingsOutput) GoString() string {
 func (s *UpdateApplicationSettingsOutput) SetApplicationSettingsResource(v *ApplicationSettingsResource) *UpdateApplicationSettingsOutput {
 	s.ApplicationSettingsResource = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApplicationSettingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationSettingsResource != nil {
+		v := s.ApplicationSettingsResource
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationSettingsResource", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateCampaignInput struct {
@@ -11002,6 +14273,27 @@ func (s *UpdateCampaignInput) SetWriteCampaignRequest(v *WriteCampaignRequest) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteCampaignRequest != nil {
+		v := s.WriteCampaignRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteCampaignRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateCampaignOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
 
@@ -11025,6 +14317,17 @@ func (s UpdateCampaignOutput) GoString() string {
 func (s *UpdateCampaignOutput) SetCampaignResponse(v *CampaignResponse) *UpdateCampaignOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateEmailChannelInput struct {
@@ -11077,6 +14380,22 @@ func (s *UpdateEmailChannelInput) SetEmailChannelRequest(v *EmailChannelRequest)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EmailChannelRequest != nil {
+		v := s.EmailChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "EmailChannelRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateEmailChannelOutput struct {
 	_ struct{} `type:"structure" payload:"EmailChannelResponse"`
 
@@ -11100,6 +14419,17 @@ func (s UpdateEmailChannelOutput) GoString() string {
 func (s *UpdateEmailChannelOutput) SetEmailChannelResponse(v *EmailChannelResponse) *UpdateEmailChannelOutput {
 	s.EmailChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailChannelResponse != nil {
+		v := s.EmailChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateEndpointInput struct {
@@ -11164,6 +14494,27 @@ func (s *UpdateEndpointInput) SetEndpointRequest(v *EndpointRequest) *UpdateEndp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointId != nil {
+		v := *s.EndpointId
+
+		e.SetValue(protocol.PathTarget, "endpoint-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointRequest != nil {
+		v := s.EndpointRequest
+
+		e.SetFields(protocol.PayloadTarget, "EndpointRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateEndpointOutput struct {
 	_ struct{} `type:"structure" payload:"MessageBody"`
 
@@ -11187,6 +14538,17 @@ func (s UpdateEndpointOutput) GoString() string {
 func (s *UpdateEndpointOutput) SetMessageBody(v *MessageBody) *UpdateEndpointOutput {
 	s.MessageBody = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageBody != nil {
+		v := s.MessageBody
+
+		e.SetFields(protocol.PayloadTarget, "MessageBody", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateEndpointsBatchInput struct {
@@ -11239,6 +14601,22 @@ func (s *UpdateEndpointsBatchInput) SetEndpointBatchRequest(v *EndpointBatchRequ
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEndpointsBatchInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointBatchRequest != nil {
+		v := s.EndpointBatchRequest
+
+		e.SetFields(protocol.PayloadTarget, "EndpointBatchRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateEndpointsBatchOutput struct {
 	_ struct{} `type:"structure" payload:"MessageBody"`
 
@@ -11262,6 +14640,17 @@ func (s UpdateEndpointsBatchOutput) GoString() string {
 func (s *UpdateEndpointsBatchOutput) SetMessageBody(v *MessageBody) *UpdateEndpointsBatchOutput {
 	s.MessageBody = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEndpointsBatchOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageBody != nil {
+		v := s.MessageBody
+
+		e.SetFields(protocol.PayloadTarget, "MessageBody", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateGcmChannelInput struct {
@@ -11314,6 +14703,22 @@ func (s *UpdateGcmChannelInput) SetGCMChannelRequest(v *GCMChannelRequest) *Upda
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GCMChannelRequest != nil {
+		v := s.GCMChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "GCMChannelRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateGcmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"GCMChannelResponse"`
 
@@ -11337,6 +14742,17 @@ func (s UpdateGcmChannelOutput) GoString() string {
 func (s *UpdateGcmChannelOutput) SetGCMChannelResponse(v *GCMChannelResponse) *UpdateGcmChannelOutput {
 	s.GCMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GCMChannelResponse != nil {
+		v := s.GCMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateSegmentInput struct {
@@ -11401,6 +14817,27 @@ func (s *UpdateSegmentInput) SetWriteSegmentRequest(v *WriteSegmentRequest) *Upd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteSegmentRequest != nil {
+		v := s.WriteSegmentRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteSegmentRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateSegmentOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
 
@@ -11424,6 +14861,17 @@ func (s UpdateSegmentOutput) GoString() string {
 func (s *UpdateSegmentOutput) SetSegmentResponse(v *SegmentResponse) *UpdateSegmentOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type UpdateSmsChannelInput struct {
@@ -11476,6 +14924,22 @@ func (s *UpdateSmsChannelInput) SetSMSChannelRequest(v *SMSChannelRequest) *Upda
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SMSChannelRequest != nil {
+		v := s.SMSChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "SMSChannelRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateSmsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"SMSChannelResponse"`
 
@@ -11499,6 +14963,17 @@ func (s UpdateSmsChannelOutput) GoString() string {
 func (s *UpdateSmsChannelOutput) SetSMSChannelResponse(v *SMSChannelResponse) *UpdateSmsChannelOutput {
 	s.SMSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SMSChannelResponse != nil {
+		v := s.SMSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Creating application setting request
@@ -11536,6 +15011,22 @@ func (s *WriteApplicationSettingsRequest) SetLimits(v *CampaignLimits) *WriteApp
 func (s *WriteApplicationSettingsRequest) SetQuietTime(v *QuietTime) *WriteApplicationSettingsRequest {
 	s.QuietTime = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteApplicationSettingsRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limits != nil {
+		v := s.Limits
+
+		e.SetFields(protocol.BodyTarget, "Limits", v, protocol.Metadata{})
+	}
+	if s.QuietTime != nil {
+		v := s.QuietTime
+
+		e.SetFields(protocol.BodyTarget, "QuietTime", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Used to create a campaign.
@@ -11663,6 +15154,72 @@ func (s *WriteCampaignRequest) SetTreatmentName(v string) *WriteCampaignRequest 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteCampaignRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdditionalTreatments) > 0 {
+		v := s.AdditionalTreatments
+
+		e.SetList(protocol.BodyTarget, "AdditionalTreatments", encodeWriteTreatmentResourceList(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HoldoutPercent != nil {
+		v := *s.HoldoutPercent
+
+		e.SetValue(protocol.BodyTarget, "HoldoutPercent", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IsPaused != nil {
+		v := *s.IsPaused
+
+		e.SetValue(protocol.BodyTarget, "IsPaused", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Limits != nil {
+		v := s.Limits
+
+		e.SetFields(protocol.BodyTarget, "Limits", v, protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.BodyTarget, "SegmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentVersion != nil {
+		v := *s.SegmentVersion
+
+		e.SetValue(protocol.BodyTarget, "SegmentVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TreatmentDescription != nil {
+		v := *s.TreatmentDescription
+
+		e.SetValue(protocol.BodyTarget, "TreatmentDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TreatmentName != nil {
+		v := *s.TreatmentName
+
+		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to save an EventStream.
 type WriteEventStream struct {
 	_ struct{} `type:"structure"`
@@ -11699,6 +15256,22 @@ func (s *WriteEventStream) SetRoleArn(v string) *WriteEventStream {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteEventStream) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DestinationStreamArn != nil {
+		v := *s.DestinationStreamArn
+
+		e.SetValue(protocol.BodyTarget, "DestinationStreamArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Segment definition.
 type WriteSegmentRequest struct {
 	_ struct{} `type:"structure"`
@@ -11730,6 +15303,22 @@ func (s *WriteSegmentRequest) SetDimensions(v *SegmentDimensions) *WriteSegmentR
 func (s *WriteSegmentRequest) SetName(v string) *WriteSegmentRequest {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteSegmentRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Dimensions != nil {
+		v := s.Dimensions
+
+		e.SetFields(protocol.BodyTarget, "Dimensions", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Used to create a campaign treatment.
@@ -11790,6 +15379,45 @@ func (s *WriteTreatmentResource) SetTreatmentDescription(v string) *WriteTreatme
 func (s *WriteTreatmentResource) SetTreatmentName(v string) *WriteTreatmentResource {
 	s.TreatmentName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteTreatmentResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+	if s.SizePercent != nil {
+		v := *s.SizePercent
+
+		e.SetValue(protocol.BodyTarget, "SizePercent", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TreatmentDescription != nil {
+		v := *s.TreatmentDescription
+
+		e.SetValue(protocol.BodyTarget, "TreatmentDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TreatmentName != nil {
+		v := *s.TreatmentName
+
+		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeWriteTreatmentResourceList(vs []*WriteTreatmentResource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/polly/api.go
+++ b/service/polly/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opDeleteLexicon = "DeleteLexicon"
@@ -627,6 +628,17 @@ func (s *DeleteLexiconInput) SetName(v string) *DeleteLexiconInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/DeleteLexiconOutput
 type DeleteLexiconOutput struct {
 	_ struct{} `type:"structure"`
@@ -640,6 +652,12 @@ func (s DeleteLexiconOutput) String() string {
 // GoString returns the string representation
 func (s DeleteLexiconOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/DescribeVoicesInput
@@ -678,6 +696,22 @@ func (s *DescribeVoicesInput) SetNextToken(v string) *DescribeVoicesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeVoicesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.QueryTarget, "LanguageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/DescribeVoicesOutput
 type DescribeVoicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -710,6 +744,22 @@ func (s *DescribeVoicesOutput) SetNextToken(v string) *DescribeVoicesOutput {
 func (s *DescribeVoicesOutput) SetVoices(v []*Voice) *DescribeVoicesOutput {
 	s.Voices = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeVoicesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Voices) > 0 {
+		v := s.Voices
+
+		e.SetList(protocol.BodyTarget, "Voices", encodeVoiceList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/GetLexiconInput
@@ -751,6 +801,17 @@ func (s *GetLexiconInput) SetName(v string) *GetLexiconInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/GetLexiconOutput
 type GetLexiconOutput struct {
 	_ struct{} `type:"structure"`
@@ -784,6 +845,22 @@ func (s *GetLexiconOutput) SetLexicon(v *Lexicon) *GetLexiconOutput {
 func (s *GetLexiconOutput) SetLexiconAttributes(v *LexiconAttributes) *GetLexiconOutput {
 	s.LexiconAttributes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Lexicon != nil {
+		v := s.Lexicon
+
+		e.SetFields(protocol.BodyTarget, "Lexicon", v, protocol.Metadata{})
+	}
+	if s.LexiconAttributes != nil {
+		v := s.LexiconAttributes
+
+		e.SetFields(protocol.BodyTarget, "LexiconAttributes", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides lexicon name and lexicon content in string format. For more information,
@@ -820,6 +897,22 @@ func (s *Lexicon) SetContent(v string) *Lexicon {
 func (s *Lexicon) SetName(v string) *Lexicon {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Lexicon) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Content != nil {
+		v := *s.Content
+
+		e.SetValue(protocol.BodyTarget, "Content", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains metadata describing the lexicon such as the number of lexemes, language
@@ -895,6 +988,42 @@ func (s *LexiconAttributes) SetSize(v int64) *LexiconAttributes {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LexiconAttributes) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Alphabet != nil {
+		v := *s.Alphabet
+
+		e.SetValue(protocol.BodyTarget, "Alphabet", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "LanguageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LexemesCount != nil {
+		v := *s.LexemesCount
+
+		e.SetValue(protocol.BodyTarget, "LexemesCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LexiconArn != nil {
+		v := *s.LexiconArn
+
+		e.SetValue(protocol.BodyTarget, "LexiconArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the content of the lexicon.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/LexiconDescription
 type LexiconDescription struct {
@@ -929,6 +1058,30 @@ func (s *LexiconDescription) SetName(v string) *LexiconDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LexiconDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Attributes != nil {
+		v := s.Attributes
+
+		e.SetFields(protocol.BodyTarget, "Attributes", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLexiconDescriptionList(vs []*LexiconDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/ListLexiconsInput
 type ListLexiconsInput struct {
 	_ struct{} `type:"structure"`
@@ -952,6 +1105,17 @@ func (s ListLexiconsInput) GoString() string {
 func (s *ListLexiconsInput) SetNextToken(v string) *ListLexiconsInput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLexiconsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/ListLexiconsOutput
@@ -986,6 +1150,22 @@ func (s *ListLexiconsOutput) SetLexicons(v []*LexiconDescription) *ListLexiconsO
 func (s *ListLexiconsOutput) SetNextToken(v string) *ListLexiconsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLexiconsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Lexicons) > 0 {
+		v := s.Lexicons
+
+		e.SetList(protocol.BodyTarget, "Lexicons", encodeLexiconDescriptionList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/PutLexiconInput
@@ -1043,6 +1223,22 @@ func (s *PutLexiconInput) SetName(v string) *PutLexiconInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Content != nil {
+		v := *s.Content
+
+		e.SetValue(protocol.BodyTarget, "Content", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/PutLexiconOutput
 type PutLexiconOutput struct {
 	_ struct{} `type:"structure"`
@@ -1056,6 +1252,12 @@ func (s PutLexiconOutput) String() string {
 // GoString returns the string representation
 func (s PutLexiconOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/SynthesizeSpeechInput
@@ -1174,6 +1376,47 @@ func (s *SynthesizeSpeechInput) SetVoiceId(v string) *SynthesizeSpeechInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SynthesizeSpeechInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LexiconNames) > 0 {
+		v := s.LexiconNames
+
+		e.SetList(protocol.BodyTarget, "LexiconNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.OutputFormat != nil {
+		v := *s.OutputFormat
+
+		e.SetValue(protocol.BodyTarget, "OutputFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "SampleRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SpeechMarkTypes) > 0 {
+		v := s.SpeechMarkTypes
+
+		e.SetList(protocol.BodyTarget, "SpeechMarkTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Text != nil {
+		v := *s.Text
+
+		e.SetValue(protocol.BodyTarget, "Text", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TextType != nil {
+		v := *s.TextType
+
+		e.SetValue(protocol.BodyTarget, "TextType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "VoiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/SynthesizeSpeechOutput
 type SynthesizeSpeechOutput struct {
 	_ struct{} `type:"structure" payload:"AudioStream"`
@@ -1228,6 +1471,23 @@ func (s *SynthesizeSpeechOutput) SetContentType(v string) *SynthesizeSpeechOutpu
 func (s *SynthesizeSpeechOutput) SetRequestCharacters(v int64) *SynthesizeSpeechOutput {
 	s.RequestCharacters = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SynthesizeSpeechOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// Skipping AudioStream Output type's body not valid.
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharacters != nil {
+		v := *s.RequestCharacters
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-RequestCharacters", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Description of the voice.
@@ -1291,6 +1551,45 @@ func (s *Voice) SetLanguageName(v string) *Voice {
 func (s *Voice) SetName(v string) *Voice {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Voice) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Gender != nil {
+		v := *s.Gender
+
+		e.SetValue(protocol.BodyTarget, "Gender", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "LanguageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageName != nil {
+		v := *s.LanguageName
+
+		e.SetValue(protocol.BodyTarget, "LanguageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVoiceList(vs []*Voice) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -4060,6 +4060,27 @@ func (s *AbortDocumentVersionUploadInput) SetVersionId(v string) *AbortDocumentV
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortDocumentVersionUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/AbortDocumentVersionUploadOutput
 type AbortDocumentVersionUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -4073,6 +4094,12 @@ func (s AbortDocumentVersionUploadOutput) String() string {
 // GoString returns the string representation
 func (s AbortDocumentVersionUploadOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortDocumentVersionUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ActivateUserRequest
@@ -4130,6 +4157,22 @@ func (s *ActivateUserInput) SetUserId(v string) *ActivateUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActivateUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ActivateUserResponse
 type ActivateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -4152,6 +4195,17 @@ func (s ActivateUserOutput) GoString() string {
 func (s *ActivateUserOutput) SetUser(v *User) *ActivateUserOutput {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActivateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the activity information.
@@ -4246,6 +4300,60 @@ func (s *Activity) SetType(v string) *Activity {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Activity) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CommentMetadata != nil {
+		v := s.CommentMetadata
+
+		e.SetFields(protocol.BodyTarget, "CommentMetadata", v, protocol.Metadata{})
+	}
+	if s.Initiator != nil {
+		v := s.Initiator
+
+		e.SetFields(protocol.BodyTarget, "Initiator", v, protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.BodyTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginalParent != nil {
+		v := s.OriginalParent
+
+		e.SetFields(protocol.BodyTarget, "OriginalParent", v, protocol.Metadata{})
+	}
+	if s.Participants != nil {
+		v := s.Participants
+
+		e.SetFields(protocol.BodyTarget, "Participants", v, protocol.Metadata{})
+	}
+	if s.ResourceMetadata != nil {
+		v := s.ResourceMetadata
+
+		e.SetFields(protocol.BodyTarget, "ResourceMetadata", v, protocol.Metadata{})
+	}
+	if s.TimeStamp != nil {
+		v := *s.TimeStamp
+
+		e.SetValue(protocol.BodyTarget, "TimeStamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeActivityList(vs []*Activity) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/AddResourcePermissionsRequest
 type AddResourcePermissionsInput struct {
 	_ struct{} `type:"structure"`
@@ -4325,6 +4433,27 @@ func (s *AddResourcePermissionsInput) SetResourceId(v string) *AddResourcePermis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Principals) > 0 {
+		v := s.Principals
+
+		e.SetList(protocol.BodyTarget, "Principals", encodeSharePrincipalList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/AddResourcePermissionsResponse
 type AddResourcePermissionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4347,6 +4476,17 @@ func (s AddResourcePermissionsOutput) GoString() string {
 func (s *AddResourcePermissionsOutput) SetShareResults(v []*ShareResult) *AddResourcePermissionsOutput {
 	s.ShareResults = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddResourcePermissionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ShareResults) > 0 {
+		v := s.ShareResults
+
+		e.SetList(protocol.BodyTarget, "ShareResults", encodeShareResultList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes a comment.
@@ -4451,6 +4591,65 @@ func (s *Comment) SetVisibility(v string) *Comment {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Comment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CommentId != nil {
+		v := *s.CommentId
+
+		e.SetValue(protocol.BodyTarget, "CommentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Contributor != nil {
+		v := s.Contributor
+
+		e.SetFields(protocol.BodyTarget, "Contributor", v, protocol.Metadata{})
+	}
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.BodyTarget, "ParentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecipientId != nil {
+		v := *s.RecipientId
+
+		e.SetValue(protocol.BodyTarget, "RecipientId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Text != nil {
+		v := *s.Text
+
+		e.SetValue(protocol.BodyTarget, "Text", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThreadId != nil {
+		v := *s.ThreadId
+
+		e.SetValue(protocol.BodyTarget, "ThreadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Visibility != nil {
+		v := *s.Visibility
+
+		e.SetValue(protocol.BodyTarget, "Visibility", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCommentList(vs []*Comment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the metadata of a comment.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CommentMetadata
 type CommentMetadata struct {
@@ -4508,6 +4707,37 @@ func (s *CommentMetadata) SetCreatedTimestamp(v time.Time) *CommentMetadata {
 func (s *CommentMetadata) SetRecipientId(v string) *CommentMetadata {
 	s.RecipientId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CommentMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CommentId != nil {
+		v := *s.CommentId
+
+		e.SetValue(protocol.BodyTarget, "CommentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CommentStatus != nil {
+		v := *s.CommentStatus
+
+		e.SetValue(protocol.BodyTarget, "CommentStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Contributor != nil {
+		v := s.Contributor
+
+		e.SetFields(protocol.BodyTarget, "Contributor", v, protocol.Metadata{})
+	}
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.RecipientId != nil {
+		v := *s.RecipientId
+
+		e.SetValue(protocol.BodyTarget, "RecipientId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateCommentRequest
@@ -4644,6 +4874,52 @@ func (s *CreateCommentInput) SetVisibility(v string) *CreateCommentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCommentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NotifyCollaborators != nil {
+		v := *s.NotifyCollaborators
+
+		e.SetValue(protocol.BodyTarget, "NotifyCollaborators", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.BodyTarget, "ParentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Text != nil {
+		v := *s.Text
+
+		e.SetValue(protocol.BodyTarget, "Text", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThreadId != nil {
+		v := *s.ThreadId
+
+		e.SetValue(protocol.BodyTarget, "ThreadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Visibility != nil {
+		v := *s.Visibility
+
+		e.SetValue(protocol.BodyTarget, "Visibility", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateCommentResponse
 type CreateCommentOutput struct {
 	_ struct{} `type:"structure"`
@@ -4666,6 +4942,17 @@ func (s CreateCommentOutput) GoString() string {
 func (s *CreateCommentOutput) SetComment(v *Comment) *CreateCommentOutput {
 	s.Comment = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := s.Comment
+
+		e.SetFields(protocol.BodyTarget, "Comment", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateCustomMetadataRequest
@@ -4753,6 +5040,32 @@ func (s *CreateCustomMetadataInput) SetVersionId(v string) *CreateCustomMetadata
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCustomMetadataInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.CustomMetadata) > 0 {
+		v := s.CustomMetadata
+
+		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionid", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateCustomMetadataResponse
 type CreateCustomMetadataOutput struct {
 	_ struct{} `type:"structure"`
@@ -4766,6 +5079,12 @@ func (s CreateCustomMetadataOutput) String() string {
 // GoString returns the string representation
 func (s CreateCustomMetadataOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCustomMetadataOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateFolderRequest
@@ -4835,6 +5154,27 @@ func (s *CreateFolderInput) SetParentFolderId(v string) *CreateFolderInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFolderInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateFolderResponse
 type CreateFolderOutput struct {
 	_ struct{} `type:"structure"`
@@ -4857,6 +5197,17 @@ func (s CreateFolderOutput) GoString() string {
 func (s *CreateFolderOutput) SetMetadata(v *FolderMetadata) *CreateFolderOutput {
 	s.Metadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateLabelsRequest
@@ -4928,6 +5279,27 @@ func (s *CreateLabelsInput) SetResourceId(v string) *CreateLabelsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLabelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Labels) > 0 {
+		v := s.Labels
+
+		e.SetList(protocol.BodyTarget, "Labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateLabelsResponse
 type CreateLabelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4941,6 +5313,12 @@ func (s CreateLabelsOutput) String() string {
 // GoString returns the string representation
 func (s CreateLabelsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLabelsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateNotificationSubscriptionRequest
@@ -5032,6 +5410,32 @@ func (s *CreateNotificationSubscriptionInput) SetSubscriptionType(v string) *Cre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateNotificationSubscriptionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Endpoint != nil {
+		v := *s.Endpoint
+
+		e.SetValue(protocol.BodyTarget, "Endpoint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionType != nil {
+		v := *s.SubscriptionType
+
+		e.SetValue(protocol.BodyTarget, "SubscriptionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateNotificationSubscriptionResponse
 type CreateNotificationSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5054,6 +5458,17 @@ func (s CreateNotificationSubscriptionOutput) GoString() string {
 func (s *CreateNotificationSubscriptionOutput) SetSubscription(v *Subscription) *CreateNotificationSubscriptionOutput {
 	s.Subscription = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateNotificationSubscriptionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Subscription != nil {
+		v := s.Subscription
+
+		e.SetFields(protocol.BodyTarget, "Subscription", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateUserRequest
@@ -5207,6 +5622,57 @@ func (s *CreateUserInput) SetUsername(v string) *CreateUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GivenName != nil {
+		v := *s.GivenName
+
+		e.SetValue(protocol.BodyTarget, "GivenName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.BodyTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Password != nil {
+		v := *s.Password
+
+		e.SetValue(protocol.BodyTarget, "Password", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageRule != nil {
+		v := s.StorageRule
+
+		e.SetFields(protocol.BodyTarget, "StorageRule", v, protocol.Metadata{})
+	}
+	if s.Surname != nil {
+		v := *s.Surname
+
+		e.SetValue(protocol.BodyTarget, "Surname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeZoneId != nil {
+		v := *s.TimeZoneId
+
+		e.SetValue(protocol.BodyTarget, "TimeZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateUserResponse
 type CreateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -5229,6 +5695,17 @@ func (s CreateUserOutput) GoString() string {
 func (s *CreateUserOutput) SetUser(v *User) *CreateUserOutput {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeactivateUserRequest
@@ -5286,6 +5763,22 @@ func (s *DeactivateUserInput) SetUserId(v string) *DeactivateUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeactivateUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeactivateUserOutput
 type DeactivateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -5299,6 +5792,12 @@ func (s DeactivateUserOutput) String() string {
 // GoString returns the string representation
 func (s DeactivateUserOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeactivateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteCommentRequest
@@ -5390,6 +5889,32 @@ func (s *DeleteCommentInput) SetVersionId(v string) *DeleteCommentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCommentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CommentId != nil {
+		v := *s.CommentId
+
+		e.SetValue(protocol.PathTarget, "CommentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteCommentOutput
 type DeleteCommentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5403,6 +5928,12 @@ func (s DeleteCommentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCommentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteCustomMetadataRequest
@@ -5492,6 +6023,37 @@ func (s *DeleteCustomMetadataInput) SetVersionId(v string) *DeleteCustomMetadata
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCustomMetadataInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeleteAll != nil {
+		v := *s.DeleteAll
+
+		e.SetValue(protocol.QueryTarget, "deleteAll", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Keys) > 0 {
+		v := s.Keys
+
+		e.SetList(protocol.QueryTarget, "keys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteCustomMetadataResponse
 type DeleteCustomMetadataOutput struct {
 	_ struct{} `type:"structure"`
@@ -5505,6 +6067,12 @@ func (s DeleteCustomMetadataOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCustomMetadataOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCustomMetadataOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteDocumentRequest
@@ -5562,6 +6130,22 @@ func (s *DeleteDocumentInput) SetDocumentId(v string) *DeleteDocumentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteDocumentOutput
 type DeleteDocumentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5575,6 +6159,12 @@ func (s DeleteDocumentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDocumentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteFolderContentsRequest
@@ -5632,6 +6222,22 @@ func (s *DeleteFolderContentsInput) SetFolderId(v string) *DeleteFolderContentsI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFolderContentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteFolderContentsOutput
 type DeleteFolderContentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5645,6 +6251,12 @@ func (s DeleteFolderContentsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFolderContentsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFolderContentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteFolderRequest
@@ -5702,6 +6314,22 @@ func (s *DeleteFolderInput) SetFolderId(v string) *DeleteFolderInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFolderInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteFolderOutput
 type DeleteFolderOutput struct {
 	_ struct{} `type:"structure"`
@@ -5715,6 +6343,12 @@ func (s DeleteFolderOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFolderOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteLabelsRequest
@@ -5790,6 +6424,32 @@ func (s *DeleteLabelsInput) SetResourceId(v string) *DeleteLabelsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLabelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeleteAll != nil {
+		v := *s.DeleteAll
+
+		e.SetValue(protocol.QueryTarget, "deleteAll", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Labels) > 0 {
+		v := s.Labels
+
+		e.SetList(protocol.QueryTarget, "labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteLabelsResponse
 type DeleteLabelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5803,6 +6463,12 @@ func (s DeleteLabelsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteLabelsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLabelsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteNotificationSubscriptionRequest
@@ -5864,6 +6530,22 @@ func (s *DeleteNotificationSubscriptionInput) SetSubscriptionId(v string) *Delet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteNotificationSubscriptionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionId != nil {
+		v := *s.SubscriptionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteNotificationSubscriptionOutput
 type DeleteNotificationSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5877,6 +6559,12 @@ func (s DeleteNotificationSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteNotificationSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteNotificationSubscriptionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteUserRequest
@@ -5934,6 +6622,22 @@ func (s *DeleteUserInput) SetUserId(v string) *DeleteUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteUserOutput
 type DeleteUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -5947,6 +6651,12 @@ func (s DeleteUserOutput) String() string {
 // GoString returns the string representation
 func (s DeleteUserOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeActivitiesRequest
@@ -6059,6 +6769,47 @@ func (s *DescribeActivitiesInput) SetUserId(v string) *DescribeActivitiesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeActivitiesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.QueryTarget, "endTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.QueryTarget, "organizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.QueryTarget, "startTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.QueryTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeActivitiesResponse
 type DescribeActivitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6090,6 +6841,22 @@ func (s *DescribeActivitiesOutput) SetMarker(v string) *DescribeActivitiesOutput
 func (s *DescribeActivitiesOutput) SetUserActivities(v []*Activity) *DescribeActivitiesOutput {
 	s.UserActivities = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeActivitiesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.UserActivities) > 0 {
+		v := s.UserActivities
+
+		e.SetList(protocol.BodyTarget, "UserActivities", encodeActivityList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeCommentsRequest
@@ -6189,6 +6956,37 @@ func (s *DescribeCommentsInput) SetVersionId(v string) *DescribeCommentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCommentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeCommentsResponse
 type DescribeCommentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6221,6 +7019,22 @@ func (s *DescribeCommentsOutput) SetComments(v []*Comment) *DescribeCommentsOutp
 func (s *DescribeCommentsOutput) SetMarker(v string) *DescribeCommentsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCommentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Comments) > 0 {
+		v := s.Comments
+
+		e.SetList(protocol.BodyTarget, "Comments", encodeCommentList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeDocumentVersionsRequest
@@ -6329,6 +7143,42 @@ func (s *DescribeDocumentVersionsInput) SetMarker(v string) *DescribeDocumentVer
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeDocumentVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Include != nil {
+		v := *s.Include
+
+		e.SetValue(protocol.QueryTarget, "include", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeDocumentVersionsResponse
 type DescribeDocumentVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6361,6 +7211,22 @@ func (s *DescribeDocumentVersionsOutput) SetDocumentVersions(v []*DocumentVersio
 func (s *DescribeDocumentVersionsOutput) SetMarker(v string) *DescribeDocumentVersionsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeDocumentVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DocumentVersions) > 0 {
+		v := s.DocumentVersions
+
+		e.SetList(protocol.BodyTarget, "DocumentVersions", encodeDocumentVersionMetadataList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeFolderContentsRequest
@@ -6482,6 +7348,52 @@ func (s *DescribeFolderContentsInput) SetType(v string) *DescribeFolderContentsI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeFolderContentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Include != nil {
+		v := *s.Include
+
+		e.SetValue(protocol.QueryTarget, "include", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sort != nil {
+		v := *s.Sort
+
+		e.SetValue(protocol.QueryTarget, "sort", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeFolderContentsResponse
 type DescribeFolderContentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6523,6 +7435,27 @@ func (s *DescribeFolderContentsOutput) SetFolders(v []*FolderMetadata) *Describe
 func (s *DescribeFolderContentsOutput) SetMarker(v string) *DescribeFolderContentsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeFolderContentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Documents) > 0 {
+		v := s.Documents
+
+		e.SetList(protocol.BodyTarget, "Documents", encodeDocumentMetadataList(v), protocol.Metadata{})
+	}
+	if len(s.Folders) > 0 {
+		v := s.Folders
+
+		e.SetList(protocol.BodyTarget, "Folders", encodeFolderMetadataList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeNotificationSubscriptionsRequest
@@ -6592,6 +7525,27 @@ func (s *DescribeNotificationSubscriptionsInput) SetOrganizationId(v string) *De
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeNotificationSubscriptionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeNotificationSubscriptionsResponse
 type DescribeNotificationSubscriptionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6624,6 +7578,22 @@ func (s *DescribeNotificationSubscriptionsOutput) SetMarker(v string) *DescribeN
 func (s *DescribeNotificationSubscriptionsOutput) SetSubscriptions(v []*Subscription) *DescribeNotificationSubscriptionsOutput {
 	s.Subscriptions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeNotificationSubscriptionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Subscriptions) > 0 {
+		v := s.Subscriptions
+
+		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeResourcePermissionsRequest
@@ -6706,6 +7676,32 @@ func (s *DescribeResourcePermissionsInput) SetResourceId(v string) *DescribeReso
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeResourcePermissionsResponse
 type DescribeResourcePermissionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6738,6 +7734,22 @@ func (s *DescribeResourcePermissionsOutput) SetMarker(v string) *DescribeResourc
 func (s *DescribeResourcePermissionsOutput) SetPrincipals(v []*Principal) *DescribeResourcePermissionsOutput {
 	s.Principals = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeResourcePermissionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Principals) > 0 {
+		v := s.Principals
+
+		e.SetList(protocol.BodyTarget, "Principals", encodePrincipalList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeRootFoldersRequest
@@ -6808,6 +7820,27 @@ func (s *DescribeRootFoldersInput) SetMarker(v string) *DescribeRootFoldersInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeRootFoldersInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeRootFoldersResponse
 type DescribeRootFoldersOutput struct {
 	_ struct{} `type:"structure"`
@@ -6839,6 +7872,22 @@ func (s *DescribeRootFoldersOutput) SetFolders(v []*FolderMetadata) *DescribeRoo
 func (s *DescribeRootFoldersOutput) SetMarker(v string) *DescribeRootFoldersOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeRootFoldersOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Folders) > 0 {
+		v := s.Folders
+
+		e.SetList(protocol.BodyTarget, "Folders", encodeFolderMetadataList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeUsersRequest
@@ -6980,6 +8029,62 @@ func (s *DescribeUsersInput) SetUserIds(v string) *DescribeUsersInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeUsersInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Include != nil {
+		v := *s.Include
+
+		e.SetValue(protocol.QueryTarget, "include", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.QueryTarget, "organizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Query != nil {
+		v := *s.Query
+
+		e.SetValue(protocol.QueryTarget, "query", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sort != nil {
+		v := *s.Sort
+
+		e.SetValue(protocol.QueryTarget, "sort", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserIds != nil {
+		v := *s.UserIds
+
+		e.SetValue(protocol.QueryTarget, "userIds", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeUsersResponse
 type DescribeUsersOutput struct {
 	_ struct{} `type:"structure"`
@@ -7021,6 +8126,27 @@ func (s *DescribeUsersOutput) SetTotalNumberOfUsers(v int64) *DescribeUsersOutpu
 func (s *DescribeUsersOutput) SetUsers(v []*User) *DescribeUsersOutput {
 	s.Users = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeUsersOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TotalNumberOfUsers != nil {
+		v := *s.TotalNumberOfUsers
+
+		e.SetValue(protocol.BodyTarget, "TotalNumberOfUsers", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Users) > 0 {
+		v := s.Users
+
+		e.SetList(protocol.BodyTarget, "Users", encodeUserList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the document.
@@ -7109,6 +8235,60 @@ func (s *DocumentMetadata) SetParentFolderId(v string) *DocumentMetadata {
 func (s *DocumentMetadata) SetResourceState(v string) *DocumentMetadata {
 	s.ResourceState = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CreatorId != nil {
+		v := *s.CreatorId
+
+		e.SetValue(protocol.BodyTarget, "CreatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Labels) > 0 {
+		v := s.Labels
+
+		e.SetList(protocol.BodyTarget, "Labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.LatestVersionMetadata != nil {
+		v := s.LatestVersionMetadata
+
+		e.SetFields(protocol.BodyTarget, "LatestVersionMetadata", v, protocol.Metadata{})
+	}
+	if s.ModifiedTimestamp != nil {
+		v := *s.ModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceState != nil {
+		v := *s.ResourceState
+
+		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentMetadataList(vs []*DocumentMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a version of a document.
@@ -7244,6 +8424,85 @@ func (s *DocumentVersionMetadata) SetThumbnail(v map[string]*string) *DocumentVe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentVersionMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentCreatedTimestamp != nil {
+		v := *s.ContentCreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ContentCreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ContentModifiedTimestamp != nil {
+		v := *s.ContentModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ContentModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "ContentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CreatorId != nil {
+		v := *s.CreatorId
+
+		e.SetValue(protocol.BodyTarget, "CreatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ModifiedTimestamp != nil {
+		v := *s.ModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "Signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Source) > 0 {
+		v := s.Source
+
+		e.SetMap(protocol.BodyTarget, "Source", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Thumbnail) > 0 {
+		v := s.Thumbnail
+
+		e.SetMap(protocol.BodyTarget, "Thumbnail", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentVersionMetadataList(vs []*DocumentVersionMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes a folder.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/FolderMetadata
 type FolderMetadata struct {
@@ -7359,6 +8618,75 @@ func (s *FolderMetadata) SetSize(v int64) *FolderMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FolderMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CreatorId != nil {
+		v := *s.CreatorId
+
+		e.SetValue(protocol.BodyTarget, "CreatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Labels) > 0 {
+		v := s.Labels
+
+		e.SetList(protocol.BodyTarget, "Labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.LatestVersionSize != nil {
+		v := *s.LatestVersionSize
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ModifiedTimestamp != nil {
+		v := *s.ModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceState != nil {
+		v := *s.ResourceState
+
+		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "Signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFolderMetadataList(vs []*FolderMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetCurrentUserRequest
 type GetCurrentUserInput struct {
 	_ struct{} `type:"structure"`
@@ -7401,6 +8729,17 @@ func (s *GetCurrentUserInput) SetAuthenticationToken(v string) *GetCurrentUserIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCurrentUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetCurrentUserResponse
 type GetCurrentUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -7423,6 +8762,17 @@ func (s GetCurrentUserOutput) GoString() string {
 func (s *GetCurrentUserOutput) SetUser(v *User) *GetCurrentUserOutput {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCurrentUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentRequest
@@ -7489,6 +8839,27 @@ func (s *GetDocumentInput) SetIncludeCustomMetadata(v bool) *GetDocumentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeCustomMetadata != nil {
+		v := *s.IncludeCustomMetadata
+
+		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentResponse
 type GetDocumentOutput struct {
 	_ struct{} `type:"structure"`
@@ -7520,6 +8891,22 @@ func (s *GetDocumentOutput) SetCustomMetadata(v map[string]*string) *GetDocument
 func (s *GetDocumentOutput) SetMetadata(v *DocumentMetadata) *GetDocumentOutput {
 	s.Metadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CustomMetadata) > 0 {
+		v := s.CustomMetadata
+
+		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentPathRequest
@@ -7614,6 +9001,37 @@ func (s *GetDocumentPathInput) SetMarker(v string) *GetDocumentPathInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentPathInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentPathResponse
 type GetDocumentPathOutput struct {
 	_ struct{} `type:"structure"`
@@ -7636,6 +9054,17 @@ func (s GetDocumentPathOutput) GoString() string {
 func (s *GetDocumentPathOutput) SetPath(v *ResourcePath) *GetDocumentPathOutput {
 	s.Path = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentPathOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := s.Path
+
+		e.SetFields(protocol.BodyTarget, "Path", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentVersionRequest
@@ -7732,6 +9161,37 @@ func (s *GetDocumentVersionInput) SetVersionId(v string) *GetDocumentVersionInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeCustomMetadata != nil {
+		v := *s.IncludeCustomMetadata
+
+		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentVersionResponse
 type GetDocumentVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7763,6 +9223,22 @@ func (s *GetDocumentVersionOutput) SetCustomMetadata(v map[string]*string) *GetD
 func (s *GetDocumentVersionOutput) SetMetadata(v *DocumentVersionMetadata) *GetDocumentVersionOutput {
 	s.Metadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CustomMetadata) > 0 {
+		v := s.CustomMetadata
+
+		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetFolderRequest
@@ -7829,6 +9305,27 @@ func (s *GetFolderInput) SetIncludeCustomMetadata(v bool) *GetFolderInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFolderInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeCustomMetadata != nil {
+		v := *s.IncludeCustomMetadata
+
+		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetFolderResponse
 type GetFolderOutput struct {
 	_ struct{} `type:"structure"`
@@ -7860,6 +9357,22 @@ func (s *GetFolderOutput) SetCustomMetadata(v map[string]*string) *GetFolderOutp
 func (s *GetFolderOutput) SetMetadata(v *FolderMetadata) *GetFolderOutput {
 	s.Metadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CustomMetadata) > 0 {
+		v := s.CustomMetadata
+
+		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetFolderPathRequest
@@ -7954,6 +9467,37 @@ func (s *GetFolderPathInput) SetMarker(v string) *GetFolderPathInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFolderPathInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetFolderPathResponse
 type GetFolderPathOutput struct {
 	_ struct{} `type:"structure"`
@@ -7976,6 +9520,17 @@ func (s GetFolderPathOutput) GoString() string {
 func (s *GetFolderPathOutput) SetPath(v *ResourcePath) *GetFolderPathOutput {
 	s.Path = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFolderPathOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := s.Path
+
+		e.SetFields(protocol.BodyTarget, "Path", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the metadata of a user group.
@@ -8010,6 +9565,30 @@ func (s *GroupMetadata) SetId(v string) *GroupMetadata {
 func (s *GroupMetadata) SetName(v string) *GroupMetadata {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GroupMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGroupMetadataList(vs []*GroupMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/InitiateDocumentVersionUploadRequest
@@ -8130,6 +9709,52 @@ func (s *InitiateDocumentVersionUploadInput) SetParentFolderId(v string) *Initia
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateDocumentVersionUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentCreatedTimestamp != nil {
+		v := *s.ContentCreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ContentCreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ContentModifiedTimestamp != nil {
+		v := *s.ContentModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ContentModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "ContentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentSizeInBytes != nil {
+		v := *s.DocumentSizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "DocumentSizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/InitiateDocumentVersionUploadResponse
 type InitiateDocumentVersionUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -8161,6 +9786,22 @@ func (s *InitiateDocumentVersionUploadOutput) SetMetadata(v *DocumentMetadata) *
 func (s *InitiateDocumentVersionUploadOutput) SetUploadMetadata(v *UploadMetadata) *InitiateDocumentVersionUploadOutput {
 	s.UploadMetadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateDocumentVersionUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+	if s.UploadMetadata != nil {
+		v := s.UploadMetadata
+
+		e.SetFields(protocol.BodyTarget, "UploadMetadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the users and/or user groups.
@@ -8197,6 +9838,22 @@ func (s *Participants) SetUsers(v []*UserMetadata) *Participants {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Participants) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Groups) > 0 {
+		v := s.Groups
+
+		e.SetList(protocol.BodyTarget, "Groups", encodeGroupMetadataList(v), protocol.Metadata{})
+	}
+	if len(s.Users) > 0 {
+		v := s.Users
+
+		e.SetList(protocol.BodyTarget, "Users", encodeUserMetadataList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the permissions.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/PermissionInfo
 type PermissionInfo struct {
@@ -8229,6 +9886,30 @@ func (s *PermissionInfo) SetRole(v string) *PermissionInfo {
 func (s *PermissionInfo) SetType(v string) *PermissionInfo {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PermissionInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePermissionInfoList(vs []*PermissionInfo) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a resource.
@@ -8272,6 +9953,35 @@ func (s *Principal) SetRoles(v []*PermissionInfo) *Principal {
 func (s *Principal) SetType(v string) *Principal {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Principal) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Roles) > 0 {
+		v := s.Roles
+
+		e.SetList(protocol.BodyTarget, "Roles", encodePermissionInfoList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePrincipalList(vs []*Principal) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/RemoveAllResourcePermissionsRequest
@@ -8329,6 +10039,22 @@ func (s *RemoveAllResourcePermissionsInput) SetResourceId(v string) *RemoveAllRe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveAllResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/RemoveAllResourcePermissionsOutput
 type RemoveAllResourcePermissionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8342,6 +10068,12 @@ func (s RemoveAllResourcePermissionsOutput) String() string {
 // GoString returns the string representation
 func (s RemoveAllResourcePermissionsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveAllResourcePermissionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/RemoveResourcePermissionRequest
@@ -8425,6 +10157,32 @@ func (s *RemoveResourcePermissionInput) SetResourceId(v string) *RemoveResourceP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveResourcePermissionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrincipalId != nil {
+		v := *s.PrincipalId
+
+		e.SetValue(protocol.PathTarget, "PrincipalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrincipalType != nil {
+		v := *s.PrincipalType
+
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/RemoveResourcePermissionOutput
 type RemoveResourcePermissionOutput struct {
 	_ struct{} `type:"structure"`
@@ -8438,6 +10196,12 @@ func (s RemoveResourcePermissionOutput) String() string {
 // GoString returns the string representation
 func (s RemoveResourcePermissionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveResourcePermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes the metadata of a resource.
@@ -8520,6 +10284,47 @@ func (s *ResourceMetadata) SetVersionId(v string) *ResourceMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginalName != nil {
+		v := *s.OriginalName
+
+		e.SetValue(protocol.BodyTarget, "OriginalName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.BodyTarget, "ParentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the path information of a resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ResourcePath
 type ResourcePath struct {
@@ -8543,6 +10348,17 @@ func (s ResourcePath) GoString() string {
 func (s *ResourcePath) SetComponents(v []*ResourcePathComponent) *ResourcePath {
 	s.Components = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourcePath) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Components) > 0 {
+		v := s.Components
+
+		e.SetList(protocol.BodyTarget, "Components", encodeResourcePathComponentList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the resource path.
@@ -8577,6 +10393,30 @@ func (s *ResourcePathComponent) SetId(v string) *ResourcePathComponent {
 func (s *ResourcePathComponent) SetName(v string) *ResourcePathComponent {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourcePathComponent) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourcePathComponentList(vs []*ResourcePathComponent) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes the recipient type and ID, if available.
@@ -8650,6 +10490,35 @@ func (s *SharePrincipal) SetType(v string) *SharePrincipal {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SharePrincipal) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSharePrincipalList(vs []*SharePrincipal) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the share results of a resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ShareResult
 type ShareResult struct {
@@ -8711,6 +10580,45 @@ func (s *ShareResult) SetStatusMessage(v string) *ShareResult {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ShareResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PrincipalId != nil {
+		v := *s.PrincipalId
+
+		e.SetValue(protocol.BodyTarget, "PrincipalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShareId != nil {
+		v := *s.ShareId
+
+		e.SetValue(protocol.BodyTarget, "ShareId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusMessage != nil {
+		v := *s.StatusMessage
+
+		e.SetValue(protocol.BodyTarget, "StatusMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeShareResultList(vs []*ShareResult) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the storage for a user.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/StorageRuleType
 type StorageRuleType struct {
@@ -8743,6 +10651,22 @@ func (s *StorageRuleType) SetStorageAllocatedInBytes(v int64) *StorageRuleType {
 func (s *StorageRuleType) SetStorageType(v string) *StorageRuleType {
 	s.StorageType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageRuleType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StorageAllocatedInBytes != nil {
+		v := *s.StorageAllocatedInBytes
+
+		e.SetValue(protocol.BodyTarget, "StorageAllocatedInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageType != nil {
+		v := *s.StorageType
+
+		e.SetValue(protocol.BodyTarget, "StorageType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes a subscription.
@@ -8786,6 +10710,35 @@ func (s *Subscription) SetProtocol(v string) *Subscription {
 func (s *Subscription) SetSubscriptionId(v string) *Subscription {
 	s.SubscriptionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Subscription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndPoint != nil {
+		v := *s.EndPoint
+
+		e.SetValue(protocol.BodyTarget, "EndPoint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionId != nil {
+		v := *s.SubscriptionId
+
+		e.SetValue(protocol.BodyTarget, "SubscriptionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSubscriptionList(vs []*Subscription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateDocumentRequest
@@ -8877,6 +10830,37 @@ func (s *UpdateDocumentInput) SetResourceState(v string) *UpdateDocumentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceState != nil {
+		v := *s.ResourceState
+
+		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateDocumentOutput
 type UpdateDocumentOutput struct {
 	_ struct{} `type:"structure"`
@@ -8890,6 +10874,12 @@ func (s UpdateDocumentOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDocumentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateDocumentVersionRequest
@@ -8973,6 +10963,32 @@ func (s *UpdateDocumentVersionInput) SetVersionStatus(v string) *UpdateDocumentV
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionStatus != nil {
+		v := *s.VersionStatus
+
+		e.SetValue(protocol.BodyTarget, "VersionStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateDocumentVersionOutput
 type UpdateDocumentVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -8986,6 +11002,12 @@ func (s UpdateDocumentVersionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDocumentVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateFolderRequest
@@ -9077,6 +11099,37 @@ func (s *UpdateFolderInput) SetResourceState(v string) *UpdateFolderInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFolderInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceState != nil {
+		v := *s.ResourceState
+
+		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateFolderOutput
 type UpdateFolderOutput struct {
 	_ struct{} `type:"structure"`
@@ -9090,6 +11143,12 @@ func (s UpdateFolderOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFolderOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateUserRequest
@@ -9210,6 +11269,52 @@ func (s *UpdateUserInput) SetUserId(v string) *UpdateUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GivenName != nil {
+		v := *s.GivenName
+
+		e.SetValue(protocol.BodyTarget, "GivenName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "Locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageRule != nil {
+		v := s.StorageRule
+
+		e.SetFields(protocol.BodyTarget, "StorageRule", v, protocol.Metadata{})
+	}
+	if s.Surname != nil {
+		v := *s.Surname
+
+		e.SetValue(protocol.BodyTarget, "Surname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeZoneId != nil {
+		v := *s.TimeZoneId
+
+		e.SetValue(protocol.BodyTarget, "TimeZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateUserResponse
 type UpdateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -9232,6 +11337,17 @@ func (s UpdateUserOutput) GoString() string {
 func (s *UpdateUserOutput) SetUser(v *User) *UpdateUserOutput {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the upload.
@@ -9266,6 +11382,22 @@ func (s *UploadMetadata) SetSignedHeaders(v map[string]*string) *UploadMetadata 
 func (s *UploadMetadata) SetUploadUrl(v string) *UploadMetadata {
 	s.UploadUrl = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SignedHeaders) > 0 {
+		v := s.SignedHeaders
+
+		e.SetMap(protocol.BodyTarget, "SignedHeaders", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.UploadUrl != nil {
+		v := *s.UploadUrl
+
+		e.SetValue(protocol.BodyTarget, "UploadUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes a user.
@@ -9419,6 +11551,95 @@ func (s *User) SetUsername(v string) *User {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *User) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GivenName != nil {
+		v := *s.GivenName
+
+		e.SetValue(protocol.BodyTarget, "GivenName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "Locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ModifiedTimestamp != nil {
+		v := *s.ModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.BodyTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecycleBinFolderId != nil {
+		v := *s.RecycleBinFolderId
+
+		e.SetValue(protocol.BodyTarget, "RecycleBinFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RootFolderId != nil {
+		v := *s.RootFolderId
+
+		e.SetValue(protocol.BodyTarget, "RootFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Storage != nil {
+		v := s.Storage
+
+		e.SetFields(protocol.BodyTarget, "Storage", v, protocol.Metadata{})
+	}
+	if s.Surname != nil {
+		v := *s.Surname
+
+		e.SetValue(protocol.BodyTarget, "Surname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeZoneId != nil {
+		v := *s.TimeZoneId
+
+		e.SetValue(protocol.BodyTarget, "TimeZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUserList(vs []*User) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the metadata of the user.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UserMetadata
 type UserMetadata struct {
@@ -9480,6 +11701,45 @@ func (s *UserMetadata) SetUsername(v string) *UserMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UserMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GivenName != nil {
+		v := *s.GivenName
+
+		e.SetValue(protocol.BodyTarget, "GivenName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Surname != nil {
+		v := *s.Surname
+
+		e.SetValue(protocol.BodyTarget, "Surname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUserMetadataList(vs []*UserMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the storage for a user.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UserStorageMetadata
 type UserStorageMetadata struct {
@@ -9512,6 +11772,22 @@ func (s *UserStorageMetadata) SetStorageRule(v *StorageRuleType) *UserStorageMet
 func (s *UserStorageMetadata) SetStorageUtilizedInBytes(v int64) *UserStorageMetadata {
 	s.StorageUtilizedInBytes = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UserStorageMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StorageRule != nil {
+		v := s.StorageRule
+
+		e.SetFields(protocol.BodyTarget, "StorageRule", v, protocol.Metadata{})
+	}
+	if s.StorageUtilizedInBytes != nil {
+		v := *s.StorageUtilizedInBytes
+
+		e.SetValue(protocol.BodyTarget, "StorageUtilizedInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/xray/api.go
+++ b/service/xray/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opBatchGetTraces = "BatchGetTraces"
@@ -612,6 +613,35 @@ func (s *Alias) SetType(v string) *Alias {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Alias) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Names) > 0 {
+		v := s.Names
+
+		e.SetList(protocol.BodyTarget, "Names", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAliasList(vs []*Alias) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Value of a segment annotation. Has one of three value types: Number, Boolean
 // or String.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/AnnotationValue
@@ -654,6 +684,27 @@ func (s *AnnotationValue) SetNumberValue(v float64) *AnnotationValue {
 func (s *AnnotationValue) SetStringValue(v string) *AnnotationValue {
 	s.StringValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnnotationValue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BooleanValue != nil {
+		v := *s.BooleanValue
+
+		e.SetValue(protocol.BodyTarget, "BooleanValue", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.NumberValue != nil {
+		v := *s.NumberValue
+
+		e.SetValue(protocol.BodyTarget, "NumberValue", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.StringValue != nil {
+		v := *s.StringValue
+
+		e.SetValue(protocol.BodyTarget, "StringValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/BackendConnectionErrors
@@ -719,6 +770,42 @@ func (s *BackendConnectionErrors) SetUnknownHostCount(v int64) *BackendConnectio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BackendConnectionErrors) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConnectionRefusedCount != nil {
+		v := *s.ConnectionRefusedCount
+
+		e.SetValue(protocol.BodyTarget, "ConnectionRefusedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HTTPCode4XXCount != nil {
+		v := *s.HTTPCode4XXCount
+
+		e.SetValue(protocol.BodyTarget, "HTTPCode4XXCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HTTPCode5XXCount != nil {
+		v := *s.HTTPCode5XXCount
+
+		e.SetValue(protocol.BodyTarget, "HTTPCode5XXCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OtherCount != nil {
+		v := *s.OtherCount
+
+		e.SetValue(protocol.BodyTarget, "OtherCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimeoutCount != nil {
+		v := *s.TimeoutCount
+
+		e.SetValue(protocol.BodyTarget, "TimeoutCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.UnknownHostCount != nil {
+		v := *s.UnknownHostCount
+
+		e.SetValue(protocol.BodyTarget, "UnknownHostCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/BatchGetTracesRequest
 type BatchGetTracesInput struct {
 	_ struct{} `type:"structure"`
@@ -767,6 +854,22 @@ func (s *BatchGetTracesInput) SetTraceIds(v []*string) *BatchGetTracesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchGetTracesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TraceIds) > 0 {
+		v := s.TraceIds
+
+		e.SetList(protocol.BodyTarget, "TraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/BatchGetTracesResult
 type BatchGetTracesOutput struct {
 	_ struct{} `type:"structure"`
@@ -807,6 +910,27 @@ func (s *BatchGetTracesOutput) SetTraces(v []*Trace) *BatchGetTracesOutput {
 func (s *BatchGetTracesOutput) SetUnprocessedTraceIds(v []*string) *BatchGetTracesOutput {
 	s.UnprocessedTraceIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchGetTracesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Traces) > 0 {
+		v := s.Traces
+
+		e.SetList(protocol.BodyTarget, "Traces", encodeTraceList(v), protocol.Metadata{})
+	}
+	if len(s.UnprocessedTraceIds) > 0 {
+		v := s.UnprocessedTraceIds
+
+		e.SetList(protocol.BodyTarget, "UnprocessedTraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information about a connection between two services.
@@ -879,6 +1003,50 @@ func (s *Edge) SetSummaryStatistics(v *EdgeStatistics) *Edge {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Edge) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Aliases) > 0 {
+		v := s.Aliases
+
+		e.SetList(protocol.BodyTarget, "Aliases", encodeAliasList(v), protocol.Metadata{})
+	}
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ReferenceId != nil {
+		v := *s.ReferenceId
+
+		e.SetValue(protocol.BodyTarget, "ReferenceId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTimeHistogram) > 0 {
+		v := s.ResponseTimeHistogram
+
+		e.SetList(protocol.BodyTarget, "ResponseTimeHistogram", encodeHistogramEntryList(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.SummaryStatistics != nil {
+		v := s.SummaryStatistics
+
+		e.SetFields(protocol.BodyTarget, "SummaryStatistics", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEdgeList(vs []*Edge) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Response statistics for an edge.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/EdgeStatistics
 type EdgeStatistics struct {
@@ -940,6 +1108,37 @@ func (s *EdgeStatistics) SetTotalResponseTime(v float64) *EdgeStatistics {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EdgeStatistics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorStatistics != nil {
+		v := s.ErrorStatistics
+
+		e.SetFields(protocol.BodyTarget, "ErrorStatistics", v, protocol.Metadata{})
+	}
+	if s.FaultStatistics != nil {
+		v := s.FaultStatistics
+
+		e.SetFields(protocol.BodyTarget, "FaultStatistics", v, protocol.Metadata{})
+	}
+	if s.OkCount != nil {
+		v := *s.OkCount
+
+		e.SetValue(protocol.BodyTarget, "OkCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCount != nil {
+		v := *s.TotalCount
+
+		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalResponseTime != nil {
+		v := *s.TotalResponseTime
+
+		e.SetValue(protocol.BodyTarget, "TotalResponseTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Information about requests that failed with a 4xx Client Error status code.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/ErrorStatistics
 type ErrorStatistics struct {
@@ -984,6 +1183,27 @@ func (s *ErrorStatistics) SetTotalCount(v int64) *ErrorStatistics {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ErrorStatistics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OtherCount != nil {
+		v := *s.OtherCount
+
+		e.SetValue(protocol.BodyTarget, "OtherCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ThrottleCount != nil {
+		v := *s.ThrottleCount
+
+		e.SetValue(protocol.BodyTarget, "ThrottleCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCount != nil {
+		v := *s.TotalCount
+
+		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Information about requests that failed with a 5xx Server Error status code.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/FaultStatistics
 type FaultStatistics struct {
@@ -1017,6 +1237,22 @@ func (s *FaultStatistics) SetOtherCount(v int64) *FaultStatistics {
 func (s *FaultStatistics) SetTotalCount(v int64) *FaultStatistics {
 	s.TotalCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FaultStatistics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OtherCount != nil {
+		v := *s.OtherCount
+
+		e.SetValue(protocol.BodyTarget, "OtherCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCount != nil {
+		v := *s.TotalCount
+
+		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetServiceGraphRequest
@@ -1081,6 +1317,27 @@ func (s *GetServiceGraphInput) SetStartTime(v time.Time) *GetServiceGraphInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetServiceGraphInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetServiceGraphResult
 type GetServiceGraphOutput struct {
 	_ struct{} `type:"structure"`
@@ -1133,6 +1390,32 @@ func (s *GetServiceGraphOutput) SetStartTime(v time.Time) *GetServiceGraphOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetServiceGraphOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Services) > 0 {
+		v := s.Services
+
+		e.SetList(protocol.BodyTarget, "Services", encodeServiceList(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetTraceGraphRequest
 type GetTraceGraphInput struct {
 	_ struct{} `type:"structure"`
@@ -1181,6 +1464,22 @@ func (s *GetTraceGraphInput) SetTraceIds(v []*string) *GetTraceGraphInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTraceGraphInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TraceIds) > 0 {
+		v := s.TraceIds
+
+		e.SetList(protocol.BodyTarget, "TraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetTraceGraphResult
 type GetTraceGraphOutput struct {
 	_ struct{} `type:"structure"`
@@ -1212,6 +1511,22 @@ func (s *GetTraceGraphOutput) SetNextToken(v string) *GetTraceGraphOutput {
 func (s *GetTraceGraphOutput) SetServices(v []*Service) *GetTraceGraphOutput {
 	s.Services = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTraceGraphOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Services) > 0 {
+		v := s.Services
+
+		e.SetList(protocol.BodyTarget, "Services", encodeServiceList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetTraceSummariesRequest
@@ -1296,6 +1611,37 @@ func (s *GetTraceSummariesInput) SetStartTime(v time.Time) *GetTraceSummariesInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTraceSummariesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.FilterExpression != nil {
+		v := *s.FilterExpression
+
+		e.SetValue(protocol.BodyTarget, "FilterExpression", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sampling != nil {
+		v := *s.Sampling
+
+		e.SetValue(protocol.BodyTarget, "Sampling", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetTraceSummariesResult
 type GetTraceSummariesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1349,6 +1695,32 @@ func (s *GetTraceSummariesOutput) SetTracesProcessedCount(v int64) *GetTraceSumm
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTraceSummariesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApproximateTime != nil {
+		v := *s.ApproximateTime
+
+		e.SetValue(protocol.BodyTarget, "ApproximateTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TraceSummaries) > 0 {
+		v := s.TraceSummaries
+
+		e.SetList(protocol.BodyTarget, "TraceSummaries", encodeTraceSummaryList(v), protocol.Metadata{})
+	}
+	if s.TracesProcessedCount != nil {
+		v := *s.TracesProcessedCount
+
+		e.SetValue(protocol.BodyTarget, "TracesProcessedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An entry in a histogram for a statistic. A histogram maps the range of observed
 // values on the X axis, and the prevalence of each value on the Y axis.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/HistogramEntry
@@ -1382,6 +1754,30 @@ func (s *HistogramEntry) SetCount(v int64) *HistogramEntry {
 func (s *HistogramEntry) SetValue(v float64) *HistogramEntry {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HistogramEntry) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHistogramEntryList(vs []*HistogramEntry) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about an HTTP request.
@@ -1445,6 +1841,37 @@ func (s *Http) SetUserAgent(v string) *Http {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Http) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientIp != nil {
+		v := *s.ClientIp
+
+		e.SetValue(protocol.BodyTarget, "ClientIp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.BodyTarget, "HttpMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpStatus != nil {
+		v := *s.HttpStatus
+
+		e.SetValue(protocol.BodyTarget, "HttpStatus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HttpURL != nil {
+		v := *s.HttpURL
+
+		e.SetValue(protocol.BodyTarget, "HttpURL", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserAgent != nil {
+		v := *s.UserAgent
+
+		e.SetValue(protocol.BodyTarget, "UserAgent", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/PutTelemetryRecordsRequest
 type PutTelemetryRecordsInput struct {
 	_ struct{} `type:"structure"`
@@ -1506,6 +1933,32 @@ func (s *PutTelemetryRecordsInput) SetTelemetryRecords(v []*TelemetryRecord) *Pu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutTelemetryRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EC2InstanceId != nil {
+		v := *s.EC2InstanceId
+
+		e.SetValue(protocol.BodyTarget, "EC2InstanceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Hostname != nil {
+		v := *s.Hostname
+
+		e.SetValue(protocol.BodyTarget, "Hostname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceARN != nil {
+		v := *s.ResourceARN
+
+		e.SetValue(protocol.BodyTarget, "ResourceARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TelemetryRecords) > 0 {
+		v := s.TelemetryRecords
+
+		e.SetList(protocol.BodyTarget, "TelemetryRecords", encodeTelemetryRecordList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/PutTelemetryRecordsResult
 type PutTelemetryRecordsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1519,6 +1972,12 @@ func (s PutTelemetryRecordsOutput) String() string {
 // GoString returns the string representation
 func (s PutTelemetryRecordsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutTelemetryRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/PutTraceSegmentsRequest
@@ -1560,6 +2019,17 @@ func (s *PutTraceSegmentsInput) SetTraceSegmentDocuments(v []*string) *PutTraceS
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutTraceSegmentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TraceSegmentDocuments) > 0 {
+		v := s.TraceSegmentDocuments
+
+		e.SetList(protocol.BodyTarget, "TraceSegmentDocuments", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/PutTraceSegmentsResult
 type PutTraceSegmentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1582,6 +2052,17 @@ func (s PutTraceSegmentsOutput) GoString() string {
 func (s *PutTraceSegmentsOutput) SetUnprocessedTraceSegments(v []*UnprocessedTraceSegment) *PutTraceSegmentsOutput {
 	s.UnprocessedTraceSegments = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutTraceSegmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.UnprocessedTraceSegments) > 0 {
+		v := s.UnprocessedTraceSegments
+
+		e.SetList(protocol.BodyTarget, "UnprocessedTraceSegments", encodeUnprocessedTraceSegmentList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A segment from a trace that has been ingested by the X-Ray service. The segment
@@ -1619,6 +2100,30 @@ func (s *Segment) SetDocument(v string) *Segment {
 func (s *Segment) SetId(v string) *Segment {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Segment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSegmentList(vs []*Segment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about an application that processed requests, users that made
@@ -1768,6 +2273,85 @@ func (s *Service) SetType(v string) *Service {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Service) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.BodyTarget, "AccountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.DurationHistogram) > 0 {
+		v := s.DurationHistogram
+
+		e.SetList(protocol.BodyTarget, "DurationHistogram", encodeHistogramEntryList(v), protocol.Metadata{})
+	}
+	if len(s.Edges) > 0 {
+		v := s.Edges
+
+		e.SetList(protocol.BodyTarget, "Edges", encodeEdgeList(v), protocol.Metadata{})
+	}
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Names) > 0 {
+		v := s.Names
+
+		e.SetList(protocol.BodyTarget, "Names", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ReferenceId != nil {
+		v := *s.ReferenceId
+
+		e.SetValue(protocol.BodyTarget, "ReferenceId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTimeHistogram) > 0 {
+		v := s.ResponseTimeHistogram
+
+		e.SetList(protocol.BodyTarget, "ResponseTimeHistogram", encodeHistogramEntryList(v), protocol.Metadata{})
+	}
+	if s.Root != nil {
+		v := *s.Root
+
+		e.SetValue(protocol.BodyTarget, "Root", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SummaryStatistics != nil {
+		v := s.SummaryStatistics
+
+		e.SetFields(protocol.BodyTarget, "SummaryStatistics", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeServiceList(vs []*Service) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/ServiceId
 type ServiceId struct {
 	_ struct{} `type:"structure"`
@@ -1813,6 +2397,40 @@ func (s *ServiceId) SetNames(v []*string) *ServiceId {
 func (s *ServiceId) SetType(v string) *ServiceId {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ServiceId) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.BodyTarget, "AccountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Names) > 0 {
+		v := s.Names
+
+		e.SetList(protocol.BodyTarget, "Names", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeServiceIdList(vs []*ServiceId) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Response statistics for a service.
@@ -1874,6 +2492,37 @@ func (s *ServiceStatistics) SetTotalCount(v int64) *ServiceStatistics {
 func (s *ServiceStatistics) SetTotalResponseTime(v float64) *ServiceStatistics {
 	s.TotalResponseTime = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ServiceStatistics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorStatistics != nil {
+		v := s.ErrorStatistics
+
+		e.SetFields(protocol.BodyTarget, "ErrorStatistics", v, protocol.Metadata{})
+	}
+	if s.FaultStatistics != nil {
+		v := s.FaultStatistics
+
+		e.SetFields(protocol.BodyTarget, "FaultStatistics", v, protocol.Metadata{})
+	}
+	if s.OkCount != nil {
+		v := *s.OkCount
+
+		e.SetValue(protocol.BodyTarget, "OkCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCount != nil {
+		v := *s.TotalCount
+
+		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalResponseTime != nil {
+		v := *s.TotalResponseTime
+
+		e.SetValue(protocol.BodyTarget, "TotalResponseTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/TelemetryRecord
@@ -1939,6 +2588,50 @@ func (s *TelemetryRecord) SetTimestamp(v time.Time) *TelemetryRecord {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TelemetryRecord) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BackendConnectionErrors != nil {
+		v := s.BackendConnectionErrors
+
+		e.SetFields(protocol.BodyTarget, "BackendConnectionErrors", v, protocol.Metadata{})
+	}
+	if s.SegmentsReceivedCount != nil {
+		v := *s.SegmentsReceivedCount
+
+		e.SetValue(protocol.BodyTarget, "SegmentsReceivedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentsRejectedCount != nil {
+		v := *s.SegmentsRejectedCount
+
+		e.SetValue(protocol.BodyTarget, "SegmentsRejectedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentsSentCount != nil {
+		v := *s.SegmentsSentCount
+
+		e.SetValue(protocol.BodyTarget, "SegmentsSentCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentsSpilloverCount != nil {
+		v := *s.SegmentsSpilloverCount
+
+		e.SetValue(protocol.BodyTarget, "SegmentsSpilloverCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.BodyTarget, "Timestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTelemetryRecordList(vs []*TelemetryRecord) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A collection of segment documents with matching trace IDs.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/Trace
 type Trace struct {
@@ -1982,6 +2675,35 @@ func (s *Trace) SetId(v string) *Trace {
 func (s *Trace) SetSegments(v []*Segment) *Trace {
 	s.Segments = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Trace) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Segments) > 0 {
+		v := s.Segments
+
+		e.SetList(protocol.BodyTarget, "Segments", encodeSegmentList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTraceList(vs []*Trace) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Metadata generated from the segment documents in a trace.
@@ -2104,6 +2826,80 @@ func (s *TraceSummary) SetUsers(v []*TraceUser) *TraceSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TraceSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Annotations) > 0 {
+		v := s.Annotations
+
+		e.SetMap(protocol.BodyTarget, "Annotations", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, encodeValueWithServiceIdsList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.HasError != nil {
+		v := *s.HasError
+
+		e.SetValue(protocol.BodyTarget, "HasError", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasFault != nil {
+		v := *s.HasFault
+
+		e.SetValue(protocol.BodyTarget, "HasFault", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasThrottle != nil {
+		v := *s.HasThrottle
+
+		e.SetValue(protocol.BodyTarget, "HasThrottle", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Http != nil {
+		v := s.Http
+
+		e.SetFields(protocol.BodyTarget, "Http", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsPartial != nil {
+		v := *s.IsPartial
+
+		e.SetValue(protocol.BodyTarget, "IsPartial", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ResponseTime != nil {
+		v := *s.ResponseTime
+
+		e.SetValue(protocol.BodyTarget, "ResponseTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if len(s.ServiceIds) > 0 {
+		v := s.ServiceIds
+
+		e.SetList(protocol.BodyTarget, "ServiceIds", encodeServiceIdList(v), protocol.Metadata{})
+	}
+	if len(s.Users) > 0 {
+		v := s.Users
+
+		e.SetList(protocol.BodyTarget, "Users", encodeTraceUserList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTraceSummaryList(vs []*TraceSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information about a user recorded in segment documents.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/TraceUser
 type TraceUser struct {
@@ -2136,6 +2932,30 @@ func (s *TraceUser) SetServiceIds(v []*ServiceId) *TraceUser {
 func (s *TraceUser) SetUserName(v string) *TraceUser {
 	s.UserName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TraceUser) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ServiceIds) > 0 {
+		v := s.ServiceIds
+
+		e.SetList(protocol.BodyTarget, "ServiceIds", encodeServiceIdList(v), protocol.Metadata{})
+	}
+	if s.UserName != nil {
+		v := *s.UserName
+
+		e.SetValue(protocol.BodyTarget, "UserName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTraceUserList(vs []*TraceUser) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about a segment that failed processing.
@@ -2181,6 +3001,35 @@ func (s *UnprocessedTraceSegment) SetMessage(v string) *UnprocessedTraceSegment 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UnprocessedTraceSegment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorCode != nil {
+		v := *s.ErrorCode
+
+		e.SetValue(protocol.BodyTarget, "ErrorCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUnprocessedTraceSegmentList(vs []*UnprocessedTraceSegment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information about a segment annotation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/ValueWithServiceIds
 type ValueWithServiceIds struct {
@@ -2213,4 +3062,28 @@ func (s *ValueWithServiceIds) SetAnnotationValue(v *AnnotationValue) *ValueWithS
 func (s *ValueWithServiceIds) SetServiceIds(v []*ServiceId) *ValueWithServiceIds {
 	s.ServiceIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ValueWithServiceIds) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AnnotationValue != nil {
+		v := s.AnnotationValue
+
+		e.SetFields(protocol.BodyTarget, "AnnotationValue", v, protocol.Metadata{})
+	}
+	if len(s.ServiceIds) > 0 {
+		v := s.ServiceIds
+
+		e.SetList(protocol.BodyTarget, "ServiceIds", encodeServiceIdList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeValueWithServiceIdsList(vs []*ValueWithServiceIds) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }


### PR DESCRIPTION
Updates the RESTJSON protocol marshalers to use code generation instead
of reflection based marshaling. These changes improve the performance of
the SDK's marshaling in both time (CPU), number and size of allocations.

The following benchmark shows a relative difference between the SDKs
previous marshaling of RESTJSON performance and the performance with the
generated marshaling.

```
benchmark                                                   old ns/op     new ns/op     delta
BenchmarkRESTJSONBuild_Complex_ETCCreateJob-4               105896        36199         -65.82%
BenchmarkRESTJSONBuild_Simple_ETCListJobsByPipeline-4       8246          5085          -38.33%
BenchmarkRESTJSONRequest_Complex_CFCreateJob-4              318451        215346        -32.38%
BenchmarkRESTJSONRequest_Simple_ETCListJobsByPipeline-4     133614        126604        -5.25%

benchmark                                                   old allocs     new allocs     delta
BenchmarkRESTJSONBuild_Complex_ETCCreateJob-4               327            239            -26.91%
BenchmarkRESTJSONBuild_Simple_ETCListJobsByPipeline-4       67             50             -25.37%
BenchmarkRESTJSONRequest_Complex_CFCreateJob-4              686            598            -12.83%
BenchmarkRESTJSONRequest_Simple_ETCListJobsByPipeline-4     245            228            -6.94%

benchmark                                                   old bytes     new bytes     delta
BenchmarkRESTJSONBuild_Complex_ETCCreateJob-4               24112         19992         -17.09%
BenchmarkRESTJSONBuild_Simple_ETCListJobsByPipeline-4       3728          3765          +0.99%
BenchmarkRESTJSONRequest_Complex_CFCreateJob-4              74537         70378         -5.58%
BenchmarkRESTJSONRequest_Simple_ETCListJobsByPipeline-4     49721         49764         +0.09%
```